### PR TITLE
feat: Add animated balls traveling along metro lines

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -33,6 +33,8 @@ def cli() -> None:
               help="Vertical spacing between tracks (default: 40)")
 @click.option("--max-layers-per-row", type=int, default=None,
               help="Max layers before folding to next row (default: auto)")
+@click.option("--animate/--no-animate", default=False,
+              help="Add animated balls traveling along lines")
 def render(
     input_file: Path,
     output: Path | None,
@@ -42,6 +44,7 @@ def render(
     x_spacing: float,
     y_spacing: float,
     max_layers_per_row: int | None,
+    animate: bool,
 ) -> None:
     """Render a Mermaid metro map definition to SVG."""
     text = input_file.read_text()
@@ -51,7 +54,7 @@ def render(
                    max_layers_per_row=max_layers_per_row)
 
     theme_obj = THEMES[theme]
-    svg = render_svg(graph, theme_obj, width=width, height=height)
+    svg = render_svg(graph, theme_obj, width=width, height=height, animate=animate)
 
     if output is None:
         output = input_file.with_suffix(".svg")

--- a/src/nf_metro/render/animate.py
+++ b/src/nf_metro/render/animate.py
@@ -1,0 +1,299 @@
+"""Animation support: animated balls traveling along metro lines."""
+
+from __future__ import annotations
+
+import math
+import re
+
+import drawsvg as draw
+
+from nf_metro.layout.routing import RoutedPath
+from nf_metro.parser.model import MetroGraph
+from nf_metro.render.style import Theme
+
+
+def render_animation(
+    d: draw.Drawing,
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    station_offsets: dict[tuple[str, str], float],
+    theme: Theme,
+    curve_radius: float = 10.0,
+) -> None:
+    """Add animated balls traveling along each metro line.
+
+    For each metro line, builds a continuous SVG path from its chained
+    edges, then injects invisible <path> elements and <circle> elements
+    with <animateMotion> to create the traveling ball effect.
+    """
+    line_paths = _build_line_motion_paths(
+        graph, routes, station_offsets, theme, curve_radius,
+    )
+
+    for idx, (line_id, d_attr) in enumerate(line_paths):
+        path_id = f"motion-path-{line_id}-{idx}"
+
+        # Invisible path for animateMotion to follow
+        d.append(draw.Raw(
+            f'<path id="{path_id}" d="{d_attr}" fill="none" stroke="none"/>'
+        ))
+
+        # Compute duration from approximate path length
+        path_length = _compute_path_length(d_attr)
+        dur = max(path_length / theme.animation_speed, 2.0)
+
+        n_balls = theme.animation_balls_per_line
+        for i in range(n_balls):
+            begin_offset = -i * dur / n_balls
+            d.append(draw.Raw(
+                f'<circle r="{theme.animation_ball_radius}" '
+                f'fill="{theme.animation_ball_color}" opacity="0.9">'
+                f'<animateMotion dur="{dur:.2f}s" '
+                f'repeatCount="indefinite" '
+                f'begin="{begin_offset:.2f}s">'
+                f'<mpath href="#{path_id}"/>'
+                f'</animateMotion>'
+                f'</circle>'
+            ))
+
+
+def _build_line_motion_paths(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    station_offsets: dict[tuple[str, str], float],
+    theme: Theme,
+    curve_radius: float = 10.0,
+) -> list[tuple[str, str]]:
+    """Build continuous SVG motion paths for each metro line.
+
+    At diamond/bubble patterns (fork-join), produces separate paths for
+    each branch so balls travel both alternatives (e.g., FastP and
+    TrimGalore). Returns list of (line_id, d_attr) pairs -- a line_id
+    may appear multiple times when it has forking branches.
+    """
+    # Index routes by (source, target, line_id) for lookup
+    route_by_edge: dict[tuple[str, str, str], RoutedPath] = {}
+    for route in routes:
+        key = (route.edge.source, route.edge.target, route.line_id)
+        route_by_edge[key] = route
+
+    # Group edges by line
+    edges_by_line: dict[str, list] = {}
+    for edge in graph.edges:
+        edges_by_line.setdefault(edge.line_id, []).append(edge)
+
+    result: list[tuple[str, str]] = []
+
+    for line_id, edges in edges_by_line.items():
+        if line_id not in graph.lines:
+            continue
+
+        # Build adjacency: source -> list of (target, edge)
+        adj: dict[str, list] = {}
+        incoming: set[str] = set()
+        for edge in edges:
+            adj.setdefault(edge.source, []).append((edge.target, edge))
+            incoming.add(edge.target)
+
+        # Find root nodes (no incoming edges for this line)
+        all_sources = set(adj.keys())
+        roots = all_sources - incoming
+        if not roots:
+            continue
+
+        # Find all distinct root-to-sink paths (covers both branches
+        # of diamonds/bubbles)
+        all_paths: list[list] = []
+        for root in sorted(roots):
+            _find_all_paths(root, adj, [], all_paths)
+
+        if not all_paths:
+            continue
+
+        for path_edges in all_paths:
+            all_points = _chain_edge_points(
+                path_edges, route_by_edge, station_offsets,
+            )
+            if len(all_points) < 2:
+                continue
+
+            d_attr = _points_to_svg_path(all_points, curve_radius)
+            if d_attr:
+                result.append((line_id, d_attr))
+
+    return result
+
+
+def _find_all_paths(
+    current: str,
+    adj: dict[str, list],
+    path_so_far: list,
+    results: list[list],
+) -> None:
+    """DFS to find all root-to-sink paths through the adjacency map."""
+    if current not in adj:
+        # Sink node: save the accumulated path
+        if path_so_far:
+            results.append(list(path_so_far))
+        return
+
+    for target, edge in adj[current]:
+        path_so_far.append(edge)
+        _find_all_paths(target, adj, path_so_far, results)
+        path_so_far.pop()
+
+
+def _chain_edge_points(
+    edges: list,
+    route_by_edge: dict[tuple[str, str, str], RoutedPath],
+    station_offsets: dict[tuple[str, str], float],
+) -> list[tuple[float, float]]:
+    """Chain edge routes into one continuous list of waypoints."""
+    all_points: list[tuple[float, float]] = []
+
+    for edge in edges:
+        route = route_by_edge.get(
+            (edge.source, edge.target, edge.line_id),
+        )
+        if not route:
+            continue
+
+        pts = _apply_offsets(route, station_offsets)
+
+        if not all_points:
+            all_points.extend(pts)
+        elif pts:
+            last = all_points[-1]
+            first = pts[0]
+            if abs(last[0] - first[0]) < 1.0 and abs(last[1] - first[1]) < 1.0:
+                all_points.extend(pts[1:])
+            else:
+                all_points.extend(pts)
+
+    return all_points
+
+
+def _apply_offsets(
+    route: RoutedPath,
+    station_offsets: dict[tuple[str, str], float],
+) -> list[tuple[float, float]]:
+    """Apply station offsets to route points, matching _render_edges logic."""
+    if route.offsets_applied:
+        return list(route.points)
+
+    src_off = station_offsets.get((route.edge.source, route.line_id), 0.0)
+    tgt_off = station_offsets.get((route.edge.target, route.line_id), 0.0)
+
+    orig_sy = route.points[0][1]
+    orig_ty = route.points[-1][1]
+    pts = []
+    for i, (x, y) in enumerate(route.points):
+        if i == 0:
+            pts.append((x, y + src_off))
+        elif i == len(route.points) - 1:
+            pts.append((x, y + tgt_off))
+        elif abs(y - orig_sy) <= abs(y - orig_ty):
+            pts.append((x, y + src_off))
+        else:
+            pts.append((x, y + tgt_off))
+    return pts
+
+
+def _points_to_svg_path(
+    pts: list[tuple[float, float]],
+    curve_radius: float = 10.0,
+    route_curve_radii: list[float] | None = None,
+) -> str:
+    """Convert a list of waypoints to an SVG path 'd' attribute.
+
+    Replicates the curve logic from _render_edges in svg.py:
+    straight lines with quadratic Bezier curves at direction changes.
+    """
+    if len(pts) < 2:
+        return ""
+
+    if len(pts) == 2:
+        return f"M {pts[0][0]:.2f} {pts[0][1]:.2f} L {pts[1][0]:.2f} {pts[1][1]:.2f}"
+
+    parts = [f"M {pts[0][0]:.2f} {pts[0][1]:.2f}"]
+
+    for i in range(1, len(pts) - 1):
+        prev = pts[i - 1]
+        curr = pts[i]
+        nxt = pts[i + 1]
+
+        dx1 = curr[0] - prev[0]
+        dy1 = curr[1] - prev[1]
+        len1 = math.hypot(dx1, dy1)
+
+        dx2 = nxt[0] - curr[0]
+        dy2 = nxt[1] - curr[1]
+        len2 = math.hypot(dx2, dy2)
+
+        max_len1 = len1 / 2 if i > 1 else len1
+        max_len2 = len2 / 2 if i < len(pts) - 2 else len2
+
+        effective_r = curve_radius
+        r = min(effective_r, max_len1, max_len2)
+
+        if len1 > 0 and len2 > 0:
+            before_x = curr[0] - (dx1 / len1) * r
+            before_y = curr[1] - (dy1 / len1) * r
+            after_x = curr[0] + (dx2 / len2) * r
+            after_y = curr[1] + (dy2 / len2) * r
+
+            parts.append(
+                f"L {before_x:.2f} {before_y:.2f} "
+                f"Q {curr[0]:.2f} {curr[1]:.2f} {after_x:.2f} {after_y:.2f}"
+            )
+        else:
+            parts.append(f"L {curr[0]:.2f} {curr[1]:.2f}")
+
+    parts.append(f"L {pts[-1][0]:.2f} {pts[-1][1]:.2f}")
+
+    return " ".join(parts)
+
+
+def _compute_path_length(d_attr: str) -> float:
+    """Approximate the length of an SVG path from its commands.
+
+    Parses M, L, and Q commands and sums segment lengths.
+    For Q (quadratic Bezier), approximates with the chord length.
+    """
+    # Extract all numbers from the path
+    tokens = re.findall(r'[MLQ]|[-+]?\d*\.?\d+', d_attr)
+
+    total = 0.0
+    cx, cy = 0.0, 0.0  # current position
+    i = 0
+
+    while i < len(tokens):
+        token = tokens[i]
+        if token == 'M':
+            cx = float(tokens[i + 1])
+            cy = float(tokens[i + 2])
+            i += 3
+        elif token == 'L':
+            nx = float(tokens[i + 1])
+            ny = float(tokens[i + 2])
+            total += math.hypot(nx - cx, ny - cy)
+            cx, cy = nx, ny
+            i += 3
+        elif token == 'Q':
+            # Q cx cy ex ey - approximate with control point polygon
+            qcx = float(tokens[i + 1])
+            qcy = float(tokens[i + 2])
+            ex = float(tokens[i + 3])
+            ey = float(tokens[i + 4])
+            # Sum of legs through control point (overestimates slightly)
+            leg1 = math.hypot(qcx - cx, qcy - cy)
+            leg2 = math.hypot(ex - qcx, ey - qcy)
+            chord = math.hypot(ex - cx, ey - cy)
+            # Average of chord and polygon for a decent approximation
+            total += (chord + leg1 + leg2) / 2
+            cx, cy = ex, ey
+            i += 5
+        else:
+            i += 1
+
+    return total

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -28,3 +28,8 @@ class Theme:
     legend_background: str
     legend_text_color: str
     legend_font_size: float
+    # Animation settings
+    animation_ball_radius: float = 3.0
+    animation_ball_color: str = "#ffffff"
+    animation_balls_per_line: int = 3
+    animation_speed: float = 80.0  # pixels per second

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -19,6 +19,7 @@ def render_svg(
     width: int | None = None,
     height: int | None = None,
     padding: float = 60.0,
+    animate: bool = False,
 ) -> str:
     """Render a metro map graph to an SVG string."""
     if not graph.stations:
@@ -127,6 +128,11 @@ def render_svg(
 
     # Draw edges (lines) behind stations
     _render_edges(d, graph, routes, station_offsets, theme)
+
+    # Animation (after edges, before stations so balls travel behind station markers)
+    if animate:
+        from nf_metro.render.animate import render_animation
+        render_animation(d, graph, routes, station_offsets, theme)
 
     # Draw stations (all circles, skip ports)
     _render_stations(d, graph, theme, station_offsets)

--- a/src/nf_metro/themes/light.py
+++ b/src/nf_metro/themes/light.py
@@ -22,4 +22,5 @@ LIGHT_THEME = Theme(
     legend_background="rgba(255, 255, 255, 0.8)",
     legend_text_color="#333333",
     legend_font_size=12.0,
+    animation_ball_color="#333333",
 )


### PR DESCRIPTION
## Summary

- Adds `--animate` CLI flag to the `render` command that injects SVG `<animateMotion>` elements, creating white circles ("balls") that travel along each metro line's path
- At diamond/bubble fork-join patterns (e.g., FastP/TrimGalore), balls travel both branches simultaneously by finding all distinct root-to-sink paths per line via DFS
- Animation speed scales with path length so balls move at consistent speed across lines of different lengths
- Light theme uses dark balls (`#333333`) for contrast

## Test plan

- [ ] `python -m nf_metro render examples/rnaseq_sections.mmd -o /tmp/test.svg --animate --x-spacing 60 --y-spacing 40` renders without errors
- [ ] Open animated SVG in browser, verify balls travel along all 5 lines
- [ ] Verify balls travel both FastP and TrimGalore branches
- [ ] `python -m nf_metro render examples/rnaseq_sections.mmd -o /tmp/static.svg` produces SVG with no animation elements
- [ ] `pytest --ignore=tests/test_auto_layout.py` passes (47/47, pre-existing title assertion failure unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)