### PR TITLE
feat: Transparent background for light theme

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -101,8 +101,9 @@ def render_svg(
 
     d = draw.Drawing(svg_width, svg_height)
 
-    # Background
-    d.append(draw.Rectangle(0, 0, svg_width, svg_height, fill=theme.background_color))
+    # Background (skip for transparent themes)
+    if theme.background_color and theme.background_color != "none":
+        d.append(draw.Rectangle(0, 0, svg_width, svg_height, fill=theme.background_color))
 
     # Title / Logo
     if show_logo:

--- a/src/nf_metro/themes/light.py
+++ b/src/nf_metro/themes/light.py
@@ -4,7 +4,7 @@ from nf_metro.render.style import Theme
 
 LIGHT_THEME = Theme(
     name="light",
-    background_color="#f5f5f5",
+    background_color="none",
     station_fill="#ffffff",
     station_stroke="#333333",
     station_radius=6.0,

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -58,7 +58,9 @@ def test_render_light_theme():
     )
     compute_layout(graph)
     svg = render_svg(graph, LIGHT_THEME)
-    assert LIGHT_THEME.background_color in svg
+    # Light theme uses transparent background (no background rectangle)
+    assert LIGHT_THEME.background_color == "none"
+    assert '#333333' in svg  # label/stroke color present
 
 
 def test_render_empty_graph():


### PR DESCRIPTION
## Summary
- Skip drawing background rectangle when `background_color` is `"none"`, producing transparent SVGs
- Updated light theme to use transparent background instead of solid `#f5f5f5`
- SVGs now work naturally on any page background (light or dark host pages)

## Test plan
- [x] Verified `pytest` passes (only pre-existing failure in `test_render_rnaseq_sections_example` remains)
- [x] Rendered rnaseq example with `--theme light` and visually confirmed transparent background

🤖 Generated with [Claude Code](https://claude.com/claude-code)