### PR TITLE
fix: Sort edge draw order to prevent middle lines appearing narrower

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -237,6 +237,19 @@ def _render_edges(
     curve_radius: float = 10.0,
 ) -> None:
     """Render metro line edges with smooth curves at direction changes."""
+    # Sort routes by effective Y of the source point (highest Y first) so
+    # lines are drawn bottom-to-top.  This ensures each interior line in a
+    # bundle only loses one boundary edge to its neighbor rather than having
+    # a line drawn first get painted over on both sides.
+    def _sort_key(route: RoutedPath) -> float:
+        if route.offsets_applied:
+            return -route.points[0][1]
+        src_off = station_offsets.get(
+            (route.edge.source, route.line_id), 0.0)
+        return -(route.points[0][1] + src_off)
+
+    routes = sorted(routes, key=_sort_key)
+
     for route in routes:
         line = graph.lines.get(route.line_id)
         color = line.color if line else "#888888"


### PR DESCRIPTION
## Summary
- Lines in a bundle were drawn in `.mmd` parse order, so a line listed first in comma-separated edge definitions (e.g. `star_salmon,star_rsem,...`) could be spatially sandwiched between two lines drawn later
- Both neighbors painted over its boundary pixels, making it appear visually thinner than the rest of the bundle
- Sort routes by effective Y (highest first) before rendering so lines are drawn bottom-to-top, ensuring each interior line loses at most one boundary edge consistently

## Test plan
- [x] Render `examples/rnaseq_sections.mmd` and verify the green (star_salmon) line in the preprocessing bundle is no longer visibly narrower than its neighbors
- [ ] Visually verify other sections (genome alignment, post-processing, QC) look correct
- [x] All existing tests pass (59/59, 1 pre-existing failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)