### PR TITLE
fix: Offset labels from pill edge, not station base Y

### DIFF
--- a/examples/rnaseq_sections_light_animated.svg
+++ b/examples/rnaseq_sections_light_animated.svg
@@ -212,10 +212,10 @@
 <rect x="812.0" y="454.0" width="12.0" height="18.0" rx="6.0" ry="6.0" fill="#ffffff" stroke="#333333" stroke-width="2.0" />
 <rect x="752.0" y="454.0" width="12.0" height="18.0" rx="6.0" ry="6.0" fill="#ffffff" stroke="#333333" stroke-width="2.0" />
 <rect x="692.0" y="454.0" width="12.0" height="18.0" rx="6.0" ry="6.0" fill="#ffffff" stroke="#333333" stroke-width="2.0" />
-<text x="80.0" y="176.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">cat fastq</text>
-<text x="698.0" y="136.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">STAR</text>
-<text x="1016.0" y="136.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">SAMtools</text>
-<text x="1058.0" y="476.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">RSeQC</text>
+<text x="80.0" y="188.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">cat fastq</text>
+<text x="698.0" y="139.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">STAR</text>
+<text x="1016.0" y="142.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">SAMtools</text>
+<text x="1058.0" y="482.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">RSeQC</text>
 <text x="698.0" y="216.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">HISAT2</text>
 <text x="698.0" y="326.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">Salmon</text>
 <text x="698.0" y="366.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">Kallisto</text>
@@ -225,21 +225,21 @@
 <text x="998.0" y="444.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="auto">Preseq</text>
 <text x="806.0" y="144.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="auto">UMI-tools dedup</text>
 <text x="782.0" y="294.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="auto">MultiQC</text>
-<text x="200.0" y="176.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">infer strandedness</text>
+<text x="200.0" y="188.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">infer strandedness</text>
 <text x="1062.0" y="200.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="end" dominant-baseline="central">BEDTools</text>
-<text x="938.0" y="476.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">Qualimap</text>
+<text x="938.0" y="482.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">Qualimap</text>
 <text x="866.0" y="176.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">Salmon</text>
 <text x="260.0" y="144.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="auto">UMI-tools extract</text>
 <text x="1062.0" y="240.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="end" dominant-baseline="central">bedGraphToBigWig</text>
 <text x="878.0" y="444.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="auto">dupRadar</text>
-<text x="344.0" y="136.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">FastP</text>
+<text x="344.0" y="148.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">FastP</text>
 <text x="1062.0" y="280.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="end" dominant-baseline="central">StringTie</text>
-<text x="818.0" y="476.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">DESeq2 PCA</text>
-<text x="344.0" y="216.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">Trim Galore!</text>
+<text x="818.0" y="482.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">DESeq2 PCA</text>
+<text x="344.0" y="228.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">Trim Galore!</text>
 <text x="428.0" y="144.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="auto">FastQC</text>
 <text x="758.0" y="444.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="auto">Kraken2/Bracken</text>
-<text x="488.0" y="176.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">BBSplit</text>
-<text x="698.0" y="476.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">MultiQC</text>
+<text x="488.0" y="188.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">BBSplit</text>
+<text x="698.0" y="482.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="hanging">MultiQC</text>
 <text x="548.0" y="144.0" font-size="11.0" fill="#333333" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" text-anchor="middle" dominant-baseline="auto">SortMeRNA</text>
 <rect x="30.0" y="351.0" width="435.0" height="144.0" rx="6" ry="6" fill="rgba(255, 255, 255, 0.8)" />
 <path d="M42.0,375.0 L66.0,375.0" stroke="#0570b0" stroke-width="4.0" stroke-linecap="round" />

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -139,7 +139,7 @@ def render_svg(
     _render_stations(d, graph, theme, station_offsets)
 
     # Draw labels (horizontal, skip ports)
-    labels = place_labels(graph)
+    labels = place_labels(graph, station_offsets=station_offsets)
     _render_labels(d, labels, theme)
 
     # Legend


### PR DESCRIPTION
## Summary
- Labels were positioned a fixed 16px from `station.y`, but multi-line station pills extend up to `max_offset + radius` below that, causing below-labels to overlap the pill
- Now `place_labels` receives `station_offsets` and measures the gap from the actual pill edge, so labels sit at a consistent distance regardless of how many lines pass through
- Re-rendered the README SVG with the fix

## Test plan
- [x] All existing tests pass (65/65, 1 pre-existing failure excluded)
- [x] Visual check: below-labels in preprocessing no longer overlap station pills
- [ ] Verify README figure renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)