### PR TITLE
feat: Add terminus file icons and grid-aware layout

### DIFF
--- a/examples/rnaseq_sections.mmd
+++ b/examples/rnaseq_sections.mmd
@@ -1,6 +1,9 @@
 %%metro title: nf-core/rnaseq
 %%metro logo: examples/nf-core-rnaseq_logo_dark.png
 %%metro style: dark
+%%metro file: cat_fastq | FASTQ
+%%metro file: multiqc_final | HTML
+%%metro file: multiqc_pseudo | HTML
 %%metro line: star_rsem | Aligner: STAR, Quantification: RSEM | #0570b0
 %%metro line: star_salmon | Aligner: STAR, Quantification: Salmon (default) | #2db572
 %%metro line: hisat2 | Aligner: HISAT2, Quantification: None | #f5c542

--- a/examples/rnaseq_sections.mmd
+++ b/examples/rnaseq_sections.mmd
@@ -2,7 +2,7 @@
 %%metro logo: examples/nf-core-rnaseq_logo_dark.png
 %%metro style: dark
 %%metro file: cat_fastq | FASTQ
-%%metro file: multiqc_final | HTML
+%%metro file: report_final | HTML
 %%metro file: multiqc_pseudo | HTML
 %%metro line: star_rsem | Aligner: STAR, Quantification: RSEM | #0570b0
 %%metro line: star_salmon | Aligner: STAR, Quantification: Salmon (default) | #2db572
@@ -91,6 +91,7 @@ graph LR
         deseq2_pca[DESeq2 PCA]
         kraken2[Kraken2/Bracken]
         multiqc_final[MultiQC]
+        report_final[ ]
 
         rseqc -->|star_salmon,star_rsem,hisat2| preseq
         preseq -->|star_salmon,star_rsem,hisat2| qualimap
@@ -98,6 +99,7 @@ graph LR
         dupradar -->|star_salmon,star_rsem,hisat2| deseq2_pca
         deseq2_pca -->|star_salmon,star_rsem,hisat2| kraken2
         kraken2 -->|star_salmon,star_rsem,hisat2| multiqc_final
+        multiqc_final -->|star_salmon,star_rsem,hisat2| report_final
     end
 
     %% Inter-section edges

--- a/examples/rnaseq_sections.mmd
+++ b/examples/rnaseq_sections.mmd
@@ -1,9 +1,9 @@
 %%metro title: nf-core/rnaseq
 %%metro logo: examples/nf-core-rnaseq_logo_dark.png
 %%metro style: dark
-%%metro file: cat_fastq | FASTQ
+%%metro file: fastq_in | FASTQ
 %%metro file: report_final | HTML
-%%metro file: multiqc_pseudo | HTML
+%%metro file: report_pseudo | HTML
 %%metro line: star_rsem | Aligner: STAR, Quantification: RSEM | #0570b0
 %%metro line: star_salmon | Aligner: STAR, Quantification: Salmon (default) | #2db572
 %%metro line: hisat2 | Aligner: HISAT2, Quantification: None | #f5c542
@@ -17,6 +17,7 @@ graph LR
     subgraph preprocessing [Pre-processing]
         %%metro exit: right | star_salmon, star_rsem, hisat2
         %%metro exit: bottom | pseudo_salmon, pseudo_kallisto
+        fastq_in[ ]
         cat_fastq[cat fastq]
         fastqc_raw[FastQC]
         infer_strandedness[infer strandedness]
@@ -27,6 +28,7 @@ graph LR
         bbsplit[BBSplit]
         sortmerna[SortMeRNA]
 
+        fastq_in -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| cat_fastq
         cat_fastq -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| fastqc_raw
         fastqc_raw -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| infer_strandedness
         infer_strandedness -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| umi_tools_extract
@@ -76,9 +78,11 @@ graph LR
         salmon_pseudo[Salmon]
         kallisto[Kallisto]
         multiqc_pseudo[MultiQC]
+        report_pseudo[ ]
 
         salmon_pseudo -->|pseudo_salmon| multiqc_pseudo
         kallisto -->|pseudo_kallisto| multiqc_pseudo
+        multiqc_pseudo -->|pseudo_salmon,pseudo_kallisto| report_pseudo
     end
 
     subgraph qc_report [Quality control & reporting]

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -35,6 +35,8 @@ def cli() -> None:
               help="Max layers before folding to next row (default: auto)")
 @click.option("--animate/--no-animate", default=False,
               help="Add animated balls traveling along lines")
+@click.option("--logo", type=click.Path(exists=True, path_type=Path), default=None,
+              help="Logo image path (overrides %%metro logo: directive)")
 def render(
     input_file: Path,
     output: Path | None,
@@ -45,10 +47,14 @@ def render(
     y_spacing: float,
     max_layers_per_row: int | None,
     animate: bool,
+    logo: Path | None,
 ) -> None:
     """Render a Mermaid metro map definition to SVG."""
     text = input_file.read_text()
     graph = parse_metro_mermaid(text)
+
+    if logo is not None:
+        graph.logo_path = str(logo)
 
     compute_layout(graph, x_spacing=x_spacing, y_spacing=y_spacing,
                    max_layers_per_row=max_layers_per_row)

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -148,6 +148,16 @@ def place_labels(
                     above=(direction < 0),
                 )
 
+        # Clamp terminus labels so they stay within section bbox
+        if station.is_terminus and station.section_id:
+            sec = graph.sections.get(station.section_id)
+            if sec and sec.bbox_w > 0:
+                char_width = 7.0
+                text_half_w = len(candidate.text) * char_width / 2
+                min_x = sec.bbox_x + text_half_w + 4
+                max_x = sec.bbox_x + sec.bbox_w - text_half_w - 4
+                candidate.x = max(min_x, min(candidate.x, max_x))
+
         placements.append(candidate)
 
     return placements

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -147,6 +147,19 @@ def place_sections(
         if c not in col_widths:
             col_widths[c] = 0.0
 
+    # Expand columns if a spanning section's intrinsic width exceeds the
+    # sum of its spanned columns. Distributes the extra to the last column.
+    for sid, section in graph.sections.items():
+        cspan = section.grid_col_span
+        if cspan <= 1:
+            continue
+        start_col = col_assign.get(sid, 0)
+        spanned = sum(col_widths[c] for c in range(start_col, start_col + cspan))
+        spanned += (cspan - 1) * section_x_gap
+        if section.bbox_w > spanned:
+            deficit = section.bbox_w - spanned
+            col_widths[start_col + cspan - 1] += deficit
+
     # Cumulative x offsets (columns are shared)
     col_offsets: dict[int, float] = {}
     cumulative_x = 0.0
@@ -173,6 +186,18 @@ def place_sections(
     for r in range(max_row + 1):
         if r not in row_heights:
             row_heights[r] = 0.0
+
+    # Expand rows if a spanning section's intrinsic height exceeds spanned rows
+    for sid, section in graph.sections.items():
+        rspan = section.grid_row_span
+        if rspan <= 1:
+            continue
+        start_row = row_assign.get(sid, 0)
+        spanned = sum(row_heights[r] for r in range(start_row, start_row + rspan))
+        spanned += (rspan - 1) * section_y_gap
+        if section.bbox_h > spanned:
+            deficit = section.bbox_h - spanned
+            row_heights[start_row + rspan - 1] += deficit
 
     # Cumulative y offsets per row
     row_offsets: dict[int, float] = {}

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -32,6 +32,8 @@ class Station:
     label: str
     section_id: str | None = None
     is_port: bool = False
+    is_terminus: bool = False
+    terminus_label: str = ""
     # Populated by layout engine
     x: float = 0.0
     y: float = 0.0
@@ -131,6 +133,8 @@ class MetroGraph:
     logo_path: str = ""
     # Section IDs that had explicit %%metro direction: directives
     _explicit_directions: set[str] = field(default_factory=set)
+    # Pending terminus designations: station_id -> extension label
+    _pending_terminus: dict[str, str] = field(default_factory=dict)
 
     def add_line(self, line: MetroLine) -> None:
         self.lines[line.id] = line

--- a/src/nf_metro/render/icons.py
+++ b/src/nf_metro/render/icons.py
@@ -1,6 +1,8 @@
-"""Icon helpers for metro map rendering (future use)."""
+"""Icon helpers for metro map rendering."""
 
 from __future__ import annotations
+
+import drawsvg as draw
 
 
 def train_icon_path(x: float, y: float, size: float = 12.0) -> str:
@@ -13,3 +15,99 @@ def train_icon_path(x: float, y: float, size: float = 12.0) -> str:
         f"L {x} {y + hs} "
         f"L {x - hs} {y} Z"
     )
+
+
+def render_file_icon(
+    d: draw.Drawing,
+    cx: float,
+    cy: float,
+    width: float,
+    height: float,
+    fold_size: float,
+    fill: str,
+    stroke: str,
+    stroke_width: float,
+    corner_radius: float,
+    label: str,
+    font_size: float,
+    font_color: str,
+    font_family: str,
+) -> None:
+    """Render a file/document icon with a dog-ear fold at top-right.
+
+    The icon is centered on (cx, cy). The shape is a rectangle with the
+    top-right corner replaced by a diagonal fold.
+    """
+    hw = width / 2
+    hh = height / 2
+    x0 = cx - hw
+    y0 = cy - hh
+    x1 = cx + hw
+    y1 = cy + hh
+    r = corner_radius
+    f = fold_size
+
+    # Main document shape: rectangle with top-right dog-ear
+    # Start at top-left + corner radius, go clockwise
+    path = draw.Path(
+        fill=fill,
+        stroke=stroke,
+        stroke_width=stroke_width,
+        stroke_linejoin="round",
+    )
+    # Top edge: from top-left corner to fold start
+    path.M(x0 + r, y0)
+    path.L(x1 - f, y0)
+    # Diagonal fold
+    path.L(x1, y0 + f)
+    # Right edge down to bottom-right corner
+    path.L(x1, y1 - r)
+    # Bottom-right corner
+    path.Q(x1, y1, x1 - r, y1)
+    # Bottom edge
+    path.L(x0 + r, y1)
+    # Bottom-left corner
+    path.Q(x0, y1, x0, y1 - r)
+    # Left edge
+    path.L(x0, y0 + r)
+    # Top-left corner
+    path.Q(x0, y0, x0 + r, y0)
+    path.Z()
+    d.append(path)
+
+    # Fold triangle (slightly darker overlay)
+    fold_path = draw.Path(
+        fill=stroke,
+        opacity=0.15,
+        stroke="none",
+    )
+    fold_path.M(x1 - f, y0)
+    fold_path.L(x1 - f, y0 + f)
+    fold_path.L(x1, y0 + f)
+    fold_path.Z()
+    d.append(fold_path)
+
+    # Fold crease line
+    crease = draw.Path(
+        fill="none",
+        stroke=stroke,
+        stroke_width=stroke_width * 0.6,
+    )
+    crease.M(x1 - f, y0)
+    crease.L(x1 - f, y0 + f)
+    crease.L(x1, y0 + f)
+    d.append(crease)
+
+    # Extension label centered in the body (shifted down slightly to
+    # account for fold taking up top-right space)
+    text_y = cy + f * 0.15
+    d.append(draw.Text(
+        label,
+        font_size,
+        cx, text_y,
+        fill=font_color,
+        font_family=font_family,
+        font_weight="bold",
+        text_anchor="middle",
+        dominant_baseline="central",
+    ))

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -33,3 +33,13 @@ class Theme:
     animation_ball_color: str = "#ffffff"
     animation_balls_per_line: int = 3
     animation_speed: float = 80.0  # pixels per second
+    # Terminus (file icon) settings
+    terminus_width: float = 28.0
+    terminus_height: float = 32.0
+    terminus_fold_size: float = 8.0
+    terminus_fill: str = ""  # empty = inherit station_fill
+    terminus_stroke: str = ""  # empty = inherit station_stroke
+    terminus_stroke_width: float = 1.5
+    terminus_corner_radius: float = 2.0
+    terminus_font_size: float = 7.0
+    terminus_font_color: str = ""  # empty = inherit label_color

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -9,6 +9,7 @@ import drawsvg as draw
 from nf_metro.layout.labels import LabelPlacement, place_labels
 from nf_metro.layout.routing import RoutedPath, compute_station_offsets, route_edges
 from nf_metro.parser.model import MetroGraph
+from nf_metro.render.icons import render_file_icon
 from nf_metro.render.legend import compute_legend_dimensions, render_legend
 from nf_metro.render.style import Theme
 
@@ -399,6 +400,47 @@ def _render_stations(
                 stroke=theme.station_stroke,
                 stroke_width=theme.station_stroke_width,
             ))
+
+        # Render file icon adjacent to terminus stations
+        if station.is_terminus:
+            section = graph.sections.get(station.section_id) if station.section_id else None
+            # Detect if station is a source (no incoming internal edges) or sink
+            is_source = True
+            if section:
+                for edge in section.internal_edges:
+                    if edge.target == station.id:
+                        is_source = False
+                        break
+            # Place icon on the "outside" of the flow
+            icon_gap = r + 6
+            icon_half_w = theme.terminus_width / 2
+            section_dir = section.direction if section else "LR"
+            if section_dir == "RL":
+                icon_cx_offset = (icon_gap + icon_half_w) if is_source else -(icon_gap + icon_half_w)
+            else:
+                icon_cx_offset = -(icon_gap + icon_half_w) if is_source else (icon_gap + icon_half_w)
+            icon_cx = station.x + icon_cx_offset
+            icon_cy = station.y + (min_off + max_off) / 2
+            # Clamp to stay within section bbox
+            if section and section.bbox_w > 0:
+                icon_cx = max(section.bbox_x + icon_half_w + 2,
+                              min(icon_cx, section.bbox_x + section.bbox_w - icon_half_w - 2))
+            render_file_icon(
+                d,
+                cx=icon_cx,
+                cy=icon_cy,
+                width=theme.terminus_width,
+                height=theme.terminus_height,
+                fold_size=theme.terminus_fold_size,
+                fill=theme.terminus_fill or theme.station_fill,
+                stroke=theme.terminus_stroke or theme.station_stroke,
+                stroke_width=theme.terminus_stroke_width,
+                corner_radius=theme.terminus_corner_radius,
+                label=station.terminus_label,
+                font_size=theme.terminus_font_size,
+                font_color="#000000",
+                font_family=theme.label_font_family,
+            )
 
 
 def _render_labels(

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -374,7 +374,20 @@ def _render_stations(
 
         span = max_off - min_off
 
-        if is_tb_vert:
+        # Non-process terminus stations: filled rectangle (same size as pill, no rounding)
+        is_blank_terminus = station.is_terminus and not station.label.strip()
+        if is_blank_terminus:
+            w = r * 2
+            h = span + r * 2
+            cy = station.y + (min_off + max_off) / 2
+            d.append(draw.Rectangle(
+                station.x - w / 2, cy - h / 2,
+                w, h,
+                fill=theme.station_fill,
+                stroke=theme.station_stroke,
+                stroke_width=theme.station_stroke_width,
+            ))
+        elif is_tb_vert:
             # Horizontal pill: lines spread along X axis
             w = span + r * 2
             h = r * 2


### PR DESCRIPTION
## Summary

- Add file icons adjacent to terminus station pills (supplementary, not replacement)
- Add non-process terminus stations (blank-label `[ ]` nodes) to preprocessing, pseudo_align, and qc_report sections in the rnaseq example
- Render non-process terminus stations as filled rectangles instead of pills
- Include terminus stations in initial bbox computation with grid-aware column/row expansion for spanning sections
- Add entry inset padding for horizontal sections with vertical entry ports, preventing straight-line drops and ensuring metro-style curves
- Generalize label clamping to keep all labels within section bounding boxes
- Add `--logo` CLI option to override the `%%metro logo:` directive (e.g. for switching between dark/light logo variants)

## Key changes

| File | Change |
|------|--------|
| `parser/model.py` | Add `is_terminus`, `terminus_label` fields and `_pending_terminus` dict |
| `parser/mermaid.py` | Parse `%%metro file:` directives, apply terminus designation after section resolution |
| `render/icons.py` | New `render_file_icon()` for dog-ear document icons |
| `render/style.py` | Add `terminus_*` theme settings |
| `render/svg.py` | Render terminus rectangles + adjacent file icons, RL-aware placement |
| `layout/engine.py` | Normalize local coords after RL mirror, entry inset for vertical-to-horizontal transitions, copy terminus fields to subgraph stations |
| `layout/section_placement.py` | Expand grid columns/rows when spanning sections exceed allocated space |
| `layout/labels.py` | Skip blank-label stations, clamp all labels to section bbox |
| `cli.py` | Add `--logo` option to override logo path from CLI |
| `examples/rnaseq_sections.mmd` | Add `fastq_in`, `report_pseudo`, `report_final` terminus stations |

## Test plan

- [ ] `pytest` passes
- [ ] Render `examples/rnaseq_sections.mmd` in dark and light themes
- [ ] Verify file icons appear adjacent to terminus pills in all three sections
- [ ] Verify section 5 (RL) entry line curves into RSeQC rather than dropping straight
- [ ] Verify labels stay within section bounding boxes
- [ ] Verify grid alignment: section boxes cover their full column/row spans
- [ ] Verify `--logo` CLI flag overrides the .mmd logo directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)