### PR TITLE
chore: Bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.1.1"
+version = "0.2.0"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from 0.1.1 to 0.2.0

New since 0.1.1: mkdocs-material website with example gallery, versioned docs via mike, codebase refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)