### PR TITLE
fix: Trigger GitHub Pages build after mike deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,3 +51,10 @@ jobs:
       - name: Deploy dev docs (manual trigger)
         if: github.event_name == 'workflow_dispatch'
         run: mike deploy --push dev
+
+      - name: Trigger GitHub Pages build
+        run: |
+          curl -sS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pages/builds"


### PR DESCRIPTION
## Summary

- After mike pushes to `gh-pages`, explicitly trigger a Pages build via the API
- Fixes the issue where legacy Pages builds don't auto-trigger from Actions pushes

Without this, every deploy requires a manual `POST /pages/builds` to actually publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)