### PR TITLE
chore: Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.2.0"
+version = "0.2.1"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from 0.2.0 to 0.2.1

Includes Pages build trigger fix since 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)