### PR TITLE
fix: Add pages:write permission, bump to 0.2.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pages: write
 
 concurrency:
   group: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.2.1"
+version = "0.2.2"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Add `pages: write` permission to docs workflow (fixes 403 on Pages build trigger)
- Bump version to 0.2.2

Supersedes #22 (if it exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)