### PR TITLE
fix: Strip explicit port hints from topology examples

### DIFF
--- a/examples/topologies/asymmetric_tree.mmd
+++ b/examples/topologies/asymmetric_tree.mmd
@@ -6,52 +6,42 @@
 
 graph LR
     subgraph root [Root]
-        %%metro exit: right | short, medium, long
         input[Input]
         dispatch[Dispatch]
         input -->|short,medium,long| dispatch
     end
 
     subgraph branch_short [Short]
-        %%metro entry: left | short
         s1[Quick]
         s2[Result]
         s1 -->|short| s2
     end
 
     subgraph branch_med_1 [Medium Step 1]
-        %%metro entry: left | medium
-        %%metro exit: right | medium
         m1[Medium A]
         m2[Medium B]
         m1 -->|medium| m2
     end
 
     subgraph branch_med_2 [Medium Step 2]
-        %%metro entry: left | medium
         m3[Medium C]
         m4[Medium D]
         m3 -->|medium| m4
     end
 
     subgraph branch_long_1 [Long Step 1]
-        %%metro entry: left | long
-        %%metro exit: right | long
         l1[Long A]
         l2[Long B]
         l1 -->|long| l2
     end
 
     subgraph branch_long_2 [Long Step 2]
-        %%metro entry: left | long
-        %%metro exit: right | long
         l3[Long C]
         l4[Long D]
         l3 -->|long| l4
     end
 
     subgraph branch_long_3 [Long Step 3]
-        %%metro entry: left | long
         l5[Long E]
         l6[Long F]
         l5 -->|long| l6

--- a/examples/topologies/complex_multipath.mmd
+++ b/examples/topologies/complex_multipath.mmd
@@ -7,23 +7,18 @@
 
 graph LR
     subgraph input_sec [Input]
-        %%metro exit: right | fast, standard, detailed, legacy
         raw[Raw Data]
         validate[Validate]
         raw -->|fast,standard,detailed,legacy| validate
     end
 
     subgraph fast_track [Fast Track]
-        %%metro entry: left | fast
-        %%metro exit: right | fast
         quick_align[Quick Align]
         quick_quant[Quick Quant]
         quick_align -->|fast| quick_quant
     end
 
     subgraph full_preprocess [Full Pre-process]
-        %%metro entry: left | standard, detailed, legacy
-        %%metro exit: right | standard, detailed, legacy
         trim[Trim]
         filter[Filter]
         qc_check[QC Check]
@@ -32,16 +27,12 @@ graph LR
     end
 
     subgraph standard_analysis [Standard Analysis]
-        %%metro entry: left | standard, legacy
-        %%metro exit: right | standard, legacy
         align[Align]
         quant[Quantify]
         align -->|standard,legacy| quant
     end
 
     subgraph deep_analysis [Deep Analysis]
-        %%metro entry: left | detailed
-        %%metro exit: right | detailed
         hq_align[HQ Align]
         dedup[Dedup]
         hq_quant[HQ Quantify]
@@ -50,7 +41,6 @@ graph LR
     end
 
     subgraph output_sec [Output]
-        %%metro entry: left | fast, standard, detailed, legacy
         aggregate[Aggregate]
         report[Report]
         aggregate -->|fast,standard,detailed,legacy| report

--- a/examples/topologies/deep_linear.mmd
+++ b/examples/topologies/deep_linear.mmd
@@ -5,23 +5,18 @@
 
 graph LR
     subgraph sec1 [Input]
-        %%metro exit: right | main, alt
         s1a[Read]
         s1b[Validate]
         s1a -->|main,alt| s1b
     end
 
     subgraph sec2 [QC]
-        %%metro entry: left | main, alt
-        %%metro exit: right | main, alt
         s2a[FastQC]
         s2b[MultiQC]
         s2a -->|main,alt| s2b
     end
 
     subgraph sec3 [Trim]
-        %%metro entry: left | main, alt
-        %%metro exit: right | main, alt
         s3a[Trim]
         s3b[Filter]
         s3c[Check]
@@ -31,8 +26,6 @@ graph LR
     end
 
     subgraph sec4 [Align]
-        %%metro entry: left | main, alt
-        %%metro exit: right | main, alt
         s4a[Index]
         s4b[Map]
         s4c[Sort]
@@ -41,16 +34,12 @@ graph LR
     end
 
     subgraph sec5 [Quant]
-        %%metro entry: left | main, alt
-        %%metro exit: right | main, alt
         s5a[Count]
         s5b[Normalize]
         s5a -->|main,alt| s5b
     end
 
     subgraph sec6 [Analysis]
-        %%metro entry: left | main, alt
-        %%metro exit: right | main, alt
         s6a[Diff Expr]
         s6b[Pathway]
         s6c[Annotate]
@@ -59,7 +48,6 @@ graph LR
     end
 
     subgraph sec7 [Report]
-        %%metro entry: left | main, alt
         s7a[Aggregate]
         s7b[Report]
         s7a -->|main,alt| s7b

--- a/examples/topologies/mixed_port_sides.mmd
+++ b/examples/topologies/mixed_port_sides.mmd
@@ -5,22 +5,18 @@
 
 graph LR
     subgraph origin [Origin]
-        %%metro exit: right | horizontal
-        %%metro exit: bottom | vertical
         start[Start]
         fork[Fork]
         start -->|horizontal,vertical| fork
     end
 
     subgraph right_sec [Right Section]
-        %%metro entry: left | horizontal
         r1[Right A]
         r2[Right B]
         r1 -->|horizontal| r2
     end
 
     subgraph bottom_sec [Bottom Section]
-        %%metro entry: top | vertical
         b1[Bottom A]
         b2[Bottom B]
         b1 -->|vertical| b2

--- a/examples/topologies/multi_line_bundle.mmd
+++ b/examples/topologies/multi_line_bundle.mmd
@@ -9,15 +9,12 @@
 
 graph LR
     subgraph input_sec [Input]
-        %%metro exit: right | line1, line2, line3, line4, line5, line6
         raw[Raw]
         qc[QC]
         raw -->|line1,line2,line3,line4,line5,line6| qc
     end
 
     subgraph process_sec [Processing]
-        %%metro entry: left | line1, line2, line3, line4, line5, line6
-        %%metro exit: right | line1, line2, line3, line4, line5, line6
         align[Align]
         sort[Sort]
         dedup[Dedup]
@@ -26,7 +23,6 @@ graph LR
     end
 
     subgraph output_sec [Output]
-        %%metro entry: left | line1, line2, line3, line4, line5, line6
         quant[Quantify]
         report[Report]
         quant -->|line1,line2,line3,line4,line5,line6| report

--- a/examples/topologies/parallel_independent.mmd
+++ b/examples/topologies/parallel_independent.mmd
@@ -5,28 +5,24 @@
 
 graph LR
     subgraph dna_input [DNA Input]
-        %%metro exit: right | dna
         di1[Read DNA]
         di2[QC DNA]
         di1 -->|dna| di2
     end
 
     subgraph dna_process [DNA Process]
-        %%metro entry: left | dna
         dp1[Align DNA]
         dp2[Call Variants]
         dp1 -->|dna| dp2
     end
 
     subgraph rna_input [RNA Input]
-        %%metro exit: right | rna
         ri1[Read RNA]
         ri2[QC RNA]
         ri1 -->|rna| ri2
     end
 
     subgraph rna_process [RNA Process]
-        %%metro entry: left | rna
         rp1[Align RNA]
         rp2[Quantify]
         rp1 -->|rna| rp2

--- a/examples/topologies/rnaseq_lite.mmd
+++ b/examples/topologies/rnaseq_lite.mmd
@@ -6,7 +6,6 @@
 
 graph LR
     subgraph preprocessing [Pre-processing]
-        %%metro exit: right | star, hisat, pseudo
         input[Input]
         fastqc_raw[FastQC]
         fastp[FastP]
@@ -25,8 +24,6 @@ graph LR
     end
 
     subgraph genome_align [Genome alignment]
-        %%metro entry: left | star, hisat
-        %%metro exit: right | star, hisat
         star_align[STAR]
         hisat_align[HISAT2]
         umi_dedup[UMI-tools dedup]
@@ -40,7 +37,6 @@ graph LR
     end
 
     subgraph pseudo_align [Pseudo-alignment]
-        %%metro entry: left | pseudo
         salmon_pseudo[Salmon]
         tximport[tximport]
         summarized_exp[Sum. Exp.]
@@ -50,8 +46,6 @@ graph LR
     end
 
     subgraph postprocessing [Post-processing]
-        %%metro entry: left | star, hisat
-        %%metro exit: right | star, hisat
         samtools[SAMtools]
         picard[Picard]
         bedtools[BEDTools]
@@ -63,7 +57,6 @@ graph LR
     end
 
     subgraph qc_report [QC & Reporting]
-        %%metro entry: left | star, hisat
         rseqc[RSeQC]
         dupradar[dupRadar]
         featurecounts[featureCounts]

--- a/examples/topologies/section_diamond.mmd
+++ b/examples/topologies/section_diamond.mmd
@@ -5,15 +5,12 @@
 
 graph LR
     subgraph start [Start]
-        %%metro exit: right | left_path, right_path
         input[Input]
         prep[Prepare]
         input -->|left_path,right_path| prep
     end
 
     subgraph branch_left [Branch Left]
-        %%metro entry: left | left_path
-        %%metro exit: right | left_path
         l1[Left Step 1]
         l2[Left Step 2]
         l3[Left Step 3]
@@ -22,15 +19,12 @@ graph LR
     end
 
     subgraph branch_right [Branch Right]
-        %%metro entry: left | right_path
-        %%metro exit: right | right_path
         r1[Right Step 1]
         r2[Right Step 2]
         r1 -->|right_path| r2
     end
 
     subgraph finish [Finish]
-        %%metro entry: left | left_path, right_path
         merge[Merge]
         report[Report]
         merge -->|left_path,right_path| report

--- a/examples/topologies/variant_calling.mmd
+++ b/examples/topologies/variant_calling.mmd
@@ -7,7 +7,6 @@
 
 graph LR
     subgraph input_qc [Input & QC]
-        %%metro exit: right | wgs, wes, panel, rna_var
         input[Input]
         fastqc[FastQC]
         fastp[FastP]
@@ -22,9 +21,6 @@ graph LR
     end
 
     subgraph alignment [Alignment]
-        %%metro entry: left | wgs, wes, panel, rna_var
-        %%metro exit: right | wgs, wes, panel
-        %%metro exit: right | rna_var
         bwa[BWA-MEM2]
         star_align[STAR]
         samtools[SAMtools sort]
@@ -38,8 +34,6 @@ graph LR
     end
 
     subgraph dna_calling [DNA Variant Calling]
-        %%metro entry: left | wgs, wes, panel
-        %%metro exit: right | wgs, wes, panel
         haplotypecaller[HaplotypeCaller]
         deepvariant[DeepVariant]
         strelka[Strelka2]
@@ -51,8 +45,6 @@ graph LR
     end
 
     subgraph rna_calling [RNA Variant Calling]
-        %%metro entry: left | rna_var
-        %%metro exit: right | rna_var
         splitncigar[SplitNCigar]
         rna_hc[HaplotypeCaller]
         rna_filter[FilterVariants]
@@ -62,8 +54,6 @@ graph LR
     end
 
     subgraph annotation [Annotation & Filtering]
-        %%metro entry: left | wgs, wes, panel, rna_var
-        %%metro exit: right | wgs, wes, panel, rna_var
         vep[VEP]
         snpsift[SnpSift]
         filter_pass[Filter PASS]
@@ -73,7 +63,6 @@ graph LR
     end
 
     subgraph reporting [Reporting]
-        %%metro entry: left | wgs, wes, panel, rna_var
         bcftools_stats[bcftools stats]
         multiqc[MultiQC]
 

--- a/examples/topologies/wide_fan_in.mmd
+++ b/examples/topologies/wide_fan_in.mmd
@@ -7,35 +7,30 @@
 
 graph LR
     subgraph src_a [Source A]
-        %%metro exit: right | alpha
         a1[Step A1]
         a2[Step A2]
         a1 -->|alpha| a2
     end
 
     subgraph src_b [Source B]
-        %%metro exit: right | beta
         b1[Step B1]
         b2[Step B2]
         b1 -->|beta| b2
     end
 
     subgraph src_c [Source C]
-        %%metro exit: right | gamma
         c1[Step C1]
         c2[Step C2]
         c1 -->|gamma| c2
     end
 
     subgraph src_d [Source D]
-        %%metro exit: right | delta
         d1[Step D1]
         d2[Step D2]
         d1 -->|delta| d2
     end
 
     subgraph sink [Sink]
-        %%metro entry: left | alpha, beta, gamma, delta
         merge[Merge]
         output[Output]
         merge -->|alpha,beta,gamma,delta| output

--- a/examples/topologies/wide_fan_out.mmd
+++ b/examples/topologies/wide_fan_out.mmd
@@ -7,35 +7,30 @@
 
 graph LR
     subgraph source [Source]
-        %%metro exit: right | alpha, beta, gamma, delta
         input[Input]
         process[Process]
         input -->|alpha,beta,gamma,delta| process
     end
 
     subgraph target_a [Target A]
-        %%metro entry: left | alpha
         a1[Step A1]
         a2[Step A2]
         a1 -->|alpha| a2
     end
 
     subgraph target_b [Target B]
-        %%metro entry: left | beta
         b1[Step B1]
         b2[Step B2]
         b1 -->|beta| b2
     end
 
     subgraph target_c [Target C]
-        %%metro entry: left | gamma
         c1[Step C1]
         c2[Step C2]
         c1 -->|gamma| c2
     end
 
     subgraph target_d [Target D]
-        %%metro entry: left | delta
         d1[Step D1]
         d2[Step D2]
         d1 -->|delta| d2


### PR DESCRIPTION
## Summary

- Remove all `%%metro entry:`/`%%metro exit:` directives from the 11 topology examples that had them
- These hints were stripped from the test fixtures at 95c5138 but the `examples/topologies/` copies still had the old versions
- The explicit hints overrode auto-layout inference, causing issues like mixed_port_sides entry port on top instead of left
- All 15 topologies render correctly with inferred ports, all 248 tests pass

## Test plan

- [x] All 15 topology examples render without errors
- [x] 248 tests pass
- [ ] Visual review of renders after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)