### PR TITLE
chore: Bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.2.2"
+version = "0.3.0"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- Bump version from 0.2.2 to 0.3.0 in `pyproject.toml` and `src/nf_metro/__init__.py`

### Changes since 0.2.2

- Guide tutorial with four progressive examples (minimal, sections, fan-out, directions)
- Fix explicit TB section layout (rowspan extension, successor placement)
- Fix TB exit port gap enforcement and target section alignment
- Fix fan-in bundle routing (overlapping vertical lines)
- Strip explicit port hints from topology examples
- Documentation site improvements (guide page, gallery build script)

## Test plan

- [ ] CI passes
- [ ] `pip install -e .` shows correct version


🤖 Generated with [Claude Code](https://claude.com/claude-code)