### PR TITLE
fix: Enforce minimum inter-section gap for smooth bypass corners

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -64,6 +64,14 @@ PLACEMENT_Y_GAP: float = 60.0
 PORT_MIN_GAP: float = 15.0
 """Minimum spacing between adjacent ports on a section boundary."""
 
+MIN_INTER_SECTION_GAP: float = 40.0
+"""Minimum physical gap between adjacent section bboxes.
+
+Ensures the gap midpoint is at least 2*CURVE_RADIUS from each section
+edge, giving enough horizontal run for smooth curves at bypass route
+corners.  Value: 40px (4 * 10px CURVE_RADIUS).
+"""
+
 # ---------------------------------------------------------------------------
 # Routing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `MIN_INTER_SECTION_GAP = 40px` constant (4 * CURVE_RADIUS) to ensure bypass route corners always have enough horizontal run for smooth curves
- Adds `_enforce_min_column_gaps()` post-placement pass in `section_placement.py` that shifts columns rightward when the physical gap between adjacent section bboxes is too narrow
- Fixes square corners visible in variant_calling topology where columns 0-1 had a gap as narrow as 20px

Closes #33

## Test plan

- [x] All 321 tests pass
- [x] All 16 topology renders succeed without regressions
- [x] All 3 Nextflow fixture renders succeed
- [x] variant_calling bypass corners are now smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)