### PR TITLE
feat: Optional span-based line ordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ The pipeline is: **Parse** -> **Layout** -> **Render**
 %%metro title: Pipeline Name
 %%metro style: dark
 %%metro line: line_id | Display Name | #hexcolor
+%%metro line_order: span
 %%metro grid: section_id | col,row
 
 graph LR

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ nf-metro render [OPTIONS] INPUT_FILE
 | `--animate / --no-animate` | off | Add animated balls traveling along lines |
 | `--debug / --no-debug` | off | Show debug overlay (ports, hidden stations, edge waypoints) |
 | `--logo PATH` | none | Logo image path (overrides `%%metro logo:` directive) |
+| `--line-order [definition\|span]` | from file | Line ordering strategy: `definition` preserves `.mmd` order, `span` sorts by section span (longest first) |
 
 The `--logo` flag lets you use the same `.mmd` file with different logos for dark/light themes:
 
@@ -280,6 +281,7 @@ These are automatically rewritten into port-to-port connections with junction st
 | `%%metro line: <id> \| <name> \| <color>` | Global | Define a metro line |
 | `%%metro grid: <section> \| <col>,<row>[,<rowspan>[,<colspan>]]` | Global | Pin section to grid position |
 | `%%metro legend: <position>` | Global | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, `none` |
+| `%%metro line_order: <strategy>` | Global | Line ordering for track assignment: `definition` (default) or `span` (longest-spanning lines get inner tracks) |
 | `%%metro file: <station> \| <label>` | Global | Mark a station as a file terminus with a document icon |
 | `%%metro entry: <side> \| <lines>` | Section | Entry port hint |
 | `%%metro exit: <side> \| <lines>` | Section | Exit port hint |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nf-metro
 
+**[Documentation](https://pinin4fjords.github.io/nf-metro/latest/)**
+
 Generate metro-map-style SVG diagrams from Mermaid graph definitions with `%%metro` directives. Designed for visualizing bioinformatics pipeline workflows (e.g., nf-core pipelines) as transit-style maps where each analysis route is a colored "metro line."
 
 <picture>

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -222,6 +222,7 @@ These go at the top of the file, before `graph LR`.
 | `%%metro line: <id> \| <name> \| <color>` | Define a metro line with ID, display name, and hex color |
 | `%%metro grid: <section> \| <col>,<row>[,<rowspan>[,<colspan>]]` | Pin a section to a grid position |
 | `%%metro legend: <position>` | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, or `none` |
+| `%%metro line_order: <strategy>` | Line ordering for track assignment: `definition` (default, preserves `.mmd` order) or `span` (longest-spanning lines get inner tracks) |
 | `%%metro file: <station> \| <label>` | Mark a station as a file terminus with a document icon |
 
 ### Section directives

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -71,6 +71,13 @@ def cli() -> None:
     help="Logo image path (overrides %%metro logo: directive)",
 )
 @click.option(
+    "--line-order",
+    type=click.Choice(["definition", "span"]),
+    default=None,
+    help="Line ordering strategy: 'definition' (default) preserves .mmd order, "
+    "'span' sorts by section span (longest first)",
+)
+@click.option(
     "--from-nextflow",
     is_flag=True,
     default=False,
@@ -94,6 +101,7 @@ def render(
     animate: bool,
     debug: bool,
     logo: Path | None,
+    line_order: str | None,
     from_nextflow: bool,
     title: str | None,
 ) -> None:
@@ -112,6 +120,9 @@ def render(
         )
     except ValueError as e:
         raise click.ClickException(str(e))
+
+    if line_order is not None:
+        graph.line_order = line_order
 
     if logo is not None:
         graph.logo_path = str(logo)

--- a/src/nf_metro/convert.py
+++ b/src/nf_metro/convert.py
@@ -544,6 +544,7 @@ def convert_nextflow_dag(text: str, title: str = "") -> str:
     out: list[str] = []
     out.append(f"%%metro title: {title}")
     out.append("%%metro style: dark")
+    out.append("%%metro line_order: span")
     out.append(f"%%metro line: {main_line_id} | {main_line_name} | {main_color}")
     if spur_line_id:
         out.append(f"%%metro line: {spur_line_id} | {spur_line_name} | {spur_color}")

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -46,6 +46,15 @@ def compute_layout(
     section_y_gap: float = SECTION_Y_GAP,
 ) -> None:
     """Compute layout positions for all stations in the graph."""
+    # Optionally reorder lines by section span before layout.
+    # Must happen here (on the full graph) before section subgraphs are
+    # built, since subgraphs share graph.lines via reference.
+    if graph.line_order == "span" and graph.lines:
+        from nf_metro.layout.ordering import _reorder_by_span
+
+        new_order = _reorder_by_span(graph, list(graph.lines.keys()))
+        graph.lines = {lid: graph.lines[lid] for lid in new_order}
+
     if not graph.sections:
         _compute_flat_layout(
             graph,

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -247,3 +247,33 @@ def _place_fan_out(
     for i, node in enumerate(nodes):
         offset = (i - (n - 1) / 2) * fan_spacing
         tracks[node] = anchor + offset
+
+
+def _reorder_by_span(graph: MetroGraph, line_order: list[str]) -> list[str]:
+    """Reorder lines by section span (descending).
+
+    Lines that span more sections get earlier (inner) tracks.
+    Ties are broken by preserving the original definition order.
+    """
+    if not graph.sections:
+        return line_order
+
+    # For each line, count how many distinct sections it touches
+    line_sections: dict[str, set[str]] = {lid: set() for lid in line_order}
+    for edge in graph.edges:
+        lid = edge.line_id
+        if lid not in line_sections:
+            continue
+        src = graph.stations.get(edge.source)
+        tgt = graph.stations.get(edge.target)
+        if src and src.section_id:
+            line_sections[lid].add(src.section_id)
+        if tgt and tgt.section_id:
+            line_sections[lid].add(tgt.section_id)
+
+    # Stable sort: descending by section count, preserving original order for ties
+    return sorted(
+        line_order,
+        key=lambda lid: (-len(line_sections.get(lid, set())),
+                         line_order.index(lid)),
+    )

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -274,6 +274,5 @@ def _reorder_by_span(graph: MetroGraph, line_order: list[str]) -> list[str]:
     # Stable sort: descending by section count, preserving original order for ties
     return sorted(
         line_order,
-        key=lambda lid: (-len(line_sections.get(lid, set())),
-                         line_order.index(lid)),
+        key=lambda lid: (-len(line_sections.get(lid, set())), line_order.index(lid)),
     )

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -148,6 +148,10 @@ def _parse_directive(
                 graph._explicit_directions.add(current_section_id)
     elif content.startswith("grid:"):
         _parse_grid_directive(content, graph)
+    elif content.startswith("line_order:"):
+        order = content[len("line_order:") :].strip().lower()
+        if order in ("definition", "span"):
+            graph.line_order = order
     elif content.startswith("logo:"):
         graph.logo_path = content[len("logo:") :].strip()
     elif content.startswith("legend:"):

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -129,6 +129,7 @@ class MetroGraph:
     ports: dict[str, Port] = field(default_factory=dict)
     junctions: list[str] = field(default_factory=list)
     grid_overrides: dict[str, tuple[int, int, int, int]] = field(default_factory=dict)
+    line_order: str = "definition"  # "definition" or "span"
     legend_position: str = "bottom"
     logo_path: str = ""
     # Section IDs that had explicit %%metro direction: directives

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,6 +19,24 @@ def test_parse_style():
     assert graph.style == "light"
 
 
+def test_parse_line_order():
+    text = "%%metro line_order: span\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.line_order == "span"
+
+
+def test_parse_line_order_default():
+    text = "graph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.line_order == "definition"
+
+
+def test_parse_line_order_invalid_ignored():
+    text = "%%metro line_order: invalid\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.line_order == "definition"
+
+
 def test_parse_lines():
     text = (
         "%%metro line: main | Main Line | #ff0000\n"


### PR DESCRIPTION
## Summary
- Adds `%%metro line_order: span` directive and `--line-order` CLI flag to optionally reorder lines by section span (longest first) before track assignment
- Lines spanning more sections get inner tracks, pushing short-lived spurs to outer tracks where they don't waste vertical space
- Default remains `definition` (preserves .mmd line order)
- The Nextflow converter (`convert.py`) now emits the directive automatically

Fixes #35

## Test plan
- [x] pytest passes (328 tests)
- [x] ruff check clean
- [x] Visual review of all topology renders + nextflow fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)