### PR TITLE
fix: Offset bypass gap1_x to avoid overlap with L-shape channels

### DIFF
--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -245,18 +245,25 @@ def route_edges(
                     by = base_y + nest_offset
 
                     # Gap midpoints adjacent to source and target columns.
-                    # Offset gap2 slightly toward the bypass side so it
-                    # doesn't overlap with standard L-shape channels
-                    # sharing the same inter-column gap.
+                    # Offset both gap verticals so they don't overlap
+                    # with standard L-shape channels sharing the same
+                    # inter-column gaps.  gap1 shifts toward the target,
+                    # gap2 shifts toward the source.
                     bypass_x_offset = curve_radius + offset_step
                     if dx > 0:
-                        gap1_x = adjacent_column_gap_x(graph, src_col, src_col + 1)
+                        gap1_x = (
+                            adjacent_column_gap_x(graph, src_col, src_col + 1)
+                            + bypass_x_offset
+                        )
                         gap2_x = (
                             adjacent_column_gap_x(graph, tgt_col - 1, tgt_col)
                             - bypass_x_offset
                         )
                     else:
-                        gap1_x = adjacent_column_gap_x(graph, src_col - 1, src_col)
+                        gap1_x = (
+                            adjacent_column_gap_x(graph, src_col - 1, src_col)
+                            - bypass_x_offset
+                        )
                         gap2_x = (
                             adjacent_column_gap_x(graph, tgt_col, tgt_col + 1)
                             + bypass_x_offset


### PR DESCRIPTION
## Summary
- Apply `bypass_x_offset` to `gap1_x` (source-side gap) in bypass routing, not just `gap2_x` (target-side)
- For left-to-right bypasses, `gap1_x` shifts right (toward target); for right-to-left, shifts left
- This separates bypass vertical segments from L-shape verticals sharing the same inter-column gap

Fixes #38

## Test plan
- [x] pytest passes (329 tests)
- [x] ruff check clean
- [x] Visual review of all topology renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)