### PR TITLE
fix: Nudge terminus stations away from passing lines

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -173,3 +173,6 @@ SIDE_BRANCH_NUDGE: float = 1.0
 
 FANOUT_SPACING: float = 1.5
 """Spacing multiplier for fan-out node layout."""
+
+TERMINUS_NUDGE: float = 0.5
+"""Track offset for nudging terminus stations away from passing lines."""


### PR DESCRIPTION
## Summary
- Terminus stations (file icons) are now nudged to a different Y track when another line passes through their position without stopping
- Added `_nudge_terminus_tracks()` in `engine.py` that detects when a terminus's predecessor connects to exit ports on lines the terminus doesn't carry, and offsets the terminus track
- Added `TERMINUS_NUDGE` constant (0.5 track units) to `constants.py`

Fixes #39

## Test plan
- [x] pytest passes (329 tests)
- [x] ruff check clean
- [x] Visual review of all 16 topology renders - no regressions
- [x] Variant Calling section: VCF terminus now sits above BCFtools Stats, giving the QC line a clear horizontal path to the exit port

🤖 Generated with [Claude Code](https://claude.com/claude-code)