### PR TITLE
fix: Uniform corner radius for bypass U-shape routes

### DIFF
--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -295,13 +295,11 @@ def route_edges(
                             + gap2_extra
                         )
 
-                    # Concentric radii: the outer line (larger gap index,
-                    # further from center) gets a larger radius at each
-                    # gap so the U-shape arcs nest visually.
-                    # NOTE: gap1 and gap2 radii may differ when a line
-                    # shares one gap but not the other (see issue #42).
-                    r_gap1 = curve_radius + gap1_extra
-                    r_gap2 = curve_radius + gap2_extra
+                    # Uniform corner radius: use the larger per-gap offset
+                    # so all 4 corners of the U-shape match visually.
+                    # The gap X positions still use per-gap offsets for
+                    # route separation; only the radius is unified.
+                    r_bypass = curve_radius + max(gap1_extra, gap2_extra)
                     routes.append(
                         RoutedPath(
                             edge=edge,
@@ -315,7 +313,7 @@ def route_edges(
                                 (tx, ty),
                             ],
                             is_inter_section=True,
-                            curve_radii=[r_gap1, r_gap1, r_gap2, r_gap2],
+                            curve_radii=[r_bypass, r_bypass, r_bypass, r_bypass],
                         )
                     )
                 else:


### PR DESCRIPTION
## Summary
- Bypass U-shape routes now use a single uniform corner radius for all 4 corners, computed as `curve_radius + max(gap1_extra, gap2_extra)`
- Previously, each gap pair used its own radius based on per-gap index, causing visually different corner sharpness when a route shared one gap with other routes but not the other
- Gap X positions remain unchanged (per-gap offsets still separate overlapping routes)

Fixes #43

## Test plan
- [x] pytest passes (329 tests)
- [x] ruff check clean
- [x] Visual review of all topology renders (including `with_subworkflows` from the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)