### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.3.0"
+version = "0.4.0"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- Bumps version from 0.3.0 to 0.4.0 in `pyproject.toml` and `src/nf_metro/__init__.py`

## Changes since 0.3.0
- Hidden stations via `_` prefix convention (#55)
- Phase 1 refactor: quick wins (#54)
- Vertical centering fix for edge station labels (#53)

## Test plan
- [ ] Verify `python -c "import nf_metro; print(nf_metro.__version__)"` prints `0.4.0`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)