### PR TITLE
fix: remove double padding from canvas sizing

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -223,8 +223,11 @@ def render_svg(
         logo_y = LOGO_Y_STANDALONE
         max_x = max(max_x, logo_x + logo_w)
 
-    auto_width = max_x + padding * 2
-    auto_height = max_y + padding * 2
+    # Right margin: use one padding width (content origin already provides
+    # the left margin).  Bottom margin: just enough room for the watermark
+    # text below the last content element.
+    auto_width = max_x + padding
+    auto_height = max_y + WATERMARK_Y_INSET * 2 + WATERMARK_FONT_SIZE
 
     svg_width = width or int(auto_width)
     svg_height = height or int(auto_height)


### PR DESCRIPTION
## Summary
- Canvas sizing formula used `max + padding * 2`, but content origin already provides left/top margins via title and section placement offsets
- Right margin: reduced from `2 * padding` (120px) to `padding` (60px)
- Bottom margin: reduced from `2 * padding` (120px) to just enough for the watermark text (~24px), so the watermark sits right below the last content element (legend or sections)
- For rnaseq example: canvas shrinks from 1720x775 to 1660x679

Fixes #59

## Test plan
- [x] pytest passes (344 tests)
- [x] ruff check clean
- [x] Visual review of all 16 topology renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)