### PR TITLE
Increase fork/join gap multiplier

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -126,7 +126,7 @@ ENTRY_SHIFT_TB_CROSS: float = 1.0
 ENTRY_INSET_LR: float = 0.3
 """Entry inset multiplier for LR/RL sections with perpendicular entry."""
 
-EXIT_GAP_MULTIPLIER: float = 0.4
+EXIT_GAP_MULTIPLIER: float = 0.6
 """Exit gap multiplier for flow-side exits."""
 
 JUNCTION_MARGIN: float = 10.0


### PR DESCRIPTION
## Summary
- Bump `EXIT_GAP_MULTIPLIER` from 0.4 to 0.6, widening bubble sections around fork/join points (e.g. fastp/trimgalore in preprocessing) for better readability

Fixes #69

## Test plan
- [x] Visual review of rnaseq example render
- [x] pytest passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)