### PR TITLE
fix: widen TB section bbox for long labels

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -7,7 +7,7 @@ section_placement.py, and ordering.py.
 # ---------------------------------------------------------------------------
 # Font / text metrics
 # ---------------------------------------------------------------------------
-CHAR_WIDTH: float = 7.0
+CHAR_WIDTH: float = 9.0
 """Approximate pixel width of a single character at default font size."""
 
 FONT_HEIGHT: float = 14.0


### PR DESCRIPTION
## Summary
- Increase `CHAR_WIDTH` from 7.0 to 9.0 to match the ~30% label font size bump in #68
- TB sections (like Post-processing in rnaseq) now have enough room for long labels like "bedGraphToBigWig"

Fixes #70

## Test plan
- [x] pytest passes (346 tests)
- [x] ruff check clean
- [x] Visual review of all topology renders + nextflow fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)