### PR TITLE
fix: clear error for unannotated edges

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -276,14 +276,13 @@ def test_rl_exit_clearance_preserves_bbox_x():
 
 
 def test_flat_layout_unnamed_edges():
-    """Flat layout with unnamed edges (no line IDs) should not crash."""
-    graph = parse_metro_mermaid(
-        "%%metro line: main | Main | #ff0000\ngraph LR\n    a --> b\n"
-    )
-    compute_layout(graph)
-    # Both stations should have coordinates assigned
-    assert graph.stations["a"].x >= 0
-    assert graph.stations["b"].x > graph.stations["a"].x
+    """Unnamed edges (no line IDs) raise a clear error (issue #75)."""
+    import pytest
+
+    with pytest.raises(ValueError, match="no metro line annotation"):
+        parse_metro_mermaid(
+            "%%metro line: main | Main | #ff0000\ngraph LR\n    a --> b\n"
+        )
 
 
 # --- Line order tests ---
@@ -420,16 +419,17 @@ def test_line_order_span_e2e():
 
 
 def test_flat_layout_no_named_lines():
-    """Flat layout with a line defined but unnamed edges should still work."""
-    graph = parse_metro_mermaid(
-        "%%metro line: main | Main | #ff0000\n"
-        "graph LR\n"
-        "    a[Start]\n"
-        "    b[End]\n"
-        "    a --> b\n"
-    )
-    compute_layout(graph)
-    assert graph.stations["a"].x < graph.stations["b"].x
+    """Unnamed edges with a declared line still raise an error (issue #75)."""
+    import pytest
+
+    with pytest.raises(ValueError, match="no metro line annotation"):
+        parse_metro_mermaid(
+            "%%metro line: main | Main | #ff0000\n"
+            "graph LR\n"
+            "    a[Start]\n"
+            "    b[End]\n"
+            "    a --> b\n"
+        )
 
 
 # --- Label clamping tests (issue #58) ---

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -54,7 +54,7 @@ def test_render_light_theme():
         "%%metro title: Light Test\n"
         "%%metro line: main | Main | #ff0000\n"
         "graph LR\n"
-        "    a --> b\n"
+        "    a -->|main| b\n"
     )
     compute_layout(graph)
     svg = render_svg(graph, LIGHT_THEME)


### PR DESCRIPTION
## Summary

- Edges without `|line_id|` annotation (e.g. `fastp --> falco`) now raise a clear `ValueError` listing the offending edges and how to fix them, instead of crashing with `KeyError: 0` deep in the layout engine
- Also validates that referenced line IDs are declared with `%%metro line:` directives
- Validation runs post-parse, before layout, so the error appears early with actionable context

Example error output:
```
Error: Some edges have no metro line annotation. Every edge must specify
which line(s) it belongs to using -->|line_id| syntax.

Edges missing annotations:
  fastp --> falco

Fix by adding line annotations, e.g.:
  fastp -->|qc| falco

Lines must also be declared with %%metro line: directives, e.g.:
  %%metro line: qc | Quality Control | #4CAF50
```

Fixes #75

## Test plan
- [x] pytest passes (351 tests)
- [x] ruff check clean
- [x] Visual review of all topology renders - no regressions
- [x] CLI error output verified with reproduction case from issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)