### PR TITLE
feat: add stroke support for animation balls

### DIFF
--- a/src/nf_metro/render/animate.py
+++ b/src/nf_metro/render/animate.py
@@ -57,10 +57,17 @@ def render_animation(
         n_balls = theme.animation_balls_per_line
         for i in range(n_balls):
             begin_offset = -i * dur / n_balls
+            stroke_attr = ""
+            if theme.animation_ball_stroke:
+                stroke_attr = (
+                    f' stroke="{theme.animation_ball_stroke}"'
+                    f' stroke-width="{theme.animation_ball_stroke_width}"'
+                )
             d.append(
                 draw.Raw(
                     f'<circle r="{theme.animation_ball_radius}" '
-                    f'fill="{theme.animation_ball_color}" opacity="0.9">'
+                    f'fill="{theme.animation_ball_color}" opacity="0.9"'
+                    f"{stroke_attr}>"
                     f'<animateMotion dur="{dur:.2f}s" '
                     f'repeatCount="indefinite" '
                     f'begin="{begin_offset:.2f}s">'

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -33,6 +33,8 @@ class Theme:
     # Animation settings
     animation_ball_radius: float = 3.0
     animation_ball_color: str = "#ffffff"
+    animation_ball_stroke: str = ""
+    animation_ball_stroke_width: float = 1.0
     animation_balls_per_line: int = 3
     animation_speed: float = 80.0  # pixels per second
     # Terminus (file icon) settings

--- a/src/nf_metro/themes/light.py
+++ b/src/nf_metro/themes/light.py
@@ -22,5 +22,7 @@ LIGHT_THEME = Theme(
     legend_background="rgba(255, 255, 255, 0.8)",
     legend_text_color="#333333",
     legend_font_size=19.0,
-    animation_ball_color="#333333",
+    animation_ball_color="#ffffff",
+    animation_ball_stroke="#333333",
+    animation_ball_stroke_width=1.5,
 )


### PR DESCRIPTION
## Summary
- Add `animation_ball_stroke` and `animation_ball_stroke_width` fields to Theme
- Light theme now uses white balls with dark stroke (#333333, 1.5px) instead of solid dark balls
- Balls are now visible on both light and dark backgrounds (e.g. GitHub dark mode)
- Dark theme unchanged (no stroke by default)

## Test plan
- [x] 351 tests pass
- [x] Animated SVG visually verified in Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)