### PR TITLE
feat: bold station labels for readability

### DIFF
--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -21,6 +21,7 @@ class Theme:
     label_color: str
     label_font_family: str
     label_font_size: float
+    label_font_weight: str
     title_color: str
     title_font_size: float
     section_fill: str

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -719,6 +719,7 @@ def _render_labels(
                     label.y,
                     fill=theme.label_color,
                     font_family=theme.label_font_family,
+                    font_weight=theme.label_font_weight,
                     text_anchor=label.text_anchor,
                     dominant_baseline=label.dominant_baseline,
                 )
@@ -733,6 +734,7 @@ def _render_labels(
                     label.y,
                     fill=theme.label_color,
                     font_family=theme.label_font_family,
+                    font_weight=theme.label_font_weight,
                     text_anchor="middle",
                     dominant_baseline=baseline,
                 )

--- a/src/nf_metro/themes/light.py
+++ b/src/nf_metro/themes/light.py
@@ -13,6 +13,7 @@ LIGHT_THEME = Theme(
     label_color="#333333",
     label_font_family="'Helvetica Neue', Helvetica, Arial, sans-serif",
     label_font_size=14.0,
+    label_font_weight="bold",
     title_color="#111111",
     title_font_size=26.0,
     section_fill="rgba(0, 0, 0, 0.07)",

--- a/src/nf_metro/themes/nfcore.py
+++ b/src/nf_metro/themes/nfcore.py
@@ -13,6 +13,7 @@ NFCORE_THEME = Theme(
     label_color="#e0e0e0",
     label_font_family="'Helvetica Neue', Helvetica, Arial, sans-serif",
     label_font_size=13.0,
+    label_font_weight="bold",
     title_color="#ffffff",
     title_font_size=24.0,
     section_fill="rgba(255, 255, 255, 0.06)",


### PR DESCRIPTION
## Summary
- Adds `label_font_weight` field to `Theme` dataclass
- Sets font weight to `bold` for station labels in both nfcore and light themes
- Addresses [review feedback](https://github.com/nf-core/rnaseq/pull/1709#discussion_r2831603956) that labels are too hard to read at current sizes

## Test plan
- [ ] Visual check of nfcore theme render
- [ ] Visual check of light theme render
- [ ] Existing tests pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)