### PR TITLE
fix: ensure SVG output ends with trailing newline

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -141,7 +141,7 @@ def render(
     if output is None:
         output = input_file.with_suffix(".svg")
 
-    output.write_text(svg)
+    output.write_text(svg if svg.endswith("\n") else svg + "\n")
     click.echo(
         f"Rendered {len(graph.stations)} stations, "
         f"{len(graph.edges)} edges, "
@@ -191,7 +191,7 @@ def convert(
     if output is None:
         click.echo(result, nl=False)
     else:
-        output.write_text(result)
+        output.write_text(result if result.endswith("\n") else result + "\n")
         # Count sections and processes in the output
         sections = result.count("subgraph ")
         processes = result.count("([")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,6 +79,16 @@ def test_render_with_theme(tmp_path):
     assert out.exists()
 
 
+def test_render_svg_ends_with_newline(tmp_path):
+    """SVG output ends with a trailing newline (nf-core end-of-file-fixer)."""
+    out = tmp_path / "output.svg"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["render", str(RNASEQ_MMD), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    content = out.read_text()
+    assert content.endswith("\n"), "SVG output must end with a trailing newline"
+
+
 def test_render_nonexistent_file():
     """render command fails gracefully on missing input."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- Ensure SVG files written by `nf-metro render` end with a trailing newline, so they pass the `end-of-file-fixer` pre-commit hook used by nf-core pipelines
- Also fix the `convert` command output for consistency
- Add regression test for trailing newline

Fixes #84

## Test plan
- [x] pytest passes (352 tests)
- [x] ruff check clean
- [x] Verified SVG output ends with `\n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)