### PR TITLE
fix: more vertical space in TB sections above first station

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -117,7 +117,7 @@ BYPASS_NEST_STEP: float = 8.0
 TB_LINE_Y_OFFSET: float = 3.0
 """Per-line Y offset increment in TB sections."""
 
-ENTRY_SHIFT_TB: float = 0.6
+ENTRY_SHIFT_TB: float = 1.0
 """Entry shift multiplier for TB sections with perpendicular entry."""
 
 ENTRY_SHIFT_TB_CROSS: float = 1.0


### PR DESCRIPTION
## Summary
- Increase `ENTRY_SHIFT_TB` from `0.6` to `1.0` so the horizontal-to-vertical entry turn in TB sections has more breathing room before the first internal station
- Addresses cramped layout of SAMtools in the rnaseq post-processing section

Fixes #86

## Test plan
- [x] pytest passes (352 tests)
- [x] ruff check clean
- [x] Visual review of all 16 topology renders + 3 nextflow fixtures - no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)