### PR TITLE
fix: expand section bbox for terminus file icons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.4.5"
+version = "0.4.6"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 __all__ = ["__version__"]

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -177,5 +177,12 @@ FANOUT_SPACING: float = 1.5
 TERMINUS_NUDGE: float = 0.5
 """Track offset for nudging terminus stations away from passing lines."""
 
+TERMINUS_ICON_CLEARANCE: float = 58.0
+"""Minimum clearance from terminus station center to section bbox edge.
+
+Accounts for station_radius (~5px) + icon gap (6px) + icon width (28px) = 39px
+extent, plus ~19px visual margin so icons don't crowd the section border.
+"""
+
 DEFAULT_LINE_PRIORITY: int = 999
 """Sentinel priority for lines not in the explicit line order."""


### PR DESCRIPTION
## Summary
- Add `_adjust_terminus_icon_clearance()` to the layout engine that expands section bounding boxes when terminus file icons would be too close to the edge
- New `TERMINUS_ICON_CLEARANCE` constant (58px) ensures ~19px visual margin between icon edge and section border
- Handles all section directions (LR, RL, TB, BT) and both source/sink terminus positions
- Bump version to 0.4.6

Fixes #87

## Test plan
- [x] pytest passes (352 tests)
- [x] ruff check clean
- [x] Visual review of all topology renders - icons have comfortable clearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)