### PR TITLE
chore: bump version to 0.4.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.4.6"
+version = "0.4.7"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- Bump version from 0.4.6 to 0.4.7 in `pyproject.toml` and `src/nf_metro/__init__.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)