### PR TITLE
feat: reduce default animation balls to 1 per track

### DIFF
--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -36,7 +36,7 @@ class Theme:
     animation_ball_color: str = "#ffffff"
     animation_ball_stroke: str = ""
     animation_ball_stroke_width: float = 1.0
-    animation_balls_per_line: int = 2
+    animation_balls_per_line: int = 1
     animation_speed: float = 80.0  # pixels per second
     # Terminus (file icon) settings
     terminus_width: float = 28.0


### PR DESCRIPTION
## Summary
- Reduce `animation_balls_per_line` default from 2 to 1
- Less visual clutter on busy maps

## Test plan
- [x] 352 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)