### PR TITLE
Reduce animation balls and fix diagonal label clearance

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -141,6 +141,9 @@ STATION_ELBOW_TOLERANCE: float = 12.0
 # ---------------------------------------------------------------------------
 # Labels
 # ---------------------------------------------------------------------------
+DIAG_LABEL_MARGIN: float = 6.0
+"""Extra margin beyond label halves + diagonal run for cross-track clearance."""
+
 LABEL_MARGIN: float = 2.0
 """Overlap detection margin for labels."""
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -9,6 +9,8 @@ __all__ = ["compute_layout"]
 
 from nf_metro.layout.constants import (
     CHAR_WIDTH,
+    DIAG_LABEL_MARGIN,
+    DIAGONAL_RUN,
     ENTRY_INSET_LR,
     ENTRY_SHIFT_TB,
     ENTRY_SHIFT_TB_CROSS,
@@ -107,7 +109,7 @@ def _compute_flat_layout(
     unique_tracks = sorted(set(tracks.values()))
     track_rank = {t: i for i, t in enumerate(unique_tracks)}
 
-    layer_extra = _compute_fork_join_gaps(graph, layers, x_spacing)
+    layer_extra = _compute_fork_join_gaps(graph, layers, x_spacing, tracks=tracks)
 
     for sid, station in graph.stations.items():
         station.layer = layers.get(sid, 0)
@@ -238,7 +240,9 @@ def _layout_single_section(
     # aren't too close to divergence/convergence points.
     # Pass full graph so port-touching edges count as forks/joins.
     section_sids = set(section.station_ids)
-    layer_extra = _compute_fork_join_gaps(sub, layers, x_spacing, graph, section_sids)
+    layer_extra = _compute_fork_join_gaps(
+        sub, layers, x_spacing, graph, section_sids, tracks=tracks
+    )
 
     # Assign local coordinates based on section direction
     for sid, station in sub.stations.items():
@@ -1121,6 +1125,7 @@ def _compute_fork_join_gaps(
     x_spacing: float,
     full_graph: MetroGraph | None = None,
     section_station_ids: set[str] | None = None,
+    tracks: dict[str, float] | None = None,
 ) -> dict[int, float]:
     """Compute extra X offset per layer at fork/join points.
 
@@ -1133,6 +1138,10 @@ def _compute_fork_join_gaps(
     edges). This catches divergences where a station connects to both
     internal stations and exit ports (e.g. umi_tools_dedup forking to
     salmon_quant and an exit port).
+
+    When tracks is provided, a second pass scans all cross-track edges
+    and adds gaps so diagonal transitions have room to clear labels at
+    both endpoints.
     """
     from collections import defaultdict
 
@@ -1164,9 +1173,6 @@ def _compute_fork_join_gaps(
         if len(sources) > 1 and sid in layers
     }
 
-    if not fork_layers and not join_layers:
-        return {}
-
     max_layer = max(layers.values()) if layers else 0
     base_gap = x_spacing * EXIT_GAP_MULTIPLIER
 
@@ -1184,6 +1190,49 @@ def _compute_fork_join_gaps(
                     max_label_half = max(max_label_half, label_half)
         layer_gap[layer] = max(base_gap, max_label_half)
 
+    # Second pass: scan ALL cross-track edges for diagonal label clearance.
+    # Any edge between different tracks needs enough horizontal room for
+    # src_label_half + diagonal_run + tgt_label_half + margin.
+    after_gap_layers: set[int] = set()
+    if tracks:
+        for edge in sub.edges:
+            s_layer = layers.get(edge.source)
+            t_layer = layers.get(edge.target)
+            if s_layer is None or t_layer is None:
+                continue
+            s_track = tracks.get(edge.source)
+            t_track = tracks.get(edge.target)
+            if s_track is None or t_track is None:
+                continue
+            if abs(s_track - t_track) < 0.01:
+                continue
+
+            src_st = sub.stations.get(edge.source)
+            tgt_st = sub.stations.get(edge.target)
+            if not src_st or not tgt_st:
+                continue
+
+            src_lh = len(src_st.label) * CHAR_WIDTH / 2 if src_st.label.strip() else 0.0
+            tgt_lh = len(tgt_st.label) * CHAR_WIDTH / 2 if tgt_st.label.strip() else 0.0
+            required = src_lh + DIAGONAL_RUN + tgt_lh + DIAG_LABEL_MARGIN
+
+            lo = min(s_layer, t_layer)
+            hi = max(s_layer, t_layer)
+            layer_diff = hi - lo
+            # Count existing gaps between the layers (exclusive of source layer)
+            existing_between = sum(
+                layer_gap.get(lyr, 0) for lyr in range(lo + 1, hi + 1)
+            )
+            available = layer_diff * x_spacing + existing_between
+
+            deficit = required - available
+            if deficit > 0:
+                layer_gap[lo] = max(layer_gap.get(lo, 0), deficit)
+                after_gap_layers.add(lo)
+
+    if not fork_layers and not join_layers and not after_gap_layers:
+        return {}
+
     cumulative = 0.0
     layer_extra: dict[int, float] = {}
     for layer in range(max_layer + 1):
@@ -1191,8 +1240,8 @@ def _compute_fork_join_gaps(
         if layer in join_layers:
             cumulative += layer_gap.get(layer, base_gap)
         layer_extra[layer] = cumulative
-        # Add gap after fork layers
-        if layer in fork_layers:
+        # Add gap after fork layers and cross-track source layers
+        if layer in fork_layers or layer in after_gap_layers:
             cumulative += layer_gap.get(layer, base_gap)
 
     return layer_extra

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -768,9 +768,9 @@ def _route_diagonal(
     # Extend straight run past labels at fork/join stations
     src_min = min_straight
     tgt_min = min_straight
-    if edge.source in ctx.fork_stations and src.label.strip():
+    if src.label.strip():
         src_min = max(min_straight, len(src.label) * CHAR_WIDTH / 2)
-    if edge.target in ctx.join_stations and tgt.label.strip():
+    if tgt.label.strip():
         tgt_min = max(min_straight, len(tgt.label) * CHAR_WIDTH / 2)
 
     # Bias diagonal toward the convergence/divergence station so that
@@ -782,7 +782,8 @@ def _route_diagonal(
     elif is_join and not is_fork:
         mid_x = tx - sign * (tgt_min + half_diag)
     elif is_fork and is_join:
-        mid_x = (sx + tx) / 2
+        # Bias toward the fork so divergence is visible early
+        mid_x = sx + sign * (src_min + half_diag)
     else:
         mid_x = (sx + tx) / 2
 


### PR DESCRIPTION
## Summary
- Reduce default animation balls from 2 to 1 per track for a cleaner look
- Generalize diagonal label clearance to all cross-track edges, not just fork/join stations. Fixes the "Samtools Index" label overlap in `with_subworkflows` and similar cases where a non-fork/non-join station sits at the end of a diagonal edge.
- Bias fork+join diagonal positioning toward the source so divergence is visible before the next station

Fixes #101

## Test plan
- [x] pytest (352 tests pass)
- [x] ruff check clean
- [x] Visual review of all 47 .mmd renders - no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)