### PR TITLE
Fix diagonal label clearance for all cross-track edges

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -144,6 +144,9 @@ STATION_ELBOW_TOLERANCE: float = 12.0
 # ---------------------------------------------------------------------------
 # Labels
 # ---------------------------------------------------------------------------
+DIAG_LABEL_MARGIN: float = 6.0
+"""Extra margin beyond label halves + diagonal run for cross-track clearance."""
+
 LABEL_MARGIN: float = 2.0
 """Overlap detection margin for labels."""
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -768,9 +768,9 @@ def _route_diagonal(
     # Extend straight run past labels at fork/join stations
     src_min = min_straight
     tgt_min = min_straight
-    if edge.source in ctx.fork_stations and src.label.strip():
+    if src.label.strip():
         src_min = max(min_straight, label_text_width(src.label) / 2)
-    if edge.target in ctx.join_stations and tgt.label.strip():
+    if tgt.label.strip():
         tgt_min = max(min_straight, label_text_width(tgt.label) / 2)
 
     # Bias diagonal toward the convergence/divergence station so that
@@ -782,7 +782,8 @@ def _route_diagonal(
     elif is_join and not is_fork:
         mid_x = tx - sign * (tgt_min + half_diag)
     elif is_fork and is_join:
-        mid_x = (sx + tx) / 2
+        # Bias toward the fork so divergence is visible early
+        mid_x = sx + sign * (src_min + half_diag)
     else:
         mid_x = (sx + tx) / 2
 


### PR DESCRIPTION
## Summary
- Generalize diagonal label clearance to all cross-track edges, not just fork/join stations. Fixes the "Samtools Index" label overlap in `with_subworkflows` and similar cases where a non-fork/non-join station sits at the end of a diagonal edge.
- Add cross-track gap computation in `_compute_fork_join_gaps` so layout provides enough horizontal room for diagonal transitions to clear labels
- Bias fork+join diagonal positioning toward the source so divergence is visible before the next station

Fixes #101

## Test plan
- [x] pytest (358 tests pass)
- [x] ruff check clean
- [x] Visual review of all 47 .mmd renders - no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)