### PR TITLE
Render script discovers all .mmd files with deduplication

### DIFF
--- a/.claude/skills/render-topologies/SKILL.md
+++ b/.claude/skills/render-topologies/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: render-topologies
-description: Re-render all nf-metro topology fixtures to PNG and open them in Preview for visual review. Use when the user wants to check renders after layout or rendering changes.
+description: Re-render all .mmd files in the repo to PNG and open them in Preview for visual review. Use when the user wants to check renders after layout or rendering changes.
 disable-model-invocation: true
 allowed-tools: Bash(rm -rf *), Bash(python *), Bash(open *)
 ---
 
 # Render Topologies
 
-Re-render all topology fixtures and open the results for visual review.
+Re-render all `.mmd` files in the repository and open the results for visual review.
 
 ## Workflow
 
@@ -29,15 +29,18 @@ python scripts/render_topologies.py
 open /tmp/nf_metro_topology_renders/*.png
 ```
 
-4. Report the results: list which topologies rendered successfully and flag any failures.
+4. Report the results: list which files rendered successfully and flag any failures.
 
 ## Notes
 
 - The render script is at `scripts/render_topologies.py` in the repo root.
+- It automatically discovers all `.mmd` files under the project root (examples, test fixtures, topologies).
+- Nextflow fixtures (`tests/fixtures/nextflow/*.mmd`) are auto-detected and converted before rendering.
+- Output filenames include the path (e.g. `examples_guide_01_minimal.png`) to avoid collisions.
 - Outputs go to `/tmp/nf_metro_topology_renders/` as PNGs.
 - The Python environment must have nf-metro installed (editable mode is fine) along with cairosvg for SVG-to-PNG conversion.
-- If the user asks to render a specific topology, use the CLI directly instead:
+- If the user asks to render a specific file, use the CLI directly instead:
 
 ```bash
-python -m nf_metro render <file.mmd> -o /tmp/output.svg --x-spacing 60 --y-spacing 40 --debug
+python -m nf_metro render <file.mmd> -o /tmp/output.svg
 ```


### PR DESCRIPTION
## Summary
- Update `scripts/render_topologies.py` to auto-discover all `.mmd` files in the repo instead of a hardcoded list
- Nextflow fixtures (`tests/fixtures/nextflow/`) are auto-detected and converted before rendering
- Files with identical content are deduplicated via SHA-256 hash (sorted order means `examples/` wins over `tests/fixtures/`)
- Output filenames include the relative path to avoid collisions (e.g. `examples_guide_01_minimal.png`)
- Update the `render-topologies` skill to match

Reduces renders from 48 to 32 by deduplicating identical topology fixtures.

## Test plan
- [x] Script runs successfully, renders 32 unique files
- [x] All renders produce valid PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)