### PR TITLE
feat: straight-through diamond fork-joins

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -78,6 +78,12 @@ def cli() -> None:
     "'span' sorts by section span (longest first)",
 )
 @click.option(
+    "--straight-diamonds/--no-straight-diamonds",
+    default=True,
+    help="Keep top branch of diamond fork-joins on the main track (default: on). "
+    "Use --no-straight-diamonds for symmetric fan-out.",
+)
+@click.option(
     "--from-nextflow",
     is_flag=True,
     default=False,
@@ -102,6 +108,7 @@ def render(
     debug: bool,
     logo: Path | None,
     line_order: str | None,
+    straight_diamonds: bool,
     from_nextflow: bool,
     title: str | None,
 ) -> None:
@@ -123,6 +130,9 @@ def render(
 
     if line_order is not None:
         graph.line_order = line_order
+
+    if not straight_diamonds:
+        graph.diamond_style = "symmetric"
 
     if logo is not None:
         graph.logo_path = str(logo)

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -132,6 +132,7 @@ class MetroGraph:
     junctions: list[str] = field(default_factory=list)
     grid_overrides: dict[str, tuple[int, int, int, int]] = field(default_factory=dict)
     line_order: str = "definition"  # "definition" or "span"
+    diamond_style: str = "straight"  # "straight" or "symmetric"
     legend_position: str = "bottom"
     logo_path: str = ""
     # Section IDs that had explicit %%metro direction: directives


### PR DESCRIPTION
## Summary

- Diamond (fork-join) patterns now keep the top branch on the trunk line by default, with only alternative branches fanning out below. This reduces visual kinks where lines unnecessarily deviate from the straight path.
- Inter-section port alignment uses mode (most-frequent Y) instead of average, so the majority of lines flow straight between sections.
- Diamond merge nodes snap back to the trunk after an asymmetric fork-join.
- New `--straight-diamonds/--no-straight-diamonds` CLI flag (default: on) controls the behaviour. Use `--no-straight-diamonds` to revert to the previous symmetric fan-out.

Fixes #115

## Test plan
- [x] 365 tests pass (8 new tests for the diamond feature)
- [x] ruff check clean
- [x] Visual review of all topology renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)