### PR TITLE
fix: offset bypass gap2 vertical to avoid overlap with L-shape routes

### DIFF
--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -376,7 +376,12 @@ def _route_bypass(
             - gap1_extra
         )
         gap1_x = max(gap1_x, sx + ctx.curve_radius)
-        gap2_x = adjacent_column_gap_x(graph, tgt_col - 1, tgt_col) - gap2_extra
+        gap2_x = (
+            adjacent_column_gap_x(graph, tgt_col - 1, tgt_col)
+            + base_bypass_offset
+            + gap2_extra
+        )
+        gap2_x = min(gap2_x, tx - ctx.curve_radius)
     else:
         gap1_x = (
             adjacent_column_gap_x(graph, src_col - 1, src_col)
@@ -384,7 +389,12 @@ def _route_bypass(
             + gap1_extra
         )
         gap1_x = min(gap1_x, sx - ctx.curve_radius)
-        gap2_x = adjacent_column_gap_x(graph, tgt_col, tgt_col + 1) + gap2_extra
+        gap2_x = (
+            adjacent_column_gap_x(graph, tgt_col, tgt_col + 1)
+            - base_bypass_offset
+            - gap2_extra
+        )
+        gap2_x = max(gap2_x, tx + ctx.curve_radius)
 
     r_bypass = ctx.curve_radius + max(gap1_extra, gap2_extra)
     return RoutedPath(


### PR DESCRIPTION
## Summary
- Bypass routes' gap2 vertical segment (near the target) was positioned at the inter-column gap midpoint, exactly where L-shape routes also place their vertical channel, causing visual overlap
- Apply `base_bypass_offset` to push `gap2_x` toward the target column, with clamping to prevent exceeding the target position
- Mirrors the existing offset treatment already applied to `gap1_x` on the source side

Fixes #111

## Test plan
- [x] pytest passes (365 tests)
- [x] ruff check clean
- [x] Visual review of all 32 topology/example renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)