### PR TITLE
fix: bias diagonal toward fork in fork+join edges

### DIFF
--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -786,15 +786,13 @@ def _route_diagonal(
         tgt_min = max(min_straight, label_text_width(tgt.label) / 2)
 
     # Bias diagonal toward the convergence/divergence station so that
-    # slopes are visually symmetric on both sides of a shared station.
+    # the visual fork/join is close to the topological fork/join.
     is_fork = edge.source in ctx.fork_stations
     is_join = edge.target in ctx.join_stations
-    if is_fork and not is_join:
+    if is_fork:
         mid_x = sx + sign * (src_min + half_diag)
-    elif is_join and not is_fork:
+    elif is_join:
         mid_x = tx - sign * (tgt_min + half_diag)
-    elif is_fork and is_join:
-        mid_x = (sx + tx) / 2
     else:
         mid_x = (sx + tx) / 2
 


### PR DESCRIPTION
## Summary
- When an edge both leaves a fork station and arrives at a join station, the diagonal midpoint was centered between source and target, causing lines to visually remain bundled well past the fork point
- Now fork bias always wins, placing the diagonal near the source so divergence is visible at the topological fork
- Simplifies the fork/join branching in `_route_diagonal()` from 4 cases to 3

Fixes #109

## Test plan
- [x] pytest passes (368 tests)
- [x] ruff check clean
- [x] Visual review of all 32 topology/example/fixture renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)