### PR TITLE
fix: center stations within sections after exit gap

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -521,13 +521,15 @@ def _adjust_lr_exit_gap(
         return
 
     exit_gap = x_spacing * EXIT_GAP_MULTIPLIER
+    # Split the gap between both sides so stations stay visually centered.
+    half_gap = exit_gap / 2
     if section.direction == "LR":
+        for s in sub.stations.values():
+            s.x += half_gap
         section.bbox_w += exit_gap
     else:
-        # Shift stations right to create clearance on the left
-        # (exit) side without moving the bbox boundary.
         for s in sub.stations.values():
-            s.x += exit_gap
+            s.x += half_gap
         section.bbox_w += exit_gap
 
 


### PR DESCRIPTION
## Summary
- Split the exit gap evenly between both sides of the section bbox so stations stay visually centered
- Previously `_adjust_lr_exit_gap` added the full gap on the exit side only, leaving stations off-center (especially noticeable in single-station sections like "Quantification" in `with_subworkflows.mmd`)
- Applies to both LR and RL section directions

Fixes #133

## Test plan
- [x] pytest passes (368 tests)
- [x] ruff check clean
- [x] Visual review of all 32 topology/fixture renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)