### PR TITLE
fix: only center exit gap for single-layer sections

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -521,15 +521,23 @@ def _adjust_lr_exit_gap(
         return
 
     exit_gap = x_spacing * EXIT_GAP_MULTIPLIER
-    # Split the gap between both sides so stations stay visually centered.
-    half_gap = exit_gap / 2
+
+    # For single-layer sections the asymmetry is very visible, so split the
+    # gap between both sides to keep the station visually centered.  For
+    # multi-layer sections the gap belongs entirely on the exit side.
+    n_layers = len(set(layers.values()))
+    center = n_layers <= 1
+
     if section.direction == "LR":
-        for s in sub.stations.values():
-            s.x += half_gap
+        if center:
+            half_gap = exit_gap / 2
+            for s in sub.stations.values():
+                s.x += half_gap
         section.bbox_w += exit_gap
     else:
+        shift = exit_gap / 2 if center else exit_gap
         for s in sub.stations.values():
-            s.x += half_gap
+            s.x += shift
         section.bbox_w += exit_gap
 
 


### PR DESCRIPTION
## Summary
- The centering introduced in #135 unconditionally shifted all stations rightward by half the exit gap, which caused multi-layer sections (like "Input Processing" in `multiline_labels.mmd`) to have excessive left-side padding
- Now only applies the centering shift when the section has a single layer, where the asymmetry is most noticeable
- Multi-layer sections revert to the original behavior: full exit gap on the exit side only

Fixes #136

## Test plan
- [x] pytest passes (368 tests)
- [x] ruff check clean
- [x] Visual review of all 32 topology/fixture renders
- [x] Verified single-station centering (#133 fix) still works (e.g. Quantification in `with_subworkflows.mmd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)