### PR TITLE
chore: tidy fix-issue and render-topologies skills

### DIFF
--- a/.claude/skills/render-topologies/SKILL.md
+++ b/.claude/skills/render-topologies/SKILL.md
@@ -1,97 +1,92 @@
 ---
 name: render-topologies
-description: Re-render all .mmd files in the repo to PNG, diff against main, and open only the changed renders (BEFORE/AFTER pairs) in Preview. Use when the user wants to check renders after layout or rendering changes.
+description: Render all .mmd files to PNG, pixel-diff against main, and open only changed renders as BEFORE/AFTER pairs in Preview. Use after layout or rendering changes to check for visual regressions. Works in worktree mode (fix branch vs main) or standalone mode (current working tree vs main). Companion to the fix-issue skill, which delegates full regression checks here.
 disable-model-invocation: true
 allowed-tools: Bash(rm -rf *), Bash(python *), Bash(open *), Bash(cd *), Bash(git *), Bash(source *), Bash(pip *), Bash(cp *)
 ---
 
 # Render Topologies
 
-Re-render all `.mmd` files from the current branch and from `origin/main`, then open only the renders that differ as BEFORE/AFTER pairs in a single Preview session.
+Pixel-diff all `.mmd` renders between the current branch and `origin/main`. Opens only changed renders as numbered BEFORE/AFTER pairs in Preview.
 
-## Workflow
+## Step 1: Detect context
 
-### Step 1: Render baseline from main
+Determine the working mode:
 
-Use the dedicated `nf-metro-main` micromamba environment and the main repo checkout at `/Users/jonathan.manning/projects/nf-metro`. First update it to match `origin/main`:
+- **Worktree mode**: A worktree exists at `/tmp/nf-metro-fix-<N>` with a matching `nf-metro-fix-<N>` env. Use the worktree path and env for branch renders.
+- **Standalone mode**: Working from the main repo at `/Users/jonathan.manning/projects/nf-metro`. Use the `nf-metro` env for branch renders. Stash or commit any uncommitted changes first.
+
+## Step 2: Render baseline from main
+
+Update the main repo checkout and render using the shared `nf-metro-main` baseline environment:
 
 ```bash
 cd /Users/jonathan.manning/projects/nf-metro && git fetch origin main && git checkout main && git pull origin main
 source ~/.local/bin/mm-activate nf-metro-main && pip install -e "/Users/jonathan.manning/projects/nf-metro[dev]" -q
 cd /Users/jonathan.manning/projects/nf-metro && python scripts/render_topologies.py
-# Note the output directory (MAIN_DIR)
+# Note the output directory → MAIN_DIR
 ```
 
-### Step 2: Render from the fix branch
-
-Use the worktree's own micromamba environment:
+## Step 3: Render from the current branch
 
 ```bash
-source ~/.local/bin/mm-activate <env> && pip install -e "<worktree>[dev]" -q
-cd <worktree> && python scripts/render_topologies.py
-# Note the output directory (FIX_DIR)
+source ~/.local/bin/mm-activate <env> && pip install -e "<repo-path>[dev]" -q
+cd <repo-path> && python scripts/render_topologies.py
+# Note the output directory → BRANCH_DIR
 ```
 
-### Step 3: Diff renders (pixel-level)
+## Step 4: Diff and open changed renders
 
-Use Pillow to compare each PNG pair. Only report files where the pixels or dimensions actually differ:
+Clean previous comparison files, diff each PNG pair, copy changed renders with sequential numbering (BEFORE/AFTER adjacent when flipping with arrow keys):
 
 ```python
 from PIL import Image, ImageChops
-import os
+import os, glob, shutil
+
+# Clean previous comparison files
+for f in glob.glob("/tmp/*_BEFORE.png") + glob.glob("/tmp/*_AFTER.png"):
+    os.remove(f)
 
 main_dir = "<MAIN_DIR>"
-fix_dir = "<FIX_DIR>"
+branch_dir = "<BRANCH_DIR>"
 
+pngs = sorted(f for f in os.listdir(branch_dir) if f.endswith('.png'))
 changed = []
-for name in sorted(os.listdir(fix_dir)):
-    if not name.endswith('.png'):
+for name in pngs:
+    path_main = os.path.join(main_dir, name)
+    if not os.path.exists(path_main):
+        changed.append(name)  # new file
         continue
-    im_fix = Image.open(os.path.join(fix_dir, name))
-    im_main = Image.open(os.path.join(main_dir, name))
-    if im_fix.size != im_main.size:
+    im_b = Image.open(os.path.join(branch_dir, name))
+    im_m = Image.open(path_main)
+    if im_b.size != im_m.size or ImageChops.difference(im_b, im_m).getbbox():
         changed.append(name)
-    else:
-        diff = ImageChops.difference(im_fix, im_main)
-        if diff.getbbox():
-            changed.append(name)
 
-print(f"{len(changed)} changed, {len(os.listdir(fix_dir)) - len(changed)} unchanged")
-for c in changed:
-    print(f"  {c}")
+print(f"{len(changed)} changed, {len(pngs) - len(changed)} unchanged")
+for i, name in enumerate(changed):
+    stem = name.replace('.png', '')
+    idx = i * 2 + 1
+    main_path = os.path.join(main_dir, name)
+    if os.path.exists(main_path):
+        shutil.copy(main_path, f"/tmp/{idx:02d}_{stem}_BEFORE.png")
+    shutil.copy(os.path.join(branch_dir, name), f"/tmp/{idx+1:02d}_{stem}_AFTER.png")
+    print(f"  {name}")
 ```
 
-### Step 4: Open changed renders as BEFORE/AFTER pairs
-
-Copy each changed render into `/tmp/` with numbered BEFORE/AFTER names so they sort together in Preview, then open all in one session:
-
 ```bash
-# For each changed file, e.g. with index N:
-cp "$MAIN_DIR/<name>.png" "/tmp/<N>_<short_name>_BEFORE.png"
-cp "$FIX_DIR/<name>.png"  "/tmp/<N+1>_<short_name>_AFTER.png"
-
-# Open all pairs in one Preview session
+# Open all pairs (skip if zero changed)
 open /tmp/*_BEFORE.png /tmp/*_AFTER.png
 ```
 
-Use sequential numbering (1, 2, 3, 4, ...) so BEFORE and AFTER for each render are adjacent when flipping with arrow keys.
+## Step 5: Report
 
-### Step 5: Report results
-
-- List how many renders changed vs unchanged
-- List the changed file names
-- If zero changed, say so and skip opening Preview
+- Count of changed vs unchanged renders
+- List changed file names
+- If zero changed, say so and skip Preview
 
 ## Notes
 
-- The render script is at `scripts/render_topologies.py` in the repo root.
-- It automatically discovers all `.mmd` files under the project root (examples, test fixtures, topologies).
+- Render script: `scripts/render_topologies.py` (discovers all `.mmd` files under project root).
 - Nextflow fixtures (`tests/fixtures/nextflow/*.mmd`) are auto-detected and converted before rendering.
-- Output filenames include the path (e.g. `examples_guide_01_minimal.png`) to avoid collisions.
-- **Baseline renders** always use the `nf-metro-main` env with the main repo at `/Users/jonathan.manning/projects/nf-metro`, updated to `origin/main`.
-- **Branch renders** use the worktree's own `nf-metro-fix-<N>` env.
-- If the user asks to render a specific file, use the CLI directly instead:
-
-```bash
-python -m nf_metro render <file.mmd> -o /tmp/output.svg
-```
+- Baseline always uses `nf-metro-main` env + main repo updated to `origin/main`.
+- To render a single file: `python -m nf_metro render <file.mmd> -o /tmp/output.svg`


### PR DESCRIPTION
## Summary
- Remove duplicated render logic from fix-issue by delegating full regression checks to the companion render-topologies skill
- Consolidate fix-issue from 7 phases to 6, tighten prose throughout (-38 net lines)
- Improve render-topologies with context detection (worktree vs standalone mode), cleanup of stale BEFORE/AFTER files, and handling of new-file diffs
- Add cross-references between the two skills so their complementary roles are clear

## Test plan
- [ ] Verify `/render-topologies` still works as expected after next layout change
- [ ] Verify fix-issue workflow delegates to render-topologies in Phase 4b

🤖 Generated with [Claude Code](https://claude.com/claude-code)