### PR TITLE
feat: add epitopeprediction and hlatyping examples

### DIFF
--- a/examples/epitopeprediction.mmd
+++ b/examples/epitopeprediction.mmd
@@ -1,0 +1,71 @@
+%%metro title: nf-core/epitopeprediction
+%%metro style: dark
+%%metro line_order: span
+%%metro logo: docs/images/nf-core-epitopeprediction_logo_dark.png
+%%metro legend: bl
+%%metro line: vcf | Variant Input | #2db572
+%%metro line: protein | Protein Input | #e6550d
+%%metro line: peptide | Peptide Input | #756bb1
+%%metro file: VCF_IN | VCF
+%%metro file: FASTA_IN | FASTA
+%%metro file: TSV_IN | TSV
+%%metro file: TSV_OUT | TSV
+%%metro file: HTML_OUT | HTML
+
+graph LR
+    subgraph input_processing [Input Processing]
+        VCF_IN[ ]
+        gunzip_vcf([Gunzip VCF])
+        snpsift_split([SnpSift Split])
+        variant_pred([Variant Pred])
+        FASTA_IN[ ]
+        fasta2peptides([Fasta2Peptides])
+        TSV_IN[ ]
+
+        VCF_IN -->|vcf| gunzip_vcf
+        gunzip_vcf -->|vcf| snpsift_split
+        snpsift_split -->|vcf| variant_pred
+        FASTA_IN -->|protein| fasta2peptides
+    end
+
+    subgraph binding_prediction [Binding Prediction]
+        split_peptides([Split Peptides])
+        prepare_input([Prepare Input])
+        mhcflurry([MHCflurry])
+        mhcnuggets([MHCnuggets])
+        mhcnuggetsii([MHCnuggetsII])
+        netmhcpan([NetMHCpan])
+        netmhciipan([NetMHCIIpan])
+        merge_pred([Merge Pred])
+
+        split_peptides -->|vcf,protein,peptide| prepare_input
+        prepare_input -->|vcf,protein,peptide| mhcflurry
+        prepare_input -->|vcf,protein,peptide| mhcnuggets
+        prepare_input -->|vcf,protein,peptide| mhcnuggetsii
+        prepare_input -->|vcf,protein,peptide| netmhcpan
+        prepare_input -->|vcf,protein,peptide| netmhciipan
+        mhcflurry -->|vcf,protein,peptide| merge_pred
+        mhcnuggets -->|vcf,protein,peptide| merge_pred
+        mhcnuggetsii -->|vcf,protein,peptide| merge_pred
+        netmhcpan -->|vcf,protein,peptide| merge_pred
+        netmhciipan -->|vcf,protein,peptide| merge_pred
+    end
+
+    subgraph reporting [Reporting]
+        summarize([Summarize Results])
+        _tsv_pad[ ]
+        multiqc([MultiQC])
+        TSV_OUT[ ]
+        HTML_OUT[ ]
+
+        summarize -->|vcf,protein,peptide| _tsv_pad
+        summarize -->|vcf,protein,peptide| multiqc
+        _tsv_pad -->|vcf,protein,peptide| TSV_OUT
+        multiqc -->|vcf,protein,peptide| HTML_OUT
+    end
+
+    %% Inter-section edges
+    variant_pred -->|vcf| split_peptides
+    fasta2peptides -->|protein| split_peptides
+    TSV_IN -->|peptide| split_peptides
+    merge_pred -->|vcf,protein,peptide| summarize

--- a/examples/hlatyping.mmd
+++ b/examples/hlatyping.mmd
@@ -1,0 +1,65 @@
+%%metro title: nf-core/hlatyping
+%%metro style: dark
+%%metro logo: docs/images/nf-core-hlatyping_logo_dark.png
+%%metro file: fastq_in | FASTQ
+%%metro file: bam_in | BAM
+%%metro file: report_tsv | TSV
+%%metro file: report_html | HTML
+%%metro line: fastq | FASTQ | #2db572
+%%metro line: bam | BAM | #e6842a
+%%metro legend: bl
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        %%metro exit: right | fastq, bam
+        fastq_in[ ]
+        bam_in[ ]
+        cat_fastq[cat FASTQ]
+        check_paired[Check Paired]
+        collatefastq[BAM to FASTQ]
+        fastqc[FastQC]
+
+        fastq_in -->|fastq| cat_fastq
+        cat_fastq -->|fastq| fastqc
+        bam_in -->|bam| check_paired
+        check_paired -->|bam| collatefastq
+        collatefastq -->|bam| fastqc
+    end
+
+    subgraph hla_typing [HLA Typing]
+        %%metro entry: left | fastq, bam
+        %%metro exit: right | fastq, bam
+        yara_index[Yara Index]
+        yara_mapper[Yara Mapper]
+        optitype_run[OptiType]
+        _hlahd_delay[ ]
+        hlahd_run[HLA-HD]
+        _hlahd_delay2[ ]
+        _merge1[ ]
+
+        yara_index -->|fastq,bam| yara_mapper
+        yara_mapper -->|fastq,bam| optitype_run
+        optitype_run -->|fastq,bam| _merge1
+        _hlahd_delay -->|fastq,bam| hlahd_run
+        hlahd_run -->|fastq,bam| _hlahd_delay2
+        _hlahd_delay2 -->|fastq,bam| _merge1
+    end
+
+    subgraph reporting [Reporting]
+        %%metro entry: left | fastq, bam
+        _branch2[ ]
+        _tsv_delay[ ]
+        report_tsv[ ]
+        multiqc[MultiQC]
+        report_html[ ]
+
+        _branch2 -->|fastq,bam| _tsv_delay
+        _tsv_delay -->|fastq,bam| report_tsv
+        _branch2 -->|fastq,bam| multiqc
+        multiqc -->|fastq,bam| report_html
+    end
+
+    %% Inter-section edges
+    fastqc -->|fastq,bam| yara_index
+    fastqc -->|fastq,bam| _hlahd_delay
+    _merge1 -->|fastq,bam| _branch2

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -29,8 +29,10 @@ EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 TOPOLOGY_FILES = sorted(TOPOLOGIES_DIR.glob("*.mmd"))
 TOPOLOGY_IDS = [f.stem for f in TOPOLOGY_FILES]
 
-# Include rnaseq as regression guard
+# Include examples as regression guards
 RNASEQ_FILE = EXAMPLES_DIR / "rnaseq_sections.mmd"
+EPITOPEPREDICTION_FILE = EXAMPLES_DIR / "epitopeprediction.mmd"
+HLATYPING_FILE = EXAMPLES_DIR / "hlatyping.mmd"
 
 
 def _load_and_layout(path: Path, max_station_columns: int = 15):
@@ -126,6 +128,76 @@ class TestRnaseqRegression:
         """All 5 rnaseq sections should have valid bounding boxes."""
         assert len(rnaseq_graph.sections) == 5
         for sid, section in rnaseq_graph.sections.items():
+            assert section.bbox_w > 0, f"Section '{sid}' has zero width"
+            assert section.bbox_h > 0, f"Section '{sid}' has zero height"
+
+
+class TestEpitopepredictionRegression:
+    """Ensure the epitopeprediction example passes all layout checks."""
+
+    @pytest.fixture
+    def epitopeprediction_graph(self):
+        return _load_and_layout(EPITOPEPREDICTION_FILE)
+
+    def test_no_section_overlap(self, epitopeprediction_graph):
+        violations = check_section_overlap(epitopeprediction_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_station_containment(self, epitopeprediction_graph):
+        violations = check_station_containment(epitopeprediction_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_coordinate_sanity(self, epitopeprediction_graph):
+        violations = check_coordinate_sanity(epitopeprediction_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_edge_waypoints(self, epitopeprediction_graph):
+        violations = check_edge_waypoints(epitopeprediction_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_all_sections_placed(self, epitopeprediction_graph):
+        """All 3 epitopeprediction sections should have valid bounding boxes."""
+        assert len(epitopeprediction_graph.sections) == 3
+        for sid, section in epitopeprediction_graph.sections.items():
+            assert section.bbox_w > 0, f"Section '{sid}' has zero width"
+            assert section.bbox_h > 0, f"Section '{sid}' has zero height"
+
+
+class TestHlatypingRegression:
+    """Ensure the hlatyping example passes all layout checks."""
+
+    @pytest.fixture
+    def hlatyping_graph(self):
+        return _load_and_layout(HLATYPING_FILE)
+
+    def test_no_section_overlap(self, hlatyping_graph):
+        violations = check_section_overlap(hlatyping_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_station_containment(self, hlatyping_graph):
+        violations = check_station_containment(hlatyping_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_coordinate_sanity(self, hlatyping_graph):
+        violations = check_coordinate_sanity(hlatyping_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_edge_waypoints(self, hlatyping_graph):
+        violations = check_edge_waypoints(hlatyping_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_all_sections_placed(self, hlatyping_graph):
+        """All 3 hlatyping sections should have valid bounding boxes."""
+        assert len(hlatyping_graph.sections) == 3
+        for sid, section in hlatyping_graph.sections.items():
             assert section.bbox_w > 0, f"Section '{sid}' has zero width"
             assert section.bbox_h > 0, f"Section '{sid}' has zero height"
 


### PR DESCRIPTION
## Summary
- Add `examples/epitopeprediction.mmd` (from jonasscheid/epitopeprediction@add-metro-map)
- Add `examples/hlatyping.mmd` (from nf-core/hlatyping@feature/metro-map)
- Add regression test classes (`TestEpitopepredictionRegression`, `TestHlatypingRegression`) with layout validation checks for both

Both are auto-discovered by `scripts/render_topologies.py` and covered by 10 new tests (151 total, all passing).

## Test plan
- [x] `pytest tests/test_topology_validation.py` - 151 passed
- [x] Both examples render to SVG/PNG without errors
- [ ] Visual review of renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)