### PR TITLE
feat: support multiple file icons per station

### DIFF
--- a/examples/guide/05b_multi_icons.mmd
+++ b/examples/guide/05b_multi_icons.mmd
@@ -1,0 +1,28 @@
+%%metro title: Multiple File Icons
+%%metro style: dark
+%%metro file: reads_in | FASTQ, BAM
+%%metro file: report_out | HTML
+%%metro file: counts_out | TSV, H5AD
+%%metro line: main | Main | #4CAF50
+%%metro line: qc | Quality Control | #2196F3
+
+graph LR
+    subgraph analysis [Analysis]
+        reads_in[ ]
+        trim[Trimming]
+        align[Alignment]
+        quant[Quantification]
+        reads_in -->|main,qc| trim
+        trim -->|main| align
+        align -->|main| quant
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+        report_out[ ]
+        counts_out[ ]
+        trim -->|qc| multiqc
+        quant -->|main| counts_out
+        quant -->|qc| multiqc
+        multiqc -->|qc| report_out
+    end

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -158,11 +158,10 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
         _resolve_sections(graph)
 
     # Apply pending terminus designations
-    for station_id, ext_label in graph._pending_terminus.items():
+    for station_id, ext_labels in graph._pending_terminus.items():
         station = graph.stations.get(station_id)
         if station:
-            station.is_terminus = True
-            station.terminus_label = ext_label
+            station.terminus_labels = ext_labels
 
     return graph
 
@@ -221,8 +220,9 @@ def _parse_directive(
         parts = content[len("file:") :].strip().split("|")
         if len(parts) >= 2:
             station_id = parts[0].strip()
-            ext_label = parts[1].strip()
-            graph._pending_terminus[station_id] = ext_label
+            raw_labels = parts[1].strip()
+            labels = [s.strip() for s in raw_labels.split(",") if s.strip()]
+            graph._pending_terminus.setdefault(station_id, []).extend(labels)
 
 
 def _parse_port_hint(

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -33,13 +33,17 @@ class Station:
     section_id: str | None = None
     is_port: bool = False
     is_hidden: bool = False
-    is_terminus: bool = False
-    terminus_label: str = ""
+    terminus_labels: list[str] = field(default_factory=list)
     # Populated by layout engine
     x: float = 0.0
     y: float = 0.0
     layer: int = 0
     track: float = 0.0
+
+    @property
+    def is_terminus(self) -> bool:
+        """Station has one or more file icons."""
+        return len(self.terminus_labels) > 0
 
 
 @dataclass
@@ -137,8 +141,8 @@ class MetroGraph:
     logo_path: str = ""
     # Section IDs that had explicit %%metro direction: directives
     _explicit_directions: set[str] = field(default_factory=set)
-    # Pending terminus designations: station_id -> extension label
-    _pending_terminus: dict[str, str] = field(default_factory=dict)
+    # Pending terminus designations: station_id -> list of extension labels
+    _pending_terminus: dict[str, list[str]] = field(default_factory=dict)
 
     def add_line(self, line: MetroLine) -> None:
         self.lines[line.id] = line

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -80,6 +80,9 @@ pixel-level measurement across CairoSVG and Chromium renderers."""
 ICON_STATION_GAP: float = 6.0
 """Gap between terminus station pill and file icon."""
 
+ICON_INTER_GAP: float = 4.0
+"""Gap between adjacent file icons when a station has multiple icons."""
+
 ICON_BBOX_MARGIN: float = 2.0
 """Margin around icon bounding box for clamping."""
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -179,3 +179,64 @@ def test_render_rnaseq_sections_example():
     assert "Pre-processing" in svg
     root = ET.fromstring(svg)
     assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+# --- Multi-icon terminus rendering ---
+
+
+def test_render_single_file_icon():
+    """Single %%metro file: directive renders one file icon."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | FASTQ\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    assert "FASTQ" in svg
+    root = ET.fromstring(svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_render_multiple_file_icons():
+    """Comma-separated %%metro file: directive renders multiple file icons."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | FASTQ, BAM\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    assert "FASTQ" in svg
+    assert "BAM" in svg
+    root = ET.fromstring(svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_render_multi_icon_fixture():
+    """The 05b_multi_icons.mmd example renders without errors."""
+    from pathlib import Path
+
+    examples = Path(__file__).parent.parent / "examples" / "guide"
+    text = (examples / "05b_multi_icons.mmd").read_text()
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    # All icon labels should be present
+    assert "FASTQ" in svg
+    assert "BAM" in svg
+    assert "HTML" in svg
+    assert "TSV" in svg
+    assert "H5AD" in svg
+    root = ET.fromstring(svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag


### PR DESCRIPTION
## Summary
- Allow stations to display multiple file-type icons side-by-side via comma-separated labels (`%%metro file: node | FASTQ, BAM`) or repeated `%%metro file:` directives for the same station
- Icons render in a horizontal row extending away from the station pill, with configurable inter-icon gap (`ICON_INTER_GAP`)
- Section bounding box clearance scales automatically with icon count
- Fully backward-compatible: existing single-icon `.mmd` files work unchanged (all 32 existing renders are pixel-identical)

Fixes #127

## Test plan
- [x] pytest passes (375 tests, 7 new)
- [x] ruff check clean
- [x] Visual review: single-icon before/after identical, multi-icon renders correctly
- [x] Full topology regression: 32 unchanged, 1 new (the multi-icon example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)