### PR TITLE
fix: shift LR/RL stations away from perpendicular entry ports (#99)

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -129,6 +129,13 @@ ENTRY_SHIFT_TB_CROSS: float = 1.0
 ENTRY_INSET_LR: float = 0.3
 """Entry inset multiplier for LR/RL sections with perpendicular entry."""
 
+ENTRY_SHIFT_LR: float = 0.5
+"""Station shift multiplier for LR/RL sections with perpendicular entry.
+
+Applied after port positioning (Phase 9+) so that internal stations move
+inward while ports stay put, creating a gap between the perpendicular
+entry port and the first internal station.  Mirrors ENTRY_SHIFT_TB."""
+
 EXIT_GAP_MULTIPLIER: float = 0.6
 """Exit gap multiplier for flow-side exits."""
 


### PR DESCRIPTION
## Summary
- In LR/RL sections with TOP/BOTTOM perpendicular entry, the vertical descent from the entry port could overlap with the first station's label (e.g. "Merge" in `fold_fan_across` section 6)
- Adds a post-port-positioning phase (Phase 10) that shifts internal stations inward when the gap between the perpendicular entry port and the nearest station is insufficient
- Phase 2 reserves bbox space via `ENTRY_SHIFT_LR` so grid column sizing accounts for the shift
- Shift is conditional: sections where the gap is already sufficient are left untouched (only `fold_fan_across` changes across all 32 renders)

Fixes #99

## Test plan
- [x] pytest passes (368 tests)
- [x] ruff check clean
- [x] Visual review of all 32 topology renders (1 changed, 31 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)