### PR TITLE
fix: conditional exit gap and LR label clearance

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -593,11 +593,16 @@ def _adjust_lr_label_clearance(
 
         if label_left < section.bbox_x:
             deficit = section.bbox_x - label_left
-            # Shift all stations right and expand bbox on the left
+            # Shift all stations right and expand bbox on the left.
+            # This moves the current station too, so we recompute
+            # label_right below.  Later stations get more left-side
+            # clearance, which is safe (they can only trigger further
+            # right-side expansion, not undo this shift).
             for st in sub.stations.values():
                 st.x += deficit
             section.bbox_w += deficit
 
+        # Recompute after possible left-side shift
         label_right = s.x + half_w + margin
         bbox_right = section.bbox_x + section.bbox_w
         if label_right > bbox_right:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -280,6 +280,27 @@ def test_lr_exit_clearance_widens_bbox_for_multi_track():
     assert w_exit > w_no
 
 
+def test_lr_label_clearance_expands_bbox():
+    """LR section bbox expands to contain wide station labels."""
+    from nf_metro.layout.labels import label_text_width
+
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "graph LR\n"
+        "    subgraph sec1 [Section One]\n"
+        "        a[A]\n"
+        "        b[GATK HaplotypeCaller]\n"
+        "        a -->|main| b\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    sec = graph.sections["sec1"]
+    station_b = graph.stations["b"]
+    label_half = label_text_width("GATK HaplotypeCaller") / 2
+    # Label right edge should fit within section bbox
+    assert station_b.x + label_half < sec.bbox_x + sec.bbox_w
+
+
 def test_rl_exit_clearance_preserves_bbox_x():
     """RL section exit clearance should shift stations right, not move bbox_x left."""
     graph = parse_metro_mermaid(


### PR DESCRIPTION
## Summary
- Make `_adjust_lr_exit_gap` conditional: only add the exit gap when lines converge from different Y tracks (requiring diagonal routing). When all feeders share the same Y, lines exit straight horizontally and no extra space is needed.
- Add `_adjust_lr_label_clearance` to expand LR/RL section bboxes for wide labels during Phase 2, before section placement equalizes column widths. Previously label expansion only happened at render time, which was too late for sibling sections to match.

Fixes #142

## Test plan
- [x] pytest passes (386 tests)
- [x] ruff check clean
- [x] Visual review of all 35 topology renders (30 changed, 5 unchanged)
- [x] Verified fan-out example: sections in same column now equalize width when one has a long label

🤖 Generated with [Claude Code](https://claude.com/claude-code)