### PR TITLE
feat: configurable section spacing with safe minimums

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -84,6 +84,18 @@ def cli() -> None:
     "Use --no-straight-diamonds for symmetric fan-out.",
 )
 @click.option(
+    "--section-x-gap",
+    type=float,
+    default=None,
+    help="Horizontal gap between sections (default: 50)",
+)
+@click.option(
+    "--section-y-gap",
+    type=float,
+    default=None,
+    help="Vertical gap between sections (default: 40)",
+)
+@click.option(
     "--from-nextflow",
     is_flag=True,
     default=False,
@@ -109,6 +121,8 @@ def render(
     logo: Path | None,
     line_order: str | None,
     straight_diamonds: bool,
+    section_x_gap: float | None,
+    section_y_gap: float | None,
     from_nextflow: bool,
     title: str | None,
 ) -> None:
@@ -137,11 +151,15 @@ def render(
     if logo is not None:
         graph.logo_path = str(logo)
 
-    compute_layout(
-        graph,
+    layout_kwargs: dict = dict(
         x_spacing=x_spacing,
         y_spacing=y_spacing,
     )
+    if section_x_gap is not None:
+        layout_kwargs["section_x_gap"] = section_x_gap
+    if section_y_gap is not None:
+        layout_kwargs["section_y_gap"] = section_y_gap
+    compute_layout(graph, **layout_kwargs)
 
     theme_obj = THEMES[theme]
     svg = render_svg(

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -75,6 +75,21 @@ edge, giving enough horizontal run for smooth curves at bypass route
 corners.  Value: 40px (4 * 10px CURVE_RADIUS).
 """
 
+SECTION_HEADER_PROTRUSION: float = 22.0
+"""Distance the section header protrudes above bbox_y.
+
+The numbered circle center sits at bbox_y - circle_r - Y_OFFSET
+(bbox_y - 9 - 4 = bbox_y - 13), and the circle top is another
+9px above that, totaling 22px above bbox_y.
+"""
+
+MIN_INTER_SECTION_ROW_GAP: float = 12.0
+"""Minimum visual gap between section bottom and the next section's header.
+
+Applied after accounting for SECTION_HEADER_PROTRUSION, so the actual
+bbox-to-bbox distance will be MIN_INTER_SECTION_ROW_GAP + protrusion.
+"""
+
 # ---------------------------------------------------------------------------
 # Routing
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,27 @@ def test_render_svg_ends_with_newline(tmp_path):
     assert content.endswith("\n"), "SVG output must end with a trailing newline"
 
 
+def test_render_section_gap_options(tmp_path):
+    """render command accepts --section-x-gap and --section-y-gap flags."""
+    out = tmp_path / "output.svg"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            str(RNASEQ_MMD),
+            "-o",
+            str(out),
+            "--section-x-gap",
+            "80",
+            "--section-y-gap",
+            "60",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+
+
 def test_render_nonexistent_file():
     """render command fails gracefully on missing input."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary

- Adds `--section-x-gap` and `--section-y-gap` CLI options to control the gap between sections (closes #126)
- Horizontal gap enforcement is **bundle-aware**: computes the minimum needed based on the number of lines routing through each column gap (`2 * (CURVE_RADIUS + (n-1) * OFFSET_STEP)`), so curves don't clip section borders
- Vertical gap enforcement accounts for the **section header protrusion** (22px for the numbered circle + label above each section box), measuring from the upper section's bottom to the lower section's header top
- Warns the user when their requested gap has been overridden, e.g.:
  ```
  Warning: Section gap between columns 0 and 1 widened from 20px to 50px to accommodate 6 routing line(s)
  Warning: Section gap between rows 0 and 1 widened to 34px to clear section headers (requested 10px)
  ```
- Default behaviour is unchanged (no CLI args = existing constants)

Fixes #126

## Test plan
- [x] pytest passes (391 tests, 4 new)
- [x] ruff check clean
- [x] Visual review of rnaseq with default, tight, and wide gaps
- [x] All 35 topology renders pixel-identical to main (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)