### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.5.0"
+version = "0.5.1"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- Bump version from 0.5.0 to 0.5.1 in `pyproject.toml` and `src/nf_metro/__init__.py`
- This release includes a fix to the light theme's `legend_font_size`, changed from 19 to 16 for better visual consistency

## Changes

- `pyproject.toml`: version 0.5.0 -> 0.5.1
- `src/nf_metro/__init__.py`: __version__ 0.5.0 -> 0.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)