### PR TITLE
fix: increase label spacing and reduce file icon font size

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -169,7 +169,7 @@ STATION_ELBOW_TOLERANCE: float = 12.0
 LABEL_MARGIN: float = 2.0
 """Overlap detection margin for labels."""
 
-LABEL_OFFSET: float = 8.0
+LABEL_OFFSET: float = 11.0
 """Vertical distance from pill edge to label."""
 
 DESCENDER_CLEARANCE: float = 3.0

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -46,5 +46,5 @@ class Theme:
     terminus_stroke: str = ""  # empty = inherit station_stroke
     terminus_stroke_width: float = 1.5
     terminus_corner_radius: float = 2.0
-    terminus_font_size: float = 9.0
+    terminus_font_size: float = 7.5
     terminus_font_color: str = ""  # empty = inherit label_color


### PR DESCRIPTION
## Summary
- Increase `LABEL_OFFSET` from 8 to 11px so station labels have more breathing room from pills (e.g. "Sylph" was too close)
- Reduce `terminus_font_size` from 9 to 7.5 so file extension text fits more comfortably inside icons

## Test plan
- [x] Visual review of rnaseq_sections render

🤖 Generated with [Claude Code](https://claude.com/claude-code)