### PR TITLE
refactor: derive related constants from CURVE_RADIUS

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -67,14 +67,6 @@ PLACEMENT_Y_GAP: float = 70.0
 PORT_MIN_GAP: float = 15.0
 """Minimum spacing between adjacent ports on a section boundary."""
 
-MIN_INTER_SECTION_GAP: float = 40.0
-"""Minimum physical gap between adjacent section bboxes.
-
-Ensures the gap midpoint is at least 2*CURVE_RADIUS from each section
-edge, giving enough horizontal run for smooth curves at bypass route
-corners.  Value: 40px (4 * 10px CURVE_RADIUS).
-"""
-
 SECTION_HEADER_PROTRUSION: float = 26.0
 """Distance the section header protrudes above bbox_y.
 
@@ -98,6 +90,14 @@ DIAGONAL_RUN: float = 30.0
 
 CURVE_RADIUS: float = 10.0
 """Default corner radius for routed paths."""
+
+MIN_INTER_SECTION_GAP: float = 4 * CURVE_RADIUS
+"""Minimum physical gap between adjacent section bboxes.
+
+Ensures the gap midpoint is at least 2*CURVE_RADIUS from each section
+edge, giving enough horizontal run for smooth curves at bypass route
+corners.  Derived as 4 * CURVE_RADIUS.
+"""
 
 OFFSET_STEP: float = 3.0
 """Per-line offset increment for parallel lines in bundles."""

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -4,6 +4,8 @@ Centralizes magic numbers from svg.py, legend.py, animate.py, and icons.py.
 Theme-dependent values remain in style.py.
 """
 
+from nf_metro.layout.constants import CURVE_RADIUS
+
 # ---------------------------------------------------------------------------
 # Canvas
 # ---------------------------------------------------------------------------
@@ -52,8 +54,10 @@ LEGEND_BORDER_RADIUS: int = 6
 # ---------------------------------------------------------------------------
 # SVG drawing
 # ---------------------------------------------------------------------------
-SVG_CURVE_RADIUS: float = 10.0
-"""Default corner radius for edge path smoothing."""
+SVG_CURVE_RADIUS: float = CURVE_RADIUS
+"""Default corner radius for edge path smoothing.
+
+Derived from the layout CURVE_RADIUS so routing and rendering agree."""
 
 SECTION_NUM_CIRCLE_R: int = 8
 """Radius of section number circle background (small variant)."""
@@ -89,8 +93,10 @@ ICON_BBOX_MARGIN: float = 2.0
 # ---------------------------------------------------------------------------
 # Animation
 # ---------------------------------------------------------------------------
-ANIMATION_CURVE_RADIUS: float = 10.0
-"""Default curve radius for animation motion paths."""
+ANIMATION_CURVE_RADIUS: float = CURVE_RADIUS
+"""Default curve radius for animation motion paths.
+
+Derived from the layout CURVE_RADIUS for consistency."""
 
 MIN_ANIMATION_DURATION: float = 2.0
 """Minimum duration in seconds for ball animation."""


### PR DESCRIPTION
## Summary
- `SVG_CURVE_RADIUS` and `ANIMATION_CURVE_RADIUS` (render) now derive from layout's `CURVE_RADIUS` instead of independently hardcoding `10.0`
- `MIN_INTER_SECTION_GAP` is now `4 * CURVE_RADIUS` instead of a magic `40.0` (moved after `CURVE_RADIUS` definition to allow the reference)
- No behavioral change (all values remain identical at runtime)

First in a series of refactoring PRs to reduce unintended side effects when making changes. See #178 for the full plan.

## Test plan
- [x] 398 tests pass
- [x] Lint clean
- [ ] Review render diffs (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)