### PR TITLE
refactor: move icon constants to layout, fix backward dependency

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -216,6 +216,16 @@ SIDE_BRANCH_NUDGE: float = 1.0
 FANOUT_SPACING: float = 1.5
 """Spacing multiplier for fan-out node layout."""
 
+TERMINUS_WIDTH: float = 28.0
+"""Default width of terminus (file) icons.
+
+Used by both layout (for clearance calculations) and render (as the
+Theme.terminus_width default).
+"""
+
+ICON_INTER_GAP: float = 4.0
+"""Gap between adjacent file icons when a station has multiple icons."""
+
 TERMINUS_ICON_CLEARANCE: float = 58.0
 """Minimum clearance from terminus station center to section bbox edge.
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -17,6 +17,7 @@ from nf_metro.layout.constants import (
     ENTRY_SHIFT_TB_CROSS,
     EXIT_GAP_MULTIPLIER,
     FONT_HEIGHT,
+    ICON_INTER_GAP,
     JUNCTION_MARGIN,
     LABEL_BBOX_MARGIN,
     LABEL_LINE_HEIGHT,
@@ -34,6 +35,7 @@ from nf_metro.layout.constants import (
     STATION_ELBOW_TOLERANCE,
     TB_LINE_Y_OFFSET,
     TERMINUS_ICON_CLEARANCE,
+    TERMINUS_WIDTH,
     X_OFFSET,
     X_SPACING,
     Y_OFFSET,
@@ -722,15 +724,11 @@ def _terminus_icon_clearance(n_icons: int) -> float:
 
     The base ``TERMINUS_ICON_CLEARANCE`` covers one icon (station_radius +
     gap + icon_width + margin).  Each additional icon adds icon_width + inter-
-    icon gap.  We import render constants here to avoid a circular dependency
-    at module level.
+    icon gap.
     """
     if n_icons <= 1:
         return TERMINUS_ICON_CLEARANCE
-    from nf_metro.render.constants import ICON_INTER_GAP
-    from nf_metro.render.style import Theme
-
-    extra = (n_icons - 1) * (Theme.terminus_width + ICON_INTER_GAP)
+    extra = (n_icons - 1) * (TERMINUS_WIDTH + ICON_INTER_GAP)
     return TERMINUS_ICON_CLEARANCE + extra
 
 

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -5,6 +5,8 @@ Theme-dependent values remain in style.py.
 """
 
 from nf_metro.layout.constants import CURVE_RADIUS
+from nf_metro.layout.constants import ICON_INTER_GAP as ICON_INTER_GAP  # re-export
+from nf_metro.layout.constants import TERMINUS_WIDTH as TERMINUS_WIDTH  # re-export
 
 # ---------------------------------------------------------------------------
 # Canvas
@@ -84,8 +86,7 @@ pixel-level measurement across CairoSVG and Chromium renderers."""
 ICON_STATION_GAP: float = 6.0
 """Gap between terminus station pill and file icon."""
 
-ICON_INTER_GAP: float = 4.0
-"""Gap between adjacent file icons when a station has multiple icons."""
+# ICON_INTER_GAP is imported from layout.constants (re-exported for render use)
 
 ICON_BBOX_MARGIN: float = 2.0
 """Margin around icon bounding box for clamping."""

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -6,6 +6,8 @@ __all__ = ["Theme"]
 
 from dataclasses import dataclass
 
+from nf_metro.layout.constants import TERMINUS_WIDTH
+
 
 @dataclass
 class Theme:
@@ -39,7 +41,7 @@ class Theme:
     animation_balls_per_line: int = 1
     animation_speed: float = 80.0  # pixels per second
     # Terminus (file icon) settings
-    terminus_width: float = 28.0
+    terminus_width: float = TERMINUS_WIDTH
     terminus_height: float = 32.0
     terminus_fold_size: float = 8.0
     terminus_fill: str = ""  # empty = inherit station_fill


### PR DESCRIPTION
## Summary
- `TERMINUS_WIDTH` (28.0) and `ICON_INTER_GAP` (4.0) now live in `layout/constants.py` as their canonical source
- `engine.py` no longer imports from `render/` (was the only layout->render backward dependency)
- `render/constants.py` re-exports both for existing render-side consumers
- `Theme.terminus_width` default now references `TERMINUS_WIDTH` constant

PR 2 of the refactoring series (after #178).

## Test plan
- [x] 398 tests pass
- [x] Lint clean
- [ ] Review render diffs (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)