### PR TITLE
refactor: extract shared resolve_curve_radii for routing/rendering

### DIFF
--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -29,6 +29,87 @@ from nf_metro.layout.constants import CURVE_RADIUS, OFFSET_STEP
 # ---------------------------------------------------------------------------
 
 
+def resolve_curve_radii(
+    points: list[tuple[float, float]],
+    desired_radii: list[float] | None,
+    default_radius: float = CURVE_RADIUS,
+) -> list[float]:
+    """Compute effective curve radii after segment-budget clamping.
+
+    For each corner (intermediate waypoint), the desired radius is clamped
+    to the available segment length on each side.  When adjacent corners
+    share a segment, space is allocated proportionally based on their
+    desired radii so concentric geometry is preserved.
+
+    This is the single source of truth for radius resolution, used by both
+    the routing layer (for validation) and the rendering layer (for SVG
+    path construction).
+
+    Parameters
+    ----------
+    points : list of (x, y) tuples
+        The waypoints of the routed path.
+    desired_radii : list of float or None
+        Desired radius at each corner (length must equal ``len(points) - 2``
+        when not None).  Falls back to *default_radius* for missing entries.
+    default_radius : float
+        Fallback radius when *desired_radii* is None or too short.
+
+    Returns
+    -------
+    list of float
+        Effective (clamped) radius for each corner.
+    """
+    n_corners = len(points) - 2
+    if n_corners <= 0:
+        return []
+
+    effective: list[float] = []
+    for i in range(1, len(points) - 1):
+        corner_idx = i - 1
+        desired_r = (
+            desired_radii[corner_idx]
+            if desired_radii and corner_idx < len(desired_radii)
+            else default_radius
+        )
+
+        prev, curr, nxt = points[i - 1], points[i], points[i + 1]
+        dx1 = curr[0] - prev[0]
+        dy1 = curr[1] - prev[1]
+        len1 = (dx1**2 + dy1**2) ** 0.5
+
+        dx2 = nxt[0] - curr[0]
+        dy2 = nxt[1] - curr[1]
+        len2 = (dx2**2 + dy2**2) ** 0.5
+
+        # Proportional allocation for segments shared between adjacent corners.
+        if i > 1:
+            prev_r = (
+                desired_radii[i - 2]
+                if desired_radii and (i - 2) < len(desired_radii)
+                else default_radius
+            )
+            total = prev_r + desired_r
+            max_len1 = len1 * desired_r / total if total > 0 else len1 / 2
+        else:
+            max_len1 = len1
+
+        if i < len(points) - 2:
+            next_r = (
+                desired_radii[i]
+                if desired_radii and i < len(desired_radii)
+                else default_radius
+            )
+            total = desired_r + next_r
+            max_len2 = len2 * desired_r / total if total > 0 else len2 / 2
+        else:
+            max_len2 = len2
+
+        effective.append(min(desired_r, max_len1, max_len2))
+
+    return effective
+
+
 def reversed_offset(offset: float, max_offset: float) -> float:
     """Flip a line's offset within a bundle.
 

--- a/src/nf_metro/render/animate.py
+++ b/src/nf_metro/render/animate.py
@@ -10,6 +10,7 @@ import re
 import drawsvg as draw
 
 from nf_metro.layout.routing import RoutedPath
+from nf_metro.layout.routing.corners import resolve_curve_radii
 from nf_metro.parser.model import MetroGraph
 from nf_metro.render.constants import (
     ANIMATION_CURVE_RADIUS,
@@ -307,8 +308,7 @@ def _points_to_svg_path(
 ) -> str:
     """Convert a list of waypoints to an SVG path 'd' attribute.
 
-    Replicates the curve logic from _render_edges in svg.py:
-    straight lines with quadratic Bezier curves at direction changes.
+    Uses resolve_curve_radii for consistent radius clamping with svg.py.
     """
     if len(pts) < 2:
         return ""
@@ -317,6 +317,7 @@ def _points_to_svg_path(
         return f"M {pts[0][0]:.2f} {pts[0][1]:.2f} L {pts[1][0]:.2f} {pts[1][1]:.2f}"
 
     parts = [f"M {pts[0][0]:.2f} {pts[0][1]:.2f}"]
+    resolved = resolve_curve_radii(pts, route_curve_radii, default_radius=curve_radius)
 
     for i in range(1, len(pts) - 1):
         prev = pts[i - 1]
@@ -331,11 +332,7 @@ def _points_to_svg_path(
         dy2 = nxt[1] - curr[1]
         len2 = math.hypot(dx2, dy2)
 
-        max_len1 = len1 / 2 if i > 1 else len1
-        max_len2 = len2 / 2 if i < len(pts) - 2 else len2
-
-        effective_r = curve_radius
-        r = min(effective_r, max_len1, max_len2)
+        r = resolved[i - 1]
 
         if len1 > 0 and len2 > 0:
             before_x = curr[0] - (dx1 / len1) * r

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -12,6 +12,7 @@ import drawsvg as draw
 from nf_metro.layout.constants import LABEL_LINE_HEIGHT
 from nf_metro.layout.labels import LabelPlacement, place_labels
 from nf_metro.layout.routing import RoutedPath, compute_station_offsets, route_edges
+from nf_metro.layout.routing.corners import resolve_curve_radii
 from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
 from nf_metro.render.constants import (
     CANVAS_PADDING,
@@ -626,6 +627,10 @@ def _render_edges(
             )
             path.M(*pts[0])
 
+            resolved = resolve_curve_radii(
+                pts, route.curve_radii, default_radius=curve_radius
+            )
+
             for i in range(1, len(pts) - 1):
                 prev = pts[i - 1]
                 curr = pts[i]
@@ -639,46 +644,7 @@ def _render_edges(
                 dy2 = nxt[1] - curr[1]
                 len2 = (dx2**2 + dy2**2) ** 0.5
 
-                corner_idx = i - 1
-                if route.curve_radii and corner_idx < len(route.curve_radii):
-                    effective_r = route.curve_radii[corner_idx]
-                else:
-                    effective_r = curve_radius
-
-                # Allocate shared segments proportionally based on the
-                # desired radii of adjacent corners.  This preserves
-                # concentric curve geometry instead of a fixed 50/50
-                # split which collapses different radii to the same
-                # clamped value.
-                if i > 1 and route.curve_radii:
-                    prev_ci = i - 2
-                    prev_r = (
-                        route.curve_radii[prev_ci]
-                        if prev_ci < len(route.curve_radii)
-                        else curve_radius
-                    )
-                    total = prev_r + effective_r
-                    max_len1 = len1 * effective_r / total if total > 0 else len1 / 2
-                elif i > 1:
-                    max_len1 = len1 / 2
-                else:
-                    max_len1 = len1
-
-                if i < len(pts) - 2 and route.curve_radii:
-                    next_ci = i
-                    next_r = (
-                        route.curve_radii[next_ci]
-                        if next_ci < len(route.curve_radii)
-                        else curve_radius
-                    )
-                    total = effective_r + next_r
-                    max_len2 = len2 * effective_r / total if total > 0 else len2 / 2
-                elif i < len(pts) - 2:
-                    max_len2 = len2 / 2
-                else:
-                    max_len2 = len2
-
-                r = min(effective_r, max_len1, max_len2)
+                r = resolved[i - 1]
 
                 if len1 > 0 and len2 > 0:
                     before_x = curr[0] - (dx1 / len1) * r

--- a/tests/test_corners.py
+++ b/tests/test_corners.py
@@ -16,6 +16,7 @@ import pytest
 from nf_metro.layout.constants import CURVE_RADIUS, OFFSET_STEP
 from nf_metro.layout.routing.corners import (
     l_shape_radii,
+    resolve_curve_radii,
     reversed_offset,
     tb_entry_corner,
     tb_exit_corner,
@@ -304,3 +305,81 @@ class TestTbEntryCorner:
             vx_entry, r_entry = tb_entry_corner(off, max_off, entry_right=entry_right)
             assert r_exit == pytest.approx(r_entry)
             assert vx_exit == pytest.approx(vx_entry)
+
+
+# ---------------------------------------------------------------------------
+# resolve_curve_radii
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCurveRadii:
+    """Tests for the shared radius resolution function."""
+
+    def test_no_corners(self):
+        """Two-point path has no corners."""
+        assert resolve_curve_radii([(0, 0), (100, 0)], None) == []
+
+    def test_single_corner_no_clamping(self):
+        """Single corner with plenty of segment length uses desired radius."""
+        pts = [(0, 0), (100, 0), (100, 100)]
+        result = resolve_curve_radii(pts, [15.0])
+        assert result == [15.0]
+
+    def test_single_corner_clamped_by_segment(self):
+        """Desired radius exceeding segment length is clamped."""
+        pts = [(0, 0), (5, 0), (5, 100)]
+        result = resolve_curve_radii(pts, [15.0])
+        assert result == [5.0]
+
+    def test_none_radii_uses_default(self):
+        """None desired_radii falls back to default_radius."""
+        pts = [(0, 0), (100, 0), (100, 100)]
+        result = resolve_curve_radii(pts, None, default_radius=8.0)
+        assert result == [8.0]
+
+    def test_adjacent_corners_proportional_allocation(self):
+        """Two corners sharing a short segment allocate proportionally."""
+        # Shared segment is 20px, desired radii are 10 and 10
+        # Each gets half = 10, which fits (equal split)
+        pts = [(0, 0), (100, 0), (120, 0), (120, 100)]
+        result = resolve_curve_radii(pts, [10.0, 10.0])
+        assert result[0] == pytest.approx(10.0)
+        assert result[1] == pytest.approx(10.0)
+
+    def test_adjacent_corners_unequal_radii(self):
+        """Unequal desired radii get proportional shares of shared segment."""
+        # Shared segment = 20px, desired r1=5, r2=15
+        # r1 gets 20 * 5/(5+15) = 5 -> min(5, 5) = 5
+        # r2 gets 20 * 15/(5+15) = 15 -> min(15, 15) = 15
+        pts = [(0, 0), (100, 0), (120, 0), (120, 100)]
+        result = resolve_curve_radii(pts, [5.0, 15.0])
+        assert result[0] == pytest.approx(5.0)
+        assert result[1] == pytest.approx(15.0)
+
+    def test_adjacent_corners_tight_segment(self):
+        """Very short shared segment clamps both adjacent radii."""
+        # Shared segment = 6px, desired r1=10, r2=10
+        # r1 budget from shared = 6 * 10/20 = 3 -> clamped to 3
+        # r2 budget from shared = 6 * 10/20 = 3 -> clamped to 3
+        pts = [(0, 0), (100, 0), (106, 0), (106, 100)]
+        result = resolve_curve_radii(pts, [10.0, 10.0])
+        assert result[0] == pytest.approx(3.0)
+        assert result[1] == pytest.approx(3.0)
+
+    def test_concentric_radii_stay_distinct(self):
+        """Bundle lines with different radii remain distinct after resolution."""
+        pts = [(0, 0), (100, 0), (100, 100)]
+        r1 = resolve_curve_radii(pts, [CURVE_RADIUS])
+        r2 = resolve_curve_radii(pts, [CURVE_RADIUS + OFFSET_STEP])
+        r3 = resolve_curve_radii(pts, [CURVE_RADIUS + 2 * OFFSET_STEP])
+        assert r1[0] < r2[0] < r3[0]
+
+    def test_four_corner_bypass(self):
+        """Six-point bypass path resolves 4 corners."""
+        pts = [(0, 0), (50, 0), (50, 200), (250, 200), (250, 0), (300, 0)]
+        radii = [10.0, 12.0, 12.0, 10.0]
+        result = resolve_curve_radii(pts, radii)
+        assert len(result) == 4
+        # All should be achievable given 50+ px segments
+        for r_eff, r_des in zip(result, radii):
+            assert r_eff == pytest.approx(r_des)


### PR DESCRIPTION
## Summary
- New `resolve_curve_radii()` function in `routing/corners.py` - single source of truth for radius resolution
- Handles proportional allocation of shared segments between adjacent corners and segment-budget clamping
- `svg.py`: replaced 40+ lines of inline radius logic with a single `resolve_curve_radii()` call
- `animate.py`: replaced its own simpler clamping logic with the same function (previously used a naive 50/50 split instead of proportional allocation)
- 9 new unit tests for `resolve_curve_radii` covering: no corners, single corner, clamping, proportional allocation, unequal radii, tight segments, concentric distinctness, and multi-corner bypass paths

This eliminates the class of bugs where routing computes curve_radii and rendering independently re-derives them with potentially different logic.

PR 4 of the refactoring series (after #178, #179, #180).

## Test plan
- [x] 490 tests pass (481 existing + 9 new)
- [x] Lint and format clean
- [ ] Review render diffs (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)