### PR TITLE
refactor: extract magic numbers to named constants

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -244,3 +244,18 @@ clear the label without overriding alternation.
 
 DEFAULT_LINE_PRIORITY: int = 999
 """Sentinel priority for lines not in the explicit line order."""
+
+# ---------------------------------------------------------------------------
+# Bubble centering
+# ---------------------------------------------------------------------------
+STATION_MOVE_TOLERANCE: float = 0.5
+"""Minimum absolute shift to consider a station as having moved.
+
+Used by bubble-centering post-processing to distinguish moved stations
+from untouched ones when checking column-companion consensus."""
+
+# ---------------------------------------------------------------------------
+# Phase-boundary guards
+# ---------------------------------------------------------------------------
+GUARD_TOLERANCE: float = 5.0
+"""Tolerance for phase-boundary invariant checks (port-on-boundary, etc.)."""

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -17,6 +17,7 @@ from nf_metro.layout.constants import (
     ENTRY_SHIFT_TB_CROSS,
     EXIT_GAP_MULTIPLIER,
     FONT_HEIGHT,
+    GUARD_TOLERANCE,
     ICON_INTER_GAP,
     JUNCTION_MARGIN,
     LABEL_BBOX_MARGIN,
@@ -102,7 +103,7 @@ def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
 
 def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:
     """After Phase 5+: ports must sit on their section's bounding box edge."""
-    tolerance = 5.0
+    tolerance = GUARD_TOLERANCE
     for pid, port in graph.ports.items():
         st = graph.stations.get(pid)
         sec = graph.sections.get(st.section_id or "") if st else None

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -25,6 +25,7 @@ from nf_metro.layout.constants import (
     MIN_STRAIGHT_EDGE,
     MIN_STRAIGHT_PORT,
     OFFSET_STEP,
+    STATION_MOVE_TOLERANCE,
 )
 from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.routing.common import (
@@ -1580,7 +1581,7 @@ def _apply_station_moves(
         flat_out,
     ) in candidates.items():
         station = graph.stations[sid]
-        if abs(new_x - station.x) > 0.5:
+        if abs(new_x - station.x) > STATION_MOVE_TOLERANCE:
             ox = original_x.get(sid, station.x)
             companions = []
             for other_sid, other_ox in original_x.items():
@@ -1639,10 +1640,14 @@ def _align_uncentered_siblings(
         if len(group) < 3:
             continue
         moved = [
-            sid for sid in group if abs(graph.stations[sid].x - original_x[sid]) > 0.5
+            sid
+            for sid in group
+            if abs(graph.stations[sid].x - original_x[sid]) > STATION_MOVE_TOLERANCE
         ]
         unmoved = [
-            sid for sid in group if abs(graph.stations[sid].x - original_x[sid]) <= 0.5
+            sid
+            for sid in group
+            if abs(graph.stations[sid].x - original_x[sid]) <= STATION_MOVE_TOLERANCE
         ]
         if not moved or not unmoved:
             continue
@@ -1656,10 +1661,10 @@ def _align_uncentered_siblings(
             old_x = graph.stations[sid].x
             graph.stations[sid].x = target_x
             for rp in routes_by_src.get(sid, []):
-                if abs(rp.points[0][0] - old_x) < 0.5:
+                if abs(rp.points[0][0] - old_x) < STATION_MOVE_TOLERANCE:
                     rp.points[0] = (target_x, rp.points[0][1])
             for rp in routes_by_tgt.get(sid, []):
-                if abs(rp.points[-1][0] - old_x) < 0.5:
+                if abs(rp.points[-1][0] - old_x) < STATION_MOVE_TOLERANCE:
                     rp.points[-1] = (target_x, rp.points[-1][1])
 
 

--- a/src/nf_metro/render/animate.py
+++ b/src/nf_metro/render/animate.py
@@ -13,6 +13,7 @@ from nf_metro.layout.routing import RoutedPath
 from nf_metro.layout.routing.corners import resolve_curve_radii
 from nf_metro.parser.model import MetroGraph
 from nf_metro.render.constants import (
+    ANIMATION_BALL_OPACITY,
     ANIMATION_CURVE_RADIUS,
     EDGE_CONNECT_TOLERANCE,
     MIN_ANIMATION_DURATION,
@@ -95,7 +96,8 @@ def render_animation(
             d.append(
                 draw.Raw(
                     f'<circle r="{theme.animation_ball_radius}" '
-                    f'fill="{theme.animation_ball_color}" opacity="0.9"'
+                    f'fill="{theme.animation_ball_color}" '
+                    f'opacity="{ANIMATION_BALL_OPACITY}"'
                     f"{stroke_attr}>"
                     f'<animateMotion dur="{max_dur:.2f}s" '
                     f"{kp_attrs}"

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -179,3 +179,30 @@ DEBUG_LABEL_OFFSET: float = 3.0
 
 DEBUG_HIDDEN_LABEL_OFFSET: float = 8.0
 """Y offset from hidden station circle to label text."""
+
+# ---------------------------------------------------------------------------
+# Icon styling
+# ---------------------------------------------------------------------------
+ICON_FOLD_OVERLAY_OPACITY: float = 0.15
+"""Opacity of the dog-ear fold overlay triangle."""
+
+ICON_FOLD_CREASE_RATIO: float = 0.6
+"""Stroke width ratio for the fold crease line relative to main stroke."""
+
+ICON_TEXT_OFFSET_RATIO: float = 0.15
+"""Vertical text offset as a fraction of icon height."""
+
+# ---------------------------------------------------------------------------
+# Animation styling
+# ---------------------------------------------------------------------------
+ANIMATION_BALL_OPACITY: str = "0.9"
+"""Opacity of animated balls traveling along lines."""
+
+# ---------------------------------------------------------------------------
+# Section labels
+# ---------------------------------------------------------------------------
+SECTION_LABEL_REGION_RATIO: float = 0.5
+"""Fraction of section width used as the label region."""
+
+ICON_CLEARANCE_MARGIN: float = 4.0
+"""Extra clearance around terminus icons when computing section bounds."""

--- a/src/nf_metro/render/icons.py
+++ b/src/nf_metro/render/icons.py
@@ -6,7 +6,12 @@ __all__ = ["render_file_icon"]
 
 import drawsvg as draw
 
-from nf_metro.render.constants import TEXT_VCENTER_DY
+from nf_metro.render.constants import (
+    ICON_FOLD_CREASE_RATIO,
+    ICON_FOLD_OVERLAY_OPACITY,
+    ICON_TEXT_OFFSET_RATIO,
+    TEXT_VCENTER_DY,
+)
 
 
 def train_icon_path(x: float, y: float, size: float = 12.0) -> str:
@@ -77,7 +82,7 @@ def render_file_icon(
     # Fold triangle (slightly darker overlay)
     fold_path = draw.Path(
         fill=stroke,
-        opacity=0.15,
+        opacity=ICON_FOLD_OVERLAY_OPACITY,
         stroke="none",
     )
     fold_path.M(x1 - f, y0)
@@ -90,7 +95,7 @@ def render_file_icon(
     crease = draw.Path(
         fill="none",
         stroke=stroke,
-        stroke_width=stroke_width * 0.6,
+        stroke_width=stroke_width * ICON_FOLD_CREASE_RATIO,
     )
     crease.M(x1 - f, y0)
     crease.L(x1 - f, y0 + f)
@@ -99,7 +104,7 @@ def render_file_icon(
 
     # Extension label centered in the body (shifted down slightly to
     # account for fold taking up top-right space)
-    text_y = cy + f * 0.15
+    text_y = cy + f * ICON_TEXT_OFFSET_RATIO
     d.append(
         draw.Text(
             label,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -28,12 +28,14 @@ from nf_metro.render.constants import (
     DEBUG_WAYPOINT_RADIUS,
     FALLBACK_LINE_COLOR,
     ICON_BBOX_MARGIN,
+    ICON_CLEARANCE_MARGIN,
     ICON_INTER_GAP,
     ICON_STATION_GAP,
     LEGEND_GAP,
     LEGEND_INSET,
     LOGO_Y_STANDALONE,
     SECTION_BOX_RADIUS,
+    SECTION_LABEL_REGION_RATIO,
     SECTION_LABEL_TEXT_OFFSET,
     SECTION_NUM_CIRCLE_R_LARGE,
     SECTION_NUM_FONT_SIZE,
@@ -196,7 +198,7 @@ def _compute_icon_obstacles(
     clearance from adjacent icons.
     """
     obstacles: list[tuple[float, float, float, float]] = []
-    margin = 4.0  # extra clearance around icons
+    margin = ICON_CLEARANCE_MARGIN
 
     for station in graph.stations.values():
         if not station.is_terminus or not station.terminus_labels:
@@ -517,7 +519,9 @@ def _render_first_class_sections(
         # label sits) but no BOTTOM exit, placing the label above would
         # overlap with incoming lines.  Only flip when the nearest top port
         # is close enough to actually conflict with the label.
-        label_region_max_x = section.bbox_x + section.bbox_w * 0.5
+        label_region_max_x = (
+            section.bbox_x + section.bbox_w * SECTION_LABEL_REGION_RATIO
+        )
         has_nearby_top_entry = any(
             graph.ports.get(pid)
             and graph.ports[pid].side == PortSide.TOP


### PR DESCRIPTION
## Summary
- Extract 8 bare numeric literals to named constants across layout and render modules
- Layout: `STATION_MOVE_TOLERANCE` (0.5, used 5x in bubble-centering), `GUARD_TOLERANCE` (5.0, phase-boundary guards)
- Render: `ICON_FOLD_OVERLAY_OPACITY`, `ICON_FOLD_CREASE_RATIO`, `ICON_TEXT_OFFSET_RATIO`, `ANIMATION_BALL_OPACITY`, `SECTION_LABEL_REGION_RATIO`, `ICON_CLEARANCE_MARGIN`
- Each constant has a docstring explaining its purpose
- 7 files touched, no logic changes

## Test plan
- [x] All 509 tests pass
- [x] Lint + format clean
- [ ] Visual review of topology renders (pure naming refactor, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)