### PR TITLE
refactor: unify section DAG construction

### DIFF
--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -27,9 +27,7 @@ def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> No
     layer count across sections in a row exceeds this threshold.
     """
     if len(graph.sections) <= 1:
-        graph.section_dag = SectionDAG(
-            successors={}, predecessors={}, edge_lines={}
-        )
+        graph.section_dag = SectionDAG(successors={}, predecessors={}, edge_lines={})
         return
 
     successors, predecessors, edge_lines = _build_section_dag(graph)

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -13,7 +13,7 @@ __all__ = ["infer_section_layout"]
 
 from collections import defaultdict, deque
 
-from nf_metro.parser.model import MetroGraph, PortSide
+from nf_metro.parser.model import MetroGraph, PortSide, SectionDAG
 
 
 def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> None:
@@ -27,9 +27,15 @@ def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> No
     layer count across sections in a row exceeds this threshold.
     """
     if len(graph.sections) <= 1:
+        graph.section_dag = SectionDAG(
+            successors={}, predecessors={}, edge_lines={}
+        )
         return
 
     successors, predecessors, edge_lines = _build_section_dag(graph)
+    graph.section_dag = SectionDAG(
+        successors=successors, predecessors=predecessors, edge_lines=edge_lines
+    )
 
     # Only run grid/direction/port inference if there are inter-section edges
     if not successors and not predecessors:

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -1,8 +1,9 @@
 """Section meta-graph layout: place sections on the canvas.
 
-Builds a DAG of sections from inter-section edges, uses topological
-layering for column assignment and row stacking within columns.
-Grid overrides can pin sections to specific positions.
+Uses the section DAG (built once by auto_layout and stored on
+MetroGraph) for topological layering of column assignment and
+row stacking within columns.  Grid overrides can pin sections
+to specific positions.
 """
 
 from __future__ import annotations
@@ -24,36 +25,6 @@ from nf_metro.layout.constants import (
     SECTION_HEADER_PROTRUSION,
 )
 from nf_metro.parser.model import MetroGraph, PortSide, Section
-
-
-def _build_section_dag(
-    graph: MetroGraph,
-) -> set[tuple[str, str]]:
-    """Build section dependency edges from graph edges, traversing junctions."""
-    section_edges: set[tuple[str, str]] = set()
-
-    junction_ids = set(graph.junctions)
-    junction_targets: dict[str, set[str]] = defaultdict(set)
-    junction_sources: dict[str, set[str]] = defaultdict(set)
-
-    for edge in graph.edges:
-        src_sec = graph.section_for_station(edge.source)
-        tgt_sec = graph.section_for_station(edge.target)
-
-        if edge.target in junction_ids and src_sec:
-            junction_sources[edge.target].add(src_sec)
-        elif edge.source in junction_ids and tgt_sec:
-            junction_targets[edge.source].add(tgt_sec)
-        elif src_sec and tgt_sec and src_sec != tgt_sec:
-            section_edges.add((src_sec, tgt_sec))
-
-    for jid in junction_ids:
-        for src_sec in junction_sources.get(jid, set()):
-            for tgt_sec in junction_targets.get(jid, set()):
-                if src_sec != tgt_sec:
-                    section_edges.add((src_sec, tgt_sec))
-
-    return section_edges
 
 
 def _assign_grid_layout(
@@ -327,7 +298,7 @@ def place_sections(
     if not graph.sections:
         return
 
-    section_edges = _build_section_dag(graph)
+    section_edges = graph.section_dag.section_edges
     col_assign, row_assign = _assign_grid_layout(graph, section_edges)
     min_col, max_col = _compute_section_offsets(
         graph, col_assign, row_assign, section_x_gap, section_y_gap

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -6,6 +6,25 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 
+@dataclass
+class SectionDAG:
+    """Section-level dependency graph built from inter-section edges.
+
+    Built once during auto-layout (before _resolve_sections rewrites edges
+    through ports and junctions) and stored on MetroGraph for reuse by
+    section_placement and other layout phases.
+    """
+
+    successors: dict[str, set[str]]
+    predecessors: dict[str, set[str]]
+    edge_lines: dict[tuple[str, str], set[str]]
+
+    @property
+    def section_edges(self) -> set[tuple[str, str]]:
+        """All (src_section, tgt_section) pairs."""
+        return set(self.edge_lines.keys())
+
+
 class PortSide(Enum):
     """Side of a section boundary where a port is located."""
 
@@ -140,6 +159,8 @@ class MetroGraph:
     compact_offsets: bool = False
     legend_position: str = "bottom"
     logo_path: str = ""
+    # Section dependency graph (populated by auto_layout)
+    section_dag: SectionDAG | None = None
     # Section IDs that had explicit %%metro direction: directives
     _explicit_directions: set[str] = field(default_factory=set)
     # Pending terminus designations: station_id -> list of extension labels


### PR DESCRIPTION
## Summary

- Add `SectionDAG` dataclass to `parser/model.py` with `successors`, `predecessors`, `edge_lines`, and a `section_edges` property
- Build the DAG once in `auto_layout.py` and store on `MetroGraph.section_dag`
- Remove duplicate `_build_section_dag()` from `section_placement.py` (28 lines), read from `graph.section_dag` instead

The two builders produced equivalent section-to-section connectivity, but the post-resolve version in section_placement had to trace through junctions to recover the same pairs that auto_layout trivially extracts from raw edges.

Closes #193

## Test plan

- [x] All 509 tests pass unchanged
- [x] Linter clean (`ruff check src/ tests/`)
- [x] Single `_build_section_dag` definition remains (in auto_layout.py)
- [ ] Visual review of rnaseq render (should be pixel-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)