### PR TITLE
chore: align skills with CI render preview workflow

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -26,7 +26,7 @@ git worktree add /tmp/nf-metro-fix-<N> -b fix/<N>-<slug> origin/main
 # Fix environment
 ulimit -n 1000000 && export CONDA_OVERRIDE_OSX=15.0 && /opt/homebrew/bin/micromamba create -n nf-metro-fix-<N> python=3.11 cairo -y
 source ~/.local/bin/mm-activate nf-metro-fix-<N>
-pip install -e "/tmp/nf-metro-fix-<N>[dev]" && pip install cairosvg
+pip install -e "/tmp/nf-metro-fix-<N>[docs]"
 
 # Baseline environment (shared across issues, create only if missing)
 if [ ! -d "/Users/jonathan.manning/micromamba/envs/nf-metro-main" ]; then
@@ -34,7 +34,7 @@ if [ ! -d "/Users/jonathan.manning/micromamba/envs/nf-metro-main" ]; then
 fi
 cd /Users/jonathan.manning/projects/nf-metro && git checkout main && git pull origin main
 source ~/.local/bin/mm-activate nf-metro-main
-pip install -e "/Users/jonathan.manning/projects/nf-metro[dev]" && pip install cairosvg
+pip install -e "/Users/jonathan.manning/projects/nf-metro[docs]"
 ```
 
 All subsequent work happens inside `/tmp/nf-metro-fix-<N>`.
@@ -73,11 +73,17 @@ Each env must point at a **different source directory** (main repo vs worktree).
 
 **STOP and ask the user to review.** If identical or non-reproducing, discuss before proceeding.
 
-### 4b: Full regression check
+### 4b: Full regression check (handled by CI)
 
-Ask the user to run `/render-topologies` for a pixel-level diff of all `.mmd` renders against main. That skill handles baseline rendering, branch rendering, diffing, and opening only the changed BEFORE/AFTER pairs.
+The PR render preview workflow (`.github/workflows/pr-renders.yml`) automatically renders all gallery examples on both the PR branch and base, generates a visual diff page, and posts a sticky comment on the PR with the preview link:
 
-**STOP and wait for the user to confirm no regressions.** If they spot problems, return to Phase 3.
+```
+https://pinin4fjords.github.io/nf-metro/_pr/<PR_NUMBER>/
+```
+
+This replaces the local `/render-topologies` step for most cases. After creating the PR in Phase 5, wait for the CI to post the preview link, then ask the user to review it.
+
+For **pre-push confidence** (before the PR exists), you can still run `/render-topologies` locally. This is optional but useful when the change is risky or the user wants early feedback.
 
 ## Phase 5: Commit and PR
 
@@ -94,7 +100,7 @@ Fixes #<N>
 ## Test plan
 - [ ] pytest passes
 - [ ] ruff check clean
-- [ ] Visual review of all topology renders
+- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/<PR_NUMBER>/)
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF

--- a/.claude/skills/render-topologies/SKILL.md
+++ b/.claude/skills/render-topologies/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: render-topologies
-description: Render all .mmd files to PNG, pixel-diff against main, and open only changed renders as BEFORE/AFTER pairs in Preview. Use after layout or rendering changes to check for visual regressions. Works in worktree mode (fix branch vs main) or standalone mode (current working tree vs main). Companion to the fix-issue skill, which delegates full regression checks here.
+description: Render all gallery examples to PNG, pixel-diff against main, and open only changed renders as BEFORE/AFTER pairs in Preview. Uses the same build_gallery.py script as the CI PR render preview, so local and CI results match. Use after layout or rendering changes to check for visual regressions before pushing. Companion to the fix-issue skill.
 disable-model-invocation: true
 allowed-tools: Bash(rm -rf *), Bash(python *), Bash(open *), Bash(cd *), Bash(git *), Bash(source *), Bash(pip *), Bash(cp *)
 ---
 
 # Render Topologies
 
-Pixel-diff all `.mmd` renders between the current branch and `origin/main`. Opens only changed renders as numbered BEFORE/AFTER pairs in Preview.
+Pixel-diff all gallery renders between the current branch and `origin/main`. Uses `scripts/build_gallery.py` (the same script CI runs), so local results match the PR render preview. Opens only changed renders as numbered BEFORE/AFTER pairs in Preview.
 
 ## Step 1: Detect context
 
@@ -18,13 +18,27 @@ Determine the working mode:
 
 ## Step 2: Render baseline from main
 
-Update the main repo checkout and render using the shared `nf-metro-main` baseline environment:
+Update the main repo checkout and render using the shared `nf-metro-main` baseline environment. Install with `[docs]` extras (same as CI).
 
 ```bash
 cd /Users/jonathan.manning/projects/nf-metro && git fetch origin main && git checkout main && git pull origin main
-source ~/.local/bin/mm-activate nf-metro-main && pip install -e "/Users/jonathan.manning/projects/nf-metro[dev]" -q
-cd /Users/jonathan.manning/projects/nf-metro && python scripts/render_topologies.py
-# Note the output directory → MAIN_DIR
+source ~/.local/bin/mm-activate nf-metro-main && pip install -e "/Users/jonathan.manning/projects/nf-metro[docs]" -q
+cd /Users/jonathan.manning/projects/nf-metro && python scripts/build_gallery.py
+# SVGs are in docs/assets/renders/ → copy to a baseline dir
+rm -rf /tmp/nf_metro_renders_main && mkdir -p /tmp/nf_metro_renders_main
+cp docs/assets/renders/*.svg /tmp/nf_metro_renders_main/
+```
+
+Convert SVGs to PNGs for pixel diffing:
+
+```bash
+source ~/.local/bin/mm-activate nf-metro-main
+python -c "
+import cairosvg
+from pathlib import Path
+for svg in sorted(Path('/tmp/nf_metro_renders_main').glob('*.svg')):
+    cairosvg.svg2png(url=str(svg), write_to=str(svg.with_suffix('.png')), scale=2)
+"
 ```
 
 ## Step 3: Render from the current branch
@@ -34,14 +48,27 @@ Switch back to the branch first (standalone mode) or use the worktree path:
 ```bash
 # Standalone: switch back to the branch
 cd /Users/jonathan.manning/projects/nf-metro && git checkout <branch-name>
-source ~/.local/bin/mm-activate nf-metro && pip install -e ".[dev]" -q
-python scripts/render_topologies.py
-# Note the output directory → BRANCH_DIR
+source ~/.local/bin/mm-activate nf-metro && pip install -e ".[docs]" -q
+python scripts/build_gallery.py
+rm -rf /tmp/nf_metro_renders_branch && mkdir -p /tmp/nf_metro_renders_branch
+cp docs/assets/renders/*.svg /tmp/nf_metro_renders_branch/
 
 # Worktree: use worktree path and env
-source ~/.local/bin/mm-activate nf-metro-fix-<N> && pip install -e "/tmp/nf-metro-fix-<N>[dev]" -q
-cd /tmp/nf-metro-fix-<N> && python scripts/render_topologies.py
-# Note the output directory → BRANCH_DIR
+source ~/.local/bin/mm-activate nf-metro-fix-<N> && pip install -e "/tmp/nf-metro-fix-<N>[docs]" -q
+cd /tmp/nf-metro-fix-<N> && python scripts/build_gallery.py
+rm -rf /tmp/nf_metro_renders_branch && mkdir -p /tmp/nf_metro_renders_branch
+cp /tmp/nf-metro-fix-<N>/docs/assets/renders/*.svg /tmp/nf_metro_renders_branch/
+```
+
+Convert SVGs to PNGs:
+
+```bash
+python -c "
+import cairosvg
+from pathlib import Path
+for svg in sorted(Path('/tmp/nf_metro_renders_branch').glob('*.svg')):
+    cairosvg.svg2png(url=str(svg), write_to=str(svg.with_suffix('.png')), scale=2)
+"
 ```
 
 ## Step 4: Diff and open changed renders
@@ -56,8 +83,8 @@ import os, glob, shutil
 for f in glob.glob("/tmp/*_BEFORE.png") + glob.glob("/tmp/*_AFTER.png"):
     os.remove(f)
 
-main_dir = "<MAIN_DIR>"
-branch_dir = "<BRANCH_DIR>"
+main_dir = "/tmp/nf_metro_renders_main"
+branch_dir = "/tmp/nf_metro_renders_branch"
 
 pngs = sorted(f for f in os.listdir(branch_dir) if f.endswith('.png'))
 changed = []
@@ -99,7 +126,9 @@ The numbered prefixes (`01_`, `02_`, ...) ensure Preview orders them correctly w
 
 ## Notes
 
-- Render script: `scripts/render_topologies.py` (discovers all `.mmd` files under project root).
-- Nextflow fixtures (`tests/fixtures/nextflow/*.mmd`) are auto-detected and converted before rendering.
+- Render script: `scripts/build_gallery.py` (same as CI PR render preview workflow).
+- Nextflow fixtures (`tests/fixtures/nextflow/*.mmd`) are included in the gallery.
 - Baseline always uses `nf-metro-main` env + main repo updated to `origin/main`.
+- Install with `[docs]` extras (not `[dev]`) to match CI dependencies.
+- After a PR is created, CI renders the authoritative diff at `https://pinin4fjords.github.io/nf-metro/_pr/<PR_NUMBER>/`.
 - To render a single file: `python -m nf_metro render <file.mmd> -o /tmp/output.svg`


### PR DESCRIPTION
## Summary
- **fix-issue skill**: Phase 4b now directs to the CI render preview page instead of requiring a local `/render-topologies` run. PR test plan links directly to the preview. Environments install with `[docs]` extras to match CI.
- **render-topologies skill**: Switches from `render_topologies.py` to `build_gallery.py` (the same script CI runs in `pr-renders.yml`), so local renders match CI exactly. Fixed output dirs replace placeholder temp dirs.

The two scripts cover the same set of `.mmd` files (verified: 38 unique sources, the only "difference" is `simple_pipeline.mmd` which is content-identical to `guide/01_minimal.mmd` and deduplicated by hash in `render_topologies.py`).

## Test plan
- [x] Verified `build_gallery.py` and `render_topologies.py` cover the same source files
- [ ] Skills-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)