### PR TITLE
chore: add timestamp to render diff report

### DIFF
--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -21,6 +21,7 @@ import json
 import shutil
 import sys
 from collections import defaultdict
+from datetime import datetime, timezone
 from pathlib import Path
 
 HTML_TEMPLATE = """\
@@ -354,7 +355,11 @@ def build_diff(
         parts.append(f"{n_added} added")
     if n_removed:
         parts.append(f"{n_removed} removed")
-    summary = f"{', '.join(parts)} out of {len(all_names)} total renders."
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    summary = (
+        f"{', '.join(parts)} out of {len(all_names)} total renders."
+        f" Generated {timestamp}."
+    )
 
     # Table of contents (grouped by section)
     toc_parts = ['<div class="toc">\n<h2>Changed renders</h2>']


### PR DESCRIPTION
## Summary

- Adds a UTC timestamp to the summary line of the CI render diff report, e.g. "3 changed out of 25 total renders. Generated 2026-04-05 00:56 UTC."

Makes it easy to tell whether you're looking at a stale render or the latest CI output.

## Test plan

- [ ] CI render diff page shows the timestamp in the summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)