### PR TITLE
feat: add stacked-files and folder icon types

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ These are automatically rewritten into port-to-port connections with junction st
 | `%%metro legend: <position>` | Global | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, `none` |
 | `%%metro line_order: <strategy>` | Global | Line ordering for track assignment: `definition` (default) or `span` (longest-spanning lines get inner tracks) |
 | `%%metro file: <station> \| <label>` | Global | Mark a station as a file terminus with a document icon |
+| `%%metro files: <station> \| <label>` | Global | Mark a station with a stacked-documents icon (e.g. paired files) |
+| `%%metro dir: <station> \| <label>` | Global | Mark a station with a folder icon (e.g. output directory) |
 | `%%metro compact_offsets: true` | Global | Use compact per-station offsets instead of global line-priority slots (better for dense maps with few lines) |
 | `%%metro legend_min_height: <pixels>` | Global | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 | `%%metro entry: <side> \| <lines>` | Section | Entry port hint |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -300,6 +300,28 @@ The FASTQ icon at the start of the Analysis section shows the pipeline input. Th
 
 For a complex real-world example using file icons, see [`examples/rnaseq_sections.mmd`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/rnaseq_sections.mmd).
 
+### Paired/multiple files
+
+When a station represents paired input files (e.g. paired-end FASTQ reads), use `%%metro files:` instead of `%%metro file:`. This renders a stacked-documents icon to visually distinguish it from a single file:
+
+```text
+%%metro files: reads_in | FASTQ
+```
+
+![Paired file icons example](assets/renders/05c_files_icon.svg)
+
+### Folder icons
+
+For stations that represent a directory of output files rather than a single file, use `%%metro dir:`:
+
+```text
+%%metro dir: results_out | Results
+```
+
+![Folder icons example](assets/renders/05d_folder_icon.svg)
+
+All three directives (`file:`, `files:`, `dir:`) work the same way: pair a station ID with a label, give the station a blank label (`[ ]`), and connect it with normal edges. The only difference is the rendered icon shape.
+
 ## 6. Hidden stations
 
 Sometimes you need a branching or merging point in the graph that doesn't represent a real pipeline step. For example, lines might diverge at a point where no tool is actually run. Adding a visible station there clutters the diagram with a meaningless marker.
@@ -396,6 +418,8 @@ These go at the top of the file, before `graph LR`.
 | `%%metro legend: <position>` | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, or `none` |
 | `%%metro line_order: <strategy>` | Line ordering for track assignment: `definition` (default, preserves `.mmd` order) or `span` (longest-spanning lines get inner tracks) |
 | `%%metro file: <station> \| <label>` | Mark a station as a file terminus with a document icon |
+| `%%metro files: <station> \| <label>` | Mark a station with a stacked-documents icon (e.g. paired files) |
+| `%%metro dir: <station> \| <label>` | Mark a station with a folder icon (e.g. output directory) |
 | `%%metro compact_offsets: true` | Compact line offsets within stations (see below) |
 | `%%metro legend_min_height: <pixels>` | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 

--- a/docs/nextflow.md
+++ b/docs/nextflow.md
@@ -335,6 +335,11 @@ The FASTQ icon at the start of Pre-processing and the FASTA icon at the start of
 
 For a more complex example with multiple file icons, see the nf-core/rnaseq diagram at [`examples/rnaseq_sections.mmd`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/rnaseq_sections.mmd), which uses FASTQ input icons and HTML report output icons across several sections.
 
+Two additional icon variants are available for common Nextflow patterns:
+
+- **`%%metro files:`** renders a stacked-documents icon, useful for paired-end reads or multi-file inputs (e.g. `%%metro files: reads_in | FASTQ`)
+- **`%%metro dir:`** renders a folder icon, useful for directory outputs like `publishDir` results (e.g. `%%metro dir: results_out | Results`)
+
 ## How the converter works
 
 Nextflow's `-with-dag` output contains three types of nodes: processes (the actual pipeline steps), channels/values (data plumbing), and operators (Nextflow internals like `mix` and `collect`). Here is the raw DAG for the flat pipeline example:

--- a/examples/guide/05c_files_icon.mmd
+++ b/examples/guide/05c_files_icon.mmd
@@ -1,0 +1,25 @@
+%%metro title: Paired File Icons
+%%metro style: dark
+%%metro files: reads_in | FASTQ
+%%metro file: report_out | HTML
+%%metro line: main | Main | #4CAF50
+%%metro line: qc | Quality Control | #2196F3
+
+graph LR
+    subgraph analysis [Analysis]
+        reads_in[ ]
+        trim[Trimming]
+        align[Alignment]
+        quant[Quantification]
+        reads_in -->|main,qc| trim
+        trim -->|main| align
+        align -->|main| quant
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+        report_out[ ]
+        trim -->|qc| multiqc
+        quant -->|qc| multiqc
+        multiqc -->|qc| report_out
+    end

--- a/examples/guide/05d_folder_icon.mmd
+++ b/examples/guide/05d_folder_icon.mmd
@@ -1,0 +1,25 @@
+%%metro title: Folder Icons
+%%metro style: dark
+%%metro file: reads_in | FASTQ
+%%metro dir: results_out | Results
+%%metro line: main | Main | #4CAF50
+%%metro line: qc | Quality Control | #2196F3
+
+graph LR
+    subgraph analysis [Analysis]
+        reads_in[ ]
+        trim[Trimming]
+        align[Alignment]
+        quant[Quantification]
+        reads_in -->|main,qc| trim
+        trim -->|main| align
+        align -->|main| quant
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+        results_out[ ]
+        trim -->|qc| multiqc
+        quant -->|qc| multiqc
+        multiqc -->|qc| results_out
+    end

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -12,6 +12,7 @@ import re
 import warnings
 
 from nf_metro.parser.model import (
+    VALID_ICON_TYPES,
     VALID_LINE_STYLES,
     Edge,
     MetroGraph,
@@ -159,10 +160,11 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
         _resolve_sections(graph)
 
     # Apply pending terminus designations
-    for station_id, ext_labels in graph._pending_terminus.items():
+    for station_id, entries in graph._pending_terminus.items():
         station = graph.stations.get(station_id)
         if station:
-            station.terminus_labels = ext_labels
+            station.terminus_labels = [label for label, _ in entries]
+            station.terminus_icon_types = [icon_type for _, icon_type in entries]
 
     return graph
 
@@ -233,13 +235,16 @@ def _parse_directive(
         pos = content[len("legend:") :].strip().lower()
         if pos in ("bl", "br", "tl", "tr", "bottom", "right", "none"):
             graph.legend_position = pos
-    elif content.startswith("file:"):
-        parts = content[len("file:") :].strip().split("|")
+    elif ":" in content and content.split(":", 1)[0] in VALID_ICON_TYPES:
+        icon_type, rest = content.split(":", 1)
+        parts = rest.strip().split("|")
         if len(parts) >= 2:
             station_id = parts[0].strip()
             raw_labels = parts[1].strip()
             labels = [s.strip() for s in raw_labels.split(",") if s.strip()]
-            graph._pending_terminus.setdefault(station_id, []).extend(labels)
+            graph._pending_terminus.setdefault(station_id, []).extend(
+                (label, icon_type) for label in labels
+            )
 
 
 def _parse_port_hint(

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -36,6 +36,11 @@ class PortSide(Enum):
 
 VALID_LINE_STYLES = ("solid", "dashed", "dotted")
 
+ICON_TYPE_FILE = "file"
+ICON_TYPE_FILES = "files"
+ICON_TYPE_DIR = "dir"
+VALID_ICON_TYPES = (ICON_TYPE_FILE, ICON_TYPE_FILES, ICON_TYPE_DIR)
+
 
 @dataclass
 class MetroLine:
@@ -57,6 +62,7 @@ class Station:
     is_port: bool = False
     is_hidden: bool = False
     terminus_labels: list[str] = field(default_factory=list)
+    terminus_icon_types: list[str] = field(default_factory=list)
     # Populated by layout engine
     x: float = 0.0
     y: float = 0.0
@@ -169,8 +175,8 @@ class MetroGraph:
     section_dag: SectionDAG | None = None
     # Section IDs that had explicit %%metro direction: directives
     _explicit_directions: set[str] = field(default_factory=set)
-    # Pending terminus designations: station_id -> list of extension labels
-    _pending_terminus: dict[str, list[str]] = field(default_factory=dict)
+    # Pending terminus designations: station_id -> list of (label, icon_type)
+    _pending_terminus: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
     # Lazy cache for station_lines(); invalidated on edge mutation
     _station_lines_cache: dict[str, list[str]] | None = field(default=None, repr=False)
     # Grid alignment metadata (populated by Phase 2.5 _align_row_y_grids)

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -195,6 +195,15 @@ ICON_FOLD_CREASE_RATIO: float = 0.6
 ICON_TEXT_OFFSET_RATIO: float = 0.15
 """Vertical text offset as a fraction of icon height."""
 
+FILES_ICON_OFFSET_RATIO: float = 0.15
+"""Offset of the back page as a fraction of icon width/height (stacked files icon)."""
+
+FOLDER_TAB_HEIGHT_RATIO: float = 0.2
+"""Height of the folder tab as a fraction of total icon height."""
+
+FOLDER_TAB_WIDTH_RATIO: float = 0.4
+"""Width of the folder tab as a fraction of total icon width."""
+
 # ---------------------------------------------------------------------------
 # Animation styling
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/render/icons.py
+++ b/src/nf_metro/render/icons.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-__all__ = ["render_file_icon"]
+__all__ = ["render_file_icon", "render_files_icon", "render_folder_icon"]
 
 import drawsvg as draw
 
 from nf_metro.render.constants import (
+    FILES_ICON_OFFSET_RATIO,
+    FOLDER_TAB_HEIGHT_RATIO,
+    FOLDER_TAB_WIDTH_RATIO,
     ICON_FOLD_CREASE_RATIO,
     ICON_FOLD_OVERLAY_OPACITY,
     ICON_TEXT_OFFSET_RATIO,
@@ -105,6 +108,153 @@ def render_file_icon(
     # Extension label centered in the body (shifted down slightly to
     # account for fold taking up top-right space)
     text_y = cy + f * ICON_TEXT_OFFSET_RATIO
+    d.append(
+        draw.Text(
+            label,
+            font_size,
+            cx,
+            text_y,
+            fill=font_color,
+            font_family=font_family,
+            font_weight="bold",
+            text_anchor="middle",
+            dy=TEXT_VCENTER_DY,
+        )
+    )
+
+
+def render_files_icon(
+    d: draw.Drawing,
+    cx: float,
+    cy: float,
+    width: float,
+    height: float,
+    fold_size: float,
+    fill: str,
+    stroke: str,
+    stroke_width: float,
+    corner_radius: float,
+    label: str,
+    font_size: float,
+    font_color: str,
+    font_family: str,
+) -> None:
+    """Render a stacked-files icon (two overlapping documents).
+
+    The icon is centered on (cx, cy). A slightly offset back page is drawn
+    first, then a front page (identical to the single file icon) on top.
+    """
+    off = width * FILES_ICON_OFFSET_RATIO
+
+    # Back page (offset up-left)
+    render_file_icon(
+        d,
+        cx=cx - off,
+        cy=cy - off,
+        width=width,
+        height=height,
+        fold_size=fold_size,
+        fill=fill,
+        stroke=stroke,
+        stroke_width=stroke_width,
+        corner_radius=corner_radius,
+        label="",
+        font_size=font_size,
+        font_color=font_color,
+        font_family=font_family,
+    )
+
+    # Front page (main position)
+    render_file_icon(
+        d,
+        cx=cx + off,
+        cy=cy + off,
+        width=width,
+        height=height,
+        fold_size=fold_size,
+        fill=fill,
+        stroke=stroke,
+        stroke_width=stroke_width,
+        corner_radius=corner_radius,
+        label=label,
+        font_size=font_size,
+        font_color=font_color,
+        font_family=font_family,
+    )
+
+
+def render_folder_icon(
+    d: draw.Drawing,
+    cx: float,
+    cy: float,
+    width: float,
+    height: float,
+    fill: str,
+    stroke: str,
+    stroke_width: float,
+    corner_radius: float,
+    label: str,
+    font_size: float,
+    font_color: str,
+    font_family: str,
+) -> None:
+    """Render a folder icon with a tab on the top-left.
+
+    The icon is centered on (cx, cy). The shape is a rectangle with a
+    smaller tab rectangle protruding from the top-left corner.
+    """
+    hw = width / 2
+    hh = height / 2
+    r = corner_radius
+
+    tab_h = height * FOLDER_TAB_HEIGHT_RATIO
+    tab_w = width * FOLDER_TAB_WIDTH_RATIO
+
+    # The body sits below the tab
+    body_top = cy - hh + tab_h
+    x0 = cx - hw
+    x1 = cx + hw
+    y1 = cy + hh
+
+    # Tab shape (top-left rectangle with rounded top corners)
+    tab = draw.Path(
+        fill=fill,
+        stroke=stroke,
+        stroke_width=stroke_width,
+        stroke_linejoin="round",
+    )
+    tab_top = cy - hh
+    tab_right = x0 + tab_w
+    tab.M(x0 + r, tab_top)
+    tab.L(tab_right - r, tab_top)
+    tab.Q(tab_right, tab_top, tab_right, tab_top + r)
+    tab.L(tab_right, body_top)
+    tab.L(x0, body_top)
+    tab.L(x0, tab_top + r)
+    tab.Q(x0, tab_top, x0 + r, tab_top)
+    tab.Z()
+    d.append(tab)
+
+    # Body rectangle (rounded bottom corners + top-right corner)
+    body = draw.Path(
+        fill=fill,
+        stroke=stroke,
+        stroke_width=stroke_width,
+        stroke_linejoin="round",
+    )
+    body.M(x0, body_top)
+    body.L(x1 - r, body_top)
+    body.Q(x1, body_top, x1, body_top + r)
+    body.L(x1, y1 - r)
+    body.Q(x1, y1, x1 - r, y1)
+    body.L(x0 + r, y1)
+    body.Q(x0, y1, x0, y1 - r)
+    body.L(x0, body_top)
+    body.Z()
+    d.append(body)
+
+    # Label centered in the body
+    text_y = (body_top + y1) / 2
     d.append(
         draw.Text(
             label,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -13,7 +13,15 @@ from nf_metro.layout.constants import LABEL_LINE_HEIGHT
 from nf_metro.layout.labels import LabelPlacement, place_labels
 from nf_metro.layout.routing import RoutedPath, compute_station_offsets, route_edges
 from nf_metro.layout.routing.corners import resolve_curve_radii
-from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
+from nf_metro.parser.model import (
+    ICON_TYPE_DIR,
+    ICON_TYPE_FILE,
+    ICON_TYPE_FILES,
+    MetroGraph,
+    PortSide,
+    Section,
+    Station,
+)
 from nf_metro.render.constants import (
     CANVAS_PADDING,
     DEBUG_DIAMOND_RADIUS,
@@ -28,6 +36,7 @@ from nf_metro.render.constants import (
     DEBUG_WAYPOINT_COLOR,
     DEBUG_WAYPOINT_RADIUS,
     FALLBACK_LINE_COLOR,
+    FILES_ICON_OFFSET_RATIO,
     ICON_BBOX_MARGIN,
     ICON_CLEARANCE_MARGIN,
     ICON_INTER_GAP,
@@ -51,7 +60,11 @@ from nf_metro.render.constants import (
     WATERMARK_PADDING_RATIO,
     WATERMARK_Y_INSET,
 )
-from nf_metro.render.icons import render_file_icon
+from nf_metro.render.icons import (
+    render_file_icon,
+    render_files_icon,
+    render_folder_icon,
+)
 from nf_metro.render.legend import compute_legend_dimensions, render_legend
 from nf_metro.render.style import Theme
 
@@ -235,6 +248,12 @@ def _compute_icon_obstacles(
         icon_gap = r + ICON_STATION_GAP
         total_w = n * theme.terminus_width + (n - 1) * ICON_INTER_GAP
 
+        # Stacked-files icons extend beyond nominal size by the offset
+        has_stacked = ICON_TYPE_FILES in (station.terminus_icon_types or [])
+        stacked_pad = (
+            theme.terminus_width * FILES_ICON_OFFSET_RATIO if has_stacked else 0.0
+        )
+
         line_offs = [
             station_offsets.get((station.id, lid), 0.0)
             for lid in graph.station_lines(station.id)
@@ -244,14 +263,14 @@ def _compute_icon_obstacles(
         icon_cy = station.y + (min_off + max_off) / 2
 
         if icons_go_right:
-            x_min = station.x + icon_gap
-            x_max = x_min + total_w
+            x_min = station.x + icon_gap - stacked_pad
+            x_max = x_min + total_w + 2 * stacked_pad
         else:
-            x_max = station.x - icon_gap
-            x_min = x_max - total_w
+            x_max = station.x - icon_gap + stacked_pad
+            x_min = x_max - total_w - 2 * stacked_pad
 
-        y_min = icon_cy - theme.terminus_height / 2
-        y_max = icon_cy + theme.terminus_height / 2
+        y_min = icon_cy - theme.terminus_height / 2 - stacked_pad
+        y_max = icon_cy + theme.terminus_height / 2 + stacked_pad
 
         obstacles.append(
             (
@@ -826,7 +845,13 @@ def _render_terminus_icons(
 
     icon_cy = station.y + (min_off + max_off) / 2
 
+    icon_types = station.terminus_icon_types or [ICON_TYPE_FILE] * len(
+        station.terminus_labels
+    )
+
     for i, label in enumerate(station.terminus_labels):
+        icon_type = icon_types[i] if i < len(icon_types) else ICON_TYPE_FILE
+
         if icons_go_right:
             icon_cx = base_cx + i * icon_step
         else:
@@ -841,13 +866,12 @@ def _render_terminus_icons(
                 section.bbox_x + icon_half_w + ICON_BBOX_MARGIN,
                 min(icon_cx, icon_right),
             )
-        render_file_icon(
-            d,
+
+        common = dict(
             cx=icon_cx,
             cy=icon_cy,
             width=theme.terminus_width,
             height=theme.terminus_height,
-            fold_size=theme.terminus_fold_size,
             fill=theme.terminus_fill or theme.station_fill,
             stroke=theme.terminus_stroke or theme.station_stroke,
             stroke_width=theme.terminus_stroke_width,
@@ -857,6 +881,13 @@ def _render_terminus_icons(
             font_color=TERMINUS_FONT_COLOR,
             font_family=theme.label_font_family,
         )
+
+        if icon_type == ICON_TYPE_DIR:
+            render_folder_icon(d, **common)
+        elif icon_type == ICON_TYPE_FILES:
+            render_files_icon(d, **common, fold_size=theme.terminus_fold_size)
+        else:
+            render_file_icon(d, **common, fold_size=theme.terminus_fold_size)
 
 
 def _render_labels(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -627,6 +627,102 @@ def test_parse_no_file_icon_not_terminus():
     assert graph.stations["a"].terminus_labels == []
 
 
+def test_parse_files_directive():
+    """%%metro files: directive produces terminus with 'files' icon type."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro files: reads_in | FASTQ\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    st = graph.stations["reads_in"]
+    assert st.is_terminus
+    assert st.terminus_labels == ["FASTQ"]
+    assert st.terminus_icon_types == ["files"]
+
+
+def test_parse_dir_directive():
+    """%%metro dir: directive produces terminus with 'dir' icon type."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro dir: output | Results\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        trim[Trim]\n"
+        "        output[ ]\n"
+        "        trim -->|main| output\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    st = graph.stations["output"]
+    assert st.is_terminus
+    assert st.terminus_labels == ["Results"]
+    assert st.terminus_icon_types == ["dir"]
+
+
+def test_parse_mixed_icon_types():
+    """Different directives on different stations produce correct types."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: src | FASTQ\n"
+        "%%metro files: paired | FASTQ\n"
+        "%%metro dir: out | Results\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        src[ ]\n"
+        "        paired[ ]\n"
+        "        step[Step]\n"
+        "        out[ ]\n"
+        "        src -->|main| step\n"
+        "        paired -->|main| step\n"
+        "        step -->|main| out\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["src"].terminus_icon_types == ["file"]
+    assert graph.stations["paired"].terminus_icon_types == ["files"]
+    assert graph.stations["out"].terminus_icon_types == ["dir"]
+
+
+def test_parse_files_comma_separated():
+    """Comma-separated labels in %%metro files: share the same icon type."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro files: reads_in | FASTQ, BAM\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    st = graph.stations["reads_in"]
+    assert st.terminus_labels == ["FASTQ", "BAM"]
+    assert st.terminus_icon_types == ["files", "files"]
+
+
+def test_parse_file_icon_type_default():
+    """%%metro file: directive defaults to 'file' icon type."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | FASTQ\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["reads_in"].terminus_icon_types == ["file"]
+
+
 def test_parse_legend_min_height():
     text = "%%metro legend_min_height: 72\ngraph LR\n"
     graph = parse_metro_mermaid(text)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -315,3 +315,84 @@ def test_render_multi_icon_fixture():
     assert "H5AD" in svg
     root = ET.fromstring(svg)
     assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_render_files_icon():
+    """%%metro files: directive renders stacked file icons."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro files: reads_in | FASTQ\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    assert "FASTQ" in svg
+    root = ET.fromstring(svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_render_folder_icon():
+    """%%metro dir: directive renders folder icon."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro dir: output | Results\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        trim[Trim]\n"
+        "        output[ ]\n"
+        "        trim -->|main| output\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    assert "Results" in svg
+    root = ET.fromstring(svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_render_mixed_icon_types():
+    """Mixed file/files/dir icons all render."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: src | FASTA\n"
+        "%%metro files: paired | FASTQ\n"
+        "%%metro dir: out | Results\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        src[ ]\n"
+        "        paired[ ]\n"
+        "        step[Step]\n"
+        "        out[ ]\n"
+        "        src -->|main| step\n"
+        "        paired -->|main| step\n"
+        "        step -->|main| out\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    assert "FASTA" in svg
+    assert "FASTQ" in svg
+    assert "Results" in svg
+    root = ET.fromstring(svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_render_icon_type_guide_fixtures():
+    """Guide examples for files and dir icons render without errors."""
+    from pathlib import Path
+
+    examples = Path(__file__).parent.parent / "examples" / "guide"
+    for fname in ("05c_files_icon.mmd", "05d_folder_icon.mmd"):
+        fpath = examples / fname
+        assert fpath.exists(), f"Missing fixture: {fpath}"
+        text = fpath.read_text()
+        graph = parse_metro_mermaid(text)
+        compute_layout(graph)
+        svg = render_svg(graph, NFCORE_THEME)
+        root = ET.fromstring(svg)
+        assert root.tag.endswith("svg") or "svg" in root.tag


### PR DESCRIPTION
## Summary
- Adds `%%metro files:` directive for stacked-documents icons (paired/multiple files)
- Adds `%%metro dir:` directive for folder icons (output directories)
- Existing `%%metro file:` behavior is unchanged
- Includes guide examples, reference table updates, and Nextflow docs

Fixes #175

## Test plan
- [x] pytest passes (683 tests, 9 new)
- [x] ruff check clean
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/<PR_NUMBER>/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)