### PR TITLE
fix: prevent near-vertical route through section interior (#241)

### DIFF
--- a/examples/phantom_port.mmd
+++ b/examples/phantom_port.mmd
@@ -1,0 +1,53 @@
+%%metro title: Phantom port
+%%metro style: dark
+%%metro line: a | Line A | #FF9800
+%%metro line: b | Line B | #4CAF50
+%%metro line: c | Line C | #2196F3
+%%metro line: d | Line D | #E91E63
+%%metro line: e | Line E | #CDDC39
+%%metro line: report | Report | #9C27B0
+
+graph LR
+    subgraph input [Input]
+        src[Source]
+        reporter[Reporter]
+    end
+
+    subgraph tall [Tall Section]
+        w1[Tool 1]
+        w2[Tool 2]
+        w3[Tool 3]
+        w4[Tool 4]
+        w5[Tool 5]
+    end
+
+    subgraph qc [QC]
+        collect[Collect]
+    end
+
+    subgraph output [Output]
+        out[Results]
+    end
+
+    src -->|a| w1
+    src -->|b| w2
+    src -->|c| w3
+    src -->|d| w4
+    src -->|e| w5
+
+    %% Report enters from input (top) AND from all tools in tall
+    reporter -->|report| collect
+    w1 -->|report| collect
+    w2 -->|report| collect
+    w3 -->|report| collect
+    w4 -->|report| collect
+    w5 -->|report| collect
+
+    %% Tool lines go to output (far), creating bypass
+    w1 -->|a| out
+    w2 -->|b| out
+    w3 -->|c| out
+    w4 -->|d| out
+    w5 -->|e| out
+
+    collect -->|report| out

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -540,35 +540,29 @@ def _route_inter_section(
             base_radius=ctx.curve_radius,
         )
         # Push channel away from target into the inter-column gap.
-        # Default: move away from target (opposite sign of dx).
         if dx < 0:
             vx = sx + ctx.curve_radius + ctx.offset_step + delta
         else:
             vx = sx - ctx.curve_radius - ctx.offset_step + delta
 
-        # Guard: if the chosen channel falls inside the source section's
-        # bounding box, route via the target's X instead.  This produces
-        # a short horizontal run into the inter-section gap followed by
-        # a smooth vertical drop to the target.
+        # If the channel would cut through the source section's
+        # interior, skip this handler and fall through to the standard
+        # L-shape which routes via the inter-column channel gap.
+        intrudes = False
         src_sec = _resolve_section(graph, src, prefer_upstream=True)
         if src_sec and src_sec.bbox_w > 0:
             left = src_sec.bbox_x
             right = src_sec.bbox_x + src_sec.bbox_w
-            if left < vx < right:
-                return RoutedPath(
-                    edge=edge,
-                    line_id=edge.line_id,
-                    points=[(sx, sy), (tx, sy), (tx, ty)],
-                    is_inter_section=True,
-                    curve_radii=[r_first],
-                )
-        return RoutedPath(
-            edge=edge,
-            line_id=edge.line_id,
-            points=[(sx, sy), (vx, sy), (vx, ty), (tx, ty)],
-            is_inter_section=True,
-            curve_radii=[r_first, r_second],
-        )
+            intrudes = left < vx < right
+
+        if not intrudes:
+            return RoutedPath(
+                edge=edge,
+                line_id=edge.line_id,
+                points=[(sx, sy), (vx, sy), (vx, ty), (tx, ty)],
+                is_inter_section=True,
+                curve_radii=[r_first, r_second],
+            )
 
     # RIGHT entry port with source to the LEFT: wrap the vertical
     # channel around the right side of the target section so the route

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -546,14 +546,23 @@ def _route_inter_section(
             vx = sx - ctx.curve_radius - ctx.offset_step + delta
 
         # If the channel would cut through the source section's
-        # interior, delegate to the standard L-shape which places the
-        # channel in the inter-column gap via inter_column_channel_x.
+        # interior, delegate to the standard L-shape routed to the
+        # entry port (if this is a merge target) so the second curve
+        # turns in the natural direction.  Skip the merge->entry edge
+        # to avoid a redundant stub.
         src_sec = _resolve_section(graph, src, prefer_upstream=True)
         if (
             src_sec
             and src_sec.bbox_w > 0
             and src_sec.bbox_x < vx < src_sec.bbox_x + src_sec.bbox_w
         ):
+            ep_id = ctx.merge.entry_port_for.get(edge.target)
+            ep = graph.stations.get(ep_id) if ep_id else None
+            if ep:
+                for e2 in graph.edges:
+                    if e2.source == edge.target and e2.target == ep_id:
+                        ctx.skip_edges.add((e2.source, e2.target, e2.line_id))
+                return _route_l_shape(edge, src, ep, i, n, ctx)
             return _route_l_shape(edge, src, tgt, i, n, ctx)
 
         return RoutedPath(

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -546,23 +546,23 @@ def _route_inter_section(
             vx = sx - ctx.curve_radius - ctx.offset_step + delta
 
         # If the channel would cut through the source section's
-        # interior, skip this handler and fall through to the standard
-        # L-shape which routes via the inter-column channel gap.
-        intrudes = False
+        # interior, delegate to the standard L-shape which places the
+        # channel in the inter-column gap via inter_column_channel_x.
         src_sec = _resolve_section(graph, src, prefer_upstream=True)
-        if src_sec and src_sec.bbox_w > 0:
-            left = src_sec.bbox_x
-            right = src_sec.bbox_x + src_sec.bbox_w
-            intrudes = left < vx < right
+        if (
+            src_sec
+            and src_sec.bbox_w > 0
+            and src_sec.bbox_x < vx < src_sec.bbox_x + src_sec.bbox_w
+        ):
+            return _route_l_shape(edge, src, tgt, i, n, ctx)
 
-        if not intrudes:
-            return RoutedPath(
-                edge=edge,
-                line_id=edge.line_id,
-                points=[(sx, sy), (vx, sy), (vx, ty), (tx, ty)],
-                is_inter_section=True,
-                curve_radii=[r_first, r_second],
-            )
+        return RoutedPath(
+            edge=edge,
+            line_id=edge.line_id,
+            points=[(sx, sy), (vx, sy), (vx, ty), (tx, ty)],
+            is_inter_section=True,
+            curve_radii=[r_first, r_second],
+        )
 
     # RIGHT entry port with source to the LEFT: wrap the vertical
     # channel around the right side of the target section so the route

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -540,10 +540,28 @@ def _route_inter_section(
             base_radius=ctx.curve_radius,
         )
         # Push channel away from target into the inter-column gap.
+        # Default: move away from target (opposite sign of dx).
         if dx < 0:
             vx = sx + ctx.curve_radius + ctx.offset_step + delta
         else:
             vx = sx - ctx.curve_radius - ctx.offset_step + delta
+
+        # Guard: if the chosen channel falls inside the source section's
+        # bounding box, route via the target's X instead.  This produces
+        # a short horizontal run into the inter-section gap followed by
+        # a smooth vertical drop to the target.
+        src_sec = _resolve_section(graph, src, prefer_upstream=True)
+        if src_sec and src_sec.bbox_w > 0:
+            left = src_sec.bbox_x
+            right = src_sec.bbox_x + src_sec.bbox_w
+            if left < vx < right:
+                return RoutedPath(
+                    edge=edge,
+                    line_id=edge.line_id,
+                    points=[(sx, sy), (tx, sy), (tx, ty)],
+                    is_inter_section=True,
+                    curve_radii=[r_first],
+                )
         return RoutedPath(
             edge=edge,
             line_id=edge.line_id,


### PR DESCRIPTION
## Summary
- When a junction is near a section's right edge and the merge target is slightly right but well above, the near-vertical handler routed its vertical channel leftward through the section interior (creating a phantom port visual)
- Added a section bounding-box check: if the computed channel X falls inside the source section, the near-vertical handler skips and falls through to the standard L-shape/merge routing, which correctly places the channel in the inter-column gap
- Added `phantom_port.mmd` example reproducing the issue

Fixes #241

## Test plan
- [x] pytest passes (684 tests)
- [x] ruff check clean
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/TBD/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)