### PR TITLE
fix: compute bypass gap directions from geometry (#240)

### DIFF
--- a/examples/topologies/mismatched_tracks.mmd
+++ b/examples/topologies/mismatched_tracks.mmd
@@ -1,0 +1,43 @@
+%%metro title: Mismatched Tracks
+%%metro style: dark
+%%metro line: a | Alpha | #0570b0
+%%metro line: b | Beta | #2db572
+%%metro line: c | Gamma | #e31a1c
+%%metro line: d | Delta | #ff7f00
+%%metro line: e | Epsilon | #6a3d9a
+
+graph LR
+    subgraph tall [Tall Section]
+        t_start[Start]
+        t_a[Path A]
+        t_b[Path B]
+        t_c[Path C]
+        t_d[Path D]
+        t_e[Path E]
+        t_end[End]
+        t_start -->|a| t_a
+        t_start -->|b| t_b
+        t_start -->|c| t_c
+        t_start -->|d| t_d
+        t_start -->|e| t_e
+        t_a -->|a| t_end
+        t_b -->|b| t_end
+        t_c -->|c| t_end
+        t_d -->|d| t_end
+        t_e -->|e| t_end
+    end
+
+    subgraph short_a [Short A]
+        sa1[Proc A]
+        sa2[Done A]
+        sa1 -->|a| sa2
+    end
+
+    subgraph short_b [Short B]
+        sb1[Proc B]
+        sb2[Done B]
+        sb1 -->|b| sb2
+    end
+
+    t_end -->|a| sa1
+    t_end -->|b| sb1

--- a/examples/topologies/upward_bypass.mmd
+++ b/examples/topologies/upward_bypass.mmd
@@ -1,0 +1,54 @@
+%%metro title: Upward Bypass Test
+%%metro style: dark
+%%metro line: a | Line A | #FF9800
+%%metro line: b | Line B | #4CAF50
+%%metro line: c | Line C | #2196F3
+%%metro line: d | Line D | #E91E63
+%%metro line: e | Line E | #9C27B0
+%%metro line: f | Line F | #00BCD4
+%%metro line: g | Line G | #CDDC39
+
+graph LR
+    subgraph input [Input]
+        hub[Hub]
+    end
+
+    subgraph wide [Wide Fan-out]
+        w1[Tool 1]
+        w2[Tool 2]
+        w3[Tool 3]
+        w4[Tool 4]
+        w5[Tool 5]
+        w6[Tool 6]
+        w7[Tool 7]
+    end
+
+    subgraph adjacent [Adjacent]
+        adj[Collect]
+    end
+
+    subgraph far [Far Target]
+        out[Output]
+    end
+
+    hub -->|a| w1
+    hub -->|b| w2
+    hub -->|c| w3
+    hub -->|d| w4
+    hub -->|e| w5
+    hub -->|f| w6
+    hub -->|g| w7
+
+    %% Adjacent (L-shape)
+    w1 -->|a| adj
+
+    %% Bypass: bottom of wide -> far (skipping adjacent)
+    w1 -->|a| out
+    w2 -->|b| out
+    w3 -->|c| out
+    w4 -->|d| out
+    w5 -->|e| out
+    w6 -->|f| out
+    w7 -->|g| out
+
+    adj -->|a| out

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -142,6 +142,17 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         TOPOLOGIES_DIR,
         "Stacked analysis sections feeding through a fold into branching targets.",
     ),
+    # --- Offset and bypass ---
+    (
+        "mismatched_tracks",
+        TOPOLOGIES_DIR,
+        "Lines with mismatched track counts at shared stations.",
+    ),
+    (
+        "upward_bypass",
+        TOPOLOGIES_DIR,
+        "Tall section bypass where the trunk is above the source (upward gap1).",
+    ),
 ]
 
 # Category headers inserted before specific entries

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -731,18 +731,6 @@ def _route_bypass(
 
     fan = ctx.junction_fan_info.get(ekey)
 
-    # Radii and per-line deltas via the same l_shape_radii logic used
-    # for all other concentric corners.
-    delta1, delta2, r1, _, r3, r4 = bypass_radii(
-        g1_j,
-        g1_n,
-        g2_j,
-        g2_n,
-        going_right=going_right,
-        offset_step=ctx.offset_step,
-        base_radius=ctx.curve_radius,
-    )
-
     # Per-line trunk Y keeps lines visually separate on the horizontal.
     if fan is not None:
         nest_offset = g2_j * ctx.offset_step
@@ -759,14 +747,36 @@ def _route_bypass(
         src_row=src_row,
         cross_row=cross_row,
     )
+
+    # Determine actual vertical direction at each gap from the geometry.
+    # Gap1 goes from source Y to trunk Y; gap2 from trunk Y to target Y.
+    # Normally gap1 goes down and gap2 goes up, but when the source is
+    # below the trunk (bottom of a tall section bypassing a shorter
+    # neighbour), gap1 also goes up.
+    gap1_going_down = base_y > sy
+    gap2_going_down = ty > base_y
+
+    # Radii and per-line deltas via the same l_shape_radii logic used
+    # for all other concentric corners.
+    delta1, delta2, r1, _, r3, r4 = bypass_radii(
+        g1_j,
+        g1_n,
+        g2_j,
+        g2_n,
+        going_right=going_right,
+        offset_step=ctx.offset_step,
+        base_radius=ctx.curve_radius,
+        gap1_going_down=gap1_going_down,
+        gap2_going_down=gap2_going_down,
+    )
     by = base_y + nest_offset
 
-    # Override r2 so corner 2 concentricity matches the trunk Y ordering:
-    # by - r2 = base_y - base_radius (constant across all lines).
+    # Override r2 so all trunk horizontals begin at the same X
+    # (gap1_x + r2 = constant across all lines in the bundle).
     r2 = corner_radius(
         nest_offset,
-        0,
-        outside=True,
+        (g2_n - 1) * ctx.offset_step,
+        outside=gap1_going_down,
         base_radius=ctx.curve_radius,
     )
 
@@ -783,7 +793,7 @@ def _route_bypass(
             fan_delta, r1, _ = l_shape_radii(
                 ui,
                 un,
-                going_down=True,
+                going_down=gap1_going_down,
                 offset_step=ctx.offset_step,
                 base_radius=ctx.curve_radius,
             )
@@ -815,7 +825,7 @@ def _route_bypass(
             fan_delta, r1, _ = l_shape_radii(
                 ui,
                 un,
-                going_down=True,
+                going_down=gap1_going_down,
                 offset_step=ctx.offset_step,
                 base_radius=ctx.curve_radius,
             )

--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -249,13 +249,15 @@ def bypass_radii(
     going_right: bool,
     offset_step: float = OFFSET_STEP,
     base_radius: float = CURVE_RADIUS,
+    gap1_going_down: bool = True,
+    gap2_going_down: bool = False,
 ) -> tuple[float, float, float, float, float, float]:
     """Compute deltas and radii for a U-shaped bypass route.
 
-    A bypass is two back-to-back L-shapes: gap1 (going down, corners 1-2)
-    and gap2 (going up, corners 3-4).  This function wraps two
-    ``l_shape_radii`` calls so that all four corners satisfy the same
-    ``delta + r = const`` concentricity invariant used everywhere else.
+    A bypass is two back-to-back L-shapes with corners 1-2 at gap1 and
+    corners 3-4 at gap2.  This function wraps two ``l_shape_radii``
+    calls so that all four corners satisfy the same ``delta + r = const``
+    concentricity invariant used everywhere else.
 
     Parameters
     ----------
@@ -268,6 +270,14 @@ def bypass_radii(
         Left-going bypasses mirror the inside/outside assignment.
     offset_step, base_radius : float
         Passed through to ``l_shape_radii``.
+    gap1_going_down : bool
+        Vertical direction at gap1.  ``True`` when the trunk is below
+        the source (standard case), ``False`` when the source is below
+        the trunk (e.g. bottom of a tall section bypassing a shorter
+        neighbour).
+    gap2_going_down : bool
+        Vertical direction at gap2.  Almost always ``False`` (trunk
+        below target).
 
     Returns
     -------
@@ -276,27 +286,26 @@ def bypass_radii(
     delta2 : float
         X offset from gap2 channel center for this line.
     r1, r2, r3, r4 : float
-        Corner radii (1: horiz->vert-down, 2: vert-down->horiz,
-        3: horiz->vert-up, 4: vert-up->horiz).
+        Corner radii at each of the four corners.
     """
     # For left-going bypasses, reverse indices so the outside/inside
     # assignment matches the mirrored corner geometry.
     g1_idx = g1_i if going_right else g1_n - 1 - g1_i
     g2_idx = g2_i if going_right else g2_n - 1 - g2_i
 
-    # Gap1: going-down L-shape (corners 1 and 2)
+    # Gap1 L-shape (corners 1 and 2)
     delta1, r1, r2 = l_shape_radii(
         g1_idx,
         g1_n,
-        going_down=True,
+        going_down=gap1_going_down,
         offset_step=offset_step,
         base_radius=base_radius,
     )
-    # Gap2: going-up L-shape (corners 3 and 4)
+    # Gap2 L-shape (corners 3 and 4)
     delta2, r3, r4 = l_shape_radii(
         g2_idx,
         g2_n,
-        going_down=False,
+        going_down=gap2_going_down,
         offset_step=offset_step,
         base_radius=base_radius,
     )

--- a/tests/fixtures/topologies/README.md
+++ b/tests/fixtures/topologies/README.md
@@ -46,6 +46,7 @@ Test fixtures and infrastructure for stress-testing the auto-layout engine again
 | `fold_fan_across.mmd` | 7 | 3 | Fan-out/fan-in across fold boundary, rowspan optimization |
 | `fold_double.mmd` | 10 | 2 | Double fold serpentine (LR -> RL -> LR), col_step zigzag |
 | `fold_stacked_branch.mmd` | 8 | 3 | Stacked sections near fold, post-fold branching, TB fan-out |
+| `upward_bypass.mmd` | 4 | 7 | Tall section bypass where trunk is above source (upward gap1) |
 
 All use auto-layout (no `%%metro grid:` directives). These are intended to eventually move to `examples/` once visually polished.
 

--- a/tests/fixtures/topologies/upward_bypass.mmd
+++ b/tests/fixtures/topologies/upward_bypass.mmd
@@ -1,0 +1,54 @@
+%%metro title: Upward Bypass Test
+%%metro style: dark
+%%metro line: a | Line A | #FF9800
+%%metro line: b | Line B | #4CAF50
+%%metro line: c | Line C | #2196F3
+%%metro line: d | Line D | #E91E63
+%%metro line: e | Line E | #9C27B0
+%%metro line: f | Line F | #00BCD4
+%%metro line: g | Line G | #CDDC39
+
+graph LR
+    subgraph input [Input]
+        hub[Hub]
+    end
+
+    subgraph wide [Wide Fan-out]
+        w1[Tool 1]
+        w2[Tool 2]
+        w3[Tool 3]
+        w4[Tool 4]
+        w5[Tool 5]
+        w6[Tool 6]
+        w7[Tool 7]
+    end
+
+    subgraph adjacent [Adjacent]
+        adj[Collect]
+    end
+
+    subgraph far [Far Target]
+        out[Output]
+    end
+
+    hub -->|a| w1
+    hub -->|b| w2
+    hub -->|c| w3
+    hub -->|d| w4
+    hub -->|e| w5
+    hub -->|f| w6
+    hub -->|g| w7
+
+    %% Adjacent (L-shape)
+    w1 -->|a| adj
+
+    %% Bypass: bottom of wide -> far (skipping adjacent)
+    w1 -->|a| out
+    w2 -->|b| out
+    w3 -->|c| out
+    w4 -->|d| out
+    w5 -->|e| out
+    w6 -->|f| out
+    w7 -->|g| out
+
+    adj -->|a| out

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -45,6 +45,14 @@ def _load_and_layout(path: Path, max_station_columns: int = 15):
     return graph
 
 
+def _compute_routes(graph):
+    """Compute station offsets and route all edges."""
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    offsets = compute_station_offsets(graph)
+    return route_edges(graph, station_offsets=offsets)
+
+
 # --- Parametrized validation across all topologies ---
 
 
@@ -639,20 +647,10 @@ class TestMergeJunctions:
 class TestMergeRouting:
     """Tests for merge trunk/branch routing patterns (#207)."""
 
-    @staticmethod
-    def _routes(graph):
-        from nf_metro.layout.routing import (
-            compute_station_offsets,
-            route_edges,
-        )
-
-        offsets = compute_station_offsets(graph)
-        return route_edges(graph, station_offsets=offsets)
-
     def test_trunk_reaches_entry_port(self):
         """Trunk route's last point should match the entry port."""
         graph = _load_and_layout(GENOMEASSEMBLY_FILE)
-        routes = self._routes(graph)
+        routes = _compute_routes(graph)
         merge_ids = {j for j in graph.junctions if j.startswith("__merge_")}
         for r in routes:
             if r.edge.target in merge_ids and len(r.points) == 6:
@@ -672,7 +670,7 @@ class TestMergeRouting:
     def test_branch_is_4_point_descent(self):
         """Branch routes should be 4-point L-shape descents."""
         graph = _load_and_layout(GENOMEASSEMBLY_FILE)
-        routes = self._routes(graph)
+        routes = _compute_routes(graph)
         merge_ids = {j for j in graph.junctions if j.startswith("__merge_")}
         for r in routes:
             if r.edge.target in merge_ids and len(r.points) != 6 and len(r.points) != 2:
@@ -684,7 +682,7 @@ class TestMergeRouting:
     def test_no_backward_segments(self):
         """No merge route should have backward (decreasing X) segments."""
         graph = _load_and_layout(GENOMEASSEMBLY_FILE)
-        routes = self._routes(graph)
+        routes = _compute_routes(graph)
         merge_ids = {j for j in graph.junctions if j.startswith("__merge_")}
         for r in routes:
             if r.edge.target not in merge_ids:
@@ -703,7 +701,7 @@ class TestMergeRouting:
         from nf_metro.layout.constants import OFFSET_STEP
 
         graph = _load_and_layout(GENOMEASSEMBLY_FILE)
-        routes = self._routes(graph)
+        routes = _compute_routes(graph)
         # Collect all horizontal segments per line for inter-section
         # bypass routes.  Bypass segments are horizontal runs that sit
         # between the source and target section Y ranges (i.e. below
@@ -724,6 +722,77 @@ class TestMergeRouting:
             min_gap = min(abs(a - h) for a in a_ys for h in h_ys if abs(a - h) > 0)
             assert min_gap == OFFSET_STEP, (
                 f"Bypass bundle gap {min_gap}px, expected {OFFSET_STEP}px"
+            )
+
+
+class TestUpwardBypass:
+    """Regression tests for upward bypass routes (#240).
+
+    When a bypass source is below the trunk (bottom of a tall section
+    bypassing a shorter neighbour), the gap1 vertical goes UP.  The
+    fan-path direction must match the L-shape sibling so they share
+    consistent positions at the first corner, and the r2 override must
+    account for the reversed gap1 direction.
+    """
+
+    UPWARD_BYPASS_FILE = TOPOLOGIES_DIR / "upward_bypass.mmd"
+
+    @pytest.fixture(scope="class")
+    def routes(self):
+        graph = _load_and_layout(self.UPWARD_BYPASS_FILE)
+        return _compute_routes(graph)
+
+    @pytest.fixture(scope="class")
+    def bypass_routes(self, routes):
+        return [r for r in routes if len(r.points) == 6 and r.curve_radii]
+
+    def test_fan_positions_consistent(self, routes):
+        """L-shape and bypass from the same junction share gap1 X."""
+        a_gap1_xs = set()
+        for r in routes:
+            if r.line_id != "a" or not r.is_inter_section:
+                continue
+            if len(r.points) >= 4:
+                a_gap1_xs.add(round(r.points[1][0], 1))
+        assert len(a_gap1_xs) == 1, (
+            f"Line 'a' L-shape and bypass have different gap1 X: {a_gap1_xs}"
+        )
+
+    def test_corner1_concentricity(self, bypass_routes):
+        """All bypass curves at corner 1 should start at the same X."""
+        xs = {round(r.points[1][0] - r.curve_radii[0], 1) for r in bypass_routes}
+        assert len(xs) == 1, f"Corner 1 start X not constant: {xs}"
+
+    def test_corner2_concentricity(self, bypass_routes):
+        """All bypass lines should start their trunk horizontal at the same X."""
+        xs = {round(r.points[1][0] + r.curve_radii[1], 1) for r in bypass_routes}
+        assert len(xs) == 1, f"Corner 2 start X not constant: {xs}"
+
+    def test_corner3_concentricity(self, bypass_routes):
+        """All bypass lines should end their trunk horizontal at the same X."""
+        xs = {round(r.points[3][0] - r.curve_radii[2], 1) for r in bypass_routes}
+        assert len(xs) == 1, f"Corner 3 end X not constant: {xs}"
+
+    def test_corner4_concentricity(self, bypass_routes):
+        """All bypass lines should reach the target at the same X."""
+        xs = {round(r.points[3][0] + r.curve_radii[3], 1) for r in bypass_routes}
+        assert len(xs) == 1, f"Corner 4 target X not constant: {xs}"
+
+    def test_no_line_crossings_on_segments(self, bypass_routes):
+        """Lines should maintain monotonic ordering on each segment."""
+        bypasses = sorted(bypass_routes, key=lambda r: r.line_id)
+        for seg_idx, coord_idx, name in [
+            (1, 0, "gap1_x"),
+            (2, 1, "trunk_y"),
+            (3, 0, "gap2_x"),
+        ]:
+            vals = [r.points[seg_idx][coord_idx] for r in bypasses]
+            is_mono = all(vals[i] <= vals[i + 1] for i in range(len(vals) - 1)) or all(
+                vals[i] >= vals[i + 1] for i in range(len(vals) - 1)
+            )
+            assert is_mono, (
+                f"{name} not monotonic: "
+                f"{[(r.line_id, vals[i]) for i, r in enumerate(bypasses)]}"
             )
 
 


### PR DESCRIPTION
## Summary
- Bypass routes from the bottom of a tall section (where the source is below the trunk) had inverted curve radii and inconsistent fan positions, causing line crossings at corners
- Root cause: `bypass_radii()` and the fan-path override in `_route_bypass()` hardcoded `going_down=True` for gap1, but the actual direction depends on whether the trunk is above or below the source
- Added `gap1_going_down` / `gap2_going_down` parameters to `bypass_radii()`, computed from actual geometry in `_route_bypass()`
- The r2 override now uses `corner_radius(..., outside=gap1_going_down)` so the concentricity invariant holds for both directions
- No changes to existing renders (verified all examples + topology fixtures produce identical SVGs)
- Added `upward_bypass` topology fixture with 6 regression tests (fan consistency, corner 1-4 concentricity, monotonic ordering)
- Added `upward_bypass` and `mismatched_tracks` to the examples gallery for CI render visibility

Fixes #240

## Test plan
- [x] 704 tests pass (6 new upward bypass tests)
- [x] ruff check clean
- [x] All existing renders identical before/after
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/243/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)