### PR TITLE
fix: center stations in single-layer sections (#244)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1232,9 +1232,13 @@ def _adjust_lr_entry_inset(
         }
         if len(targets) > 1:
             entry_inset = x_spacing * EXIT_GAP_MULTIPLIER
-            # Shift stations away from the entry edge to make room
+            # For single-layer sections the asymmetry is very visible,
+            # so split the inset between both sides to keep stations
+            # visually centered (same logic as _adjust_lr_exit_gap).
+            n_layers = len({s.layer for s in sub.stations.values()})
+            shift = entry_inset / 2 if n_layers <= 1 else entry_inset
             for s in sub.stations.values():
-                s.x += entry_inset
+                s.x += shift
             section.bbox_w += entry_inset
             return
 

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -60,6 +60,7 @@ def validate_layout(graph: MetroGraph) -> list[Violation]:
         violations.extend(
             check_almost_horizontal_edges(graph, _precomputed=precomputed)
         )
+    violations.extend(check_single_layer_centering(graph))
     violations.extend(check_station_as_elbow(graph))
     return violations
 
@@ -602,6 +603,63 @@ def check_bypass_section_clearance(
                             },
                         )
                     )
+
+    return violations
+
+
+def check_single_layer_centering(
+    graph: MetroGraph, tolerance: float = 5.0
+) -> list[Violation]:
+    """Check that single-layer sections have stations centered in bbox.
+
+    For LR/RL sections where all internal stations share the same layer
+    (single column of stations), the station X should be approximately
+    at the horizontal center of the section bounding box.  A drift
+    indicates asymmetric bbox expansion without recentering.
+    """
+    violations: list[Violation] = []
+    junction_ids = set(graph.junctions)
+
+    for sec_id, section in graph.sections.items():
+        if section.bbox_w == 0 or section.direction not in ("LR", "RL"):
+            continue
+
+        # Collect internal (non-port, non-junction) stations
+        internals = [
+            st
+            for sid, st in graph.stations.items()
+            if st.section_id == sec_id and not st.is_port and sid not in junction_ids
+        ]
+        if not internals:
+            continue
+
+        # Only check single-layer sections (all stations at same X)
+        xs = [st.x for st in internals]
+        if max(xs) - min(xs) > tolerance:
+            continue
+
+        station_x = sum(xs) / len(xs)
+        bbox_center = section.bbox_x + section.bbox_w / 2
+        offset = abs(station_x - bbox_center)
+
+        if offset > tolerance:
+            violations.append(
+                Violation(
+                    check="single_layer_centering",
+                    severity=Severity.WARNING,
+                    message=(
+                        f"Section {sec_id!r}: single-layer stations at "
+                        f"x={station_x:.1f} are {offset:.1f}px from "
+                        f"bbox center ({bbox_center:.1f})"
+                    ),
+                    context={
+                        "section": sec_id,
+                        "station_x": station_x,
+                        "bbox_center": bbox_center,
+                        "offset": offset,
+                    },
+                )
+            )
 
     return violations
 


### PR DESCRIPTION
## Summary
- Single-layer LR/RL sections had stations offset from the bbox center because `_adjust_lr_entry_inset` shifted stations by the full entry inset without centering
- Applied the same half-shift centering logic already used in `_adjust_lr_exit_gap` for single-layer sections
- Added `check_single_layer_centering` validator to catch future regressions (runs against all topology fixtures)

Fixes #244

## Test plan
- [x] pytest passes (704 tests)
- [x] ruff check clean
- [ ] Visual review of render preview (link below after CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)