### PR TITLE
fix: re-align row bboxes after port-terminus spacing

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -411,6 +411,11 @@ def _compute_section_layout(
     # padding around the final non-port station range.
     _recompute_grid_group_bboxes(graph)
 
+    # Phase 11c: Re-run top-align after Phase 11 may have shifted
+    # individual section bbox_y values (via _expand_bbox_for_y) so
+    # bbox tops within each row stay flush after port-terminus spacing.
+    _top_align_row_sections(graph)
+
     # ---- Pass C: Junction positioning (single pass) --------------------
     # All port positions are now final; position junctions once.
 

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -699,68 +699,7 @@ def place_labels(
 
         placements.append(candidate)
 
-    _stagger_stacked_labels(placements, sorted_stations, graph)
-
     return [p for p in placements if p.obstacle_bbox is None]
-
-
-def _stagger_stacked_labels(
-    placements: list[LabelPlacement],
-    sorted_stations: list,
-    graph: MetroGraph,
-) -> None:
-    """Diagonally stagger labels of vertically stacked same-X stations.
-
-    When two stations in the same section share an X column and sit on
-    adjacent (or nearby) Y tracks, their centered labels appear stacked
-    in the same vertical line - visually crowded even when bboxes don't
-    overlap.  Shifting the upper label slightly leftward and the lower
-    rightward (or vice versa) decorrelates the visual centerlines.
-
-    Only applied when the shift won't introduce a label-label collision
-    and when both labels are short enough that the shift remains within
-    a single character width (subtle, but visible).
-    """
-    placement_by_sid = {p.station_id: p for p in placements if p.obstacle_bbox is None}
-
-    col_groups: dict[tuple[str | None, float], list] = {}
-    for s in sorted_stations:
-        if s.id not in placement_by_sid:
-            continue
-        col_groups.setdefault((s.section_id, round(s.x, 1)), []).append(s)
-
-    step = CHAR_WIDTH * 0.7
-    others = [p for p in placements if p.obstacle_bbox is not None]
-
-    for (sec_id, _x), group in col_groups.items():
-        if sec_id is None or len(group) < 2:
-            continue
-        group.sort(key=lambda s: s.y)
-        n = len(group)
-        for idx, st in enumerate(group):
-            shift = (idx - (n - 1) / 2.0) * step
-            if abs(shift) < 0.5:
-                continue
-            placement = placement_by_sid[st.id]
-            # Skip TB-section labels (anchored end/start, not centered).
-            if placement.text_anchor != "middle":
-                continue
-            trial = LabelPlacement(
-                station_id=placement.station_id,
-                text=placement.text,
-                x=placement.x + shift,
-                y=placement.y,
-                above=placement.above,
-                angle=placement.angle,
-                text_anchor=placement.text_anchor,
-                dominant_baseline=placement.dominant_baseline,
-            )
-            siblings = [
-                p for p in placements if p is not placement and p.obstacle_bbox is None
-            ] + others
-            if _has_collision(trial, siblings):
-                continue
-            placement.x = trial.x
 
 
 def _clamp_label_vertical(

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -699,7 +699,68 @@ def place_labels(
 
         placements.append(candidate)
 
+    _stagger_stacked_labels(placements, sorted_stations, graph)
+
     return [p for p in placements if p.obstacle_bbox is None]
+
+
+def _stagger_stacked_labels(
+    placements: list[LabelPlacement],
+    sorted_stations: list,
+    graph: MetroGraph,
+) -> None:
+    """Diagonally stagger labels of vertically stacked same-X stations.
+
+    When two stations in the same section share an X column and sit on
+    adjacent (or nearby) Y tracks, their centered labels appear stacked
+    in the same vertical line - visually crowded even when bboxes don't
+    overlap.  Shifting the upper label slightly leftward and the lower
+    rightward (or vice versa) decorrelates the visual centerlines.
+
+    Only applied when the shift won't introduce a label-label collision
+    and when both labels are short enough that the shift remains within
+    a single character width (subtle, but visible).
+    """
+    placement_by_sid = {p.station_id: p for p in placements if p.obstacle_bbox is None}
+
+    col_groups: dict[tuple[str | None, float], list] = {}
+    for s in sorted_stations:
+        if s.id not in placement_by_sid:
+            continue
+        col_groups.setdefault((s.section_id, round(s.x, 1)), []).append(s)
+
+    step = CHAR_WIDTH * 0.7
+    others = [p for p in placements if p.obstacle_bbox is not None]
+
+    for (sec_id, _x), group in col_groups.items():
+        if sec_id is None or len(group) < 2:
+            continue
+        group.sort(key=lambda s: s.y)
+        n = len(group)
+        for idx, st in enumerate(group):
+            shift = (idx - (n - 1) / 2.0) * step
+            if abs(shift) < 0.5:
+                continue
+            placement = placement_by_sid[st.id]
+            # Skip TB-section labels (anchored end/start, not centered).
+            if placement.text_anchor != "middle":
+                continue
+            trial = LabelPlacement(
+                station_id=placement.station_id,
+                text=placement.text,
+                x=placement.x + shift,
+                y=placement.y,
+                above=placement.above,
+                angle=placement.angle,
+                text_anchor=placement.text_anchor,
+                dominant_baseline=placement.dominant_baseline,
+            )
+            siblings = [
+                p for p in placements if p is not placement and p.obstacle_bbox is None
+            ] + others
+            if _has_collision(trial, siblings):
+                continue
+            placement.x = trial.x
 
 
 def _clamp_label_vertical(


### PR DESCRIPTION
Re-aligns row bboxes after the port-terminus spacing phase mutates them, so same-row sections retain consistent bbox tops.

**Problem:** `_space_ports_from_termini` (Phase 11) calls `_expand_bbox_for_y` when a pushed entry port lands above the section's bbox top. `_recompute_grid_group_bboxes` (Phase 11b) bakes the shift in. `_top_align_row_sections` ran before Phase 11, so it couldn't undo the divergence.

**Fix:** Phase 11c re-runs `_top_align_row_sections` after `_recompute_grid_group_bboxes`. Row-mate sections now sit flush at a consistent bbox_y after port-terminus expansion.

The branch carries an in-flight label-staggering experiment (`d9f98c1`) that was determined not to be a visual improvement and is reverted at the tip (`43d429a`). Net diff vs `main` is the row-bbox re-alignment only.