### PR TITLE
fix(layout): anchor inter-section exit ports to downstream bundle Y

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -53,7 +53,7 @@ SECTION_GAP: float = 3.0
 SECTION_X_PADDING: float = 50.0
 """Horizontal padding around section content."""
 
-SECTION_Y_PADDING: float = 35.0
+SECTION_Y_PADDING: float = 50.0
 """Vertical padding around section content."""
 
 SECTION_X_GAP: float = 50.0

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1648,14 +1648,19 @@ def _resolve_source_section_id(
 
 
 def _resolve_source_xy(
-    graph: MetroGraph, edge_source: str, junction_ids: set[str]
+    graph: MetroGraph,
+    edge_source: str,
+    junction_ids: set[str],
+    _seen: set[str] | None = None,
 ) -> tuple[float, float] | None:
     """Return effective (x, y) for an edge source.
 
     For port stations, returns coordinates directly.  For junctions,
     derives coordinates from the feeding exit port, mirroring
     ``_position_junctions`` logic so that entry-port alignment does
-    not depend on junctions being pre-positioned.
+    not depend on junctions being pre-positioned.  Recurses through
+    chained junctions (junction-to-junction edges) to find the
+    underlying exit port.
     """
     src = graph.stations.get(edge_source)
     if not src:
@@ -1663,9 +1668,19 @@ def _resolve_source_xy(
     if edge_source not in junction_ids:
         return src.x, src.y
 
+    if _seen is None:
+        _seen = set()
+    if edge_source in _seen:
+        return src.x, src.y
+    _seen.add(edge_source)
+
     # Junction: find the feeding exit port and compute placement.
+    chained: list[str] = []
     for e in graph.edges:
         if e.target != edge_source:
+            continue
+        if e.source in junction_ids:
+            chained.append(e.source)
             continue
         exit_st = graph.stations.get(e.source)
         if not exit_st or not exit_st.is_port:
@@ -1681,6 +1696,12 @@ def _resolve_source_xy(
             return exit_st.x - JUNCTION_MARGIN, exit_st.y
         else:
             return exit_st.x + JUNCTION_MARGIN, exit_st.y
+
+    # Recurse through chained junctions to find the underlying exit port.
+    for js in chained:
+        resolved = _resolve_source_xy(graph, js, junction_ids, _seen)
+        if resolved is not None and resolved != (0.0, 0.0):
+            return resolved
 
     # Fallback: use junction station's current coordinates.
     return src.x, src.y

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -411,6 +411,11 @@ def _compute_section_layout(
     # padding around the final non-port station range.
     _recompute_grid_group_bboxes(graph)
 
+    # Phase 11c: Re-run top-align after Phase 11 may have shifted
+    # individual section bbox_y values (via _expand_bbox_for_y) so
+    # bbox tops within each row stay flush after port-terminus spacing.
+    _top_align_row_sections(graph)
+
     # ---- Pass C: Junction positioning (single pass) --------------------
     # All port positions are now final; position junctions once.
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1000,6 +1000,11 @@ def _layout_single_section(
             station.x = station.layer * x_spacing + layer_extra.get(station.layer, 0)
             station.y = track_rank[station.track] * effective_y_spacing
 
+    # Resolve same-cell station collisions: two stations on the same line
+    # priority can land on identical (x,y) when the track allocator collapses
+    # distinct line tracks at a layer with only one occupant per line.
+    _resolve_station_collisions(sub, section, x_spacing, effective_y_spacing)
+
     # Normalize Y so minimum is 0 (raw tracks can be negative)
     _normalize_min(sub, axis="y")
 
@@ -1034,6 +1039,59 @@ def _layout_single_section(
     _adjust_terminus_icon_clearance(sub, section, graph)
 
     return sub
+
+
+def _resolve_station_collisions(
+    sub: MetroGraph,
+    section: Section,
+    x_spacing: float,
+    y_spacing: float,
+) -> None:
+    """Push stations apart when track compaction collides them in the same cell.
+
+    The track allocator can return identical track values for two stations on
+    different lines when each is the sole occupant of its line at a given
+    layer (e.g. side-by-side terminus branches). After coordinate assignment
+    they end up at the same (x, y), causing visual overlap. This pass detects
+    such collisions and shifts the later-defined station along the section's
+    secondary axis by one spacing unit, repeating until the cell is unique.
+    """
+    if section.direction == "TB":
+        primary, secondary, primary_step, step = "y", "x", y_spacing, x_spacing
+    else:
+        primary, secondary, primary_step, step = "x", "y", x_spacing, y_spacing
+
+    EPS = 0.5
+    real = [s for s in sub.stations.values() if not s.is_port and not s.is_hidden]
+    real.sort(key=lambda s: (getattr(s, primary), getattr(s, secondary)))
+
+    # Group stations by primary-axis bucket (layer column for LR/RL,
+    # row for TB).  Use the primary-axis step size; the bucket spans a
+    # half-step either side of a layer centre so off-grid layer_extra
+    # offsets stay in the same bucket as their layer peers.
+    by_primary: dict[float, list] = {}
+    for s in real:
+        bucket = round(getattr(s, primary) / max(primary_step, 1.0))
+        by_primary.setdefault(bucket, []).append(s)
+
+    for stations in by_primary.values():
+        if len(stations) < 2:
+            continue
+        # Sort by current secondary coord, then station definition order
+        # (insertion order in sub.stations) as a stable tiebreaker so the
+        # earlier-defined station keeps its slot.
+        order = {sid: i for i, sid in enumerate(sub.stations)}
+        stations.sort(
+            key=lambda s: (getattr(s, secondary), order.get(s.id, 0))
+        )
+        used: list[float] = []
+        for s in stations:
+            pos = getattr(s, secondary)
+            while any(abs(pos - u) < step - EPS for u in used):
+                pos += step
+            if pos != getattr(s, secondary):
+                setattr(s, secondary, pos)
+            used.append(pos)
 
 
 def _multiline_track_spacing(sub: MetroGraph, y_spacing: float) -> float:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1063,27 +1063,27 @@ def _resolve_station_collisions(
 
     EPS = 0.5
     real = [s for s in sub.stations.values() if not s.is_port and not s.is_hidden]
-    real.sort(key=lambda s: (getattr(s, primary), getattr(s, secondary)))
+    if len(real) < 2:
+        return
 
     # Group stations by primary-axis bucket (layer column for LR/RL,
-    # row for TB).  Use the primary-axis step size; the bucket spans a
-    # half-step either side of a layer centre so off-grid layer_extra
-    # offsets stay in the same bucket as their layer peers.
+    # row for TB).  The bucket spans a half-step either side of a layer
+    # centre so off-grid layer_extra offsets stay in the same bucket as
+    # their layer peers.
+    primary_step_norm = max(primary_step, 1.0)
     by_primary: dict[float, list] = {}
     for s in real:
-        bucket = round(getattr(s, primary) / max(primary_step, 1.0))
+        bucket = round(getattr(s, primary) / primary_step_norm)
         by_primary.setdefault(bucket, []).append(s)
+
+    # Stable tiebreaker so the earlier-defined station keeps its slot
+    # when two share a secondary coord (insertion order in sub.stations).
+    order = {sid: i for i, sid in enumerate(sub.stations)}
 
     for stations in by_primary.values():
         if len(stations) < 2:
             continue
-        # Sort by current secondary coord, then station definition order
-        # (insertion order in sub.stations) as a stable tiebreaker so the
-        # earlier-defined station keeps its slot.
-        order = {sid: i for i, sid in enumerate(sub.stations)}
-        stations.sort(
-            key=lambda s: (getattr(s, secondary), order.get(s.id, 0))
-        )
+        stations.sort(key=lambda s: (getattr(s, secondary), order.get(s.id, 0)))
         used: list[float] = []
         for s in stations:
             pos = getattr(s, secondary)

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -699,68 +699,7 @@ def place_labels(
 
         placements.append(candidate)
 
-    _stagger_stacked_labels(placements, sorted_stations, graph)
-
     return [p for p in placements if p.obstacle_bbox is None]
-
-
-def _stagger_stacked_labels(
-    placements: list[LabelPlacement],
-    sorted_stations: list,
-    graph: MetroGraph,
-) -> None:
-    """Diagonally stagger labels of vertically stacked same-X stations.
-
-    When two stations in the same section share an X column and sit on
-    adjacent (or nearby) Y tracks, their centered labels appear stacked
-    in the same vertical line - visually crowded even when bboxes don't
-    overlap.  Shifting the upper label slightly leftward and the lower
-    rightward (or vice versa) decorrelates the visual centerlines.
-
-    Only applied when the shift won't introduce a label-label collision
-    and when both labels are short enough that the shift remains within
-    a single character width (subtle, but visible).
-    """
-    placement_by_sid = {p.station_id: p for p in placements if p.obstacle_bbox is None}
-
-    col_groups: dict[tuple[str | None, float], list] = {}
-    for s in sorted_stations:
-        if s.id not in placement_by_sid:
-            continue
-        col_groups.setdefault((s.section_id, round(s.x, 1)), []).append(s)
-
-    step = CHAR_WIDTH * 0.7
-    others = [p for p in placements if p.obstacle_bbox is not None]
-
-    for (sec_id, _x), group in col_groups.items():
-        if sec_id is None or len(group) < 2:
-            continue
-        group.sort(key=lambda s: s.y)
-        n = len(group)
-        for idx, st in enumerate(group):
-            shift = (idx - (n - 1) / 2.0) * step
-            if abs(shift) < 0.5:
-                continue
-            placement = placement_by_sid[st.id]
-            # Skip TB-section labels (anchored end/start, not centered).
-            if placement.text_anchor != "middle":
-                continue
-            trial = LabelPlacement(
-                station_id=placement.station_id,
-                text=placement.text,
-                x=placement.x + shift,
-                y=placement.y,
-                above=placement.above,
-                angle=placement.angle,
-                text_anchor=placement.text_anchor,
-                dominant_baseline=placement.dominant_baseline,
-            )
-            siblings = [
-                p for p in placements if p is not placement and p.obstacle_bbox is None
-            ] + others
-            if _has_collision(trial, siblings):
-                continue
-            placement.x = trial.x
 
 
 def _clamp_label_vertical(

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -699,7 +699,68 @@ def place_labels(
 
         placements.append(candidate)
 
+    _stagger_stacked_labels(placements, sorted_stations, graph)
+
     return [p for p in placements if p.obstacle_bbox is None]
+
+
+def _stagger_stacked_labels(
+    placements: list[LabelPlacement],
+    sorted_stations: list,
+    graph: MetroGraph,
+) -> None:
+    """Diagonally stagger labels of vertically stacked same-X stations.
+
+    When two stations in the same section share an X column and sit on
+    adjacent (or nearby) Y tracks, their centered labels appear stacked
+    in the same vertical line - visually crowded even when bboxes don't
+    overlap.  Shifting the upper label slightly leftward and the lower
+    rightward (or vice versa) decorrelates the visual centerlines.
+
+    Only applied when the shift won't introduce a label-label collision
+    and when both labels are short enough that the shift remains within
+    a single character width (subtle, but visible).
+    """
+    placement_by_sid = {p.station_id: p for p in placements if p.obstacle_bbox is None}
+
+    col_groups: dict[tuple[str | None, float], list] = {}
+    for s in sorted_stations:
+        if s.id not in placement_by_sid:
+            continue
+        col_groups.setdefault((s.section_id, round(s.x, 1)), []).append(s)
+
+    step = CHAR_WIDTH * 0.7
+    others = [p for p in placements if p.obstacle_bbox is not None]
+
+    for (sec_id, _x), group in col_groups.items():
+        if sec_id is None or len(group) < 2:
+            continue
+        group.sort(key=lambda s: s.y)
+        n = len(group)
+        for idx, st in enumerate(group):
+            shift = (idx - (n - 1) / 2.0) * step
+            if abs(shift) < 0.5:
+                continue
+            placement = placement_by_sid[st.id]
+            # Skip TB-section labels (anchored end/start, not centered).
+            if placement.text_anchor != "middle":
+                continue
+            trial = LabelPlacement(
+                station_id=placement.station_id,
+                text=placement.text,
+                x=placement.x + shift,
+                y=placement.y,
+                above=placement.above,
+                angle=placement.angle,
+                text_anchor=placement.text_anchor,
+                dominant_baseline=placement.dominant_baseline,
+            )
+            siblings = [
+                p for p in placements if p is not placement and p.obstacle_bbox is None
+            ] + others
+            if _has_collision(trial, siblings):
+                continue
+            placement.x = trial.x
 
 
 def _clamp_label_vertical(

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -681,9 +681,7 @@ def _position_ports_on_boundary(
         if free_axis == "y" and port is not None and not port.is_entry:
             anchor = _find_downstream_bundle_y(pid, section, graph)
         if anchor is None:
-            anchor = _find_connected_internal_coord(
-                pid, section, graph, free_axis
-            )
+            anchor = _find_connected_internal_coord(pid, section, graph, free_axis)
         if free_axis == "y":
             default = section.bbox_y + section.bbox_h / 2
         else:
@@ -776,9 +774,7 @@ def _find_downstream_bundle_y(
         ds = sections.get(ep.section_id)
         if not ds or ds.grid_row != same_row:
             continue
-        ds_internal = (
-            set(ds.station_ids) - set(ds.entry_ports) - set(ds.exit_ports)
-        )
+        ds_internal = set(ds.station_ids) - set(ds.entry_ports) - set(ds.exit_ports)
         targets: dict[str, set[str]] = {}
         for edge in edges_by_source.get(eid, ()):
             if edge.target not in ds_internal:

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -728,7 +728,15 @@ def _find_downstream_bundle_y(
     fall back to the local-internal centre.
     """
     junction_ids = set(graph.junctions)
+    ports = graph.ports
+    stations = graph.stations
+    sections = graph.sections
     same_row = section.grid_row
+
+    # Index edges by source once: every other lookup is by source.
+    edges_by_source: dict[str, list] = {}
+    for edge in graph.edges:
+        edges_by_source.setdefault(edge.source, []).append(edge)
 
     # Fan-in exits stay centred: 2+ distinct internal source Ys means
     # the visual convergence is meaningful and downstream anchoring
@@ -737,55 +745,55 @@ def _find_downstream_bundle_y(
         set(section.station_ids) - set(section.entry_ports) - set(section.exit_ports)
     )
     src_ys: set[float] = set()
-    for edge in graph.edges:
-        if edge.target == exit_port_id and edge.source in internal_ids:
-            st = graph.stations.get(edge.source)
+    for sid in internal_ids:
+        for edge in edges_by_source.get(sid, ()):
+            if edge.target != exit_port_id:
+                continue
+            st = stations.get(sid)
             if st and not st.is_port:
                 src_ys.add(round(st.y, 1))
-    if len(src_ys) >= 2:
-        return None
+                if len(src_ys) >= 2:
+                    return None
+                break
 
     entry_ids: list[str] = []
-    for edge in graph.edges:
-        if edge.source != exit_port_id:
-            continue
+    for edge in edges_by_source.get(exit_port_id, ()):
         tgt = edge.target
-        if tgt in graph.ports and graph.ports[tgt].is_entry:
+        if tgt in ports and ports[tgt].is_entry:
             entry_ids.append(tgt)
         elif tgt in junction_ids:
-            for e2 in graph.edges:
-                if e2.source == tgt and e2.target in graph.ports and (
-                    graph.ports[e2.target].is_entry
-                ):
+            for e2 in edges_by_source.get(tgt, ()):
+                if e2.target in ports and ports[e2.target].is_entry:
                     entry_ids.append(e2.target)
     if not entry_ids:
         return None
 
     candidates: list[float] = []
     for eid in entry_ids:
-        ep = graph.ports.get(eid)
+        ep = ports.get(eid)
         if not ep:
             continue
-        ds = graph.sections.get(ep.section_id)
+        ds = sections.get(ep.section_id)
         if not ds or ds.grid_row != same_row:
             continue
         ds_internal = (
             set(ds.station_ids) - set(ds.entry_ports) - set(ds.exit_ports)
         )
         targets: dict[str, set[str]] = {}
-        for edge in graph.edges:
-            if edge.source != eid or edge.target not in ds_internal:
+        for edge in edges_by_source.get(eid, ()):
+            if edge.target not in ds_internal:
                 continue
-            st = graph.stations.get(edge.target)
+            st = stations.get(edge.target)
             if st and not st.is_port:
                 targets.setdefault(edge.target, set()).add(edge.line_id)
         if not targets:
             continue
-        line_sets = list(targets.values())
-        if any(ls != line_sets[0] for ls in line_sets[1:]):
+        line_sets = iter(targets.values())
+        first = next(line_sets)
+        if any(ls != first for ls in line_sets):
             # Branch fan-out: different stations carry different lines.
             return None
-        candidates.append(min(graph.stations[sid].y for sid in targets))
+        candidates.append(min(stations[sid].y for sid in targets))
 
     if not candidates or max(candidates) - min(candidates) > 1.0:
         return None

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -673,16 +673,25 @@ def _position_ports_on_boundary(
         if not station:
             continue
 
-        connected = _find_connected_internal_coord(pid, section, graph, free_axis)
+        port = graph.ports.get(pid)
+        # LEFT/RIGHT exit ports prefer the downstream bundle Y so the
+        # inter-section run stays horizontal; fall back to the local
+        # internal-station average for entry ports and fan-in exits.
+        anchor: float | None = None
+        if free_axis == "y" and port is not None and not port.is_entry:
+            anchor = _find_downstream_bundle_y(pid, section, graph)
+        if anchor is None:
+            anchor = _find_connected_internal_coord(
+                pid, section, graph, free_axis
+            )
         if free_axis == "y":
             default = section.bbox_y + section.bbox_h / 2
         else:
             default = section.bbox_x + section.bbox_w / 2
 
         setattr(station, fixed_axis, fixed_coord)
-        setattr(station, free_axis, connected if connected is not None else default)
+        setattr(station, free_axis, anchor if anchor is not None else default)
 
-        port = graph.ports.get(pid)
         if port:
             port.x = station.x
             port.y = station.y
@@ -701,6 +710,89 @@ def _position_ports_on_boundary(
         span_start=span_start,
         span_end=span_end,
     )
+
+
+def _find_downstream_bundle_y(
+    exit_port_id: str,
+    section: Section,
+    graph: MetroGraph,
+) -> float | None:
+    """Find the Y where this exit port's bundle materialises downstream.
+
+    Traces forward to the downstream entry ports (direct or via a
+    fan-out junction) and resolves the Y of the topmost internal
+    station each one feeds when the fan-out is a parallel bundle
+    (every internal station carries the same line set).  Returns the
+    bundle Y when all same-row downstream entries agree and the value
+    fits inside this section's bbox, otherwise None so the caller can
+    fall back to the local-internal centre.
+    """
+    junction_ids = set(graph.junctions)
+    same_row = section.grid_row
+
+    # Fan-in exits stay centred: 2+ distinct internal source Ys means
+    # the visual convergence is meaningful and downstream anchoring
+    # would collapse the bundle onto one source.
+    internal_ids = (
+        set(section.station_ids) - set(section.entry_ports) - set(section.exit_ports)
+    )
+    src_ys: set[float] = set()
+    for edge in graph.edges:
+        if edge.target == exit_port_id and edge.source in internal_ids:
+            st = graph.stations.get(edge.source)
+            if st and not st.is_port:
+                src_ys.add(round(st.y, 1))
+    if len(src_ys) >= 2:
+        return None
+
+    entry_ids: list[str] = []
+    for edge in graph.edges:
+        if edge.source != exit_port_id:
+            continue
+        tgt = edge.target
+        if tgt in graph.ports and graph.ports[tgt].is_entry:
+            entry_ids.append(tgt)
+        elif tgt in junction_ids:
+            for e2 in graph.edges:
+                if e2.source == tgt and e2.target in graph.ports and (
+                    graph.ports[e2.target].is_entry
+                ):
+                    entry_ids.append(e2.target)
+    if not entry_ids:
+        return None
+
+    candidates: list[float] = []
+    for eid in entry_ids:
+        ep = graph.ports.get(eid)
+        if not ep:
+            continue
+        ds = graph.sections.get(ep.section_id)
+        if not ds or ds.grid_row != same_row:
+            continue
+        ds_internal = (
+            set(ds.station_ids) - set(ds.entry_ports) - set(ds.exit_ports)
+        )
+        targets: dict[str, set[str]] = {}
+        for edge in graph.edges:
+            if edge.source != eid or edge.target not in ds_internal:
+                continue
+            st = graph.stations.get(edge.target)
+            if st and not st.is_port:
+                targets.setdefault(edge.target, set()).add(edge.line_id)
+        if not targets:
+            continue
+        line_sets = list(targets.values())
+        if any(ls != line_sets[0] for ls in line_sets[1:]):
+            # Branch fan-out: different stations carry different lines.
+            return None
+        candidates.append(min(graph.stations[sid].y for sid in targets))
+
+    if not candidates or max(candidates) - min(candidates) > 1.0:
+        return None
+    target_y = candidates[0]
+    if not (section.bbox_y <= target_y <= section.bbox_y + section.bbox_h):
+        return None
+    return target_y
 
 
 def _find_connected_internal_coord(


### PR DESCRIPTION
## Summary

- LR/RL exit ports now snap to the downstream bundle Y when the next section's entry feeds a parallel bundle (every connected internal station carries the same line set), so the inter-section run stays horizontal instead of dropping diagonally to a centred join hub.
- Falls back to the local-internal centre when the exit has fan-in from distinct Ys, the downstream entry is a branch fan-out, multiple downstream entries land at different Ys, or the anchor falls outside the section bbox.
- `SECTION_Y_PADDING` bumped from 35 to 50 so the new straight runs have visible margin above the topmost station inside each section.
- `_resolve_source_xy` now recurses through chained junctions; the (0, 0) fallback was previously masked by tighter padding but would otherwise drag entry-section bbox tops off-canvas (visible in `genomeassembly`).

## Test plan

- [x] `pytest` 704/704
- [x] Render gallery: 43/46 changed, 0 broken (genomeassembly bbox overflow fixed, other deltas are expected padding/anchor effects)
- [x] Fan-in exits still keep their centred midpoint