### PR TITLE
fix(layout): symmetric fan around centred trunk when center-ports is on

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -53,7 +53,7 @@ SECTION_GAP: float = 3.0
 SECTION_X_PADDING: float = 50.0
 """Horizontal padding around section content."""
 
-SECTION_Y_PADDING: float = 35.0
+SECTION_Y_PADDING: float = 50.0
 """Vertical padding around section content."""
 
 SECTION_X_GAP: float = 50.0

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -2264,9 +2264,24 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
         if len(unique_source_ys) >= 3 and (
             unique_source_ys[-1] - unique_source_ys[0] > 1.0
         ):
-            # 3+ sources at distinct Y values: this is a fan-in merge.
-            # Keep the centered midpoint so lines converge symmetrically.
-            continue
+            # 3+ sources at distinct Y values is normally a fan-in merge
+            # and the centered midpoint preserves the convergence visual.
+            # Exception: when the exit carries a multi-line bundle (every
+            # source contributes the full line set) and one source Y
+            # matches the downstream entry, the sources are parallel-
+            # redundant rather than truly merging.  Snap to that source Y
+            # so the inter-section run stays horizontal.
+            exit_lines = {
+                e.line_id for e in graph.edges if e.target == port_id
+            }
+            if (
+                len(exit_lines) >= 2
+                and ds_y is not None
+                and any(abs(y - ds_y) < 1.0 for y in unique_source_ys)
+            ):
+                target_y = next(y for y in unique_source_ys if abs(y - ds_y) < 1.0)
+            else:
+                continue
         elif len(unique_source_ys) == 2 and (
             unique_source_ys[-1] - unique_source_ys[0] > 1.0
         ):

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -416,6 +416,12 @@ def _compute_section_layout(
     # bbox tops within each row stay flush after port-terminus spacing.
     _top_align_row_sections(graph)
 
+    # Phase 11d: When --center-ports is on, fan each row-mate section
+    # symmetrically around the smallest section's vertical centre.
+    # Trunk stations land on the shared target Y; side stations split
+    # above/below so sections don't leave empty space above the trunk.
+    _redistribute_row_symmetric(graph, y_spacing)
+
     # ---- Pass C: Junction positioning (single pass) --------------------
     # All port positions are now final; position junctions once.
 
@@ -912,6 +918,135 @@ def _top_align_row_sections(graph: MetroGraph) -> None:
                     if station:
                         station.y -= delta
                 section.bbox_y -= delta
+
+
+def _redistribute_row_symmetric(graph: MetroGraph, y_spacing: float) -> None:
+    """Fan each row-mate section symmetrically around a shared trunk Y.
+
+    Active when ``graph.center_ports`` is True.  For every grid row with
+    at least two LR/RL sections, this phase picks a target trunk Y --
+    the vertical centre of the smallest section in the row -- and
+    redistributes each row-mate section's internal stations so each
+    column is balanced above and below that trunk.
+
+    Within a column, a unique trunk station (line set equals the full
+    bundle crossing the section's LEFT/RIGHT ports) is pinned at the
+    target Y and side stations fan around it in alternating slots
+    ``+1, -1, +2, -2, ...`` at ``y_spacing`` pitch.  Columns without a
+    unique trunk centre all stations symmetrically.  Entry/exit ports
+    on LEFT/RIGHT sides are snapped to the target Y so inter-section
+    lines stay horizontal.  Section bboxes are recomputed and the row
+    is equalised so headers align.
+
+    No-op when ``--no-center-ports`` is set; the default PR #262 trunk
+    behaviour is preserved.
+    """
+    if not graph.center_ports:
+        return
+    grid_sec_ids = _grid_group_section_ids(graph)
+    if not grid_sec_ids:
+        return
+
+    row_sections: dict[int, list[Section]] = defaultdict(list)
+    for section in graph.sections.values():
+        if (
+            section.id in grid_sec_ids
+            and section.direction in ("LR", "RL")
+            and section.grid_row >= 0
+            and section.bbox_h > 0
+        ):
+            row_sections[section.grid_row].append(section)
+
+    grid_info = graph._row_y_grid_info
+    rows_touched: set[int] = set()
+    for row, sections in row_sections.items():
+        if len(sections) < 2:
+            continue
+        smallest = min(sections, key=lambda s: s.bbox_h)
+        target_y = smallest.bbox_y + smallest.bbox_h / 2
+
+        for section in sections:
+            bundle = _section_bundle(graph, section)
+            port_ids = set(section.entry_ports) | set(section.exit_ports)
+            cols: dict[float, list[str]] = defaultdict(list)
+            for sid in section.station_ids:
+                if sid in port_ids:
+                    continue
+                st = graph.stations.get(sid)
+                if st is None:
+                    continue
+                cols[round(st.x, 3)].append(sid)
+
+            for sids in cols.values():
+                if not sids:
+                    continue
+                lines_by_sid = {s: set(graph.station_lines(s)) for s in sids}
+                trunk_sids = [s for s in sids if lines_by_sid[s] == bundle]
+                if len(trunk_sids) == 1 and len(sids) > 1:
+                    trunk_sid = trunk_sids[0]
+                    side_sids = [s for s in sids if s != trunk_sid]
+                    side_sids.sort(key=lambda s: graph.stations[s].y)
+                    graph.stations[trunk_sid].y = target_y
+                    for i, sid in enumerate(side_sids, 1):
+                        k = (i + 1) // 2
+                        sign = 1 if (i % 2 == 1) else -1
+                        graph.stations[sid].y = target_y + sign * k * y_spacing
+                else:
+                    sids_sorted = sorted(sids, key=lambda s: graph.stations[s].y)
+                    n = len(sids_sorted)
+                    for i, sid in enumerate(sids_sorted):
+                        offset = (i - (n - 1) / 2.0) * y_spacing
+                        graph.stations[sid].y = target_y + offset
+
+            for pid in port_ids:
+                port = graph.ports.get(pid)
+                port_st = graph.stations.get(pid)
+                if port is None or port_st is None:
+                    continue
+                if port.side not in (PortSide.LEFT, PortSide.RIGHT):
+                    continue
+                port_st.y = target_y
+
+        rows_touched.add(row)
+
+    if not rows_touched:
+        return
+
+    _recompute_grid_group_bboxes(graph)
+
+    for row in rows_touched:
+        sections = row_sections[row]
+        info = grid_info.get(row, {})
+        pad = info.get("max_y_pad", y_spacing)
+        non_port_ys: list[float] = []
+        for section in sections:
+            port_ids = set(section.entry_ports) | set(section.exit_ports)
+            for sid in section.station_ids:
+                if sid in port_ids:
+                    continue
+                st = graph.stations.get(sid)
+                if st is not None:
+                    non_port_ys.append(st.y)
+        if not non_port_ys:
+            continue
+        row_top = min(non_port_ys) - pad
+        row_bot = max(non_port_ys) + pad
+        for section in sections:
+            section.bbox_y = row_top
+            section.bbox_h = row_bot - row_top
+
+
+def _section_bundle(graph: MetroGraph, section: Section) -> set[str]:
+    """Return the set of line IDs crossing a section's LEFT/RIGHT ports."""
+    bundle: set[str] = set()
+    for pid in list(section.entry_ports) + list(section.exit_ports):
+        port = graph.ports.get(pid)
+        if port is None or port.side not in (PortSide.LEFT, PortSide.RIGHT):
+            continue
+        for edge in graph.edges:
+            if edge.source == pid or edge.target == pid:
+                bundle.add(edge.line_id)
+    return bundle
 
 
 def _layout_single_section(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -411,6 +411,11 @@ def _compute_section_layout(
     # padding around the final non-port station range.
     _recompute_grid_group_bboxes(graph)
 
+    # Phase 11c: Re-run top-align after Phase 11 may have shifted
+    # individual section bbox_y values (via _expand_bbox_for_y) so
+    # bbox tops within each row stay flush after port-terminus spacing.
+    _top_align_row_sections(graph)
+
     # ---- Pass C: Junction positioning (single pass) --------------------
     # All port positions are now final; position junctions once.
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1000,6 +1000,11 @@ def _layout_single_section(
             station.x = station.layer * x_spacing + layer_extra.get(station.layer, 0)
             station.y = track_rank[station.track] * effective_y_spacing
 
+    # Resolve same-cell station collisions: two stations on the same line
+    # priority can land on identical (x,y) when the track allocator collapses
+    # distinct line tracks at a layer with only one occupant per line.
+    _resolve_station_collisions(sub, section, x_spacing, effective_y_spacing)
+
     # Normalize Y so minimum is 0 (raw tracks can be negative)
     _normalize_min(sub, axis="y")
 
@@ -1034,6 +1039,59 @@ def _layout_single_section(
     _adjust_terminus_icon_clearance(sub, section, graph)
 
     return sub
+
+
+def _resolve_station_collisions(
+    sub: MetroGraph,
+    section: Section,
+    x_spacing: float,
+    y_spacing: float,
+) -> None:
+    """Push stations apart when track compaction collides them in the same cell.
+
+    The track allocator can return identical track values for two stations on
+    different lines when each is the sole occupant of its line at a given
+    layer (e.g. side-by-side terminus branches). After coordinate assignment
+    they end up at the same (x, y), causing visual overlap. This pass detects
+    such collisions and shifts the later-defined station along the section's
+    secondary axis by one spacing unit, repeating until the cell is unique.
+    """
+    if section.direction == "TB":
+        primary, secondary, primary_step, step = "y", "x", y_spacing, x_spacing
+    else:
+        primary, secondary, primary_step, step = "x", "y", x_spacing, y_spacing
+
+    EPS = 0.5
+    real = [s for s in sub.stations.values() if not s.is_port and not s.is_hidden]
+    real.sort(key=lambda s: (getattr(s, primary), getattr(s, secondary)))
+
+    # Group stations by primary-axis bucket (layer column for LR/RL,
+    # row for TB).  Use the primary-axis step size; the bucket spans a
+    # half-step either side of a layer centre so off-grid layer_extra
+    # offsets stay in the same bucket as their layer peers.
+    by_primary: dict[float, list] = {}
+    for s in real:
+        bucket = round(getattr(s, primary) / max(primary_step, 1.0))
+        by_primary.setdefault(bucket, []).append(s)
+
+    for stations in by_primary.values():
+        if len(stations) < 2:
+            continue
+        # Sort by current secondary coord, then station definition order
+        # (insertion order in sub.stations) as a stable tiebreaker so the
+        # earlier-defined station keeps its slot.
+        order = {sid: i for i, sid in enumerate(sub.stations)}
+        stations.sort(
+            key=lambda s: (getattr(s, secondary), order.get(s.id, 0))
+        )
+        used: list[float] = []
+        for s in stations:
+            pos = getattr(s, secondary)
+            while any(abs(pos - u) < step - EPS for u in used):
+                pos += step
+            if pos != getattr(s, secondary):
+                setattr(s, secondary, pos)
+            used.append(pos)
 
 
 def _multiline_track_spacing(sub: MetroGraph, y_spacing: float) -> float:

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -113,6 +113,7 @@ def assign_tracks(
                     tracks,
                     straight_diamonds=graph.diamond_style == "straight",
                     layer_idx=layer_idx if entry_top else -1,
+                    graph=graph,
                 )
                 for n in nodes:
                     layer_occupancy[layer_idx][n] = tracks[n]
@@ -312,8 +313,19 @@ def _place_single_node(
         # base track so the main bundle stays compact and downstream
         # stations don't zigzag between the merged and base positions.
         if len(preds) > 1:
-            max_pred_lines = max(len(set(graph.station_lines(p))) for p in preds)
+            pred_line_sets = [set(graph.station_lines(p)) for p in preds]
+            max_pred_lines = max(len(pls) for pls in pred_line_sets)
             if len(node_lines) > max_pred_lines:
+                return base
+
+            # Trunk junction: at least one predecessor already carries the
+            # full node-line bundle, so side branches (subset preds) merge
+            # into the existing trunk here.  Anchor on the trunk's primary
+            # line track instead of the predecessor centroid so the bundle
+            # stays straight through the junction.
+            if len(node_lines) >= 2 and any(
+                pls == node_lines for pls in pred_line_sets
+            ):
                 return base
 
         # Diamond merge: when straight diamonds are active, snap the
@@ -369,6 +381,30 @@ def _is_diamond_fanout(nodes: list[str], G: nx.DiGraph) -> bool:
     return len(common_succs) > 0
 
 
+def _trunk_fanout_node(
+    nodes: list[str], graph: MetroGraph | None
+) -> str | None:
+    """Return the unique fan-out node carrying a strict superset of all siblings.
+
+    When one sibling's line set strictly contains every other sibling's
+    line set, it represents the trunk bundle while the others are
+    branches.  Anchoring the trunk keeps the bundle straight through
+    the fan-out.  Returns ``None`` if no such unique trunk exists.
+    """
+    if graph is None or len(nodes) < 2:
+        return None
+    line_sets = [(n, set(graph.station_lines(n))) for n in nodes]
+    trunk = None
+    for cand, cand_lines in line_sets:
+        if all(
+            other_lines < cand_lines for other, other_lines in line_sets if other != cand
+        ):
+            if trunk is not None:
+                return None
+            trunk = cand
+    return trunk
+
+
 def _place_fan_out(
     nodes: list[str],
     base: float,
@@ -378,6 +414,7 @@ def _place_fan_out(
     *,
     straight_diamonds: bool = False,
     layer_idx: int = -1,
+    graph: MetroGraph | None = None,
 ) -> None:
     """Place multiple nodes in the same layer+line, centered around an anchor.
 
@@ -448,7 +485,17 @@ def _place_fan_out(
     elif layer_idx == 1 and n == 2:
         use_asymmetric = True
 
-    if use_asymmetric:
+    # Trunk-anchored placement: when one node carries a strict superset
+    # of every sibling's line set, it's the bundle trunk.  Pin it at
+    # anchor and fan the side branches below so the trunk stays straight
+    # through the junction.
+    trunk_node = _trunk_fanout_node(nodes, graph)
+    if trunk_node is not None:
+        tracks[trunk_node] = anchor
+        others = [n for n in nodes if n != trunk_node]
+        for i, node in enumerate(others, 1):
+            tracks[node] = anchor + i * fan_spacing
+    elif use_asymmetric:
         # First node stays at anchor, others fan out below.
         tracks[nodes[0]] = anchor
         for i, node in enumerate(nodes[1:], 1):

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -673,16 +673,25 @@ def _position_ports_on_boundary(
         if not station:
             continue
 
-        connected = _find_connected_internal_coord(pid, section, graph, free_axis)
+        port = graph.ports.get(pid)
+        # LEFT/RIGHT exit ports prefer the downstream bundle Y so the
+        # inter-section run stays horizontal; fall back to the local
+        # internal-station average for entry ports and fan-in exits.
+        anchor: float | None = None
+        if free_axis == "y" and port is not None and not port.is_entry:
+            anchor = _find_downstream_bundle_y(pid, section, graph)
+        if anchor is None:
+            anchor = _find_connected_internal_coord(
+                pid, section, graph, free_axis
+            )
         if free_axis == "y":
             default = section.bbox_y + section.bbox_h / 2
         else:
             default = section.bbox_x + section.bbox_w / 2
 
         setattr(station, fixed_axis, fixed_coord)
-        setattr(station, free_axis, connected if connected is not None else default)
+        setattr(station, free_axis, anchor if anchor is not None else default)
 
-        port = graph.ports.get(pid)
         if port:
             port.x = station.x
             port.y = station.y
@@ -701,6 +710,89 @@ def _position_ports_on_boundary(
         span_start=span_start,
         span_end=span_end,
     )
+
+
+def _find_downstream_bundle_y(
+    exit_port_id: str,
+    section: Section,
+    graph: MetroGraph,
+) -> float | None:
+    """Find the Y where this exit port's bundle materialises downstream.
+
+    Traces forward to the downstream entry ports (direct or via a
+    fan-out junction) and resolves the Y of the topmost internal
+    station each one feeds when the fan-out is a parallel bundle
+    (every internal station carries the same line set).  Returns the
+    bundle Y when all same-row downstream entries agree and the value
+    fits inside this section's bbox, otherwise None so the caller can
+    fall back to the local-internal centre.
+    """
+    junction_ids = set(graph.junctions)
+    same_row = section.grid_row
+
+    # Fan-in exits stay centred: 2+ distinct internal source Ys means
+    # the visual convergence is meaningful and downstream anchoring
+    # would collapse the bundle onto one source.
+    internal_ids = (
+        set(section.station_ids) - set(section.entry_ports) - set(section.exit_ports)
+    )
+    src_ys: set[float] = set()
+    for edge in graph.edges:
+        if edge.target == exit_port_id and edge.source in internal_ids:
+            st = graph.stations.get(edge.source)
+            if st and not st.is_port:
+                src_ys.add(round(st.y, 1))
+    if len(src_ys) >= 2:
+        return None
+
+    entry_ids: list[str] = []
+    for edge in graph.edges:
+        if edge.source != exit_port_id:
+            continue
+        tgt = edge.target
+        if tgt in graph.ports and graph.ports[tgt].is_entry:
+            entry_ids.append(tgt)
+        elif tgt in junction_ids:
+            for e2 in graph.edges:
+                if e2.source == tgt and e2.target in graph.ports and (
+                    graph.ports[e2.target].is_entry
+                ):
+                    entry_ids.append(e2.target)
+    if not entry_ids:
+        return None
+
+    candidates: list[float] = []
+    for eid in entry_ids:
+        ep = graph.ports.get(eid)
+        if not ep:
+            continue
+        ds = graph.sections.get(ep.section_id)
+        if not ds or ds.grid_row != same_row:
+            continue
+        ds_internal = (
+            set(ds.station_ids) - set(ds.entry_ports) - set(ds.exit_ports)
+        )
+        targets: dict[str, set[str]] = {}
+        for edge in graph.edges:
+            if edge.source != eid or edge.target not in ds_internal:
+                continue
+            st = graph.stations.get(edge.target)
+            if st and not st.is_port:
+                targets.setdefault(edge.target, set()).add(edge.line_id)
+        if not targets:
+            continue
+        line_sets = list(targets.values())
+        if any(ls != line_sets[0] for ls in line_sets[1:]):
+            # Branch fan-out: different stations carry different lines.
+            return None
+        candidates.append(min(graph.stations[sid].y for sid in targets))
+
+    if not candidates or max(candidates) - min(candidates) > 1.0:
+        return None
+    target_y = candidates[0]
+    if not (section.bbox_y <= target_y <= section.bbox_y + section.bbox_h):
+        return None
+    return target_y
 
 
 def _find_connected_internal_coord(


### PR DESCRIPTION
## Summary

- When ``--center-ports`` is enabled, picks a shared trunk Y per grid row (the vertical centre of the smallest section in the row) and fans each row-mate section's content symmetrically around it.
- Within a column the unique trunk station is pinned at the target Y; side stations occupy alternating ``+1, -1, +2, -2, ...`` slots. Columns without a unique trunk centre all stations symmetrically. LEFT/RIGHT ports snap to the shared Y so the bundle stays horizontal across the row.
- Replaces the reverted PR #263 approach (which shifted every station by the same delta and just relocated the empty space lower in the section).
- Default ``--no-center-ports`` keeps the PR #262 top-track trunk behaviour.

## Test plan

- [x] ``pytest`` -- 704 passed.
- [x] Render ``differentialabundance`` mermaid with ``--center-ports``: limma sits at trunk Y, dream above, DESeq2 / propd below; GSEA / decoupler / gprofiler2 / grea fan around the trunk Y in functional; reporting and data_prep also balanced around the same Y.
- [x] Render with ``--no-center-ports``: layout matches the PR #262 baseline.

Stations of interest in the differential section (``--center-ports`` on):

| station | before | after |
| --- | --- | --- |
| limma  | 120 | 170 |
| dream  | 230 | 115 |
| DESeq2 | 175 | 225 |
| propd  | 285 | 280 |

Trunk Y is now 170 (== reporting section centre) and the section fans both above and below limma.

This PR supersedes #263.