### PR TITLE
fix(layout): keep trunk straight when minor side branches join at exit ports

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1937,10 +1937,22 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
         ]
 
         for x, full in full_by_col.items():
-            # Fire only when every column station carries the full bundle
-            # and there are >=2 (so no unique trunk station exists).
-            if len(full) < 2 or len(full) != len(cols[x]):
+            # Fire when the column is a fan-out group: every station in
+            # it has at least one inbound edge (so it's not a column of
+            # source file inputs whose per-line tracks must be
+            # preserved), AND there's at least one full-bundle anchor
+            # plus another column-mate.  Subset-bundle siblings
+            # (single-line side branches) are fanned alongside so the
+            # whole column distributes symmetrically around the trunk.
+            if not full or len(cols[x]) < 2:
                 continue
+            if not all(
+                any(e.target == s for e in graph.edges) for s in cols[x]
+            ):
+                continue
+            # When every station carries the full bundle (no subset
+            # siblings), fall through to the original symmetric fan
+            # behaviour.  Mixed columns (full + subset) ride together.
             # Trunk Y is the section's LR port Y when available (the
             # inter-section bundle line) so all full-bundle columns
             # in the section share a single trunk reference.  Falls
@@ -1957,15 +1969,15 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
                 if not others:
                     continue
                 trunk_y = others[len(others) // 2]
-            full.sort(key=lambda s: pre_fan_y[s])
-            n = len(full)
+            members = sorted(cols[x], key=lambda s: pre_fan_y[s])
+            n = len(members)
             # Even: offsets -n//2..-1, 1..n//2 (skipping 0).
             # Odd:  offsets -(n//2)..n//2 inclusive (0 = trunk_y).
             if n % 2 == 0:
                 offsets = list(range(-(n // 2), 0)) + list(range(1, n // 2 + 1))
             else:
                 offsets = list(range(-(n // 2), n // 2 + 1))
-            for sid, off in zip(full, offsets):
+            for sid, off in zip(members, offsets):
                 graph.stations[sid].y = trunk_y + off * y_spacing
 
 
@@ -2061,15 +2073,24 @@ def _recenter_full_bundle_columns(
                 anchor_y = sorted(all_full)[len(all_full) // 2]
 
         for x, full in full_by_col.items():
-            if len(full) < 2 or len(full) != len(cols[x]):
+            # Mirror the relaxed gate of the early pass: fire when the
+            # column is a fan-out group (every station has an inbound
+            # edge) with at least one full-bundle anchor plus another
+            # column-mate.  Subset-bundle siblings (single-line side
+            # branches) ride along symmetrically.
+            if not full or len(cols[x]) < 2:
                 continue
-            full.sort(key=lambda s: graph.stations[s].y)
-            n = len(full)
+            if not all(
+                any(e.target == s for e in graph.edges) for s in cols[x]
+            ):
+                continue
+            members = sorted(cols[x], key=lambda s: graph.stations[s].y)
+            n = len(members)
             if n % 2 == 0:
                 offsets = list(range(-(n // 2), 0)) + list(range(1, n // 2 + 1))
             else:
                 offsets = list(range(-(n // 2), n // 2 + 1))
-            for sid, off in zip(full, offsets):
+            for sid, off in zip(members, offsets):
                 graph.stations[sid].y = anchor_y + off * y_spacing
 
 

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -526,7 +526,19 @@ def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
                     line_ys.setdefault(edge.line_id, []).append(src_st.y)
         if len(line_ys) < 2:
             continue
-        line_avg_y = {lid: sum(ys) / len(ys) for lid, ys in line_ys.items()}
+        # Per-line representative Y for spatial sorting: pick each line's
+        # feeder closest to the port's own Y (with min-Y tiebreak).  This
+        # ignores lone off-trunk minor feeders (e.g. a single-line side
+        # branch joining at the exit port) that would otherwise drag the
+        # line's representative Y and reorder the bundle.  Reordering the
+        # bundle when the dominant trunk feeder sits at port_y forces
+        # horizontal-reconcile to shift the trunk station's offsets,
+        # producing a visible kink at the section boundary.
+        port_y = graph.stations[port_id].y
+        line_avg_y: dict[str, float] = {
+            lid: min(ys, key=lambda y: (abs(y - port_y), y))
+            for lid, ys in line_ys.items()
+        }
         unique_ys = set(line_avg_y.values())
         if len(unique_ys) < 2:
             continue
@@ -540,7 +552,6 @@ def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
         # Without this, reconciliation snaps same-Y stations to the
         # port's non-zero spatial offset, pushing them off-grid.
         # Ties broken by lowest spatial offset to avoid negative shifts.
-        port_y = graph.stations[port_id].y
         anchor_line = min(
             line_avg_y,
             key=lambda lid: (abs(line_avg_y[lid] - port_y), spatial_offs[lid]),


### PR DESCRIPTION
## Summary

Two related layout regressions surfaced when a section's exit port collects both a dominant trunk station and a minor (single-line) side-branch feeder (e.g. ``propd -> grea`` in the differentialabundance map). Both produced visible trunk kinks or stranded stations.

- Trunk-Y kink at section boundaries: the exit-port spatial-Y ordering averaged feeder Ys per line, so a lone below-trunk feeder dragged a line's representative Y down and reordered the bundle at the port. Horizontal-reconcile then shifted the trunk station's per-line offsets, producing a visible kink crossing the boundary. Use the feeder Y closest to ``port_y`` per line (with min-Y tiebreak) instead.
- Reserved-offset gap in functional/reporting style sections: ``_redistribute_full_bundle_columns`` (both early and late passes) refused to fire on columns mixing full-bundle stations with subset siblings, leaving full-bundle stations stranded at a deep track while their subset sibling occupied a nearby slot. Relax the gate to fire on any column with a full-bundle anchor plus column-mates whose members all have inbound edges (so source file-input banks still keep their per-line tracks). Subset siblings ride along the symmetric fan around the row trunk Y.

## Test plan

- [x] ``pytest tests/`` (736 pass)
- [x] Render ``nf-core/differentialabundance`` metro map: trunk runs straight across sections 1 -> 2 -> 3 -> 5 at a single Y; section 3 fans gprofiler2/GSEA above and grea/decoupler below symmetrically.