### PR TITLE
fix(layout): v104 auto-balance + terminus convergence on top of v103

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -322,6 +322,17 @@ For stations that represent a directory of output files rather than a single fil
 
 All three directives (`file:`, `files:`, `dir:`) work the same way: pair a station ID with a label, give the station a blank label (`[ ]`), and connect it with normal edges. The only difference is the rendered icon shape.
 
+### Naming an icon
+
+The label inside an icon is meant for a short type chip (e.g. `CSV`, `FASTQ`). To attach a human-readable name without overlapping the chip, add an optional third field to the directive:
+
+```text
+%%metro file: samples_in | CSV | Samples
+%%metro file: contrasts_in | YAML | Contrasts
+```
+
+The name is rendered as a caption directly below the icon. If multiple labels are listed (`FASTQ, BAM`), the same name applies to all of them.
+
 ## 6. Hidden stations
 
 Sometimes you need a branching or merging point in the graph that doesn't represent a real pipeline step. For example, lines might diverge at a point where no tool is actually run. Adding a visible station there clutters the diagram with a meaningless marker.
@@ -417,9 +428,9 @@ These go at the top of the file, before `graph LR`.
 | `%%metro grid: <section> \| <col>,<row>[,<rowspan>[,<colspan>]]` | Pin a section to a grid position |
 | `%%metro legend: <position>` | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, or `none` |
 | `%%metro line_order: <strategy>` | Line ordering for track assignment: `definition` (default, preserves `.mmd` order) or `span` (longest-spanning lines get inner tracks) |
-| `%%metro file: <station> \| <label>` | Mark a station as a file terminus with a document icon |
-| `%%metro files: <station> \| <label>` | Mark a station with a stacked-documents icon (e.g. paired files) |
-| `%%metro dir: <station> \| <label>` | Mark a station with a folder icon (e.g. output directory) |
+| `%%metro file: <station> \| <label> [\| <name>]` | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon. |
+| `%%metro files: <station> \| <label> [\| <name>]` | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption. |
+| `%%metro dir: <station> \| <label> [\| <name>]` | Mark a station with a folder icon (e.g. output directory). Optional `name` caption. |
 | `%%metro compact_offsets: true` | Compact line offsets within stations (see below) |
 | `%%metro legend_min_height: <pixels>` | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -53,7 +53,7 @@ SECTION_GAP: float = 3.0
 SECTION_X_PADDING: float = 50.0
 """Horizontal padding around section content."""
 
-SECTION_Y_PADDING: float = 35.0
+SECTION_Y_PADDING: float = 50.0
 """Vertical padding around section content."""
 
 SECTION_X_GAP: float = 50.0

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1889,11 +1889,16 @@ def _balance_section_content_around_trunk(
             # above-marker label without forcing the bbox to expand
             # upward (which would break row-mate bbox alignment).
             # Stations with empty labels (file icons whose names sit
-            # below) don't need the extra clearance.
+            # below) don't need the extra clearance, but every station
+            # still needs marker/icon half-height clearance so the
+            # marker stays inside the bbox.
             st = graph.stations.get(candidate)
             has_above_label = bool(st and st.label and st.label.strip())
             label_clearance = y_spacing / 2 if has_above_label else 0.0
-            min_y = section.bbox_y + label_clearance
+            # Off-track file icons reach ~16 px above centre; on-track
+            # markers reach ~9.5 px.  Use the wider reach when relevant.
+            marker_clearance = 16.0 if (st and st.off_track) else 9.5
+            min_y = section.bbox_y + max(label_clearance, marker_clearance)
             if new_y < min_y - 0.5:
                 # No room for a new top slot.  Try a SWAP: take the
                 # topmost above-trunk station's Y for the candidate,

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -494,6 +494,18 @@ def _compute_section_layout(
     # consumer.y - n*y_spacing on the final grid.
     _reanchor_off_track_to_consumer(graph, y_spacing)
 
+    # Phase 13g: Re-center full-bundle columns around the row's final
+    # trunk Y.  ``_redistribute_full_bundle_columns`` runs early when
+    # only local port Ys are available; for terminal sections whose
+    # port Y differs from the row's eventual trunk Y, the symmetric
+    # fan ends up offset from the trunk row (e.g. Reporting's Shiny at
+    # the trunk row, Quarto two slots below, instead of one above and
+    # one below).  This re-center uses the final inter-section bundle
+    # Y as the anchor so the trunk row stays empty in each fanned
+    # column.
+    if graph.center_ports:
+        _recenter_full_bundle_columns(graph, y_spacing)
+
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
@@ -1547,17 +1559,14 @@ def _fan_source_inputs_upward(
 
         sources.sort(key=lambda s: graph.stations[s].y)
         section_internal_set = set(internal_ids)
-        for i, src in enumerate(sources[:n_lift], 1):
-            new_y = trunk_y - i * y_spacing
-            delta = new_y - graph.stations[src].y
-            if abs(delta) < 0.5:
-                continue
-            graph.stations[src].y = new_y
+
+        def _shift_chain(src: str, delta: float) -> None:
             # Walk a strictly linear consumer chain: each step requires
             # a single inbound edge from the previous link, an identical
             # line set, and section-internal placement.  Stop on fan-in
             # (consumer has another feeder) or line-set change.
             cur = src
+            src_lines = set(graph.station_lines(src))
             while True:
                 # De-dup parallel edges by target/source: each (src,tgt)
                 # pair may have one edge per line.
@@ -1570,10 +1579,32 @@ def _fan_source_inputs_upward(
                 in_srcs = {e.source for e in graph.edges if e.target == nxt}
                 if len(in_srcs) != 1:
                     break
-                if set(graph.station_lines(nxt)) != set(graph.station_lines(src)):
+                if set(graph.station_lines(nxt)) != src_lines:
                     break
                 graph.stations[nxt].y += delta
                 cur = nxt
+
+        for i, src in enumerate(sources[:n_lift], 1):
+            new_y = trunk_y - i * y_spacing
+            delta = new_y - graph.stations[src].y
+            if abs(delta) < 0.5:
+                continue
+            graph.stations[src].y = new_y
+            _shift_chain(src, delta)
+
+        # Compact the remaining below-trunk sources upward to fill the
+        # rows their predecessors vacated.  Without this step, lifted
+        # sources leave a multi-slot gap between the trunk and the
+        # first below-trunk source (e.g. trunk -> empty -> empty -> Affy
+        # row when GTF and Matrix were lifted).  Place the i-th
+        # below-trunk source at ``trunk_y + i * y_spacing``.
+        for i, src in enumerate(sources[n_lift:], 1):
+            new_y = trunk_y + i * y_spacing
+            delta = new_y - graph.stations[src].y
+            if abs(delta) < 0.5:
+                continue
+            graph.stations[src].y = new_y
+            _shift_chain(src, delta)
 
 
 def _lift_would_cause_uturn(
@@ -1917,6 +1948,110 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
                 offsets = list(range(-(n // 2), n // 2 + 1))
             for sid, off in zip(full, offsets):
                 graph.stations[sid].y = trunk_y + off * y_spacing
+
+
+def _recenter_full_bundle_columns(
+    graph: MetroGraph, y_spacing: float
+) -> None:
+    """Re-fan full-bundle station columns around the row's final trunk Y.
+
+    Late-pass companion to ``_redistribute_full_bundle_columns``.  The
+    early pass uses the section's local LR port Y as the symmetric
+    centre, which becomes stale when subsequent phases shift the
+    section relative to the row trunk (e.g. terminal sections whose
+    sole LR port doesn't match the bundle line entering from upstream).
+
+    For each LR/RL grid section, locate the inter-section bundle Y by
+    looking at LR port-connected internal stations in OTHER columns
+    (single-station columns whose Y is therefore the natural trunk).
+    Then re-distribute each column of >=2 full-bundle stations around
+    that anchor at ``y_spacing`` pitch, preserving the order produced
+    by the first pass.
+
+    No-op when the existing layout is already symmetric around the
+    anchor; bbox heights are not adjusted because earlier compaction
+    already sized the band to fit two slots either side of the trunk.
+    """
+    grid_sec_ids = _grid_group_section_ids(graph)
+    if not grid_sec_ids:
+        return
+
+    for section in graph.sections.values():
+        if (
+            section.id not in grid_sec_ids
+            or section.direction not in ("LR", "RL")
+            or section.bbox_h <= 0
+        ):
+            continue
+        bundle = _section_bundle_lines(graph, section)
+        if not bundle:
+            continue
+        port_ids = set(section.entry_ports) | set(section.exit_ports)
+
+        cols: dict[float, list[str]] = defaultdict(list)
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            st = graph.stations.get(sid)
+            if st is None or st.off_track:
+                continue
+            cols[round(st.x, 3)].append(sid)
+
+        full_by_col = {
+            x: [s for s in sids if set(graph.station_lines(s)) == bundle]
+            for x, sids in cols.items()
+        }
+
+        # Trunk anchor: prefer the row's actual bundle line Y, which is
+        # the entry port station's Y after row alignment.  Falls back
+        # to a single-station full-bundle column (natural pass-through)
+        # or the median Y when neither is available.
+        anchor_y: float | None = None
+        for pid in section.entry_ports:
+            p = graph.ports.get(pid)
+            ps = graph.stations.get(pid)
+            if p is None or ps is None:
+                continue
+            if p.side in (PortSide.LEFT, PortSide.RIGHT):
+                anchor_y = ps.y
+                break
+        if anchor_y is None:
+            for pid in section.exit_ports:
+                p = graph.ports.get(pid)
+                ps = graph.stations.get(pid)
+                if p is None or ps is None:
+                    continue
+                if p.side in (PortSide.LEFT, PortSide.RIGHT):
+                    anchor_y = ps.y
+                    break
+        if anchor_y is None:
+            single_ys = [
+                graph.stations[full[0]].y
+                for full in full_by_col.values()
+                if len(full) == 1
+            ]
+            if single_ys:
+                anchor_y = sorted(single_ys)[len(single_ys) // 2]
+            else:
+                all_full = [
+                    graph.stations[s].y
+                    for full in full_by_col.values() for s in full
+                ]
+                if not all_full:
+                    continue
+                anchor_y = sorted(all_full)[len(all_full) // 2]
+
+        for x, full in full_by_col.items():
+            if len(full) < 2 or len(full) != len(cols[x]):
+                continue
+            full.sort(key=lambda s: graph.stations[s].y)
+            n = len(full)
+            if n % 2 == 0:
+                offsets = list(range(-(n // 2), 0)) + list(range(1, n // 2 + 1))
+            else:
+                offsets = list(range(-(n // 2), n // 2 + 1))
+            for sid, off in zip(full, offsets):
+                graph.stations[sid].y = anchor_y + off * y_spacing
 
 
 def _layout_single_section(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -2264,9 +2264,24 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
         if len(unique_source_ys) >= 3 and (
             unique_source_ys[-1] - unique_source_ys[0] > 1.0
         ):
-            # 3+ sources at distinct Y values: this is a fan-in merge.
-            # Keep the centered midpoint so lines converge symmetrically.
-            continue
+            # 3+ sources at distinct Y values is normally a fan-in merge
+            # and the centered midpoint preserves the convergence visual.
+            # Exception: when the exit carries a multi-line bundle (every
+            # source contributes the full line set) and one source Y
+            # matches the downstream entry, the sources are parallel-
+            # redundant rather than truly merging.  Snap to that source Y
+            # so the inter-section run stays horizontal.
+            exit_lines = {
+                e.line_id for e in graph.edges if e.target == port_id
+            }
+            if (
+                len(exit_lines) >= 2
+                and ds_y is not None
+                and any(abs(y - ds_y) < 1.0 for y in unique_source_ys)
+            ):
+                target_y = next(y for y in unique_source_ys if abs(y - ds_y) < 1.0)
+            else:
+                continue
         elif len(unique_source_ys) == 2 and (
             unique_source_ys[-1] - unique_source_ys[0] > 1.0
         ):

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -506,6 +506,18 @@ def _compute_section_layout(
     if graph.center_ports:
         _recenter_full_bundle_columns(graph, y_spacing)
 
+    # Phase 13h: After fan-re-centering, single-station downstream
+    # columns (e.g. terminus file icons) may have stayed at their
+    # pre-fan Y while their sole upstream moved to the trunk.  Pin
+    # them back onto the source Y so the connection stays horizontal.
+    _align_terminus_to_upstream(graph)
+
+    # Phase 13i: Shrink rowspan / row-mate bboxes whose content moved
+    # up after compact (e.g. ``_fan_source_inputs_upward`` lifted the
+    # bottom rows away from the bbox bottom).  Bottom-only shrink, so
+    # trunk alignment is unaffected.
+    _shrink_bboxes_to_content_bottom(graph, section_y_padding)
+
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
@@ -2054,6 +2066,82 @@ def _recenter_full_bundle_columns(
                 graph.stations[sid].y = anchor_y + off * y_spacing
 
 
+def _shrink_bboxes_to_content_bottom(
+    graph: MetroGraph, section_y_padding: float
+) -> None:
+    """Bottom-only bbox shrink after late content lifts.
+
+    ``_compact_row_content_to_bbox_top`` shrinks the bottom slack to
+    ``section_y_padding`` once, but later phases
+    (``_fan_source_inputs_upward``, ``_recenter_full_bundle_columns``)
+    can pull content further up, leaving fresh empty space below the
+    last station.  Re-shrink each section's ``bbox_h`` so the bottom
+    sits ``section_y_padding`` below the bottom-most station/port.
+    Station Ys are unchanged, so trunk alignment is preserved.
+    """
+    for section in graph.sections.values():
+        if section.bbox_h <= 0:
+            continue
+        content_max_ys = [
+            graph.stations[sid].y
+            for sid in section.station_ids
+            if sid in graph.stations
+            and not graph.stations[sid].is_port
+        ]
+        port_max_ys = [
+            graph.stations[sid].y
+            for sid in section.station_ids
+            if sid in graph.stations and graph.stations[sid].is_port
+        ]
+        if not content_max_ys:
+            continue
+        desired_bot = max(content_max_ys) + section_y_padding
+        if port_max_ys:
+            desired_bot = max(desired_bot, max(port_max_ys))
+        new_h = desired_bot - section.bbox_y
+        if new_h < section.bbox_h - 0.5:
+            section.bbox_h = max(0.0, new_h)
+
+
+def _align_terminus_to_upstream(graph: MetroGraph) -> None:
+    """Pin a single downstream terminus to its sole upstream's Y.
+
+    After ``_recenter_full_bundle_columns`` re-pitches fanned columns,
+    a single-station downstream column (e.g. a ``file`` terminus
+    consuming the fanned station's output) can be left at its pre-fan Y,
+    so the connecting line and the icon caption drift away from the
+    source station.  When the downstream station has exactly one in-
+    section predecessor, snap it back onto the source's Y so its file
+    icon sits level with the station it follows.
+    """
+    for section in graph.sections.values():
+        if section.direction not in ("LR", "RL"):
+            continue
+        sec_sids = set(section.station_ids)
+        for sid in section.station_ids:
+            st = graph.stations.get(sid)
+            if st is None or st.is_port or st.off_track:
+                continue
+            # Scope: terminus stations only (those carrying file icons),
+            # since their visual is anchored to their source by a short
+            # straight line and a side-by-side icon.  Avoids touching
+            # ordinary chain stations that may participate in trunk
+            # alignment or port routing.
+            if not st.is_terminus:
+                continue
+            preds = {
+                e.source for e in graph.edges
+                if e.target == sid and e.source in sec_sids
+                and not graph.stations[e.source].is_port
+            }
+            if len(preds) != 1:
+                continue
+            src = graph.stations[next(iter(preds))]
+            if abs(src.y - st.y) < 0.5:
+                continue
+            st.y = src.y
+
+
 def _layout_single_section(
     graph: MetroGraph,
     section: Section,
@@ -2541,16 +2629,43 @@ def _adjust_lr_label_clearance(
             section.bbox_w = label_right - section.bbox_x
 
 
-def _terminus_icon_clearance(n_icons: int) -> float:
+def _terminus_icon_clearance(
+    n_icons: int,
+    names: list[str] | None = None,
+) -> float:
     """Compute clearance needed for *n_icons* file icons side-by-side.
 
     The base ``TERMINUS_ICON_CLEARANCE`` covers one icon (station_radius +
-    gap + icon_width + margin).  Each additional icon adds icon_width + inter-
-    icon gap.
+    gap + icon_width + margin).  Each additional icon adds the per-icon
+    centre-to-centre step.
+
+    When *names* is supplied, the step is widened to fit adjacent
+    captions on the same row (mirrors ``caption_aware_icon_step`` in
+    the renderer).  Without names, the default ``ICON_INTER_GAP`` step
+    is used.
     """
     if n_icons <= 1:
         return TERMINUS_ICON_CLEARANCE
-    extra = (n_icons - 1) * (TERMINUS_WIDTH + ICON_INTER_GAP)
+    step = TERMINUS_WIDTH + ICON_INTER_GAP
+    if names:
+        # Caption font is computed in render at theme.label_font_size *
+        # ICON_NAME_FONT_SCALE; layout doesn't know the theme so use
+        # the default label size (14px, matches built-in themes) as a
+        # heuristic.  Slight over-budget is harmless: bbox just gets a
+        # few extra px of right padding.
+        from nf_metro.render.constants import ICON_NAME_FONT_SCALE
+        caption_font_size = 14.0 * ICON_NAME_FONT_SCALE
+        for i in range(len(names) - 1):
+            if not names[i] or not names[i + 1]:
+                continue
+            pair_max = max(
+                len(names[i]) * caption_font_size * 0.55,
+                len(names[i + 1]) * caption_font_size * 0.55,
+            )
+            needed = pair_max + ICON_INTER_GAP
+            if needed > step:
+                step = needed
+    extra = (n_icons - 1) * step
     return TERMINUS_ICON_CLEARANCE + extra
 
 
@@ -2571,7 +2686,7 @@ def _adjust_terminus_icon_clearance(
             continue
 
         n_icons = len(station.terminus_labels)
-        needed = _terminus_icon_clearance(n_icons)
+        needed = _terminus_icon_clearance(n_icons, station.terminus_names)
 
         # Determine source vs sink from the full graph's edges
         is_source = not any(e.target == station.id for e in graph.edges)
@@ -4017,6 +4132,8 @@ def _build_section_subgraph(graph: MetroGraph, section: Section) -> MetroGraph:
                     section_id=station.section_id,
                     is_port=False,
                     terminus_labels=list(station.terminus_labels),
+                    terminus_icon_types=list(station.terminus_icon_types),
+                    terminus_names=list(station.terminus_names),
                 )
             )
             real_station_ids.add(sid)

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1186,20 +1186,33 @@ def _compact_row_content_to_bbox_top(
         if not sections:
             continue
         sections_by_col = sorted(sections, key=lambda s: s.grid_col)
-        # Build contiguous-column groups, but rowspan>1 sections trunk
-        # at a Y of their own (no horizontal bundle shared with row
-        # mates) so each one shifts independently.
+        # Build contiguous-column groups.  A rowspan>1 section is only
+        # isolated from row mates when its trunk Y differs from theirs
+        # (no shared horizontal bundle); when its trunk aligns with the
+        # row's trunk, compact must group it with neighbours so the
+        # shared bundle stays straight.
+        def _trunk_or_none(s: Section) -> float | None:
+            return _section_trunk_y(graph, s)
+
         groups: list[list[Section]] = [[sections_by_col[0]]]
         for s in sections_by_col[1:]:
             prev = groups[-1][-1]
-            if (
-                s.grid_col - prev.grid_col <= 1
-                and s.grid_row_span <= 1
-                and prev.grid_row_span <= 1
-            ):
-                groups[-1].append(s)
-            else:
+            adjacent = s.grid_col - prev.grid_col <= 1
+            if not adjacent:
                 groups.append([s])
+                continue
+            spans = s.grid_row_span > 1 or prev.grid_row_span > 1
+            if spans:
+                s_t = _trunk_or_none(s)
+                p_t = _trunk_or_none(prev)
+                aligned = (
+                    s_t is not None and p_t is not None
+                    and abs(s_t - p_t) < 0.5
+                )
+                if not aligned:
+                    groups.append([s])
+                    continue
+            groups[-1].append(s)
 
         for group in groups:
             allowed_shifts: list[float] = []

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -257,6 +257,8 @@ def _compute_section_layout(
 
     Pass C - Junction positioning (single pass):
       Phase 12: Position junction stations in inter-section gaps
+      Phase 13: Lift off-track stations above section's top track
+      Phase 13a: Re-align bbox tops within each row (bbox-only)
     """
     from nf_metro.layout.section_placement import place_sections, position_ports
 
@@ -436,6 +438,13 @@ def _compute_section_layout(
     # Phase 13: Lift off_track stations above their section's top track.
     # Runs last so it operates on finalised station Ys and bboxes.
     _lift_off_track_stations(graph, y_spacing, section_y_padding)
+
+    # Phase 13a: Re-align bbox tops within each grid row after off-track
+    # lifting expanded some sections upward.  Unlike Phase 9/11c which
+    # shifts stations with the bbox, this only grows the bbox upward so
+    # the empty input-band space lines up across the row.  Station Ys
+    # in unlifted sections are preserved.
+    _top_align_row_bboxes_only(graph)
 
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
@@ -927,6 +936,49 @@ def _top_align_row_sections(graph: MetroGraph) -> None:
                     if station:
                         station.y -= delta
                 section.bbox_y -= delta
+
+
+def _top_align_row_bboxes_only(graph: MetroGraph) -> None:
+    """Align bbox tops within each row by growing bboxes upward.
+
+    Unlike ``_top_align_row_sections`` (which shifts stations together
+    with their bbox), this phase only moves ``bbox_y`` and grows
+    ``bbox_h`` so the section background extends upward to match the
+    row's topmost bbox.  Station, port and junction Ys inside the
+    section are left in place, producing empty space at the top of
+    sections that didn't have off-track inputs to lift.
+
+    Used after ``_lift_off_track_stations`` so off-track expansion in
+    one section doesn't leave other row-mates with misaligned bbox
+    tops.  Same contiguous-column-group logic as ``_top_align_row``
+    callers above.
+    """
+    row_sections: dict[int, list[Section]] = defaultdict(list)
+    for section in graph.sections.values():
+        if section.bbox_h > 0 and section.grid_row >= 0:
+            row_sections[section.grid_row].append(section)
+
+    for sections in row_sections.values():
+        if len(sections) < 2:
+            continue
+        sections_by_col = sorted(sections, key=lambda s: s.grid_col)
+        groups: list[list[Section]] = [[sections_by_col[0]]]
+        for s in sections_by_col[1:]:
+            if s.grid_col - groups[-1][-1].grid_col <= 1:
+                groups[-1].append(s)
+            else:
+                groups.append([s])
+
+        for group in groups:
+            if len(group) < 2:
+                continue
+            min_top = min(s.bbox_y for s in group)
+            for section in group:
+                delta = section.bbox_y - min_top
+                if delta <= 0:
+                    continue
+                section.bbox_y = min_top
+                section.bbox_h += delta
 
 
 def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -429,6 +429,11 @@ def _compute_section_layout(
     # structures, and file inputs are left in place.
     _redistribute_fanout_siblings(graph, y_spacing)
 
+    # Phase 11da: Symmetrically fan a column of full-bundle stations
+    # around the trunk Y when no unique trunk exists (e.g. Reporting's
+    # Shiny app + Quarto report, both carrying the full bundle).
+    _redistribute_full_bundle_columns(graph, y_spacing)
+
     # ---- Pass C: Junction positioning (single pass) --------------------
     # All port positions are now final; position junctions once.
 
@@ -1681,6 +1686,86 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
                 k = (i + 1) // 2
                 sign = 1 if (i % 2 == 1) else -1
                 graph.stations[sid].y = trunk_y + sign * k * y_spacing
+
+
+def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
+    """Fan a terminal section's full-bundle column around the trunk Y.
+
+    Active when ``graph.center_ports`` is True.  Handles the
+    Reporting-style case where a *terminal* section (no exit ports)
+    holds a column of two or more full-bundle stations with no unique
+    trunk junction, so the existing fan-out logic skips it.  Stations
+    are placed symmetrically around a trunk Y derived from other
+    full-bundle stations in the section (or the LR port Y).
+
+    Even count leaves the trunk row empty (``trunk_y ± s, ± 2s, ...``);
+    odd count keeps a middle station at ``trunk_y`` with the rest
+    flanking.  Non-terminal sections are left untouched so the
+    Differential symfan, Functional method bank, file inputs and
+    fan-in chains keep their natural Y ordering.
+    """
+    if not graph.center_ports:
+        return
+    grid_sec_ids = _grid_group_section_ids(graph)
+    if not grid_sec_ids:
+        return
+
+    for section in graph.sections.values():
+        if (
+            section.id not in grid_sec_ids
+            or section.direction not in ("LR", "RL")
+            or section.bbox_h <= 0
+            or section.exit_ports
+        ):
+            continue
+        bundle = _section_bundle_lines(graph, section)
+        if not bundle:
+            continue
+        port_ids = set(section.entry_ports) | set(section.exit_ports)
+
+        cols: dict[float, list[str]] = defaultdict(list)
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            if (st := graph.stations.get(sid)) is not None:
+                cols[round(st.x, 3)].append(sid)
+
+        full_by_col = {
+            x: [s for s in sids if set(graph.station_lines(s)) == bundle]
+            for x, sids in cols.items()
+        }
+
+        for x, full in full_by_col.items():
+            # Fire only when every column station carries the full bundle
+            # and there are >=2 (so no unique trunk station exists).
+            if len(full) < 2 or len(full) != len(cols[x]):
+                continue
+            others = sorted(
+                graph.stations[s].y
+                for ox, sids in full_by_col.items() if ox != x
+                for s in sids
+            )
+            if others:
+                trunk_y = others[len(others) // 2]
+            else:
+                port_ys = [
+                    graph.ports[pid].y for pid in port_ids
+                    if graph.ports.get(pid) is not None
+                    and graph.ports[pid].side in (PortSide.LEFT, PortSide.RIGHT)
+                ]
+                if not port_ys:
+                    continue
+                trunk_y = sum(port_ys) / len(port_ys)
+            full.sort(key=lambda s: graph.stations[s].y)
+            n = len(full)
+            # Even: offsets -n//2..-1, 1..n//2 (skipping 0).
+            # Odd:  offsets -(n//2)..n//2 inclusive (0 = trunk_y).
+            if n % 2 == 0:
+                offsets = list(range(-(n // 2), 0)) + list(range(1, n // 2 + 1))
+            else:
+                offsets = list(range(-(n // 2), n // 2 + 1))
+            for sid, off in zip(full, offsets):
+                graph.stations[sid].y = trunk_y + off * y_spacing
 
 
 def _layout_single_section(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -411,6 +411,11 @@ def _compute_section_layout(
     # padding around the final non-port station range.
     _recompute_grid_group_bboxes(graph)
 
+    # Phase 11c: Re-run top-align after Phase 11 may have shifted
+    # individual section bbox_y values (via _expand_bbox_for_y) so
+    # bbox tops within each row stay flush after port-terminus spacing.
+    _top_align_row_sections(graph)
+
     # ---- Pass C: Junction positioning (single pass) --------------------
     # All port positions are now final; position junctions once.
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -446,6 +446,12 @@ def _compute_section_layout(
     # in unlifted sections are preserved.
     _top_align_row_bboxes_only(graph)
 
+    # Phase 13b: Compact row-mate sections so content sits just inside
+    # the bbox top edge.  Shifts an entire row's column group up by the
+    # smallest above-content slack, preserving trunk alignment.  Bbox
+    # heights shrink correspondingly so the empty top space disappears.
+    _compact_row_content_to_bbox_top(graph, section_y_padding, y_spacing)
+
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
@@ -1109,6 +1115,125 @@ def _align_row_trunk_ys(graph: MetroGraph) -> None:
                                 target_aligned = True
                     if len(connected_ys) < 2 and target_aligned:
                         _set_port_y(graph, pid, target_y)
+
+
+def _compact_row_content_to_bbox_top(
+    graph: MetroGraph, section_y_padding: float, y_spacing: float
+) -> None:
+    """Pull row-mate sections up and shrink bottoms so content fits snugly.
+
+    Two-step compaction within each grid row's contiguous column run:
+
+    1. Per section, compute the allowable upward shift of on-track
+       content:
+
+       * bounded above by ``min(on_track_y) - bbox_y - section_y_padding``
+         so on-track content stays inside the bbox padding zone;
+       * bounded above by ``min(on_track_y) - max(off_track_y) - y_spacing_floor``
+         so on-track content stays clear of any lifted off-track band.
+
+       The uniform shift applied to the group is the minimum allowable
+       shift across same-row sections; that preserves the trunk-Y
+       alignment established by Phase 11ca.  Only on-track stations
+       and ports move; off-track stations stay anchored to the lifted
+       band Phase 13 placed them on.
+    2. Shrink each section's ``bbox_h`` so the bottom slack matches
+       ``section_y_padding`` (clamped so ports inside the section stay
+       within the bbox).
+
+    Sections with ``grid_row_span > 1`` are excluded because their
+    content spans multiple rows and the per-row frame doesn't apply.
+    """
+
+    def _is_off_track(sid: str) -> bool:
+        st = graph.stations.get(sid)
+        return bool(st and getattr(st, "off_track", False))
+
+    row_sections: dict[int, list[Section]] = defaultdict(list)
+    for section in graph.sections.values():
+        if (
+            section.bbox_h <= 0
+            or section.grid_row < 0
+            or section.grid_row_span > 1
+        ):
+            continue
+        row_sections[section.grid_row].append(section)
+
+    # Minimum clearance between the off-track lift band and any
+    # on-track content shifted upward toward it.  Phase 13 installs a
+    # full ``y_spacing`` gap; compaction may shrink it to roughly one
+    # station-row's worth of clearance so labels still avoid the
+    # topmost line track.
+    off_track_gap = max(FONT_HEIGHT + STATION_RADIUS_APPROX * 2, y_spacing / 2)
+
+    for sections in row_sections.values():
+        if not sections:
+            continue
+        sections_by_col = sorted(sections, key=lambda s: s.grid_col)
+        groups: list[list[Section]] = [[sections_by_col[0]]]
+        for s in sections_by_col[1:]:
+            if s.grid_col - groups[-1][-1].grid_col <= 1:
+                groups[-1].append(s)
+            else:
+                groups.append([s])
+
+        for group in groups:
+            allowed_shifts: list[float] = []
+            for section in group:
+                on_track_ys = [
+                    graph.stations[sid].y
+                    for sid in section.station_ids
+                    if sid in graph.stations
+                    and not graph.stations[sid].is_port
+                    and not _is_off_track(sid)
+                ]
+                if not on_track_ys:
+                    continue
+                on_track_min = min(on_track_ys)
+                shift = on_track_min - section.bbox_y - section_y_padding
+                off_track_ys = [
+                    graph.stations[sid].y
+                    for sid in section.station_ids
+                    if sid in graph.stations and _is_off_track(sid)
+                ]
+                if off_track_ys:
+                    clear_shift = on_track_min - max(off_track_ys) - off_track_gap
+                    shift = min(shift, clear_shift)
+                allowed_shifts.append(max(0.0, shift))
+            delta = min(allowed_shifts) if allowed_shifts else 0.0
+            if delta >= 0.5:
+                for section in group:
+                    for sid in section.station_ids:
+                        if _is_off_track(sid):
+                            continue
+                        st = graph.stations.get(sid)
+                        if st:
+                            st.y -= delta
+                        port = graph.ports.get(sid)
+                        if port:
+                            port.y -= delta
+                    section.bbox_h = max(0.0, section.bbox_h - delta)
+
+            for section in group:
+                content_max_ys = [
+                    graph.stations[sid].y
+                    for sid in section.station_ids
+                    if sid in graph.stations
+                    and not graph.stations[sid].is_port
+                ]
+                port_max_ys = [
+                    graph.stations[sid].y
+                    for sid in section.station_ids
+                    if sid in graph.stations and graph.stations[sid].is_port
+                ]
+                if not content_max_ys:
+                    continue
+                desired_bot = max(content_max_ys) + section_y_padding
+                if port_max_ys:
+                    desired_bot = max(desired_bot, max(port_max_ys))
+                new_h = desired_bot - section.bbox_y
+                if new_h < section.bbox_h - 0.5:
+                    section.bbox_h = max(0.0, new_h)
 
 
 def _section_bundle_lines(graph: MetroGraph, section: Section) -> set[str]:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -491,8 +491,9 @@ def _compute_section_layout(
     # consumer Ys; snapping the consumer to the grid can shift it by
     # up to half a pitch, which would collapse the y_spacing gap above
     # off-track.  Recomputing here pins each off-track at
-    # consumer.y - n*y_spacing on the final grid.
-    _reanchor_off_track_to_consumer(graph, y_spacing)
+    # consumer.y - n*y_spacing on the final grid and grows the bbox
+    # upward if the new position rises above the padding zone.
+    _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
 
     # Phase 13g: Re-center full-bundle columns around the row's final
     # trunk Y.  ``_redistribute_full_bundle_columns`` runs early when
@@ -510,8 +511,14 @@ def _compute_section_layout(
         # leave the off-track icon stranded at the old consumer Y
         # (overlapping the consumer station instead of sitting one
         # row above it).  This second reanchor uses each consumer's
-        # post-recenter Y as the new anchor.
-        _reanchor_off_track_to_consumer(graph, y_spacing)
+        # post-recenter Y as the new anchor and grows the section
+        # bbox upward when the lifted band moves above its current top.
+        _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
+        # Re-run the row top-align: a reanchor-driven bbox grow leaves
+        # the section's bbox above its row mates'.  Pull row mates'
+        # bbox tops up to match so the section row stays flush along
+        # its top edge.
+        _top_align_row_bboxes_only(graph)
 
     # Phase 13h: After fan-re-centering, single-station downstream
     # columns (e.g. terminus file icons) may have stayed at their
@@ -4731,23 +4738,64 @@ def _lift_off_track_stations(
             port.y += shift
 
 
-def _reanchor_off_track_to_consumer(graph: MetroGraph, y_spacing: float) -> None:
+def _reanchor_off_track_to_consumer(
+    graph: MetroGraph,
+    y_spacing: float,
+    section_y_padding: float = SECTION_Y_PADDING,
+) -> None:
     """Re-place off-track inputs relative to consumer Ys after final snap.
 
     Phase 13 placed each off-track input at ``consumer.y - n*y_spacing``
     using the consumer's pre-snap Y.  Later phases (compaction, grid
-    snap) may shift the consumer to land on the section's row grid,
-    which changes the absolute Y of every consumer by up to half a
-    pitch.  This pass re-pins each off-track at the same offset
-    relative to the consumer's final snapped Y so the visible gap
-    stays at exactly one (or n) ``y_spacing`` slots.
+    snap, fan re-centering) may shift the consumer, which would
+    collapse or shrink the gap between the off-track input and its
+    consumer.  This pass re-pins each off-track at
+    ``consumer.y - n*y_spacing`` on the consumer's final snapped Y.
 
-    Bboxes that were grown upward in Phase 13 to fit the lifted band
-    are left as-is: the row-bbox alignment downstream phases performed
-    already accounted for the lifted height.
+    Bboxes were grown in Phase 13 based on the off-track positions at
+    the time.  If a re-anchor moves an off-track above the current bbox
+    top minus padding, expand the bbox upward so the lifted input still
+    sits inside the section's padding zone.  Same-section TOP ports
+    follow the new top edge.  When the growth pushes any section bbox
+    above the canvas top margin, shift the whole graph down so the
+    topmost section keeps its ``section_y_padding`` margin from the
+    canvas edge (mirrors the safeguard in ``_lift_off_track_stations``).
     """
     groups = _off_track_groups(graph)
+    grew = False
     for sec_id, (fallback_id, by_consumer) in groups.items():
-        _place_off_track_above_consumers(
+        highest_y = _place_off_track_above_consumers(
             graph, y_spacing, sec_id, fallback_id, by_consumer
         )
+        if highest_y is None:
+            continue
+        section = graph.sections.get(sec_id)
+        if section is None:
+            continue
+        desired_top = highest_y - section_y_padding
+        if desired_top < section.bbox_y - 0.5:
+            section.bbox_h += section.bbox_y - desired_top
+            section.bbox_y = desired_top
+            grew = True
+            for pid in section.entry_ports + section.exit_ports:
+                port = graph.ports.get(pid)
+                port_st = graph.stations.get(pid)
+                if not port or not port_st:
+                    continue
+                if port.side == PortSide.TOP:
+                    port_st.y = section.bbox_y
+                    port.y = port_st.y
+
+    if grew:
+        min_top = min(
+            (s.bbox_y for s in graph.sections.values() if s.bbox_h > 0),
+            default=section_y_padding,
+        )
+        if min_top < section_y_padding:
+            shift = section_y_padding - min_top
+            for st in graph.stations.values():
+                st.y += shift
+            for section in graph.sections.values():
+                section.bbox_y += shift
+            for port in graph.ports.values():
+                port.y += shift

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -416,6 +416,11 @@ def _compute_section_layout(
     # bbox tops within each row stay flush after port-terminus spacing.
     _top_align_row_sections(graph)
 
+    # Phase 11ca: Align trunk Ys across same-row sections.  Shifts
+    # content downward in shallower sections so the inter-section bundle
+    # passes through at a single Y per row.  Bbox tops are preserved.
+    _align_row_trunk_ys(graph)
+
     # Phase 11d: When --center-ports is on, redistribute fan-out siblings
     # of a section's trunk junction symmetrically around the trunk Y.
     # Scoped to fan-out side branches only: linear chains, fan-in
@@ -922,6 +927,136 @@ def _top_align_row_sections(graph: MetroGraph) -> None:
                     if station:
                         station.y -= delta
                 section.bbox_y -= delta
+
+
+def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
+    """Topmost Y of a full-bundle internal station connected to an LR port.
+
+    This Y is what neighbouring sections must line up with for the row
+    bundle to flow horizontally.  Returns ``None`` when no full-bundle
+    internal station is directly connected to any LR port.
+    """
+    if section.direction not in ("LR", "RL"):
+        return None
+    bundle = _section_bundle_lines(graph, section)
+    if not bundle:
+        return None
+    port_ids = set(section.entry_ports) | set(section.exit_ports)
+    internal_ids = set(section.station_ids) - port_ids
+    trunk_ys: set[float] = set()
+    for pid in port_ids:
+        p = graph.ports.get(pid)
+        if p is None or p.side not in (PortSide.LEFT, PortSide.RIGHT):
+            continue
+        for edge in graph.edges:
+            other_id = (
+                edge.target if edge.source == pid and edge.target in internal_ids
+                else edge.source if edge.target == pid and edge.source in internal_ids
+                else None
+            )
+            if other_id is None:
+                continue
+            st = graph.stations.get(other_id)
+            if st and not st.is_port and set(graph.station_lines(other_id)) == bundle:
+                trunk_ys.add(round(st.y, 3))
+    return min(trunk_ys) if trunk_ys else None
+
+
+def _align_row_trunk_ys(graph: MetroGraph) -> None:
+    """Shift sections vertically so trunk Ys align within each grid row.
+
+    Sections in a row's contiguous column run whose trunk Y sits above
+    the row's deepest trunk shift down to match.  Bbox tops are
+    preserved (heights grow downward).  Row-spanning sections
+    (grid_row_span > 1) are skipped to avoid disturbing cross-row
+    vertical relationships.
+    """
+    row_sections: dict[int, list[Section]] = defaultdict(list)
+    for section in graph.sections.values():
+        if (
+            section.bbox_h <= 0
+            or section.grid_row < 0
+            or section.direction not in ("LR", "RL")
+            or section.grid_row_span > 1
+        ):
+            continue
+        row_sections[section.grid_row].append(section)
+
+    for sections in row_sections.values():
+        if len(sections) < 2:
+            continue
+        sections_by_col = sorted(sections, key=lambda s: s.grid_col)
+        groups: list[list[Section]] = [[sections_by_col[0]]]
+        for s in sections_by_col[1:]:
+            if s.grid_col - groups[-1][-1].grid_col <= 1:
+                groups[-1].append(s)
+            else:
+                groups.append([s])
+
+        for group in groups:
+            if len(group) < 2:
+                continue
+            trunks = {
+                s.id: t
+                for s in group
+                if (t := _section_trunk_y(graph, s)) is not None
+            }
+            if len(trunks) < 2:
+                continue
+            target_y = max(trunks.values())
+            shifted: set[str] = set()
+            for section in group:
+                ty = trunks.get(section.id)
+                if ty is None:
+                    continue
+                delta = target_y - ty
+                if delta < 0.5:
+                    continue
+                for sid in section.station_ids:
+                    st = graph.stations.get(sid)
+                    if st:
+                        st.y += delta
+                    port = graph.ports.get(sid)
+                    if port:
+                        port.y += delta
+                section.bbox_h += delta
+                shifted.add(section.id)
+
+            # Re-snap each shifted section's LR ports to target_y when
+            # they have a single internal station at target_y.  Skip
+            # ports with 2+ distinct internal Ys (fan-in centering).
+            for section in group:
+                if section.id not in shifted:
+                    continue
+                port_set = set(section.entry_ports) | set(section.exit_ports)
+                internal_ids = set(section.station_ids) - port_set
+                for pid in port_set:
+                    p = graph.ports.get(pid)
+                    port_st = graph.stations.get(pid)
+                    if (
+                        p is None
+                        or port_st is None
+                        or p.side not in (PortSide.LEFT, PortSide.RIGHT)
+                        or abs(port_st.y - target_y) < 0.5
+                    ):
+                        continue
+                    connected_ys: set[float] = set()
+                    target_aligned = False
+                    for edge in graph.edges:
+                        other_id = (
+                            edge.target if edge.source == pid and edge.target in internal_ids
+                            else edge.source if edge.target == pid and edge.source in internal_ids
+                            else None
+                        )
+                        if other_id is None:
+                            continue
+                        st = graph.stations.get(other_id)
+                        if st and not st.is_port:
+                            connected_ys.add(round(st.y, 1))
+                            if abs(st.y - target_y) < 0.5:
+                                target_aligned = True
+                    if len(connected_ys) < 2 and target_aligned:
+                        _set_port_y(graph, pid, target_y)
 
 
 def _section_bundle_lines(graph: MetroGraph, section: Section) -> set[str]:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -526,6 +526,18 @@ def _compute_section_layout(
     # them back onto the source Y so the connection stays horizontal.
     _align_terminus_to_upstream(graph)
 
+    # Phase 13h2: Auto-balance pass.  For sections whose final layout
+    # still leaves an empty band above the trunk while more siblings
+    # sit below than above (e.g. differential's dream alone above the
+    # trunk while DESeq2 and propd hang below), lift bottommost
+    # movable siblings into the empty top band so content sits
+    # symmetrically around the trunk.  Runs after re-centering and
+    # terminus-Y pinning so it sees the final trunk Y.  U-turn-safe
+    # and bbox-bounded.
+    _balance_section_content_around_trunk(
+        graph, section_y_padding, y_spacing
+    )
+
     # Phase 13i: Shrink rowspan / row-mate bboxes whose content moved
     # up after compact (e.g. ``_fan_source_inputs_upward`` lifted the
     # bottom rows away from the bbox bottom).  Bottom-only shrink, so
@@ -1638,6 +1650,291 @@ def _fan_source_inputs_upward(
                 continue
             graph.stations[src].y = new_y
             _shift_chain(src, delta)
+
+
+def _balance_direct_external_feeder_ys(
+    graph: MetroGraph, station_id: str, section_id: str
+) -> list[float]:
+    """Return Ys of the candidate station's per-line external feeders.
+
+    Walks edges INTO ``station_id`` by line: for each inbound (src, lid)
+    pair, traverse the (src, lid) chain through junctions and ports
+    until reaching the first non-port, non-junction station.  Filtering
+    by line means transit-only stations feeding the same shared port
+    on a different line are not counted (e.g. limma feeds the
+    differential exit port for four lines but only propd feeds grea
+    via the ``rnaseq`` line, so limma should not register as grea's
+    feeder).
+    """
+    junction_ids = set(graph.junctions)
+    feeder_ys: list[float] = []
+    seen: set[tuple[str, str]] = set()
+    # Seed with each (predecessor, line) pair of the candidate.
+    stack: list[tuple[str, str]] = []
+    for edge in graph.edges:
+        if edge.target == station_id:
+            stack.append((edge.source, edge.line_id))
+    while stack:
+        cur_id, lid = stack.pop()
+        if (cur_id, lid) in seen:
+            continue
+        seen.add((cur_id, lid))
+        if cur_id in junction_ids:
+            # Recurse into edges of this line targeting the junction.
+            for edge in graph.edges:
+                if edge.target == cur_id and edge.line_id == lid:
+                    stack.append((edge.source, lid))
+            continue
+        src = graph.stations.get(cur_id)
+        if src is None:
+            continue
+        if src.is_port:
+            for edge in graph.edges:
+                if edge.target == cur_id and edge.line_id == lid:
+                    stack.append((edge.source, lid))
+            continue
+        if src.section_id == section_id:
+            continue
+        feeder_ys.append(src.y)
+    return feeder_ys
+
+
+def _balance_section_content_around_trunk(
+    graph: MetroGraph, section_y_padding: float, y_spacing: float
+) -> None:
+    """Rebalance fan-out siblings to fill empty bands above the trunk.
+
+    Runs after ``_fan_free_content_upward`` / ``_fan_source_inputs_upward``
+    have done what they can with conservative slot accounting and after
+    re-centering (Phase 13g) finalises the trunk Y.  This pass looks
+    for sections whose final layout still leaves a >= 1 * ``y_spacing``
+    empty band above the topmost station while more siblings sit below
+    the trunk than above, then either:
+
+    - LIFTS the bottommost (or topmost, depending on line homogeneity)
+      below-trunk movable sibling to one slot above the topmost station
+      when the bbox has room for the marker plus its above-marker
+      label.  The lifted station's linear consumer chain follows so
+      per-line tracks stay straight.
+
+    - SWAPS the bottommost below-trunk movable with the topmost above-
+      trunk station when the bbox has no headroom for an extra slot.
+      The swap reorders the above-trunk band without growing the bbox
+      and is reserved for sections where the user benefits from the
+      deeper-branch station (e.g. propd) sitting higher than a shallow-
+      branch sibling (e.g. dream).
+
+    "Movable" siblings: stations in a column that contains a full-
+    bundle trunk station and that themselves carry a strict subset of
+    the section's bundle.  Off-track inputs, hidden phantoms, the
+    trunk, and full-bundle pass-throughs are left untouched.
+
+    Scoped to explicit ``%%metro grid:`` pipelines so the auto-layout
+    path is unaffected.  Line-aware U-turn safety prevents lifts that
+    would force the line to climb past the trunk and double back.
+    """
+    if not getattr(graph, "_explicit_grid", None):
+        return
+    if not graph.center_ports:
+        return
+
+    for section in graph.sections.values():
+        if (
+            section.bbox_h <= 0
+            or section.direction not in ("LR", "RL")
+        ):
+            continue
+        bundle = _section_bundle_lines(graph, section)
+        if not bundle:
+            continue
+        port_set = set(section.entry_ports) | set(section.exit_ports)
+        internal_ids = [
+            sid for sid in section.station_ids
+            if sid not in port_set and sid in graph.stations
+            and not graph.stations[sid].is_port
+            and not graph.stations[sid].is_hidden
+            and not graph.stations[sid].off_track
+        ]
+        if not internal_ids:
+            continue
+
+        # Trunk Y from LR ports (anchor for the row bundle).  Falls
+        # back to the section's median full-bundle station Y when no
+        # LR port exists (rare).
+        trunk_y: float | None = None
+        for pid in section.entry_ports + section.exit_ports:
+            port = graph.ports.get(pid)
+            st = graph.stations.get(pid)
+            if port and st and port.side in (PortSide.LEFT, PortSide.RIGHT):
+                trunk_y = st.y
+                break
+        if trunk_y is None:
+            full_ys = sorted(
+                graph.stations[s].y for s in internal_ids
+                if set(graph.station_lines(s)) == bundle
+            )
+            if not full_ys:
+                continue
+            trunk_y = full_ys[len(full_ys) // 2]
+
+        # Group by column.
+        cols: dict[float, list[str]] = defaultdict(list)
+        for sid in internal_ids:
+            cols[round(graph.stations[sid].x, 3)].append(sid)
+
+        # Find the global topmost station in this section (across all
+        # columns) and its current bbox-top gap.  We only fire when
+        # the top is visibly empty.
+        section_top_y = min(graph.stations[s].y for s in internal_ids)
+        top_band = section_top_y - section.bbox_y
+        if top_band <= y_spacing + 0.5:
+            continue
+
+        # Collect movable siblings across all columns (filtered to
+        # those whose move respects the trunk-Y row alignment).
+        movable: list[str] = []
+        for x, sids in cols.items():
+            trunks_in_col = [
+                s for s in sids
+                if set(graph.station_lines(s)) == bundle
+            ]
+            if not trunks_in_col:
+                continue
+            for s in sids:
+                if s in trunks_in_col:
+                    continue
+                lines = set(graph.station_lines(s))
+                if not lines or not (lines < bundle):
+                    continue
+                # All strict-subset siblings (fan-out branches or
+                # source files) are movable: source files want to
+                # fill the empty top band, and fan-out branches can
+                # be shuffled to balance the column.
+                movable.append(s)
+
+        if not movable:
+            continue
+
+        ys = [graph.stations[s].y for s in movable]
+        above_count = sum(1 for y in ys if y < trunk_y - 0.5)
+        below_count = sum(1 for y in ys if y > trunk_y + 0.5)
+        if below_count <= above_count:
+            continue
+
+        # Topmost movable station; we'll place one bottom-side movable
+        # one slot above it.  Continue lifting while top_band still
+        # exceeds y_spacing AND there are more below than above.
+        section_internal_set = set(internal_ids)
+
+        def _shift_chain(src: str, delta: float) -> None:
+            cur = src
+            src_lines = set(graph.station_lines(src))
+            while True:
+                outs = {e.target for e in graph.edges if e.source == cur}
+                if len(outs) != 1:
+                    break
+                nxt = next(iter(outs))
+                if nxt not in section_internal_set:
+                    break
+                in_srcs = {e.source for e in graph.edges if e.target == nxt}
+                if len(in_srcs) != 1:
+                    break
+                if set(graph.station_lines(nxt)) != src_lines:
+                    break
+                graph.stations[nxt].y += delta
+                cur = nxt
+
+        # Iteratively rebalance.  Each iteration moves the bottommost
+        # movable station up by one slot to fill the above-trunk band.
+        # The lift target is either:
+        #   - A new top slot above the current section topmost, when
+        #     the bbox has room for the marker + label, OR
+        #   - A swap into the top above-trunk slot, when there is no
+        #     bbox-top room but the topmost above-trunk station has
+        #     a deeper Y available (e.g. propd swaps with dream so
+        #     propd ends up above dream without growing the bbox).
+        # Stops when the imbalance is resolved or no slot is available.
+        max_iters = len(movable)
+        for _ in range(max_iters):
+            section_top_y = min(
+                graph.stations[s].y for s in internal_ids
+            )
+            top_band = section_top_y - section.bbox_y
+            if top_band <= y_spacing + 0.5:
+                break
+            ys = {s: graph.stations[s].y for s in movable}
+            above = [s for s, y in ys.items() if y < trunk_y - 0.5]
+            below = [s for s, y in ys.items() if y > trunk_y + 0.5]
+            if len(below) <= len(above):
+                break
+            # Choosing which below-trunk station to lift:
+            # - When all movable siblings carry the SAME line set
+            #   (e.g. dream/DESeq2/propd in differential all carry just
+            #   rnaseq), per-line track conflicts are not a concern, so
+            #   prefer the BOTTOMMOST to also shrink the bottom band.
+            # - When siblings carry different line sets (e.g. file
+            #   inputs each on their own line track), prefer the
+            #   TOPMOST to minimise the diagonal climb needed to
+            #   rejoin the trunk and keep per-line tracks clean.
+            line_sets = {
+                frozenset(graph.station_lines(s)) for s in movable
+            }
+            if len(line_sets) == 1:
+                below.sort(key=lambda s: graph.stations[s].y, reverse=True)
+            else:
+                below.sort(key=lambda s: graph.stations[s].y)
+            candidate = below[0]
+            new_y = section_top_y - y_spacing
+            # Guard: the new Y must leave room for the station's
+            # above-marker label without forcing the bbox to expand
+            # upward (which would break row-mate bbox alignment).
+            # Stations with empty labels (file icons whose names sit
+            # below) don't need the extra clearance.
+            st = graph.stations.get(candidate)
+            has_above_label = bool(st and st.label and st.label.strip())
+            label_clearance = y_spacing / 2 if has_above_label else 0.0
+            min_y = section.bbox_y + label_clearance
+            if new_y < min_y - 0.5:
+                # No room for a new top slot.  Try a SWAP: take the
+                # topmost above-trunk station's Y for the candidate,
+                # and push that station to the candidate's old Y.
+                # This re-orders the above-trunk band without growing
+                # the bbox.  Useful when the user expects a deeper-
+                # branch station (e.g. propd) above a shallower one
+                # (e.g. dream) for visual emphasis.
+                if not above:
+                    break
+                above.sort(key=lambda s: graph.stations[s].y)
+                top_above = above[0]
+                ya = graph.stations[top_above].y
+                yc = graph.stations[candidate].y
+                # Only swap when the candidate is the bottommost
+                # below-trunk movable AND the swap improves visual
+                # balance.  Use a simple proxy: the candidate must
+                # be the unique bottommost.
+                if candidate != below[0]:
+                    break
+                graph.stations[candidate].y = ya
+                graph.stations[top_above].y = yc
+                _shift_chain(candidate, ya - yc)
+                _shift_chain(top_above, yc - ya)
+                break  # one swap per section
+            # Direct feeder U-turn check: walk the candidate's direct
+            # predecessors only (not transitively through junctions to
+            # all stations feeding the same port).  A U-turn occurs
+            # when the only direct external feeders sit at Y >= anchor
+            # AND there are 2+ of them; a single feeder cannot make a
+            # U-turn (the line just bends once toward the candidate).
+            ext_feeders = _balance_direct_external_feeder_ys(
+                graph, candidate, section.id
+            )
+            if len(ext_feeders) >= 2 and all(
+                fy >= new_y - 0.5 for fy in ext_feeders
+            ):
+                break
+            delta = new_y - graph.stations[candidate].y
+            graph.stations[candidate].y = new_y
+            _shift_chain(candidate, delta)
 
 
 def _lift_would_cause_uturn(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1141,8 +1141,10 @@ def _compact_row_content_to_bbox_top(
        ``section_y_padding`` (clamped so ports inside the section stay
        within the bbox).
 
-    Sections with ``grid_row_span > 1`` are excluded because their
-    content spans multiple rows and the per-row frame doesn't apply.
+    Row-spanning sections (``grid_row_span > 1``) are included so their
+    content is compacted to their bbox top and the bbox shrinks to fit;
+    the rowspan was already consumed by earlier placement phases and no
+    downstream phase relies on the inflated height.
     """
 
     def _is_off_track(sid: str) -> bool:
@@ -1151,11 +1153,7 @@ def _compact_row_content_to_bbox_top(
 
     row_sections: dict[int, list[Section]] = defaultdict(list)
     for section in graph.sections.values():
-        if (
-            section.bbox_h <= 0
-            or section.grid_row < 0
-            or section.grid_row_span > 1
-        ):
+        if section.bbox_h <= 0 or section.grid_row < 0:
             continue
         row_sections[section.grid_row].append(section)
 
@@ -1165,14 +1163,31 @@ def _compact_row_content_to_bbox_top(
     # station-row's worth of clearance so labels still avoid the
     # topmost line track.
     off_track_gap = max(FONT_HEIGHT + STATION_RADIUS_APPROX * 2, y_spacing / 2)
+    # Captioned off-track icons (PR #269) render a label line under the
+    # icon body; that text needs to clear the topmost line track too,
+    # so the gap below a captioned bottom-of-band station is widened
+    # by the caption extent.
+    captioned_extra = FONT_HEIGHT + STATION_RADIUS_APPROX * 2
+
+    def _has_caption(sid: str) -> bool:
+        st = graph.stations.get(sid)
+        return bool(st and st.terminus_names and any(st.terminus_names))
 
     for sections in row_sections.values():
         if not sections:
             continue
         sections_by_col = sorted(sections, key=lambda s: s.grid_col)
+        # Build contiguous-column groups, but rowspan>1 sections trunk
+        # at a Y of their own (no horizontal bundle shared with row
+        # mates) so each one shifts independently.
         groups: list[list[Section]] = [[sections_by_col[0]]]
         for s in sections_by_col[1:]:
-            if s.grid_col - groups[-1][-1].grid_col <= 1:
+            prev = groups[-1][-1]
+            if (
+                s.grid_col - prev.grid_col <= 1
+                and s.grid_row_span <= 1
+                and prev.grid_row_span <= 1
+            ):
                 groups[-1].append(s)
             else:
                 groups.append([s])
@@ -1197,7 +1212,18 @@ def _compact_row_content_to_bbox_top(
                     if sid in graph.stations and _is_off_track(sid)
                 ]
                 if off_track_ys:
-                    clear_shift = on_track_min - max(off_track_ys) - off_track_gap
+                    gap = off_track_gap
+                    bottom_off_y = max(off_track_ys)
+                    bottom_off_ids = [
+                        sid
+                        for sid in section.station_ids
+                        if sid in graph.stations
+                        and _is_off_track(sid)
+                        and abs(graph.stations[sid].y - bottom_off_y) < 0.5
+                    ]
+                    if any(_has_caption(sid) for sid in bottom_off_ids):
+                        gap += captioned_extra
+                    clear_shift = on_track_min - bottom_off_y - gap
                     shift = min(shift, clear_shift)
                 allowed_shifts.append(max(0.0, shift))
             delta = min(allowed_shifts) if allowed_shifts else 0.0
@@ -3020,6 +3046,14 @@ def _space_ports_from_termini(
         for sid in real_sids:
             st = graph.stations.get(sid)
             if not st or not st.is_terminus or st.is_port:
+                continue
+            # Off-track stations get lifted above the topmost line track
+            # later (Phase 13), so they no longer share a Y with the
+            # inter-section bundle.  Excluding them here prevents ports
+            # from being pushed away (and dragging the upstream port via
+            # junction propagation) for a conflict that won't exist by
+            # render time.
+            if getattr(st, "off_track", False):
                 continue
             preds = predecessors.get(sid, set())
             succs = successors.get(sid, set())

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -505,6 +505,13 @@ def _compute_section_layout(
     # column.
     if graph.center_ports:
         _recenter_full_bundle_columns(graph, y_spacing)
+        # Re-anchor off-track inputs again: ``_recenter`` moves
+        # their consumers to the final trunk-anchored Y, which can
+        # leave the off-track icon stranded at the old consumer Y
+        # (overlapping the consumer station instead of sitting one
+        # row above it).  This second reanchor uses each consumer's
+        # post-recenter Y as the new anchor.
+        _reanchor_off_track_to_consumer(graph, y_spacing)
 
     # Phase 13h: After fan-re-centering, single-station downstream
     # columns (e.g. terminus file icons) may have stayed at their
@@ -1797,12 +1804,15 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
     siblings carrying the full bundle (linear pass-throughs) are left
     in place so non-fan-out topologies keep their natural Y ordering.
 
-    Additionally, a sibling is only redistributed when it shares an
-    upstream predecessor with the trunk station.  This excludes
-    columns of source stations (file inputs) that happen to sit in a
-    column with a full-bundle station: with no shared upstream
-    junction, they aren't fan-out branches and must stay on their
+    Additionally, a sibling is only redistributed when it has at
+    least one predecessor in the edge graph.  This excludes columns
+    of source stations (file inputs, in-degree 0) that happen to sit
+    in a column with a full-bundle station: with no upstream
+    producer, they aren't fan-out branches and must stay on their
     per-line track Y so they line up with their downstream consumers.
+    Siblings fed by a different predecessor than the trunk (but still
+    fed by something) are real fan-out branches arriving via separate
+    upstream methods and DO participate in the symmetric fan.
 
     No-op when ``--no-center-ports`` is set, when a section has no
     qualifying trunk-junction column, or when there are no
@@ -1832,13 +1842,16 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
             continue
         port_ids = set(section.entry_ports) | set(section.exit_ports)
 
-        # Group non-port stations by column x.
+        # Group non-port, on-track stations by column x.  Off-track
+        # stations (file inputs lifted above their consumer) are placed
+        # by ``_lift_off_track_stations`` and must not occupy a column
+        # slot here.
         cols: dict[float, list[str]] = defaultdict(list)
         for sid in section.station_ids:
             if sid in port_ids:
                 continue
             st = graph.stations.get(sid)
-            if st is None:
+            if st is None or st.off_track:
                 continue
             cols[round(st.x, 3)].append(sid)
 
@@ -1849,22 +1862,21 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
                 continue
             trunk_sid = trunks[0]
             trunk_y = graph.stations[trunk_sid].y
-            trunk_preds = (
-                set(G.predecessors(trunk_sid)) if trunk_sid in G else set()
-            )
             # Fan-out siblings: strict subset of bundle (skip full-bundle
             # pass-throughs and orphan stations with no lines).  Require
-            # a shared predecessor with the trunk so source stations
-            # (file inputs with no inbound edges) stay on their per-line
-            # track Y instead of being pulled to a uniform fan around
-            # an unrelated trunk.
+            # at least one predecessor so source stations (file inputs
+            # with no inbound edges) stay on their per-line track Y
+            # instead of being pulled to a uniform fan around an
+            # unrelated trunk.  Siblings whose predecessor differs
+            # from the trunk's are still real fan-out branches (e.g.
+            # methods fed by separate upstream stations within the
+            # same upstream section) and DO participate.
             siblings = [
                 s for s in sids
                 if s != trunk_sid
                 and set(graph.station_lines(s))
                 and set(graph.station_lines(s)) < bundle
-                and trunk_preds
-                and (set(G.predecessors(s)) if s in G else set()) & trunk_preds
+                and (s in G and any(True for _ in G.predecessors(s)))
             ]
             if not siblings:
                 continue
@@ -1878,25 +1890,40 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
 def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
     """Fan a full-bundle column around the trunk Y.
 
-    Active when ``graph.center_ports`` is True.  Handles columns of
-    two or more full-bundle stations with no unique trunk junction
-    (so ``_redistribute_fanout_siblings`` skips them).  Stations are
-    placed symmetrically around a trunk Y derived from other
-    full-bundle stations in the section (or the LR port Y).
+    Active when ``graph.center_ports`` is True.  Handles columns where
+    every on-track station carries the full section bundle (so no
+    unique trunk junction exists for ``_redistribute_fanout_siblings``
+    to anchor on).  Stations are placed symmetrically around a trunk Y
+    derived from the section's LR ports (or other full-bundle stations).
+
+    A relaxed mode also fires when the column has at least one
+    full-bundle station AND every non-full column-mate is a
+    strict-subset sibling with a predecessor (i.e. a real fan-out
+    branch arriving via a separate upstream method, not a source
+    file).  In that mixed-bundle case every column-mate participates
+    in the symmetric fan, so a minor side branch (e.g. a single-line
+    method joining three full-bundle methods) slots into the
+    arrangement instead of stranding at the bottom of the section.
 
     Even count leaves the trunk row empty (``trunk_y ± s, ± 2s, ...``);
     odd count keeps a middle station at ``trunk_y`` with the rest
     flanking.  Fires on both terminal (Reporting-style) and
-    non-terminal (Functional-style) sections; the strict
-    "every station in the column carries the full bundle" gate keeps
-    file inputs, fan-in chains and method banks with strict-subset
-    lines untouched.
+    non-terminal (Functional-style) sections; columns containing a
+    non-full, predecessorless station (a source file with no inbound
+    edges) are left untouched so file-input stacks keep their per-line
+    track Y.
     """
     if not graph.center_ports:
         return
     grid_sec_ids = _grid_group_section_ids(graph)
     if not grid_sec_ids:
         return
+
+    import networkx as nx
+
+    G = nx.DiGraph()
+    for edge in graph.edges:
+        G.add_edge(edge.source, edge.target)
 
     for section in graph.sections.values():
         if (
@@ -1922,6 +1949,9 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
                 continue
             cols[round(st.x, 3)].append(sid)
 
+        def _has_pred(sid: str) -> bool:
+            return sid in G and next(iter(G.predecessors(sid)), None) is not None
+
         full_by_col = {
             x: [s for s in sids if set(graph.station_lines(s)) == bundle]
             for x, sids in cols.items()
@@ -1936,11 +1966,49 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
             and graph.ports[pid].side in (PortSide.LEFT, PortSide.RIGHT)
         ]
 
-        for x, full in full_by_col.items():
-            # Fire only when every column station carries the full bundle
-            # and there are >=2 (so no unique trunk station exists).
-            if len(full) < 2 or len(full) != len(cols[x]):
+        # A column participates in the section-wide symfan when it has
+        # at least one full-bundle station to anchor on AND any other
+        # column-mates are non-source subset siblings (real fan-out
+        # branches with predecessors, not file inputs).  Source files
+        # in a column with a full-bundle station leave it ineligible
+        # so they stay on their per-line track Y.
+        col_eligible: dict[float, list[str]] = {}
+        for x, sids in cols.items():
+            full = full_by_col[x]
+            non_full = [s for s in sids if s not in full]
+            ok = bool(full) and all(
+                set(graph.station_lines(s))
+                and set(graph.station_lines(s)) < bundle
+                and _has_pred(s)
+                for s in non_full
+            )
+            if ok and len(sids) >= 2:
+                col_eligible[x] = sids
+        # Suppress the column when at least one full-bundle column-mate
+        # would otherwise be the unique trunk for a SINGLE sibling and
+        # there's no other full-bundle column in the section to fix
+        # the row-wide anchor (handed off to fanout_siblings instead).
+        # In practice we still fire whenever another column has >=2
+        # full-bundle stations, so all full-bundle columns share a
+        # consistent trunk_y.
+        any_all_full_col = any(
+            len(full_by_col[x]) >= 2 and len(full_by_col[x]) == len(cols[x])
+            for x in cols
+        )
+
+        for x, sids in col_eligible.items():
+            full = full_by_col[x]
+            non_full = [s for s in sids if s not in full]
+            # Strict all-full columns always fire (the original
+            # behaviour).  Mixed columns (full + non-source siblings)
+            # only fire when another column in the section is
+            # all-full, so we have a consistent trunk_y for the row
+            # and don't accidentally fan single trunk + 1 sibling
+            # cases that belong to ``_redistribute_fanout_siblings``.
+            all_full = not non_full
+            if not all_full and not any_all_full_col:
                 continue
+            participants = list(sids)
             # Trunk Y is the section's LR port Y when available (the
             # inter-section bundle line) so all full-bundle columns
             # in the section share a single trunk reference.  Falls
@@ -1957,15 +2025,15 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
                 if not others:
                     continue
                 trunk_y = others[len(others) // 2]
-            full.sort(key=lambda s: pre_fan_y[s])
-            n = len(full)
+            participants.sort(key=lambda s: pre_fan_y[s])
+            n = len(participants)
             # Even: offsets -n//2..-1, 1..n//2 (skipping 0).
             # Odd:  offsets -(n//2)..n//2 inclusive (0 = trunk_y).
             if n % 2 == 0:
                 offsets = list(range(-(n // 2), 0)) + list(range(1, n // 2 + 1))
             else:
                 offsets = list(range(-(n // 2), n // 2 + 1))
-            for sid, off in zip(full, offsets):
+            for sid, off in zip(participants, offsets):
                 graph.stations[sid].y = trunk_y + off * y_spacing
 
 
@@ -1995,6 +2063,12 @@ def _recenter_full_bundle_columns(
     if not grid_sec_ids:
         return
 
+    import networkx as nx
+
+    G = nx.DiGraph()
+    for edge in graph.edges:
+        G.add_edge(edge.source, edge.target)
+
     for section in graph.sections.values():
         if (
             section.id not in grid_sec_ids
@@ -2015,6 +2089,9 @@ def _recenter_full_bundle_columns(
             if st is None or st.off_track:
                 continue
             cols[round(st.x, 3)].append(sid)
+
+        def _has_pred(sid: str) -> bool:
+            return sid in G and next(iter(G.predecessors(sid)), None) is not None
 
         full_by_col = {
             x: [s for s in sids if set(graph.station_lines(s)) == bundle]
@@ -2060,16 +2137,37 @@ def _recenter_full_bundle_columns(
                     continue
                 anchor_y = sorted(all_full)[len(all_full) // 2]
 
+        # Mirror the gate from ``_redistribute_full_bundle_columns``:
+        # strict (all column-mates full) always fires; mixed (full +
+        # non-source siblings) fires only when another column has
+        # >=2 all-full stations, so we don't accidentally pull
+        # fanout_siblings columns onto a different anchor.
+        any_all_full_col = any(
+            len(full_by_col[x]) >= 2 and len(full_by_col[x]) == len(cols[x])
+            for x in cols
+        )
+
         for x, full in full_by_col.items():
-            if len(full) < 2 or len(full) != len(cols[x]):
+            non_full = [s for s in cols[x] if s not in full]
+            mixed_ok = bool(full) and non_full and all(
+                set(graph.station_lines(s))
+                and set(graph.station_lines(s)) < bundle
+                and _has_pred(s)
+                for s in non_full
+            )
+            all_full = len(full) >= 2 and len(full) == len(cols[x])
+            if not (all_full or (mixed_ok and any_all_full_col)):
                 continue
-            full.sort(key=lambda s: graph.stations[s].y)
-            n = len(full)
+            participants = list(full) + (non_full if mixed_ok else [])
+            if len(participants) < 2:
+                continue
+            participants.sort(key=lambda s: graph.stations[s].y)
+            n = len(participants)
             if n % 2 == 0:
                 offsets = list(range(-(n // 2), 0)) + list(range(1, n // 2 + 1))
             else:
                 offsets = list(range(-(n // 2), n // 2 + 1))
-            for sid, off in zip(full, offsets):
+            for sid, off in zip(participants, offsets):
                 graph.stations[sid].y = anchor_y + off * y_spacing
 
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -472,6 +472,13 @@ def _compute_section_layout(
     # padding by more than one ``y_spacing`` slot.
     _fan_free_content_upward(graph, section_y_padding, y_spacing)
 
+    # Phase 13d2: Companion to 13d for source-stack sections.  When the
+    # entry column has a single full-bundle trunk plus subset-bundle
+    # source inputs (file icons with no inbound edges), lift the
+    # nearest-to-trunk sources into the empty top band so the section
+    # is bottom- and top-weighted instead of stacked below the trunk.
+    _fan_source_inputs_upward(graph, section_y_padding, y_spacing)
+
     # Phase 13e: Snap all station/port Ys to a per-section y_spacing
     # grid.  Trunk-Y align, port-snap, and the row compaction/fan
     # phases compute shifts that don't respect the grid pitch, leaving
@@ -1444,6 +1451,129 @@ def _fan_free_content_upward(
         ]
         for i, sid in enumerate(to_lift, 1):
             graph.stations[sid].y = anchor_y - i * y_spacing
+
+
+def _fan_source_inputs_upward(
+    graph: MetroGraph, section_y_padding: float, y_spacing: float
+) -> None:
+    """Fill empty top space by lifting source-input chains above the trunk.
+
+    Companion to ``_fan_free_content_upward`` for sections whose entry
+    column contains a single full-bundle trunk station plus subset-bundle
+    sources (file inputs with no inbound edges).  The trunk-candidate
+    path skips these (it requires >=2 full-bundle candidates), leaving
+    every source stacked at or below the trunk and the bbox top empty.
+
+    For each qualifying LR/RL grid section, sort sources by current Y
+    (closest to trunk first) and lift up to ``slack // y_spacing`` of
+    them above the trunk at ``y_spacing`` pitch.  Each lifted source
+    drags its linear consumer chain (one inbound edge, identical line
+    set, strictly inside the section) so per-line tracks stay straight.
+
+    Scoped to explicit ``%%metro grid:`` pipelines so the auto-layout
+    path is unaffected.  U-turn risk is nil because sources have no
+    upstream feeders by definition.
+    """
+    if not getattr(graph, "_explicit_grid", None):
+        return
+    for section in graph.sections.values():
+        if (
+            section.bbox_h <= 0
+            or section.direction not in ("LR", "RL")
+        ):
+            continue
+        if any(
+            getattr(graph.stations.get(sid), "off_track", False)
+            for sid in section.station_ids
+        ):
+            continue
+        port_set = set(section.entry_ports) | set(section.exit_ports)
+        internal_ids = [
+            sid for sid in section.station_ids
+            if sid not in port_set and sid in graph.stations
+            and not graph.stations[sid].is_port
+        ]
+        if not internal_ids:
+            continue
+        bundle = _section_bundle_lines(graph, section)
+        if not bundle:
+            continue
+
+        xs = sorted({round(graph.stations[sid].x, 3) for sid in internal_ids})
+        entry_x = xs[0] if section.direction == "LR" else xs[-1]
+        entry_col = [
+            sid for sid in internal_ids
+            if round(graph.stations[sid].x, 3) == entry_x
+        ]
+        trunks = [
+            s for s in entry_col
+            if set(graph.station_lines(s)) == bundle
+        ]
+        if len(trunks) != 1:
+            continue
+        trunk_sid = trunks[0]
+        trunk_y = graph.stations[trunk_sid].y
+
+        # Sources: entry-column siblings of the trunk with no inbound
+        # edges and a strict-subset line set.  These are file-input
+        # icons (or input-only stations) that carry one or two lines.
+        sources = [
+            s for s in entry_col
+            if s != trunk_sid
+            and set(graph.station_lines(s))
+            and set(graph.station_lines(s)) < bundle
+            and not any(e.target == s for e in graph.edges)
+            and graph.stations[s].y > trunk_y - 0.5
+        ]
+        if len(sources) < 2:
+            continue
+
+        # Cap the lift so the topmost lifted station stays inside the
+        # bbox with a quarter-slot margin.  ``section_y_padding`` is
+        # ignored here because compaction already pulled row mates as
+        # tight as their off-track inputs allow; further padding would
+        # strand empty top space that this phase is meant to fill.
+        top_margin = y_spacing / 4
+        slack = trunk_y - section.bbox_y - top_margin
+        slots = int((slack + 0.5) // y_spacing)
+        if slots < 1:
+            continue
+        # Lift at most floor(n_sources / 2) so a majority of sources
+        # stay at or below the trunk.  Keeps the bottom-heavy ordering
+        # when only a couple of sources can fit above.
+        n_lift = min(slots, max(0, len(sources) // 2))
+        if n_lift == 0:
+            continue
+
+        sources.sort(key=lambda s: graph.stations[s].y)
+        section_internal_set = set(internal_ids)
+        for i, src in enumerate(sources[:n_lift], 1):
+            new_y = trunk_y - i * y_spacing
+            delta = new_y - graph.stations[src].y
+            if abs(delta) < 0.5:
+                continue
+            graph.stations[src].y = new_y
+            # Walk a strictly linear consumer chain: each step requires
+            # a single inbound edge from the previous link, an identical
+            # line set, and section-internal placement.  Stop on fan-in
+            # (consumer has another feeder) or line-set change.
+            cur = src
+            while True:
+                # De-dup parallel edges by target/source: each (src,tgt)
+                # pair may have one edge per line.
+                outs = {e.target for e in graph.edges if e.source == cur}
+                if len(outs) != 1:
+                    break
+                nxt = next(iter(outs))
+                if nxt not in section_internal_set:
+                    break
+                in_srcs = {e.source for e in graph.edges if e.target == nxt}
+                if len(in_srcs) != 1:
+                    break
+                if set(graph.station_lines(nxt)) != set(graph.station_lines(src)):
+                    break
+                graph.stations[nxt].y += delta
+                cur = nxt
 
 
 def _lift_would_cause_uturn(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1000,6 +1000,11 @@ def _layout_single_section(
             station.x = station.layer * x_spacing + layer_extra.get(station.layer, 0)
             station.y = track_rank[station.track] * effective_y_spacing
 
+    # Resolve same-cell station collisions: two stations on the same line
+    # priority can land on identical (x,y) when the track allocator collapses
+    # distinct line tracks at a layer with only one occupant per line.
+    _resolve_station_collisions(sub, section, x_spacing, effective_y_spacing)
+
     # Normalize Y so minimum is 0 (raw tracks can be negative)
     _normalize_min(sub, axis="y")
 
@@ -1034,6 +1039,59 @@ def _layout_single_section(
     _adjust_terminus_icon_clearance(sub, section, graph)
 
     return sub
+
+
+def _resolve_station_collisions(
+    sub: MetroGraph,
+    section: Section,
+    x_spacing: float,
+    y_spacing: float,
+) -> None:
+    """Push stations apart when track compaction collides them in the same cell.
+
+    The track allocator can return identical track values for two stations on
+    different lines when each is the sole occupant of its line at a given
+    layer (e.g. side-by-side terminus branches). After coordinate assignment
+    they end up at the same (x, y), causing visual overlap. This pass detects
+    such collisions and shifts the later-defined station along the section's
+    secondary axis by one spacing unit, repeating until the cell is unique.
+    """
+    if section.direction == "TB":
+        primary, secondary, primary_step, step = "y", "x", y_spacing, x_spacing
+    else:
+        primary, secondary, primary_step, step = "x", "y", x_spacing, y_spacing
+
+    EPS = 0.5
+    real = [s for s in sub.stations.values() if not s.is_port and not s.is_hidden]
+    real.sort(key=lambda s: (getattr(s, primary), getattr(s, secondary)))
+
+    # Group stations by primary-axis bucket (layer column for LR/RL,
+    # row for TB).  Use the primary-axis step size; the bucket spans a
+    # half-step either side of a layer centre so off-grid layer_extra
+    # offsets stay in the same bucket as their layer peers.
+    by_primary: dict[float, list] = {}
+    for s in real:
+        bucket = round(getattr(s, primary) / max(primary_step, 1.0))
+        by_primary.setdefault(bucket, []).append(s)
+
+    for stations in by_primary.values():
+        if len(stations) < 2:
+            continue
+        # Sort by current secondary coord, then station definition order
+        # (insertion order in sub.stations) as a stable tiebreaker so the
+        # earlier-defined station keeps its slot.
+        order = {sid: i for i, sid in enumerate(sub.stations)}
+        stations.sort(
+            key=lambda s: (getattr(s, secondary), order.get(s.id, 0))
+        )
+        used: list[float] = []
+        for s in stations:
+            pos = getattr(s, secondary)
+            while any(abs(pos - u) < step - EPS for u in used):
+                pos += step
+            if pos != getattr(s, secondary):
+                setattr(s, secondary, pos)
+            used.append(pos)
 
 
 def _multiline_track_spacing(sub: MetroGraph, y_spacing: float) -> float:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -416,6 +416,12 @@ def _compute_section_layout(
     # bbox tops within each row stay flush after port-terminus spacing.
     _top_align_row_sections(graph)
 
+    # Phase 11d: When --center-ports is on, redistribute fan-out siblings
+    # of a section's trunk junction symmetrically around the trunk Y.
+    # Scoped to fan-out side branches only: linear chains, fan-in
+    # structures, and file inputs are left in place.
+    _redistribute_fanout_siblings(graph, y_spacing)
+
     # ---- Pass C: Junction positioning (single pass) --------------------
     # All port positions are now final; position junctions once.
 
@@ -912,6 +918,94 @@ def _top_align_row_sections(graph: MetroGraph) -> None:
                     if station:
                         station.y -= delta
                 section.bbox_y -= delta
+
+
+def _section_bundle_lines(graph: MetroGraph, section: Section) -> set[str]:
+    """Return the set of line IDs crossing a section's LEFT/RIGHT ports."""
+    bundle: set[str] = set()
+    for pid in list(section.entry_ports) + list(section.exit_ports):
+        port = graph.ports.get(pid)
+        if port is None or port.side not in (PortSide.LEFT, PortSide.RIGHT):
+            continue
+        for edge in graph.edges:
+            if edge.source == pid or edge.target == pid:
+                bundle.add(edge.line_id)
+    return bundle
+
+
+def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
+    """Symmetrically distribute fan-out siblings around a trunk junction.
+
+    Active when ``graph.center_ports`` is True.  For each LR/RL section
+    in the grid, iterate by column: a column qualifies as a fan-out
+    junction when it has exactly one station whose line set equals the
+    section's full LEFT/RIGHT bundle (the trunk junction) AND at least
+    one sibling whose line set is a strict subset of the bundle.
+
+    In those columns, the trunk station is pinned at its current Y and
+    the strict-subset siblings are redistributed in alternating slots
+    ``+1, -1, +2, -2, ...`` at ``y_spacing`` pitch above and below it.
+
+    Strict scoping: only stations in a trunk-junction column AND with
+    a strict-subset line set are moved.  File inputs, processing
+    chains, fan-in stations, columns without a unique trunk, and
+    siblings carrying the full bundle (linear pass-throughs) are left
+    in place so non-fan-out topologies keep their natural Y ordering.
+
+    No-op when ``--no-center-ports`` is set, when a section has no
+    qualifying trunk-junction column, or when there are no
+    strict-subset siblings.
+    """
+    if not graph.center_ports:
+        return
+    grid_sec_ids = _grid_group_section_ids(graph)
+    if not grid_sec_ids:
+        return
+
+    for section in graph.sections.values():
+        if (
+            section.id not in grid_sec_ids
+            or section.direction not in ("LR", "RL")
+            or section.bbox_h <= 0
+        ):
+            continue
+        bundle = _section_bundle_lines(graph, section)
+        if not bundle:
+            continue
+        port_ids = set(section.entry_ports) | set(section.exit_ports)
+
+        # Group non-port stations by column x.
+        cols: dict[float, list[str]] = defaultdict(list)
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            st = graph.stations.get(sid)
+            if st is None:
+                continue
+            cols[round(st.x, 3)].append(sid)
+
+        for sids in cols.values():
+            # Identify trunk station in this column: lines == bundle, unique.
+            trunks = [s for s in sids if set(graph.station_lines(s)) == bundle]
+            if len(trunks) != 1:
+                continue
+            trunk_sid = trunks[0]
+            trunk_y = graph.stations[trunk_sid].y
+            # Fan-out siblings: strict subset of bundle (skip full-bundle
+            # pass-throughs and orphan stations with no lines).
+            siblings = [
+                s for s in sids
+                if s != trunk_sid
+                and set(graph.station_lines(s))
+                and set(graph.station_lines(s)) < bundle
+            ]
+            if not siblings:
+                continue
+            siblings.sort(key=lambda s: graph.stations[s].y)
+            for i, sid in enumerate(siblings, 1):
+                k = (i + 1) // 2
+                sign = 1 if (i % 2 == 1) else -1
+                graph.stations[sid].y = trunk_y + sign * k * y_spacing
 
 
 def _layout_single_section(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1604,6 +1604,13 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
     siblings carrying the full bundle (linear pass-throughs) are left
     in place so non-fan-out topologies keep their natural Y ordering.
 
+    Additionally, a sibling is only redistributed when it shares an
+    upstream predecessor with the trunk station.  This excludes
+    columns of source stations (file inputs) that happen to sit in a
+    column with a full-bundle station: with no shared upstream
+    junction, they aren't fan-out branches and must stay on their
+    per-line track Y so they line up with their downstream consumers.
+
     No-op when ``--no-center-ports`` is set, when a section has no
     qualifying trunk-junction column, or when there are no
     strict-subset siblings.
@@ -1613,6 +1620,12 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
     grid_sec_ids = _grid_group_section_ids(graph)
     if not grid_sec_ids:
         return
+
+    import networkx as nx
+
+    G = nx.DiGraph()
+    for edge in graph.edges:
+        G.add_edge(edge.source, edge.target)
 
     for section in graph.sections.values():
         if (
@@ -1643,13 +1656,22 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
                 continue
             trunk_sid = trunks[0]
             trunk_y = graph.stations[trunk_sid].y
+            trunk_preds = (
+                set(G.predecessors(trunk_sid)) if trunk_sid in G else set()
+            )
             # Fan-out siblings: strict subset of bundle (skip full-bundle
-            # pass-throughs and orphan stations with no lines).
+            # pass-throughs and orphan stations with no lines).  Require
+            # a shared predecessor with the trunk so source stations
+            # (file inputs with no inbound edges) stay on their per-line
+            # track Y instead of being pulled to a uniform fan around
+            # an unrelated trunk.
             siblings = [
                 s for s in sids
                 if s != trunk_sid
                 and set(graph.station_lines(s))
                 and set(graph.station_lines(s)) < bundle
+                and trunk_preds
+                and (set(G.predecessors(s)) if s in G else set()) & trunk_preds
             ]
             if not siblings:
                 continue

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -452,6 +452,21 @@ def _compute_section_layout(
     # heights shrink correspondingly so the empty top space disappears.
     _compact_row_content_to_bbox_top(graph, section_y_padding, y_spacing)
 
+    # Phase 13c: Snap inter-section LR/RL port pairs to a common Y so
+    # the trunk bundle stays perfectly horizontal across boundaries.
+    # Picks the downstream entry port's Y as the anchor since it sits
+    # on the row's aligned trunk grid.  Junctions are re-positioned
+    # afterwards because Phase 12 fixed their Y to the old exit port Y.
+    if _snap_inter_section_port_pairs(graph):
+        _position_junctions(graph)
+
+    # Phase 13d: Fan a section's free content upward when the row's
+    # compaction left visible empty space at the bbox top.  Only fires
+    # for sections whose internal stations have no upward dependency
+    # (no off-track band) and whose trunk Y sits below the bbox top
+    # padding by more than one ``y_spacing`` slot.
+    _fan_free_content_upward(graph, section_y_padding, y_spacing)
+
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
@@ -1163,11 +1178,15 @@ def _compact_row_content_to_bbox_top(
     # station-row's worth of clearance so labels still avoid the
     # topmost line track.
     off_track_gap = max(FONT_HEIGHT + STATION_RADIUS_APPROX * 2, y_spacing / 2)
-    # Captioned off-track icons (PR #269) render a label line under the
-    # icon body; that text needs to clear the topmost line track too,
-    # so the gap below a captioned bottom-of-band station is widened
-    # by the caption extent.
-    captioned_extra = FONT_HEIGHT + STATION_RADIUS_APPROX * 2
+    # Captioned off-track icons (PR #269) render a smaller label line
+    # under the icon body; that text needs to clear the topmost line
+    # track too, so the gap below a captioned bottom-of-band station is
+    # widened by the (scaled) caption extent.
+    from nf_metro.render.constants import ICON_NAME_FONT_SCALE, ICON_NAME_GAP
+
+    captioned_extra = (
+        FONT_HEIGHT * ICON_NAME_FONT_SCALE + ICON_NAME_GAP
+    )
 
     def _has_caption(sid: str) -> bool:
         st = graph.stations.get(sid)
@@ -1260,6 +1279,173 @@ def _compact_row_content_to_bbox_top(
                 new_h = desired_bot - section.bbox_y
                 if new_h < section.bbox_h - 0.5:
                     section.bbox_h = max(0.0, new_h)
+
+
+def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
+    """Snap exit/entry port pairs in the same row to a shared Y.
+
+    For each LEFT/RIGHT exit port that connects (directly or via a
+    junction) to a same-row LEFT/RIGHT entry port, picks the entry's Y
+    as the shared anchor.  This eliminates the small Y kinks left by
+    sections whose trunk Y couldn't be aligned via Phase 11ca (e.g.
+    row-spanning sections that the trunk aligner skips); the inside-
+    section link from the internal source to the port may bend by a
+    pixel or two but the inter-section bundle stays perfectly
+    horizontal.
+
+    Fan-in exits (two or more distinct internal source Ys) are skipped
+    so the visual convergence into a single port stays meaningful.
+
+    Returns True when at least one port was moved (caller may need to
+    re-run junction positioning to pick up the new exit-port Y).
+
+    Scoped to pipelines that use explicit ``%%metro grid:`` directives;
+    auto-layout pipelines keep their existing inter-section routing so
+    line-offset ordering tests stay stable.
+    """
+    if not getattr(graph, "_explicit_grid", None):
+        return False
+    junction_ids = set(graph.junctions)
+    moved = False
+
+    for port_id, port in graph.ports.items():
+        if port.is_entry:
+            continue
+        if port.side not in (PortSide.LEFT, PortSide.RIGHT):
+            continue
+        section = graph.sections.get(port.section_id)
+        if section is None or section.direction not in ("LR", "RL"):
+            continue
+        port_st = graph.stations.get(port_id)
+        if port_st is None:
+            continue
+
+        # Find downstream entry port(s) in the same row.
+        targets: list[float] = []
+        for edge in graph.edges:
+            if edge.source != port_id:
+                continue
+            entry_candidates: list[str] = []
+            tgt_port = graph.ports.get(edge.target)
+            if tgt_port and tgt_port.is_entry:
+                entry_candidates.append(edge.target)
+            elif edge.target in junction_ids:
+                for e2 in graph.edges:
+                    if e2.source != edge.target:
+                        continue
+                    tp2 = graph.ports.get(e2.target)
+                    if tp2 and tp2.is_entry:
+                        entry_candidates.append(e2.target)
+            for eid in entry_candidates:
+                ep = graph.ports.get(eid)
+                if ep is None or ep.side not in (PortSide.LEFT, PortSide.RIGHT):
+                    continue
+                ds_sec = graph.sections.get(ep.section_id)
+                if ds_sec is None or ds_sec.grid_row != section.grid_row:
+                    continue
+                ep_st = graph.stations.get(eid)
+                if ep_st is not None:
+                    targets.append(ep_st.y)
+        if not targets:
+            continue
+        target_y = min(targets, key=lambda y: abs(y - port_st.y))
+        if abs(port_st.y - target_y) < 0.5:
+            continue
+
+        # Skip fan-in exits: multiple distinct internal source Ys
+        # signal a meaningful convergence; keep the centred midpoint.
+        port_set = set(section.entry_ports) | set(section.exit_ports)
+        src_ys: set[float] = set()
+        for edge in graph.edges:
+            if edge.target != port_id:
+                continue
+            src = graph.stations.get(edge.source)
+            if src and not src.is_port and edge.source not in port_set:
+                src_ys.add(round(src.y, 1))
+        if len(src_ys) >= 2:
+            continue
+
+        _set_port_y(graph, port_id, target_y)
+        moved = True
+
+    return moved
+
+
+def _fan_free_content_upward(
+    graph: MetroGraph, section_y_padding: float, y_spacing: float
+) -> None:
+    """Fill empty top space by fanning trunk-candidate siblings up.
+
+    When ``_compact_row_content_to_bbox_top`` is bounded by a row-mate
+    section (e.g. one with off-track inputs), other sections in the
+    group may keep visible empty space above their topmost station.
+    For each LR/RL section with no off-track stations and at least one
+    ``y_spacing`` slot of top slack, redistribute the section's
+    trunk-candidate siblings (stations carrying the full bundle in the
+    same entry column) into the empty top space.
+
+    The topmost trunk candidate stays pinned (preserves the row trunk
+    Y); the rest are stacked above it at ``y_spacing`` pitch.  Stations
+    in later columns are not moved here so downstream chains keep their
+    relative position to the trunk station they branch from.
+
+    Scoped to pipelines using explicit ``%%metro grid:`` directives so
+    the auto-layout path is unaffected.
+    """
+    if not getattr(graph, "_explicit_grid", None):
+        return
+    for section in graph.sections.values():
+        if (
+            section.bbox_h <= 0
+            or section.direction not in ("LR", "RL")
+        ):
+            continue
+        if any(
+            getattr(graph.stations.get(sid), "off_track", False)
+            for sid in section.station_ids
+        ):
+            continue
+        port_set = set(section.entry_ports) | set(section.exit_ports)
+        internal_ids = [
+            sid for sid in section.station_ids
+            if sid not in port_set and sid in graph.stations
+            and not graph.stations[sid].is_port
+        ]
+        if not internal_ids:
+            continue
+        ys = [graph.stations[sid].y for sid in internal_ids]
+        top_y = min(ys)
+        slack = top_y - section.bbox_y - section_y_padding
+        if slack < y_spacing - 0.5:
+            continue
+        slots = int(slack // y_spacing)
+        if slots <= 0:
+            continue
+
+        bundle = _section_bundle_lines(graph, section)
+        if not bundle:
+            continue
+
+        # Trunk candidates: stations in the entry column carrying the
+        # full bundle.  Sort by current Y; topmost stays pinned, others
+        # stack above at y_spacing pitch.
+        xs = sorted({round(graph.stations[sid].x, 3) for sid in internal_ids})
+        if not xs:
+            continue
+        entry_x = xs[0] if section.direction == "LR" else xs[-1]
+        trunk_candidates = [
+            sid for sid in internal_ids
+            if round(graph.stations[sid].x, 3) == entry_x
+            and set(graph.station_lines(sid)) == bundle
+        ]
+        if len(trunk_candidates) < 2:
+            continue
+        trunk_candidates.sort(key=lambda s: graph.stations[s].y)
+        pinned = trunk_candidates[0]
+        anchor_y = graph.stations[pinned].y
+        to_lift = trunk_candidates[1 : 1 + slots]
+        for i, sid in enumerate(to_lift, 1):
+            graph.stations[sid].y = anchor_y - i * y_spacing
 
 
 def _section_bundle_lines(graph: MetroGraph, section: Section) -> set[str]:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -428,6 +428,10 @@ def _compute_section_layout(
     # Phase 12: Position junction stations in the inter-section gap.
     _position_junctions(graph)
 
+    # Phase 13: Lift off_track stations above their section's top track.
+    # Runs last so it operates on finalised station Ys and bboxes.
+    _lift_off_track_stations(graph, y_spacing, section_y_padding)
+
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
@@ -3230,3 +3234,117 @@ def _compute_fork_join_gaps(
             cumulative += layer_gap.get(layer, base_gap)
 
     return layer_extra
+
+
+def _lift_off_track_stations(
+    graph: MetroGraph,
+    y_spacing: float,
+    section_y_padding: float,
+) -> None:
+    """Lift off_track stations above their section's topmost line track.
+
+    Off-track stations are file-input nodes that should not consume a
+    line-track Y slot.  This phase moves each marked station's Y to a
+    new "input band" above the topmost non-off-track station in its
+    section, then expands the section bbox upward to fit them.  When
+    multiple off-track stations sit at the same X (the normal case for
+    sources stacked on layer 0), they are spread horizontally along
+    the band so file icons don't overlap.
+
+    Same-section ports already at the top edge are shifted with the
+    bbox so their entry coordinates remain on the boundary.
+    """
+    junction_ids = set(graph.junctions)
+
+    # Group off_track stations by section
+    by_section: dict[str, list[Station]] = defaultdict(list)
+    for sid, st in graph.stations.items():
+        if not st.off_track or st.is_port or sid in junction_ids:
+            continue
+        if not st.section_id:
+            continue
+        by_section[st.section_id].append(st)
+
+    # Band step matches y_spacing so each input gets a full slot
+    # (matches original station spacing, leaving room for label text).
+    # Inputs stay at their original X (layer 0 for sources) but stack
+    # vertically in a band above the topmost line track so file icons
+    # no longer share Y with the study-type lanes.
+    BAND_STEP = y_spacing
+
+    for sec_id, off_stations in by_section.items():
+        section = graph.sections.get(sec_id)
+        if not section:
+            continue
+
+        # Topmost Y of non-off-track real stations in the section
+        anchor_ys = [
+            graph.stations[sid].y
+            for sid in section.station_ids
+            if sid in graph.stations
+            and not graph.stations[sid].is_port
+            and not graph.stations[sid].off_track
+            and sid not in junction_ids
+        ]
+        if not anchor_ys:
+            continue
+        top_y = min(anchor_ys)
+
+        # Group inputs by X column (layer): each column gets its own
+        # vertical stack within the input band, preserving original
+        # Y order so e.g. Samples ends up above Contrasts above Matrix.
+        by_col: dict[float, list[Station]] = defaultdict(list)
+        for st in off_stations:
+            by_col[round(st.x, 1)].append(st)
+        for stations in by_col.values():
+            stations.sort(key=lambda s: s.y)
+
+        # Lowest slot in the band sits one y_spacing above top_y so
+        # there's room for the icon plus clearance from the topmost
+        # line track.  Higher slots stack upward in BAND_STEP units.
+        max_per_col = max(len(v) for v in by_col.values())
+        band_bottom = top_y - y_spacing
+        band_top = band_bottom - (max_per_col - 1) * BAND_STEP
+
+        for stations in by_col.values():
+            n = len(stations)
+            # Distribute n stations across the band, topmost first
+            for i, st in enumerate(stations):
+                st.y = band_top + i * BAND_STEP
+
+        # Expand section bbox upward so the band + label clearance
+        # fits inside the section box.
+        new_bbox_top = band_top - section_y_padding
+        if new_bbox_top < section.bbox_y:
+            delta = section.bbox_y - new_bbox_top
+            section.bbox_y = new_bbox_top
+            section.bbox_h += delta
+            # Shift TOP ports back to the (new) top edge so they stay
+            # on the boundary.  BOTTOM ports stay put because bbox_h
+            # only grew upward.
+            for pid in section.entry_ports + section.exit_ports:
+                port = graph.ports.get(pid)
+                port_st = graph.stations.get(pid)
+                if not port or not port_st:
+                    continue
+                if port.side == PortSide.TOP:
+                    port_st.y = section.bbox_y
+                    port.y = port_st.y
+
+    if not by_section:
+        return
+
+    # Phase 3b ran before our lift, so y_offset doesn't account for the
+    # new bbox tops.  Shift the whole graph down so the topmost section
+    # sits inside the canvas with the standard margin.
+    min_top = min(
+        s.bbox_y for s in graph.sections.values() if s.bbox_h > 0
+    )
+    if min_top < section_y_padding:
+        shift = section_y_padding - min_top
+        for st in graph.stations.values():
+            st.y += shift
+        for section in graph.sections.values():
+            section.bbox_y += shift
+        for port in graph.ports.values():
+            port.y += shift

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -518,6 +518,13 @@ def _compute_section_layout(
     # trunk alignment is unaffected.
     _shrink_bboxes_to_content_bottom(graph, section_y_padding)
 
+    # Phase 13j: Close vertical slack that the pre-shrink row-height
+    # estimate (in ``_compute_section_offsets``) left between row ``r``
+    # and row ``r + 1`` once 13i has collapsed bboxes to their content.
+    # Only fires when a rowspan section's content fell short of its row
+    # claim; multi-row layouts with content-filled rows are untouched.
+    _tighten_lower_rows_after_shrink(graph, section_y_gap)
+
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
@@ -2101,6 +2108,72 @@ def _shrink_bboxes_to_content_bottom(
         new_h = desired_bot - section.bbox_y
         if new_h < section.bbox_h - 0.5:
             section.bbox_h = max(0.0, new_h)
+
+
+def _tighten_lower_rows_after_shrink(
+    graph: MetroGraph, section_y_gap: float
+) -> None:
+    """Pull lower-row sections up to close slack left by rowspan claims.
+
+    ``_compute_section_offsets`` sizes ``row_heights[r]`` from pre-shrink
+    bbox heights, and a rowspan section that ends at row ``r`` inflates
+    the height further to fit its (then-tall) bbox.  After
+    ``_shrink_bboxes_to_content_bottom`` collapses bbox bottoms to
+    actual content, row ``r+1`` sits below empty space when the only
+    section "filling" row ``r`` was the rowspanned one (whose own bbox
+    now ends well above the row bottom).
+
+    For each row ``r >= 1``, this measures the slack between row ``r``'s
+    current top and the max bbox bottom of sections that *end* at row
+    ``r - 1`` (single-row sections in row ``r - 1`` plus rowspan
+    sections that terminate there).  Rowspan sections that *extend
+    into* row ``r`` are excluded: their bbox bottom is now content-
+    bounded, not row-bounded, so they no longer constrain row ``r``'s
+    top.  Sections in row ``r`` and below are shifted up by that slack
+    (minus ``section_y_gap``) along with their stations and ports.
+    Junctions live in inter-section space and routing recomputes after
+    layout, so their positions are left alone.
+    """
+    if not graph.sections:
+        return
+
+    sections_by_row_start: dict[int, list[Section]] = defaultdict(list)
+    for s in graph.sections.values():
+        sections_by_row_start[s.grid_row].append(s)
+    if not sections_by_row_start:
+        return
+    max_row = max(
+        s.grid_row + s.grid_row_span - 1 for s in graph.sections.values()
+    )
+
+    for r in range(1, max_row + 1):
+        lower = sections_by_row_start.get(r, [])
+        if not lower:
+            continue
+        ending_at_prev = [
+            s for s in graph.sections.values()
+            if s.grid_row + s.grid_row_span - 1 == r - 1 and s.bbox_h > 0
+        ]
+        if not ending_at_prev:
+            continue
+        max_above_bot = max(s.bbox_y + s.bbox_h for s in ending_at_prev)
+        current_top = min(s.bbox_y for s in lower if s.bbox_h > 0)
+        slack = current_top - (max_above_bot + section_y_gap)
+        if slack <= 0.5:
+            continue
+
+        shifted_section_ids = {
+            sid for sid, s in graph.sections.items() if s.grid_row >= r
+        }
+        for sid in shifted_section_ids:
+            graph.sections[sid].bbox_y -= slack
+        shifted_station_ids = set()
+        for sid in shifted_section_ids:
+            shifted_station_ids.update(graph.sections[sid].station_ids)
+        for stid in shifted_station_ids:
+            st = graph.stations.get(stid)
+            if st is not None:
+                st.y -= slack
 
 
 def _align_terminus_to_upstream(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -479,6 +479,14 @@ def _compute_section_layout(
     # This final pass restores clean grid positions before validation.
     _snap_all_y_to_grid(graph, y_spacing)
 
+    # Phase 13f: Re-anchor off-track inputs to their consumer's final
+    # (snapped) Y.  Phase 13's lift placed them relative to pre-snap
+    # consumer Ys; snapping the consumer to the grid can shift it by
+    # up to half a pitch, which would collapse the y_spacing gap above
+    # off-track.  Recomputing here pins each off-track at
+    # consumer.y - n*y_spacing on the final grid.
+    _reanchor_off_track_to_consumer(graph, y_spacing)
+
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
@@ -1151,19 +1159,14 @@ def _compact_row_content_to_bbox_top(
 
     Two-step compaction within each grid row's contiguous column run:
 
-    1. Per section, compute the allowable upward shift of on-track
-       content:
-
-       * bounded above by ``min(on_track_y) - bbox_y - section_y_padding``
-         so on-track content stays inside the bbox padding zone;
-       * bounded above by ``min(on_track_y) - max(off_track_y) - y_spacing_floor``
-         so on-track content stays clear of any lifted off-track band.
-
-       The uniform shift applied to the group is the minimum allowable
-       shift across same-row sections; that preserves the trunk-Y
-       alignment established by Phase 11ca.  Only on-track stations
-       and ports move; off-track stations stay anchored to the lifted
-       band Phase 13 placed them on.
+    1. Per section, compute the allowable upward shift bounded by
+       ``min(content_y) - bbox_y - section_y_padding`` so the topmost
+       station (on-track or off-track) stays inside the bbox padding
+       zone.  The uniform shift applied to the group is the minimum
+       allowable shift across same-row sections; that preserves the
+       trunk-Y alignment established by Phase 11ca.  Both on-track and
+       off-track stations move together so the gap between each
+       off-track input and its consumer is preserved.
     2. Shrink each section's ``bbox_h`` so the bottom slack matches
        ``section_y_padding`` (clamped so ports inside the section stay
        within the bbox).
@@ -1173,36 +1176,11 @@ def _compact_row_content_to_bbox_top(
     the rowspan was already consumed by earlier placement phases and no
     downstream phase relies on the inflated height.
     """
-
-    def _is_off_track(sid: str) -> bool:
-        st = graph.stations.get(sid)
-        return bool(st and getattr(st, "off_track", False))
-
     row_sections: dict[int, list[Section]] = defaultdict(list)
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.grid_row < 0:
             continue
         row_sections[section.grid_row].append(section)
-
-    # Minimum clearance between the off-track lift band and any
-    # on-track content shifted upward toward it.  Phase 13 installs a
-    # full ``y_spacing`` gap; compaction may shrink it to roughly one
-    # station-row's worth of clearance so labels still avoid the
-    # topmost line track.
-    off_track_gap = max(FONT_HEIGHT + STATION_RADIUS_APPROX * 2, y_spacing / 2)
-    # Captioned off-track icons (PR #269) render a smaller label line
-    # under the icon body; that text needs to clear the topmost line
-    # track too, so the gap below a captioned bottom-of-band station is
-    # widened by the (scaled) caption extent.
-    from nf_metro.render.constants import ICON_NAME_FONT_SCALE, ICON_NAME_GAP
-
-    captioned_extra = (
-        FONT_HEIGHT * ICON_NAME_FONT_SCALE + ICON_NAME_GAP
-    )
-
-    def _has_caption(sid: str) -> bool:
-        st = graph.stations.get(sid)
-        return bool(st and st.terminus_names and any(st.terminus_names))
 
     for sections in row_sections.values():
         if not sections:
@@ -1226,43 +1204,25 @@ def _compact_row_content_to_bbox_top(
         for group in groups:
             allowed_shifts: list[float] = []
             for section in group:
-                on_track_ys = [
+                # Use all real (non-port) stations as the top reference so
+                # off-track inputs lifted above their consumers also stay
+                # inside the bbox padding zone.  Off-track stations now
+                # move together with on-track during compaction.
+                content_ys = [
                     graph.stations[sid].y
                     for sid in section.station_ids
                     if sid in graph.stations
                     and not graph.stations[sid].is_port
-                    and not _is_off_track(sid)
                 ]
-                if not on_track_ys:
+                if not content_ys:
                     continue
-                on_track_min = min(on_track_ys)
-                shift = on_track_min - section.bbox_y - section_y_padding
-                off_track_ys = [
-                    graph.stations[sid].y
-                    for sid in section.station_ids
-                    if sid in graph.stations and _is_off_track(sid)
-                ]
-                if off_track_ys:
-                    gap = off_track_gap
-                    bottom_off_y = max(off_track_ys)
-                    bottom_off_ids = [
-                        sid
-                        for sid in section.station_ids
-                        if sid in graph.stations
-                        and _is_off_track(sid)
-                        and abs(graph.stations[sid].y - bottom_off_y) < 0.5
-                    ]
-                    if any(_has_caption(sid) for sid in bottom_off_ids):
-                        gap += captioned_extra
-                    clear_shift = on_track_min - bottom_off_y - gap
-                    shift = min(shift, clear_shift)
+                content_min = min(content_ys)
+                shift = content_min - section.bbox_y - section_y_padding
                 allowed_shifts.append(max(0.0, shift))
             delta = min(allowed_shifts) if allowed_shifts else 0.0
             if delta >= 0.5:
                 for section in group:
                     for sid in section.station_ids:
-                        if _is_off_track(sid):
-                            continue
                         st = graph.stations.get(sid)
                         if st:
                             st.y -= delta
@@ -1452,6 +1412,16 @@ def _fan_free_content_upward(
         ]
         if len(trunk_candidates) < 2:
             continue
+        # Skip if every station in the entry column carries the full
+        # bundle (no unique trunk): ``_redistribute_full_bundle_columns``
+        # has already symmetrically fanned them around the section's
+        # port Y and we must not collapse that into a one-sided stack.
+        entry_col_all = [
+            sid for sid in internal_ids
+            if round(graph.stations[sid].x, 3) == entry_x
+        ]
+        if len(trunk_candidates) == len(entry_col_all) and graph.center_ports:
+            continue
         trunk_candidates.sort(key=lambda s: graph.stations[s].y)
         pinned = trunk_candidates[0]
         anchor_y = graph.stations[pinned].y
@@ -1552,7 +1522,9 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
         half = pitch / 2.0
         # Collect non-port, on-track station Ys across the whole group
         # to estimate the row's shared grid offset.  Off-track stations
-        # were deliberately lifted by Phase 13 and must not pull origin.
+        # were lifted by Phase 13 relative to their consumers; they
+        # snap to the same grid (so the y_spacing gap above the
+        # consumer is preserved) but don't influence the origin.
         residues: Counter[float] = Counter()
         per_section_ports: dict[str, set[str]] = {}
         for sec_id in sec_ids:
@@ -1587,7 +1559,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
                 if sid in port_ids:
                     continue
                 st = graph.stations.get(sid)
-                if st is None or getattr(st, "off_track", False):
+                if st is None:
                     continue
                 st.y = _snap(st.y)
             for pid in port_ids:
@@ -1689,20 +1661,21 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
 
 
 def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
-    """Fan a terminal section's full-bundle column around the trunk Y.
+    """Fan a full-bundle column around the trunk Y.
 
-    Active when ``graph.center_ports`` is True.  Handles the
-    Reporting-style case where a *terminal* section (no exit ports)
-    holds a column of two or more full-bundle stations with no unique
-    trunk junction, so the existing fan-out logic skips it.  Stations
-    are placed symmetrically around a trunk Y derived from other
+    Active when ``graph.center_ports`` is True.  Handles columns of
+    two or more full-bundle stations with no unique trunk junction
+    (so ``_redistribute_fanout_siblings`` skips them).  Stations are
+    placed symmetrically around a trunk Y derived from other
     full-bundle stations in the section (or the LR port Y).
 
     Even count leaves the trunk row empty (``trunk_y ± s, ± 2s, ...``);
     odd count keeps a middle station at ``trunk_y`` with the rest
-    flanking.  Non-terminal sections are left untouched so the
-    Differential symfan, Functional method bank, file inputs and
-    fan-in chains keep their natural Y ordering.
+    flanking.  Fires on both terminal (Reporting-style) and
+    non-terminal (Functional-style) sections; the strict
+    "every station in the column carries the full bundle" gate keeps
+    file inputs, fan-in chains and method banks with strict-subset
+    lines untouched.
     """
     if not graph.center_ports:
         return
@@ -1715,7 +1688,6 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
             section.id not in grid_sec_ids
             or section.direction not in ("LR", "RL")
             or section.bbox_h <= 0
-            or section.exit_ports
         ):
             continue
         bundle = _section_bundle_lines(graph, section)
@@ -1727,36 +1699,50 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
         for sid in section.station_ids:
             if sid in port_ids:
                 continue
-            if (st := graph.stations.get(sid)) is not None:
-                cols[round(st.x, 3)].append(sid)
+            st = graph.stations.get(sid)
+            if st is None or st.off_track:
+                # Off-track inputs (file icons) are placed later by
+                # ``_lift_off_track_stations`` and must not occupy a
+                # column slot in the fan-out logic.
+                continue
+            cols[round(st.x, 3)].append(sid)
 
         full_by_col = {
             x: [s for s in sids if set(graph.station_lines(s)) == bundle]
             for x, sids in cols.items()
         }
+        # Snapshot pre-fan Ys so iteration order of columns doesn't
+        # drift the trunk reference: a later column must not see an
+        # earlier column's already-fanned positions.
+        pre_fan_y = {sid: graph.stations[sid].y for sids in cols.values() for sid in sids}
+        port_ys = [
+            graph.ports[pid].y for pid in port_ids
+            if graph.ports.get(pid) is not None
+            and graph.ports[pid].side in (PortSide.LEFT, PortSide.RIGHT)
+        ]
 
         for x, full in full_by_col.items():
             # Fire only when every column station carries the full bundle
             # and there are >=2 (so no unique trunk station exists).
             if len(full) < 2 or len(full) != len(cols[x]):
                 continue
-            others = sorted(
-                graph.stations[s].y
-                for ox, sids in full_by_col.items() if ox != x
-                for s in sids
-            )
-            if others:
-                trunk_y = others[len(others) // 2]
-            else:
-                port_ys = [
-                    graph.ports[pid].y for pid in port_ids
-                    if graph.ports.get(pid) is not None
-                    and graph.ports[pid].side in (PortSide.LEFT, PortSide.RIGHT)
-                ]
-                if not port_ys:
-                    continue
+            # Trunk Y is the section's LR port Y when available (the
+            # inter-section bundle line) so all full-bundle columns
+            # in the section share a single trunk reference.  Falls
+            # back to the median pre-fan Y of full-bundle stations in
+            # other columns when the section has no LR ports.
+            if port_ys:
                 trunk_y = sum(port_ys) / len(port_ys)
-            full.sort(key=lambda s: graph.stations[s].y)
+            else:
+                others = sorted(
+                    pre_fan_y[s]
+                    for ox, sids in full_by_col.items() if ox != x
+                    for s in sids
+                )
+                if not others:
+                    continue
+                trunk_y = others[len(others) // 2]
+            full.sort(key=lambda s: pre_fan_y[s])
             n = len(full)
             # Even: offsets -n//2..-1, 1..n//2 (skipping 0).
             # Odd:  offsets -(n//2)..n//2 inclusive (0 = trunk_y).
@@ -4000,27 +3986,19 @@ def _compute_fork_join_gaps(
     return layer_extra
 
 
-def _lift_off_track_stations(
+def _off_track_groups(
     graph: MetroGraph,
-    y_spacing: float,
-    section_y_padding: float,
-) -> None:
-    """Lift off_track stations above their section's topmost line track.
+) -> dict[str, tuple[str, dict[str, list[Station]]]]:
+    """Group off-track stations by section and consumer.
 
-    Off-track stations are file-input nodes that should not consume a
-    line-track Y slot.  This phase moves each marked station's Y to a
-    new "input band" above the topmost non-off-track station in its
-    section, then expands the section bbox upward to fit them.  When
-    multiple off-track stations sit at the same X (the normal case for
-    sources stacked on layer 0), they are spread horizontally along
-    the band so file icons don't overlap.
-
-    Same-section ports already at the top edge are shifted with the
-    bbox so their entry coordinates remain on the boundary.
+    Returns a mapping ``section_id -> (fallback_consumer_id, groups)``
+    where ``groups`` maps consumer-station-id (or ``""`` for inputs with
+    no same-section consumer) to a list of off-track stations feeding
+    that consumer.  ``fallback_consumer_id`` is the topmost on-track
+    station in the section, used as the anchor for the ``""`` bucket.
     """
     junction_ids = set(graph.junctions)
 
-    # Group off_track stations by section
     by_section: dict[str, list[Station]] = defaultdict(list)
     for sid, st in graph.stations.items():
         if not st.off_track or st.is_port or sid in junction_ids:
@@ -4029,60 +4007,114 @@ def _lift_off_track_stations(
             continue
         by_section[st.section_id].append(st)
 
-    # Band step matches y_spacing so each input gets a full slot
-    # (matches original station spacing, leaving room for label text).
-    # Inputs stay at their original X (layer 0 for sources) but stack
-    # vertically in a band above the topmost line track so file icons
-    # no longer share Y with the study-type lanes.
-    BAND_STEP = y_spacing
+    consumer_of: dict[str, str] = {}
+    for edge in graph.edges:
+        src = graph.stations.get(edge.source)
+        tgt = graph.stations.get(edge.target)
+        if src is None or tgt is None:
+            continue
+        if not src.off_track or src.is_port or src.id in junction_ids:
+            continue
+        if tgt.is_port or tgt.id in junction_ids or tgt.off_track:
+            continue
+        if src.section_id != tgt.section_id:
+            continue
+        consumer_of.setdefault(src.id, tgt.id)
 
+    result: dict[str, tuple[str, dict[str, list[Station]]]] = {}
     for sec_id, off_stations in by_section.items():
         section = graph.sections.get(sec_id)
         if not section:
             continue
-
-        # Topmost Y of non-off-track real stations in the section
-        anchor_ys = [
-            graph.stations[sid].y
+        anchor_pairs = [
+            (graph.stations[sid].y, sid)
             for sid in section.station_ids
             if sid in graph.stations
             and not graph.stations[sid].is_port
             and not graph.stations[sid].off_track
             and sid not in junction_ids
         ]
-        if not anchor_ys:
+        if not anchor_pairs:
             continue
-        top_y = min(anchor_ys)
-
-        # Group inputs by X column (layer): each column gets its own
-        # vertical stack within the input band, preserving original
-        # Y order so e.g. Samples ends up above Contrasts above Matrix.
-        by_col: dict[float, list[Station]] = defaultdict(list)
+        fallback_id = min(anchor_pairs)[1]
+        groups: dict[str, list[Station]] = defaultdict(list)
         for st in off_stations:
-            by_col[round(st.x, 1)].append(st)
-        for stations in by_col.values():
-            stations.sort(key=lambda s: s.y)
+            groups[consumer_of.get(st.id, "")].append(st)
+        result[sec_id] = (fallback_id, groups)
+    return result
 
-        # Lowest slot in the band sits one y_spacing above top_y so
-        # there's room for the icon plus clearance from the topmost
-        # line track.  Higher slots stack upward in BAND_STEP units.
-        max_per_col = max(len(v) for v in by_col.values())
-        band_bottom = top_y - y_spacing
-        band_top = band_bottom - (max_per_col - 1) * BAND_STEP
 
-        for stations in by_col.values():
-            n = len(stations)
-            # Distribute n stations across the band, topmost first
-            for i, st in enumerate(stations):
-                st.y = band_top + i * BAND_STEP
+def _place_off_track_above_consumers(
+    graph: MetroGraph,
+    y_spacing: float,
+    section_id: str,
+    fallback_consumer_id: str,
+    by_consumer: dict[str, list[Station]],
+) -> float | None:
+    """Place each off-track input ``n*y_spacing`` above its consumer.
 
-        # Expand section bbox upward so the band + label clearance
-        # fits inside the section box.
-        new_bbox_top = band_top - section_y_padding
+    Multiple inputs feeding the same consumer stack upward in
+    ``y_spacing`` steps.  Returns the smallest assigned Y (topmost
+    lifted station), or ``None`` when no stations were placed.
+    """
+    highest_y: float | None = None
+    for consumer_id, stations in by_consumer.items():
+        anchor_id = consumer_id if consumer_id else fallback_consumer_id
+        anchor = graph.stations.get(anchor_id)
+        if anchor is None:
+            continue
+        consumer_y = anchor.y
+        # Preserve original Y order: input closest to the top stays
+        # topmost in the stack.
+        stations.sort(key=lambda s: s.y)
+        n = len(stations)
+        for i, st in enumerate(stations):
+            st.y = consumer_y - (n - i) * y_spacing
+            if highest_y is None or st.y < highest_y:
+                highest_y = st.y
+    return highest_y
+
+
+def _lift_off_track_stations(
+    graph: MetroGraph,
+    y_spacing: float,
+    section_y_padding: float,
+) -> None:
+    """Lift off_track stations to the row above their consumer station.
+
+    Off-track stations are file-input nodes that should not consume a
+    line-track Y slot.  Each marked station is placed one ``y_spacing``
+    row above its consumer (the on-track station it feeds), so the
+    input sits adjacent to where its data is read rather than at a
+    uniform top-of-section band.  When several off-track inputs feed
+    the same consumer, they stack upward in ``y_spacing`` steps.
+
+    If an off-track station has no on-track consumer in the same
+    section, it falls back to the section's topmost on-track station
+    as its anchor.  After placement, the section bbox grows upward to
+    fit the highest lifted input, and same-section TOP ports are
+    nudged back to the new top edge.
+    """
+    groups = _off_track_groups(graph)
+    if not groups:
+        return
+
+    for sec_id, (fallback_id, by_consumer) in groups.items():
+        section = graph.sections.get(sec_id)
+        if section is None:
+            continue
+        highest_y = _place_off_track_above_consumers(
+            graph, y_spacing, sec_id, fallback_id, by_consumer
+        )
+        if highest_y is None:
+            continue
+
+        # Expand section bbox upward so the highest lifted input + its
+        # label clearance fits inside the section box.
+        new_bbox_top = highest_y - section_y_padding
         if new_bbox_top < section.bbox_y:
-            delta = section.bbox_y - new_bbox_top
+            section.bbox_h += section.bbox_y - new_bbox_top
             section.bbox_y = new_bbox_top
-            section.bbox_h += delta
             # Shift TOP ports back to the (new) top edge so they stay
             # on the boundary.  BOTTOM ports stay put because bbox_h
             # only grew upward.
@@ -4094,9 +4126,6 @@ def _lift_off_track_stations(
                 if port.side == PortSide.TOP:
                     port_st.y = section.bbox_y
                     port.y = port_st.y
-
-    if not by_section:
-        return
 
     # Phase 3b ran before our lift, so y_offset doesn't account for the
     # new bbox tops.  Shift the whole graph down so the topmost section
@@ -4112,3 +4141,25 @@ def _lift_off_track_stations(
             section.bbox_y += shift
         for port in graph.ports.values():
             port.y += shift
+
+
+def _reanchor_off_track_to_consumer(graph: MetroGraph, y_spacing: float) -> None:
+    """Re-place off-track inputs relative to consumer Ys after final snap.
+
+    Phase 13 placed each off-track input at ``consumer.y - n*y_spacing``
+    using the consumer's pre-snap Y.  Later phases (compaction, grid
+    snap) may shift the consumer to land on the section's row grid,
+    which changes the absolute Y of every consumer by up to half a
+    pitch.  This pass re-pins each off-track at the same offset
+    relative to the consumer's final snapped Y so the visible gap
+    stays at exactly one (or n) ``y_spacing`` slots.
+
+    Bboxes that were grown upward in Phase 13 to fit the lifted band
+    are left as-is: the row-bbox alignment downstream phases performed
+    already accounted for the lifted height.
+    """
+    groups = _off_track_groups(graph)
+    for sec_id, (fallback_id, by_consumer) in groups.items():
+        _place_off_track_above_consumers(
+            graph, y_spacing, sec_id, fallback_id, by_consumer
+        )

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1443,9 +1443,59 @@ def _fan_free_content_upward(
         trunk_candidates.sort(key=lambda s: graph.stations[s].y)
         pinned = trunk_candidates[0]
         anchor_y = graph.stations[pinned].y
-        to_lift = trunk_candidates[1 : 1 + slots]
+        to_lift = [
+            sid for sid in trunk_candidates[1 : 1 + slots]
+            if not _lift_would_cause_uturn(graph, sid, section.id, anchor_y)
+        ]
         for i, sid in enumerate(to_lift, 1):
             graph.stations[sid].y = anchor_y - i * y_spacing
+
+
+def _lift_would_cause_uturn(
+    graph: MetroGraph, station_id: str, section_id: str, anchor_y: float
+) -> bool:
+    """Return True when lifting *station_id* above ``anchor_y`` would
+    force its incoming bundle to make a U-turn.
+
+    A station U-turns when every external feeder sits at Y >= anchor_y:
+    the line bundle has to climb from the section's entry port (anchored
+    at the row's trunk Y) up to the lifted station, then back down to
+    rejoin the trunk for downstream stations.  When two or more feeders
+    share that situation, the upward climb visibly bends the bundle
+    against the trunk and may cross sibling routes that stay at trunk Y.
+
+    Returns False when there's no risk (no feeders, single feeder, or
+    any feeder sits above the anchor giving the bundle a reason to climb).
+    """
+    junction_ids = set(graph.junctions)
+    seen: set[str] = set()
+    feeder_ys: list[float] = []
+
+    def _collect(node_id: str) -> None:
+        for edge in graph.edges:
+            if edge.target != node_id:
+                continue
+            src_id = edge.source
+            if src_id in seen:
+                continue
+            seen.add(src_id)
+            if src_id in junction_ids:
+                _collect(src_id)
+                continue
+            src = graph.stations.get(src_id)
+            if src is None:
+                continue
+            if src.is_port:
+                _collect(src_id)
+                continue
+            if src.section_id == section_id:
+                continue
+            feeder_ys.append(src.y)
+
+    _collect(station_id)
+    if len(feeder_ys) < 2:
+        return False
+    return all(y >= anchor_y - 0.5 for y in feeder_ys)
 
 
 def _section_bundle_lines(graph: MetroGraph, section: Section) -> set[str]:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -467,6 +467,13 @@ def _compute_section_layout(
     # padding by more than one ``y_spacing`` slot.
     _fan_free_content_upward(graph, section_y_padding, y_spacing)
 
+    # Phase 13e: Snap all station/port Ys to a per-section y_spacing
+    # grid.  Trunk-Y align, port-snap, and the row compaction/fan
+    # phases compute shifts that don't respect the grid pitch, leaving
+    # coordinates at fractional Ys (e.g. 298.785 when the pitch is 55).
+    # This final pass restores clean grid positions before validation.
+    _snap_all_y_to_grid(graph, y_spacing)
+
     if validate:
         _guard_coordinates_finite(graph, "after Phase 12 (final)")
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
@@ -1496,6 +1503,96 @@ def _lift_would_cause_uturn(
     if len(feeder_ys) < 2:
         return False
     return all(y >= anchor_y - 0.5 for y in feeder_ys)
+
+
+def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
+    """Snap every station and port Y to the nearest row-wide grid slot.
+
+    Earlier phases (``_align_row_trunk_ys``, port-snap, downstream
+    alignment) compute shifts that don't respect the grid pitch, so
+    stations can land at fractional Ys (e.g. ``298.785`` when the pitch
+    is 55).  This final pass restores a clean grid by:
+
+    1. Grouping sections by row.  Sections sharing a row from
+       ``_align_row_y_grids`` use the row's ``slot_spacing`` as pitch
+       and snap to a single origin so trunks stay co-linear across the
+       row.  Sections without a row grid entry are treated as their
+       own one-section group at the input ``y_spacing``.
+    2. Finding the group's grid origin as the mode of ``y % pitch``
+       across ALL non-port, on-track stations in the group.  Using a
+       global mode prevents per-section origins from drifting (which
+       would kink the trunk between sections).
+    3. Snapping every station and LEFT/RIGHT port in the group to the
+       nearest ``origin + n * pitch``, bounded by half a pitch so
+       adjacency cannot flip.
+
+    Groups with no on-grid majority are left untouched.
+    """
+    if y_spacing <= 0:
+        return
+    # Build {group_key: (pitch, [section_ids])}.  Row-grid groups key
+    # by row id; ungrouped sections each become their own group.
+    groups: dict[object, tuple[float, list[str]]] = {}
+    grouped_ids: set[str] = set()
+    for row, info in (graph._row_y_grid_info or {}).items():
+        pitch = info.get("slot_spacing", y_spacing)
+        sec_ids = list(info.get("section_ids", []))
+        groups[("row", row)] = (pitch, sec_ids)
+        grouped_ids.update(sec_ids)
+    for section in graph.sections.values():
+        if section.id not in grouped_ids:
+            groups[("solo", section.id)] = (y_spacing, [section.id])
+
+    for pitch, sec_ids in groups.values():
+        half = pitch / 2.0
+        # Collect non-port, on-track station Ys across the whole group
+        # to estimate the row's shared grid offset.  Off-track stations
+        # were deliberately lifted by Phase 13 and must not pull origin.
+        residues: Counter[float] = Counter()
+        per_section_ports: dict[str, set[str]] = {}
+        for sec_id in sec_ids:
+            section = graph.sections.get(sec_id)
+            if section is None or section.bbox_h <= 0:
+                continue
+            port_ids = set(section.entry_ports) | set(section.exit_ports)
+            per_section_ports[sec_id] = port_ids
+            for sid in section.station_ids:
+                if sid in port_ids:
+                    continue
+                st = graph.stations.get(sid)
+                if st is None or getattr(st, "off_track", False):
+                    continue
+                residues[round(st.y % pitch, 3)] += 1
+        if not residues:
+            continue
+        origin_r, top = residues.most_common(1)[0]
+        if top < 2 and len(residues) > 1:
+            continue
+
+        def _snap(y: float, origin: float = origin_r, p: float = pitch,
+                  h: float = half) -> float:
+            snapped = origin + round((y - origin) / p) * p
+            return snapped if abs(snapped - y) <= h + 1e-6 else y
+
+        for sec_id, port_ids in per_section_ports.items():
+            section = graph.sections.get(sec_id)
+            if section is None:
+                continue
+            for sid in section.station_ids:
+                if sid in port_ids:
+                    continue
+                st = graph.stations.get(sid)
+                if st is None or getattr(st, "off_track", False):
+                    continue
+                st.y = _snap(st.y)
+            for pid in port_ids:
+                port = graph.ports.get(pid)
+                port_st = graph.stations.get(pid)
+                if port is None or port_st is None:
+                    continue
+                if port.side not in (PortSide.LEFT, PortSide.RIGHT):
+                    continue
+                port_st.y = _snap(port_st.y)
 
 
 def _section_bundle_lines(graph: MetroGraph, section: Section) -> set[str]:

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -699,7 +699,68 @@ def place_labels(
 
         placements.append(candidate)
 
+    _stagger_stacked_labels(placements, sorted_stations, graph)
+
     return [p for p in placements if p.obstacle_bbox is None]
+
+
+def _stagger_stacked_labels(
+    placements: list[LabelPlacement],
+    sorted_stations: list,
+    graph: MetroGraph,
+) -> None:
+    """Diagonally stagger labels of vertically stacked same-X stations.
+
+    When two stations in the same section share an X column and sit on
+    adjacent (or nearby) Y tracks, their centered labels appear stacked
+    in the same vertical line - visually crowded even when bboxes don't
+    overlap.  Shifting the upper label slightly leftward and the lower
+    rightward (or vice versa) decorrelates the visual centerlines.
+
+    Only applied when the shift won't introduce a label-label collision
+    and when both labels are short enough that the shift remains within
+    a single character width (subtle, but visible).
+    """
+    placement_by_sid = {p.station_id: p for p in placements if p.obstacle_bbox is None}
+
+    col_groups: dict[tuple[str | None, float], list] = {}
+    for s in sorted_stations:
+        if s.id not in placement_by_sid:
+            continue
+        col_groups.setdefault((s.section_id, round(s.x, 1)), []).append(s)
+
+    step = CHAR_WIDTH * 0.7
+    others = [p for p in placements if p.obstacle_bbox is not None]
+
+    for (sec_id, _x), group in col_groups.items():
+        if sec_id is None or len(group) < 2:
+            continue
+        group.sort(key=lambda s: s.y)
+        n = len(group)
+        for idx, st in enumerate(group):
+            shift = (idx - (n - 1) / 2.0) * step
+            if abs(shift) < 0.5:
+                continue
+            placement = placement_by_sid[st.id]
+            # Skip TB-section labels (anchored end/start, not centered).
+            if placement.text_anchor != "middle":
+                continue
+            trial = LabelPlacement(
+                station_id=placement.station_id,
+                text=placement.text,
+                x=placement.x + shift,
+                y=placement.y,
+                above=placement.above,
+                angle=placement.angle,
+                text_anchor=placement.text_anchor,
+                dominant_baseline=placement.dominant_baseline,
+            )
+            siblings = [
+                p for p in placements if p is not placement and p.obstacle_bbox is None
+            ] + others
+            if _has_collision(trial, siblings):
+                continue
+            placement.x = trial.x
 
 
 def _clamp_label_vertical(

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -408,6 +408,7 @@ def place_labels(
     label_offset: float = LABEL_OFFSET,
     station_offsets: dict[tuple[str, str], float] | None = None,
     icon_obstacles: list[tuple[float, float, float, float]] | None = None,
+    routes: list | None = None,
 ) -> list[LabelPlacement]:
     """Place horizontal labels alternating above/below stations.
 
@@ -701,6 +702,9 @@ def place_labels(
 
     _stagger_stacked_labels(placements, sorted_stations, graph)
 
+    if routes:
+        _avoid_diagonal_routes(placements, graph, routes, station_offsets)
+
     return [p for p in placements if p.obstacle_bbox is None]
 
 
@@ -761,6 +765,106 @@ def _stagger_stacked_labels(
             if _has_collision(trial, siblings):
                 continue
             placement.x = trial.x
+
+
+def _segment_intersects_bbox(
+    x1: float, y1: float, x2: float, y2: float,
+    bbox: tuple[float, float, float, float],
+) -> bool:
+    """Liang-Barsky test: True iff segment touches/crosses *bbox*."""
+    bx_min, by_min, bx_max, by_max = bbox
+    if max(x1, x2) < bx_min or min(x1, x2) > bx_max:
+        return False
+    if max(y1, y2) < by_min or min(y1, y2) > by_max:
+        return False
+    dx, dy = x2 - x1, y2 - y1
+    t_min, t_max = 0.0, 1.0
+    for p, q in ((-dx, x1 - bx_min), (dx, bx_max - x1),
+                 (-dy, y1 - by_min), (dy, by_max - y1)):
+        if abs(p) < 1e-9:
+            if q < 0:
+                return False
+            continue
+        t = q / p
+        if p < 0 and t > t_min:
+            t_min = t
+        elif p > 0 and t < t_max:
+            t_max = t
+        if t_min > t_max:
+            return False
+    return True
+
+
+def _avoid_diagonal_routes(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+    routes: list,
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> None:
+    """Flip labels overlapping a non-horizontal route segment.
+
+    Trunk segments are horizontal by design so labels offset above or
+    below them clear naturally.  Diagonal segments (trunk-to-fan
+    transitions, off-track entries) can land on top of a label and need
+    explicit avoidance: flip the label to the opposite side of its
+    station when the flipped position is free of label and route
+    collisions; otherwise leave it.
+    """
+    diag: list[tuple[float, float, float, float]] = []
+    for route in routes:
+        pts = list(getattr(route, "points", []))
+        if station_offsets and not getattr(route, "offsets_applied", False) and pts:
+            so = station_offsets.get((route.edge.source, route.line_id), 0.0)
+            to = station_offsets.get((route.edge.target, route.line_id), 0.0)
+            pts[0] = (pts[0][0], pts[0][1] + so)
+            pts[-1] = (pts[-1][0], pts[-1][1] + to)
+        for i in range(len(pts) - 1):
+            (x1, y1), (x2, y2) = pts[i], pts[i + 1]
+            dx, dy = x2 - x1, y2 - y1
+            if abs(dy) < max(abs(dx), 1.0) * 0.05:
+                continue  # ~horizontal; not a label obstacle.
+            diag.append((x1, y1, x2, y2))
+    if not diag:
+        return
+
+    m = LABEL_MARGIN
+
+    def hits(box: tuple[float, float, float, float]) -> bool:
+        padded = (box[0] - m, box[1] - m, box[2] + m, box[3] + m)
+        return any(_segment_intersects_bbox(*s, padded) for s in diag)
+
+    for placement in [p for p in placements if p.obstacle_bbox is None]:
+        if placement.dominant_baseline or placement.angle:
+            continue
+        if not hits(_label_bbox(placement)):
+            continue
+        station = graph.stations.get(placement.station_id)
+        if station is None:
+            continue
+        if station_offsets:
+            offs = [
+                station_offsets.get((station.id, lid), 0.0)
+                for lid in graph.station_lines(station.id)
+            ]
+            min_off, max_off = (min(offs), max(offs)) if offs else (0.0, 0.0)
+        else:
+            min_off = max_off = 0.0
+        if placement.above:
+            gap = max((station.y + min_off) - placement.y, LABEL_OFFSET)
+            trial = LabelPlacement(
+                station_id=placement.station_id, text=placement.text,
+                x=placement.x, y=station.y + max_off + gap, above=False,
+            )
+        else:
+            gap = max(placement.y - (station.y + max_off), LABEL_OFFSET)
+            trial = LabelPlacement(
+                station_id=placement.station_id, text=placement.text,
+                x=placement.x, y=station.y + min_off - gap, above=True,
+            )
+        siblings = [p for p in placements if p is not placement]
+        if _has_collision(trial, siblings) or hits(_label_bbox(trial)):
+            continue
+        placement.x, placement.y, placement.above = trial.x, trial.y, trial.above
 
 
 def _clamp_label_vertical(

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -113,6 +113,7 @@ def assign_tracks(
                     tracks,
                     straight_diamonds=graph.diamond_style == "straight",
                     layer_idx=layer_idx if entry_top else -1,
+                    graph=graph,
                 )
                 for n in nodes:
                     layer_occupancy[layer_idx][n] = tracks[n]
@@ -312,8 +313,19 @@ def _place_single_node(
         # base track so the main bundle stays compact and downstream
         # stations don't zigzag between the merged and base positions.
         if len(preds) > 1:
-            max_pred_lines = max(len(set(graph.station_lines(p))) for p in preds)
+            pred_line_sets = [set(graph.station_lines(p)) for p in preds]
+            max_pred_lines = max(len(pls) for pls in pred_line_sets)
             if len(node_lines) > max_pred_lines:
+                return base
+
+            # Trunk junction: at least one predecessor already carries the
+            # full node-line bundle, so side branches (subset preds) merge
+            # into the existing trunk here.  Anchor on the trunk's primary
+            # line track instead of the predecessor centroid so the bundle
+            # stays straight through the junction.
+            if len(node_lines) >= 2 and any(
+                pls == node_lines for pls in pred_line_sets
+            ):
                 return base
 
         # Diamond merge: when straight diamonds are active, snap the
@@ -369,6 +381,30 @@ def _is_diamond_fanout(nodes: list[str], G: nx.DiGraph) -> bool:
     return len(common_succs) > 0
 
 
+def _trunk_fanout_node(
+    nodes: list[str], graph: MetroGraph | None
+) -> str | None:
+    """Return the unique fan-out node carrying a strict superset of all siblings.
+
+    When one sibling's line set strictly contains every other sibling's
+    line set, it represents the trunk bundle while the others are
+    branches.  Anchoring the trunk keeps the bundle straight through
+    the fan-out.  Returns ``None`` if no such unique trunk exists.
+    """
+    if graph is None or len(nodes) < 2:
+        return None
+    line_sets = [(n, set(graph.station_lines(n))) for n in nodes]
+    trunk = None
+    for cand, cand_lines in line_sets:
+        if all(
+            other_lines < cand_lines for other, other_lines in line_sets if other != cand
+        ):
+            if trunk is not None:
+                return None
+            trunk = cand
+    return trunk
+
+
 def _place_fan_out(
     nodes: list[str],
     base: float,
@@ -378,6 +414,7 @@ def _place_fan_out(
     *,
     straight_diamonds: bool = False,
     layer_idx: int = -1,
+    graph: MetroGraph | None = None,
 ) -> None:
     """Place multiple nodes in the same layer+line, centered around an anchor.
 
@@ -448,7 +485,17 @@ def _place_fan_out(
     elif layer_idx == 1 and n == 2:
         use_asymmetric = True
 
-    if use_asymmetric:
+    # Trunk-anchored placement: when one node carries a strict superset
+    # of every sibling's line set, it's the bundle trunk.  Pin it at
+    # anchor and fan the side branches below so the trunk stays straight
+    # through the junction.
+    trunk_node = _trunk_fanout_node(nodes, graph)
+    if trunk_node is not None:
+        tracks[trunk_node] = anchor
+        others = [n for n in nodes if n != trunk_node]
+        for i, node in enumerate(others, 1):
+            tracks[node] = anchor + i * fan_spacing
+    elif use_asymmetric:
         # First node stays at anchor, others fan out below.
         tracks[nodes[0]] = anchor
         for i, node in enumerate(nodes[1:], 1):

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -106,6 +106,7 @@ class _RoutingCtx:
     curve_radius: float
     skip_edges: set[_EdgeKey] = field(default_factory=set)
     junction_fan_info: dict[_EdgeKey, tuple[int, int]] = field(default_factory=dict)
+    section_trunk_y: dict[str, float] = field(default_factory=dict)
     merge: _MergeRouting = field(
         default_factory=lambda: _MergeRouting(
             junctions=set(),
@@ -365,6 +366,12 @@ def _build_routing_context(
     # Merge routing classification
     merge = _classify_merge_edges(graph, junction_ids, join_sources, fork_targets)
 
+    # Section trunk Ys: the dominant on-track Y per LR/RL section, used
+    # to detect side-branch ascents (a below-trunk station feeding the
+    # trunk bundle).  Routing such edges with a late diagonal keeps the
+    # side-branch line on its own track until the section boundary.
+    section_trunk_y = _compute_section_trunk_ys(graph)
+
     # Bundle assignments and bypass gap indices
     line_priority = {lid: i for i, lid in enumerate(graph.lines.keys())}
     bundle_info = compute_bundle_info(
@@ -396,8 +403,37 @@ def _build_routing_context(
         curve_radius=curve_radius,
         junction_fan_info=junction_fan_info,
         skip_edges=merge.skip_edges,
+        section_trunk_y=section_trunk_y,
         merge=merge,
     )
+
+
+def _compute_section_trunk_ys(graph: MetroGraph) -> dict[str, float]:
+    """Return a mapping ``section_id -> trunk_y`` for LR/RL sections.
+
+    The trunk Y is the Y of the section's exit/entry ports, which
+    coincides with the dominant on-track bundle level.  Returns an
+    empty mapping for sections without horizontal ports.
+    """
+    result: dict[str, float] = {}
+    for sec_id, section in graph.sections.items():
+        if section.direction not in ("LR", "RL"):
+            continue
+        port_ys: list[float] = []
+        for pid in list(section.entry_ports) + list(section.exit_ports):
+            port = graph.ports.get(pid)
+            if port is None or port.side not in (PortSide.LEFT, PortSide.RIGHT):
+                continue
+            port_st = graph.stations.get(pid)
+            if port_st is None:
+                continue
+            port_ys.append(port_st.y)
+        if port_ys:
+            # Use the median to ignore outliers; all LR ports in a section
+            # typically share the same Y after alignment.
+            port_ys.sort()
+            result[sec_id] = port_ys[len(port_ys) // 2]
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1712,6 +1748,53 @@ def _route_intra_section(
     return _route_diagonal(edge, src, tgt, ctx)
 
 
+def _is_side_branch_ascent(
+    edge: Edge, src: Station, tgt: Station, ctx: _RoutingCtx
+) -> bool:
+    """Return True for a side-branch edge climbing to the section trunk.
+
+    A side-branch ascent edge starts at a non-port internal station
+    sitting off the section's trunk Y, with target either an exit port
+    of the same section or another internal station on the trunk Y.
+    Visually we want the line to stay on the side-branch track until
+    just before the target, so the bundle ordering inside the section
+    stays meaningful (the side-branch line does not appear to merge
+    with the main trunk bundle mid-section).
+
+    Only fires for non-port sources with a single outgoing line set
+    that exits the section via a shared exit port or feeds the trunk
+    bundle's join station.
+    """
+    if src.is_port or src.section_id is None:
+        return False
+    sec_id = src.section_id
+    trunk_y = ctx.section_trunk_y.get(sec_id)
+    if trunk_y is None:
+        return False
+    # Source must sit clearly off the trunk Y (at least a quarter slot).
+    if abs(src.y - trunk_y) < ctx.offset_step * 2:
+        return False
+    # Target must sit at or very close to trunk Y (the bundle level).
+    if abs(tgt.y - trunk_y) >= ctx.offset_step * 2:
+        return False
+    # Target must be in the same section or an exit port of this section.
+    tgt_port = ctx.graph.ports.get(edge.target)
+    same_sec = tgt.section_id == sec_id and not tgt.is_port
+    is_exit_port = (
+        tgt_port is not None
+        and not tgt_port.is_entry
+        and tgt_port.section_id == sec_id
+    )
+    if not (same_sec or is_exit_port):
+        return False
+    # Side branch carries a single line set (typical fanout slot).  Skip
+    # multi-line trunks that happen to sit below trunk Y momentarily.
+    src_lines = ctx.graph.station_lines(edge.source)
+    if len(src_lines) > 1:
+        return False
+    return True
+
+
 def _route_diagonal(
     edge: Edge, src: Station, tgt: Station, ctx: _RoutingCtx
 ) -> RoutedPath:
@@ -1740,14 +1823,22 @@ def _route_diagonal(
         src_min = min_straight
         tgt_min = min_straight
 
+    # Side-branch ascents: override the fork bias so the diagonal lands
+    # near the target.  The side-branch line then stays on its own track
+    # from the source until the section boundary, instead of merging
+    # with the main trunk bundle mid-section.
+    is_side_branch = _is_side_branch_ascent(edge, src, tgt, ctx)
+    is_fork_flag = edge.source in ctx.fork_stations and not is_side_branch
+    is_join_flag = edge.target in ctx.join_stations or is_side_branch
+
     diag_start_x, diag_end_x = _compute_diagonal_placement(
         sx,
         tx,
         ctx.diagonal_run,
         src_min,
         tgt_min,
-        edge.source in ctx.fork_stations,
-        edge.target in ctx.join_stations,
+        is_fork_flag,
+        is_join_flag,
     )
 
     return RoutedPath(

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -518,15 +518,41 @@ def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
             continue
         if port_obj.side not in (PortSide.LEFT, PortSide.RIGHT):
             continue
-        line_ys: dict[str, list[float]] = {}
+        # Collect (feeder_id, y) per line.  When a single full-bundle
+        # feeder carries every port line, side-branch feeders that only
+        # contribute a subset must not pull their line's "average Y"
+        # off the trunk: the kink belongs at the side branch, not at
+        # the bundle's exit.
+        line_feeders: dict[str, list[tuple[str, float]]] = {}
         for edge in graph.edges:
             if edge.target == port_id:
                 src_st = graph.stations.get(edge.source)
                 if src_st and not src_st.is_port:
-                    line_ys.setdefault(edge.line_id, []).append(src_st.y)
-        if len(line_ys) < 2:
+                    line_feeders.setdefault(edge.line_id, []).append(
+                        (edge.source, src_st.y)
+                    )
+        if len(line_feeders) < 2:
             continue
-        line_avg_y = {lid: sum(ys) / len(ys) for lid, ys in line_ys.items()}
+        port_lines = set(line_feeders.keys())
+        trunk_feeder_id: str | None = None
+        for sid in {fid for entries in line_feeders.values() for fid, _ in entries}:
+            if port_lines.issubset(set(graph.station_lines(sid))):
+                trunk_feeder_id = sid
+                break
+        if trunk_feeder_id is not None:
+            trunk_y = graph.stations[trunk_feeder_id].y
+            line_avg_y = {}
+            for lid, entries in line_feeders.items():
+                trunk_ys = [y for fid, y in entries if fid == trunk_feeder_id]
+                if trunk_ys:
+                    line_avg_y[lid] = trunk_ys[0]
+                else:
+                    line_avg_y[lid] = trunk_y
+        else:
+            line_avg_y = {
+                lid: sum(y for _, y in entries) / len(entries)
+                for lid, entries in line_feeders.items()
+            }
         unique_ys = set(line_avg_y.values())
         if len(unique_ys) < 2:
             continue

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -24,6 +24,7 @@ from nf_metro.layout.constants import (
     PLACEMENT_Y_GAP,
     PORT_MIN_GAP,
     SECTION_HEADER_PROTRUSION,
+    SECTION_X_PADDING,
 )
 from nf_metro.parser.model import MetroGraph, PortSide, Section
 
@@ -131,12 +132,20 @@ def _compute_section_offsets(
         min_col = min(min_col, col)
         max_col = max(max_col, col + cspan - 1)
 
-    # Max width per column (only from single-column sections)
+    # Max width per column (only from single-column sections).
+    # Use the right reach from offset_x (bbox_x + bbox_w) re-anchored to the
+    # standard left edge (-SECTION_X_PADDING) so that sections whose bbox_x
+    # was pushed further left by terminus-icon clearance don't inflate the
+    # column.  The leftward overhang lands left of offset_x and is later
+    # absorbed by the global x_offset bump in Phase 3b of compute_layout.
+    def _effective_width(section: Section) -> float:
+        return section.bbox_x + section.bbox_w + SECTION_X_PADDING
+
     col_widths: dict[int, float] = defaultdict(float)
     for sid, section in graph.sections.items():
         if section.grid_col_span == 1:
             col = col_assign.get(sid, 0)
-            col_widths[col] = max(col_widths[col], section.bbox_w)
+            col_widths[col] = max(col_widths[col], _effective_width(section))
 
     for c in range(min_col, max_col + 1):
         if c not in col_widths:
@@ -150,8 +159,9 @@ def _compute_section_offsets(
         start_col = col_assign.get(sid, 0)
         spanned = sum(col_widths[c] for c in range(start_col, start_col + cspan))
         spanned += (cspan - 1) * section_x_gap
-        if section.bbox_w > spanned:
-            deficit = section.bbox_w - spanned
+        eff_w = _effective_width(section)
+        if eff_w > spanned:
+            deficit = eff_w - spanned
             col_widths[start_col + cspan - 1] += deficit
 
     # Cumulative x offsets

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -673,16 +673,25 @@ def _position_ports_on_boundary(
         if not station:
             continue
 
-        connected = _find_connected_internal_coord(pid, section, graph, free_axis)
+        port = graph.ports.get(pid)
+        # LEFT/RIGHT exit ports prefer the downstream bundle Y so the
+        # inter-section run stays horizontal; fall back to the local
+        # internal-station average for entry ports and fan-in exits.
+        anchor: float | None = None
+        if free_axis == "y" and port is not None and not port.is_entry:
+            anchor = _find_downstream_bundle_y(pid, section, graph)
+        if anchor is None:
+            anchor = _find_connected_internal_coord(
+                pid, section, graph, free_axis
+            )
         if free_axis == "y":
             default = section.bbox_y + section.bbox_h / 2
         else:
             default = section.bbox_x + section.bbox_w / 2
 
         setattr(station, fixed_axis, fixed_coord)
-        setattr(station, free_axis, connected if connected is not None else default)
+        setattr(station, free_axis, anchor if anchor is not None else default)
 
-        port = graph.ports.get(pid)
         if port:
             port.x = station.x
             port.y = station.y
@@ -701,6 +710,89 @@ def _position_ports_on_boundary(
         span_start=span_start,
         span_end=span_end,
     )
+
+
+def _find_downstream_bundle_y(
+    exit_port_id: str,
+    section: Section,
+    graph: MetroGraph,
+) -> float | None:
+    """Find the Y where this exit port's bundle materialises downstream.
+
+    Traces forward to the downstream entry ports (direct or via a
+    fan-out junction) and resolves the Y of the topmost internal
+    station each one feeds when the fan-out is a parallel bundle
+    (every internal station carries the same line set).  Returns the
+    bundle Y when all same-row downstream entries agree and the value
+    fits inside this section's bbox, otherwise None so the caller can
+    fall back to the local-internal centre.
+    """
+    junction_ids = set(graph.junctions)
+    same_row = section.grid_row
+
+    # Fan-in exits stay centred: 2+ distinct internal source Ys means
+    # the visual convergence is meaningful and downstream anchoring
+    # would collapse the bundle onto one source.
+    internal_ids = (
+        set(section.station_ids) - set(section.entry_ports) - set(section.exit_ports)
+    )
+    src_ys: set[float] = set()
+    for edge in graph.edges:
+        if edge.target == exit_port_id and edge.source in internal_ids:
+            st = graph.stations.get(edge.source)
+            if st and not st.is_port:
+                src_ys.add(round(st.y, 1))
+    if len(src_ys) >= 2:
+        return None
+
+    entry_ids: list[str] = []
+    for edge in graph.edges:
+        if edge.source != exit_port_id:
+            continue
+        tgt = edge.target
+        if tgt in graph.ports and graph.ports[tgt].is_entry:
+            entry_ids.append(tgt)
+        elif tgt in junction_ids:
+            for e2 in graph.edges:
+                if e2.source == tgt and e2.target in graph.ports and (
+                    graph.ports[e2.target].is_entry
+                ):
+                    entry_ids.append(e2.target)
+    if not entry_ids:
+        return None
+
+    candidates: list[float] = []
+    for eid in entry_ids:
+        ep = graph.ports.get(eid)
+        if not ep:
+            continue
+        ds = graph.sections.get(ep.section_id)
+        if not ds or ds.grid_row != same_row:
+            continue
+        ds_internal = (
+            set(ds.station_ids) - set(ds.entry_ports) - set(ds.exit_ports)
+        )
+        targets: dict[str, set[str]] = {}
+        for edge in graph.edges:
+            if edge.source != eid or edge.target not in ds_internal:
+                continue
+            st = graph.stations.get(edge.target)
+            if st and not st.is_port:
+                targets.setdefault(edge.target, set()).add(edge.line_id)
+        if not targets:
+            continue
+        line_sets = list(targets.values())
+        if any(ls != line_sets[0] for ls in line_sets[1:]):
+            # Branch fan-out: different stations carry different lines.
+            return None
+        candidates.append(min(graph.stations[sid].y for sid in targets))
+
+    if not candidates or max(candidates) - min(candidates) > 1.0:
+        return None
+    target_y = candidates[0]
+    if not (section.bbox_y <= target_y <= section.bbox_y + section.bbox_h):
+        return None
+    return target_y
 
 
 def _find_connected_internal_coord(

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -163,8 +163,9 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
     for station_id, entries in graph._pending_terminus.items():
         station = graph.stations.get(station_id)
         if station:
-            station.terminus_labels = [label for label, _ in entries]
-            station.terminus_icon_types = [icon_type for _, icon_type in entries]
+            station.terminus_labels = [label for label, _, _ in entries]
+            station.terminus_icon_types = [icon_type for _, icon_type, _ in entries]
+            station.terminus_names = [name for _, _, name in entries]
 
     # Apply pending off-track marks
     for station_id in graph._pending_off_track:
@@ -251,8 +252,11 @@ def _parse_directive(
             station_id = parts[0].strip()
             raw_labels = parts[1].strip()
             labels = [s.strip() for s in raw_labels.split(",") if s.strip()]
+            # Optional third field: human-readable caption rendered below the
+            # icon. A single name applies to all labels from this directive.
+            name = parts[2].strip() if len(parts) >= 3 else ""
             graph._pending_terminus.setdefault(station_id, []).extend(
-                (label, icon_type) for label in labels
+                (label, icon_type, name) for label in labels
             )
 
 

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -166,6 +166,12 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
             station.terminus_labels = [label for label, _ in entries]
             station.terminus_icon_types = [icon_type for _, icon_type in entries]
 
+    # Apply pending off-track marks
+    for station_id in graph._pending_off_track:
+        station = graph.stations.get(station_id)
+        if station:
+            station.off_track = True
+
     return graph
 
 
@@ -235,6 +241,9 @@ def _parse_directive(
         pos = content[len("legend:") :].strip().lower()
         if pos in ("bl", "br", "tl", "tr", "bottom", "right", "none"):
             graph.legend_position = pos
+    elif content.startswith("off_track:"):
+        ids = [s.strip() for s in content[len("off_track:") :].split(",")]
+        graph._pending_off_track.extend(sid for sid in ids if sid)
     elif ":" in content and content.split(":", 1)[0] in VALID_ICON_TYPES:
         icon_type, rest = content.split(":", 1)
         parts = rest.strip().split("|")

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -318,6 +318,7 @@ def _parse_grid_directive(content: str, graph: MetroGraph) -> None:
     except ValueError:
         return
     graph.grid_overrides[section_id] = (col, row, rowspan, colspan)
+    graph._explicit_grid.add(section_id)
 
 
 # Regex patterns for node shapes

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -157,6 +157,7 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
         from nf_metro.layout.auto_layout import infer_section_layout
 
         infer_section_layout(graph, max_station_columns=max_station_columns)
+        _insert_terminus_convergence_stations(graph)
         _resolve_sections(graph)
 
     # Apply pending terminus designations
@@ -462,6 +463,88 @@ def _create_implicit_section(graph: MetroGraph) -> None:
         s.section_id = "__implicit__"
         implicit.station_ids.append(s.id)
     graph.add_section(implicit)
+
+
+def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
+    """Insert virtual convergence stations before multi-source termini.
+
+    When a terminus station (a file/files/dir output) has 2+ direct
+    inbound edges from distinct sources, the layout typically places
+    the sources at different Ys and routes diagonals into the terminus
+    marker, producing a Y-shaped converge AT the icon.  Inserting a
+    hidden convergence station between the sources and the terminus
+    forces the layout to allocate a column for the converge, so the
+    diagonals meet there and the final segment to the terminus marker
+    is a clean horizontal/vertical line.
+
+    The convergence station inherits the terminus's section.  It is
+    marked ``is_hidden`` so the renderer skips its label and marker.
+    For each inbound edge ``source -> terminus`` carrying line ``L``,
+    the edge is replaced with ``source -> converge`` followed by a
+    single ``converge -> terminus`` edge per distinct line.
+    """
+    pending_terminus = graph._pending_terminus
+    if not pending_terminus:
+        return
+
+    new_stations: list[Station] = []
+    new_edges: list[Edge] = []
+    edges_to_remove: set[int] = set()
+    converge_count = 0
+
+    for terminus_id in list(pending_terminus.keys()):
+        # Find direct inbound edges and their sources.
+        inbound: list[tuple[int, Edge]] = []
+        for i, edge in enumerate(graph.edges):
+            if edge.target == terminus_id:
+                inbound.append((i, edge))
+        if not inbound:
+            continue
+        sources = {e.source for _, e in inbound}
+        if len(sources) < 2:
+            continue
+
+        terminus = graph.stations.get(terminus_id)
+        if terminus is None:
+            continue
+
+        converge_count += 1
+        converge_id = f"__converge_{terminus_id}_{converge_count}"
+        new_stations.append(
+            Station(
+                id=converge_id,
+                label="",
+                section_id=terminus.section_id,
+                is_hidden=True,
+            )
+        )
+
+        # Replace each ``src -> terminus (line)`` with
+        # ``src -> converge (line)`` and add ``converge -> terminus (line)``.
+        seen_lines: set[str] = set()
+        for idx, edge in inbound:
+            edges_to_remove.add(idx)
+            new_edges.append(
+                Edge(source=edge.source, target=converge_id, line_id=edge.line_id)
+            )
+            if edge.line_id not in seen_lines:
+                seen_lines.add(edge.line_id)
+                new_edges.append(
+                    Edge(source=converge_id, target=terminus_id, line_id=edge.line_id)
+                )
+
+    if not new_stations:
+        return
+
+    for st in new_stations:
+        graph.register_station(st)
+
+    if edges_to_remove:
+        graph.edges = [
+            e for i, e in enumerate(graph.edges) if i not in edges_to_remove
+        ]
+    for edge in new_edges:
+        graph.add_edge(edge)
 
 
 def _resolve_sections(graph: MetroGraph) -> None:

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -172,6 +172,11 @@ class MetroGraph:
     ports: dict[str, Port] = field(default_factory=dict)
     junctions: list[str] = field(default_factory=list)
     grid_overrides: dict[str, tuple[int, int, int, int]] = field(default_factory=dict)
+    # Section IDs that received an explicit %%metro grid: directive (i.e.
+    # the user laid out the grid manually, as opposed to auto_layout
+    # filling in the placement).  Used to gate alignment polish passes
+    # that would distort auto-layout pipelines.
+    _explicit_grid: set[str] = field(default_factory=set)
     line_order: str = "definition"  # "definition" or "span"
     diamond_style: str = "straight"  # "straight" or "symmetric"
     compact_offsets: bool = False

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -67,6 +67,10 @@ class Station:
     off_track: bool = False
     terminus_labels: list[str] = field(default_factory=list)
     terminus_icon_types: list[str] = field(default_factory=list)
+    # Optional human-readable names for each terminus icon, rendered as a
+    # caption outside the icon (e.g. "Samples" below a CSV file icon).
+    # Parallel list to terminus_labels; empty string means no caption.
+    terminus_names: list[str] = field(default_factory=list)
     # Populated by layout engine
     x: float = 0.0
     y: float = 0.0

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -61,6 +61,10 @@ class Station:
     section_id: str | None = None
     is_port: bool = False
     is_hidden: bool = False
+    # When True, the station is lifted above the section's top track in a
+    # final layout phase.  Used for file-input nodes that would otherwise
+    # consume a line-track Y slot.
+    off_track: bool = False
     terminus_labels: list[str] = field(default_factory=list)
     terminus_icon_types: list[str] = field(default_factory=list)
     # Populated by layout engine
@@ -177,6 +181,8 @@ class MetroGraph:
     _explicit_directions: set[str] = field(default_factory=set)
     # Pending terminus designations: station_id -> list of (label, icon_type)
     _pending_terminus: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+    # Pending off-track marks: station_ids to lift above section top track
+    _pending_off_track: list[str] = field(default_factory=list)
     # Lazy cache for station_lines(); invalidated on edge mutation
     _station_lines_cache: dict[str, list[str]] | None = field(default=None, repr=False)
     # Grid alignment metadata (populated by Phase 2.5 _align_row_y_grids)

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -94,6 +94,9 @@ ICON_BBOX_MARGIN: float = 2.0
 ICON_NAME_GAP: float = 4.0
 """Gap between the bottom of a terminus icon and its name caption."""
 
+ICON_NAME_FONT_SCALE: float = 0.6
+"""Caption font size as a fraction of the theme label font size."""
+
 # ---------------------------------------------------------------------------
 # Animation
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -91,6 +91,9 @@ ICON_STATION_GAP: float = 6.0
 ICON_BBOX_MARGIN: float = 2.0
 """Margin around icon bounding box for clamping."""
 
+ICON_NAME_GAP: float = 4.0
+"""Gap between the bottom of a terminus icon and its name caption."""
+
 # ---------------------------------------------------------------------------
 # Animation
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -40,6 +40,7 @@ from nf_metro.render.constants import (
     ICON_BBOX_MARGIN,
     ICON_CLEARANCE_MARGIN,
     ICON_INTER_GAP,
+    ICON_NAME_GAP,
     ICON_STATION_GAP,
     LEGEND_GAP,
     LEGEND_INSET,
@@ -271,6 +272,11 @@ def _compute_icon_obstacles(
 
         y_min = icon_cy - theme.terminus_height / 2 - stacked_pad
         y_max = icon_cy + theme.terminus_height / 2 + stacked_pad
+
+        # Extend the obstacle downward to cover any caption text rendered
+        # below the icon, so neighbouring labels keep their distance.
+        if any(station.terminus_names or []):
+            y_max += ICON_NAME_GAP + theme.label_font_size
 
         obstacles.append(
             (
@@ -848,9 +854,11 @@ def _render_terminus_icons(
     icon_types = station.terminus_icon_types or [ICON_TYPE_FILE] * len(
         station.terminus_labels
     )
+    names = station.terminus_names or [""] * len(station.terminus_labels)
 
     for i, label in enumerate(station.terminus_labels):
         icon_type = icon_types[i] if i < len(icon_types) else ICON_TYPE_FILE
+        name = names[i] if i < len(names) else ""
 
         if icons_go_right:
             icon_cx = base_cx + i * icon_step
@@ -888,6 +896,26 @@ def _render_terminus_icons(
             render_files_icon(d, **common, fold_size=theme.terminus_fold_size)
         else:
             render_file_icon(d, **common, fold_size=theme.terminus_fold_size)
+
+        # Optional caption rendered below the icon so the type chip
+        # inside the icon stays readable.
+        if name:
+            caption_y = (
+                icon_cy + theme.terminus_height / 2 + ICON_NAME_GAP
+            )
+            d.append(
+                draw.Text(
+                    name,
+                    theme.label_font_size,
+                    icon_cx,
+                    caption_y,
+                    fill=theme.label_color,
+                    font_family=theme.label_font_family,
+                    font_weight=theme.label_font_weight,
+                    text_anchor="middle",
+                    dominant_baseline="hanging",
+                )
+            )
 
 
 def _render_labels(

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -860,6 +860,24 @@ def _render_terminus_icons(
     )
     names = station.terminus_names or [""] * len(station.terminus_labels)
 
+    # Pre-compute caption font size so adjacent-icon caption overlap
+    # can be detected before icons are emitted.  Captions sitting at
+    # the same Y overlap when their estimated widths exceed icon_step;
+    # in that case, every other caption is dropped to the next row.
+    caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
+    name_widths = [
+        len(n) * caption_font_size * 0.55 if n else 0.0
+        for n in names
+    ]
+    stagger_captions = False
+    for i in range(len(names) - 1):
+        if not names[i] or not names[i + 1]:
+            continue
+        max_w = max(name_widths[i], name_widths[i + 1])
+        if max_w > icon_step - 2.0:
+            stagger_captions = True
+            break
+
     for i, label in enumerate(station.terminus_labels):
         icon_type = icon_types[i] if i < len(icon_types) else ICON_TYPE_FILE
         name = names[i] if i < len(names) else ""
@@ -907,7 +925,12 @@ def _render_terminus_icons(
             caption_y = (
                 icon_cy + theme.terminus_height / 2 + ICON_NAME_GAP
             )
-            caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
+            # When adjacent icon captions would overlap horizontally
+            # (their estimated width exceeds the per-icon X step), drop
+            # odd-indexed captions to a second row so each name is
+            # legible.
+            if stagger_captions and i % 2 == 1:
+                caption_y += caption_font_size * 1.4
             caption_cx = icon_cx
             if section and section.bbox_w > 0:
                 # Estimate caption width and clamp so it stays inside the

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -311,7 +311,10 @@ def render_svg(
     # before section boxes are drawn and canvas bounds are computed.
     icon_obstacles = _compute_icon_obstacles(graph, theme, station_offsets)
     labels = place_labels(
-        graph, station_offsets=station_offsets, icon_obstacles=icon_obstacles
+        graph,
+        station_offsets=station_offsets,
+        icon_obstacles=icon_obstacles,
+        routes=routes,
     )
 
     max_x, max_y = _compute_canvas_bounds(graph, routes, debug)

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -40,6 +40,7 @@ from nf_metro.render.constants import (
     ICON_BBOX_MARGIN,
     ICON_CLEARANCE_MARGIN,
     ICON_INTER_GAP,
+    ICON_NAME_FONT_SCALE,
     ICON_NAME_GAP,
     ICON_STATION_GAP,
     LEGEND_GAP,
@@ -276,7 +277,7 @@ def _compute_icon_obstacles(
         # Extend the obstacle downward to cover any caption text rendered
         # below the icon, so neighbouring labels keep their distance.
         if any(station.terminus_names or []):
-            y_max += ICON_NAME_GAP + theme.label_font_size
+            y_max += ICON_NAME_GAP + theme.label_font_size * ICON_NAME_FONT_SCALE
 
         obstacles.append(
             (
@@ -903,11 +904,26 @@ def _render_terminus_icons(
             caption_y = (
                 icon_cy + theme.terminus_height / 2 + ICON_NAME_GAP
             )
+            caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
+            caption_cx = icon_cx
+            if section and section.bbox_w > 0:
+                # Estimate caption width and clamp so it stays inside the
+                # section bbox right edge (and left edge for symmetry).
+                approx_w = len(name) * caption_font_size * 0.55
+                left_bound = (
+                    section.bbox_x + approx_w / 2 + ICON_BBOX_MARGIN
+                )
+                right_bound = (
+                    section.bbox_x + section.bbox_w
+                    - approx_w / 2 - ICON_BBOX_MARGIN
+                )
+                if right_bound > left_bound:
+                    caption_cx = max(left_bound, min(caption_cx, right_bound))
             d.append(
                 draw.Text(
                     name,
-                    theme.label_font_size,
-                    icon_cx,
+                    caption_font_size,
+                    caption_cx,
                     caption_y,
                     fill=theme.label_color,
                     font_family=theme.label_font_family,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -808,6 +808,35 @@ def _render_stations(
             _render_terminus_icons(d, station, graph, theme, r, min_off, max_off)
 
 
+def caption_aware_icon_step(
+    names: list[str],
+    name_widths: list[float],
+    terminus_width: float,
+) -> float:
+    """Return the horizontal centre-to-centre step for adjacent icons.
+
+    The default step is ``terminus_width + ICON_INTER_GAP``.  When two
+    adjacent icons both carry a caption whose estimated width would
+    overrun that step (causing captions to overlap on the same row),
+    widen the step so the wider of the two captions fits with a small
+    visual gap on each side.  The widened step is shared by every icon
+    in the row, keeping spacing uniform.
+    """
+    default_step = terminus_width + ICON_INTER_GAP
+    required = default_step
+    for i in range(len(names) - 1):
+        if not names[i] or not names[i + 1]:
+            continue
+        pair_max = max(name_widths[i], name_widths[i + 1])
+        # Allow a small gap each side of the wider caption before its
+        # neighbour caption starts.  ICON_INTER_GAP gives us a uniform
+        # min visual breathing room.
+        needed = pair_max + ICON_INTER_GAP
+        if needed > required:
+            required = needed
+    return required
+
+
 def _render_terminus_icons(
     d: draw.Drawing,
     station: Station,
@@ -837,7 +866,6 @@ def _render_terminus_icons(
     # Place icons on the "outside" of the flow
     icon_gap = r + ICON_STATION_GAP
     icon_half_w = theme.terminus_width / 2
-    icon_step = theme.terminus_width + ICON_INTER_GAP
     section_dir = section.direction if section else "LR"
 
     # Determine direction: icons extend leftward for sources (LR/TB)
@@ -847,12 +875,6 @@ def _render_terminus_icons(
     else:
         icons_go_right = not is_source
 
-    # Base X for the first (nearest) icon center
-    if icons_go_right:
-        base_cx = station.x + icon_gap + icon_half_w
-    else:
-        base_cx = station.x - icon_gap - icon_half_w
-
     icon_cy = station.y + (min_off + max_off) / 2
 
     icon_types = station.terminus_icon_types or [ICON_TYPE_FILE] * len(
@@ -860,23 +882,22 @@ def _render_terminus_icons(
     )
     names = station.terminus_names or [""] * len(station.terminus_labels)
 
-    # Pre-compute caption font size so adjacent-icon caption overlap
-    # can be detected before icons are emitted.  Captions sitting at
-    # the same Y overlap when their estimated widths exceed icon_step;
-    # in that case, every other caption is dropped to the next row.
+    # Compute per-icon X step.  When adjacent captions would overlap
+    # at the default step, widen it so both fit on the same row.
     caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
     name_widths = [
         len(n) * caption_font_size * 0.55 if n else 0.0
         for n in names
     ]
-    stagger_captions = False
-    for i in range(len(names) - 1):
-        if not names[i] or not names[i + 1]:
-            continue
-        max_w = max(name_widths[i], name_widths[i + 1])
-        if max_w > icon_step - 2.0:
-            stagger_captions = True
-            break
+    icon_step = caption_aware_icon_step(
+        names, name_widths, theme.terminus_width
+    )
+
+    # Base X for the first (nearest) icon center
+    if icons_go_right:
+        base_cx = station.x + icon_gap + icon_half_w
+    else:
+        base_cx = station.x - icon_gap - icon_half_w
 
     for i, label in enumerate(station.terminus_labels):
         icon_type = icon_types[i] if i < len(icon_types) else ICON_TYPE_FILE
@@ -925,12 +946,6 @@ def _render_terminus_icons(
             caption_y = (
                 icon_cy + theme.terminus_height / 2 + ICON_NAME_GAP
             )
-            # When adjacent icon captions would overlap horizontally
-            # (their estimated width exceeds the per-icon X step), drop
-            # odd-indexed captions to a second row so each name is
-            # legible.
-            if stagger_captions and i % 2 == 1:
-                caption_y += caption_font_size * 1.4
             caption_cx = icon_cx
             if section and section.bbox_w > 0:
                 # Estimate caption width and clamp so it stays inside the

--- a/tests/fixtures/da_pipeline.mmd
+++ b/tests/fixtures/da_pipeline.mmd
@@ -1,0 +1,132 @@
+%%metro title: nf-core/differentialabundance
+%%metro style: dark
+%%metro legend: bl
+%%metro line_order: definition
+%%metro compact_offsets: true
+%%metro file: meta_in | YAML | Contrasts
+%%metro file: meta_in | CSV | Samples
+%%metro file: matrix_in | TSV | Matrix
+%%metro file: cel_in | CEL | Affy CEL
+%%metro file: mq_in | TSV | MaxQuant
+%%metro file: geo_in | STR | GEO ID
+%%metro file: gtf_in | GTF | GTF
+%%metro file: gmt_in | GMT | Gene sets
+%%metro file: net_in | TSV | Network
+%%metro file: report_html | HTML | Report
+%%metro file: bundle_zip | ZIP | Bundle
+%%metro file: shiny_html | HTML | Shiny
+%%metro file: plots_png | PNG | Plots
+%%metro line: rnaseq | RNA-seq counts | #2db572
+%%metro line: affy | Affymetrix microarray | #e6550d
+%%metro line: maxquant | MaxQuant proteomics | #0570b0
+%%metro line: geo | GEO SOFT file | #756bb1
+%%metro grid: data_prep | 0,0,2,1
+%%metro grid: differential | 1,0,1,1
+%%metro grid: functional | 2,0,1,1
+%%metro grid: reporting | 3,0,1,1
+%%metro grid: plots | 2,1,1,1
+%%metro off_track: gmt_in, net_in
+
+graph LR
+    subgraph data_prep [Data import and preparation]
+        %%metro exit: right | rnaseq, affy, maxquant, geo
+        meta_in[ ]
+        matrix_in[ ]
+        gtf_in[ ]
+        cel_in[ ]
+        mq_in[ ]
+        geo_in[ ]
+        gtf_to_table[GTF to table]
+        affy_load[Affy load]
+        proteus[Proteus]
+        geoquery[GEOquery]
+        validator[Validate]
+        matrix_filter[Filter matrix]
+
+        meta_in -->|rnaseq,affy,maxquant,geo| validator
+        matrix_in -->|rnaseq| validator
+        gtf_in -->|rnaseq,maxquant| gtf_to_table
+        gtf_to_table -->|rnaseq,maxquant| validator
+        cel_in -->|affy| affy_load
+        affy_load -->|affy| validator
+        mq_in -->|maxquant| proteus
+        proteus -->|maxquant| validator
+        geo_in -->|geo| geoquery
+        geoquery -->|geo| validator
+        validator -->|rnaseq,affy,maxquant,geo| matrix_filter
+    end
+
+    subgraph differential [Differential analysis]
+        %%metro entry: left | rnaseq, affy, maxquant, geo
+        %%metro exit: right | rnaseq, affy, maxquant, geo
+        limma[limma]
+        deseq2[DESeq2]
+        dream[dream]
+        propd[propd]
+        annotate[Annotate results]
+
+        limma -->|rnaseq,affy| annotate
+        deseq2 -->|rnaseq| annotate
+        dream -->|rnaseq| annotate
+        propd -->|rnaseq| annotate
+    end
+
+    subgraph functional [Functional enrichment]
+        %%metro entry: left | rnaseq, affy, maxquant, geo
+        %%metro exit: right | rnaseq, affy, maxquant, geo
+        gmt_in[ ]
+        net_in[ ]
+        gsea[GSEA]
+        gprofiler2[gprofiler2]
+        decoupler[decoupler]
+        grea[grea]
+
+        gmt_in -->|rnaseq,affy,maxquant,geo| gsea
+        net_in -->|rnaseq,affy,maxquant,geo| decoupler
+    end
+
+    subgraph reporting [Reporting]
+        %%metro entry: left | rnaseq, affy, maxquant, geo
+        shinyngs[Shiny app]
+        quarto[Quarto report]
+        bundle[Zip bundle]
+        shiny_html[ ]
+        report_html[ ]
+        bundle_zip[ ]
+
+        shinyngs -->|rnaseq,affy,maxquant,geo| shiny_html
+        quarto -->|rnaseq,affy,maxquant,geo| report_html
+        quarto -->|rnaseq,affy,maxquant,geo| bundle
+        bundle -->|rnaseq,affy,maxquant,geo| bundle_zip
+    end
+
+    subgraph plots [Plots]
+        %%metro entry: left | rnaseq, affy, maxquant, geo
+        plot_expl[Exploratory]
+        plot_diff[Differential]
+        plots_png[ ]
+
+        plot_expl -->|rnaseq,affy,maxquant,geo| plots_png
+        plot_diff -->|rnaseq,affy,maxquant,geo| plots_png
+    end
+
+    %% Inter-section edges
+    matrix_filter -->|rnaseq,affy,maxquant,geo| limma
+    matrix_filter -->|rnaseq| deseq2
+    matrix_filter -->|rnaseq| dream
+    matrix_filter -->|rnaseq| propd
+    %% Section 2 -> Section 3 (functional from differential results)
+    limma -->|rnaseq,affy,maxquant,geo| gsea
+    limma -->|rnaseq,affy,maxquant,geo| gprofiler2
+    limma -->|rnaseq,affy,maxquant,geo| decoupler
+    propd -->|rnaseq| grea
+    %% Section 2 -> Section 4 (plots are parallel, both from differential trunk)
+    limma -->|rnaseq,affy,maxquant,geo| plot_expl
+    limma -->|rnaseq,affy,maxquant,geo| plot_diff
+    %% Section 2/3 -> Section 5 (reporting from differential + functional)
+    limma -->|rnaseq,affy,maxquant,geo| shinyngs
+    limma -->|rnaseq,affy,maxquant,geo| quarto
+    gsea -->|rnaseq,affy,maxquant,geo| quarto
+    gprofiler2 -->|rnaseq,affy,maxquant,geo| quarto
+    decoupler -->|rnaseq,affy,maxquant,geo| quarto
+    grea -->|rnaseq| quarto

--- a/tests/fixtures/rnaseq_sections.mmd
+++ b/tests/fixtures/rnaseq_sections.mmd
@@ -1,0 +1,151 @@
+%%metro title: nf-core/rnaseq
+%%metro logo: examples/nf-core-rnaseq_logo_dark.png
+%%metro style: dark
+%%metro file: fastq_in | FASTQ
+%%metro file: report_final | HTML
+%%metro file: report_quant | HTML
+%%metro file: report_bowtie2 | HTML
+%%metro line: star_rsem | Aligner: STAR, Quantification: RSEM | #0570b0
+%%metro line: star_salmon | Aligner: STAR, Quantification: Salmon (default) | #2db572
+%%metro line: hisat2 | Aligner: HISAT2, Quantification: None | #f5c542
+%%metro line: bowtie2_salmon | Aligner: Bowtie2, Quantification: Salmon | #ff8c00
+%%metro line: pseudo_salmon | Pseudo-aligner: Salmon, Quantification: Salmon | #e63946
+%%metro line: pseudo_kallisto | Pseudo-aligner: Kallisto, Quantification: Kallisto | #7b2d3b
+%%metro legend: bl
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        %%metro exit: right | star_salmon, star_rsem, hisat2, bowtie2_salmon
+        %%metro exit: bottom | pseudo_salmon, pseudo_kallisto
+        fastq_in[ ]
+        cat_fastq[Cat FASTQ]
+        fastqc_raw[FastQC]
+        infer_strandedness[Infer Strandedness]
+        umi_tools_extract[UMI-tools Extract]
+        fastp[fastp]
+        trimgalore[Trim Galore!]
+        fastqc_trimmed[FastQC]
+        bbsplit[BBSplit]
+        sortmerna[SortMeRNA]
+        ribodetector[RiboDetector]
+        fastqc_filtered[FastQC]
+
+        fastq_in -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| cat_fastq
+        cat_fastq -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| fastqc_raw
+        fastqc_raw -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| infer_strandedness
+        infer_strandedness -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| umi_tools_extract
+
+        umi_tools_extract -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| fastp
+        umi_tools_extract -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| trimgalore
+        fastp -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| fastqc_trimmed
+        trimgalore -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| fastqc_trimmed
+
+        fastqc_trimmed -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| bbsplit
+        fastqc_trimmed -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| sortmerna
+        fastqc_trimmed -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| ribodetector
+        bbsplit -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| fastqc_filtered
+        sortmerna -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| fastqc_filtered
+        ribodetector -->|pseudo_salmon,pseudo_kallisto,star_salmon,star_rsem,hisat2,bowtie2_salmon| fastqc_filtered
+    end
+
+    subgraph genome_align [Genome alignment & quantification]
+        %%metro entry: left | star_salmon, star_rsem, hisat2, bowtie2_salmon
+        %%metro exit: right | star_salmon, star_rsem
+        %%metro exit: right | hisat2
+        star[STAR]
+        hisat2_align[HISAT2]
+        bowtie2_align[Bowtie2]
+        rsem[RSEM]
+        salmon_quant[Salmon]
+        umi_tools_dedup[UMI-tools Dedup]
+        tximport_ga[tximport]
+        summarized_exp_ga[Sum. Exp.]
+        multiqc_bowtie2[MultiQC]
+        report_bowtie2[ ]
+        _h1[hidden]
+        _h2[hidden]
+        _h3[hidden]
+
+        star -->|star_rsem| rsem
+        star -->|star_salmon| umi_tools_dedup
+        hisat2_align -->|hisat2| umi_tools_dedup
+        bowtie2_align -->|bowtie2_salmon| umi_tools_dedup
+        umi_tools_dedup -->|star_salmon| salmon_quant
+        umi_tools_dedup -->|hisat2| _h1
+        _h1 -->|hisat2| _h2
+        _h2 -->|hisat2| _h3
+        salmon_quant -->|star_salmon| tximport_ga
+        rsem -->|star_rsem| tximport_ga
+        tximport_ga -->|star_salmon,star_rsem| summarized_exp_ga
+        umi_tools_dedup -->|bowtie2_salmon| salmon_quant
+        salmon_quant -->|bowtie2_salmon| multiqc_bowtie2
+        multiqc_bowtie2 -->|bowtie2_salmon| report_bowtie2
+    end
+
+    subgraph pseudo_align [Pseudo-alignment & quantification]
+        %%metro entry: left | pseudo_salmon, pseudo_kallisto
+        salmon_pseudo[Salmon]
+        kallisto[Kallisto]
+        tximport_pa[tximport]
+        summarized_exp_pa[Sum. Exp.]
+        multiqc_quant[MultiQC]
+        report_quant[ ]
+
+        salmon_pseudo -->|pseudo_salmon| tximport_pa
+        kallisto -->|pseudo_kallisto| tximport_pa
+        tximport_pa -->|pseudo_salmon,pseudo_kallisto| summarized_exp_pa
+        summarized_exp_pa -->|pseudo_salmon,pseudo_kallisto| multiqc_quant
+        multiqc_quant -->|pseudo_salmon,pseudo_kallisto| report_quant
+    end
+
+    subgraph postprocessing [Post-processing]
+        %%metro direction: TB
+        %%metro entry: left | star_salmon, star_rsem, hisat2
+        %%metro exit: bottom | star_salmon, star_rsem, hisat2
+        samtools[SAMtools]
+        picard[Picard]
+        bedtools[BEDTools]
+        bedgraph[bedGraphToBigWig]
+        stringtie[StringTie]
+
+        samtools -->|star_salmon,star_rsem,hisat2| picard
+        picard -->|star_salmon,star_rsem,hisat2| bedtools
+        bedtools -->|star_salmon,star_rsem,hisat2| bedgraph
+        bedgraph -->|star_salmon,star_rsem,hisat2| stringtie
+    end
+
+    subgraph qc_report [Quality control & reporting]
+        %%metro direction: RL
+        %%metro entry: top | star_salmon, star_rsem, hisat2
+        rseqc[RSeQC]
+        preseq[Preseq]
+        qualimap[Qualimap]
+        dupradar[dupRadar]
+        featurecounts[featureCounts]
+        deseq2_pca[DESeq2 PCA]
+        kraken2[Kraken2/Bracken]
+        sylph[Sylph]
+        multiqc_final[MultiQC]
+        report_final[ ]
+
+        rseqc -->|star_salmon,star_rsem,hisat2| preseq
+        preseq -->|star_salmon,star_rsem,hisat2| qualimap
+        qualimap -->|star_salmon,star_rsem,hisat2| dupradar
+        dupradar -->|star_salmon,star_rsem,hisat2| featurecounts
+        featurecounts -->|star_salmon,star_rsem,hisat2| deseq2_pca
+        deseq2_pca -->|star_salmon,star_rsem,hisat2| kraken2
+        deseq2_pca -->|star_salmon,star_rsem,hisat2| sylph
+        kraken2 -->|star_salmon,star_rsem,hisat2| multiqc_final
+        sylph -->|star_salmon,star_rsem,hisat2| multiqc_final
+        multiqc_final -->|star_salmon,star_rsem,hisat2| report_final
+    end
+
+    %% Inter-section edges
+    fastqc_filtered -->|star_salmon,star_rsem| star
+    fastqc_filtered -->|hisat2| hisat2_align
+    fastqc_filtered -->|bowtie2_salmon| bowtie2_align
+    fastqc_filtered -->|pseudo_salmon| salmon_pseudo
+    fastqc_filtered -->|pseudo_kallisto| kallisto
+    summarized_exp_ga -->|star_salmon,star_rsem| samtools
+    _h3 -->|hisat2| samtools
+    stringtie -->|star_salmon,star_rsem,hisat2| rseqc

--- a/tests/test_grid_alignment.py
+++ b/tests/test_grid_alignment.py
@@ -88,26 +88,28 @@ class TestGridInvariants:
                         f"(first_y={first_y:.1f}, eff={eff})"
                     )
 
-    def test_first_station_y_consistent(self, grid_graph):
-        """First station Y matches across sections in each row group."""
+    def test_bbox_top_aligned(self, grid_graph):
+        """Section bbox tops align within each row group."""
         name, g = grid_graph
         for row, info in _grid_info(g).items():
-            first_ys = []
-            for sec_id in info["section_ids"]:
-                stations = [
-                    s
-                    for s in g.stations.values()
-                    if s.section_id == sec_id and not s.is_port
-                ]
-                if stations:
-                    first_ys.append(min(s.y for s in stations))
-            if len(first_ys) >= 2:
-                assert max(first_ys) - min(first_ys) < 2.0, (
-                    f"{name} row {row}: first_ys differ: {first_ys}"
+            tops = [
+                g.sections[sec_id].bbox_y
+                for sec_id in info["section_ids"]
+                if sec_id in g.sections and g.sections[sec_id].bbox_h > 0
+            ]
+            if len(tops) >= 2:
+                assert max(tops) - min(tops) < 2.0, (
+                    f"{name} row {row}: bbox tops differ: {tops}"
                 )
 
-    def test_symmetric_bbox_padding(self, grid_graph):
-        """Grid group section bboxes have symmetric top/bottom padding."""
+    def test_bottom_padding_at_least_top(self, grid_graph):
+        """Bot padding >= top padding (no content below bbox).
+
+        With trunk-Y alignment, sections may shift content downward, so
+        top padding can exceed the original symmetric value.  But bottom
+        padding must remain non-negative (content within bbox) and at
+        least as large as the original section_y_padding floor.
+        """
         name, g = grid_graph
         for sec_id in _grid_secs(g):
             sec = g.sections.get(sec_id)
@@ -120,13 +122,10 @@ class TestGridInvariants:
             ]
             if not stations:
                 continue
-            min_y = min(s.y for s in stations)
             max_y = max(s.y for s in stations)
-            top_pad = min_y - sec.bbox_y
             bot_pad = (sec.bbox_y + sec.bbox_h) - max_y
-            assert abs(top_pad - bot_pad) <= 1.0, (
-                f"{name} {sec_id}: asymmetric padding "
-                f"top={top_pad:.1f} bot={bot_pad:.1f}"
+            assert bot_pad >= -0.5, (
+                f"{name} {sec_id}: content below bbox bot_pad={bot_pad:.1f}"
             )
 
 

--- a/tests/test_grid_alignment.py
+++ b/tests/test_grid_alignment.py
@@ -363,3 +363,52 @@ class TestVariantbenchmarkingSpacing:
         assert len(layer1) >= 2
         xs = [s.x for s in layer1]
         assert max(xs) - min(xs) < 2.0, f"layer-1 X spread: {xs}"
+
+
+# ---------------------------------------------------------------------------
+# Inter-section port pair snap (final-polish phase 13c)
+# ---------------------------------------------------------------------------
+
+
+class TestInterSectionPortSnap:
+    """Exit port Y snaps to downstream entry Y in explicit-grid pipelines."""
+
+    def test_snap_aligns_rowspan_neighbour_to_row_trunk(self):
+        """With explicit grid, an LR exit port whose section's trunk Y
+        differs from a same-row downstream entry snaps to the entry Y."""
+        mmd = (
+            "%%metro line: main | Main | #ff0000\n"
+            "%%metro grid: a | 0,0,2,1\n"
+            "%%metro grid: b | 1,0\n"
+            "graph LR\n"
+            "    subgraph a [A]\n"
+            "        a1[A1]\n"
+            "        a2[A2]\n"
+            "        a1 -->|main| a2\n"
+            "    end\n"
+            "    subgraph b [B]\n"
+            "        b1[B1]\n"
+            "        b2[B2]\n"
+            "        b1 -->|main| b2\n"
+            "    end\n"
+            "    a2 -->|main| b1\n"
+        )
+        g = parse_metro_mermaid(mmd)
+        compute_layout(g)
+        a_exit = next(
+            g.stations[pid]
+            for pid in g.sections["a"].exit_ports
+        )
+        b_entry = next(
+            g.stations[pid]
+            for pid in g.sections["b"].entry_ports
+        )
+        assert abs(a_exit.y - b_entry.y) < 1.0, (
+            f"a exit y={a_exit.y} != b entry y={b_entry.y}"
+        )
+
+    def test_auto_layout_unaffected(self):
+        """The snap stays off for purely auto-layout pipelines."""
+        g = _load("variant_calling_tuned")
+        # Without any %%metro grid: directive, no explicit_grid entries.
+        assert not g._explicit_grid

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,6 +1,13 @@
 """Tests for label placement helpers."""
 
-from nf_metro.layout.labels import _compute_port_label_preference
+from dataclasses import dataclass, field
+
+from nf_metro.layout.labels import (
+    LabelPlacement,
+    _avoid_diagonal_routes,
+    _compute_port_label_preference,
+    _segment_intersects_bbox,
+)
 from nf_metro.parser.model import Edge, MetroGraph, Port, PortSide, Station
 
 
@@ -127,3 +134,82 @@ class TestComputePortLabelPreference:
         )
         pref = _compute_port_label_preference(g)
         assert pref["a"] is True  # both below -> prefer above
+
+
+@dataclass
+class _FakeEdge:
+    source: str = ""
+    target: str = ""
+
+
+@dataclass
+class _FakeRoute:
+    edge: _FakeEdge = field(default_factory=_FakeEdge)
+    line_id: str = "L1"
+    points: list = field(default_factory=list)
+    offsets_applied: bool = True
+
+
+class TestSegmentIntersectsBbox:
+    """Tests for _segment_intersects_bbox."""
+
+    def test_segment_inside_bbox(self):
+        assert _segment_intersects_bbox(5, 5, 10, 10, (0, 0, 20, 20))
+
+    def test_segment_crosses_bbox(self):
+        assert _segment_intersects_bbox(-5, 10, 25, 10, (0, 0, 20, 20))
+
+    def test_segment_outside_bbox(self):
+        assert not _segment_intersects_bbox(100, 100, 200, 200, (0, 0, 20, 20))
+
+    def test_diagonal_clips_corner(self):
+        assert _segment_intersects_bbox(0, 30, 30, 0, (10, 10, 20, 20))
+
+    def test_diagonal_misses_bbox(self):
+        # Diagonal passes well clear of the bbox.
+        assert not _segment_intersects_bbox(0, 0, 5, 5, (50, 50, 60, 60))
+
+
+class TestAvoidDiagonalRoutes:
+    """Tests for _avoid_diagonal_routes."""
+
+    def test_label_flipped_off_diagonal(self):
+        g = MetroGraph()
+        g.stations["a"] = Station(id="a", label="A", x=100, y=200)
+        # Label placed above the station (y_max = 195) right where a
+        # diagonal route segment crosses.
+        placement = LabelPlacement(
+            station_id="a", text="A", x=100, y=195, above=True
+        )
+        # Diagonal segment passes through the label area above.
+        route = _FakeRoute(points=[(50, 250), (150, 150)])
+        _avoid_diagonal_routes([placement], g, [route], None)
+        # Should have flipped to below.
+        assert placement.above is False
+        assert placement.y > 200
+
+    def test_horizontal_segment_ignored(self):
+        g = MetroGraph()
+        g.stations["a"] = Station(id="a", label="A", x=100, y=200)
+        placement = LabelPlacement(
+            station_id="a", text="A", x=100, y=195, above=True
+        )
+        # Pure horizontal segment crossing the label area.
+        route = _FakeRoute(points=[(0, 195), (200, 195)])
+        _avoid_diagonal_routes([placement], g, [route], None)
+        # Should not flip - horizontal trunk routes aren't treated as
+        # label obstacles.
+        assert placement.above is True
+        assert placement.y == 195
+
+    def test_no_route_collision_no_flip(self):
+        g = MetroGraph()
+        g.stations["a"] = Station(id="a", label="A", x=100, y=200)
+        placement = LabelPlacement(
+            station_id="a", text="A", x=100, y=195, above=True
+        )
+        # Diagonal far away from the label.
+        route = _FakeRoute(points=[(500, 500), (600, 600)])
+        _avoid_diagonal_routes([placement], g, [route], None)
+        assert placement.above is True
+        assert placement.y == 195

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -134,6 +134,126 @@ def test_compute_layout_off_track_bbox_contains_stations():
         )
 
 
+def test_compute_layout_rowspan_section_compacts_content():
+    """Row-spanning sections get their content compacted to the bbox top.
+
+    Without this, a rowspan>1 section gets bbox-top-aligned to taller
+    same-row neighbours but its own content stays anchored further
+    down, leaving a large empty band above the first row.
+    """
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro grid: tall | 0,0,2,1\n"
+        "%%metro grid: short | 1,0,1,1\n"
+        "%%metro grid: low | 1,1,1,1\n"
+        "%%metro off_track: ofs\n"
+        "graph LR\n"
+        "    subgraph tall [Tall]\n"
+        "        a[A]\n"
+        "        a_out[Aout]\n"
+        "        a -->|main| a_out\n"
+        "    end\n"
+        "    subgraph short [Short]\n"
+        "        ofs[Off]\n"
+        "        b[B]\n"
+        "        ofs -->|main| b\n"
+        "    end\n"
+        "    subgraph low [Low]\n"
+        "        c[C]\n"
+        "    end\n"
+        "    a_out -->|main| b\n"
+    )
+    compute_layout(graph, x_spacing=70, y_spacing=55)
+    tall = graph.sections["tall"]
+    a_y = graph.stations["a"].y
+    # Empty band above first content should be at most one station row.
+    assert a_y - tall.bbox_y < 55, (
+        f"tall section has {a_y - tall.bbox_y:.1f}px empty space above its "
+        f"first station (>= y_spacing of 55)"
+    )
+
+
+def test_compute_layout_off_track_terminus_does_not_kink_port():
+    """Off-track sources don't push inter-section ports away from trunk.
+
+    A captioned/uncaptioned off-track station at the top of the
+    downstream section's input band must not be treated as a terminus
+    when spacing the inter-section entry port: otherwise the port
+    (and its upstream partner via junction propagation) gets shoved
+    above the on-track row and the inter-section bundle takes a
+    detour.
+    """
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: extra\n"
+        "graph LR\n"
+        "    subgraph up [Up]\n"
+        "        u1[U1]\n"
+        "        u_exit[Exit]\n"
+        "        u1 -->|main| u_exit\n"
+        "    end\n"
+        "    subgraph down [Down]\n"
+        "        extra[Extra]\n"
+        "        d1[D1]\n"
+        "        extra -->|main| d1\n"
+        "    end\n"
+        "    u_exit -->|main| d1\n"
+    )
+    compute_layout(graph, x_spacing=70, y_spacing=55)
+    # Entry and exit ports between up and down should align with each
+    # other on the inter-section bundle.
+    up_exit_y = graph.stations[graph.sections["up"].exit_ports[0]].y
+    down_entry_y = graph.stations[graph.sections["down"].entry_ports[0]].y
+    assert abs(up_exit_y - down_entry_y) < 0.5, (
+        f"inter-section ports misaligned: up_exit_y={up_exit_y:.1f} "
+        f"down_entry_y={down_entry_y:.1f}"
+    )
+    # The down entry port should be at the on-track trunk Y, not lifted
+    # away above (i.e. not within the off-track band).
+    d1_y = graph.stations["d1"].y
+    assert abs(down_entry_y - d1_y) < 0.5, (
+        f"down entry port y={down_entry_y:.1f} does not match the on-track "
+        f"trunk station d1 at y={d1_y:.1f}; off-track 'extra' incorrectly "
+        f"pushed the port"
+    )
+
+
+def test_compute_layout_captioned_off_track_clears_line_bundle():
+    """Captioned off-track icons keep clearance from the line bundle.
+
+    The optional caption rendered under a file/files/dir icon extends
+    one extra label line below the station Y, so compaction must
+    preserve enough gap that the caption text doesn't end up
+    overlapping the topmost on-track row after content is shifted up.
+    """
+    graph = parse_metro_mermaid(
+        "%%metro file: net_in | TSV | Network\n"
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: net_in\n"
+        "graph LR\n"
+        "    subgraph up [Up]\n"
+        "        u1[U1]\n"
+        "    end\n"
+        "    subgraph s [S]\n"
+        "        net_in[ ]\n"
+        "        gsea[GSEA]\n"
+        "        next[Next]\n"
+        "        net_in -->|main| gsea\n"
+        "        gsea -->|main| next\n"
+        "    end\n"
+        "    u1 -->|main| gsea\n"
+    )
+    compute_layout(graph, x_spacing=70, y_spacing=55)
+    net_y = graph.stations["net_in"].y
+    gsea_y = graph.stations["gsea"].y
+    # Need room for the icon body half (~16px) + caption gap + font
+    # line.  Use 30px as a conservative lower bound.
+    assert gsea_y - net_y >= 30, (
+        f"caption clearance too tight: gsea_y={gsea_y:.1f} net_in_y={net_y:.1f} "
+        f"(gap={gsea_y - net_y:.1f}px, need >=30)"
+    )
+
+
 # --- Section-first layout tests ---
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -84,6 +84,56 @@ def test_compute_layout_branching():
     assert graph.stations["b"].track != graph.stations["c"].track
 
 
+def test_compute_layout_off_track_lifts_above_topmost():
+    """off_track stations end up above the section's topmost line track."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: src\n"
+        "graph LR\n"
+        "    subgraph sec1 [Section]\n"
+        "        src[Input]\n"
+        "        mid[Middle]\n"
+        "        sink[Sink]\n"
+        "        src -->|main| mid\n"
+        "        mid -->|main| sink\n"
+        "    end\n"
+    )
+    compute_layout(graph, x_spacing=100, y_spacing=50)
+    src_y = graph.stations["src"].y
+    mid_y = graph.stations["mid"].y
+    sink_y = graph.stations["sink"].y
+    # src is off-track so it sits above the lowest of the on-track Ys
+    assert src_y < mid_y
+    assert src_y < sink_y
+    # Section bbox grew upward to fit it
+    sec = graph.sections["sec1"]
+    assert sec.bbox_y <= src_y
+
+
+def test_compute_layout_off_track_bbox_contains_stations():
+    """Lifted off_track stations stay inside their section's bbox."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: a, b\n"
+        "graph LR\n"
+        "    subgraph sec1 [Section]\n"
+        "        a[A]\n"
+        "        b[B]\n"
+        "        mid[Mid]\n"
+        "        a -->|main| mid\n"
+        "        b -->|main| mid\n"
+        "    end\n"
+    )
+    compute_layout(graph, x_spacing=100, y_spacing=50)
+    sec = graph.sections["sec1"]
+    for sid in ("a", "b"):
+        st = graph.stations[sid]
+        assert sec.bbox_y <= st.y <= sec.bbox_y + sec.bbox_h, (
+            f"{sid} at y={st.y} outside bbox "
+            f"y={sec.bbox_y}..{sec.bbox_y + sec.bbox_h}"
+        )
+
+
 # --- Section-first layout tests ---
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -869,6 +869,95 @@ def test_straight_diamond_merge_returns_to_trunk():
     assert graph.stations["d"].y == graph.stations["a"].y
 
 
+def _terminal_full_bundle_text():
+    """Two full-bundle terminal stations fed from upstream methods.
+
+    Reproduces the Reporting-style topology: a terminal section (no
+    exit ports) where two stations both carry the full bundle and both
+    receive from the same upstream branches.
+    """
+    return (
+        "%%metro line: L1 | Line1 | #ff0000\n"
+        "%%metro line: L2 | Line2 | #00ff00\n"
+        "graph LR\n"
+        "    subgraph methods [Methods]\n"
+        "        m1[M1]\n"
+        "        m2[M2]\n"
+        "    end\n"
+        "    subgraph report [Report]\n"
+        "        a[A]\n"
+        "        b[B]\n"
+        "    end\n"
+        "    m1 -->|L1,L2| a\n"
+        "    m2 -->|L1,L2| a\n"
+        "    m1 -->|L1,L2| b\n"
+        "    m2 -->|L1,L2| b\n"
+    )
+
+
+def test_full_bundle_column_fans_around_trunk_with_center_ports():
+    """Terminal section's full-bundle column fans symmetrically when --center-ports is on."""
+    graph = parse_metro_mermaid(_terminal_full_bundle_text())
+    graph.center_ports = True
+    compute_layout(graph, y_spacing=50.0)
+    ay = graph.stations["a"].y
+    by = graph.stations["b"].y
+    assert ay != by, "a and b should not share Y after fan"
+    # Symmetric around the section trunk Y (here derived from the LR port).
+    mid = (ay + by) / 2
+    assert abs((by - mid) - (mid - ay)) < 1e-6, (
+        f"a and b should be symmetric around trunk Y: a={ay}, b={by}, mid={mid}"
+    )
+    assert abs(abs(by - ay) - 100.0) < 1e-6, (
+        f"a and b should be 2*y_spacing apart: |b-a|={abs(by-ay)}"
+    )
+
+
+def test_full_bundle_column_no_op_without_center_ports():
+    """The new fan-out only fires when --center-ports is enabled."""
+    graph = parse_metro_mermaid(_terminal_full_bundle_text())
+    graph.center_ports = False
+    compute_layout(graph, y_spacing=50.0)
+    # Without center_ports, a and b should sit on adjacent tracks (1 step apart).
+    delta = abs(graph.stations["b"].y - graph.stations["a"].y)
+    assert delta == pytest.approx(50.0), (
+        f"Without center_ports, a/b should be 1 y_spacing apart: delta={delta}"
+    )
+
+
+def test_full_bundle_column_skips_non_terminal_section():
+    """The fan-out leaves non-terminal sections untouched."""
+    text = (
+        "%%metro line: L1 | Line1 | #ff0000\n"
+        "%%metro line: L2 | Line2 | #00ff00\n"
+        "graph LR\n"
+        "    subgraph upstream [Upstream]\n"
+        "        u[U]\n"
+        "    end\n"
+        "    subgraph middle [Middle]\n"
+        "        a[A]\n"
+        "        b[B]\n"
+        "    end\n"
+        "    subgraph downstream [Downstream]\n"
+        "        d[D]\n"
+        "    end\n"
+        "    u -->|L1,L2| a\n"
+        "    u -->|L1,L2| b\n"
+        "    a -->|L1,L2| d\n"
+        "    b -->|L1,L2| d\n"
+    )
+    graph = parse_metro_mermaid(text)
+    graph.center_ports = True
+    compute_layout(graph, y_spacing=50.0)
+    # `middle` has exit ports so the new fan-out should NOT fire.
+    # Verify that a and b sit on adjacent track slots, not flanking a
+    # vacant trunk row.
+    delta = abs(graph.stations["b"].y - graph.stations["a"].y)
+    assert delta == pytest.approx(50.0), (
+        f"Non-terminal middle should keep tight spacing: delta={delta}"
+    )
+
+
 def test_cli_straight_diamonds_default(tmp_path):
     """--straight-diamonds is on by default."""
     from click.testing import CliRunner

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -925,8 +925,8 @@ def test_full_bundle_column_no_op_without_center_ports():
     )
 
 
-def test_full_bundle_column_skips_non_terminal_section():
-    """The fan-out leaves non-terminal sections untouched."""
+def test_full_bundle_column_fans_non_terminal_section():
+    """Non-terminal full-bundle columns also fan around the trunk Y."""
     text = (
         "%%metro line: L1 | Line1 | #ff0000\n"
         "%%metro line: L2 | Line2 | #00ff00\n"
@@ -949,12 +949,86 @@ def test_full_bundle_column_skips_non_terminal_section():
     graph = parse_metro_mermaid(text)
     graph.center_ports = True
     compute_layout(graph, y_spacing=50.0)
-    # `middle` has exit ports so the new fan-out should NOT fire.
-    # Verify that a and b sit on adjacent track slots, not flanking a
-    # vacant trunk row.
-    delta = abs(graph.stations["b"].y - graph.stations["a"].y)
-    assert delta == pytest.approx(50.0), (
-        f"Non-terminal middle should keep tight spacing: delta={delta}"
+    # `middle` has exit ports but its column carries only full-bundle
+    # stations with no unique trunk, so the symfan should fire and the
+    # pair should flank a vacant trunk row.
+    ay = graph.stations["a"].y
+    by = graph.stations["b"].y
+    delta = abs(by - ay)
+    assert delta == pytest.approx(100.0), (
+        f"Non-terminal full-bundle column should flank trunk: delta={delta}"
+    )
+    mid = (ay + by) / 2
+    assert abs((by - mid) - (mid - ay)) < 1e-6, (
+        f"a and b should be symmetric around trunk Y: a={ay}, b={by}, mid={mid}"
+    )
+
+
+def test_off_track_input_sits_adjacent_to_its_consumer():
+    """Each off-track input lands one y_spacing above its consumer.
+
+    When two off-track inputs in the same section feed different
+    consumer stations, they should sit at distinct Ys derived from
+    their respective consumers, not stack at a uniform top-of-section
+    band.
+    """
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: in_a, in_b\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        in_a[A]\n"
+        "        in_b[B]\n"
+        "        upper[Upper]\n"
+        "        lower[Lower]\n"
+        "        upper -->|main| lower\n"
+        "        in_a -->|main| upper\n"
+        "        in_b -->|main| lower\n"
+        "    end\n"
+    )
+    compute_layout(graph, x_spacing=70, y_spacing=55)
+    upper_y = graph.stations["upper"].y
+    lower_y = graph.stations["lower"].y
+    in_a_y = graph.stations["in_a"].y
+    in_b_y = graph.stations["in_b"].y
+    # Each input sits one row above its respective consumer.
+    assert in_a_y == pytest.approx(upper_y - 55), (
+        f"in_a y={in_a_y} should be upper_y - y_spacing = {upper_y - 55}"
+    )
+    assert in_b_y == pytest.approx(lower_y - 55), (
+        f"in_b y={in_b_y} should be lower_y - y_spacing = {lower_y - 55}"
+    )
+    # Inputs sit at different Ys (not a uniform band).
+    assert in_a_y != in_b_y
+
+
+def test_multiple_off_track_inputs_share_consumer_stack_above_it():
+    """Multiple off-track inputs feeding one consumer stack above it."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: in_a, in_b\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        in_a[A]\n"
+        "        in_b[B]\n"
+        "        mid[Mid]\n"
+        "        sink[Sink]\n"
+        "        mid -->|main| sink\n"
+        "        in_a -->|main| mid\n"
+        "        in_b -->|main| mid\n"
+        "    end\n"
+    )
+    compute_layout(graph, x_spacing=70, y_spacing=55)
+    mid_y = graph.stations["mid"].y
+    in_a_y = graph.stations["in_a"].y
+    in_b_y = graph.stations["in_b"].y
+    # The two inputs stack above mid at 1*step and 2*step respectively.
+    ys = sorted([in_a_y, in_b_y])
+    assert ys[0] == pytest.approx(mid_y - 110), (
+        f"topmost input should be 2*y_spacing above consumer: {ys[0]} vs {mid_y - 110}"
+    )
+    assert ys[1] == pytest.approx(mid_y - 55), (
+        f"second input should be 1*y_spacing above consumer: {ys[1]} vs {mid_y - 55}"
     )
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -793,6 +793,50 @@ def test_is_diamond_fanout():
     assert _is_diamond_fanout(["b", "c"], G2) is False
 
 
+def test_lift_would_cause_uturn_skips_when_feeders_below_anchor():
+    """A trunk candidate with all-below feeders should NOT be lifted."""
+    from nf_metro.layout.engine import _lift_would_cause_uturn
+    from nf_metro.parser.model import Edge, MetroGraph, Station
+
+    g = MetroGraph()
+    g.stations["f1"] = Station(id="f1", label="F1", x=0, y=200, section_id="upstream")
+    g.stations["f2"] = Station(id="f2", label="F2", x=0, y=250, section_id="upstream")
+    g.stations["cand"] = Station(id="cand", label="C", x=100, y=200, section_id="ds")
+    g.edges = [
+        Edge(source="f1", target="cand", line_id="L1"),
+        Edge(source="f2", target="cand", line_id="L2"),
+    ]
+    assert _lift_would_cause_uturn(g, "cand", "ds", anchor_y=200) is True
+
+
+def test_lift_would_cause_uturn_allows_when_feeder_above():
+    """When at least one feeder sits above anchor_y, lifting is safe."""
+    from nf_metro.layout.engine import _lift_would_cause_uturn
+    from nf_metro.parser.model import Edge, MetroGraph, Station
+
+    g = MetroGraph()
+    g.stations["f1"] = Station(id="f1", label="F1", x=0, y=100, section_id="upstream")
+    g.stations["f2"] = Station(id="f2", label="F2", x=0, y=250, section_id="upstream")
+    g.stations["cand"] = Station(id="cand", label="C", x=100, y=200, section_id="ds")
+    g.edges = [
+        Edge(source="f1", target="cand", line_id="L1"),
+        Edge(source="f2", target="cand", line_id="L2"),
+    ]
+    assert _lift_would_cause_uturn(g, "cand", "ds", anchor_y=200) is False
+
+
+def test_lift_would_cause_uturn_ignores_single_feeder():
+    """A single external feeder is not enough to flag a U-turn."""
+    from nf_metro.layout.engine import _lift_would_cause_uturn
+    from nf_metro.parser.model import Edge, MetroGraph, Station
+
+    g = MetroGraph()
+    g.stations["f1"] = Station(id="f1", label="F1", x=0, y=250, section_id="upstream")
+    g.stations["cand"] = Station(id="cand", label="C", x=100, y=200, section_id="ds")
+    g.edges = [Edge(source="f1", target="cand", line_id="L1")]
+    assert _lift_would_cause_uturn(g, "cand", "ds", anchor_y=200) is False
+
+
 def test_straight_diamond_top_branch_stays_flat():
     """With diamond_style='straight', the top branch of a diamond stays on the trunk."""
     graph = parse_metro_mermaid(_diamond_section_text())

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1,0 +1,326 @@
+"""Cross-section layout invariants for inter-section bundle alignment.
+
+These tests assert that the row trunk Y is consistent across sections in
+the same grid row, that symmetric-fan column-mates land at mirrored Ys,
+and that off-track inputs sit above their consumer's trunk.  They catch
+regressions where one section's trunk drifts from the row's anchor (the
+"limma kink" bug) or where fan re-centering leaves stations asymmetric.
+
+The fixtures exercise real pipeline graphs with multi-line bundles,
+fan-out columns, and off-track inputs (differentialabundance) plus a
+two-section grid with simpler topology (variant calling).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph, PortSide
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+# Tolerance for "same Y" assertions.  The grid pitch defaults to 55px;
+# 1px slack absorbs sub-pixel rounding from fan-recenter phases.
+_Y_TOL = 1.0
+
+
+def _layout(fixture: str, **kwargs) -> MetroGraph:
+    """Parse a fixture file and run the full layout pipeline."""
+    text = (FIXTURES / fixture).read_text()
+    graph = parse_metro_mermaid(text)
+    graph.center_ports = True
+    compute_layout(graph, **kwargs)
+    return graph
+
+
+def _row_lr_sections(graph: MetroGraph) -> dict[int, list]:
+    """Group LR/RL sections by grid_row, skipping row-spanners."""
+    rows: dict[int, list] = defaultdict(list)
+    for sec in graph.sections.values():
+        if (
+            sec.bbox_h <= 0
+            or sec.grid_row < 0
+            or sec.direction not in ("LR", "RL")
+            or sec.grid_row_span > 1
+        ):
+            continue
+        rows[sec.grid_row].append(sec)
+    return rows
+
+
+def _section_lr_port_ys(graph: MetroGraph, section) -> list[float]:
+    """Return Y values of the section's LR (LEFT/RIGHT) ports."""
+    ys: list[float] = []
+    for pid in list(section.entry_ports) + list(section.exit_ports):
+        port = graph.ports.get(pid)
+        st = graph.stations.get(pid)
+        if (
+            port is not None
+            and st is not None
+            and port.side in (PortSide.LEFT, PortSide.RIGHT)
+        ):
+            ys.append(st.y)
+    return ys
+
+
+def _section_trunk_marker_cy(graph: MetroGraph, section) -> float | None:
+    """Render-time cy of the trunk station that anchors the row bundle.
+
+    The trunk station is the one whose marker the inter-section bundle
+    passes through.  We approximate it as the full-bundle internal
+    station whose marker centre (station.y + (min_off + max_off) / 2)
+    is closest to the section's LR port Y.
+
+    Returns ``None`` when no full-bundle station exists internally
+    (e.g. a section whose bundle exits via a non-trunk station).
+    """
+    port_ys = _section_lr_port_ys(graph, section)
+    if not port_ys:
+        return None
+    port_y = port_ys[0]
+    bundle = _section_full_bundle(graph, section)
+    if not bundle:
+        return None
+    offsets = compute_station_offsets(graph)
+    port_set = set(section.entry_ports) | set(section.exit_ports)
+    best: tuple[float, float] | None = None  # (distance, cy)
+    for sid in section.station_ids:
+        if sid in port_set:
+            continue
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.is_hidden:
+            continue
+        lines = graph.station_lines(sid)
+        if set(lines) != bundle:
+            continue
+        line_offs = [offsets.get((sid, lid), 0.0) for lid in lines]
+        if not line_offs:
+            continue
+        cy = st.y + (min(line_offs) + max(line_offs)) / 2
+        dist = abs(cy - port_y)
+        if best is None or dist < best[0]:
+            best = (dist, cy)
+    return best[1] if best is not None else None
+
+
+def _section_full_bundle(graph: MetroGraph, section) -> set[str] | None:
+    """The set of line ids that traverse the section's row bundle.
+
+    Defined as the line set carried by the section's LR ports.
+    """
+    port_lines: set[str] = set()
+    has_lr_port = False
+    for pid in list(section.entry_ports) + list(section.exit_ports):
+        port = graph.ports.get(pid)
+        if port is None or port.side not in (PortSide.LEFT, PortSide.RIGHT):
+            continue
+        has_lr_port = True
+        port_lines.update(graph.station_lines(pid))
+    return port_lines if (has_lr_port and port_lines) else None
+
+
+# ---------------------------------------------------------------------------
+# Row trunk Y consistency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture", ["da_pipeline.mmd", "rnaseq_sections.mmd"]
+)
+def test_row_trunk_marker_cy_consistent(fixture):
+    """All same-row LR sections must render their trunk marker at the
+    same cy.  Inter-section bundles run horizontally between sections
+    in the same grid row; a per-section drift in the trunk marker's
+    rendered cy produces a visible kink at the section boundary.
+
+    This is the regression test for the "9px limma kink" bug where
+    section 2's trunk station sat 9px below sections 1 and 5 because
+    of a stray bundle offset shift triggered by a side-branch feeder
+    on the section's exit port.
+    """
+    graph = _layout(fixture)
+    rows = _row_lr_sections(graph)
+    for row, sections in rows.items():
+        cys: list[tuple[str, float]] = []
+        for sec in sections:
+            cy = _section_trunk_marker_cy(graph, sec)
+            if cy is not None:
+                cys.append((sec.id, cy))
+        if len(cys) < 2:
+            continue
+        target = cys[0][1]
+        for sid, cy in cys[1:]:
+            assert abs(cy - target) < _Y_TOL, (
+                f"Row {row}: section {sid} trunk cy={cy} drifts from "
+                f"{cys[0][0]} cy={target}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Symmetric fan column-mate Y equality
+# ---------------------------------------------------------------------------
+
+
+def _section_fan_columns(graph: MetroGraph, section) -> dict[float, list[str]]:
+    """Group full-bundle internal stations of a section by X column.
+
+    Returns ``{x: [station_id, ...]}`` for columns with >= 2 full-bundle
+    stations - the configurations that the symmetric-fan phases target.
+    """
+    bundle = _section_full_bundle(graph, section)
+    if not bundle:
+        return {}
+    port_set = set(section.entry_ports) | set(section.exit_ports)
+    cols: dict[float, list[str]] = defaultdict(list)
+    for sid in section.station_ids:
+        if sid in port_set:
+            continue
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.is_hidden or st.off_track:
+            continue
+        if set(graph.station_lines(sid)) != bundle:
+            continue
+        cols[round(st.x, 1)].append(sid)
+    return {x: sids for x, sids in cols.items() if len(sids) >= 2}
+
+
+@pytest.mark.parametrize("fixture", ["da_pipeline.mmd"])
+def test_symfan_pairs_share_y(fixture):
+    """When a section has exactly two full-bundle stations in the same
+    column (a classic symmetric-fan pair such as Reporting's Shiny app
+    + Quarto report, or Functional's GSEA + decoupler), the pair must
+    be mirrored around the row's trunk Y so the rendered cys are
+    equidistant from the trunk.
+
+    Stronger property than "pair has matching Y": catches asymmetric
+    placements like (trunk-55, trunk+0) that leave the bottom-fan slot
+    empty.
+    """
+    graph = _layout(fixture)
+    for sec in graph.sections.values():
+        cols = _section_fan_columns(graph, sec)
+        trunk_cy = _section_trunk_marker_cy(graph, sec)
+        if trunk_cy is None:
+            continue
+        offsets = compute_station_offsets(graph)
+        for x, sids in cols.items():
+            if len(sids) != 2:
+                continue  # Only assert on pairs; 3+ has its own ordering
+            cys = []
+            for sid in sids:
+                st = graph.stations[sid]
+                lines = graph.station_lines(sid)
+                line_offs = [offsets.get((sid, lid), 0.0) for lid in lines]
+                cys.append(st.y + (min(line_offs) + max(line_offs)) / 2)
+            cys.sort()
+            above_gap = trunk_cy - cys[0]
+            below_gap = cys[1] - trunk_cy
+            assert abs(above_gap - below_gap) < _Y_TOL, (
+                f"Section {sec.id} column x={x}: pair cys={cys} not "
+                f"mirrored around trunk cy={trunk_cy} "
+                f"(above_gap={above_gap}, below_gap={below_gap})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Off-track inputs sit above their consumer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ["da_pipeline.mmd"])
+def test_off_track_inputs_above_consumer(fixture):
+    """Off-track input stations (declared via ``%%metro off_track:``)
+    must sit at least one ``y_spacing`` slot above their on-track
+    consumer.  Catches the regression where ``_lift_off_track_stations``
+    leaves an off-track input on the same Y as its consumer (or below).
+    """
+    graph = _layout(fixture)
+    junction_ids = set(graph.junctions)
+    # Build off_track -> consumer map from edges
+    consumer_of: dict[str, str] = {}
+    for edge in graph.edges:
+        src = graph.stations.get(edge.source)
+        tgt = graph.stations.get(edge.target)
+        if (
+            src is None
+            or tgt is None
+            or not src.off_track
+            or src.is_port
+            or src.id in junction_ids
+            or tgt.is_port
+            or tgt.id in junction_ids
+            or tgt.off_track
+        ):
+            continue
+        consumer_of.setdefault(src.id, tgt.id)
+
+    assert consumer_of, f"{fixture}: no off-track edges found"
+
+    for off_id, consumer_id in consumer_of.items():
+        off_st = graph.stations[off_id]
+        cons_st = graph.stations[consumer_id]
+        assert off_st.y < cons_st.y - _Y_TOL, (
+            f"Off-track {off_id} y={off_st.y} not above consumer "
+            f"{consumer_id} y={cons_st.y}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bundle offsets must not jump at a section boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ["da_pipeline.mmd"])
+def test_no_kink_at_section_boundary(fixture):
+    """Adjacent same-row LR sections must agree on the rendered cy
+    of the row bundle's pass-through stations.  This catches the
+    "limma kink" pattern: matrix_filter (data_prep exit) at cy=110.5
+    but limma (differential entry) at cy=119.5, a 9px diagonal line
+    visually breaking the horizontal trunk.
+
+    The check pairs each section's exit port with the next section's
+    entry port and asserts they share a Y at the rendered (offset-
+    adjusted) level.
+    """
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    rows = _row_lr_sections(graph)
+    for row, sections in rows.items():
+        sorted_secs = sorted(sections, key=lambda s: s.grid_col)
+        for sec, nxt in zip(sorted_secs, sorted_secs[1:]):
+            if nxt.grid_col - sec.grid_col != 1:
+                continue
+            # Exit port of sec
+            for pid in sec.exit_ports:
+                port = graph.ports.get(pid)
+                if port is None or port.side != PortSide.RIGHT:
+                    continue
+                exit_lines = graph.station_lines(pid)
+                if not exit_lines:
+                    continue
+                exit_offs = [offsets.get((pid, lid), 0.0) for lid in exit_lines]
+                exit_cy = graph.stations[pid].y + (
+                    min(exit_offs) + max(exit_offs)
+                ) / 2
+                # Matching entry port of next section
+                for npid in nxt.entry_ports:
+                    nport = graph.ports.get(npid)
+                    if nport is None or nport.side != PortSide.LEFT:
+                        continue
+                    entry_lines = graph.station_lines(npid)
+                    entry_offs = [
+                        offsets.get((npid, lid), 0.0) for lid in entry_lines
+                    ]
+                    entry_cy = graph.stations[npid].y + (
+                        min(entry_offs) + max(entry_offs)
+                    ) / 2
+                    assert abs(exit_cy - entry_cy) < _Y_TOL, (
+                        f"Row {row}: exit port {pid} cy={exit_cy} != "
+                        f"entry port {npid} cy={entry_cy}"
+                    )

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pytest
 
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets
+from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph, PortSide
 
@@ -324,3 +324,193 @@ def test_no_kink_at_section_boundary(fixture):
                         f"Row {row}: exit port {pid} cy={exit_cy} != "
                         f"entry port {npid} cy={entry_cy}"
                     )
+
+
+# ---------------------------------------------------------------------------
+# Side-branch single-line edges stay off the trunk inside the section
+# ---------------------------------------------------------------------------
+
+
+def _section_for(graph: MetroGraph, sid: str):
+    """Return the section a station belongs to (or None)."""
+    st = graph.stations.get(sid)
+    if st is None or st.section_id is None:
+        return None
+    return graph.sections.get(st.section_id)
+
+
+@pytest.mark.parametrize("fixture", ["da_pipeline.mmd"])
+def test_side_branch_edge_stays_off_trunk(fixture):
+    """A side-branch single-line exit edge must keep its own track
+    inside the section instead of joining the main trunk bundle
+    immediately after the source station.
+
+    For each non-port internal station S that sits clearly off the
+    section's trunk Y (a side branch) and feeds the section's exit
+    port or another internal station on the trunk via a single
+    outgoing line, walking the routed path from the source forward
+    must keep the line on the source Y for at least half of the
+    horizontal distance to the target.  The diagonal/climb to the
+    trunk must therefore start past the path midpoint between source
+    and target, not within the first quarter as the propd regression
+    produced.
+
+    Catches the propd regression where the rnaseq line from propd
+    climbed to trunk Y immediately after the station, leaving the
+    side-branch slot empty for the rest of the section and visually
+    merging with the main bundle.
+    """
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+
+    rows = _row_lr_sections(graph)
+    section_trunk_y: dict[str, float] = {}
+    for sections in rows.values():
+        for sec in sections:
+            port_ys = _section_lr_port_ys(graph, sec)
+            if port_ys:
+                section_trunk_y[sec.id] = port_ys[0]
+
+    # Build per-station outbound edges with line set
+    outbound: dict[str, list] = defaultdict(list)
+    for edge in graph.edges:
+        outbound[edge.source].append(edge)
+
+    junction_ids = set(graph.junctions)
+    asserted = 0
+    for sid, st in graph.stations.items():
+        if st.is_port or st.off_track or sid in junction_ids:
+            continue
+        sec = _section_for(graph, sid)
+        if sec is None:
+            continue
+        trunk_y = section_trunk_y.get(sec.id)
+        if trunk_y is None:
+            continue
+        # Side branch: clearly off the trunk Y (> 2 grid slot offsets).
+        if abs(st.y - trunk_y) < 6.0:
+            continue
+        # Single-line source only.
+        src_lines = graph.station_lines(sid)
+        if len(src_lines) != 1:
+            continue
+        for edge in outbound[sid]:
+            # Find the matching routed path
+            rp = next(
+                (r for r in routes
+                 if r.edge.source == edge.source
+                 and r.edge.target == edge.target
+                 and r.edge.line_id == edge.line_id),
+                None,
+            )
+            if rp is None or len(rp.points) < 2:
+                continue
+            tgt = graph.stations.get(edge.target)
+            if tgt is None:
+                continue
+            tgt_port = graph.ports.get(edge.target)
+            same_sec_target = (
+                tgt.section_id == sec.id and not tgt.is_port
+            )
+            is_exit_port = (
+                tgt_port is not None
+                and not tgt_port.is_entry
+                and tgt_port.section_id == sec.id
+                and tgt_port.side in (PortSide.LEFT, PortSide.RIGHT)
+            )
+            if not (same_sec_target or is_exit_port):
+                continue
+            # Target must sit at or near trunk Y (where the bundle lives).
+            if abs(tgt.y - trunk_y) > 6.0:
+                continue
+            # Walk the path from source: find the X at which the path
+            # leaves the source's Y (where the climb starts).
+            pts = rp.points
+            src_x, src_y = pts[0]
+            tgt_x = tgt.x
+            leave_x: float | None = None
+            for (x0, y0), (x1, y1) in zip(pts, pts[1:]):
+                if abs(y0 - src_y) < _Y_TOL and abs(y1 - src_y) >= _Y_TOL:
+                    leave_x = x0
+                    break
+                if abs(y1 - src_y) >= _Y_TOL:
+                    leave_x = x1
+                    break
+            if leave_x is None:
+                continue
+            # The climb must start past 30% of the source->target run.
+            # Pre-fix routes climbed within the first 15% (the diagonal
+            # sat near the source under the standard fork bias).
+            run = tgt_x - src_x
+            if abs(run) < 1.0:
+                continue
+            climb_frac = (leave_x - src_x) / run
+            assert climb_frac >= 0.30 - 1e-6, (
+                f"Side-branch edge {edge.source}->{edge.target} "
+                f"({edge.line_id}) climbs at x={leave_x:.2f} "
+                f"({climb_frac:.0%} of source->target run); expected "
+                f">= 30% (src_x={src_x:.2f}, tgt_x={tgt_x:.2f}, "
+                f"section={sec.id})"
+            )
+            asserted += 1
+    assert asserted > 0, (
+        f"{fixture}: no side-branch single-line exits found to test"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section bbox must contain all stations and off-track inputs
+# ---------------------------------------------------------------------------
+
+
+def _icon_half_height(graph: MetroGraph) -> float:
+    """Vertical reach of a file-input icon above/below its centre.
+
+    Mirrors the renderer's terminus icon height (32 px default).  Used
+    to verify the section bbox encloses off-track icon tops.
+    """
+    # Default terminus_height in Theme is 32 px; half = 16.
+    return 16.0
+
+
+@pytest.mark.parametrize(
+    "fixture", ["da_pipeline.mmd", "rnaseq_sections.mmd"]
+)
+def test_section_bbox_contains_all_content(fixture):
+    """Every section's bbox must contain its on-track stations and any
+    off-track input icons.  Catches the regression where an off-track
+    input is re-anchored above the section's bbox top so the icon
+    spills outside the section background.
+
+    Margin: on-track station markers reach ~9.5 px above the centre,
+    file-input icons reach ~16 px above the centre.  We assert
+    ``station.y - reach >= bbox_y - 0.5`` (sub-pixel tolerance) and
+    ``station.y + reach <= bbox_y + bbox_h + 0.5``.
+    """
+    graph = _layout(fixture)
+    junction_ids = set(graph.junctions)
+    icon_half = _icon_half_height(graph)
+    marker_half = 9.5  # station marker height / 2
+
+    for sec_id, section in graph.sections.items():
+        if section.bbox_h <= 0:
+            continue
+        for sid in section.station_ids:
+            st = graph.stations.get(sid)
+            if st is None or st.is_port or sid in junction_ids:
+                continue
+            # Use icon half-height for off-track (file-input) stations,
+            # marker half-height otherwise.
+            half = icon_half if st.off_track else marker_half
+            top = st.y - half
+            bot = st.y + half
+            assert top >= section.bbox_y - 0.5, (
+                f"Section {sec_id}: station {sid} top={top} "
+                f"(y={st.y}, half={half}) overflows bbox top "
+                f"y={section.bbox_y}"
+            )
+            assert bot <= section.bbox_y + section.bbox_h + 0.5, (
+                f"Section {sec_id}: station {sid} bottom={bot} "
+                f"(y={st.y}, half={half}) overflows bbox bottom "
+                f"y={section.bbox_y + section.bbox_h}"
+            )

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -459,6 +459,192 @@ def test_side_branch_edge_stays_off_trunk(fixture):
 
 
 # ---------------------------------------------------------------------------
+# Section content balance around the trunk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ["da_pipeline.mmd"])
+def test_section_top_band_filled(fixture):
+    """LR/RL sections with room for another above-trunk slot AND
+    multiple below-trunk movable siblings should fill the empty top
+    band, not leave it stranded.
+
+    Specifically: when the top band (between bbox_y and the topmost
+    station) is large enough to fit another station with its label
+    (>= y_spacing + label_clearance), AND there are >= 2 movable
+    below-trunk siblings versus at most 1 above, the balance pass
+    should have lifted one of them so the top band shrinks to within
+    one y_spacing of the bbox.
+
+    Catches the v103 ``data_prep`` layout where only Matrix was lifted
+    above the trunk while four other file inputs stayed below.
+    """
+    import networkx as nx
+
+    y_spacing = 55.0
+    label_clearance = y_spacing / 2
+    graph = _layout(fixture, y_spacing=y_spacing)
+    G = nx.DiGraph()
+    for e in graph.edges:
+        G.add_edge(e.source, e.target)
+
+    for section in graph.sections.values():
+        if (
+            section.bbox_h <= 0
+            or section.direction not in ("LR", "RL")
+        ):
+            continue
+        bundle = _section_full_bundle(graph, section)
+        if not bundle:
+            continue
+        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        cols: dict[float, list[str]] = defaultdict(list)
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            st = graph.stations.get(sid)
+            if st is None or st.is_port or st.is_hidden or st.off_track:
+                continue
+            cols[round(st.x, 1)].append(sid)
+
+        # Trunk Y: prefer an LR port; fall back to a full-bundle station.
+        trunk_y: float | None = None
+        for pid in section.entry_ports + section.exit_ports:
+            port = graph.ports.get(pid)
+            st = graph.stations.get(pid)
+            if port and st and port.side in (PortSide.LEFT, PortSide.RIGHT):
+                trunk_y = st.y
+                break
+        if trunk_y is None:
+            for sids in cols.values():
+                for s in sids:
+                    if set(graph.station_lines(s)) == bundle:
+                        trunk_y = graph.stations[s].y
+                        break
+                if trunk_y is not None:
+                    break
+        if trunk_y is None:
+            continue
+
+        all_internal = [s for sids in cols.values() for s in sids]
+        if not all_internal:
+            continue
+        top_y = min(graph.stations[s].y for s in all_internal)
+        top_band = top_y - section.bbox_y
+        if top_band <= y_spacing + _Y_TOL:
+            continue  # band is already tight
+
+        # Count movable siblings above vs below trunk.
+        movable_above = 0
+        movable_below_candidates: list[str] = []
+        for x, sids in cols.items():
+            trunks_here = [
+                s for s in sids
+                if set(graph.station_lines(s)) == bundle
+            ]
+            if not trunks_here:
+                continue
+            for s in sids:
+                if s in trunks_here:
+                    continue
+                lines = set(graph.station_lines(s))
+                if not lines or not (lines < bundle):
+                    continue
+                y = graph.stations[s].y
+                if y < trunk_y - _Y_TOL:
+                    movable_above += 1
+                elif y > trunk_y + _Y_TOL:
+                    movable_below_candidates.append(s)
+
+        # Only flag sections where >= 2 below-trunk movables exist
+        # AND at least one would fit in a new top slot with its
+        # label.  Sections where slot -k of every below station
+        # would clip into the bbox stroke are skipped.
+        if len(movable_below_candidates) < 2 or movable_above >= len(
+            movable_below_candidates
+        ):
+            continue
+
+        target_y = top_y - y_spacing
+        any_fits = any(
+            target_y >= section.bbox_y + (
+                label_clearance
+                if graph.stations[s].label and graph.stations[s].label.strip()
+                else 0.0
+            ) - _Y_TOL
+            for s in movable_below_candidates
+        )
+        if not any_fits:
+            continue
+
+        assert top_band <= y_spacing + _Y_TOL, (
+            f"Section {section.id}: top band {top_band:.1f}px > "
+            f"{y_spacing:.1f} while {len(movable_below_candidates)} "
+            f"movable siblings sit below trunk and only "
+            f"{movable_above} above; balance pass should lift one "
+            f"into the top slot"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 1 (data_prep): at least one input must sit above the trunk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ["da_pipeline.mmd"])
+def test_section1_input_above_trunk(fixture):
+    """In ``data_prep`` (the source-stack section) inputs must fill
+    the above-trunk band: at least one input sits above the trunk, and
+    the topmost input is no more than y_spacing below the bbox top.
+
+    Catches the regression where ``_fan_source_inputs_upward`` lifts
+    only a single input (e.g. just Matrix), leaving a 2+ y_spacing
+    gap between the bbox top and the topmost input.
+    """
+    y_spacing = 55.0
+    graph = _layout(fixture, y_spacing=y_spacing)
+    section = graph.sections.get("data_prep")
+    assert section is not None
+    port_ids = set(section.entry_ports) | set(section.exit_ports)
+    trunk_y: float | None = None
+    for pid in section.entry_ports + section.exit_ports:
+        port = graph.ports.get(pid)
+        st = graph.stations.get(pid)
+        if port and st and port.side in (PortSide.LEFT, PortSide.RIGHT):
+            trunk_y = st.y
+            break
+    assert trunk_y is not None, "data_prep has no LR port for trunk Y"
+
+    # Inputs: stations with no inbound edges (sources).
+    has_in: set[str] = {e.target for e in graph.edges}
+    inputs = [
+        sid for sid in section.station_ids
+        if sid not in port_ids
+        and sid not in has_in
+        and sid in graph.stations
+        and not graph.stations[sid].is_port
+    ]
+    inputs_above = [
+        sid for sid in inputs
+        if graph.stations[sid].y < trunk_y - _Y_TOL
+    ]
+    assert inputs_above, (
+        f"data_prep: no input sits above trunk_y={trunk_y:.1f} "
+        f"(inputs at y={[graph.stations[s].y for s in inputs]})"
+    )
+    # Top of section: the topmost input should sit within one
+    # y_spacing of the bbox top so the top band is visibly filled.
+    top_input_y = min(graph.stations[s].y for s in inputs_above)
+    top_band = top_input_y - section.bbox_y
+    assert top_band <= y_spacing + _Y_TOL, (
+        f"data_prep: top input at y={top_input_y:.1f} leaves "
+        f"top_band={top_band:.1f}px > {y_spacing:.1f} (bbox_y="
+        f"{section.bbox_y:.1f}); balance pass should lift another "
+        f"input into the top slot"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Section bbox must contain all stations and off-track inputs
 # ---------------------------------------------------------------------------
 
@@ -514,3 +700,66 @@ def test_section_bbox_contains_all_content(fixture):
                 f"(y={st.y}, half={half}) overflows bbox bottom "
                 f"y={section.bbox_y + section.bbox_h}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Terminus stations must not be hit by a diagonal route segment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ["da_pipeline.mmd"])
+def test_terminus_not_directly_after_diagonal(fixture):
+    """Routes terminating at an output terminus must arrive on an
+    orthogonal (horizontal or vertical) final segment.
+
+    Catches the v103 layout where ``plot_expl`` and ``plot_diff`` both
+    fed ``plots_png`` via diagonals that converged AT the terminus
+    marker, producing a Y-shape with the file icon at the convergence
+    point.  After v104 the layout should insert a virtual convergence
+    station so the last segment to the terminus is purely orthogonal.
+
+    The check tolerates short corner segments (curve smoothing) by
+    requiring the LAST segment of length >= MIN_LEN to be axis-aligned.
+    """
+    from nf_metro.layout.routing import route_edges
+
+    MIN_LEN = 30.0  # require axis-aligned approach for the last >= 30px
+    AXIS_TOL = 1.0
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+    # Group routes by terminus target id.
+    by_target: dict[str, list] = defaultdict(list)
+    for r in routes:
+        tgt = graph.stations.get(r.edge.target)
+        if tgt is None or not tgt.is_terminus:
+            continue
+        by_target[r.edge.target].append(r)
+
+    for tid, paths in by_target.items():
+        # Only enforce the invariant when a terminus has 2+ direct
+        # inbound edges (the convergence case).  Single-source termini
+        # already inherit their source's Y.
+        sources = {r.edge.source for r in paths}
+        if len(sources) < 2:
+            continue
+        for r in paths:
+            pts = r.points
+            if len(pts) < 2:
+                continue
+            # Find the last segment of length >= MIN_LEN
+            for i in range(len(pts) - 1, 0, -1):
+                x1, y1 = pts[i - 1]
+                x2, y2 = pts[i]
+                length = ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+                if length < MIN_LEN:
+                    continue
+                dx = abs(x2 - x1)
+                dy = abs(y2 - y1)
+                axis_aligned = dx <= AXIS_TOL or dy <= AXIS_TOL
+                assert axis_aligned, (
+                    f"Terminus {tid}: edge {r.edge.source}->{tid} "
+                    f"last segment ({x1:.1f},{y1:.1f}) -> "
+                    f"({x2:.1f},{y2:.1f}) is diagonal "
+                    f"(dx={dx:.1f}, dy={dy:.1f})"
+                )
+                break

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -771,6 +771,58 @@ def test_parse_file_icon_type_default():
     assert graph.stations["reads_in"].terminus_icon_types == ["file"]
 
 
+def test_parse_file_icon_with_name():
+    """Optional third field on %%metro file: sets a caption name."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | CSV | Samples\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    st = graph.stations["reads_in"]
+    assert st.terminus_labels == ["CSV"]
+    assert st.terminus_names == ["Samples"]
+
+
+def test_parse_file_icon_without_name_empty():
+    """Without the optional name field, terminus_names is empty string."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | CSV\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["reads_in"].terminus_names == [""]
+
+
+def test_parse_file_icon_name_applies_to_all_comma_labels():
+    """The optional name applies to every comma-separated label."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | FASTQ, BAM | Reads\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    st = graph.stations["reads_in"]
+    assert st.terminus_labels == ["FASTQ", "BAM"]
+    assert st.terminus_names == ["Reads", "Reads"]
+
+
 def test_parse_legend_min_height():
     text = "%%metro legend_min_height: 72\ngraph LR\n"
     graph = parse_metro_mermaid(text)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -168,6 +168,54 @@ def test_ignores_comments():
     assert len(graph.edges) == 1
 
 
+def test_parse_off_track_single():
+    """%%metro off_track: marks a single station as off-track."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: samples_in\n"
+        "graph LR\n"
+        "    samples_in[Samples]\n"
+        "    samples_in -->|main| validator\n"
+        "    validator[Validate]\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["samples_in"].off_track is True
+    assert graph.stations["validator"].off_track is False
+
+
+def test_parse_off_track_multiple():
+    """%%metro off_track: accepts a comma-separated list."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: a, b, c\n"
+        "graph LR\n"
+        "    a -->|main| d\n"
+        "    b -->|main| d\n"
+        "    c -->|main| d\n"
+        "    d[Sink]\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["a"].off_track is True
+    assert graph.stations["b"].off_track is True
+    assert graph.stations["c"].off_track is True
+    assert graph.stations["d"].off_track is False
+
+
+def test_parse_off_track_unknown_id_ignored():
+    """Unknown station ids in %%metro off_track: silently skip."""
+    text = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro off_track: a, missing\n"
+        "graph LR\n"
+        "    a[A]\n"
+        "    a -->|main| b\n"
+        "    b[B]\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["a"].off_track is True
+    assert "missing" not in graph.stations
+
+
 # --- Subgraph (first-class section) tests ---
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -298,6 +298,46 @@ def test_render_multiple_file_icons():
     assert root.tag.endswith("svg") or "svg" in root.tag
 
 
+def test_render_file_icon_with_name_caption():
+    """Optional name on %%metro file: directive renders as a caption."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | CSV | Samples\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    # Caption name and inner type label should both appear
+    assert "Samples" in svg
+    assert "CSV" in svg
+    root = ET.fromstring(svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_render_file_icon_no_name_no_caption():
+    """When no name is provided, no caption text appears in the SVG."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | FASTQ\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    # The station has no label and there's no caption directive, so the only
+    # text inside the terminus block should be the type chip.
+    assert "FASTQ" in svg
+
+
 def test_render_multi_icon_fixture():
     """The 05b_multi_icons.mmd example renders without errors."""
     from pathlib import Path

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -319,6 +319,35 @@ def test_render_file_icon_with_name_caption():
     assert root.tag.endswith("svg") or "svg" in root.tag
 
 
+def test_caption_font_smaller_than_label_font():
+    """Caption renders smaller than the station label to fit the icon."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | CSV | LongCaptionName\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    label_size = NFCORE_THEME.label_font_size
+    # The caption text must reference a font-size strictly smaller than
+    # the theme label_font_size (60% of it, per ICON_NAME_FONT_SCALE).
+    import re
+
+    caption_matches = re.findall(
+        r'font-size="([0-9.]+)"[^>]*>LongCaptionName', svg
+    )
+    assert caption_matches, "Caption text not found in SVG"
+    caption_size = float(caption_matches[0])
+    assert caption_size < label_size, (
+        f"Caption font ({caption_size}) should be < label font ({label_size})"
+    )
+
+
 def test_render_file_icon_no_name_no_caption():
     """When no name is provided, no caption text appears in the SVG."""
     graph = parse_metro_mermaid(


### PR DESCRIPTION
Cherry-pick of #290 (v104 auto-balance + terminus convergence) onto #289 (v103 propd routing + bbox content containment), with a follow-up fix for the cross-PR interaction.

## Resolution summary

The cherry-pick conflict was in \`tests/test_layout_invariants.py\`, where both branches added new tests to the same trailing region. Resolved by keeping all tests from both branches:

- v103: \`test_side_branch_edge_stays_off_trunk\`, \`test_section_bbox_contains_all_content\` (+ helpers \`_section_for\`, \`_icon_half_height\`)
- v104: \`test_section_top_band_filled\`, \`test_section1_input_above_trunk\`, \`test_terminus_not_directly_after_diagonal\`

## Cross-PR bug fix

After resolving the test conflict, \`test_section_bbox_contains_all_content\` failed: v104's \`_balance_section_content_around_trunk\` lifted \`cel_in\` (an empty-label file input) flush with \`bbox_y\`, so the 9.5 px marker top overflowed the bbox.

The second commit clamps the lift floor to \`max(label_clearance, marker_half)\` so the marker (or off-track icon) stays inside the bbox. This honours v104's "bbox-bounded" design intent and v103's content-containment invariant simultaneously.

## Test plan

- [x] All 747 tests pass with both v103 and v104 invariants enforced.