### PR TITLE
fix(routing): diagonal-fork bypass + collision guard (v109)

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -147,6 +147,15 @@ BYPASS_CLEARANCE: float = 25.0
 BYPASS_NEST_STEP: float = 8.0
 """Per-line vertical offset for stacking multiple bypass routes."""
 
+MARKER_BYPASS_CORNER_GAP: float = 2.0
+"""Horizontal clearance between a non-consuming station's marker edge and
+the start of the U-turn corner arc.
+
+The detour's diverge X is placed ``STATION_RADIUS_APPROX +
+MARKER_BYPASS_CORNER_GAP + CURVE_RADIUS`` from the station center so the
+corner arc clears the marker pill without grazing it.
+"""
+
 HEADER_CLEARANCE: float = 30.0
 """Clearance above/below section headers for inter-row routing channels.
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -136,6 +136,55 @@ def _guard_section_bboxes_positive(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _guard_no_marker_bbox_crossings(graph: MetroGraph, phase: str) -> None:
+    """After edge routing: a routed line must not pass through the
+    marker bbox of a station that doesn't consume that line.
+
+    Routes a copy of the edges with finalised station offsets and walks
+    every horizontal segment; flags any segment whose rendered Y falls
+    inside a non-consuming station's marker bbox.  This catches drift
+    where a downstream layout phase shifts a station onto an active
+    bundle Y, or where the bypass post-pass misses a corner case.
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.routing.core import _build_marker_bboxes
+    from nf_metro.render.svg import apply_route_offsets
+
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    junction_ids = set(graph.junctions)
+    bboxes = _build_marker_bboxes(graph, junction_ids, offsets)
+    if not bboxes:
+        return
+    margin = 1.0
+    for r in routes:
+        pts = apply_route_offsets(r, offsets)
+        endpoints = {r.edge.source, r.edge.target}
+        for i in range(len(pts) - 1):
+            x1, y1 = pts[i]
+            x2, y2 = pts[i + 1]
+            if abs(y2 - y1) > 1.0:
+                continue
+            seg_y = (y1 + y2) / 2
+            xlo, xhi = (x1, x2) if x1 <= x2 else (x2, x1)
+            for sid, bb in bboxes.items():
+                if sid in endpoints:
+                    continue
+                if r.line_id in bb.consumed:
+                    continue
+                if bb.cx <= xlo + 1e-3 or bb.cx >= xhi - 1e-3:
+                    continue
+                top = bb.cy - bb.half_h - margin
+                bot = bb.cy + bb.half_h + margin
+                if top <= seg_y <= bot:
+                    raise PhaseInvariantError(
+                        f"{phase}: line {r.line_id!r} crosses "
+                        f"non-consuming station {sid!r} at "
+                        f"(x={bb.cx:.1f}, y={seg_y:.1f}) "
+                        f"[bbox y-range {top:.1f}..{bot:.1f}]"
+                    )
+
+
 def compute_layout(
     graph: MetroGraph,
     x_spacing: float = X_SPACING,
@@ -156,6 +205,10 @@ def compute_layout(
     key phases.  Violations raise ``PhaseInvariantError`` instead of
     silently producing broken layouts.
     """
+    # Record the grid pitch on the graph so the routing layer can size
+    # full-row detours around non-consuming stations.
+    graph._y_spacing = y_spacing
+
     # Optionally reorder lines by section span before layout.
     # Must happen here (on the full graph) before section subgraphs are
     # built, since subgraphs share graph.lines via reference.
@@ -556,6 +609,7 @@ def _compute_section_layout(
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
         _guard_stations_in_sections(graph, "after Phase 12 (final)")
         _guard_ports_on_boundaries(graph, "after Phase 12 (final)")
+        _guard_no_marker_bbox_crossings(graph, "after edge routing")
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -136,6 +136,64 @@ def _guard_section_bboxes_positive(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _station_marker_bbox(
+    graph: MetroGraph, sid: str, offsets: dict | None = None, radius: float = 5.0
+) -> tuple[float, float, float, float] | None:
+    """Compute the rendered marker / icon bbox for ``sid``.
+
+    Mirrors the renderer in ``nf_metro.render.svg``: each on-track and
+    off-track station gets a pill of width ``2 * radius`` and height
+    ``span + 2 * radius`` (span = max line offset - min line offset),
+    centred at ``(station.x, station.y + (min_off + max_off) / 2)``.
+
+    Returns ``(x_min, y_min, x_max, y_max)`` or ``None`` for stations
+    that have no rendered marker (ports, hidden nodes, junctions).
+    """
+    from nf_metro.layout.routing import compute_station_offsets
+
+    st = graph.stations.get(sid)
+    if st is None or st.is_port or st.is_hidden:
+        return None
+    if sid in graph.junctions:
+        return None
+    if offsets is None:
+        offsets = compute_station_offsets(graph)
+    line_offs = [offsets.get((sid, lid), 0.0) for lid in graph.station_lines(sid)]
+    if not line_offs:
+        line_offs = [0.0]
+    min_off, max_off = min(line_offs), max(line_offs)
+    cy = st.y + (min_off + max_off) / 2
+    w = 2 * radius
+    h = (max_off - min_off) + 2 * radius
+    return (st.x - w / 2, cy - h / 2, st.x + w / 2, cy + h / 2)
+
+
+def _guard_no_station_overlap(graph: MetroGraph, phase: str) -> None:
+    """Final-phase: no two station markers (incl. off-track file icons)
+    may overlap at render time.
+
+    A collision between markers / icons produces an unreadable rendering
+    where one station hides another.  Catches the regression where the
+    auto-balance pass lifts an internal station into a slot already
+    occupied by an off-track input icon.
+    """
+    from nf_metro.layout.routing import compute_station_offsets
+
+    offsets = compute_station_offsets(graph)
+    boxes: list[tuple[str, tuple[float, float, float, float]]] = []
+    for sid in graph.stations:
+        b = _station_marker_bbox(graph, sid, offsets=offsets)
+        if b is not None:
+            boxes.append((sid, b))
+    tol = 0.5
+    for i, (s1, (x1, y1, X1, Y1)) in enumerate(boxes):
+        for s2, (x2, y2, X2, Y2) in boxes[i + 1:]:
+            if x1 < X2 - tol and x2 < X1 - tol and y1 < Y2 - tol and y2 < Y1 - tol:
+                raise PhaseInvariantError(
+                    f"{phase}: position clash: {s1!r} at "
+                    f"({(x1 + X1) / 2:.1f},{(y1 + Y1) / 2:.1f}) overlaps "
+                    f"{s2!r} at ({(x2 + X2) / 2:.1f},{(y2 + Y2) / 2:.1f})"
+                )
 def _guard_no_marker_bbox_crossings(graph: MetroGraph, phase: str) -> None:
     """After edge routing: a routed line must not pass through the
     marker bbox of a station that doesn't consume that line.
@@ -609,6 +667,7 @@ def _compute_section_layout(
         _guard_section_bboxes_positive(graph, "after Phase 12 (final)")
         _guard_stations_in_sections(graph, "after Phase 12 (final)")
         _guard_ports_on_boundaries(graph, "after Phase 12 (final)")
+        _guard_no_station_overlap(graph, "after Phase 12 (final)")
         _guard_no_marker_bbox_crossings(graph, "after edge routing")
 
 
@@ -1908,6 +1967,23 @@ def _balance_section_content_around_trunk(
         #     a deeper Y available (e.g. propd swaps with dream so
         #     propd ends up above dream without growing the bbox).
         # Stops when the imbalance is resolved or no slot is available.
+        # Collect the Y of every other station in the section (including
+        # off-track inputs whose icons reserve a grid slot).  The lift
+        # target column must avoid these Ys or the lifted marker overlaps
+        # an existing marker / file icon at render time.
+        def _column_occupied_ys(col_x: float, skip_sid: str) -> list[float]:
+            occ: list[float] = []
+            for sid2 in section.station_ids:
+                if sid2 == skip_sid:
+                    continue
+                st2 = graph.stations.get(sid2)
+                if st2 is None or st2.is_port or st2.is_hidden:
+                    continue
+                if abs(st2.x - col_x) > 0.5:
+                    continue
+                occ.append(st2.y)
+            return occ
+
         max_iters = len(movable)
         for _ in range(max_iters):
             section_top_y = min(
@@ -1937,8 +2013,23 @@ def _balance_section_content_around_trunk(
                 below.sort(key=lambda s: graph.stations[s].y, reverse=True)
             else:
                 below.sort(key=lambda s: graph.stations[s].y)
-            candidate = below[0]
+            # Find the first below-trunk candidate whose lift Y does
+            # not collide with another station/icon already occupying
+            # the same column at the lift target.  Off-track icons
+            # placed by ``_lift_off_track_stations`` reserve a slot
+            # in their column (e.g. ``gmt_in`` at the top of section
+            # 3) and the auto-balance must respect that.
+            candidate = None
             new_y = section_top_y - y_spacing
+            for cand in below:
+                col_x = graph.stations[cand].x
+                occ = _column_occupied_ys(col_x, cand)
+                if any(abs(oy - new_y) < y_spacing - 0.5 for oy in occ):
+                    continue
+                candidate = cand
+                break
+            if candidate is None:
+                break
             # Guard: the new Y must leave room for the station's
             # above-marker label without forcing the bbox to expand
             # upward (which would break row-mate bbox alignment).

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -2724,11 +2724,17 @@ def _bypass_non_consuming_stations(
         sides are clear.
     2.  Shift detour_y by exactly ``y_spacing`` from each segment's
         current Y (one full grid row offset).
-    3.  Position the U-turn diverge X at
-        ``station.cx - direction * (r + corner_gap + curve_radius)`` and
-        the re-converge X mirrored on the other side.
+    3.  Diverge with a DIAGONAL from the trunk Y to the detour Y at
+        ``x_diverge_start = cx - direction * (r + corner_gap +
+        curve_radius + diag_run)``, reaching the detour-row corner at
+        ``x_diverge_end = cx - direction * (r + corner_gap +
+        curve_radius)``.  Run horizontally along the detour row, then
+        re-converge symmetrically on the other side of the marker.
+        This matches the visual language of the trunk fan-out (no
+        vertical U-turn segments anywhere on the metro map).
     4.  Build per-line concentric corner offsets using ``bypass_radii``
-        so the inner/outer corner radii nest cleanly.
+        so the inner/outer corner radii nest cleanly at all four
+        corners of the fork-diverge / fork-converge pair.
 
     Routes whose paths are rewritten are tagged ``offsets_applied=True``
     because the new points are computed in render-space.
@@ -2958,7 +2964,8 @@ def _bypass_non_consuming_stations(
                         gap1_going_down=gap1_going_down,
                         gap2_going_down=gap2_going_down,
                     )
-                    # Diverge / reconverge X centers (channel centers).
+                    # Diverge / reconverge X centers (channel centers
+                    # for the detour-row inner corners).
                     corner_half = (
                         STATION_RADIUS_APPROX
                         + MARKER_BYPASS_CORNER_GAP
@@ -2970,26 +2977,69 @@ def _bypass_non_consuming_stations(
                     x_pre = x_pre_center + d1
                     x_post = x_post_center + d2
 
+                    # Diagonal fork: instead of a vertical U-turn segment
+                    # at x_pre/x_post, splay the trunk-Y end of each
+                    # corner outward by ``diag_run`` so the segment
+                    # between trunk Y and detour Y is a diagonal (matching
+                    # the trunk fan-out's visual language).  ``diag_run``
+                    # is bounded by the available horizontal slack on
+                    # each side so adjacent detours / segment endpoints
+                    # don't collide.
+                    dy_abs = abs(dy - seg_y)
+                    # Aim for a ~45-degree diagonal, but cap by the
+                    # available horizontal headroom so the diagonal
+                    # stays inside the segment span.
+                    if direction > 0:
+                        pre_headroom = max(0.0, x_pre - last_x - COORD_TOLERANCE_FINE)
+                        post_headroom = max(0.0, p2[0] - x_post - COORD_TOLERANCE_FINE)
+                    else:
+                        pre_headroom = max(0.0, last_x - x_pre - COORD_TOLERANCE_FINE)
+                        post_headroom = max(0.0, x_post - p2[0] - COORD_TOLERANCE_FINE)
+                    diag_pre = min(dy_abs, pre_headroom)
+                    diag_post = min(dy_abs, post_headroom)
+                    # Diverge start sits ``diag_pre`` upstream of the
+                    # inside corner at (x_pre, dy); converge end sits
+                    # ``diag_post`` downstream of (x_post, dy).
+                    x_diverge_start = x_pre - direction * diag_pre
+                    x_converge_end = x_post + direction * diag_post
+
                     # Guard against degenerate ordering when adjacent
                     # detours overlap or the segment is too short.
                     if direction > 0:
-                        x_pre = max(x_pre, last_x + COORD_TOLERANCE_FINE)
-                        x_post = min(x_post, p2[0] - COORD_TOLERANCE_FINE)
+                        x_diverge_start = max(
+                            x_diverge_start, last_x + COORD_TOLERANCE_FINE
+                        )
+                        x_pre = max(x_pre, x_diverge_start + COORD_TOLERANCE_FINE)
+                        x_converge_end = min(
+                            x_converge_end, p2[0] - COORD_TOLERANCE_FINE
+                        )
+                        x_post = min(x_post, x_converge_end - COORD_TOLERANCE_FINE)
                     else:
-                        x_pre = min(x_pre, last_x - COORD_TOLERANCE_FINE)
-                        x_post = max(x_post, p2[0] + COORD_TOLERANCE_FINE)
+                        x_diverge_start = min(
+                            x_diverge_start, last_x - COORD_TOLERANCE_FINE
+                        )
+                        x_pre = min(x_pre, x_diverge_start - COORD_TOLERANCE_FINE)
+                        x_converge_end = max(
+                            x_converge_end, p2[0] + COORD_TOLERANCE_FINE
+                        )
+                        x_post = max(x_post, x_converge_end + COORD_TOLERANCE_FINE)
 
                     # Insert the 4 detour corners.  Radii r1..r4 line
                     # up with the 4 new intermediate points we add.
-                    new_pts.append((x_pre, seg_y))
+                    # Diagonal-fork geometry (no vertical segments):
+                    #   (x_diverge_start, seg_y)  - outer corner of fan-out
+                    #   (x_pre,           dy)     - inner corner on detour row
+                    #   (x_post,          dy)     - inner corner on detour row
+                    #   (x_converge_end,  seg_y)  - outer corner of fan-in
+                    new_pts.append((x_diverge_start, seg_y))
                     new_radii.append(r1)
                     new_pts.append((x_pre, dy))
                     new_radii.append(r2)
                     new_pts.append((x_post, dy))
                     new_radii.append(r3)
-                    new_pts.append((x_post, seg_y))
+                    new_pts.append((x_converge_end, seg_y))
                     new_radii.append(r4)
-                    last_x = x_post
+                    last_x = x_converge_end
 
             new_pts.append(p2)
             # If si+1 was an interior point (not the final endpoint),

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -22,11 +22,14 @@ from nf_metro.layout.constants import (
     FOLD_MARGIN,
     HEADER_CLEARANCE,
     JUNCTION_MARGIN,
+    MARKER_BYPASS_CORNER_GAP,
     MERGE_ROUTE_MARGIN,
     MIN_STRAIGHT_EDGE,
     MIN_STRAIGHT_PORT,
     OFFSET_STEP,
     STATION_MOVE_TOLERANCE,
+    STATION_RADIUS_APPROX,
+    Y_SPACING,
 )
 from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.routing.common import (
@@ -168,6 +171,7 @@ def route_edges(
 
     _center_bubble_stations(routes, graph)
     _spread_diagonal_bundles(routes, ctx)
+    _bypass_non_consuming_stations(routes, ctx)
 
     return routes
 
@@ -2566,3 +2570,441 @@ def _compute_junction_fan_info(
             )
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Post-processing: bypass non-consuming stations
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MarkerBBox:
+    """Rendered marker bbox for an on-track station.
+
+    All values are in render-space (post-offset) coordinates.
+    """
+
+    sid: str
+    cy: float
+    half_h: float
+    cx: float
+    half_w: float
+    consumed: frozenset[str]
+    section_id: str | None
+
+
+def _build_marker_bboxes(
+    graph: MetroGraph,
+    junction_ids: set[str],
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> dict[str, _MarkerBBox]:
+    """Compute rendered marker bboxes and consumed-line sets per station.
+
+    The bbox spans the visible marker pill: width = 2*STATION_RADIUS_APPROX
+    horizontally, height = bundle_span + 2*STATION_RADIUS_APPROX vertically.
+
+    Skipped:
+      * ports, hidden, off-track stations.
+      * Junction stations (virtual, not rendered as markers).
+      * TB-vertical stations (their bundle spreads along X, not Y).
+      * Blank terminus stations (rendered as a separate file icon).
+
+    Consumed lines are derived from inbound edge line IDs - the lines
+    that actually terminate at the station as a stop.
+    """
+    consumed_by: dict[str, set[str]] = defaultdict(set)
+    for edge in graph.edges:
+        if edge.target in graph.stations:
+            consumed_by[edge.target].add(edge.line_id)
+
+    r = STATION_RADIUS_APPROX
+    bboxes: dict[str, _MarkerBBox] = {}
+    for sid, st in graph.stations.items():
+        if st.is_port or st.is_hidden or st.off_track:
+            continue
+        if sid in junction_ids:
+            continue
+        if st.is_terminus and not st.label.strip():
+            continue
+        sec = graph.sections.get(st.section_id) if st.section_id else None
+        if sec is not None and sec.direction == "TB":
+            continue
+
+        lines = graph.station_lines(sid)
+        if station_offsets:
+            line_offs = [station_offsets.get((sid, lid), 0.0) for lid in lines]
+        else:
+            line_offs = [0.0]
+        if not line_offs:
+            line_offs = [0.0]
+        min_off = min(line_offs)
+        max_off = max(line_offs)
+        span = max_off - min_off
+        cy = st.y + (min_off + max_off) / 2
+        bboxes[sid] = _MarkerBBox(
+            sid=sid,
+            cy=cy,
+            half_h=span / 2 + r,
+            cx=st.x,
+            half_w=r,
+            consumed=frozenset(consumed_by.get(sid, set())),
+            section_id=st.section_id,
+        )
+    return bboxes
+
+
+def _render_y_at_point(
+    rp: RoutedPath,
+    idx: int,
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> float:
+    """Rendered Y of point *idx* on route *rp*.
+
+    Mirrors ``apply_route_offsets``: endpoint Ys get the endpoint offset,
+    intermediate points get whichever endpoint offset is closer to the
+    original Y.
+    """
+    if rp.offsets_applied or station_offsets is None:
+        return rp.points[idx][1]
+    src_off = station_offsets.get((rp.edge.source, rp.line_id), 0.0)
+    tgt_off = station_offsets.get((rp.edge.target, rp.line_id), 0.0)
+    orig_sy = rp.points[0][1]
+    orig_ty = rp.points[-1][1]
+    y = rp.points[idx][1]
+    if idx == 0:
+        return y + src_off
+    if idx == len(rp.points) - 1:
+        return y + tgt_off
+    if abs(y - orig_sy) <= abs(y - orig_ty):
+        return y + src_off
+    return y + tgt_off
+
+
+def _detour_row_is_blocked(
+    bboxes: dict[str, _MarkerBBox],
+    station_sid: str,
+    detour_y: float,
+    x_lo: float,
+    x_hi: float,
+    y_pitch: float,
+) -> bool:
+    """True if another station's marker bbox sits on the detour row in [x_lo, x_hi]."""
+    # A row is "blocked" if any OTHER station's marker center sits within
+    # half a pitch of detour_y and overlaps the X range of the detour.
+    row_tol = y_pitch * 0.5
+    for sid, bb in bboxes.items():
+        if sid == station_sid:
+            continue
+        if bb.cx + bb.half_w < x_lo - COORD_TOLERANCE:
+            continue
+        if bb.cx - bb.half_w > x_hi + COORD_TOLERANCE:
+            continue
+        if abs(bb.cy - detour_y) <= row_tol - COORD_TOLERANCE_FINE:
+            return True
+    return False
+
+
+def _bypass_non_consuming_stations(
+    routes: list[RoutedPath], ctx: _RoutingCtx
+) -> None:
+    """Reroute horizontal segments that pass through non-consuming stations.
+
+    Structural rule: lines passing through a station's column that the
+    station doesn't consume must visually route AROUND the station's
+    marker, shifting a full grid row above or below the trunk (not a
+    small nudge).  This preserves the bundle's relative spacing through
+    the detour by shifting all bypassing lines on the same side together.
+
+    Geometry
+    --------
+    Per ``(station, direction)`` group of bypassing line segments:
+
+    1.  Pick a detour side (above / below).  Default to whichever side
+        has clear grid space on the target row; prefer "below" when both
+        sides are clear.
+    2.  Shift detour_y by exactly ``y_spacing`` from each segment's
+        current Y (one full grid row offset).
+    3.  Position the U-turn diverge X at
+        ``station.cx - direction * (r + corner_gap + curve_radius)`` and
+        the re-converge X mirrored on the other side.
+    4.  Build per-line concentric corner offsets using ``bypass_radii``
+        so the inner/outer corner radii nest cleanly.
+
+    Routes whose paths are rewritten are tagged ``offsets_applied=True``
+    because the new points are computed in render-space.
+    """
+    graph = ctx.graph
+    station_offsets = ctx.station_offsets
+    bboxes = _build_marker_bboxes(graph, ctx.junction_ids, station_offsets)
+    if not bboxes:
+        return
+
+    # Resolve the layout's grid pitch.  Stored on the graph by
+    # compute_layout; fall back to the module default if route_edges
+    # was invoked standalone (tests without compute_layout).
+    y_pitch = graph._y_spacing or Y_SPACING
+
+    # Render-space coordinates for every route point.  Collision
+    # detection runs in this frame so we don't double-apply offsets.
+    rendered_pts: list[list[tuple[float, float]]] = [
+        [
+            (rp.points[i][0], _render_y_at_point(rp, i, station_offsets))
+            for i in range(len(rp.points))
+        ]
+        for rp in routes
+    ]
+
+    # For each (station, direction), collect bypassing crossings.
+    # Key: (sid, direction)
+    Candidates = dict[tuple[str, int], list[tuple[int, int, float]]]
+    candidates: Candidates = defaultdict(list)
+
+    visual_margin = 2.0
+    for ri, rp in enumerate(routes):
+        pts = rendered_pts[ri]
+        endpoint_ids = {rp.edge.source, rp.edge.target}
+        for si in range(len(pts) - 1):
+            p1, p2 = pts[si], pts[si + 1]
+            x1, y1 = p1
+            x2, y2 = p2
+            if abs(y2 - y1) > COORD_TOLERANCE:
+                continue
+            if abs(x2 - x1) < COORD_TOLERANCE_FINE:
+                continue
+            seg_y = (y1 + y2) / 2
+            direction = 1 if x2 > x1 else -1
+            xlo, xhi = (x1, x2) if direction > 0 else (x2, x1)
+            for sid, bb in bboxes.items():
+                if sid in endpoint_ids:
+                    continue
+                if rp.line_id in bb.consumed:
+                    continue
+                if bb.cx <= xlo + COORD_TOLERANCE_FINE:
+                    continue
+                if bb.cx >= xhi - COORD_TOLERANCE_FINE:
+                    continue
+                candidates[(sid, direction)].append((ri, si, seg_y))
+
+    if not candidates:
+        return
+
+    # detour_plan: (route_idx, seg_idx) -> list of (cx, detour_y, side, group_key)
+    # group_key lets us order bypass corners and compute concentric radii.
+    DetourEntry = tuple[float, float, str, tuple[str, int]]
+    detour_plan: dict[tuple[int, int], list[DetourEntry]] = defaultdict(list)
+    # group_lines: group_key -> ordered list of (route_idx, seg_idx, orig_y)
+    # used downstream to compute per-line corner positions and radii.
+    group_lines: dict[tuple[str, int], list[tuple[int, int, float]]] = {}
+    # group_side: group_key -> "above" or "below".
+    group_side: dict[tuple[str, int], str] = {}
+
+    for (sid, direction), entries in candidates.items():
+        bb = bboxes[sid]
+        bbox_top_strict = bb.cy - bb.half_h - visual_margin
+        bbox_bot_strict = bb.cy + bb.half_h + visual_margin
+
+        # Only trigger the detour when at least one non-consumed line
+        # actually intersects the marker bbox (within visual margin).
+        crossers = [e for e in entries if bbox_top_strict <= e[2] <= bbox_bot_strict]
+        if not crossers:
+            continue
+
+        # Determine xlo/xhi range for the detour-row collision check.
+        # Use the corner zone: from diverge-X to reconverge-X, i.e. a
+        # window of ~2 * (r + corner_gap + curve_radius) around bb.cx.
+        corner_half_w = (
+            STATION_RADIUS_APPROX + MARKER_BYPASS_CORNER_GAP + ctx.curve_radius
+        )
+        det_xlo = bb.cx - corner_half_w
+        det_xhi = bb.cx + corner_half_w
+
+        # Choose side: prefer the side with a clear detour row.
+        below_y = bb.cy + y_pitch
+        above_y = bb.cy - y_pitch
+        below_blocked = _detour_row_is_blocked(
+            bboxes, sid, below_y, det_xlo, det_xhi, y_pitch
+        )
+        above_blocked = _detour_row_is_blocked(
+            bboxes, sid, above_y, det_xlo, det_xhi, y_pitch
+        )
+        if not below_blocked and not above_blocked:
+            # Prefer below: in the DA pipeline lines tend to fan above
+            # the trunk for inputs and below for sinks; pushing detours
+            # below keeps the section header zone clear.
+            side = "below"
+        elif not below_blocked:
+            side = "below"
+        elif not above_blocked:
+            side = "above"
+        else:
+            # Both blocked - fall back to below.  In practice the live
+            # pipelines we target have one clear side; leave the
+            # escalation path to a future layout-engine extension.
+            side = "below"
+
+        # Bypass every non-consumed candidate so the bundle stays
+        # visually parallel through the detour (lines on the chosen
+        # side AND in-bbox crossers shift together).
+        bypass: list[tuple[int, int, float]] = []
+        if side == "below":
+            for ri, si, seg_y in entries:
+                if seg_y > bbox_top_strict:
+                    bypass.append((ri, si, seg_y))
+        else:
+            for ri, si, seg_y in entries:
+                if seg_y < bbox_bot_strict:
+                    bypass.append((ri, si, seg_y))
+
+        if not bypass:
+            continue
+
+        # Group key encodes "this station, this direction" so all
+        # bypassing lines through the same marker share corner geometry.
+        gkey = (sid, direction)
+        group_lines[gkey] = bypass
+        group_side[gkey] = side
+
+        for ri, si, seg_y in bypass:
+            # Detour shifts the line by exactly one grid pitch.  All
+            # lines in the group shift by the same delta so the bundle
+            # parallel spacing is preserved through the detour.
+            shift = y_pitch if side == "below" else -y_pitch
+            dy = seg_y + shift
+            detour_plan[(ri, si)].append((bb.cx, dy, side, gkey))
+
+    if not detour_plan:
+        return
+
+    # Per route, sort entries on each segment by direction so the corners
+    # are inserted in path order.
+    by_route: dict[int, dict[int, list[DetourEntry]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for (ri, si), entries in detour_plan.items():
+        pts = rendered_pts[ri]
+        p1, p2 = pts[si], pts[si + 1]
+        direction = 1 if p2[0] > p1[0] else -1
+        entries.sort(key=lambda e: e[0] * direction)
+        by_route[ri][si] = entries
+
+    # Pre-compute per-line bundle index within each group so corner
+    # radii nest concentrically.  ``l_shape_radii(i, n, going_down=True)``
+    # assigns i=0 to the line that ends up RIGHTMOST in the vertical
+    # channel after a RIGHT->DOWN turn, which corresponds to the line
+    # whose original Y was SMALLEST (furthest from the detour row when
+    # detouring below).  Mirror for "above".
+    bundle_pos: dict[tuple[int, int, tuple[str, int]], tuple[int, int]] = {}
+    for gkey, members in group_lines.items():
+        side = group_side[gkey]
+        # Sort so members FURTHEST from the detour row come first.
+        # That puts the outermost-radius line at i=0, matching the
+        # concentric-corner convention in l_shape_radii / bypass_radii.
+        if side == "below":
+            ordered = sorted(members, key=lambda m: m[2])
+        else:
+            ordered = sorted(members, key=lambda m: -m[2])
+        n = len(ordered)
+        for idx, (ri, si, _y) in enumerate(ordered):
+            bundle_pos[(ri, si, gkey)] = (idx, n)
+
+    for ri, seg_map in by_route.items():
+        rp = routes[ri]
+        pts = rendered_pts[ri]
+        new_pts: list[tuple[float, float]] = [pts[0]]
+        new_radii: list[float] = []
+        # Carry over original interior corner radii.  The renderer
+        # treats curve_radii[k] as the radius at intermediate point
+        # k+1.  When we insert detours we splice in 4 new radii per
+        # detour around the existing ones.
+        orig_radii = rp.curve_radii
+        # Existing radius for the interior point at index `i` (1-based
+        # in the path) is orig_radii[i-1] if available, else default.
+        def _orig_radius_for_point(i: int) -> float:
+            if orig_radii is not None and 0 <= i - 1 < len(orig_radii):
+                return orig_radii[i - 1]
+            return ctx.curve_radius
+
+        for si in range(len(pts) - 1):
+            p1, p2 = pts[si], pts[si + 1]
+            seg_y = (p1[1] + p2[1]) / 2
+            detours = seg_map.get(si)
+            # We may need to insert a corner radius for the interior
+            # point pts[si+1] (the join with the NEXT segment) at the
+            # end of this iteration.  Track whether it was already
+            # added via a detour's reconverge.
+            last_x = p1[0]
+
+            if detours:
+                direction = 1 if p2[0] > p1[0] else -1
+                for cx, dy, side, gkey in detours:
+                    g_i, g_n = bundle_pos[(ri, si, gkey)]
+                    # bypass_radii returns per-line delta1/delta2 and
+                    # 4 corner radii.  delta1/delta2 nudge the
+                    # vertical-channel X per line so all corners share
+                    # a common center -> concentric arcs.
+                    going_right = direction > 0
+                    # Gap1 goes "down" when the detour is below the
+                    # trunk, "up" when above.
+                    gap1_going_down = side == "below"
+                    gap2_going_down = not gap1_going_down
+                    d1, d2, r1, r2, r3, r4 = bypass_radii(
+                        g_i,
+                        g_n,
+                        g_i,
+                        g_n,
+                        going_right,
+                        offset_step=OFFSET_STEP,
+                        base_radius=ctx.curve_radius,
+                        gap1_going_down=gap1_going_down,
+                        gap2_going_down=gap2_going_down,
+                    )
+                    # Diverge / reconverge X centers (channel centers).
+                    corner_half = (
+                        STATION_RADIUS_APPROX
+                        + MARKER_BYPASS_CORNER_GAP
+                        + ctx.curve_radius
+                    )
+                    x_pre_center = cx - direction * corner_half
+                    x_post_center = cx + direction * corner_half
+                    # Per-line offsets within the bundle channel.
+                    x_pre = x_pre_center + d1
+                    x_post = x_post_center + d2
+
+                    # Guard against degenerate ordering when adjacent
+                    # detours overlap or the segment is too short.
+                    if direction > 0:
+                        x_pre = max(x_pre, last_x + COORD_TOLERANCE_FINE)
+                        x_post = min(x_post, p2[0] - COORD_TOLERANCE_FINE)
+                    else:
+                        x_pre = min(x_pre, last_x - COORD_TOLERANCE_FINE)
+                        x_post = max(x_post, p2[0] + COORD_TOLERANCE_FINE)
+
+                    # Insert the 4 detour corners.  Radii r1..r4 line
+                    # up with the 4 new intermediate points we add.
+                    new_pts.append((x_pre, seg_y))
+                    new_radii.append(r1)
+                    new_pts.append((x_pre, dy))
+                    new_radii.append(r2)
+                    new_pts.append((x_post, dy))
+                    new_radii.append(r3)
+                    new_pts.append((x_post, seg_y))
+                    new_radii.append(r4)
+                    last_x = x_post
+
+            new_pts.append(p2)
+            # If si+1 was an interior point (not the final endpoint),
+            # carry over its original radius.
+            if si + 1 < len(pts) - 1:
+                new_radii.append(_orig_radius_for_point(si + 1))
+
+        rp.points = new_pts
+        rp.offsets_applied = True
+        # Trim/grow new_radii to match (len(new_pts) - 2).
+        target_n = max(0, len(new_pts) - 2)
+        if len(new_radii) < target_n:
+            new_radii.extend(
+                [ctx.curve_radius] * (target_n - len(new_radii))
+            )
+        elif len(new_radii) > target_n:
+            new_radii = new_radii[:target_n]
+        rp.curve_radii = new_radii

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -196,6 +196,9 @@ class MetroGraph:
     _station_lines_cache: dict[str, list[str]] | None = field(default=None, repr=False)
     # Grid alignment metadata (populated by Phase 2.5 _align_row_y_grids)
     _row_y_grid_info: dict = field(default_factory=dict, repr=False)
+    # Grid pitch used by compute_layout; read by routing to size detours
+    # that bypass non-consuming stations (one full row offset).
+    _y_spacing: float = 0.0
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""

--- a/tests/fixtures/da_pipeline.mmd
+++ b/tests/fixtures/da_pipeline.mmd
@@ -37,8 +37,8 @@ graph LR
         mq_in[ ]
         geo_in[ ]
         gtf_to_table[GTF to table]
-        affy_load[Affy load]
-        proteus[Proteus]
+        affy_load[affy load]
+        proteus[proteus]
         geoquery[GEOquery]
         validator[Validate]
         matrix_filter[Filter matrix]
@@ -87,7 +87,7 @@ graph LR
 
     subgraph reporting [Reporting]
         %%metro entry: left | rnaseq, affy, maxquant, geo
-        shinyngs[Shiny app]
+        shinyngs[shinyngs]
         quarto[Quarto report]
         bundle[Zip bundle]
         shiny_html[ ]
@@ -119,7 +119,7 @@ graph LR
     limma -->|rnaseq,affy,maxquant,geo| gsea
     limma -->|rnaseq,affy,maxquant,geo| gprofiler2
     limma -->|rnaseq,affy,maxquant,geo| decoupler
-    propd -->|rnaseq| grea
+    limma -->|rnaseq| grea
     %% Section 2 -> Section 4 (plots are parallel, both from differential trunk)
     limma -->|rnaseq,affy,maxquant,geo| plot_expl
     limma -->|rnaseq,affy,maxquant,geo| plot_diff

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -909,3 +909,59 @@ def test_lines_bypass_non_consumers_at_full_grid_row(fixture, y_spacing):
                     )
 
     assert not violations, "Bypass violations:\n  " + "\n  ".join(violations)
+
+
+# ---------------------------------------------------------------------------
+# Station markers and off-track file icons must never overlap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture", ["da_pipeline.mmd", "rnaseq_sections.mmd"]
+)
+def test_no_station_or_icon_overlap(fixture):
+    """No two station markers (incl. off-track file icons) may share a
+    bounding-box footprint.  Each station / off-track input renders a
+    pill-shaped marker centred at ``(station.x, station.y + offset_mid)``;
+    if two such pills overlap, the rendered SVG shows one station hidden
+    behind another - the v106 regression where the auto-balance pass
+    lifted ``grea`` into the slot already occupied by the off-track
+    ``gmt_in`` icon in section 3 (Functional enrichment).
+
+    Iterates every pair of station marker bboxes and asserts they do
+    not overlap (sub-pixel tolerance).
+    """
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    radius = 5.0  # matches nfcore theme station_radius; pill width = 10px
+    junction_ids = set(graph.junctions)
+    boxes: list[tuple[str, tuple[float, float, float, float]]] = []
+    for sid, st in graph.stations.items():
+        if st.is_port or st.is_hidden or sid in junction_ids:
+            continue
+        line_offs = [
+            offsets.get((sid, lid), 0.0) for lid in graph.station_lines(sid)
+        ] or [0.0]
+        min_off, max_off = min(line_offs), max(line_offs)
+        cy = st.y + (min_off + max_off) / 2
+        w = 2 * radius
+        h = (max_off - min_off) + 2 * radius
+        boxes.append(
+            (sid, (st.x - w / 2, cy - h / 2, st.x + w / 2, cy + h / 2))
+        )
+
+    tol = 0.5
+    for i, (s1, (x1, y1, X1, Y1)) in enumerate(boxes):
+        for s2, (x2, y2, X2, Y2) in boxes[i + 1:]:
+            overlap = (
+                x1 < X2 - tol
+                and x2 < X1 - tol
+                and y1 < Y2 - tol
+                and y2 < Y1 - tol
+            )
+            assert not overlap, (
+                f"{fixture}: marker overlap between {s1!r} "
+                f"bbox=({x1:.1f},{y1:.1f},{X1:.1f},{Y1:.1f}) "
+                f"and {s2!r} "
+                f"bbox=({x2:.1f},{y2:.1f},{X2:.1f},{Y2:.1f})"
+            )

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -965,3 +965,106 @@ def test_no_station_or_icon_overlap(fixture):
                 f"and {s2!r} "
                 f"bbox=({x2:.1f},{y2:.1f},{X2:.1f},{Y2:.1f})"
             )
+
+
+# ---------------------------------------------------------------------------
+# Bypass routes around non-consuming stations must use diagonal forks, not
+# vertical U-turn segments.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture,y_spacing",
+    [
+        ("da_pipeline.mmd", 55.0),
+        ("rnaseq_sections.mmd", 55.0),
+    ],
+)
+def test_bypass_uses_diagonal_forks_not_verticals(fixture, y_spacing):
+    """A line detouring around a non-consuming station's marker must
+    do so with DIAGONAL fork-out / fork-in segments matching the trunk
+    fan-out's visual language.  Strictly-vertical U-turn segments (dx
+    near zero) on the bypass detour are forbidden because they're
+    alien to the metro-map style used everywhere else.
+
+    Pinpoints bypass detour segments by reading the marker bboxes:
+    a bypass segment is one whose Y deviates ~y_spacing from the trunk
+    Y at the bbox column, AND whose midpoint X sits within the bbox's
+    immediate horizontal vicinity (the corner-clearance zone around
+    the marker).  Within that zone, any non-horizontal segment must
+    have |dy| / |dx| <= 3 (diagonal, not vertical).
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.routing.core import _build_marker_bboxes
+    from nf_metro.render.svg import apply_route_offsets
+
+    graph = _layout(fixture, y_spacing=y_spacing)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    junction_ids = set(graph.junctions)
+    bboxes = _build_marker_bboxes(graph, junction_ids, offsets)
+
+    # The corner-clearance zone extends ~3.5 * y_spacing horizontally
+    # either side of the marker centre (allows diag_run + corner +
+    # offset slack).  Segments outside this zone aren't bypass detours;
+    # they're trunk fans, inter-section L-shapes, or normal routing.
+    HALF_ZONE = y_spacing * 3.5
+    # "Near vertical" threshold: anything steeper than 3:1 reads as a
+    # vertical line.  Trunk fan-outs are ~1:1 (45 deg) or shallower.
+    MAX_SLOPE = 3.0
+    # Only check segments whose dy is at least half a grid pitch:
+    # short corner-rounded segments aren't a concern here.
+    MIN_DY = y_spacing * 0.4
+
+    violations: list[str] = []
+    for r in routes:
+        pts = apply_route_offsets(r, offsets)
+        endpoints = {r.edge.source, r.edge.target}
+        for i in range(1, len(pts)):
+            x1, y1 = pts[i - 1]
+            x2, y2 = pts[i]
+            dx = x2 - x1
+            dy = y2 - y1
+            if abs(dy) < MIN_DY:
+                continue
+            mid_x = (x1 + x2) / 2
+            mid_y = (y1 + y2) / 2
+            # Is this segment inside the corner-clearance zone of some
+            # non-consuming station's bbox, AND between the bbox's Y
+            # row and the detour row (one y_spacing offset)?
+            in_bypass_zone = False
+            for sid, bb in bboxes.items():
+                if sid in endpoints:
+                    continue
+                if r.line_id in bb.consumed:
+                    continue
+                if abs(mid_x - bb.cx) > HALF_ZONE:
+                    continue
+                # Y must straddle the trunk Y (bb.cy) and the detour
+                # row (~one y_spacing offset).  Loose vertical bounds:
+                # |mid_y - bb.cy| within 1.3 * y_spacing.
+                if abs(mid_y - bb.cy) > y_spacing * 1.3:
+                    continue
+                # The endpoints of this segment must straddle two
+                # distinct horizontal levels separated by ~y_spacing.
+                if abs(abs(dy) - y_spacing) > y_spacing * 0.4:
+                    continue
+                in_bypass_zone = True
+                break
+            if not in_bypass_zone:
+                continue
+            # Bypass segment found: must be diagonal, not near-vertical.
+            slope = abs(dy) / max(abs(dx), 1e-6)
+            if abs(dx) < 1e-6 or slope > MAX_SLOPE:
+                violations.append(
+                    f"{fixture}: route {r.line_id} edge "
+                    f"{r.edge.source}->{r.edge.target} has near-vertical "
+                    f"bypass segment ({x1:.1f},{y1:.1f}) -> "
+                    f"({x2:.1f},{y2:.1f}) dx={dx:.1f}, dy={dy:.1f} "
+                    f"slope={slope:.2f}"
+                )
+
+    assert not violations, (
+        "Bypass uses vertical U-turn (should use diagonal forks):\n  "
+        + "\n  ".join(violations)
+    )

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -763,3 +763,149 @@ def test_terminus_not_directly_after_diagonal(fixture):
                     f"(dx={dx:.1f}, dy={dy:.1f})"
                 )
                 break
+
+
+# ---------------------------------------------------------------------------
+# Lines passing through a non-consuming station's column must detour a
+# full grid row (~y_spacing), not just nudge around the marker.
+# ---------------------------------------------------------------------------
+
+
+def _render_y_at_x(pts: list[tuple[float, float]], x: float) -> float | None:
+    """Y of a polyline at the given X, or None if X is outside its span."""
+    for i in range(len(pts) - 1):
+        x1, y1 = pts[i]
+        x2, y2 = pts[i + 1]
+        xlo, xhi = (x1, x2) if x1 <= x2 else (x2, x1)
+        if xlo - 1e-6 <= x <= xhi + 1e-6:
+            # Linear interp along the segment.
+            if abs(x2 - x1) < 1e-6:
+                return (y1 + y2) / 2
+            frac = (x - x1) / (x2 - x1)
+            return y1 + frac * (y2 - y1)
+    return None
+
+
+@pytest.mark.parametrize(
+    "fixture,y_spacing",
+    [
+        ("da_pipeline.mmd", 55.0),
+        ("rnaseq_sections.mmd", 55.0),
+    ],
+)
+def test_lines_bypass_non_consumers_at_full_grid_row(fixture, y_spacing):
+    """A line whose route crosses a non-consuming station's X must
+    visually clear the marker bbox AND sit at least a full grid row
+    (~y_spacing) away from the trunk at that X.
+
+    This catches v107 baseline where ``maxquant`` and ``geo`` lines
+    passed straight through ``Annotate results`` (and earlier, through
+    ``grea``), violating the structural rule that lines route AROUND
+    non-consuming stations rather than THROUGH them.  v105's 5px nudge
+    cleared the marker but didn't reach a full row; v108 shifts by
+    exactly ``y_spacing``.
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.routing.core import _build_marker_bboxes
+    from nf_metro.render.svg import apply_route_offsets
+
+    # Threshold for "a full grid row": 0.9 * y_spacing absorbs slight
+    # sub-pixel jitter from the line-bundle spacing within the row.
+    FULL_ROW = 0.9 * y_spacing
+
+    graph = _layout(fixture, y_spacing=y_spacing)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    # Junction set: any station listed in graph.junctions.
+    junction_ids = set(graph.junctions)
+    bboxes = _build_marker_bboxes(graph, junction_ids, offsets)
+
+    # Build per-line trunk-Y lookup per station: the average rendered Y
+    # of CONSUMED lines at the station's X.  Lines bypassing must sit
+    # at least FULL_ROW away from this trunk Y.
+    rendered: list[list[tuple[float, float]]] = [
+        apply_route_offsets(r, offsets) for r in routes
+    ]
+
+    violations: list[str] = []
+    # "Near the station's row" Y-band: routes whose Y at bb.cx falls
+    # within this band are considered the trunk passing through the
+    # station's row; routes outside it are in a different row entirely
+    # (e.g. cross-section bundles in a lower row that happen to share
+    # an X column with this station).
+    NEAR_ROW = y_spacing * 0.6
+    for sid, bb in bboxes.items():
+        trunk_ys: list[float] = []
+        crossing_lines: list[tuple[str, int, float]] = []
+        for ri, r in enumerate(routes):
+            if r.edge.source == sid or r.edge.target == sid:
+                continue
+            pts = rendered[ri]
+            # Find a horizontal segment crossing bb.cx near bb.cy.
+            seg_y_at_cx: float | None = None
+            for i in range(len(pts) - 1):
+                x1, y1 = pts[i]
+                x2, y2 = pts[i + 1]
+                xlo, xhi = (x1, x2) if x1 <= x2 else (x2, x1)
+                if not (xlo - 1e-6 <= bb.cx <= xhi + 1e-6):
+                    continue
+                if abs(y2 - y1) > 1.0:
+                    continue
+                seg_y = (y1 + y2) / 2
+                if abs(seg_y - bb.cy) > NEAR_ROW:
+                    continue  # Different grid row entirely
+                seg_y_at_cx = seg_y
+                break
+            if seg_y_at_cx is None:
+                continue
+            if r.line_id in bb.consumed:
+                trunk_ys.append(seg_y_at_cx)
+            else:
+                crossing_lines.append((r.line_id, ri, seg_y_at_cx))
+
+        if not crossing_lines:
+            continue
+
+        # Trunk Y: average of consumed lines' rendered Ys at bb.cx, or
+        # fall back to the marker center if no consumed line crosses.
+        if trunk_ys:
+            trunk_y = sum(trunk_ys) / len(trunk_ys)
+        else:
+            trunk_y = bb.cy
+
+        bbox_top = bb.cy - bb.half_h - 0.5
+        bbox_bot = bb.cy + bb.half_h + 0.5
+        # A non-consumed line is considered "in the trunk band" if its
+        # rendered Y at the station X is within the marker bbox extent
+        # plus one OFFSET_STEP slot of slack.  Such a line was at risk
+        # of crossing the marker pre-bypass and must therefore be
+        # detoured a full grid row away (v108 invariant).  Lines that
+        # are already clear (e.g. above an off-track station or below
+        # a low feeder) are unaffected.
+        trunk_band_top = trunk_y - bb.half_h - 4.0
+        trunk_band_bot = trunk_y + bb.half_h + 4.0
+
+        for line_id, ri, y_at in crossing_lines:
+            # Rule 1: line must clear the marker bbox itself.
+            if bbox_top <= y_at <= bbox_bot:
+                violations.append(
+                    f"{fixture}: line {line_id} crosses non-consuming "
+                    f"station {sid} marker bbox at "
+                    f"(x={bb.cx:.1f}, y={y_at:.1f}) "
+                    f"[bbox y-range {bbox_top:.1f}..{bbox_bot:.1f}]"
+                )
+                continue
+            # Rule 2: when the line would otherwise sit in the trunk
+            # band (the v107 "passes through marker" case), it must
+            # have been detoured a full grid row away.
+            if trunk_band_top <= y_at <= trunk_band_bot:
+                if abs(y_at - trunk_y) < FULL_ROW:
+                    violations.append(
+                        f"{fixture}: line {line_id} at non-consuming "
+                        f"station {sid} (trunk y={trunk_y:.1f}) sits at "
+                        f"y={y_at:.1f}, gap={abs(y_at - trunk_y):.1f} < "
+                        f"{FULL_ROW:.1f} (full grid row)"
+                    )
+
+    assert not violations, "Bypass violations:\n  " + "\n  ".join(violations)


### PR DESCRIPTION
## Summary

Layered fix on top of v107 (#293) and v108 (#294) to replace the v108 vertical U-turn bypass with diagonal fork-out / fork-in segments matching the trunk fan-out's visual language, while bringing the v107 station-marker collision guard back into the chain so the live differentialabundance render no longer ships a ``grea`` / ``gmt_in`` marker clash.

- **Bypass uses diagonals, not verticals.** The four bypass detour points are repositioned so the segments between trunk Y and detour Y are diagonal (``|dx| ~= |dy|``, capped by available horizontal headroom).  Concentric corner radii via ``bypass_radii`` are preserved at all four corners.
- **Wire v107's ``_guard_no_station_overlap`` back into the validate chain.**  PR #294 branched off ``3ced84b`` (pre-v107), losing the auto-balance column-occupancy check and the post-layout overlap validator.  Cherry-picked onto v109 so the live pipeline's clash is now both prevented (at layout) and detected (at validate).
- **Sync ``tests/fixtures/da_pipeline.mmd`` with the live metro map.** The fixture had drifted (``propd|rnaseq -> grea`` where the live mmd has ``limma|rnaseq -> grea``, label case-changes).  The drift masked the regression: the fixture's topology didn't trigger the auto-balance lift onto the off-track icon slot.
- **New invariant ``test_bypass_uses_diagonal_forks_not_verticals``** parametrised over both fixtures.  Pinpoints bypass segments via marker bbox + corner-clearance zone and asserts ``|dy|/|dx| <= 3`` (well clear of vertical).  Verified to fail when the diagonal fork is disabled.

## Diagnosis (why v107's mechanisms didn't fire in v108's render)

v107 (#293) added ``_guard_no_station_overlap`` + auto-balance column-occupancy check (commit ``e5cb515``).
v108 (#294) committed ``15eecdc`` on top of ``3ced84b``, NOT on top of ``e5cb515``.
So the v108 branch lacked both v107 changes.  This PR's first commit is a clean cherry-pick of ``e5cb515``; the second is the new diagonal-fork + test + fixture sync.

## Test plan

- [x] All existing tests pass (753 total: 749 baseline + 2 v107 + 2 new)
- [x] Live nf-core/differentialabundance render: no marker clashes, no vertical bypass segments, fork-diverge / fork-converge visible at annotate and grea
- [x] Section 4 (Reporting) unchanged: trunk and stations consume all 4 lines, no bypass triggers there
- [x] New invariant ``test_bypass_uses_diagonal_forks_not_verticals`` fails when diag_run is set to 0 (reproduces v108 U-turn shape)