### PR TITLE
fix(layout): bypass non-consuming stations via virtual stations (v110)

### DIFF
--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -159,6 +159,7 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
         infer_section_layout(graph, max_station_columns=max_station_columns)
         _insert_terminus_convergence_stations(graph)
         _resolve_sections(graph)
+        _insert_bypass_stations(graph)
 
     # Apply pending terminus designations
     for station_id, entries in graph._pending_terminus.items():
@@ -532,6 +533,237 @@ def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
                 new_edges.append(
                     Edge(source=converge_id, target=terminus_id, line_id=edge.line_id)
                 )
+
+    if not new_stations:
+        return
+
+    for st in new_stations:
+        graph.register_station(st)
+
+    if edges_to_remove:
+        graph.edges = [
+            e for i, e in enumerate(graph.edges) if i not in edges_to_remove
+        ]
+    for edge in new_edges:
+        graph.add_edge(edge)
+
+
+def _insert_bypass_stations(graph: MetroGraph) -> None:
+    """Insert virtual stations so non-consumed lines bypass intermediate stops.
+
+    When a station S sits between a predecessor P and one or more
+    downstream targets, lines that flow ``P -> downstream`` but are
+    *not* consumed by S would otherwise route straight through S's
+    column at S's trunk Y, crashing into the marker.  By inserting a
+    hidden virtual station ``V`` in the same section at S's column
+    (i.e. one layer past P, same as S), the routing engine treats V
+    just like any other column-mate of S: the line gets a Y track of
+    its own and fans diagonally to/from the trunk exactly like a
+    regular parallel branch.
+
+    Detection (per section):
+
+      * Compute longest-path layers within the section subgraph.
+      * For each non-port station S in the section, gather
+        ``consumed_lines(S)`` = ``{e.line_id for e in inbound edges
+        to S}``.
+      * For each predecessor ``P -> S`` and each other outbound
+        edge ``P -> T`` (T != S), the lines on ``P -> T`` that are
+        *not* in ``consumed_lines(S)`` and whose path traverses S's
+        column (``layer(P) < layer(S) <= layer(T)``) are bypassers.
+
+    Rewrite:
+      * Add ``V`` (``id=f"__bypass_{S}_{P}"``, ``is_hidden=True``).
+      * For each bypassed line L, replace edge ``P -> T (L)`` with
+        ``P -> V (L)`` + ``V -> T (L)``.
+
+    The virtual station inherits S's section so it participates in
+    section layout / fan / symfan with the same primitives the rest
+    of the section uses.  Cross-section targets (where T is in a
+    different section) participate too because section resolution
+    happens after this pass.
+    """
+    if not graph.sections:
+        return
+
+    import networkx as nx
+
+    # Stations that will be designated as termini after parsing (carry
+    # file/files/dir icons).  Terminus stations get their convergence
+    # via ``_insert_terminus_convergence_stations`` and shouldn't be
+    # bypass candidates -- they already render as icons, not pill
+    # markers, and don't have line-bundle markers to clash with.
+    pending_terminus_ids: set[str] = set(graph._pending_terminus.keys())
+
+    # Pre-compute consumed-line sets keyed by station ID.
+    consumed_by: dict[str, set[str]] = {}
+    for edge in graph.edges:
+        consumed_by.setdefault(edge.target, set()).add(edge.line_id)
+
+    new_stations: list[Station] = []
+    new_edges: list[Edge] = []
+    edges_to_remove: set[int] = set()
+    bypass_count = 0
+
+    # Index edges by source for fast lookup.
+    edges_by_source: dict[str, list[tuple[int, Edge]]] = {}
+    for i, edge in enumerate(graph.edges):
+        edges_by_source.setdefault(edge.source, []).append((i, edge))
+
+    def _section_layers(section_ids: set[str]) -> dict[str, int]:
+        """Per-section longest-path layers matching ``_build_section_subgraph``.
+
+        Includes intra-section ports so entry/exit ports get a layer
+        anchored to the section's flow.  Edges crossing the section
+        boundary are excluded -- they're rewritten through ports.
+        """
+        sub = nx.DiGraph()
+        for sid in section_ids:
+            sub.add_node(sid)
+        for edge in graph.edges:
+            if edge.source in section_ids and edge.target in section_ids:
+                sub.add_edge(edge.source, edge.target)
+        try:
+            topo = list(nx.topological_sort(sub))
+        except nx.NetworkXUnfeasible:
+            return {}
+        layers: dict[str, int] = {}
+        for node in topo:
+            preds = list(sub.predecessors(node))
+            layers[node] = (
+                max((layers[p] for p in preds), default=-1) + 1 if preds else 0
+            )
+        # Pin exit ports to ``max(layer) + 1`` so they always sit past
+        # any internal station -- ``_build_section_subgraph`` excludes
+        # ports altogether, so longest-path within the section may give
+        # the port the same layer as an internal station that shares its
+        # predecessor (e.g. ``limma -> annotate`` and
+        # ``limma -> exit_port`` both end up at layer 1).
+        return layers
+
+    for section in graph.sections.values():
+        station_ids = set(section.station_ids)
+        if not station_ids:
+            continue
+
+        sec_layers = _section_layers(station_ids)
+        exit_port_ids = set(section.exit_ports)
+        # Pin exit ports past all internal stations so any internal
+        # station with a non-consumed line bound for the exit gets a
+        # bypass column.
+        if exit_port_ids and sec_layers:
+            internal_max = max(
+                v for k, v in sec_layers.items() if k not in exit_port_ids
+            )
+            for pid in exit_port_ids:
+                if sec_layers.get(pid, 0) <= internal_max:
+                    sec_layers[pid] = internal_max + 1
+
+        # For each station S in section, consider only NON-PORT,
+        # NON-HIDDEN, non-terminus stations as bypass candidates.
+        # (Terminus stations get their convergence via the v104 pass.)
+        for sid in list(section.station_ids):
+            station = graph.stations.get(sid)
+            if station is None:
+                continue
+            if station.is_port or station.is_hidden:
+                continue
+            if station.is_terminus or sid in pending_terminus_ids:
+                continue
+
+            consumed = consumed_by.get(sid, set())
+            s_layer = sec_layers.get(sid)
+            if s_layer is None:
+                continue
+
+            # Find predecessors of S that are in the same section.
+            preds_in_section: dict[str, list[int]] = {}
+            for i, edge in enumerate(graph.edges):
+                if edge.target != sid:
+                    continue
+                if edge.source in station_ids:
+                    preds_in_section.setdefault(edge.source, []).append(i)
+
+            for pred_id in preds_in_section:
+                pred_layer = sec_layers.get(pred_id)
+                if pred_layer is None or pred_layer >= s_layer:
+                    continue
+
+                # Outbound edges from P that aren't going to S.
+                # Only fire when:
+                #   1. Target is an EXIT PORT past S's column.
+                #   2. The exit port's inbound from P shares at least
+                #      one consumed-by-S line.  This means S sits on
+                #      the same trunk the bypass line wants to take --
+                #      P -> S -> exit_port and P -> exit_port both
+                #      route at S's trunk Y, so a non-consumed line
+                #      on the second edge crashes S's marker.
+                #
+                # Skipping case-2 prevents over-detouring branch
+                # stations (e.g. ``salmon_quant`` after
+                # ``umi_tools_dedup`` in rnaseq_auto) where the
+                # bypass line and the consumed-line bundle never
+                # share a row.
+                bypass_edges: list[tuple[int, Edge]] = []
+                p_exit_lines: dict[str, set[str]] = {}
+                for i, edge in edges_by_source.get(pred_id, []):
+                    if edge.target in exit_port_ids:
+                        p_exit_lines.setdefault(edge.target, set()).add(
+                            edge.line_id
+                        )
+                for i, edge in edges_by_source.get(pred_id, []):
+                    if edge.target == sid:
+                        continue
+                    if edge.line_id in consumed:
+                        continue
+                    t_layer = sec_layers.get(edge.target)
+                    if t_layer is None or t_layer <= s_layer:
+                        continue
+                    tgt_station = graph.stations.get(edge.target)
+                    if tgt_station is None:
+                        continue
+                    is_exit_port = (
+                        tgt_station.is_port
+                        and edge.target in exit_port_ids
+                    )
+                    if not is_exit_port:
+                        continue
+                    # Require an overlap: P also feeds the exit port
+                    # with at least one of S's consumed lines.
+                    if not (p_exit_lines.get(edge.target, set()) & consumed):
+                        continue
+                    bypass_edges.append((i, edge))
+
+                if not bypass_edges:
+                    continue
+
+                bypass_count += 1
+                v_id = f"__bypass_{sid}_{pred_id}_{bypass_count}"
+                new_stations.append(
+                    Station(
+                        id=v_id,
+                        label="",
+                        section_id=section.id,
+                        is_hidden=True,
+                    )
+                )
+
+                for idx, edge in bypass_edges:
+                    edges_to_remove.add(idx)
+                    new_edges.append(
+                        Edge(
+                            source=edge.source,
+                            target=v_id,
+                            line_id=edge.line_id,
+                        )
+                    )
+                    new_edges.append(
+                        Edge(
+                            source=v_id,
+                            target=edge.target,
+                            line_id=edge.line_id,
+                        )
+                    )
 
     if not new_stations:
         return

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -763,3 +763,134 @@ def test_terminus_not_directly_after_diagonal(fixture):
                     f"(dx={dx:.1f}, dy={dy:.1f})"
                 )
                 break
+
+
+# ---------------------------------------------------------------------------
+# Non-consumed lines bypass intermediate stations via a virtual station
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ["da_pipeline.mmd"])
+def test_non_consumed_lines_route_via_virtual_station(fixture):
+    """A line not consumed by station S must not enter S's marker bbox
+    and, when it would otherwise cross S's column, must be routed
+    through an invisible (``is_hidden``) virtual station in the same
+    section.
+
+    Mirrors the v104 terminus-convergence pattern applied to bypassing:
+    inserting a hidden station in S's column at a separate trunk-Y row
+    forces the layout to allocate the bypass a parallel-branch track,
+    so the path uses the existing fan-out / fan-in primitives.
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.render.svg import apply_route_offsets
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    # Identify the bypass case in this fixture: ``annotate`` in the
+    # ``differential`` section consumes only rnaseq+affy but maxquant
+    # and geo travel from limma to differential's exit port, so they
+    # would otherwise route past annotate.  After v110, those lines
+    # must enter a hidden station in the same section.
+    bypass_station_ids = {
+        sid
+        for sid, st in graph.stations.items()
+        if st.is_hidden and sid.startswith("__bypass_")
+    }
+    assert bypass_station_ids, (
+        f"{fixture}: expected at least one __bypass_ hidden station "
+        "from _insert_bypass_stations"
+    )
+
+    # For each bypass station, the section_id should be a real
+    # (visible) section and the virtual station should not have a
+    # rendered marker.  Test by inspecting station attributes.
+    for vsid in bypass_station_ids:
+        vstation = graph.stations[vsid]
+        assert vstation.is_hidden, f"{vsid} should be is_hidden"
+        assert not vstation.label, f"{vsid} should have no label"
+        assert vstation.section_id is not None, f"{vsid} needs section_id"
+
+    # For the specific differential-section case, verify the maxquant
+    # and geo lines are routed via a hidden bypass station and the
+    # paths' rendered Y at annotate's X does NOT enter annotate's bbox.
+    annotate = graph.stations.get("annotate")
+    assert annotate is not None, "fixture must contain ``annotate`` station"
+
+    diff_bypass = [
+        sid for sid in bypass_station_ids if graph.stations[sid].section_id
+        == annotate.section_id
+    ]
+    assert diff_bypass, (
+        f"{fixture}: expected a bypass virtual station in "
+        f"section {annotate.section_id}"
+    )
+
+    # The two bypassing lines (maxquant, geo) should each have edges
+    # ending at and starting from the same hidden bypass station.
+    bypass_predecessors_for = {
+        v: {e.source for e in graph.edges if e.target == v}
+        for v in diff_bypass
+    }
+    bypass_successors_for = {
+        v: {e.target for e in graph.edges if e.source == v}
+        for v in diff_bypass
+    }
+    bypass_lines_for = {
+        v: {e.line_id for e in graph.edges if e.source == v}
+        for v in diff_bypass
+    }
+    # At least one bypass virtual station should carry the
+    # non-consumed lines and chain limma -> V -> exit_port.
+    found_bypass_for_lines = False
+    for v in diff_bypass:
+        if {"maxquant", "geo"}.issubset(bypass_lines_for[v]):
+            assert "limma" in bypass_predecessors_for[v]
+            assert any(
+                "exit" in succ for succ in bypass_successors_for[v]
+            ), (
+                f"{v}: expected an exit-port successor, "
+                f"got {bypass_successors_for[v]}"
+            )
+            found_bypass_for_lines = True
+            break
+    assert found_bypass_for_lines, (
+        f"{fixture}: expected a bypass V carrying maxquant and geo from "
+        f"limma to the differential exit port"
+    )
+
+    # Rendered routes for the bypassing lines must not cross annotate's
+    # bbox.  Use a half-bbox approximation centered at annotate (x, y).
+    HALF_H = 14.0  # pill half-height plus slack
+    HALF_W = 14.0  # marker half-width plus slack
+    ann_cx = annotate.x
+    ann_cy = annotate.y
+    rendered = [apply_route_offsets(r, offsets) for r in routes]
+    for ri, r in enumerate(routes):
+        # Only interested in lines NOT consumed by annotate.
+        if r.line_id not in {"maxquant", "geo"}:
+            continue
+        # Skip routes whose endpoints don't span past annotate.
+        if r.edge.source == "annotate" or r.edge.target == "annotate":
+            continue
+        pts = rendered[ri]
+        for i in range(len(pts) - 1):
+            x1, y1 = pts[i]
+            x2, y2 = pts[i + 1]
+            xlo, xhi = (x1, x2) if x1 <= x2 else (x2, x1)
+            if xhi < ann_cx - HALF_W or xlo > ann_cx + HALF_W:
+                continue
+            # Linearly interpolate Y at ann_cx along this segment.
+            if abs(x2 - x1) < 1e-6:
+                seg_y = (y1 + y2) / 2
+            else:
+                t = (ann_cx - x1) / (x2 - x1)
+                t = max(0.0, min(1.0, t))
+                seg_y = y1 + t * (y2 - y1)
+            assert abs(seg_y - ann_cy) > HALF_H, (
+                f"{fixture}: line {r.line_id} enters annotate marker "
+                f"bbox at x={ann_cx:.1f}, y={seg_y:.1f} (annotate "
+                f"cy={ann_cy:.1f})"
+            )


### PR DESCRIPTION
## Summary

When lines flow through a section but aren't consumed by every station-column they cross, they were routing straight through the non-consumer's marker bbox. The differential-abundance pipeline shows this at ``Annotate results``: ``limma`` carries rnaseq/affy/maxquant/geo to the section's exit port, but only rnaseq+affy stop at the annotate marker -- maxquant and geo continue and pinned to the trunk Y, crashing the annotate pill.

This PR extends the v104 terminus-convergence pattern to handle this case. Inserting a hidden virtual station ``V`` (``is_hidden=True``) in the bypassed station's section gives the routing engine a column-mate to fan to/from, so the bypass uses the same fork-out and fork-in diagonals the rest of the diagram uses for any parallel branch.

This supersedes PRs #294 (full-grid-row vertical U-turn) and #295 (diagonal-fork bypass), both of which wrote bespoke routing geometry that didn't match the diagram's visual language.

### Approach

In ``_insert_bypass_stations`` (run after ``_resolve_sections``):

  1. For each non-port, non-hidden, non-terminus station ``S``, gather ``consumed_lines(S)`` from inbound edges.
  2. For each in-section predecessor ``P`` with ``layer(P) < layer(S)``, look at outbound edges ``P -> exit_port`` carrying a line ``L`` not in consumed.
  3. Require P also feeds the same exit_port with at least one line from ``consumed_lines(S)`` -- this is the signal that P and the exit_port both sit on the trunk that S is on, so the non-consumed line would cross S's row.
  4. Replace ``P -> exit_port (L)`` with ``P -> V (L) + V -> exit_port (L)``.

Per-section layers are computed locally (intra-section subgraph, including ports) with exit ports pinned past internal stations, so longest-path quirks where two layer-equal stations sit in adjacent columns don't suppress the trigger.

### Test plan

- [x] ``test_non_consumed_lines_route_via_virtual_station[da_pipeline.mmd]`` (new) asserts the bypass V chains ``limma -> V -> exit_port`` for maxquant and geo and verifies the rendered routes clear annotate's marker bbox
- [x] Full suite: 748 passed (747 baseline + 1 new)
- [x] Visual render against ``da-metro-work/metro_map.mmd`` shows the maxquant+geo bypass at annotate using the same fan-out diagonals as parallel branches elsewhere in the diagram
- [x] rnaseq_auto.mmd no longer gets a spurious bypass at salmon_quant (the overlap heuristic correctly identifies when P/exit_port and S share a trunk row)
- [x] v104 terminus convergence at ``plots_png`` continues to fire and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)