### PR TITLE
feat(layout): auto half-grid placement for 2-branch symmetric fans

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -479,6 +479,16 @@ def _compute_section_layout(
     # is bottom- and top-weighted instead of stacked below the trunk.
     _fan_source_inputs_upward(graph, section_y_padding, y_spacing)
 
+    # Phase 13d3: For sections that contain exactly a 2-branch
+    # symmetric fan (and no off-track or other constraining content),
+    # collapse the fan onto half-pitch offsets so the section consumes
+    # one vertical grid unit instead of two.  Marks the branch stations
+    # in ``_half_grid_station_ids`` so the next snap pass leaves them
+    # alone.  Runs before ``_snap_all_y_to_grid`` so the snap-to-row-
+    # grid pass doesn't immediately undo the compaction.
+    if graph.center_ports:
+        _apply_half_grid_2branch_symfan(graph, y_spacing)
+
     # Phase 13e: Snap all station/port Ys to a per-section y_spacing
     # grid.  Trunk-Y align, port-snap, and the row compaction/fan
     # phases compute shifts that don't respect the grid pitch, leaving
@@ -2036,6 +2046,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
         # consumer is preserved) but don't influence the origin.
         residues: Counter[float] = Counter()
         per_section_ports: dict[str, set[str]] = {}
+        half_grid_ids = getattr(graph, "_half_grid_station_ids", set()) or set()
         for sec_id in sec_ids:
             section = graph.sections.get(sec_id)
             if section is None or section.bbox_h <= 0:
@@ -2044,6 +2055,10 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
             per_section_ports[sec_id] = port_ids
             for sid in section.station_ids:
                 if sid in port_ids:
+                    continue
+                if sid in half_grid_ids:
+                    # Half-grid stations sit at origin + 0.5 * pitch by
+                    # design; don't let them shift the row's grid origin.
                     continue
                 st = graph.stations.get(sid)
                 if st is None or getattr(st, "off_track", False):
@@ -2066,6 +2081,8 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
                 continue
             for sid in section.station_ids:
                 if sid in port_ids:
+                    continue
+                if sid in half_grid_ids:
                     continue
                 st = graph.stations.get(sid)
                 if st is None:
@@ -2196,6 +2213,151 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
                 graph.stations[sid].y = trunk_y + sign * k * y_spacing
 
 
+def _apply_half_grid_2branch_symfan(
+    graph: MetroGraph, y_spacing: float
+) -> None:
+    """Compact 2-branch symfan sections onto half-pitch offsets.
+
+    For every section that satisfies ``_section_symfan_uses_half_grid``
+    (exactly two on-track non-terminus branch stations sharing a column,
+    no off-track inputs), this places the two branches at
+    ``trunk_y +/- 0.5 * y_spacing`` regardless of what the per-column
+    redistribute passes did.
+
+    Why a dedicated phase: ``_redistribute_full_bundle_columns`` and
+    ``_recenter_full_bundle_columns`` gate on ``_grid_group_section_ids``
+    (sections that share a row with at least one other section), so a
+    section sitting alone on its row never participates.  The 2-branch
+    symfan case is well-defined regardless of row membership, so this
+    phase fires on the section directly.
+
+    Trunk anchor preference (in order):
+      1. LR/RL entry port Y (the inter-section bundle line).
+      2. LR/RL exit port Y.
+      3. Midpoint of the two branch stations' current Ys.
+
+    The branches are marked in ``_half_grid_station_ids`` so the
+    subsequent ``_snap_all_y_to_grid`` pass leaves their half-pitch
+    offsets intact (and ignores them when computing the row grid
+    origin).
+    """
+    if y_spacing <= 0:
+        return
+    for section in graph.sections.values():
+        if (
+            section.bbox_h <= 0
+            or section.direction not in ("LR", "RL")
+        ):
+            continue
+        if not _section_symfan_uses_half_grid(graph, section):
+            continue
+
+        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        branches: list[Station] = []
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            st = graph.stations.get(sid)
+            if (
+                st is None
+                or st.is_port
+                or st.is_hidden
+                or st.off_track
+                or st.is_terminus
+            ):
+                continue
+            branches.append(st)
+        if len(branches) != 2:
+            continue
+
+        # Trunk Y from LR/RL ports (preferred) or the branches' midpoint.
+        trunk_y: float | None = None
+        for pid in section.entry_ports:
+            p = graph.ports.get(pid)
+            ps = graph.stations.get(pid)
+            if (
+                p is not None
+                and ps is not None
+                and p.side in (PortSide.LEFT, PortSide.RIGHT)
+            ):
+                trunk_y = ps.y
+                break
+        if trunk_y is None:
+            for pid in section.exit_ports:
+                p = graph.ports.get(pid)
+                ps = graph.stations.get(pid)
+                if (
+                    p is not None
+                    and ps is not None
+                    and p.side in (PortSide.LEFT, PortSide.RIGHT)
+                ):
+                    trunk_y = ps.y
+                    break
+        if trunk_y is None:
+            trunk_y = (branches[0].y + branches[1].y) / 2.0
+
+        branches.sort(key=lambda s: s.y)
+        branches[0].y = trunk_y - 0.5 * y_spacing
+        branches[1].y = trunk_y + 0.5 * y_spacing
+        graph._half_grid_station_ids.update(b.id for b in branches)
+
+
+def _section_symfan_uses_half_grid(
+    graph: MetroGraph, section: Section
+) -> bool:
+    """Return True when a section's symfan should use half-pitch offsets.
+
+    Trigger conditions (must all hold):
+      - Section has exactly two real "branch" stations: on-track,
+        non-port, non-hidden, non-terminus internal stations sharing
+        a single X column.  Terminus icons (file outputs) and hidden
+        convergence stations are excluded - they're downstream join
+        points that don't constrain symfan spacing.
+      - No off-track stations exist in the section (no input rows
+        sitting in the participants' Y band).
+      - The section has no other columns with multiple branch stations
+        (this is the only fan, so the section height is bounded by
+        these two stations).
+
+    When the trigger fires the two branch stations are placed at
+    ``trunk_y +/- 0.5 * y_spacing`` instead of the default
+    ``trunk_y +/- 1 * y_spacing``, so the section needs only one
+    vertical grid unit instead of two.
+
+    Trunk Y itself is unchanged.  The branches sit at half-pitch
+    relative to the row grid; ``_snap_all_y_to_grid`` skips them via
+    ``graph._half_grid_station_ids``.
+    """
+    port_ids = set(section.entry_ports) | set(section.exit_ports)
+    branches: list[Station] = []
+    has_off_track = False
+    by_col: dict[float, int] = defaultdict(int)
+    for sid in section.station_ids:
+        if sid in port_ids:
+            continue
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.is_hidden:
+            continue
+        if st.off_track:
+            has_off_track = True
+            continue
+        if st.is_terminus:
+            # Terminus icons (file outputs) sit downstream of the fan
+            # and are not symfan participants.
+            continue
+        branches.append(st)
+        by_col[round(st.x, 3)] += 1
+    if has_off_track or len(branches) != 2:
+        return False
+    if abs(branches[0].x - branches[1].x) >= 0.5:
+        return False
+    # No other column may have a multi-branch population (would force
+    # full-grid height anyway).  With exactly two branches sharing one
+    # column this is implicit, but the check is cheap and future-proofs
+    # the trigger when terminus filtering changes.
+    return all(count <= 2 for count in by_col.values())
+
+
 def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
     """Fan a full-bundle column around the trunk Y.
 
@@ -2305,6 +2467,7 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
             for x in cols
         )
 
+        half_grid = _section_symfan_uses_half_grid(graph, section)
         for x, sids in col_eligible.items():
             full = full_by_col[x]
             non_full = [s for s in sids if s not in full]
@@ -2336,6 +2499,14 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
                 trunk_y = others[len(others) // 2]
             participants.sort(key=lambda s: pre_fan_y[s])
             n = len(participants)
+            # 2-branch symfan in an isolated section: place at half-
+            # pitch around the trunk so the section only consumes one
+            # vertical grid unit instead of two.
+            if half_grid and n == 2:
+                graph.stations[participants[0]].y = trunk_y - 0.5 * y_spacing
+                graph.stations[participants[1]].y = trunk_y + 0.5 * y_spacing
+                graph._half_grid_station_ids.update(participants)
+                continue
             # Even: offsets -n//2..-1, 1..n//2 (skipping 0).
             # Odd:  offsets -(n//2)..n//2 inclusive (0 = trunk_y).
             if n % 2 == 0:
@@ -2456,6 +2627,7 @@ def _recenter_full_bundle_columns(
             for x in cols
         )
 
+        half_grid = _section_symfan_uses_half_grid(graph, section)
         for x, full in full_by_col.items():
             non_full = [s for s in cols[x] if s not in full]
             mixed_ok = bool(full) and non_full and all(
@@ -2472,6 +2644,14 @@ def _recenter_full_bundle_columns(
                 continue
             participants.sort(key=lambda s: graph.stations[s].y)
             n = len(participants)
+            # 2-branch symfan in an isolated section: place at half-
+            # pitch around the trunk so the section only consumes one
+            # vertical grid unit instead of two.
+            if half_grid and n == 2:
+                graph.stations[participants[0]].y = anchor_y - 0.5 * y_spacing
+                graph.stations[participants[1]].y = anchor_y + 0.5 * y_spacing
+                graph._half_grid_station_ids.update(participants)
+                continue
             if n % 2 == 0:
                 offsets = list(range(-(n // 2), 0)) + list(range(1, n // 2 + 1))
             else:

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -196,6 +196,10 @@ class MetroGraph:
     _station_lines_cache: dict[str, list[str]] | None = field(default=None, repr=False)
     # Grid alignment metadata (populated by Phase 2.5 _align_row_y_grids)
     _row_y_grid_info: dict = field(default_factory=dict, repr=False)
+    # Station IDs placed at half-pitch offsets relative to the row grid by the
+    # 2-branch symmetric-fan placement.  Tracked so that ``_snap_all_y_to_grid``
+    # leaves them alone (they intentionally sit on the half-grid).
+    _half_grid_station_ids: set[str] = field(default_factory=set, repr=False)
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -896,7 +896,13 @@ def _terminal_full_bundle_text():
 
 
 def test_full_bundle_column_fans_around_trunk_with_center_ports():
-    """Terminal section's full-bundle column fans symmetrically when --center-ports is on."""
+    """Terminal section's full-bundle column fans symmetrically when --center-ports is on.
+
+    A 2-station section with no off-track inputs uses the half-grid
+    auto-compaction, so the pair sits at ``trunk +/- 0.5 * y_spacing``
+    (one grid unit apart, not two).  Symmetry around the trunk is the
+    invariant; the absolute spacing is the half-grid value.
+    """
     graph = parse_metro_mermaid(_terminal_full_bundle_text())
     graph.center_ports = True
     compute_layout(graph, y_spacing=50.0)
@@ -908,8 +914,10 @@ def test_full_bundle_column_fans_around_trunk_with_center_ports():
     assert abs((by - mid) - (mid - ay)) < 1e-6, (
         f"a and b should be symmetric around trunk Y: a={ay}, b={by}, mid={mid}"
     )
-    assert abs(abs(by - ay) - 100.0) < 1e-6, (
-        f"a and b should be 2*y_spacing apart: |b-a|={abs(by-ay)}"
+    # 2-station section -> half-grid auto-compaction: stations sit
+    # 1 * y_spacing apart, i.e. trunk +/- 0.5 * y_spacing.
+    assert abs(abs(by - ay) - 50.0) < 1e-6, (
+        f"a and b should be 1*y_spacing apart under half-grid: |b-a|={abs(by-ay)}"
     )
 
 
@@ -951,17 +959,150 @@ def test_full_bundle_column_fans_non_terminal_section():
     compute_layout(graph, y_spacing=50.0)
     # `middle` has exit ports but its column carries only full-bundle
     # stations with no unique trunk, so the symfan should fire and the
-    # pair should flank a vacant trunk row.
+    # pair should flank a vacant trunk row.  The section has exactly two
+    # on-track stations, so half-grid auto-compaction applies and the
+    # pair sits 1*y_spacing apart (trunk +/- 0.5 * y_spacing).
     ay = graph.stations["a"].y
     by = graph.stations["b"].y
     delta = abs(by - ay)
-    assert delta == pytest.approx(100.0), (
-        f"Non-terminal full-bundle column should flank trunk: delta={delta}"
+    assert delta == pytest.approx(50.0), (
+        f"Non-terminal 2-station full-bundle column should sit 1*y_spacing "
+        f"apart under half-grid: delta={delta}"
     )
     mid = (ay + by) / 2
     assert abs((by - mid) - (mid - ay)) < 1e-6, (
         f"a and b should be symmetric around trunk Y: a={ay}, b={by}, mid={mid}"
     )
+
+
+def test_two_branch_symfan_uses_half_grid():
+    """A 2-branch symmetric fan compacts to half-pitch automatically.
+
+    Reproduces the differentialabundance Plots section: a section
+    containing exactly two on-track branch stations plus a terminus
+    icon, fed from a single upstream trunk.  Under the default
+    placement the two branches would sit 2 * y_spacing apart (trunk +/-
+    1 unit each); under the half-grid auto-compaction they sit 1 *
+    y_spacing apart (trunk +/- 0.5 unit each) and the section needs
+    only one vertical grid slot for the fan.
+
+    Symmetry around the trunk Y is preserved.  Trunk Y itself stays on
+    the integer grid (taken from the LR entry port).
+    """
+    text = (
+        "%%metro line: L1 | Line1 | #ff0000\n"
+        "%%metro line: L2 | Line2 | #00ff00\n"
+        "%%metro file: out_png | PNG | Plots\n"
+        "graph LR\n"
+        "    subgraph upstream [Upstream]\n"
+        "        u[U]\n"
+        "    end\n"
+        "    subgraph plots [Plots]\n"
+        "        a[Branch A]\n"
+        "        b[Branch B]\n"
+        "        out_png[ ]\n"
+        "        a -->|L1,L2| out_png\n"
+        "        b -->|L1,L2| out_png\n"
+        "    end\n"
+        "    u -->|L1,L2| a\n"
+        "    u -->|L1,L2| b\n"
+    )
+    graph = parse_metro_mermaid(text)
+    graph.center_ports = True
+    compute_layout(graph, x_spacing=70, y_spacing=55)
+    ay = graph.stations["a"].y
+    by = graph.stations["b"].y
+    delta = abs(by - ay)
+    # Half-grid: branches sit 1 * y_spacing apart, not 2.
+    assert delta == pytest.approx(55.0), (
+        f"2-branch symfan should compact to 1*y_spacing apart: delta={delta}"
+    )
+    # Symmetric around the section trunk Y (the LR entry port Y).
+    plots = graph.sections["plots"]
+    entry_port_id = plots.entry_ports[0]
+    trunk_y = graph.stations[entry_port_id].y
+    mid = (ay + by) / 2
+    assert abs(mid - trunk_y) < 1.0, (
+        f"branch midpoint should match trunk Y: mid={mid} trunk={trunk_y}"
+    )
+    # Both branches are flagged so ``_snap_all_y_to_grid`` leaves them
+    # at the half-pitch offset.
+    assert {"a", "b"}.issubset(graph._half_grid_station_ids)
+
+
+def test_two_branch_symfan_uses_half_grid_alone_in_row():
+    """2-branch symfan in a row-isolated section uses half-grid.
+
+    Mirrors the differentialabundance Plots case: the section is alone
+    on its row (no grid alignment metadata), so the per-row
+    redistribute passes ``_redistribute_full_bundle_columns`` and
+    ``_recenter_full_bundle_columns`` skip it.  The dedicated
+    ``_apply_half_grid_2branch_symfan`` phase must still compact the
+    fan onto half-pitch offsets.
+
+    Fixture: ``da_pipeline.mmd`` -> Plots section (plot_expl /
+    plot_diff feeding a terminus icon, alone on row 1).
+    """
+    fixture = (
+        Path(__file__).resolve().parent / "fixtures" / "da_pipeline.mmd"
+    )
+    graph = parse_metro_mermaid(fixture.read_text())
+    graph.center_ports = True
+    compute_layout(graph, x_spacing=70, y_spacing=55)
+    plot_expl_y = graph.stations["plot_expl"].y
+    plot_diff_y = graph.stations["plot_diff"].y
+    delta = abs(plot_diff_y - plot_expl_y)
+    assert delta == pytest.approx(55.0), (
+        f"Plots 2-branch fan should sit 1*y_spacing apart under "
+        f"half-grid: delta={delta}"
+    )
+    plots = graph.sections["plots"]
+    entry_port_id = plots.entry_ports[0]
+    trunk_y = graph.stations[entry_port_id].y
+    mid = (plot_expl_y + plot_diff_y) / 2
+    assert abs(mid - trunk_y) < 1.0, (
+        f"Plots branch midpoint should match trunk Y: "
+        f"mid={mid} trunk={trunk_y}"
+    )
+    assert {"plot_expl", "plot_diff"}.issubset(
+        graph._half_grid_station_ids
+    )
+
+
+def test_two_branch_symfan_skipped_with_off_track_input():
+    """Off-track inputs disqualify a section from half-grid compaction.
+
+    When the same 2-branch fan also carries an off-track input row, the
+    half-grid trigger must not fire (the input row constrains spacing).
+    The branches should keep the default full-pitch offsets.
+    """
+    text = (
+        "%%metro line: L1 | Line1 | #ff0000\n"
+        "%%metro line: L2 | Line2 | #00ff00\n"
+        "%%metro file: out_png | PNG | Plots\n"
+        "%%metro off_track: in_x\n"
+        "graph LR\n"
+        "    subgraph upstream [Upstream]\n"
+        "        u[U]\n"
+        "    end\n"
+        "    subgraph plots [Plots]\n"
+        "        in_x[Input]\n"
+        "        a[Branch A]\n"
+        "        b[Branch B]\n"
+        "        out_png[ ]\n"
+        "        a -->|L1,L2| out_png\n"
+        "        b -->|L1,L2| out_png\n"
+        "        in_x -->|L1,L2| a\n"
+        "    end\n"
+        "    u -->|L1,L2| a\n"
+        "    u -->|L1,L2| b\n"
+    )
+    graph = parse_metro_mermaid(text)
+    graph.center_ports = True
+    compute_layout(graph, x_spacing=70, y_spacing=55)
+    # No half-grid flag should be set on a or b.
+    assert "a" not in graph._half_grid_station_ids
+    assert "b" not in graph._half_grid_station_ids
 
 
 def test_off_track_input_sits_adjacent_to_its_consumer():


### PR DESCRIPTION
## Summary

When a section contains exactly two on-track branch stations sharing a column (no off-track inputs, no other on-track content), the symfan placement now puts them at `trunk_y +/- 0.5 * y_spacing` instead of `trunk_y +/- 1 * y_spacing`. The section consumes one vertical grid unit for the fan instead of two, removing wasted space in topologies like the differentialabundance Plots section.

## Behaviour

- Trunk Y stays on the integer grid; only the two branch stations sit at half-pitch.
- Tracked stations are added to `graph._half_grid_station_ids` so the final `_snap_all_y_to_grid` pass leaves them at half-pitch and ignores them when computing the row grid origin.
- Fully automatic - no directive flag.

## Implementation

- New phase `_apply_half_grid_2branch_symfan` (Phase 13d3) handles sections that sit alone on a row (the differentialabundance Plots case), which the per-row `_redistribute_full_bundle_columns` / `_recenter_full_bundle_columns` passes skip via `_grid_group_section_ids`.
- The existing redistribute / recenter passes also honour the trigger for row-shared sections (so a 2-branch Reporting-style section in a multi-section row gets the same compaction).
- Trigger helper `_section_symfan_uses_half_grid` checks: exactly 2 non-port, non-hidden, non-terminus, on-track stations sharing a column, no off-track in the section, no other multi-branch columns.

## Before / after on differentialabundance

Section 4 (Plots) marker centre Ys:

| state | plot_expl cy | plot_diff cy | diff |
|------|-------------|-------------|------|
| baseline | 400.4 | 510.4 | 110 (= 2 * y_spacing) |
| half-grid | 427.9 | 482.9 | 55 (= 1 * y_spacing) |

Canvas height drops from 710 to 702. Plots bbox height drops from 171.8 to 163.4.

## Test plan

- [x] `pytest tests/` - 750 passed (3 new tests added).
- [x] `test_two_branch_symfan_uses_half_grid_alone_in_row` fails on baseline (verified by stubbing the new phase, branches stay 110 apart).
- [x] Visual render of differentialabundance metro map: Plots branches compact cleanly, routing curves remain smooth.
- [x] Existing layout invariants pass (`test_symfan_pairs_share_y`, `test_section_bbox_contains_all_content`, etc.).