### PR TITLE
refactor(skill): defer per-PR vetting from nf-metro-layout-fix to pr-chain-vet

### DIFF
--- a/.claude/skills/nf-metro-layout-fix/SKILL.md
+++ b/.claude/skills/nf-metro-layout-fix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nf-metro-layout-fix
-description: Drive code-level fixes to nf-metro when a real pipeline render exposes a layout bug that isn't a mmd mistake, without regressing pipelines that already ship metro maps. Use when working in nf-metro's src/ (layout engine, routing, parser) to fix kinks, station overlaps, breeze-past, asymmetric fans, bypass routing, or bbox overflow on a real pipeline diagram. Covers the savepoint tag pattern, the invariant-test-first-then-fix-then-runtime-validator loop, gallery regression vetting with build_gallery and build_render_diff, converting global fixes to conditional ones so other renders aren't pushed around, and the additive-commits-only PR chain workflow. For authoring the mmd content itself (deciding lines, stations, sections), see the `pipeline-metro-diagram` skill. For routine gallery regression testing of nf-metro, see `render-topologies`.
+description: Drive code-level fixes to nf-metro when a real pipeline render exposes a layout bug that isn't a mmd mistake, without regressing pipelines that already ship metro maps. Use when working in nf-metro's src/ (layout engine, routing, parser) to fix kinks, station overlaps, breeze-past, asymmetric fans, bypass routing, or bbox overflow on a real pipeline diagram. Covers the savepoint tag pattern, the invariant-test-first-then-fix-then-runtime-validator loop, gallery regression vetting with build_gallery and build_render_diff, converting global fixes to conditional ones so other renders aren't pushed around, and the additive-commits-only PR chain rule. For the per-PR vetting workflow (reconcile vs main, /simplify, render+diff, sweep comments, rewrite description, trigger CI, post-merge cleanup), see the `pr-chain-vet` skill. For authoring the mmd content itself (deciding lines, stations, sections), see the `pipeline-metro-diagram` skill. For routine gallery regression testing of nf-metro, see `render-topologies`.
 ---
 
 # Fixing nf-metro Layout Bugs Surfaced by a Real Pipeline Render
@@ -132,31 +132,17 @@ chain pattern:
 - Each subsequent PR is based on the previous PR's branch.
 - As each merges, the next PR's base auto-updates to `main`.
 
-### Strict rules
+The chain-level rule that matters here: **no force-pushes**. Every change
+to a PR in the chain is an additive commit; to undo something already in a
+branch, append a `git revert <hash>`. Rewrites break GitHub review threads
+and silently destroy other people's local state.
 
-- **NO force-pushes.** Every change to a PR is an additive commit. To undo
-  an earlier commit, append a `git revert <hash>` — don't rewrite history.
-- **Each PR must be vetted before review.** The vetting workflow:
-  1. Render the gallery on the PR HEAD.
-  2. Diff against the parent (the prior PR's HEAD, or `main` for the bottom
-     of the chain).
-  3. Inspect every changed example visually. Classify deltas.
-  4. For each detrimental, append a fix commit.
-  5. Run the simplify skill (`/simplify`) on the changed code; commit as a
-     separate refactor commit.
-  6. Sweep narrative comments off the PR. Keep the CI render-preview
-     comment.
-  7. Rewrite the PR description to be standalone: explain the net diff vs
-     `main` without referencing the chain or in-flight history.
-  8. Ensure CI's render-preview workflow ran on the latest commit (append
-     `git commit --allow-empty -m "chore: trigger CI"` if needed).
-
-### After merge
-
-- Delete the remote branch (`gh api -X DELETE
-  repos/<owner>/<repo>/git/refs/heads/<branch>`).
-- Delete the local branch and worktree.
-- Re-target the next PR's base to `main`.
+For the per-PR work of taking one PR from the chain and making it
+mergeable - reconciling against `main`, the `/simplify` pass, gallery
+render+diff, classifying deltas, sweeping narrative comments, rewriting
+the description, triggering CI, and the post-merge re-target/delete order -
+see the `pr-chain-vet` skill. It's the operational counterpart to the
+authoring concerns this skill covers.
 
 ## Step 5: Reconciling stack regressions
 


### PR DESCRIPTION
## Summary

Trim Step 4 of `nf-metro-layout-fix` (the duplicated per-PR vetting workflow) and point at the new `pr-chain-vet` skill instead. Keep the chain-level rule that's still in scope here (no force-pushes, additive commits only). Update the description frontmatter so the cross-link is discoverable from triggering metadata.

## Why

The per-PR vetting workflow (reconcile vs main, `/simplify` pass, render+diff, sweep narrative comments, rewrite description, trigger CI, post-merge re-target+delete) is now captured in detail in `pr-chain-vet` (#313). Keeping a shrunken version in `nf-metro-layout-fix` Step 4 would mean two skills drift apart over time.

This PR scopes `nf-metro-layout-fix` to its actual concern: code-level fixes to nf-metro itself (savepoint, invariant tests, conditional gating), with a one-line pointer at `pr-chain-vet` for the operational vetting side.

> [!NOTE]
> The original task brief referred to "trimming Steps 9-10 of `pipeline-metro-diagram`", but the overlapping content actually lives in `nf-metro-layout-fix` Step 4 (not in `pipeline-metro-diagram`, which only has Steps 1-6 and covers mmd authoring). Trimming `nf-metro-layout-fix` here matches the stated intent.

## Depends on

#313 (the `pr-chain-vet` skill itself). This PR is a follow-up; it's safe to merge in either order, but the cross-reference is most useful once #313 is in.

## Testing

- `nf-metro-layout-fix/SKILL.md` reads coherently end-to-end with Step 4 shrunk.
- Cross-references to `pr-chain-vet`, `pipeline-metro-diagram`, `render-topologies` all resolve to skills that exist (assuming #313 lands).