### PR TITLE
docs(skills): cohort cleanup pass

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,69 @@
+# `.claude/skills`
+
+Claude Code skills for working on and with nf-metro. Skills auto-trigger
+from the descriptions in each `SKILL.md` frontmatter; for the conventions
+each one assumes (local paths, env names, render-preview URL), see the
+preamble at the top of the relevant `SKILL.md`.
+
+## Cohort map
+
+The six skills fall into three conceptual groups.
+
+### Pipeline-side
+
+For someone integrating nf-metro into their own Nextflow pipeline repo:
+
+| Skill | When to use |
+|---|---|
+| [`pipeline-metro-diagram`](pipeline-metro-diagram/SKILL.md) | Author the `.mmd` content for a pipeline's metro map: lines, stations, sections, off-track inputs, the render-inspect-edit iteration loop. |
+| [`pipeline-metro-setup`](pipeline-metro-setup/SKILL.md) | Wire the rendered map into the pipeline repo: file layout, render commands, README image swap, CHANGELOG, install-line pinning (released version vs named-branch on a fork). |
+
+### nf-metro-side authoring
+
+For someone changing nf-metro itself:
+
+| Skill | When to use |
+|---|---|
+| [`fix-issue`](fix-issue/SKILL.md) | General end-to-end workflow for a GitHub issue: worktree, environment, implement, test, push, PR. The "skeleton" most other nf-metro authoring tasks build on. |
+| [`nf-metro-layout-fix`](nf-metro-layout-fix/SKILL.md) | Drive code-level fixes to nf-metro layout when a real pipeline render exposes a bug. Savepoint pattern, invariant-test-first-then-fix-then-runtime-validator loop, conditional gating, the "improvement ratchet". |
+| [`pr-chain-vet`](pr-chain-vet/SKILL.md) | Per-PR vetting on a stacked PR chain: gallery diff vs `main`, classify every changed example, `/simplify` pass, sweep narrative comments, get CI green, post-merge cleanup in the right order. |
+
+### Visual verification
+
+Opt-in only (`disable-model-invocation: true` — the user must invoke
+explicitly):
+
+| Skill | When to use |
+|---|---|
+| [`render-topologies`](render-topologies/SKILL.md) | Local pixel-diff of all gallery renders between the current branch and `origin/main`. Only needed for pre-push confidence; the CI render preview on the PR is the authoritative review. |
+
+## How the skills relate
+
+- `pipeline-metro-diagram`'s "is it mmd or nf-metro?" triage in Step 5
+  hands off to `nf-metro-layout-fix` when the diagnosis is engine-side.
+- `nf-metro-layout-fix` Step 4 hands off to `pr-chain-vet` for the
+  per-PR vetting workflow that ships the resulting chain back to `main`.
+- `pipeline-metro-setup` Stage 2 Case B (named-branch pin on a fork) is
+  the bridge developers use *while* `nf-metro-layout-fix` +
+  `pr-chain-vet` work is in flight.
+- `fix-issue` Step 4 references `render-topologies` for the optional
+  pre-push local diff.
+
+## Conventions
+
+Most skills assume:
+
+- Local nf-metro checkout at `~/projects/nf-metro`
+- Upstream slug `pinin4fjords/nf-metro` (issues + PR targets)
+- CI render preview at `pinin4fjords.github.io/nf-metro/_pr/<N>/`
+
+If your setup differs, substitute in the commands; the conventions are
+called out at the top of each `SKILL.md` so the substitution points are
+visible.
+
+## Step / Stage nomenclature
+
+Most skills use `## Step N: ...` for numbered procedural sections.
+`pipeline-metro-setup` uses `## Stage N: ...` instead — its four stages
+are deliberately coarser-grained (a pipeline-integration journey, not a
+debugging checklist) and the word choice signals that.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -15,7 +15,7 @@ Structured workflow for fixing nf-metro GitHub issues in an isolated worktree.
 - micromamba: `/opt/homebrew/bin/micromamba` (macOS Apple Silicon codesign
   workaround). On other platforms, just `micromamba` if it's on PATH.
 
-## Phase 1: Understand the Issue
+## Step 1: Understand the Issue
 
 ```bash
 gh issue view <N> --repo pinin4fjords/nf-metro
@@ -23,7 +23,7 @@ gh issue view <N> --repo pinin4fjords/nf-metro
 
 Summarize the problem and proposed approach. Wait for user confirmation before proceeding.
 
-## Phase 2: Worktree + Environment Setup
+## Step 2: Worktree + Environment Setup
 
 ```bash
 # Worktree
@@ -39,7 +39,7 @@ pip install -e "/tmp/nf-metro-fix-<N>[docs]"
 
 All subsequent work happens inside `/tmp/nf-metro-fix-<N>`.
 
-## Phase 3: Implement the Fix
+## Step 3: Implement the Fix
 
 The shell cwd resets after each Bash call. Always chain `cd` into the worktree:
 
@@ -49,7 +49,7 @@ source ~/.local/bin/mm-activate nf-metro-fix-<N> && cd /tmp/nf-metro-fix-<N> && 
 
 Fix any failures before proceeding.
 
-## Phase 4: Visual Review
+## Step 4: Visual Review
 
 ### Primary method: CI render preview (recommended)
 
@@ -78,7 +78,7 @@ This is useful for quick iteration but does not replace the full CI gallery revi
 
 If you need a before/after comparison before pushing (e.g. risky change, user wants early feedback), use the `/render-topologies` skill.
 
-## Phase 5: Commit and PR
+## Step 5: Commit and PR
 
 Once tests pass:
 
@@ -102,7 +102,7 @@ EOF
 
 After CI posts the render preview link, ask the user to review it.
 
-## Phase 6: Cleanup
+## Step 6: Cleanup
 
 Offer to clean up (only if user agrees):
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -7,6 +7,14 @@ description: End-to-end workflow for fixing GitHub issues on the nf-metro repo. 
 
 Structured workflow for fixing nf-metro GitHub issues in an isolated worktree.
 
+**Conventions** (substitute if your setup differs):
+- Local nf-metro checkout: `~/projects/nf-metro`
+- Issues + PRs target the canonical upstream `pinin4fjords/nf-metro`. If
+  you're working from a fork, resolve the owner with
+  `gh repo view --json owner -q .owner.login`.
+- micromamba: `/opt/homebrew/bin/micromamba` (macOS Apple Silicon codesign
+  workaround). On other platforms, just `micromamba` if it's on PATH.
+
 ## Phase 1: Understand the Issue
 
 ```bash
@@ -19,7 +27,7 @@ Summarize the problem and proposed approach. Wait for user confirmation before p
 
 ```bash
 # Worktree
-cd /Users/jonathan.manning/projects/nf-metro
+cd ~/projects/nf-metro
 git fetch origin main
 git worktree add /tmp/nf-metro-fix-<N> -b fix/<N>-<slug> origin/main
 
@@ -99,7 +107,7 @@ After CI posts the render preview link, ask the user to review it.
 Offer to clean up (only if user agrees):
 
 ```bash
-cd /Users/jonathan.manning/projects/nf-metro
+cd ~/projects/nf-metro
 git worktree remove /tmp/nf-metro-fix-<N>
 /opt/homebrew/bin/micromamba env remove -n nf-metro-fix-<N> -y
 ```

--- a/.claude/skills/nf-metro-layout-fix/SKILL.md
+++ b/.claude/skills/nf-metro-layout-fix/SKILL.md
@@ -123,50 +123,31 @@ When dispatching agents to do nf-metro work, include in their brief: "you
 must add an invariant test that fails on the bug AND a matching runtime
 validator. Both are mandatory; the fix is not complete without them."
 
-## Step 4: Managing the PR chain back to nf-metro main
+## Step 4: Shipping the chain back to main
 
-Layout fixes accumulate into a stack of PRs against nf-metro `main`. The
-chain pattern:
+Layout fixes accumulate into a stack of PRs against nf-metro `main`: the
+bottom-of-chain PR is based on `main`, each subsequent PR is based on its
+predecessor's branch, and bases auto-retarget as each PR merges.
 
-- The bottom-of-chain PR is based on `main`.
-- Each subsequent PR is based on the previous PR's branch.
-- As each merges, the next PR's base auto-updates to `main`.
+The actual per-PR shipping workflow — worktree setup, reverting
+known-rejected commits, `/simplify` as a separate commit, gallery diff vs
+`main`, classifying every changed example, sweeping narrative comments,
+rewriting the description to be standalone, triggering CI, and the exact
+after-merge cleanup order (re-target children **before** deleting the
+merged branch) — lives in the `pr-chain-vet` skill. Reach for that one
+when you're walking the chain into `main` one PR at a time.
 
-### Strict rules
+A few rules live here as well because they shape how the fixes are written
+in the first place, not just how they're shipped:
 
-- **NO force-pushes.** Every change to a PR is an additive commit. To undo
-  an earlier commit, append a `git revert <hash>` — don't rewrite history.
-- **Each PR must be vetted before review.** The vetting workflow:
-  1. Render the gallery on the PR HEAD.
-  2. Diff against the parent (the prior PR's HEAD, or `main` for the bottom
-     of the chain).
-  3. Inspect every changed example visually. Classify deltas.
-  4. For each detrimental, append a fix commit.
-  5. Run the simplify skill (`/simplify`) on the changed code; commit as a
-     separate refactor commit.
-  6. Sweep narrative comments off the PR. Keep the CI render-preview
-     comment.
-  7. Rewrite the PR description to be standalone: explain the net diff vs
-     `main` without referencing the chain or in-flight history.
-  8. Ensure CI's render-preview workflow ran on the latest commit (append
-     `git commit --allow-empty -m "chore: trigger CI"` if needed).
-
-### After merge
-
-- Delete the remote branch (`gh api -X DELETE
-  repos/<owner>/<repo>/git/refs/heads/<branch>`).
-- Delete the local branch and worktree.
-- Re-target the next PR's base to `main`.
-
-## Step 5: Reconciling stack regressions
-
-When the chain is built progressively, a regression introduced by an early
-PR may only become visible later. The triage workflow:
-
-1. After all fixes land in the savepoint, render every PR's tip (rebased onto
-   main individually) and diff against main.
-2. Classify each PR's effect as I / N / D.
-3. For each detrimental, identify the **earliest** PR where the issue first
-   appears. The fix should be folded back into that PR (as an additive
-   commit on its branch), not as a top-of-stack bolt-on PR.
-4. Re-vet the modified PR + all downstream PRs to confirm no new issues.
+- **No force-pushes.** Every change to a PR is an additive commit. To undo
+  something already in the branch, append a `git revert <hash>` — don't
+  rewrite history.
+- **One concern per commit.** The fix, the `/simplify` pass, and any
+  follow-on detrimental cleanup land as separate commits so each can be
+  read on its own.
+- **Reconciling stack regressions: fold fixes into the earliest PR where
+  the issue first appears,** not as a bolt-on top-of-stack PR. A regression
+  introduced by an early PR may only become visible later in the chain;
+  when that happens, append the fix commit to the offending PR's branch
+  and re-vet that PR plus everything downstream.

--- a/.claude/skills/pr-chain-vet/SKILL.md
+++ b/.claude/skills/pr-chain-vet/SKILL.md
@@ -152,14 +152,18 @@ outcome - skip the commit and move on.
 
 ## Step 5: Render the gallery on PR HEAD
 
+`scripts/build_gallery.py` writes SVGs to `docs/assets/renders/`. Copy
+them to a stable per-PR temp directory so the diff in Step 7 is
+reproducible across iterations:
+
 ```bash
+python scripts/build_gallery.py --debug
 mkdir -p /tmp/gallery-pr<N>
-python scripts/build_gallery.py --debug --out /tmp/gallery-pr<N>
+cp docs/assets/renders/*.svg /tmp/gallery-pr<N>/
 ```
 
-Capture into a stable temporary directory so the diff in Step 7 is
-reproducible. The `--debug` flag draws grid lines and bbox boundaries -
-they make most layout regressions visible at a glance.
+The `--debug` flag draws grid lines and bbox boundaries — they make most
+layout regressions visible at a glance.
 
 ## Step 6: Render the gallery on main (if not cached)
 
@@ -167,8 +171,9 @@ they make most layout regressions visible at a glance.
 # In a separate worktree on main
 git -C /tmp/nf-metro-main fetch origin main
 git -C /tmp/nf-metro-main checkout origin/main
+cd /tmp/nf-metro-main && python scripts/build_gallery.py --debug
 mkdir -p /tmp/gallery-main
-python -C /tmp/nf-metro-main scripts/build_gallery.py --debug --out /tmp/gallery-main
+cp /tmp/nf-metro-main/docs/assets/renders/*.svg /tmp/gallery-main/
 ```
 
 If you already rendered main during a previous PR's vetting pass and `main`
@@ -177,13 +182,16 @@ loop.
 
 ## Step 7: Diff and open the report
 
+`build_render_diff.py` takes an output **directory** and writes
+`index.html` inside it:
+
 ```bash
 python scripts/build_render_diff.py \
   /tmp/gallery-main \
   /tmp/gallery-pr<N> \
-  /tmp/diff-pr<N>.html \
+  /tmp/diff-pr<N> \
   --pr <N>
-open /tmp/diff-pr<N>.html
+open /tmp/diff-pr<N>/index.html
 ```
 
 The diff report renders side-by-side SVGs and flags pixel-level changes.

--- a/.claude/skills/render-topologies/SKILL.md
+++ b/.claude/skills/render-topologies/SKILL.md
@@ -9,6 +9,13 @@ allowed-tools: Bash(rm -rf *), Bash(python *), Bash(open *), Bash(cd *), Bash(gi
 
 Local pixel-diff of all gallery renders between the current branch and `origin/main`. Uses `scripts/build_gallery.py` (the same script CI runs), so local results match the PR render preview.
 
+**Conventions** (substitute if your setup differs):
+- Local nf-metro checkout: `~/projects/nf-metro`
+- Baseline env: `nf-metro-main`; branch env: `nf-metro` (or `nf-metro-fix-<N>` in worktree mode)
+- CI render preview is published at the upstream's GitHub Pages site
+  (`pinin4fjords.github.io/nf-metro/_pr/<N>/`); if you ship from a fork
+  with Pages enabled, the URL will track your fork's owner
+
 **In most cases you don't need this.** Push to a PR and review the CI-generated render preview at `https://pinin4fjords.github.io/nf-metro/_pr/<PR_NUMBER>/` instead. Use this skill only when:
 - You want pre-push confidence before creating a PR
 - The user explicitly asks for a local visual comparison
@@ -19,16 +26,16 @@ Local pixel-diff of all gallery renders between the current branch and `origin/m
 Determine the working mode:
 
 - **Worktree mode**: A worktree exists at `/tmp/nf-metro-fix-<N>` with a matching `nf-metro-fix-<N>` env. Use the worktree path and env for branch renders.
-- **Standalone mode**: Working from the main repo at `/Users/jonathan.manning/projects/nf-metro`. Use the `nf-metro` env for branch renders. Stash or commit any uncommitted changes first.
+- **Standalone mode**: Working from the main repo at `~/projects/nf-metro`. Use the `nf-metro` env for branch renders. Stash or commit any uncommitted changes first.
 
 ## Step 2: Render baseline from main
 
 Update the main repo checkout and render using the shared `nf-metro-main` baseline environment. Install with `[docs]` extras (same as CI).
 
 ```bash
-cd /Users/jonathan.manning/projects/nf-metro && git fetch origin main && git checkout main && git pull origin main
-source ~/.local/bin/mm-activate nf-metro-main && pip install -e "/Users/jonathan.manning/projects/nf-metro[docs]" -q
-cd /Users/jonathan.manning/projects/nf-metro && python scripts/build_gallery.py
+cd ~/projects/nf-metro && git fetch origin main && git checkout main && git pull origin main
+source ~/.local/bin/mm-activate nf-metro-main && pip install -e "$HOME/projects/nf-metro[docs]" -q
+cd ~/projects/nf-metro && python scripts/build_gallery.py
 # SVGs are in docs/assets/renders/ → copy to a baseline dir
 rm -rf /tmp/nf_metro_renders_main && mkdir -p /tmp/nf_metro_renders_main
 cp docs/assets/renders/*.svg /tmp/nf_metro_renders_main/
@@ -52,7 +59,7 @@ Switch back to the branch first (standalone mode) or use the worktree path:
 
 ```bash
 # Standalone: switch back to the branch
-cd /Users/jonathan.manning/projects/nf-metro && git checkout <branch-name>
+cd ~/projects/nf-metro && git checkout <branch-name>
 source ~/.local/bin/mm-activate nf-metro && pip install -e ".[docs]" -q
 python scripts/build_gallery.py
 rm -rf /tmp/nf_metro_renders_branch && mkdir -p /tmp/nf_metro_renders_branch

--- a/.claude/skills/render-topologies/SKILL.md
+++ b/.claude/skills/render-topologies/SKILL.md
@@ -41,18 +41,6 @@ rm -rf /tmp/nf_metro_renders_main && mkdir -p /tmp/nf_metro_renders_main
 cp docs/assets/renders/*.svg /tmp/nf_metro_renders_main/
 ```
 
-Convert SVGs to PNGs for pixel diffing:
-
-```bash
-source ~/.local/bin/mm-activate nf-metro-main
-python -c "
-import cairosvg
-from pathlib import Path
-for svg in sorted(Path('/tmp/nf_metro_renders_main').glob('*.svg')):
-    cairosvg.svg2png(url=str(svg), write_to=str(svg.with_suffix('.png')), scale=2)
-"
-```
-
 ## Step 3: Render from the current branch
 
 Switch back to the branch first (standalone mode) or use the worktree path:
@@ -72,71 +60,37 @@ rm -rf /tmp/nf_metro_renders_branch && mkdir -p /tmp/nf_metro_renders_branch
 cp /tmp/nf-metro-fix-<N>/docs/assets/renders/*.svg /tmp/nf_metro_renders_branch/
 ```
 
-Convert SVGs to PNGs:
+## Step 4: Diff and open the report
+
+Use `scripts/build_render_diff.py` — the same script the CI render-preview
+workflow uses — to compare the two SVG directories. It writes a
+self-contained HTML page (`index.html`) showing side-by-side before/after
+for changed examples only, grouped by section.
 
 ```bash
-python -c "
-import cairosvg
-from pathlib import Path
-for svg in sorted(Path('/tmp/nf_metro_renders_branch').glob('*.svg')):
-    cairosvg.svg2png(url=str(svg), write_to=str(svg.with_suffix('.png')), scale=2)
-"
+cd ~/projects/nf-metro
+rm -rf /tmp/render_diff && mkdir -p /tmp/render_diff
+python scripts/build_render_diff.py \
+  /tmp/nf_metro_renders_main \
+  /tmp/nf_metro_renders_branch \
+  /tmp/render_diff
+open /tmp/render_diff/index.html
 ```
 
-## Step 4: Diff and open changed renders
-
-Clean previous comparison files, diff each PNG pair, copy changed renders with sequential numbering (BEFORE/AFTER adjacent when flipping with arrow keys):
-
-```python
-from PIL import Image, ImageChops
-import os, glob, shutil
-
-# Clean previous comparison files
-for f in glob.glob("/tmp/*_BEFORE.png") + glob.glob("/tmp/*_AFTER.png"):
-    os.remove(f)
-
-main_dir = "/tmp/nf_metro_renders_main"
-branch_dir = "/tmp/nf_metro_renders_branch"
-
-pngs = sorted(f for f in os.listdir(branch_dir) if f.endswith('.png'))
-changed = []
-for name in pngs:
-    path_main = os.path.join(main_dir, name)
-    if not os.path.exists(path_main):
-        changed.append(name)  # new file
-        continue
-    im_b = Image.open(os.path.join(branch_dir, name))
-    im_m = Image.open(path_main)
-    if im_b.size != im_m.size or ImageChops.difference(im_b, im_m).getbbox():
-        changed.append(name)
-
-print(f"{len(changed)} changed, {len(pngs) - len(changed)} unchanged")
-for i, name in enumerate(changed):
-    stem = name.replace('.png', '')
-    idx = i * 2 + 1
-    main_path = os.path.join(main_dir, name)
-    if os.path.exists(main_path):
-        shutil.copy(main_path, f"/tmp/{idx:02d}_{stem}_BEFORE.png")
-    shutil.copy(os.path.join(branch_dir, name), f"/tmp/{idx+1:02d}_{stem}_AFTER.png")
-    print(f"  {name}")
-```
-
-**IMPORTANT**: Write the diff script to a file (`/tmp/diff_renders.py`) and run it with `python3`, rather than inlining Python in the shell. Inline Python with `!=` gets mangled by shell escaping.
-
-```bash
-# Open all pairs sorted so BEFORE/AFTER interleave correctly (skip if zero changed)
-ls /tmp/[0-9][0-9]_*_BEFORE.png /tmp/[0-9][0-9]_*_AFTER.png | sort | xargs open -a Preview
-```
+Exit codes: `0` = changes detected and report written, `2` = no changes
+(skip `open`), `1` = error. The report works directly on SVGs, so no
+PNG conversion is needed.
 
 ## Step 5: Report
 
-- Count of changed vs unchanged renders
-- List changed file names
-- If zero changed, say so and skip Preview
+- Whether any examples changed (the script's exit code tells you)
+- For changed examples, point the user at `/tmp/render_diff/index.html`
+- If zero changed, say so and skip `open`
 
 ## Notes
 
 - Render script: `scripts/build_gallery.py` (same as CI PR render preview workflow).
+- Diff script: `scripts/build_render_diff.py` (also matches CI), so local results match the PR render preview.
 - Nextflow fixtures (`tests/fixtures/nextflow/*.mmd`) are included in the gallery.
 - Baseline always uses `nf-metro-main` env + main repo updated to `origin/main`.
 - Install with `[docs]` extras (not `[dev]`) to match CI dependencies.


### PR DESCRIPTION
Pass over the six skills in `.claude/skills/` to address overlap and portability
issues that accumulated as the cohort grew. Five focused commits.

## What changes

- **`docs(skills): add cohort README`** - new `.claude/skills/README.md` mapping
  the six skills into three groups (pipeline-side, nf-metro-side authoring,
  visual verification) with a "how the skills relate" section spelling out the
  handoff points.

- **Dedupe `nf-metro-layout-fix` ↔ `pr-chain-vet`** - layout-fix Steps 4-5
  duplicated workflow that pr-chain-vet now owns in detail. Collapse to a
  pointer at pr-chain-vet, keeping only the rules that shape how fixes get
  *written* (no force-push, one concern per commit, fold regressions into the
  earliest PR).

- **Fix command typos in `pr-chain-vet`** - `build_gallery.py` doesn't accept
  `--out`, `python -C` isn't a flag (likely a slip from `git -C`), and
  `build_render_diff.py` takes an output directory, not a `.html` file.
  Verified against the actual scripts.

- **Generalize hardcoded paths** - `fix-issue` and `render-topologies` baked
  in `/Users/jonathan.manning/projects/nf-metro`. Replace with `~/projects/nf-metro`
  (or `\$HOME` inside double-quoted pip args, where tilde expansion is
  suppressed) and add a "Conventions" preamble at the top of each.
  Project-canonical refs (`pinin4fjords/nf-metro`, the Pages URL) are left
  alone and documented as upstream.

- **Use `scripts/build_render_diff.py` in `render-topologies`** - replace ~30
  lines of inline PIL pixel-diff Python + Preview.app workflow with one call
  to the script the CI render-preview uses. Local results now match the PR
  preview. Drops the self-contradicting "IMPORTANT: write the diff script to
  a file rather than inlining" note. Skill is ~50 lines lighter.

- **Normalize nomenclature** - `fix-issue` used "Phase N" while every other
  procedural skill used "Step N". Normalize. `pipeline-metro-setup`'s "Stage N"
  stays (coarser-grained integration journey, deliberate; documented in README).

## Test plan

- [ ] Render the gallery on main, then on a branch, and run \`scripts/build_render_diff.py\`
      per the new \`render-topologies\` Step 4 to confirm the simplified flow works
- [ ] Confirm \`pr-chain-vet\` Steps 5-7 commands resolve against current \`scripts/\`
- [ ] Read \`.claude/skills/README.md\` cold and check it accurately maps the cohort

🤖 Generated with [Claude Code](https://claude.com/claude-code)