### PR TITLE
feat(parser): support %%metro center_ports: directive

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -85,9 +85,10 @@ def cli() -> None:
 )
 @click.option(
     "--center-ports/--no-center-ports",
-    default=False,
+    default=None,
     help="Centre inter-section ports on the shorter of the two connected "
-    "sections, so lines enter/exit at the visual midpoint.",
+    "sections, so lines enter/exit at the visual midpoint. When unset, "
+    "the value of the %%metro center_ports: directive (if any) is used.",
 )
 @click.option(
     "--section-x-gap",
@@ -127,7 +128,7 @@ def render(
     logo: Path | None,
     line_order: str | None,
     straight_diamonds: bool,
-    center_ports: bool,
+    center_ports: bool | None,
     section_x_gap: float | None,
     section_y_gap: float | None,
     from_nextflow: bool,
@@ -155,8 +156,8 @@ def render(
     if not straight_diamonds:
         graph.diamond_style = "symmetric"
 
-    if center_ports:
-        graph.center_ports = True
+    if center_ports is not None:
+        graph.center_ports = center_ports
 
     if logo is not None:
         graph.logo_path = str(logo)

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -233,6 +233,9 @@ def _parse_directive(
     elif content.startswith("compact_offsets:"):
         val = content[len("compact_offsets:") :].strip().lower()
         graph.compact_offsets = val in ("true", "yes", "1")
+    elif content.startswith("center_ports:"):
+        val = content[len("center_ports:") :].strip().lower()
+        graph.center_ports = val in ("true", "yes", "1")
     elif content.startswith("legend_min_height:"):
         try:
             graph.legend_min_height = float(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,3 +115,53 @@ def test_render_nonexistent_file():
     runner = CliRunner()
     result = runner.invoke(cli, ["render", "/nonexistent/file.mmd"])
     assert result.exit_code != 0
+
+
+def test_render_center_ports_cli_flag_accepted(tmp_path):
+    """--center-ports / --no-center-ports flags both render successfully."""
+    out = tmp_path / "out.svg"
+    runner = CliRunner()
+    for flag in ("--center-ports", "--no-center-ports"):
+        result = runner.invoke(cli, ["render", str(RNASEQ_MMD), "-o", str(out), flag])
+        assert result.exit_code == 0, f"{flag}: {result.output}"
+        assert out.exists()
+
+
+def test_render_center_ports_cli_overrides_directive(tmp_path, monkeypatch):
+    """CLI --no-center-ports overrides a mmd %%metro center_ports: true directive."""
+    from nf_metro.parser.mermaid import parse_metro_mermaid
+
+    captured: dict = {}
+    original_compute_layout = None
+
+    import nf_metro.cli as cli_mod
+
+    original_compute_layout = cli_mod.compute_layout
+
+    def spy_compute_layout(graph, **kw):
+        captured["center_ports"] = graph.center_ports
+        return original_compute_layout(graph, **kw)
+
+    monkeypatch.setattr(cli_mod, "compute_layout", spy_compute_layout)
+
+    mmd_text = "%%metro center_ports: true\n" + RNASEQ_MMD.read_text()
+    mmd = tmp_path / "with_directive.mmd"
+    mmd.write_text(mmd_text)
+    out = tmp_path / "out.svg"
+    runner = CliRunner()
+
+    # Directive alone -> True
+    result = runner.invoke(cli, ["render", str(mmd), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert captured["center_ports"] is True
+
+    # CLI --no-center-ports overrides directive
+    result = runner.invoke(
+        cli, ["render", str(mmd), "-o", str(out), "--no-center-ports"]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["center_ports"] is False
+
+    # Sanity check: parser alone preserves the directive
+    parsed = parse_metro_mermaid(mmd_text)
+    assert parsed.center_ports is True

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -39,6 +39,26 @@ def test_parse_line_order_invalid_ignored():
     assert graph.line_order == "definition"
 
 
+def test_center_ports_directive_default():
+    text = "graph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.center_ports is False
+
+
+@pytest.mark.parametrize("value", ["true", "True", "TRUE", "yes", "1"])
+def test_center_ports_directive_parsed_truthy(value):
+    text = f"%%metro center_ports: {value}\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.center_ports is True
+
+
+@pytest.mark.parametrize("value", ["false", "False", "no", "0", "anything"])
+def test_center_ports_directive_parsed_falsy(value):
+    text = f"%%metro center_ports: {value}\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.center_ports is False
+
+
 def test_parse_lines():
     text = (
         "%%metro line: main | Main Line | #ff0000\n"


### PR DESCRIPTION
## Summary
- Adds a graph-level `%%metro center_ports: true|false` directive (case-insensitive, accepts `true|yes|1`) so mmd files can opt into vertical centering of inter-section ports without requiring the `--center-ports` CLI flag at render time.
- Parsed in `src/nf_metro/parser/mermaid.py` alongside `compact_offsets:` and the other graph-level directives; sets `MetroGraph.center_ports`.
- The `--center-ports/--no-center-ports` CLI flag now defaults to `None` and overrides the directive when explicitly passed. Omitting the flag falls back to whatever the directive sets (or `False`).

## Test plan
- [x] `test_center_ports_directive_default` - default `graph.center_ports` is `False`
- [x] `test_center_ports_directive_parsed_truthy` (parametrized: `true`, `True`, `TRUE`, `yes`, `1`)
- [x] `test_center_ports_directive_parsed_falsy` (parametrized: `false`, `False`, `no`, `0`, junk)
- [x] `test_render_center_ports_cli_flag_accepted` - both flag forms render OK
- [x] `test_render_center_ports_cli_overrides_directive` - mmd directive sets `True`, `--no-center-ports` flips back to `False`, parser-only path preserves directive
- [x] Full pytest suite: 804 passed (was 791)
- [x] `ruff format .` + `ruff check .` clean

## Follow-ups
- The differentialabundance gallery map (PR #319) will start using `%%metro center_ports: true` once this lands - small additive commit already prepared on `feat/gallery-differentialabundance`.