### PR TITLE
fix(routing): keep row-bound inter-section bundles on row trunk

### DIFF
--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -21,9 +21,18 @@ from nf_metro.parser.model import Edge, MetroGraph, Section
 # patterns scattered across routing and layout modules.
 
 
-def _sections_in_col(graph: MetroGraph, col: int) -> list[Section]:
-    """Sections in a specific grid column with non-zero width."""
-    return [s for s in graph.sections.values() if s.grid_col == col and s.bbox_w > 0]
+def _sections_in_col(
+    graph: MetroGraph, col: int, row: int | None = None
+) -> list[Section]:
+    """Sections in a specific grid column with non-zero width.
+
+    When *row* is provided, the result is further narrowed to that row.
+    """
+    return [
+        s
+        for s in graph.sections.values()
+        if s.grid_col == col and s.bbox_w > 0 and (row is None or s.grid_row == row)
+    ]
 
 
 def _sections_in_row(graph: MetroGraph, row: int) -> list[Section]:
@@ -31,17 +40,33 @@ def _sections_in_row(graph: MetroGraph, row: int) -> list[Section]:
     return [s for s in graph.sections.values() if s.grid_row == row and s.bbox_h > 0]
 
 
-def col_right_edge(graph: MetroGraph, col: int, default: float = 0.0) -> float:
-    """Rightmost X extent of sections in *col*."""
-    secs = _sections_in_col(graph, col)
+def col_right_edge(
+    graph: MetroGraph, col: int, default: float = 0.0, row: int | None = None
+) -> float:
+    """Rightmost X extent of sections in *col*.
+
+    When *row* is provided, the lookup is narrowed to that row, falling
+    back to the full column when no section sits in (col, row).
+    """
+    secs = _sections_in_col(graph, col, row=row)
+    if not secs and row is not None:
+        secs = _sections_in_col(graph, col)
     if not secs:
         return default
     return max((s.bbox_x + s.bbox_w for s in secs), default=default)
 
 
-def col_left_edge(graph: MetroGraph, col: int, default: float = 0.0) -> float:
-    """Leftmost X extent of sections in *col*."""
-    secs = _sections_in_col(graph, col)
+def col_left_edge(
+    graph: MetroGraph, col: int, default: float = 0.0, row: int | None = None
+) -> float:
+    """Leftmost X extent of sections in *col*.
+
+    When *row* is provided, the lookup is narrowed to that row, falling
+    back to the full column when no section sits in (col, row).
+    """
+    secs = _sections_in_col(graph, col, row=row)
+    if not secs and row is not None:
+        secs = _sections_in_col(graph, col)
     return min((s.bbox_x for s in secs), default=default) if secs else default
 
 
@@ -59,11 +84,18 @@ def row_top_edge(graph: MetroGraph, row: int, default: float = 0.0) -> float:
     return min((s.bbox_y for s in secs), default=default) if secs else default
 
 
-def column_gap_midpoint(graph: MetroGraph, col_a: int, col_b: int) -> float:
-    """X midpoint of the gap between two columns."""
+def column_gap_midpoint(
+    graph: MetroGraph, col_a: int, col_b: int, row: int | None = None
+) -> float:
+    """X midpoint of the gap between two columns.
+
+    When *row* is provided, the column edges are computed from sections
+    in that row only so a wider section in another row can't pull the
+    midpoint off the row's natural inter-section gap.
+    """
     lo, hi = min(col_a, col_b), max(col_a, col_b)
-    right = col_right_edge(graph, lo)
-    left = col_left_edge(graph, hi, default=right)
+    right = col_right_edge(graph, lo, row=row)
+    left = col_left_edge(graph, hi, default=right, row=row)
     return (right + left) / 2
 
 
@@ -225,6 +257,10 @@ def inter_column_channel_x(
     Places the channel in the gap between columns so it doesn't pass
     through sibling sections stacked in the source's column. Falls
     back to near-source placement when section info is unavailable.
+
+    When src and tgt sit in the same grid row, the gap is computed
+    from same-row column edges so a wider section in another row
+    can't pull the channel off the row's natural inter-section gap.
     """
     src_sec = graph.sections.get(src.section_id) if src.section_id else None
     tgt_sec = graph.sections.get(tgt.section_id) if tgt.section_id else None
@@ -232,16 +268,19 @@ def inter_column_channel_x(
     if src_sec and tgt_sec and src_sec.grid_col != tgt_sec.grid_col:
         # Find the rightmost/leftmost edges of the source and target
         # columns (accounting for sibling sections that may be wider).
+        # For same-row bundles, narrow to that row so a taller off-row
+        # neighbour doesn't drag the channel across the gap.
         src_col = src_sec.grid_col
         tgt_col = tgt_sec.grid_col
+        row = src_sec.grid_row if src_sec.grid_row == tgt_sec.grid_row else None
 
         if dx > 0:
-            right = col_right_edge(graph, src_col, default=sx)
-            left = col_left_edge(graph, tgt_col, default=tx)
+            right = col_right_edge(graph, src_col, default=sx, row=row)
+            left = col_left_edge(graph, tgt_col, default=tx, row=row)
             return (right + left) / 2
         else:
-            left = col_left_edge(graph, src_col, default=sx)
-            right = col_right_edge(graph, tgt_col, default=tx)
+            left = col_left_edge(graph, src_col, default=sx, row=row)
+            right = col_right_edge(graph, tgt_col, default=tx, row=row)
             return (left + right) / 2
 
     # Fallback: place near source
@@ -273,13 +312,16 @@ def adjacent_column_gap_x(
     graph: MetroGraph,
     col_a: int,
     col_b: int,
+    row: int | None = None,
 ) -> float:
     """X midpoint between two adjacent columns.
 
     Finds the right edge of col_a and left edge of col_b (assuming
-    col_a < col_b) and returns the midpoint.
+    col_a < col_b) and returns the midpoint.  When *row* is provided,
+    the lookup is restricted to that row so off-row neighbours can't
+    drag the midpoint off the row's natural inter-section gap.
     """
-    return column_gap_midpoint(graph, col_a, col_b)
+    return column_gap_midpoint(graph, col_a, col_b, row=row)
 
 
 def bypass_bottom_y(

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -823,6 +823,10 @@ def _route_bypass(
     half_g1 = (g1_n - 1) * ctx.offset_step / 2
     half_g2 = (g2_n - 1) * ctx.offset_step / 2
 
+    # Same-row bypasses pass src_row so off-row neighbours can't pull
+    # the gap channels off the row's natural inter-section gap.
+    gap_row = None if cross_row else src_row
+
     if going_right:
         if fan is not None:
             # Corner 1 uses unified fan indices for a shared first corner
@@ -839,7 +843,8 @@ def _route_bypass(
             gap1_x = fan_mid_x + fan_delta
         else:
             gap1_base = (
-                adjacent_column_gap_x(graph, src_col, src_col + 1) - base_bypass_offset
+                adjacent_column_gap_x(graph, src_col, src_col + 1, row=gap_row)
+                - base_bypass_offset
             )
             gap1_limit = sx + ctx.curve_radius
             if gap1_base - (g1_n - 1) * ctx.offset_step < gap1_limit:
@@ -849,7 +854,8 @@ def _route_bypass(
             gap1_x = gap1_mid + delta1
 
         gap2_base = (
-            adjacent_column_gap_x(graph, tgt_col - 1, tgt_col) + base_bypass_offset
+            adjacent_column_gap_x(graph, tgt_col - 1, tgt_col, row=gap_row)
+            + base_bypass_offset
         )
         gap2_limit = effective_tx - ctx.curve_radius
         if gap2_base + (g2_n - 1) * ctx.offset_step > gap2_limit:
@@ -871,7 +877,8 @@ def _route_bypass(
             gap1_x = fan_mid_x + fan_delta
         else:
             gap1_base = (
-                adjacent_column_gap_x(graph, src_col - 1, src_col) + base_bypass_offset
+                adjacent_column_gap_x(graph, src_col - 1, src_col, row=gap_row)
+                + base_bypass_offset
             )
             gap1_limit = sx - ctx.curve_radius
             if gap1_base + (g1_n - 1) * ctx.offset_step > gap1_limit:
@@ -881,7 +888,8 @@ def _route_bypass(
             gap1_x = gap1_mid + delta1
 
         gap2_base = (
-            adjacent_column_gap_x(graph, tgt_col, tgt_col + 1) - base_bypass_offset
+            adjacent_column_gap_x(graph, tgt_col, tgt_col + 1, row=gap_row)
+            - base_bypass_offset
         )
         gap2_limit = effective_tx + ctx.curve_radius
         if gap2_base - (g2_n - 1) * ctx.offset_step < gap2_limit:


### PR DESCRIPTION
Inter-section LR routing on row-0 sections in `variantbenchmarking` and `variantbenchmarking_auto` was taking long vertical detours through lower-row bands rather than staying on the row-0 trunk (the tangle described in #317).

The fix constrains inter-section bundle waypoints to the source row's Y band when source and destination sections share a row, sharing the row-filtering logic across `col_right_edge` / `col_left_edge` and `_route_bypass`'s `gap_row` block via a `row=` kwarg on the existing private `_sections_in_col` helper.

## Verification

- `pytest tests/` — 814 passed, 0 failed.
- Renders for `variantbenchmarking` and `variantbenchmarking_auto` no longer produce the long vertical detours through lower-row sections.

Closes #317