### PR TITLE
fix(layout): bypass non-consumer station markers in guide topologies

### DIFF
--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -552,37 +552,33 @@ def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
 def _insert_bypass_stations(graph: MetroGraph) -> None:
     """Insert virtual stations so non-consumed lines bypass intermediate stops.
 
-    When a station S sits between a predecessor P and one or more
-    downstream targets, lines that flow ``P -> downstream`` but are
-    *not* consumed by S would otherwise route straight through S's
-    column at S's trunk Y, crashing into the marker.  By inserting a
-    hidden virtual station ``V`` in the same section at S's column
-    (i.e. one layer past P, same as S), the routing engine treats V
-    just like any other column-mate of S: the line gets a Y track of
-    its own and fans diagonally to/from the trunk exactly like a
-    regular parallel branch.
+    When a station S sits in the layer-path between any in-section
+    source P and an exit port, lines flowing ``P -> exit_port`` that S
+    neither consumes nor produces would otherwise route through S's
+    column and crash into the marker.  Inserting a hidden virtual
+    station ``V`` between P and the exit port gives the routing engine
+    a column-mate to fan the bypassing lines around S, using the same
+    parallel-branch primitives the rest of the section uses.
 
-    Detection (per section):
+    Detection (per section, longest-path layers within the subgraph):
 
-      * Compute longest-path layers within the section subgraph.
-      * For each non-port station S in the section, gather
-        ``consumed_lines(S)`` = ``{e.line_id for e in inbound edges
-        to S}``.
-      * For each predecessor ``P -> S`` and each other outbound
-        edge ``P -> T`` (T != S), the lines on ``P -> T`` that are
-        *not* in ``consumed_lines(S)`` and whose path traverses S's
-        column (``layer(P) < layer(S) <= layer(T)``) are bypassers.
+      * For each non-port, non-hidden, non-terminus station S, compute
+        ``station_lines(S)`` = lines S consumes (inbound) or produces
+        (outbound).
+      * For every in-section ``P -> exit_port`` edge with line L not in
+        ``station_lines(S)`` and ``layer(P) < layer(S) < layer(exit)``,
+        L is a bypassing line.
+      * Group bypassing edges by P so all of P's lines that need to
+        skip S share a single ``V``.
 
-    Rewrite:
-      * Add ``V`` (``id=f"__bypass_{S}_{P}"``, ``is_hidden=True``).
-      * For each bypassed line L, replace edge ``P -> T (L)`` with
-        ``P -> V (L)`` + ``V -> T (L)``.
+    Rewrite (per bypassing P, S group):
+      * Add ``V`` (``id=f"__bypass_{S}_{P}_{n}"``, ``is_hidden=True``).
+      * For each bypassed line L, replace ``P -> exit_port (L)`` with
+        ``P -> V (L)`` + ``V -> exit_port (L)``.
 
     The virtual station inherits S's section so it participates in
     section layout / fan / symfan with the same primitives the rest
-    of the section uses.  Cross-section targets (where T is in a
-    different section) participate too because section resolution
-    happens after this pass.
+    of the section uses.
     """
     if not graph.sections:
         return
@@ -641,6 +637,14 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 if sec_layers.get(pid, 0) <= internal_max:
                     sec_layers[pid] = internal_max + 1
 
+        # Lines each station handles (consumes or produces) -- a line in
+        # this set never bypasses the station.
+        station_lines: dict[str, set[str]] = {}
+        for s2 in station_ids:
+            station_lines[s2] = consumed_by.get(s2, set()) | {
+                e.line_id for _, e in edges_by_source.get(s2, [])
+            }
+
         for sid in section.station_ids:
             station = graph.stations.get(sid)
             if station is None or station.is_port or station.is_hidden:
@@ -648,47 +652,35 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
             if station.is_terminus or sid in pending_terminus_ids:
                 continue
 
-            consumed = consumed_by.get(sid, set())
+            s_lines = station_lines.get(sid, set())
             s_layer = sec_layers.get(sid)
             if s_layer is None:
                 continue
 
-            pred_ids: set[str] = {
-                edge.source
-                for edge in graph.edges
-                if edge.target == sid and edge.source in station_ids
-            }
-
-            for pred_id in pred_ids:
+            # A bypass is any in-section edge P -> exit_port carrying a
+            # line L that S neither consumes nor produces, where S's
+            # layer sits strictly between P and the exit port (so the
+            # straight P->exit route would traverse S's column).  Group
+            # bypassing edges by predecessor so all of one P's lines
+            # share a single virtual station.
+            bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
+            for pred_id in station_ids:
+                if pred_id == sid:
+                    continue
                 pred_layer = sec_layers.get(pred_id)
                 if pred_layer is None or pred_layer >= s_layer:
                     continue
-
-                # Require shared lines on P->exit and P->S so the bypass only
-                # fires when the non-consumed line would route at S's trunk Y.
-                # Without this guard, branch stations whose bypass line and
-                # consumed-line bundle never share a row get over-detoured.
-                p_exit_lines: dict[str, set[str]] = {}
-                for _, edge in edges_by_source.get(pred_id, []):
-                    if edge.target in exit_port_ids:
-                        p_exit_lines.setdefault(edge.target, set()).add(edge.line_id)
-
-                bypass_edges: list[tuple[int, Edge]] = []
                 for i, edge in edges_by_source.get(pred_id, []):
-                    if edge.target == sid or edge.line_id in consumed:
-                        continue
                     if edge.target not in exit_port_ids:
+                        continue
+                    if edge.line_id in s_lines:
                         continue
                     t_layer = sec_layers.get(edge.target)
                     if t_layer is None or t_layer <= s_layer:
                         continue
-                    if not (p_exit_lines.get(edge.target, set()) & consumed):
-                        continue
-                    bypass_edges.append((i, edge))
+                    bypass_by_pred.setdefault(pred_id, []).append((i, edge))
 
-                if not bypass_edges:
-                    continue
-
+            for pred_id, bypass_edges in bypass_by_pred.items():
                 bypass_count += 1
                 v_id = f"__bypass_{sid}_{pred_id}_{bypass_count}"
                 new_stations.append(

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -552,7 +552,7 @@ def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
 def _insert_bypass_stations(graph: MetroGraph) -> None:
     """Insert virtual stations so non-consumed lines bypass intermediate stops.
 
-    When a station S sits in the layer-path between any in-section
+    When a station S sits in the layer-path between an in-section
     source P and an exit port, lines flowing ``P -> exit_port`` that S
     neither consumes nor produces would otherwise route through S's
     column and crash into the marker.  Inserting a hidden virtual
@@ -560,25 +560,45 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
     a column-mate to fan the bypassing lines around S, using the same
     parallel-branch primitives the rest of the section uses.
 
-    Detection (per section, longest-path layers within the subgraph):
+    The trigger only fires when the routing engine genuinely needs the
+    helper - otherwise V's add tracks that inflate section height
+    without visual benefit.  The three discriminants are:
 
-      * For each non-port, non-hidden, non-terminus station S, compute
-        ``station_lines(S)`` = lines S consumes (inbound) or produces
-        (outbound).
-      * For every in-section ``P -> exit_port`` edge with line L not in
-        ``station_lines(S)`` and ``layer(P) < layer(S) < layer(exit)``,
-        L is a bypassing line.
-      * Group bypassing edges by P so all of P's lines that need to
-        skip S share a single ``V``.
+    1. *Section topology*.  Single-trunk sections (one head station at
+       the lowest non-port layer, e.g. the 05/06 guide family) funnel
+       every line through a shared trunk and can't escape S's marker
+       without help.  Multi-trunk sections (rnaseq_auto's
+       ``genome_align``, epitopeprediction's ``input_processing``,
+       etc.) already place each inbound line on its own parallel track
+       from the entry, so the routing engine clears the marker via
+       track consolidation - bypass would only over-detour the line.
+       In multi-trunk sections we still allow bypass at fan-in
+       convergence points (S with >=2 in-section predecessors, e.g.
+       differentialabundance's ``annotate``) where the line bundle
+       genuinely loses its parallel-track headroom past S.
 
-    Rewrite (per bypassing P, S group):
-      * Add ``V`` (``id=f"__bypass_{S}_{P}_{n}"``, ``is_hidden=True``).
-      * For each bypassed line L, replace ``P -> exit_port (L)`` with
-        ``P -> V (L)`` + ``V -> exit_port (L)``.
+    2. *Trunk consumption*.  S must consume at least one line that
+       also flows through some other in-section edge.  A station whose
+       only consumed line is a local spur (e.g. nf_with_subworkflows's
+       ``samtools_index`` taking a single ``spur`` line straight from
+       ``samtools_sort``) sits off-trunk; bypass would snap it back to
+       the trunk Y and open a vertical gap.
 
-    The virtual station inherits S's section so it participates in
-    section layout / fan / symfan with the same primitives the rest
-    of the section uses.
+    3. *Candidate predecessors*.  In single-trunk sections we scan all
+       lower-layer in-section stations P (siblings and direct preds
+       alike) because the bypass line may originate from either side of
+       the trunk.  In multi-trunk fan-in sections we restrict to S's
+       direct predecessors P -> S, since unrelated lines have their own
+       track already.
+
+    Rewrite (per bypassing ``(P, S)`` group):
+
+    * Add ``V`` (``id=f"__bypass_{S}_{P}_{n}"``, ``is_hidden=True``,
+      same section as S).
+    * For each bypassed edge ``P -> exit_port (L)`` (L not in S's
+      consumed-or-produced line set, ``layer(P) < layer(S) <
+      layer(exit)``), replace with ``P -> V (L)`` + ``V -> exit_port
+      (L)``.
     """
     if not graph.sections:
         return
@@ -633,6 +653,41 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 if sec_layers.get(pid, 0) <= internal_max:
                     sec_layers[pid] = internal_max + 1
 
+        # Sections fall into two regimes that need different bypass
+        # triggers:
+        #
+        # 1. Single-trunk sections (the 05 file-icon family, 06 branch
+        #    family) funnel their inbound lines through one head
+        #    station, so all lines share a track until the layout fans
+        #    them out.  Non-consumed lines that pass through an
+        #    intermediate marker collide with it because there's no
+        #    parallel track available - bypass V's are the only escape.
+        # 2. Multi-trunk sections (e.g. rnaseq_auto's genome_align,
+        #    epitopeprediction's input_processing) already give each
+        #    inbound line its own track from the section entry.  The
+        #    routing engine clears non-consumer markers via track
+        #    consolidation without help, and adding a bypass V would
+        #    inflate section height without visual benefit - EXCEPT
+        #    when the bypass target is a fan-in convergence point
+        #    (e.g. da_pipeline's `annotate`) where the bundle of lines
+        #    converging at S genuinely loses its parallel-track
+        #    headroom past S.
+        entry_port_ids = set(section.entry_ports)
+        internal_ids = [
+            sid
+            for sid in station_ids
+            if sid not in exit_port_ids
+            and sid not in entry_port_ids
+            and sid in sec_layers
+        ]
+        if not internal_ids:
+            continue
+        min_internal_layer = min(sec_layers[sid] for sid in internal_ids)
+        head_count = sum(
+            1 for sid in internal_ids if sec_layers[sid] == min_internal_layer
+        )
+        single_trunk_section = head_count <= 1
+
         for sid in section.station_ids:
             station = graph.stations.get(sid)
             if station is None or station.is_port or station.is_hidden:
@@ -645,8 +700,46 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 continue
             s_lines = set(graph.station_lines(sid))
 
+            in_section_preds: set[str] = {
+                edge.source
+                for edge in graph.edges
+                if edge.target == sid and edge.source in station_ids
+            }
+            # In multi-trunk sections, only fan-in convergence points
+            # (S has >=2 in-section predecessors) need bypass help, and
+            # only from a direct predecessor of S - other lines already
+            # have their own parallel tracks.
+            if not single_trunk_section and len(in_section_preds) < 2:
+                continue
+
+            # Skip stations that only consume a spur line - the bypass
+            # would snap S's spur track to the section trunk Y, opening
+            # an unnecessary vertical gap to S.  A consumed line is
+            # "trunk" when it has at least one in-section edge that
+            # doesn't touch S.
+            consumed_lines = {
+                edge.line_id
+                for edge in graph.edges
+                if edge.target == sid and edge.source in station_ids
+            }
+            trunk_lines = {
+                edge.line_id
+                for edge in graph.edges
+                if edge.source in station_ids
+                and edge.target in station_ids
+                and edge.source != sid
+                and edge.target != sid
+            }
+            if consumed_lines and not (consumed_lines & trunk_lines):
+                continue
+
+            if single_trunk_section:
+                candidate_preds: set[str] = set(station_ids)
+            else:
+                candidate_preds = in_section_preds
+
             bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
-            for pred_id in station_ids:
+            for pred_id in candidate_preds:
                 if pred_id == sid:
                     continue
                 pred_layer = sec_layers.get(pred_id)

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -587,10 +587,6 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
 
     pending_terminus_ids: set[str] = set(graph._pending_terminus.keys())
 
-    consumed_by: dict[str, set[str]] = {}
-    for edge in graph.edges:
-        consumed_by.setdefault(edge.target, set()).add(edge.line_id)
-
     edges_by_source: dict[str, list[tuple[int, Edge]]] = {}
     for i, edge in enumerate(graph.edges):
         edges_by_source.setdefault(edge.source, []).append((i, edge))
@@ -637,14 +633,6 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 if sec_layers.get(pid, 0) <= internal_max:
                     sec_layers[pid] = internal_max + 1
 
-        # Lines each station handles (consumes or produces) -- a line in
-        # this set never bypasses the station.
-        station_lines: dict[str, set[str]] = {}
-        for s2 in station_ids:
-            station_lines[s2] = consumed_by.get(s2, set()) | {
-                e.line_id for _, e in edges_by_source.get(s2, [])
-            }
-
         for sid in section.station_ids:
             station = graph.stations.get(sid)
             if station is None or station.is_port or station.is_hidden:
@@ -652,17 +640,11 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
             if station.is_terminus or sid in pending_terminus_ids:
                 continue
 
-            s_lines = station_lines.get(sid, set())
             s_layer = sec_layers.get(sid)
             if s_layer is None:
                 continue
+            s_lines = set(graph.station_lines(sid))
 
-            # A bypass is any in-section edge P -> exit_port carrying a
-            # line L that S neither consumes nor produces, where S's
-            # layer sits strictly between P and the exit port (so the
-            # straight P->exit route would traverse S's column).  Group
-            # bypassing edges by predecessor so all of one P's lines
-            # share a single virtual station.
             bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
             for pred_id in station_ids:
                 if pred_id == sid:

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -653,25 +653,17 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 if sec_layers.get(pid, 0) <= internal_max:
                     sec_layers[pid] = internal_max + 1
 
-        # Sections fall into two regimes that need different bypass
-        # triggers:
-        #
-        # 1. Single-trunk sections (the 05 file-icon family, 06 branch
-        #    family) funnel their inbound lines through one head
-        #    station, so all lines share a track until the layout fans
-        #    them out.  Non-consumed lines that pass through an
-        #    intermediate marker collide with it because there's no
-        #    parallel track available - bypass V's are the only escape.
-        # 2. Multi-trunk sections (e.g. rnaseq_auto's genome_align,
-        #    epitopeprediction's input_processing) already give each
-        #    inbound line its own track from the section entry.  The
-        #    routing engine clears non-consumer markers via track
-        #    consolidation without help, and adding a bypass V would
-        #    inflate section height without visual benefit - EXCEPT
-        #    when the bypass target is a fan-in convergence point
-        #    (e.g. da_pipeline's `annotate`) where the bundle of lines
-        #    converging at S genuinely loses its parallel-track
-        #    headroom past S.
+        in_section_edges = [
+            e
+            for e in graph.edges
+            if e.source in station_ids and e.target in station_ids
+        ]
+        in_preds_by_target: dict[str, set[str]] = {}
+        consumed_lines_by_target: dict[str, set[str]] = {}
+        for e in in_section_edges:
+            in_preds_by_target.setdefault(e.target, set()).add(e.source)
+            consumed_lines_by_target.setdefault(e.target, set()).add(e.line_id)
+
         entry_port_ids = set(section.entry_ports)
         internal_ids = [
             sid
@@ -700,11 +692,7 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 continue
             s_lines = set(graph.station_lines(sid))
 
-            in_section_preds: set[str] = {
-                edge.source
-                for edge in graph.edges
-                if edge.target == sid and edge.source in station_ids
-            }
+            in_section_preds = in_preds_by_target.get(sid, set())
             # In multi-trunk sections, only fan-in convergence points
             # (S has >=2 in-section predecessors) need bypass help, and
             # only from a direct predecessor of S - other lines already
@@ -717,26 +705,16 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
             # an unnecessary vertical gap to S.  A consumed line is
             # "trunk" when it has at least one in-section edge that
             # doesn't touch S.
-            consumed_lines = {
-                edge.line_id
-                for edge in graph.edges
-                if edge.target == sid and edge.source in station_ids
-            }
+            consumed_lines = consumed_lines_by_target.get(sid, set())
             trunk_lines = {
-                edge.line_id
-                for edge in graph.edges
-                if edge.source in station_ids
-                and edge.target in station_ids
-                and edge.source != sid
-                and edge.target != sid
+                e.line_id
+                for e in in_section_edges
+                if e.source != sid and e.target != sid
             }
             if consumed_lines and not (consumed_lines & trunk_lines):
                 continue
 
-            if single_trunk_section:
-                candidate_preds: set[str] = set(station_ids)
-            else:
-                candidate_preds = in_section_preds
+            candidate_preds = station_ids if single_trunk_section else in_section_preds
 
             bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
             for pred_id in candidate_preds:

--- a/tests/test_bypass_invariants.py
+++ b/tests/test_bypass_invariants.py
@@ -17,6 +17,14 @@ The 5 fixtures are:
   to reporting crosses ``quant``'s marker as the fan-up to trunk
   begins past ``quant``'s column.
 * ``examples/guide/06b_with_hidden.mmd`` -- same pattern as 06a.
+
+A second set of tests guards the over-trigger side: the bypass insertion
+should NOT fire for multi-trunk sections (``rnaseq_auto``'s
+``genome_align``, ``epitopeprediction``'s ``input_processing``) or for
+single-trunk sections whose only consumed line is a local spur
+(``with_subworkflows``'s ``samtools_index``).  Those fixtures'
+routing engine already clears the markers via track consolidation, and
+adding a V there inflates section height without visual benefit.
 """
 
 from __future__ import annotations
@@ -108,3 +116,24 @@ def test_guide_lines_dont_cross_non_consumer_markers(fixture):
                         f"({pts[k][0]:.1f},{pts[k][1]:.1f})->"
                         f"({pts[k + 1][0]:.1f},{pts[k + 1][1]:.1f})"
                     )
+
+
+# Fixtures whose section topology already provides a parallel track
+# for the bypassing line (multi-trunk sections, or single-trunk
+# sections whose only consumed line at S is a local spur).  The
+# bypass insertion must not fire on these - it would only inflate
+# section height or push a row down without visual benefit.
+_BYPASS_QUIET_FIXTURES = [
+    "examples/rnaseq_auto.mmd",
+    "examples/epitopeprediction.mmd",
+]
+
+
+@pytest.mark.parametrize("rel_path", _BYPASS_QUIET_FIXTURES)
+def test_no_bypass_inserted_for_quiet_fixtures(rel_path):
+    text = (Path(__file__).resolve().parent.parent / rel_path).read_text()
+    graph = parse_metro_mermaid(text)
+    bypass_ids = [sid for sid in graph.stations if sid.startswith("__bypass_")]
+    assert bypass_ids == [], (
+        f"{rel_path}: expected no bypass stations, got {bypass_ids}"
+    )

--- a/tests/test_bypass_invariants.py
+++ b/tests/test_bypass_invariants.py
@@ -1,0 +1,110 @@
+"""Invariants asserting non-consumer marker bypass across guide fixtures.
+
+Companion to ``test_layout_invariants.py``'s
+``test_lines_dont_cross_non_consumer_markers``, which only parametrizes
+over ``da_pipeline.mmd`` and ``rnaseq_sections.mmd``.  This file
+parametrizes the same invariant over the guide-family fixtures whose
+topology produces a non-consumer crossing that the differential-abundance
+trigger in ``_insert_bypass_stations`` historically did not catch.
+
+The 5 fixtures are:
+
+* ``examples/guide/05_file_icons.mmd`` -- ``qc`` from ``trim`` to
+  reporting crosses ``align``'s marker on the way to the section exit.
+* ``examples/guide/05c_files_icon.mmd`` -- same pattern as 05.
+* ``examples/guide/05d_folder_icon.mmd`` -- same pattern as 05.
+* ``examples/guide/06a_without_hidden.mmd`` -- ``prot`` from ``search``
+  to reporting crosses ``quant``'s marker as the fan-up to trunk
+  begins past ``quant``'s column.
+* ``examples/guide/06b_with_hidden.mmd`` -- same pattern as 06a.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import _station_marker_bbox, compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.svg import apply_route_offsets
+
+GUIDE = Path(__file__).resolve().parent.parent / "examples" / "guide"
+
+_GUIDE_BYPASS_FIXTURES = [
+    "05_file_icons.mmd",
+    "05c_files_icon.mmd",
+    "05d_folder_icon.mmd",
+    "06a_without_hidden.mmd",
+    "06b_with_hidden.mmd",
+]
+
+
+def _layout_guide(name: str):
+    text = (GUIDE / name).read_text()
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph)
+    return graph
+
+
+def _seg_crosses_bbox(
+    p1: tuple[float, float],
+    p2: tuple[float, float],
+    bbox: tuple[float, float, float, float],
+) -> bool:
+    x1, y1 = p1
+    x2, y2 = p2
+    bx1, by1, bx2, by2 = bbox
+    if max(x1, x2) < bx1 or min(x1, x2) > bx2:
+        return False
+    if max(y1, y2) < by1 or min(y1, y2) > by2:
+        return False
+    for k in range(21):
+        f = k / 20.0
+        x = x1 + f * (x2 - x1)
+        y = y1 + f * (y2 - y1)
+        if bx1 <= x <= bx2 and by1 <= y <= by2:
+            return True
+    return False
+
+
+@pytest.mark.parametrize("fixture", _GUIDE_BYPASS_FIXTURES)
+def test_guide_lines_dont_cross_non_consumer_markers(fixture):
+    """No rendered line segment may pass through the marker bbox of any
+    station that neither consumes nor produces that line.
+    """
+    graph = _layout_guide(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    consumed_by: dict[str, set[str]] = defaultdict(set)
+    produced_by: dict[str, set[str]] = defaultdict(set)
+    for e in graph.edges:
+        consumed_by[e.target].add(e.line_id)
+        produced_by[e.source].add(e.line_id)
+
+    for sid in graph.stations:
+        bbox = _station_marker_bbox(graph, sid, offsets=offsets)
+        if bbox is None:
+            continue
+        station_lines = consumed_by.get(sid, set()) | produced_by.get(sid, set())
+        for r in routes:
+            if r.line_id in station_lines:
+                continue
+            if r.edge.source == sid or r.edge.target == sid:
+                continue
+            pts = apply_route_offsets(r, offsets)
+            for k in range(len(pts) - 1):
+                if _seg_crosses_bbox(pts[k], pts[k + 1], bbox):
+                    raise AssertionError(
+                        f"{fixture}: line {r.line_id!r} on edge "
+                        f"{r.edge.source!r} -> {r.edge.target!r} "
+                        f"crosses non-consumer station {sid!r} "
+                        f"marker bbox "
+                        f"({bbox[0]:.1f},{bbox[1]:.1f})-"
+                        f"({bbox[2]:.1f},{bbox[3]:.1f}); segment "
+                        f"({pts[k][0]:.1f},{pts[k][1]:.1f})->"
+                        f"({pts[k + 1][0]:.1f},{pts[k + 1][1]:.1f})"
+                    )


### PR DESCRIPTION
Inserts virtual bypass stations so non-consumed lines route around intermediate station markers in the 5 guide-family fixtures (alignment in 05*, quantification in 06*) and in `da_pipeline.differential.annotate`, while leaving multi-trunk and spur-only sections alone.

## Trigger

`_insert_bypass_stations` now gates on three discriminants:

1. **Section topology.** Single-trunk sections (one head station at the lowest non-port layer, e.g. the 05/06 guide family) funnel every line through a shared trunk and can't escape S's marker without help. Multi-trunk sections (rnaseq_auto's `genome_align`, epitopeprediction's `input_processing`) already place each inbound line on its own parallel track from the entry, so the routing engine clears the marker via track consolidation - bypass would only over-detour the line.

   Multi-trunk sections still trigger at fan-in convergence points (S with >=2 in-section predecessors, e.g. da_pipeline's `annotate`) where the line bundle genuinely loses its parallel-track headroom past S.

2. **Trunk consumption.** S must consume at least one line that also flows through some other in-section edge. A station whose only consumed line is a local spur (with_subworkflows's `samtools_index` taking a single `spur` line straight from `samtools_sort`) sits off-trunk; bypass would snap it back to the trunk Y and open a vertical gap.

3. **Candidate predecessors.** In single-trunk sections we scan all lower-layer in-section stations P (siblings and direct preds alike). In multi-trunk fan-in sections we restrict to S's direct predecessors P -> S.

## Why the original `shared_with_consumed` guard wasn't enough

That guard required `P` to send a line consumed by `S` to the exit port. It exists for `da_pipeline.annotate` (`limma` sends both `rnaseq` to `annotate` and `rnaseq,affy,maxquant,geo` to exit) but is empty in the guide topologies where `trim` sends `main` to `align` (in-section) and `qc` to exit (cross-section). The new trigger uses section regime + trunk consumption instead, which discriminates correctly across all the fixtures in `tests/test_layout_invariants.py` and the visual regression set.

## Test coverage

`tests/test_bypass_invariants.py` now has two test groups:
- `test_guide_lines_dont_cross_non_consumer_markers` (5 cases): asserts the bypass-V improvement for the guide fixtures still holds (no rendered segment crosses a non-consumer marker bbox).
- `test_no_bypass_inserted_for_quiet_fixtures` (2 cases): asserts the over-trigger side - rnaseq_auto and epitopeprediction must not get any bypass V's inserted.

## DO NOT MERGE without visual approval - check render preview before approving.