### PR TITLE
fix(layout): snap single-line passthrough stations to pred/succ Y band

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -790,6 +790,13 @@ def _compute_section_layout(
     # claim; multi-row layouts with content-filled rows are untouched.
     _tighten_lower_rows_after_shrink(graph, section_y_gap)
 
+    # Phase 13ka: Pull single-line passthrough stations into the
+    # ``[min(pred.y, succ.y), max(pred.y, succ.y)]`` band so their
+    # route doesn't dive past the pred/succ Y range and climb back
+    # (closes #317).  Conservative gates preserve pure fan-out
+    # diagrams.
+    _snap_single_line_passthrough_to_band(graph, x_spacing)
+
     # Phase 13k: Shift sparse loop-side stations (e.g. ``grea`` -- one
     # incoming, one outgoing, single-line consumer) onto a half-grid Y
     # when sharing the full-row Y with a busier sibling whose inbound
@@ -2511,6 +2518,190 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                 continue
             for sid in trunk_members:
                 graph.stations[sid].x = target_x
+
+
+def _snap_single_line_passthrough_to_band(
+    graph: MetroGraph,
+    x_spacing: float,
+) -> None:
+    """Pull a single-line passthrough station into its pred/succ Y band.
+
+    Targets stations S in an LR/RL section where:
+
+      * S carries exactly one line and is the only non-port stop of
+        that line in the section,
+      * S has exactly one same-section predecessor P and one same-
+        section successor T (the section's hub and exit port for a
+        typical fan-out branch), and
+      * S currently sits outside ``[min(P.y, T.y), max(P.y, T.y)]``.
+
+    Such a station was placed by the per-line track allocator at a Y
+    far from both P and T (e.g. ``gatk4_conc`` in variantbenchmarking,
+    sitting at y=742 between a hub at y=460 and an exit port at
+    y=507), forcing the route to dive down to S and climb back up for
+    no payload reason.  Snapping S into the band straightens the
+    route.
+
+    The candidate Y is chosen as the band endpoint closer to S's
+    current Y, then nudged toward the midpoint when neither endpoint
+    has a free slot in S's column.  The marker X is offset by a half
+    ``x_spacing`` step toward P when an on-band same-column sibling
+    would otherwise sit at the snapped (x, y).
+
+    Conservative gates:
+
+      * Skip when every off-band sibling is itself a candidate
+        (pure fan-out diagrams keep their parallel tracks).
+      * Skip when a busier multi-line non-hub sibling already sits
+        on the snap target Y in S's column (its bundle would route
+        through S's marker after the snap).
+    """
+    if not graph.sections:
+        return
+
+    in_by_tgt: dict[str, list[Edge]] = defaultdict(list)
+    out_by_src: dict[str, list[Edge]] = defaultdict(list)
+    for e in graph.edges:
+        in_by_tgt[e.target].append(e)
+        out_by_src[e.source].append(e)
+
+    # Single-line, non-port, non-hidden stops per (section, line).
+    # Hub markers (full-bundle) are implicitly excluded by the
+    # ``len(lines) == 1`` filter.
+    single_line_stops: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for sid, st in graph.stations.items():
+        if not st.section_id or st.is_port or st.is_hidden:
+            continue
+        lines = graph.station_lines(sid)
+        if len(lines) != 1:
+            continue
+        single_line_stops[(st.section_id, lines[0])].append(sid)
+
+    half_step = x_spacing / 2.0
+
+    for section in graph.sections.values():
+        if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
+            continue
+        port_ids = set(section.entry_ports) | set(section.exit_ports)
+
+        candidates: list[tuple[Station, float, float, float]] = []
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            st = graph.stations.get(sid)
+            if st is None or st.is_port or st.is_hidden or st.off_track:
+                continue
+            lines = graph.station_lines(sid)
+            if len(lines) != 1:
+                continue
+            (lid,) = lines
+            if len(single_line_stops.get((section.id, lid), [])) != 1:
+                continue
+            ins = in_by_tgt.get(sid, [])
+            outs = out_by_src.get(sid, [])
+            if len(ins) != 1 or len(outs) != 1:
+                continue
+            pred = graph.stations.get(ins[0].source)
+            succ = graph.stations.get(outs[0].target)
+            if pred is None or succ is None:
+                continue
+            band_lo = min(pred.y, succ.y)
+            band_hi = max(pred.y, succ.y)
+            if band_lo - 0.5 <= st.y <= band_hi + 0.5:
+                continue
+            candidates.append((st, band_lo, band_hi, pred.x))
+
+        if not candidates:
+            continue
+
+        # Skip when every off-band sibling is a candidate too: pulling
+        # all of them onto the band would collapse a fan-out diagram
+        # (e.g. mismatched_tracks's parallel branches).
+        cand_ids = {id(c[0]) for c in candidates}
+        has_other_off_band = False
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            sib_st = graph.stations.get(sid)
+            if (
+                sib_st is None
+                or sib_st.is_port
+                or sib_st.is_hidden
+                or sib_st.off_track
+                or id(sib_st) in cand_ids
+            ):
+                continue
+            # Off-band relative to ANY candidate's band suffices; the
+            # gate is that the section has non-candidate content
+            # outside a candidate's pred/succ band.
+            for _, lo, hi, _ in candidates:
+                if not (lo - 0.5 <= sib_st.y <= hi + 0.5):
+                    has_other_off_band = True
+                    break
+            if has_other_off_band:
+                break
+        if not has_other_off_band:
+            continue
+
+        # Collect on-band same-column occupancy so we can pick a
+        # collision-free snap Y for each candidate.
+        column_y_occupied: dict[float, list[float]] = defaultdict(list)
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            sib_st = graph.stations.get(sid)
+            if (
+                sib_st is None
+                or sib_st.is_port
+                or sib_st.is_hidden
+                or sib_st.off_track
+                or id(sib_st) in cand_ids
+            ):
+                continue
+            column_y_occupied[round(sib_st.x, 3)].append(sib_st.y)
+
+        for st, band_lo, band_hi, pred_x in candidates:
+            # Prefer the band endpoint closer to the station's
+            # current Y so the snap moves the marker as little as
+            # possible.
+            if abs(st.y - band_lo) <= abs(st.y - band_hi):
+                snap_y = band_lo
+            else:
+                snap_y = band_hi
+            col_xs = column_y_occupied.get(round(st.x, 3), [])
+            collides = any(abs(snap_y - y) < 1.0 for y in col_xs)
+            new_x = st.x
+            if collides:
+                # Nudge X by a half pitch toward the predecessor so
+                # the marker lands between the column and the hub.
+                toward_pred = 1.0 if pred_x > st.x else -1.0
+                new_x = st.x + toward_pred * half_step
+            # Final guard: a busier multi-line non-hub sibling on the
+            # snap row in the same column would have its bundle route
+            # through the snapped marker.  Skip the snap in that case.
+            blocked = False
+            for sib_sid in section.station_ids:
+                if sib_sid in port_ids:
+                    continue
+                sib = graph.stations.get(sib_sid)
+                if (
+                    sib is None
+                    or sib.is_port
+                    or sib.is_hidden
+                    or sib.off_track
+                    or id(sib) == id(st)
+                ):
+                    continue
+                if abs(sib.x - new_x) > 1.0 or abs(sib.y - snap_y) > 1.0:
+                    continue
+                if len(graph.station_lines(sib_sid)) > 1:
+                    blocked = True
+                    break
+            if blocked:
+                continue
+            st.x = new_x
+            st.y = snap_y
+            column_y_occupied.setdefault(round(new_x, 3), []).append(snap_y)
 
 
 def _shift_sparse_loop_stations_to_clear_bundle(

--- a/tests/test_inter_section_routing_invariants.py
+++ b/tests/test_inter_section_routing_invariants.py
@@ -1,0 +1,121 @@
+"""Inter-section and intra-section routing invariants.
+
+These tests catch the U-shaped detour that occurs when a fan-out
+section places a single-line passthrough station far off the trunk
+row.  The line then dives from the hub trunk Y down to the station's
+per-line track Y and climbs back up to the exit-port Y for no
+payload reason (the symptom described in #317).
+
+The invariant: for a station S that is the only consumer of its line
+within an LR/RL section, with one predecessor P and one successor T,
+S's Y must lie within the [min(P.y, T.y), max(P.y, T.y)] band so the
+route doesn't dip below (or rise above) the source-to-target band.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+# 1px slack absorbs sub-pixel rounding from fan-recenter passes.
+_Y_TOL = 1.0
+
+
+def _layout_example(name: str, **kwargs) -> MetroGraph:
+    text = (EXAMPLES / name).read_text()
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, **kwargs)
+    return graph
+
+
+def _in_section_edges(
+    graph: MetroGraph, section_id: str
+) -> tuple[dict[str, list], dict[str, list]]:
+    """Return per-target and per-source edge maps restricted to a section."""
+    in_by_tgt: dict[str, list] = defaultdict(list)
+    out_by_src: dict[str, list] = defaultdict(list)
+    sids = set(graph.sections[section_id].station_ids)
+    for e in graph.edges:
+        if e.source in sids and e.target in sids:
+            in_by_tgt[e.target].append(e)
+            out_by_src[e.source].append(e)
+    return in_by_tgt, out_by_src
+
+
+@pytest.mark.parametrize(
+    "example_name",
+    ["variantbenchmarking.mmd", "variantbenchmarking_auto.mmd"],
+)
+def test_single_line_passthrough_station_stays_in_pred_succ_band(
+    example_name: str,
+) -> None:
+    """Single-line passthrough stations must sit in the [pred.y, succ.y] band.
+
+    A passthrough station S in an LR/RL section is one whose line has
+    no other stop in the same section, with exactly one same-section
+    predecessor and one same-section successor.  Placing S outside
+    the [min(P.y, T.y), max(P.y, T.y)] band produces a U-shaped
+    detour visible in the rendered route (#317).
+    """
+    graph = _layout_example(example_name)
+
+    # Count non-port, non-hidden stations per (section, line) so we
+    # can identify lines with exactly one real stop in the section.
+    # Hub/port markers are excluded because every line passes through
+    # the section's entry/exit ports by definition.
+    stations_per_section_line: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for sid, st in graph.stations.items():
+        if st.is_port or st.is_hidden or not st.section_id:
+            continue
+        # Skip stations that carry the section's full bundle: they're
+        # hub/trunk markers, not single-line stops.
+        lines = graph.station_lines(sid)
+        if len(lines) > 1:
+            continue
+        for lid in lines:
+            stations_per_section_line[(st.section_id, lid)].append(sid)
+
+    failures: list[str] = []
+    for section in graph.sections.values():
+        if section.direction not in ("LR", "RL") or section.bbox_h <= 0:
+            continue
+        in_by_tgt, out_by_src = _in_section_edges(graph, section.id)
+        for sid in section.station_ids:
+            st = graph.stations.get(sid)
+            if st is None or st.is_port or st.is_hidden or st.off_track:
+                continue
+            lines = graph.station_lines(sid)
+            if len(lines) != 1:
+                continue
+            (lid,) = lines
+            if len(stations_per_section_line.get((section.id, lid), [])) != 1:
+                continue
+            ins = in_by_tgt.get(sid, [])
+            outs = out_by_src.get(sid, [])
+            if len(ins) != 1 or len(outs) != 1:
+                continue
+            pred = graph.stations.get(ins[0].source)
+            succ = graph.stations.get(outs[0].target)
+            if pred is None or succ is None:
+                continue
+            band_lo = min(pred.y, succ.y) - _Y_TOL
+            band_hi = max(pred.y, succ.y) + _Y_TOL
+            if not (band_lo <= st.y <= band_hi):
+                failures.append(
+                    f"{section.id}/{sid} (line={lid}): "
+                    f"y={st.y:.2f} not in [{band_lo:.2f}, {band_hi:.2f}] "
+                    f"(pred={pred.y:.2f}, succ={succ.y:.2f})"
+                )
+
+    assert not failures, (
+        f"Single-line passthrough stations out of pred/succ band in "
+        f"{example_name}:\n  " + "\n  ".join(failures)
+    )


### PR DESCRIPTION
Addresses issue #317 (inter-section routing dip in variantbenchmarking).

## The bug
Lines through the benchmarking section in \`variantbenchmarking.mmd\` and \`variantbenchmarking_auto.mmd\` dive far below their natural Y for no payload reason. Concordance (orange, #FFB300) path on main:
- Path 1: \`M1328.66,589.2\` -> dives to \`(1289.77, 848.26)\` -> \`(1212.5, 858.2)\`
- Path 2: \`M1212.5,858.2\` -> climbs back to \`(1091.33, 589.2)\`

A 270px vertical detour with no payload reason; both endpoints sit at y=589.

## Root cause
Single-line passthrough stations (one consumer, one pred, one succ) are placed at their per-line track Y inside fan sections rather than within the pred/succ Y band. The downstream routing engine respects the placement and produces the dip.

## Fix
After fan-section layout, snap any station with \`len(consumers)==1 && len(preds)==1 && len(succs)==1 && len(lines)==1\` into the \`[min(pred.y, succ.y), max(pred.y, succ.y)]\` band.

## Test coverage
New \`tests/test_inter_section_routing_invariants.py\` parametrised over both variantbenchmarking fixtures. Verified to FAIL on main before fix, PASS after.

## Known regression
This fix breaks \`tests/test_grid_alignment.py::TestVariantbenchmarkingSpacing::test_benchmarking_layer1_same_x\`. The existing test asserts specific X coordinates for benchmarking-layer-1 stations under the old (off-trunk) placement. The X-alignment claim becomes meaningless when Y is constrained because the stations now share Y rather than spreading vertically. Needs either: (a) test re-keyed onto a different anchor, (b) different fix approach, (c) test acknowledged as superseded.

## Why prior attempts (#328, #329) failed
Both routed-around the symptom (manipulating waypoints) rather than addressing root cause (placement). #329 happened to straighten the orange line but inappropriately routed a different line through the Variant Statistics station. This PR addresses placement directly.

## DO NOT MERGE without visual approval - check render preview AND resolve the regression first.

Refs: #317