### PR TITLE
fix(layout): anchor fork-group distribution on trunk member

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -678,9 +678,11 @@ def _compute_section_layout(
     # the trunk bundle stays perfectly horizontal across boundaries.
     # Picks the downstream entry port's Y as the anchor since it sits
     # on the row's aligned trunk grid.  Junctions are re-positioned
-    # afterwards because Phase 12 fixed their Y to the old exit port Y.
-    if _snap_inter_section_port_pairs(graph):
-        _position_junctions(graph)
+    # afterwards: Phase 12 fixed their Y to the pre-compaction exit
+    # port Y, and either the snap pass or ``_compact_row_content_to_bbox_top``
+    # may have moved the exit port since then.
+    _snap_inter_section_port_pairs(graph)
+    _position_junctions(graph)
 
     # Phase 13d: Fan a section's free content upward when the row's
     # compaction left visible empty space at the bbox top.  Only fires

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -594,18 +594,12 @@ def _equalize_fork_groups(
         pred_tracks = [
             tracks[p] for sid in group for p in G.predecessors(sid) if p in tracks
         ]
-
-        if not pred_tracks:
-            base_track = tracks[group[0]]
-            for i, sid in enumerate(group):
-                tracks[sid] = base_track + i * line_gap
-            continue
-
-        pred_mean = sum(pred_tracks) / len(pred_tracks)
+        pred_mean = sum(pred_tracks) / len(pred_tracks) if pred_tracks else None
 
         def _anchor_key(sid: str) -> tuple:
             t = tracks[sid]
-            return (-len(graph.station_lines(sid)), abs(t - pred_mean), t)
+            pred_dist = abs(t - pred_mean) if pred_mean is not None else 0.0
+            return (-len(graph.station_lines(sid)), pred_dist, t)
 
         anchor_idx = min(range(len(group)), key=lambda i: _anchor_key(group[i]))
         anchor_track = tracks[group[anchor_idx]]

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -590,29 +590,25 @@ def _equalize_fork_groups(
         # Distribute as signed offsets around an anchor so the column
         # stays centred on the trunk feeding the fork.  Anchor key:
         # most lines first (the in-column trunk), then closest to the
-        # mean predecessor track, then lowest current track.
-        #
-        # Source columns (no predecessors) have no trunk to centre on;
-        # fall back to top-anchored distribution from the group's lowest
-        # track so hidden hubs and exit ports stay at the section top
-        # rather than drifting to the column centre.
+        # mean predecessor track, then lowest current track.  Source
+        # columns (no predecessors) have no trunk to centre on, so the
+        # anchor falls to group[0] (the topmost station), keeping
+        # hidden hubs and exit ports at the section top rather than
+        # drifting to the column centre.
         pred_tracks = [
             tracks[p] for sid in group for p in G.predecessors(sid) if p in tracks
         ]
+        if pred_tracks:
+            pred_mean = sum(pred_tracks) / len(pred_tracks)
 
-        if not pred_tracks:
-            base_track = tracks[group[0]]
-            for i, sid in enumerate(group):
-                tracks[sid] = base_track + i * line_gap
-            continue
+            def _anchor_key(sid: str) -> tuple:
+                t = tracks[sid]
+                return (-len(graph.station_lines(sid)), abs(t - pred_mean), t)
 
-        pred_mean = sum(pred_tracks) / len(pred_tracks)
+            anchor_idx = min(range(len(group)), key=lambda i: _anchor_key(group[i]))
+        else:
+            anchor_idx = 0
 
-        def _anchor_key(sid: str) -> tuple:
-            t = tracks[sid]
-            return (-len(graph.station_lines(sid)), abs(t - pred_mean), t)
-
-        anchor_idx = min(range(len(group)), key=lambda i: _anchor_key(group[i]))
         anchor_track = tracks[group[anchor_idx]]
         for i, sid in enumerate(group):
             tracks[sid] = anchor_track + (i - anchor_idx) * line_gap

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -587,10 +587,36 @@ def _equalize_fork_groups(
             if max(spacings) - min(spacings) < 0.01:
                 continue
 
-        # Compact to consecutive positions starting from the lowest track
-        base_track = tracks[group[0]]
+        # Choose an anchor and distribute siblings as signed offsets
+        # around it so the column stays centred on the trunk feeding it
+        # rather than walking downward from the topmost member.
+        #
+        # Anchor preference:
+        #   1. The column member carrying the most lines (this is the
+        #      "in-column trunk" used by `_redistribute_fanout_siblings`
+        #      and similar phases).
+        #   2. Tie-break: the member whose current track is closest to
+        #      the average track of the group's predecessor(s) -- the
+        #      "natural" trunk Y feeding the fork.
+        #   3. Final tie-break: the member at the lowest current track,
+        #      preserving the prior behaviour for fully symmetric cases.
+        preds_union: set[str] = set()
+        for sid in group:
+            preds_union.update(G.predecessors(sid))
+        pred_tracks = [tracks[p] for p in preds_union if p in tracks]
+        pred_anchor = sum(pred_tracks) / len(pred_tracks) if pred_tracks else None
+
+        def _anchor_key(sid: str) -> tuple:
+            nlines = len(graph.station_lines(sid))
+            pred_dist = (
+                abs(tracks[sid] - pred_anchor) if pred_anchor is not None else 0.0
+            )
+            return (-nlines, pred_dist, tracks[sid])
+
+        anchor_idx = min(range(len(group)), key=lambda i: _anchor_key(group[i]))
+        anchor_track = tracks[group[anchor_idx]]
         for i, sid in enumerate(group):
-            tracks[sid] = base_track + i * line_gap
+            tracks[sid] = anchor_track + (i - anchor_idx) * line_gap
 
 
 def _reorder_by_span(graph: MetroGraph, line_order: list[str]) -> list[str]:

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -594,12 +594,18 @@ def _equalize_fork_groups(
         pred_tracks = [
             tracks[p] for sid in group for p in G.predecessors(sid) if p in tracks
         ]
-        pred_mean = sum(pred_tracks) / len(pred_tracks) if pred_tracks else None
+
+        if not pred_tracks:
+            base_track = tracks[group[0]]
+            for i, sid in enumerate(group):
+                tracks[sid] = base_track + i * line_gap
+            continue
+
+        pred_mean = sum(pred_tracks) / len(pred_tracks)
 
         def _anchor_key(sid: str) -> tuple:
             t = tracks[sid]
-            pred_dist = abs(t - pred_mean) if pred_mean is not None else 0.0
-            return (-len(graph.station_lines(sid)), pred_dist, t)
+            return (-len(graph.station_lines(sid)), abs(t - pred_mean), t)
 
         anchor_idx = min(range(len(group)), key=lambda i: _anchor_key(group[i]))
         anchor_track = tracks[group[anchor_idx]]

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -591,15 +591,26 @@ def _equalize_fork_groups(
         # stays centred on the trunk feeding the fork.  Anchor key:
         # most lines first (the in-column trunk), then closest to the
         # mean predecessor track, then lowest current track.
+        #
+        # Source columns (no predecessors) have no trunk to centre on;
+        # fall back to top-anchored distribution from the group's lowest
+        # track so hidden hubs and exit ports stay at the section top
+        # rather than drifting to the column centre.
         pred_tracks = [
             tracks[p] for sid in group for p in G.predecessors(sid) if p in tracks
         ]
-        pred_mean = sum(pred_tracks) / len(pred_tracks) if pred_tracks else None
+
+        if not pred_tracks:
+            base_track = tracks[group[0]]
+            for i, sid in enumerate(group):
+                tracks[sid] = base_track + i * line_gap
+            continue
+
+        pred_mean = sum(pred_tracks) / len(pred_tracks)
 
         def _anchor_key(sid: str) -> tuple:
             t = tracks[sid]
-            pred_dist = abs(t - pred_mean) if pred_mean is not None else 0.0
-            return (-len(graph.station_lines(sid)), pred_dist, t)
+            return (-len(graph.station_lines(sid)), abs(t - pred_mean), t)
 
         anchor_idx = min(range(len(group)), key=lambda i: _anchor_key(group[i]))
         anchor_track = tracks[group[anchor_idx]]

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -587,31 +587,19 @@ def _equalize_fork_groups(
             if max(spacings) - min(spacings) < 0.01:
                 continue
 
-        # Choose an anchor and distribute siblings as signed offsets
-        # around it so the column stays centred on the trunk feeding it
-        # rather than walking downward from the topmost member.
-        #
-        # Anchor preference:
-        #   1. The column member carrying the most lines (this is the
-        #      "in-column trunk" used by `_redistribute_fanout_siblings`
-        #      and similar phases).
-        #   2. Tie-break: the member whose current track is closest to
-        #      the average track of the group's predecessor(s) -- the
-        #      "natural" trunk Y feeding the fork.
-        #   3. Final tie-break: the member at the lowest current track,
-        #      preserving the prior behaviour for fully symmetric cases.
-        preds_union: set[str] = set()
-        for sid in group:
-            preds_union.update(G.predecessors(sid))
-        pred_tracks = [tracks[p] for p in preds_union if p in tracks]
-        pred_anchor = sum(pred_tracks) / len(pred_tracks) if pred_tracks else None
+        # Distribute as signed offsets around an anchor so the column
+        # stays centred on the trunk feeding the fork.  Anchor key:
+        # most lines first (the in-column trunk), then closest to the
+        # mean predecessor track, then lowest current track.
+        pred_tracks = [
+            tracks[p] for sid in group for p in G.predecessors(sid) if p in tracks
+        ]
+        pred_mean = sum(pred_tracks) / len(pred_tracks) if pred_tracks else None
 
         def _anchor_key(sid: str) -> tuple:
-            nlines = len(graph.station_lines(sid))
-            pred_dist = (
-                abs(tracks[sid] - pred_anchor) if pred_anchor is not None else 0.0
-            )
-            return (-nlines, pred_dist, tracks[sid])
+            t = tracks[sid]
+            pred_dist = abs(t - pred_mean) if pred_mean is not None else 0.0
+            return (-len(graph.station_lines(sid)), pred_dist, t)
 
         anchor_idx = min(range(len(group)), key=lambda i: _anchor_key(group[i]))
         anchor_track = tracks[group[anchor_idx]]

--- a/tests/test_fork_anchor_invariants.py
+++ b/tests/test_fork_anchor_invariants.py
@@ -1,0 +1,130 @@
+"""Invariants for `_equalize_fork_groups` track distribution.
+
+Issue #317: fan-out columns with multiple distinct primary lines and a
+common predecessor can have their members distributed lopsidedly below
+the predecessor when `_equalize_fork_groups` anchors on the topmost
+station ("group[0]") and walks downward by primary-line priority.
+
+These tests assert that when a fan-out group shares a common
+predecessor (the "trunk" feeding the column), the column's Y
+center-of-mass is close to the predecessor's Y rather than being
+heavily biased above/below. Symmetric distribution around the trunk is
+what produces clean horizontal trunk routing without dipping V detours
+on the orphan lines that land furthest from the trunk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_DIRS = [
+    ROOT / "examples",
+    ROOT / "examples" / "topologies",
+    ROOT / "tests" / "fixtures",
+]
+
+_Y_BIAS_TOL = 75.0  # ~one track unit at default y_spacing
+
+
+def _load(name: str):
+    for d in FIXTURE_DIRS:
+        p = d / f"{name}.mmd"
+        if p.exists():
+            text = p.read_text()
+            g = parse_metro_mermaid(text)
+            compute_layout(g)
+            return g
+    raise FileNotFoundError(name)
+
+
+def _shared_pred_fanout_columns(g):
+    """Yield (section, col_x, sids, pred_id) for fan-out columns with:
+    - >=2 stations,
+    - >=2 distinct primary lines (so `_equalize_fork_groups` fires),
+    - a non-empty common predecessor set in the section subgraph.
+    """
+    line_priority = {lid: i for i, lid in enumerate(g.lines)}
+    G = nx.DiGraph()
+    for e in g.edges:
+        G.add_edge(e.source, e.target)
+
+    for section in g.sections.values():
+        if section.direction not in ("LR", "RL"):
+            continue
+        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        cols: dict[float, list[str]] = {}
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            st = g.stations.get(sid)
+            if st is None or st.is_port:
+                continue
+            cols.setdefault(round(st.x, 1), []).append(sid)
+        for col_x, sids in cols.items():
+            if len(sids) < 2:
+                continue
+            primaries: set[str] = set()
+            for sid in sids:
+                lines = g.station_lines(sid)
+                if lines:
+                    primaries.add(
+                        min(lines, key=lambda ln: line_priority.get(ln, 1_000_000))
+                    )
+            if len(primaries) < 2:
+                continue
+
+            pred_sets = [set(G.predecessors(s)) for s in sids]
+            if not pred_sets[0]:
+                continue
+            if not all(p == pred_sets[0] for p in pred_sets):
+                continue
+            pred = next(iter(pred_sets[0]))
+            if pred not in g.stations:
+                continue
+            yield section, col_x, sids, pred
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "variantbenchmarking",
+        "variantbenchmarking_auto",
+        "differentialabundance",
+        "epitopeprediction",
+        "rnaseq_sections",
+        "da_pipeline",
+    ],
+)
+def test_fork_group_symmetric_about_trunk(fixture):
+    """Fan-out columns with a common predecessor should be distributed
+    symmetrically about the predecessor's Y.
+
+    Asymmetry means orphan-line siblings (the ones whose primary line
+    is far from the predecessor's primary line) land far from the trunk
+    Y. Their inter-section route then has to climb back to trunk Y,
+    producing a visible V-shaped detour (issue #317).
+    """
+    g = _load(fixture)
+    violations = []
+    for section, col_x, sids, pred in _shared_pred_fanout_columns(g):
+        pred_y = g.stations[pred].y
+        ys = [g.stations[s].y for s in sids]
+        mean_y = sum(ys) / len(ys)
+        bias = mean_y - pred_y
+        if abs(bias) > _Y_BIAS_TOL:
+            violations.append(
+                f"  section={section.id} col_x={col_x} pred={pred} "
+                f"pred_y={pred_y:.1f} mean_y={mean_y:.1f} bias={bias:+.1f}"
+            )
+
+    assert not violations, (
+        f"Fan-out column not symmetric about trunk in {fixture}:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
Fork-group track distribution previously started from the topmost station's track and stepped sequentially down. In sections with multiple distinct primary lines (e.g. variantbenchmarking's `benchmarking` column), this placed orphan-line stations far below the trunk: `gatk4_conc` landed at track 7 of 9, ~275px below `bench_hub`, producing a visible V-shaped vertical dip in the concordance line route.

## Fix

`_equalize_fork_groups`: distribute siblings as signed offsets around an anchor instead. The anchor is the column member carrying the most lines, tie-broken by proximity to the predecessor mean track and current track index. Source columns (no predecessors) fall back to top-anchoring at `group[0]`, preserving the original behaviour for hidden hubs and inter-section trunk entries.

`_compute_section_layout`: always re-run `_position_junctions` after row compaction. Previously this only ran when `_snap_inter_section_port_pairs` moved a port; with the source-column fallback, port snapping no longer needs to fire to correct intermediate junction Ys.

## Effect

- `gatk4_conc` rendered Y reduced from ~858 to ~742 (concordance dip halved).
- `_inputs_hub` stays at the top of its section (Y=103) where the source-column trunk runs.
- Junctions stay on grid Ys after compaction.

Only `variantbenchmarking.svg` and `variantbenchmarking_auto.svg` change vs `main`. All other 46 gallery fixtures byte-identical. 820 tests pass; ruff lint and format clean.

Closes #317