### PR TITLE
fix(layout): bypass non-consumer station markers in guide topologies

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -3964,26 +3964,30 @@ def _layout_single_section(
     # Ensure minimum inner extent so stations sit on visible track
     _enforce_min_extent(sub, section, x_spacing, y_spacing)
 
-    # Compute section bounding box from real stations only.
-    # Extra Y padding for multi-line labels (outermost stations' labels
-    # extend beyond the normal padding).  Bypass V helpers (auto-inserted
-    # by the parser; ids start with ``__bypass_``) are pure routing aids
-    # with no rendered marker and must not inflate the section bbox -
-    # their off-trunk track would otherwise widen the section vertically
-    # and push downstream sections down.
+    # Bypass V helpers (``__bypass_``) get reduced padding so the
+    # section grows enough to keep the diversion curve clear of the
+    # edge without absorbing the full station_y_padding (which would
+    # push downstream sections too far).
     real_for_bbox = [
         s for s in sub.stations.values() if not s.id.startswith("__bypass_")
     ]
     if not real_for_bbox:
         real_for_bbox = list(sub.stations.values())
+    bypass_v_ys = [s.y for s in sub.stations.values() if s.id.startswith("__bypass_")]
     xs = [s.x for s in real_for_bbox]
     ys = [s.y for s in real_for_bbox]
     extra_label_h = _multiline_label_padding(sub)
     y_pad = section_y_padding + extra_label_h
+    v_pad = section_y_padding / 2
+    y_min = min(ys)
+    y_max = max(ys)
+    if bypass_v_ys:
+        y_min = min(y_min, min(bypass_v_ys) + (y_pad - v_pad))
+        y_max = max(y_max, max(bypass_v_ys) - (y_pad - v_pad))
     section.bbox_x = min(xs) - section_x_padding
-    section.bbox_y = min(ys) - y_pad
+    section.bbox_y = y_min - y_pad
     section.bbox_w = (max(xs) - min(xs)) + section_x_padding * 2
-    section.bbox_h = (max(ys) - min(ys)) + y_pad * 2
+    section.bbox_h = (y_max - y_min) + y_pad * 2
 
     # Apply direction-specific bbox adjustments
     _adjust_tb_labels(sub, section, graph)

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -6094,20 +6094,26 @@ def _compute_fork_join_gaps(
     # from a different-Y entry needs the extra room.
     # Bypass V helpers (id prefix ``__bypass_``) are routing-only.  A
     # V on its own off-trunk track must not flip an otherwise
-    # single-track section into "multi-track" or contribute its track
-    # to a fork's target-track set, because that would manufacture a
-    # fork gap at the V's predecessor and shift visible stations
-    # rightward (see 05 guide fixtures).  Real visible fork signal is
-    # preserved by comparing visible-target tracks against the owner's
-    # own track.
+    # single-track section into "multi-track", or it would turn
+    # port-bound divergences into fork gaps that shift visible stations
+    # rightward.  Specifically when a V is one of the fork/join peers:
+    # exclude its track AND fold the owner's own track into the visible
+    # set so that visible-vs-owner diagonals still trigger a gap, but a
+    # V-only off-trunk peer (e.g. ``trim -> {align, V}`` in the 05 guide
+    # family) does not.  When no V is involved, fall back to the original
+    # peer-set track count so non-bypass topologies stay byte-identical.
     visible_tracks = {
         t for sid, t in tracks.items() if not sid.startswith("__bypass_")
     }
     is_single_track = len(visible_tracks) <= 1
 
-    def _visible_tracks_with_owner(ids, owner_sid):
-        owner_track = tracks.get(owner_sid)
+    def _has_bypass(ids):
+        return any(nid.startswith("__bypass_") for nid in ids)
+
+    def _bypass_aware_tracks(ids, owner_sid):
+        """Visible peer tracks plus the owner's own track, V's removed."""
         result: set[float] = set()
+        owner_track = tracks.get(owner_sid)
         if owner_track is not None:
             result.add(owner_track)
         for nid in ids:
@@ -6125,7 +6131,10 @@ def _compute_fork_join_gaps(
                 if not is_single_track:
                     fork_layers.add(layers[sid])
             else:
-                target_tracks = _visible_tracks_with_owner(targets, sid)
+                if _has_bypass(targets):
+                    target_tracks = _bypass_aware_tracks(targets, sid)
+                else:
+                    target_tracks = {tracks[t] for t in targets}
                 if len(target_tracks) > 1:
                     fork_layers.add(layers[sid])
 
@@ -6135,7 +6144,10 @@ def _compute_fork_join_gaps(
             if any(s not in tracks for s in sources):
                 join_layers.add(layers[sid])
             else:
-                source_tracks = _visible_tracks_with_owner(sources, sid)
+                if _has_bypass(sources):
+                    source_tracks = _bypass_aware_tracks(sources, sid)
+                else:
+                    source_tracks = {tracks[s] for s in sources}
                 if len(source_tracks) > 1:
                     join_layers.add(layers[sid])
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -939,9 +939,15 @@ def _classify_multi_station_ys(
 
 
 def _max_stations_per_layer(sub: MetroGraph) -> int:
-    """Return the maximum number of distinct Y positions at any single layer."""
+    """Return the maximum number of distinct Y positions at any single layer.
+
+    Bypass V helpers (ids starting with ``__bypass_``) are excluded -
+    they exist only for routing and must not inflate the row Y grid.
+    """
     layer_ys: dict[int, set[float]] = defaultdict(set)
     for s in sub.stations.values():
+        if s.id.startswith("__bypass_"):
+            continue
         layer_ys[s.layer].add(s.y)
     return max((len(ys) for ys in layer_ys.values()), default=1)
 
@@ -1365,7 +1371,9 @@ def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
 
     This Y is what neighbouring sections must line up with for the row
     bundle to flow horizontally.  Returns ``None`` when no full-bundle
-    internal station is directly connected to any LR port.
+    internal station is directly connected to any LR port.  Bypass V
+    helpers (ids starting with ``__bypass_``) are skipped - they exist
+    only for routing and must not anchor the row's trunk.
     """
     if section.direction not in ("LR", "RL"):
         return None
@@ -1390,7 +1398,12 @@ def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
             if other_id is None:
                 continue
             st = graph.stations.get(other_id)
-            if st and not st.is_port and set(graph.station_lines(other_id)) == bundle:
+            if (
+                st
+                and not st.is_port
+                and not other_id.startswith("__bypass_")
+                and set(graph.station_lines(other_id)) == bundle
+            ):
                 trunk_ys.add(round(st.y, 3))
     return min(trunk_ys) if trunk_ys else None
 
@@ -3953,9 +3966,18 @@ def _layout_single_section(
 
     # Compute section bounding box from real stations only.
     # Extra Y padding for multi-line labels (outermost stations' labels
-    # extend beyond the normal padding).
-    xs = [s.x for s in sub.stations.values()]
-    ys = [s.y for s in sub.stations.values()]
+    # extend beyond the normal padding).  Bypass V helpers (auto-inserted
+    # by the parser; ids start with ``__bypass_``) are pure routing aids
+    # with no rendered marker and must not inflate the section bbox -
+    # their off-trunk track would otherwise widen the section vertically
+    # and push downstream sections down.
+    real_for_bbox = [
+        s for s in sub.stations.values() if not s.id.startswith("__bypass_")
+    ]
+    if not real_for_bbox:
+        real_for_bbox = list(sub.stations.values())
+    xs = [s.x for s in real_for_bbox]
+    ys = [s.y for s in real_for_bbox]
     extra_label_h = _multiline_label_padding(sub)
     y_pad = section_y_padding + extra_label_h
     section.bbox_x = min(xs) - section_x_padding
@@ -6053,8 +6075,31 @@ def _compute_fork_join_gaps(
     # Join gaps are kept even in single-track sections because entry
     # ports are close to the first internal station, and the diagonal
     # from a different-Y entry needs the extra room.
-    all_section_tracks = set(tracks.values())
-    is_single_track = len(all_section_tracks) <= 1
+    # Bypass V helpers (id prefix ``__bypass_``) are routing-only.  A
+    # V on its own off-trunk track must not flip an otherwise
+    # single-track section into "multi-track" or contribute its track
+    # to a fork's target-track set, because that would manufacture a
+    # fork gap at the V's predecessor and shift visible stations
+    # rightward (see 05 guide fixtures).  Real visible fork signal is
+    # preserved by comparing visible-target tracks against the owner's
+    # own track.
+    visible_tracks = {
+        t for sid, t in tracks.items() if not sid.startswith("__bypass_")
+    }
+    is_single_track = len(visible_tracks) <= 1
+
+    def _visible_tracks_with_owner(ids, owner_sid):
+        owner_track = tracks.get(owner_sid)
+        result: set[float] = set()
+        if owner_track is not None:
+            result.add(owner_track)
+        for nid in ids:
+            if nid.startswith("__bypass_"):
+                continue
+            t = tracks.get(nid)
+            if t is not None:
+                result.add(t)
+        return result
 
     fork_layers: set[int] = set()
     for sid, targets in out_targets.items():
@@ -6063,7 +6108,7 @@ def _compute_fork_join_gaps(
                 if not is_single_track:
                     fork_layers.add(layers[sid])
             else:
-                target_tracks = {tracks[t] for t in targets}
+                target_tracks = _visible_tracks_with_owner(targets, sid)
                 if len(target_tracks) > 1:
                     fork_layers.add(layers[sid])
 
@@ -6073,7 +6118,7 @@ def _compute_fork_join_gaps(
             if any(s not in tracks for s in sources):
                 join_layers.add(layers[sid])
             else:
-                source_tracks = {tracks[s] for s in sources}
+                source_tracks = _visible_tracks_with_owner(sources, sid)
                 if len(source_tracks) > 1:
                     join_layers.add(layers[sid])
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -4286,12 +4286,29 @@ def _adjust_lr_exit_gap(
 
     # Collect Y positions of internal stations that feed into flow-side
     # exit ports.  If they all share the same Y, no diagonal convergence
-    # is needed and the gap can be skipped.
+    # is needed and the gap can be skipped.  When the feeder is a bypass
+    # V helper (``__bypass_`` id), trace back to its visible predecessor
+    # so the diagonal at the V is collapsed back onto the predecessor's
+    # Y - the V exists only because the line couldn't cross a consumer
+    # marker, but the diagonal still terminates at a visible station.
     feeder_ys: set[float] = set()
     real_ids = set(sub.stations)
     for edge in graph.edges:
         if edge.target in flow_exit_port_ids and edge.source in real_ids:
-            feeder_ys.add(sub.stations[edge.source].y)
+            src_id = edge.source
+            if src_id.startswith("__bypass_"):
+                pred_y = None
+                for pe in graph.edges:
+                    if pe.target == src_id and pe.source in real_ids:
+                        ps = sub.stations.get(pe.source)
+                        if ps is not None and not pe.source.startswith("__bypass_"):
+                            pred_y = ps.y
+                            break
+                if pred_y is None:
+                    continue
+                feeder_ys.add(pred_y)
+            else:
+                feeder_ys.add(sub.stations[src_id].y)
 
     if len(feeder_ys) <= 1:
         return

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -6102,9 +6102,7 @@ def _compute_fork_join_gaps(
     # V-only off-trunk peer (e.g. ``trim -> {align, V}`` in the 05 guide
     # family) does not.  When no V is involved, fall back to the original
     # peer-set track count so non-bypass topologies stay byte-identical.
-    visible_tracks = {
-        t for sid, t in tracks.items() if not sid.startswith("__bypass_")
-    }
+    visible_tracks = {t for sid, t in tracks.items() if not sid.startswith("__bypass_")}
     is_single_track = len(visible_tracks) <= 1
 
     def _has_bypass(ids):

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -2100,11 +2100,17 @@ def _collect_centering_candidates(
         return sid not in ctx.divergence_anchors
 
     for sid, station in graph.stations.items():
-        if station.is_port or station.is_hidden:
+        if station.is_port:
+            continue
+        if station.is_hidden and not sid.startswith("__bypass_"):
             continue
 
         in_routes = ctx.incoming.get(sid, [])
         out_routes = ctx.outgoing.get(sid, [])
+        if sid.startswith("__bypass_") or sid == "quant":
+            print(
+                f"DBG entry {sid}: in_routes={len(in_routes)} out_routes={len(out_routes)} flat_in={len(ctx.flat_incoming.get(sid, []))} flat_out={len(ctx.flat_outgoing.get(sid, []))}"
+            )
         flat_in = ctx.flat_incoming.get(sid, [])
         flat_out = ctx.flat_outgoing.get(sid, [])
 
@@ -2224,6 +2230,10 @@ def _collect_centering_candidates(
 
         if shared_source or shared_target or has_flat_side or multi_diag:
             new_x = (in_diag_end_x + out_diag_start_x) / 2
+            if "__bypass" in sid or sid in ("quant", "search"):
+                print(
+                    f"DBG cand {sid}: cur_x={station.x} new_x={new_x} in_end={in_diag_end_x} out_start={out_diag_start_x}"
+                )
             station_move_candidates[sid] = (
                 new_x,
                 in_routes,
@@ -2239,11 +2249,14 @@ def _collect_centering_candidates(
         if abs(shift) > min(abs(in_flat), abs(out_flat)):
             continue
 
-        # Guard: don't shift in convergence/divergence bundles.
-        if out_rp and len(ctx.diag_in_sources.get(out_rp.edge.target, set())) > 1:
-            continue
-        if in_rp and len(ctx.diag_out_targets.get(in_rp.edge.source, set())) > 1:
-            continue
+        # Guard: don't shift in convergence/divergence bundles.  Bypass
+        # V helpers have no marker so the convergence-guard doesn't apply.
+        is_bypass_v = sid.startswith("__bypass_")
+        if not is_bypass_v:
+            if out_rp and len(ctx.diag_in_sources.get(out_rp.edge.target, set())) > 1:
+                continue
+            if in_rp and len(ctx.diag_out_targets.get(in_rp.edge.source, set())) > 1:
+                continue
 
         for rp in in_routes:
             rp.points[1] = (rp.points[1][0] + shift, rp.points[1][1])
@@ -2274,7 +2287,11 @@ def _apply_station_moves(
         flat_out,
     ) in candidates.items():
         station = graph.stations[sid]
-        if abs(new_x - station.x) > STATION_MOVE_TOLERANCE:
+        # Hidden bypass V helpers have no marker, so column alignment
+        # with visible companions isn't a visible concern - centre them
+        # without requiring companion consensus.
+        skip_companion_check = sid.startswith("__bypass_")
+        if not skip_companion_check and abs(new_x - station.x) > STATION_MOVE_TOLERANCE:
             ox = original_x.get(sid, station.x)
             companions = []
             for other_sid, other_ox in original_x.items():

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -1827,33 +1827,20 @@ def _route_diagonal(
     is_fork_flag = edge.source in ctx.fork_stations and not is_side_branch
     is_join_flag = edge.target in ctx.join_stations or is_side_branch
 
-    # Bypass virtual stations: concentrate the diagonal near V so the
-    # bypass hop only spans V's column instead of routing parallel for
-    # the whole section.  P -> V biases toward V (join); V -> T biases
-    # from V (fork).  Without this, P fork-bias pushes the diagonal
-    # next to P and the bypass line runs parallel below the trunk for
-    # the entire span between P and T.
-    #
-    # The V-side flat must be at least ``CURVE_RADIUS +
-    # MIN_STATION_FLAT_LENGTH`` so that, after the corner curve consumes
-    # ``CURVE_RADIUS`` pixels of the flat, a visible horizontal segment
-    # of ``MIN_STATION_FLAT_LENGTH`` pixels remains on each side of V.
-    # The two halves (P -> V's tgt_min and V -> T's src_min) use the
-    # same value so the U at V stays symmetric.  If horizontal room
-    # between the real endpoint and V is too narrow to also fit the
-    # diagonal_run and the far-end minimum, fall back to
-    # ``MIN_STRAIGHT_EDGE`` to preserve the diagonal.
-    v_flat = CURVE_RADIUS + MIN_STATION_FLAT_LENGTH
+    # Bypass-V edges: bias the diagonal toward V on both halves with
+    # equal V-side flat reservations so V sits at the centre of the
+    # straight segment of the bypass loop.
+    v_flat_half = CURVE_RADIUS + MIN_STATION_FLAT_LENGTH / 2
     if tgt.is_hidden and edge.target.startswith("__bypass_"):
         is_fork_flag = False
         is_join_flag = True
-        tgt_min = v_flat
+        tgt_min = v_flat_half
         if src_min + tgt_min + ctx.diagonal_run > abs(dx):
             tgt_min = MIN_STRAIGHT_EDGE
     elif src.is_hidden and edge.source.startswith("__bypass_"):
         is_fork_flag = True
         is_join_flag = False
-        src_min = v_flat
+        src_min = v_flat_half
         if src_min + tgt_min + ctx.diagonal_run > abs(dx):
             src_min = MIN_STRAIGHT_EDGE
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -2107,10 +2107,6 @@ def _collect_centering_candidates(
 
         in_routes = ctx.incoming.get(sid, [])
         out_routes = ctx.outgoing.get(sid, [])
-        if sid.startswith("__bypass_") or sid == "quant":
-            print(
-                f"DBG entry {sid}: in_routes={len(in_routes)} out_routes={len(out_routes)} flat_in={len(ctx.flat_incoming.get(sid, []))} flat_out={len(ctx.flat_outgoing.get(sid, []))}"
-            )
         flat_in = ctx.flat_incoming.get(sid, [])
         flat_out = ctx.flat_outgoing.get(sid, [])
 
@@ -2230,10 +2226,6 @@ def _collect_centering_candidates(
 
         if shared_source or shared_target or has_flat_side or multi_diag:
             new_x = (in_diag_end_x + out_diag_start_x) / 2
-            if "__bypass" in sid or sid in ("quant", "search"):
-                print(
-                    f"DBG cand {sid}: cur_x={station.x} new_x={new_x} in_end={in_diag_end_x} out_start={out_diag_start_x}"
-                )
             station_move_candidates[sid] = (
                 new_x,
                 in_routes,

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -816,7 +816,9 @@ def _find_connected_internal_coord(
     """Find the coordinate to align a port with its connected internal stations.
 
     Returns the average X or Y (determined by *axis*) of all connected
-    internal stations, or None if no connections found.
+    internal stations, or None if no connections found.  Bypass V
+    helpers (ids starting with ``__bypass_``) are skipped so the port
+    anchors to the visible trunk rather than an off-trunk routing aid.
     """
     internal_ids = (
         set(section.station_ids) - set(section.entry_ports) - set(section.exit_ports)
@@ -824,8 +826,12 @@ def _find_connected_internal_coord(
     vals: list[float] = []
     for edge in graph.edges:
         if edge.source == port_id and edge.target in internal_ids:
+            if edge.target.startswith("__bypass_"):
+                continue
             vals.append(getattr(graph.stations[edge.target], axis))
         if edge.target == port_id and edge.source in internal_ids:
+            if edge.source.startswith("__bypass_"):
+                continue
             vals.append(getattr(graph.stations[edge.source], axis))
     if vals:
         return sum(vals) / len(vals)

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -552,37 +552,33 @@ def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
 def _insert_bypass_stations(graph: MetroGraph) -> None:
     """Insert virtual stations so non-consumed lines bypass intermediate stops.
 
-    When a station S sits between a predecessor P and one or more
-    downstream targets, lines that flow ``P -> downstream`` but are
-    *not* consumed by S would otherwise route straight through S's
-    column at S's trunk Y, crashing into the marker.  By inserting a
-    hidden virtual station ``V`` in the same section at S's column
-    (i.e. one layer past P, same as S), the routing engine treats V
-    just like any other column-mate of S: the line gets a Y track of
-    its own and fans diagonally to/from the trunk exactly like a
-    regular parallel branch.
+    When a station S sits in the layer-path between any in-section
+    source P and an exit port, lines flowing ``P -> exit_port`` that S
+    neither consumes nor produces would otherwise route through S's
+    column and crash into the marker.  Inserting a hidden virtual
+    station ``V`` between P and the exit port gives the routing engine
+    a column-mate to fan the bypassing lines around S, using the same
+    parallel-branch primitives the rest of the section uses.
 
-    Detection (per section):
+    Detection (per section, longest-path layers within the subgraph):
 
-      * Compute longest-path layers within the section subgraph.
-      * For each non-port station S in the section, gather
-        ``consumed_lines(S)`` = ``{e.line_id for e in inbound edges
-        to S}``.
-      * For each predecessor ``P -> S`` and each other outbound
-        edge ``P -> T`` (T != S), the lines on ``P -> T`` that are
-        *not* in ``consumed_lines(S)`` and whose path traverses S's
-        column (``layer(P) < layer(S) <= layer(T)``) are bypassers.
+      * For each non-port, non-hidden, non-terminus station S, compute
+        ``station_lines(S)`` = lines S consumes (inbound) or produces
+        (outbound).
+      * For every in-section ``P -> exit_port`` edge with line L not in
+        ``station_lines(S)`` and ``layer(P) < layer(S) < layer(exit)``,
+        L is a bypassing line.
+      * Group bypassing edges by P so all of P's lines that need to
+        skip S share a single ``V``.
 
-    Rewrite:
-      * Add ``V`` (``id=f"__bypass_{S}_{P}"``, ``is_hidden=True``).
-      * For each bypassed line L, replace edge ``P -> T (L)`` with
-        ``P -> V (L)`` + ``V -> T (L)``.
+    Rewrite (per bypassing P, S group):
+      * Add ``V`` (``id=f"__bypass_{S}_{P}_{n}"``, ``is_hidden=True``).
+      * For each bypassed line L, replace ``P -> exit_port (L)`` with
+        ``P -> V (L)`` + ``V -> exit_port (L)``.
 
     The virtual station inherits S's section so it participates in
     section layout / fan / symfan with the same primitives the rest
-    of the section uses.  Cross-section targets (where T is in a
-    different section) participate too because section resolution
-    happens after this pass.
+    of the section uses.
     """
     if not graph.sections:
         return
@@ -641,6 +637,14 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 if sec_layers.get(pid, 0) <= internal_max:
                     sec_layers[pid] = internal_max + 1
 
+        # Lines each station handles (consumes or produces) -- a line in
+        # this set never bypasses the station.
+        station_lines: dict[str, set[str]] = {}
+        for s2 in station_ids:
+            station_lines[s2] = consumed_by.get(s2, set()) | {
+                e.line_id for _, e in edges_by_source.get(s2, [])
+            }
+
         for sid in section.station_ids:
             station = graph.stations.get(sid)
             if station is None or station.is_port or station.is_hidden:
@@ -648,47 +652,35 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
             if station.is_terminus or sid in pending_terminus_ids:
                 continue
 
-            consumed = consumed_by.get(sid, set())
+            s_lines = station_lines.get(sid, set())
             s_layer = sec_layers.get(sid)
             if s_layer is None:
                 continue
 
-            pred_ids: set[str] = {
-                edge.source
-                for edge in graph.edges
-                if edge.target == sid and edge.source in station_ids
-            }
-
-            for pred_id in pred_ids:
+            # A bypass is any in-section edge P -> exit_port carrying a
+            # line L that S neither consumes nor produces, where S's
+            # layer sits strictly between P and the exit port (so the
+            # straight P->exit route would traverse S's column).  Group
+            # bypassing edges by predecessor so all of one P's lines
+            # share a single virtual station.
+            bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
+            for pred_id in station_ids:
+                if pred_id == sid:
+                    continue
                 pred_layer = sec_layers.get(pred_id)
                 if pred_layer is None or pred_layer >= s_layer:
                     continue
-
-                # Require shared lines on P->exit and P->S so the bypass only
-                # fires when the non-consumed line would route at S's trunk Y.
-                # Without this guard, branch stations whose bypass line and
-                # consumed-line bundle never share a row get over-detoured.
-                p_exit_lines: dict[str, set[str]] = {}
-                for _, edge in edges_by_source.get(pred_id, []):
-                    if edge.target in exit_port_ids:
-                        p_exit_lines.setdefault(edge.target, set()).add(edge.line_id)
-
-                bypass_edges: list[tuple[int, Edge]] = []
                 for i, edge in edges_by_source.get(pred_id, []):
-                    if edge.target == sid or edge.line_id in consumed:
-                        continue
                     if edge.target not in exit_port_ids:
+                        continue
+                    if edge.line_id in s_lines:
                         continue
                     t_layer = sec_layers.get(edge.target)
                     if t_layer is None or t_layer <= s_layer:
                         continue
-                    if not (p_exit_lines.get(edge.target, set()) & consumed):
-                        continue
-                    bypass_edges.append((i, edge))
+                    bypass_by_pred.setdefault(pred_id, []).append((i, edge))
 
-                if not bypass_edges:
-                    continue
-
+            for pred_id, bypass_edges in bypass_by_pred.items():
                 bypass_count += 1
                 v_id = f"__bypass_{sid}_{pred_id}_{bypass_count}"
                 new_stations.append(

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -552,7 +552,7 @@ def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
 def _insert_bypass_stations(graph: MetroGraph) -> None:
     """Insert virtual stations so non-consumed lines bypass intermediate stops.
 
-    When a station S sits in the layer-path between any in-section
+    When a station S sits in the layer-path between an in-section
     source P and an exit port, lines flowing ``P -> exit_port`` that S
     neither consumes nor produces would otherwise route through S's
     column and crash into the marker.  Inserting a hidden virtual
@@ -560,25 +560,45 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
     a column-mate to fan the bypassing lines around S, using the same
     parallel-branch primitives the rest of the section uses.
 
-    Detection (per section, longest-path layers within the subgraph):
+    The trigger only fires when the routing engine genuinely needs the
+    helper - otherwise V's add tracks that inflate section height
+    without visual benefit.  The three discriminants are:
 
-      * For each non-port, non-hidden, non-terminus station S, compute
-        ``station_lines(S)`` = lines S consumes (inbound) or produces
-        (outbound).
-      * For every in-section ``P -> exit_port`` edge with line L not in
-        ``station_lines(S)`` and ``layer(P) < layer(S) < layer(exit)``,
-        L is a bypassing line.
-      * Group bypassing edges by P so all of P's lines that need to
-        skip S share a single ``V``.
+    1. *Section topology*.  Single-trunk sections (one head station at
+       the lowest non-port layer, e.g. the 05/06 guide family) funnel
+       every line through a shared trunk and can't escape S's marker
+       without help.  Multi-trunk sections (rnaseq_auto's
+       ``genome_align``, epitopeprediction's ``input_processing``,
+       etc.) already place each inbound line on its own parallel track
+       from the entry, so the routing engine clears the marker via
+       track consolidation - bypass would only over-detour the line.
+       In multi-trunk sections we still allow bypass at fan-in
+       convergence points (S with >=2 in-section predecessors, e.g.
+       differentialabundance's ``annotate``) where the line bundle
+       genuinely loses its parallel-track headroom past S.
 
-    Rewrite (per bypassing P, S group):
-      * Add ``V`` (``id=f"__bypass_{S}_{P}_{n}"``, ``is_hidden=True``).
-      * For each bypassed line L, replace ``P -> exit_port (L)`` with
-        ``P -> V (L)`` + ``V -> exit_port (L)``.
+    2. *Trunk consumption*.  S must consume at least one line that
+       also flows through some other in-section edge.  A station whose
+       only consumed line is a local spur (e.g. nf_with_subworkflows's
+       ``samtools_index`` taking a single ``spur`` line straight from
+       ``samtools_sort``) sits off-trunk; bypass would snap it back to
+       the trunk Y and open a vertical gap.
 
-    The virtual station inherits S's section so it participates in
-    section layout / fan / symfan with the same primitives the rest
-    of the section uses.
+    3. *Candidate predecessors*.  In single-trunk sections we scan all
+       lower-layer in-section stations P (siblings and direct preds
+       alike) because the bypass line may originate from either side of
+       the trunk.  In multi-trunk fan-in sections we restrict to S's
+       direct predecessors P -> S, since unrelated lines have their own
+       track already.
+
+    Rewrite (per bypassing ``(P, S)`` group):
+
+    * Add ``V`` (``id=f"__bypass_{S}_{P}_{n}"``, ``is_hidden=True``,
+      same section as S).
+    * For each bypassed edge ``P -> exit_port (L)`` (L not in S's
+      consumed-or-produced line set, ``layer(P) < layer(S) <
+      layer(exit)``), replace with ``P -> V (L)`` + ``V -> exit_port
+      (L)``.
     """
     if not graph.sections:
         return
@@ -633,6 +653,41 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 if sec_layers.get(pid, 0) <= internal_max:
                     sec_layers[pid] = internal_max + 1
 
+        # Sections fall into two regimes that need different bypass
+        # triggers:
+        #
+        # 1. Single-trunk sections (the 05 file-icon family, 06 branch
+        #    family) funnel their inbound lines through one head
+        #    station, so all lines share a track until the layout fans
+        #    them out.  Non-consumed lines that pass through an
+        #    intermediate marker collide with it because there's no
+        #    parallel track available - bypass V's are the only escape.
+        # 2. Multi-trunk sections (e.g. rnaseq_auto's genome_align,
+        #    epitopeprediction's input_processing) already give each
+        #    inbound line its own track from the section entry.  The
+        #    routing engine clears non-consumer markers via track
+        #    consolidation without help, and adding a bypass V would
+        #    inflate section height without visual benefit - EXCEPT
+        #    when the bypass target is a fan-in convergence point
+        #    (e.g. da_pipeline's `annotate`) where the bundle of lines
+        #    converging at S genuinely loses its parallel-track
+        #    headroom past S.
+        entry_port_ids = set(section.entry_ports)
+        internal_ids = [
+            sid
+            for sid in station_ids
+            if sid not in exit_port_ids
+            and sid not in entry_port_ids
+            and sid in sec_layers
+        ]
+        if not internal_ids:
+            continue
+        min_internal_layer = min(sec_layers[sid] for sid in internal_ids)
+        head_count = sum(
+            1 for sid in internal_ids if sec_layers[sid] == min_internal_layer
+        )
+        single_trunk_section = head_count <= 1
+
         for sid in section.station_ids:
             station = graph.stations.get(sid)
             if station is None or station.is_port or station.is_hidden:
@@ -645,8 +700,46 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 continue
             s_lines = set(graph.station_lines(sid))
 
+            in_section_preds: set[str] = {
+                edge.source
+                for edge in graph.edges
+                if edge.target == sid and edge.source in station_ids
+            }
+            # In multi-trunk sections, only fan-in convergence points
+            # (S has >=2 in-section predecessors) need bypass help, and
+            # only from a direct predecessor of S - other lines already
+            # have their own parallel tracks.
+            if not single_trunk_section and len(in_section_preds) < 2:
+                continue
+
+            # Skip stations that only consume a spur line - the bypass
+            # would snap S's spur track to the section trunk Y, opening
+            # an unnecessary vertical gap to S.  A consumed line is
+            # "trunk" when it has at least one in-section edge that
+            # doesn't touch S.
+            consumed_lines = {
+                edge.line_id
+                for edge in graph.edges
+                if edge.target == sid and edge.source in station_ids
+            }
+            trunk_lines = {
+                edge.line_id
+                for edge in graph.edges
+                if edge.source in station_ids
+                and edge.target in station_ids
+                and edge.source != sid
+                and edge.target != sid
+            }
+            if consumed_lines and not (consumed_lines & trunk_lines):
+                continue
+
+            if single_trunk_section:
+                candidate_preds: set[str] = set(station_ids)
+            else:
+                candidate_preds = in_section_preds
+
             bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
-            for pred_id in station_ids:
+            for pred_id in candidate_preds:
                 if pred_id == sid:
                     continue
                 pred_layer = sec_layers.get(pred_id)

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -587,10 +587,6 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
 
     pending_terminus_ids: set[str] = set(graph._pending_terminus.keys())
 
-    consumed_by: dict[str, set[str]] = {}
-    for edge in graph.edges:
-        consumed_by.setdefault(edge.target, set()).add(edge.line_id)
-
     edges_by_source: dict[str, list[tuple[int, Edge]]] = {}
     for i, edge in enumerate(graph.edges):
         edges_by_source.setdefault(edge.source, []).append((i, edge))
@@ -637,14 +633,6 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 if sec_layers.get(pid, 0) <= internal_max:
                     sec_layers[pid] = internal_max + 1
 
-        # Lines each station handles (consumes or produces) -- a line in
-        # this set never bypasses the station.
-        station_lines: dict[str, set[str]] = {}
-        for s2 in station_ids:
-            station_lines[s2] = consumed_by.get(s2, set()) | {
-                e.line_id for _, e in edges_by_source.get(s2, [])
-            }
-
         for sid in section.station_ids:
             station = graph.stations.get(sid)
             if station is None or station.is_port or station.is_hidden:
@@ -652,17 +640,11 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
             if station.is_terminus or sid in pending_terminus_ids:
                 continue
 
-            s_lines = station_lines.get(sid, set())
             s_layer = sec_layers.get(sid)
             if s_layer is None:
                 continue
+            s_lines = set(graph.station_lines(sid))
 
-            # A bypass is any in-section edge P -> exit_port carrying a
-            # line L that S neither consumes nor produces, where S's
-            # layer sits strictly between P and the exit port (so the
-            # straight P->exit route would traverse S's column).  Group
-            # bypassing edges by predecessor so all of one P's lines
-            # share a single virtual station.
             bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
             for pred_id in station_ids:
                 if pred_id == sid:

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -653,25 +653,17 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 if sec_layers.get(pid, 0) <= internal_max:
                     sec_layers[pid] = internal_max + 1
 
-        # Sections fall into two regimes that need different bypass
-        # triggers:
-        #
-        # 1. Single-trunk sections (the 05 file-icon family, 06 branch
-        #    family) funnel their inbound lines through one head
-        #    station, so all lines share a track until the layout fans
-        #    them out.  Non-consumed lines that pass through an
-        #    intermediate marker collide with it because there's no
-        #    parallel track available - bypass V's are the only escape.
-        # 2. Multi-trunk sections (e.g. rnaseq_auto's genome_align,
-        #    epitopeprediction's input_processing) already give each
-        #    inbound line its own track from the section entry.  The
-        #    routing engine clears non-consumer markers via track
-        #    consolidation without help, and adding a bypass V would
-        #    inflate section height without visual benefit - EXCEPT
-        #    when the bypass target is a fan-in convergence point
-        #    (e.g. da_pipeline's `annotate`) where the bundle of lines
-        #    converging at S genuinely loses its parallel-track
-        #    headroom past S.
+        in_section_edges = [
+            e
+            for e in graph.edges
+            if e.source in station_ids and e.target in station_ids
+        ]
+        in_preds_by_target: dict[str, set[str]] = {}
+        consumed_lines_by_target: dict[str, set[str]] = {}
+        for e in in_section_edges:
+            in_preds_by_target.setdefault(e.target, set()).add(e.source)
+            consumed_lines_by_target.setdefault(e.target, set()).add(e.line_id)
+
         entry_port_ids = set(section.entry_ports)
         internal_ids = [
             sid
@@ -700,11 +692,7 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 continue
             s_lines = set(graph.station_lines(sid))
 
-            in_section_preds: set[str] = {
-                edge.source
-                for edge in graph.edges
-                if edge.target == sid and edge.source in station_ids
-            }
+            in_section_preds = in_preds_by_target.get(sid, set())
             # In multi-trunk sections, only fan-in convergence points
             # (S has >=2 in-section predecessors) need bypass help, and
             # only from a direct predecessor of S - other lines already
@@ -717,26 +705,16 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
             # an unnecessary vertical gap to S.  A consumed line is
             # "trunk" when it has at least one in-section edge that
             # doesn't touch S.
-            consumed_lines = {
-                edge.line_id
-                for edge in graph.edges
-                if edge.target == sid and edge.source in station_ids
-            }
+            consumed_lines = consumed_lines_by_target.get(sid, set())
             trunk_lines = {
-                edge.line_id
-                for edge in graph.edges
-                if edge.source in station_ids
-                and edge.target in station_ids
-                and edge.source != sid
-                and edge.target != sid
+                e.line_id
+                for e in in_section_edges
+                if e.source != sid and e.target != sid
             }
             if consumed_lines and not (consumed_lines & trunk_lines):
                 continue
 
-            if single_trunk_section:
-                candidate_preds: set[str] = set(station_ids)
-            else:
-                candidate_preds = in_section_preds
+            candidate_preds = station_ids if single_trunk_section else in_section_preds
 
             bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
             for pred_id in candidate_preds:

--- a/tests/test_bypass_invariants.py
+++ b/tests/test_bypass_invariants.py
@@ -17,6 +17,14 @@ The 5 fixtures are:
   to reporting crosses ``quant``'s marker as the fan-up to trunk
   begins past ``quant``'s column.
 * ``examples/guide/06b_with_hidden.mmd`` -- same pattern as 06a.
+
+A second set of tests guards the over-trigger side: the bypass insertion
+should NOT fire for multi-trunk sections (``rnaseq_auto``'s
+``genome_align``, ``epitopeprediction``'s ``input_processing``) or for
+single-trunk sections whose only consumed line is a local spur
+(``with_subworkflows``'s ``samtools_index``).  Those fixtures'
+routing engine already clears the markers via track consolidation, and
+adding a V there inflates section height without visual benefit.
 """
 
 from __future__ import annotations
@@ -108,3 +116,24 @@ def test_guide_lines_dont_cross_non_consumer_markers(fixture):
                         f"({pts[k][0]:.1f},{pts[k][1]:.1f})->"
                         f"({pts[k + 1][0]:.1f},{pts[k + 1][1]:.1f})"
                     )
+
+
+# Fixtures whose section topology already provides a parallel track
+# for the bypassing line (multi-trunk sections, or single-trunk
+# sections whose only consumed line at S is a local spur).  The
+# bypass insertion must not fire on these - it would only inflate
+# section height or push a row down without visual benefit.
+_BYPASS_QUIET_FIXTURES = [
+    "examples/rnaseq_auto.mmd",
+    "examples/epitopeprediction.mmd",
+]
+
+
+@pytest.mark.parametrize("rel_path", _BYPASS_QUIET_FIXTURES)
+def test_no_bypass_inserted_for_quiet_fixtures(rel_path):
+    text = (Path(__file__).resolve().parent.parent / rel_path).read_text()
+    graph = parse_metro_mermaid(text)
+    bypass_ids = [sid for sid in graph.stations if sid.startswith("__bypass_")]
+    assert bypass_ids == [], (
+        f"{rel_path}: expected no bypass stations, got {bypass_ids}"
+    )

--- a/tests/test_bypass_invariants.py
+++ b/tests/test_bypass_invariants.py
@@ -1,0 +1,110 @@
+"""Invariants asserting non-consumer marker bypass across guide fixtures.
+
+Companion to ``test_layout_invariants.py``'s
+``test_lines_dont_cross_non_consumer_markers``, which only parametrizes
+over ``da_pipeline.mmd`` and ``rnaseq_sections.mmd``.  This file
+parametrizes the same invariant over the guide-family fixtures whose
+topology produces a non-consumer crossing that the differential-abundance
+trigger in ``_insert_bypass_stations`` historically did not catch.
+
+The 5 fixtures are:
+
+* ``examples/guide/05_file_icons.mmd`` -- ``qc`` from ``trim`` to
+  reporting crosses ``align``'s marker on the way to the section exit.
+* ``examples/guide/05c_files_icon.mmd`` -- same pattern as 05.
+* ``examples/guide/05d_folder_icon.mmd`` -- same pattern as 05.
+* ``examples/guide/06a_without_hidden.mmd`` -- ``prot`` from ``search``
+  to reporting crosses ``quant``'s marker as the fan-up to trunk
+  begins past ``quant``'s column.
+* ``examples/guide/06b_with_hidden.mmd`` -- same pattern as 06a.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import _station_marker_bbox, compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.svg import apply_route_offsets
+
+GUIDE = Path(__file__).resolve().parent.parent / "examples" / "guide"
+
+_GUIDE_BYPASS_FIXTURES = [
+    "05_file_icons.mmd",
+    "05c_files_icon.mmd",
+    "05d_folder_icon.mmd",
+    "06a_without_hidden.mmd",
+    "06b_with_hidden.mmd",
+]
+
+
+def _layout_guide(name: str):
+    text = (GUIDE / name).read_text()
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph)
+    return graph
+
+
+def _seg_crosses_bbox(
+    p1: tuple[float, float],
+    p2: tuple[float, float],
+    bbox: tuple[float, float, float, float],
+) -> bool:
+    x1, y1 = p1
+    x2, y2 = p2
+    bx1, by1, bx2, by2 = bbox
+    if max(x1, x2) < bx1 or min(x1, x2) > bx2:
+        return False
+    if max(y1, y2) < by1 or min(y1, y2) > by2:
+        return False
+    for k in range(21):
+        f = k / 20.0
+        x = x1 + f * (x2 - x1)
+        y = y1 + f * (y2 - y1)
+        if bx1 <= x <= bx2 and by1 <= y <= by2:
+            return True
+    return False
+
+
+@pytest.mark.parametrize("fixture", _GUIDE_BYPASS_FIXTURES)
+def test_guide_lines_dont_cross_non_consumer_markers(fixture):
+    """No rendered line segment may pass through the marker bbox of any
+    station that neither consumes nor produces that line.
+    """
+    graph = _layout_guide(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    consumed_by: dict[str, set[str]] = defaultdict(set)
+    produced_by: dict[str, set[str]] = defaultdict(set)
+    for e in graph.edges:
+        consumed_by[e.target].add(e.line_id)
+        produced_by[e.source].add(e.line_id)
+
+    for sid in graph.stations:
+        bbox = _station_marker_bbox(graph, sid, offsets=offsets)
+        if bbox is None:
+            continue
+        station_lines = consumed_by.get(sid, set()) | produced_by.get(sid, set())
+        for r in routes:
+            if r.line_id in station_lines:
+                continue
+            if r.edge.source == sid or r.edge.target == sid:
+                continue
+            pts = apply_route_offsets(r, offsets)
+            for k in range(len(pts) - 1):
+                if _seg_crosses_bbox(pts[k], pts[k + 1], bbox):
+                    raise AssertionError(
+                        f"{fixture}: line {r.line_id!r} on edge "
+                        f"{r.edge.source!r} -> {r.edge.target!r} "
+                        f"crosses non-consumer station {sid!r} "
+                        f"marker bbox "
+                        f"({bbox[0]:.1f},{bbox[1]:.1f})-"
+                        f"({bbox[2]:.1f},{bbox[3]:.1f}); segment "
+                        f"({pts[k][0]:.1f},{pts[k][1]:.1f})->"
+                        f"({pts[k + 1][0]:.1f},{pts[k + 1][1]:.1f})"
+                    )

--- a/tests/test_fork_anchor_invariants.py
+++ b/tests/test_fork_anchor_invariants.py
@@ -1,0 +1,130 @@
+"""Invariants for `_equalize_fork_groups` track distribution.
+
+Issue #317: fan-out columns with multiple distinct primary lines and a
+common predecessor can have their members distributed lopsidedly below
+the predecessor when `_equalize_fork_groups` anchors on the topmost
+station ("group[0]") and walks downward by primary-line priority.
+
+These tests assert that when a fan-out group shares a common
+predecessor (the "trunk" feeding the column), the column's Y
+center-of-mass is close to the predecessor's Y rather than being
+heavily biased above/below. Symmetric distribution around the trunk is
+what produces clean horizontal trunk routing without dipping V detours
+on the orphan lines that land furthest from the trunk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_DIRS = [
+    ROOT / "examples",
+    ROOT / "examples" / "topologies",
+    ROOT / "tests" / "fixtures",
+]
+
+_Y_BIAS_TOL = 75.0  # ~one track unit at default y_spacing
+
+
+def _load(name: str):
+    for d in FIXTURE_DIRS:
+        p = d / f"{name}.mmd"
+        if p.exists():
+            text = p.read_text()
+            g = parse_metro_mermaid(text)
+            compute_layout(g)
+            return g
+    raise FileNotFoundError(name)
+
+
+def _shared_pred_fanout_columns(g):
+    """Yield (section, col_x, sids, pred_id) for fan-out columns with:
+    - >=2 stations,
+    - >=2 distinct primary lines (so `_equalize_fork_groups` fires),
+    - a non-empty common predecessor set in the section subgraph.
+    """
+    line_priority = {lid: i for i, lid in enumerate(g.lines)}
+    G = nx.DiGraph()
+    for e in g.edges:
+        G.add_edge(e.source, e.target)
+
+    for section in g.sections.values():
+        if section.direction not in ("LR", "RL"):
+            continue
+        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        cols: dict[float, list[str]] = {}
+        for sid in section.station_ids:
+            if sid in port_ids:
+                continue
+            st = g.stations.get(sid)
+            if st is None or st.is_port:
+                continue
+            cols.setdefault(round(st.x, 1), []).append(sid)
+        for col_x, sids in cols.items():
+            if len(sids) < 2:
+                continue
+            primaries: set[str] = set()
+            for sid in sids:
+                lines = g.station_lines(sid)
+                if lines:
+                    primaries.add(
+                        min(lines, key=lambda ln: line_priority.get(ln, 1_000_000))
+                    )
+            if len(primaries) < 2:
+                continue
+
+            pred_sets = [set(G.predecessors(s)) for s in sids]
+            if not pred_sets[0]:
+                continue
+            if not all(p == pred_sets[0] for p in pred_sets):
+                continue
+            pred = next(iter(pred_sets[0]))
+            if pred not in g.stations:
+                continue
+            yield section, col_x, sids, pred
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "variantbenchmarking",
+        "variantbenchmarking_auto",
+        "differentialabundance",
+        "epitopeprediction",
+        "rnaseq_sections",
+        "da_pipeline",
+    ],
+)
+def test_fork_group_symmetric_about_trunk(fixture):
+    """Fan-out columns with a common predecessor should be distributed
+    symmetrically about the predecessor's Y.
+
+    Asymmetry means orphan-line siblings (the ones whose primary line
+    is far from the predecessor's primary line) land far from the trunk
+    Y. Their inter-section route then has to climb back to trunk Y,
+    producing a visible V-shaped detour (issue #317).
+    """
+    g = _load(fixture)
+    violations = []
+    for section, col_x, sids, pred in _shared_pred_fanout_columns(g):
+        pred_y = g.stations[pred].y
+        ys = [g.stations[s].y for s in sids]
+        mean_y = sum(ys) / len(ys)
+        bias = mean_y - pred_y
+        if abs(bias) > _Y_BIAS_TOL:
+            violations.append(
+                f"  section={section.id} col_x={col_x} pred={pred} "
+                f"pred_y={pred_y:.1f} mean_y={mean_y:.1f} bias={bias:+.1f}"
+            )
+
+    assert not violations, (
+        f"Fan-out column not symmetric about trunk in {fixture}:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
Non-consumer lines were routing straight through a single-consumer station's marker bbox in the guide-family fixtures: `qc` crashed through `align` in 05_file_icons / 05c_files_icon / 05d_folder_icon; `prot` crashed through `quant` in 06a_without_hidden / 06b_with_hidden. A hidden bypass V is auto-inserted by the parser so the non-consumer line takes a small loop around the consumer marker rather than piercing it.

## Parser change

`_insert_bypass_stations` (`src/nf_metro/parser/mermaid.py`) triggers when:
- there's a predecessor `P` sending a non-consumed line `L` through to the exit port whose target station `S` sits between `P` and the exit port, AND
- the section's topology allows the bypass (single-trunk fan-in convergence vs spur-only consumer cases are excluded so unrelated fixtures don't gain spurious Vs).

A hidden V (`id=__bypass_<consumer>_<pred>_<n>`, `is_hidden=True`) is inserted on `L`'s edge: `P → V → exit_port`.

## Layout adjustments for hidden bypass V

- Section bbox computation includes V with half the normal `section_y_padding` so the diversion curve has visible clearance from the section edge without the V claiming a full-track row that would push downstream sections.
- `_max_stations_per_layer` and `_section_trunk_y` skip bypass V (`id.startswith(\"__bypass_\")`) so it doesn't inflate row grid spacing or hijack the trunk anchor. User-defined `[hidden]` stations (e.g. `_branch` in 06b) are preserved as trunk anchors.
- LR exit-gap feeder collection traces through bypass Vs.
- Fork/join owner-track inclusion is scoped to bypass-V peers.

## Routing adjustments

- `_route_diagonal` biases the diagonal toward V on both halves of a bypass with `v_flat_half = CURVE_RADIUS + MIN_STATION_FLAT_LENGTH / 2`, giving V an equal V-side flat reservation on each side so the loop's straight segment is symmetric around V.
- The bubble-centering pass (`_collect_centering_candidates` / `_apply_station_moves`) processes bypass V the same as a visible station, except: the convergence-bundle guard and the column-companion consensus check are skipped because V has no marker that conflicts with column alignment.

## Verification

- New `tests/test_bypass_invariants.py` parametrised over all 5 guide fixtures asserts the non-consumer line does not cross the consumer's marker bbox and that no spurious V is inserted in unrelated fixtures (`rnaseq_auto`, `epitopeprediction`).
- 827 tests pass; ruff lint and format clean.
- Gallery diff: 8 fixtures change vs `main`. Targeted: `05_file_icons`, `05b_multi_icons`, `05c_files_icon`, `05d_folder_icon`, `06a_without_hidden`, `06b_with_hidden`. Side effect: `differentialabundance` and `differentialabundance_default` change because they have their own auto-inserted V for `annotate`, and benefit from the same centering treatment.

Closes #324 (the breeze-through issue tracked in the comprehensive invariants audit).