### PR TITLE
fix(layout): align fan-in inter-section trunks by snapping the downstream entry

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1657,10 +1657,11 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
 
     Scoped to pipelines that use explicit ``%%metro grid:`` directives;
     auto-layout pipelines keep their existing inter-section routing so
-    line-offset ordering tests stay stable.
+    line-offset ordering tests stay stable.  The fan-in entry-port snap
+    branch below runs unconditionally because it only moves the entry
+    port (not the exit), preserving the auto-layout fan-in convergence.
     """
-    if not getattr(graph, "_explicit_grid", None):
-        return False
+    explicit_grid = bool(getattr(graph, "_explicit_grid", None))
     junction_ids = set(graph.junctions)
     moved = False
 
@@ -1708,8 +1709,10 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
         if abs(port_st.y - target_y) < 0.5:
             continue
 
-        # Skip fan-in exits: multiple distinct internal source Ys
-        # signal a meaningful convergence; keep the centred midpoint.
+        # Fan-in exits (multiple distinct internal source Ys) want to
+        # keep their centred-midpoint convergence Y, so don't move the
+        # exit port itself.  Instead, snap the downstream entry port
+        # to the exit port's Y so the inter-section trunk stays flat.
         port_set = set(section.entry_ports) | set(section.exit_ports)
         src_ys: set[float] = set()
         for edge in graph.edges:
@@ -1719,8 +1722,36 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
             if src and not src.is_port and edge.source not in port_set:
                 src_ys.add(round(src.y, 1))
         if len(src_ys) >= 2:
+            for edge in graph.edges:
+                if edge.source != port_id:
+                    continue
+                entry_candidates: list[str] = []
+                tgt_port = graph.ports.get(edge.target)
+                if tgt_port and tgt_port.is_entry:
+                    entry_candidates.append(edge.target)
+                elif edge.target in junction_ids:
+                    for e2 in graph.edges:
+                        if e2.source != edge.target:
+                            continue
+                        tp2 = graph.ports.get(e2.target)
+                        if tp2 and tp2.is_entry:
+                            entry_candidates.append(e2.target)
+                for eid in entry_candidates:
+                    ep = graph.ports.get(eid)
+                    if ep is None or ep.side not in (PortSide.LEFT, PortSide.RIGHT):
+                        continue
+                    ds_sec = graph.sections.get(ep.section_id)
+                    if ds_sec is None or ds_sec.grid_row != section.grid_row:
+                        continue
+                    ep_st = graph.stations.get(eid)
+                    if ep_st is None or abs(ep_st.y - port_st.y) < 0.5:
+                        continue
+                    _set_port_y(graph, eid, port_st.y)
+                    moved = True
             continue
 
+        if not explicit_grid:
+            continue
         _set_port_y(graph, port_id, target_y)
         moved = True
 


### PR DESCRIPTION
Addresses the filtering->stats trunk-Y kink in variantbenchmarking that wasn't covered by #334's fork-anchor fix.

## The bug

In \`examples/variantbenchmarking.mmd\` (and \`_auto\`), the row-0 trunk for the \`test\` line had a 40px vertical step at the filtering->stats boundary:

- filtering exit port y=143.2 (fan-in midpoint: filter_contigs y=103 + bcftools_filter y=143 + survivor_filter y=183, mean=143)
- stats entry port y=103.2 (snapped to bcftools_stats's internal Y by Phase 10c)

Both ports carry identical bundle \`{test}\`; the kink isn't a bundle-membership change.

## Root cause

\`_snap_inter_section_port_pairs\` (Phase 13c) had a guard: if the exit port is a fan-in (>= 2 distinct internal source Ys), skip the snap to preserve the centred-midpoint convergence. This left the downstream entry port free to snap to its own internal station, creating the row-trunk kink.

## Fix

For fan-in exits: keep the exit port at the centred midpoint, and instead snap the **downstream entry port** to match the exit's Y. The fan-in convergence is preserved, the row trunk stays flat, and the entry side gets a small intra-section diagonal (which is a smaller visual cost than a 40px row-trunk kink).

This branch of the function runs for both explicit-grid and auto-layout pipelines because it only adjusts the entry port (not the exit), preserving the auto-layout fan-in convergence.

## Verification

- \`variantbenchmarking\`: filt_exit=143.2 / stats_entry=143.2 (was 143.2 / 103.2, delta 40 -> 0)
- \`variantbenchmarking_auto\`: same fix
- 827 tests pass, lint clean
- Gallery diff: only \`variantbenchmarking.svg\` and \`variantbenchmarking_auto.svg\` change vs \`main\`. No collateral.

## DO NOT MERGE without visual approval.

Refs: #317