### PR TITLE
fix(routing): prevent backward L-segments in cross-column junction routes

### DIFF
--- a/examples/genomeassembly_staggered.mmd
+++ b/examples/genomeassembly_staggered.mmd
@@ -1,0 +1,88 @@
+%%metro title: sanger-tol/genomeassembly
+%%metro style: dark
+%%metro line: long_reads | Long reads | #3d95fd
+%%metro line: hic_reads | Hi-C reads | #FA6863
+%%metro line: i10x_reads | 10X reads | #EB7AEB
+%%metro line: assemblies | Assembly | #24B064
+%%metro file: input_long_reads | FASTX
+%%metro file: input_hic_reads | CRAM
+%%metro file: input_10x_reads | FASTQ
+%%metro grid: raw_asm | 0, 0, 2
+%%metro grid: purging | 2, 2, 2
+%%metro grid: polishing | 4, 4, 2
+%%metro grid: scaffolding | 6, 6, 4
+%%metro grid: genome_statistics | 8, 8, 4
+%%metro line_order: span
+%%metro compact_offsets: true
+%%metro legend: bl
+
+graph LR
+    subgraph raw_asm [Raw assembly]
+        %%metro exit: bottom | hic_reads
+        %%metro exit: right | assemblies,long_reads
+        input_long_reads[ ]
+        input_hic_reads[ ]
+        hifiasm[hifiasm]
+        input_long_reads -->|long_reads| hifiasm
+        input_hic_reads -->|hic_reads| hifiasm
+    end
+    subgraph purging [Purging]
+        %%metro entry: left | assemblies,long_reads
+        %%metro exit: right | assemblies
+        purging_minimap2[minimap2]
+        purge_dups[purge_dups]
+        purging_minimap2 -->|assemblies,long_reads| purge_dups
+    end
+    subgraph polishing [Polishing]
+        %%metro entry: left | assemblies
+        %%metro exit: right | assemblies
+        input_10x_reads[ ]
+        longranger[Longranger]
+        freebayes[FreeBayes]
+        input_10x_reads -->|i10x_reads| longranger
+        longranger -->|i10x_reads,assemblies| freebayes
+    end
+    subgraph scaffolding [Scaffolding]
+        %%metro entry: left | assemblies
+        %%metro entry: bottom | hic_reads
+        %%metro exit: right | assemblies
+        scaffolding_bwamem2[bwa-mem2]
+        scaffolding_minimap2[minimap2]
+        yahs[YaHS]
+        pretextmap[PretextMap]
+        juicer[Juicer]
+        cooler[Cooler]
+        scaffolding_bwamem2 -->|assemblies,hic_reads| yahs
+        scaffolding_minimap2 -->|assemblies,hic_reads| yahs
+        yahs -->|assemblies,hic_reads| pretextmap
+        yahs -->|assemblies,hic_reads| juicer
+        yahs -->|assemblies,hic_reads| cooler
+    end
+    subgraph genome_statistics [Genome QC]
+        %%metro entry: left | assemblies
+        asmstats[asmstats]
+        gfastats[GFAStats]
+        busco[BUSCO]
+        merquryfk[MerquryFK]
+        asmstats -->|assemblies| gfastats
+        asmstats -->|assemblies| busco
+        asmstats -->|assemblies| merquryfk
+    end
+
+    %% Inter-section edges
+    hifiasm -->|assemblies,long_reads| purging_minimap2
+    hifiasm -->|hic_reads| scaffolding_bwamem2
+    hifiasm -->|hic_reads| scaffolding_minimap2
+    hifiasm -->|assemblies| longranger
+    hifiasm -->|assemblies| scaffolding_bwamem2
+    hifiasm -->|assemblies| scaffolding_minimap2
+    purge_dups -->|assemblies| longranger
+    purge_dups -->|assemblies| scaffolding_bwamem2
+    purge_dups -->|assemblies| scaffolding_minimap2
+    freebayes -->|assemblies| scaffolding_bwamem2
+    freebayes -->|assemblies| scaffolding_minimap2
+    hifiasm -->|assemblies| asmstats
+    purge_dups -->|assemblies| asmstats
+    freebayes -->|assemblies| asmstats
+    yahs -->|assemblies| asmstats
+

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -64,6 +64,11 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         EXAMPLES_DIR,
         "Same nf-core/differentialabundance map at default (uncentered) layout — useful for spotting regressions that only show with default port placement.",
     ),
+    (
+        "genomeassembly_staggered",
+        EXAMPLES_DIR,
+        "sanger-tol/genomeassembly with explicit `%%metro grid:` directives stacking each section in its own grid row. Regression fixture for #250 (cross-column junction routes were going backward in X).",
+    ),
     # --- Simple topologies ---
     (
         "single_section",

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -564,10 +564,28 @@ def _route_inter_section(
     # which is back inside the section).  Instead, route the channel
     # further into the inter-column gap (away from the target) so the
     # line continues in the junction's natural direction before dropping.
+    # Only fires for true same-column cases: both source and target
+    # belong to the same grid column (so the "wrong side" intrudes into
+    # their shared column).  When source and target sit in different
+    # columns the standard L-shape naturally drops in the inter-column
+    # gap and going "away from target" would route backward through a
+    # neighbouring section.
+    src_col_for_special = (
+        _resolve_section_col(graph, src, ctx.junction_ids)
+        if edge.source in ctx.junction_ids
+        else None
+    )
+    tgt_col_for_special = _resolve_section_col(graph, tgt, ctx.junction_ids)
+    same_col_special = (
+        src_col_for_special is not None
+        and tgt_col_for_special is not None
+        and src_col_for_special == tgt_col_for_special
+    )
     if (
         edge.source in ctx.junction_ids
         and abs(dx) <= JUNCTION_MARGIN + COORD_TOLERANCE
         and abs(dy) > abs(dx) * 3
+        and same_col_special
     ):
         delta, r_first, r_second = l_shape_radii(
             i,

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2662,3 +2662,101 @@ def test_grid_snap_does_not_mutate_x(fixture):
         if abs(st1.x - st2.x) > 0.5:
             offenders.append(f"{sid!r} run1.x={st1.x:.2f} != run2.x={st2.x:.2f}")
     assert not offenders, f"{fixture}: " + "; ".join(offenders[:3])
+
+
+# ---------------------------------------------------------------------------
+# LR routes do not go backwards (#250)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_routes_dont_loop_backwards(fixture):
+    """Cross-column routes must not contain a segment that reverses
+    the route's overall X direction.  Catches issue #250's "pinwheel"
+    artefact: a junction at the boundary of one column exits going +x
+    then immediately turns -x to curve down into the next column's
+    section.
+
+    Same-column near-vertical routes are exempt: when source and
+    target share a grid column with tiny dx, the routing engine
+    legitimately wraps the channel beyond the column to enter from the
+    appropriate side.  Routes touching TB/BT sections are also exempt
+    (those route in either X direction internally).
+    """
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    offenders: list[str] = []
+    for r in routes:
+        pts = r.points
+        if len(pts) < 2:
+            continue
+        src_st = graph.stations.get(r.edge.source)
+        tgt_st = graph.stations.get(r.edge.target)
+        src_sec = (
+            graph.sections.get(src_st.section_id)
+            if src_st and src_st.section_id
+            else None
+        )
+        tgt_sec = (
+            graph.sections.get(tgt_st.section_id)
+            if tgt_st and tgt_st.section_id
+            else None
+        )
+        if (src_sec and src_sec.direction in ("TB", "BT")) or (
+            tgt_sec and tgt_sec.direction in ("TB", "BT")
+        ):
+            continue
+        src_col = _resolve_section_col_for_station(graph, src_st)
+        tgt_col = _resolve_section_col_for_station(graph, tgt_st)
+        if src_col is not None and tgt_col is not None and src_col == tgt_col:
+            continue
+        overall_dx = pts[-1][0] - pts[0][0]
+        if abs(overall_dx) < 1.0:
+            continue
+        # Final-segment reversal is legitimate: a route arriving at an
+        # entry port on the opposite side from its overall direction
+        # must curve back to enter (RL section's right-entry, LR
+        # section's right-entry from below, etc.).  Only check segments
+        # before the final approach.
+        check_until = len(pts) - 1 if len(pts) >= 3 else len(pts)
+        for j in range(1, check_until):
+            seg_dx = pts[j][0] - pts[j - 1][0]
+            if overall_dx > 0 and seg_dx < -0.5:
+                offenders.append(
+                    f"{r.edge.source} -> {r.edge.target} (line={r.line_id}, "
+                    f"overall +x): "
+                    f"{tuple(round(c, 1) for c in pts[j - 1])} -> "
+                    f"{tuple(round(c, 1) for c in pts[j])}"
+                )
+                break
+            if overall_dx < 0 and seg_dx > 0.5:
+                offenders.append(
+                    f"{r.edge.source} -> {r.edge.target} (line={r.line_id}, "
+                    f"overall -x): "
+                    f"{tuple(round(c, 1) for c in pts[j - 1])} -> "
+                    f"{tuple(round(c, 1) for c in pts[j])}"
+                )
+                break
+    assert not offenders, f"{fixture}: " + "; ".join(offenders[:3])
+
+
+def _resolve_section_col_for_station(graph, station):
+    """Resolve a station's grid column.  For ports, use the section.
+    For junctions, follow an incoming edge back to a real station.
+    """
+    if station is None:
+        return None
+    if station.section_id:
+        sec = graph.sections.get(station.section_id)
+        if sec and sec.grid_col >= 0:
+            return sec.grid_col
+    if station.id in graph.junctions:
+        for e in graph.edges:
+            if e.target == station.id:
+                pred = graph.stations.get(e.source)
+                if pred and pred.section_id:
+                    sec = graph.sections.get(pred.section_id)
+                    if sec and sec.grid_col >= 0:
+                        return sec.grid_col
+    return None


### PR DESCRIPTION
Fixes #250 — junctions exiting toward a section in a different grid column were routing backward in X, producing visible pinwheel artefacts (line exits going +x then immediately turns -x to curve down to its target).

## Repro

Render `examples/genomeassembly.mmd` from issue #250 (staggered grid: one section per row at rows 0, 2, 4, 6, 8).  Two visible pinwheels show on the `assemblies` line at the boundaries after Polishing and Longranger.

## Diagnosis

`_route_inter_section`'s near-vertical junction handler placed the vertical channel "away from target":
- `dx > 0`: `vx = sx - curve_radius - offset_step + delta` (backward, LEFT of source)
- `dx < 0`: `vx = sx + curve_radius + offset_step + delta` (backward, RIGHT of source)

The comment explains this was for same-column cases where the standard L-shape would intrude into the column.  But when source and target sit in different grid columns, "away from target" pushes the channel into the previous column rather than into the inter-column gap.

## Fix

Gate the special block on source and target sharing a grid column (resolved via `_resolve_section_col` for ports + a junction-predecessor walk for junctions).  When they don't share a column, fall through to the standard L-shape which places the channel in the inter-column gap via `inter_column_channel_x`.

Same-column near-vertical wraps in variantbenchmarking (e.g. `__junction_15` -> `benchmarking__entry_right_11`) continue to use the special block, since both endpoints sit in column 3.

## Invariant

Adds `test_routes_dont_loop_backwards` in `tests/test_layout_invariants.py`, parametrised over `ALL_FIXTURES`.  Checks each route's intermediate segments for X-direction reversal against the route's overall X direction.  Exempts:
- Routes touching TB/BT sections (legitimately go either direction)
- Same-column routes (legitimate wraps)
- The final segment (entry-port approach can reverse to enter from opposite side)

Verification: with the engine fix reverted, the invariant flags 3 backward routes on the new staggered fixture; with the fix in place, all 49 fixtures pass.

## Fixture

Adds `examples/genomeassembly_staggered.mmd` — the staggered grid from the issue — as a regression fixture.  The existing `examples/genomeassembly.mmd` uses a different (compact) grid that didn't exercise the broken code path.

## Result

- 1685 passed, 4 xfailed (inherited), 0 failed
- Lint clean

Closes #250