### PR TITLE
fix: animated balls fly off-piste at merge junctions (#251)

### DIFF
--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -282,6 +282,37 @@ def adjacent_column_gap_x(
     return column_gap_midpoint(graph, col_a, col_b)
 
 
+def point_on_polyline(
+    point: tuple[float, float],
+    pts: list[tuple[float, float]],
+    tol: float = COORD_TOLERANCE,
+) -> tuple[int, float] | None:
+    """Locate *point* on a polyline within *tol* perpendicular distance.
+
+    Returns ``(segment_idx, t)`` where ``segment_idx`` is the index of
+    the segment's start vertex and ``t`` is the parameter along the
+    segment in [0, 1].  Returns None when no segment covers the point.
+    """
+    for i in range(len(pts) - 1):
+        ax, ay = pts[i]
+        bx, by = pts[i + 1]
+        dx, dy = bx - ax, by - ay
+        seg_len2 = dx * dx + dy * dy
+        if seg_len2 == 0:
+            if abs(point[0] - ax) <= tol and abs(point[1] - ay) <= tol:
+                return (i, 0.0)
+            continue
+        t = ((point[0] - ax) * dx + (point[1] - ay) * dy) / seg_len2
+        if t < -0.01 or t > 1.01:
+            continue
+        t = max(0.0, min(1.0, t))
+        proj_x = ax + t * dx
+        proj_y = ay + t * dy
+        if abs(point[0] - proj_x) <= tol and abs(point[1] - proj_y) <= tol:
+            return (i, t)
+    return None
+
+
 def bypass_bottom_y(
     graph: MetroGraph,
     src_col: int,

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -221,10 +221,15 @@ def _classify_merge_edges(
                     entry_port_for[mjid] = e.target
                     break
 
-        # Find farthest bypass predecessor (trunk carrier)
+        # Find farthest bypass predecessor (trunk carrier).  Branches
+        # must land on the trunk's own bypass_bottom_y -- the value the
+        # trunk's route actually uses -- not the deepest across all
+        # preds (which can disagree when the cap-at-midpoint guard in
+        # bypass_bottom_y fires for the trunk's span but not a closer
+        # branch's).
         farthest_source: str | None = None
         farthest_span = 0
-        deepest_by = 0.0
+        trunk_pred_by = 0.0
         for edge in graph.edges:
             if edge.target != mjid:
                 continue
@@ -246,14 +251,13 @@ def _classify_merge_edges(
                     BYPASS_CLEARANCE,
                     src_row=pred_row,
                 )
-                if by > deepest_by:
-                    deepest_by = by
                 if span > farthest_span:
                     farthest_span = span
                     farthest_source = edge.source
-        if farthest_source and deepest_by > 0:
+                    trunk_pred_by = by
+        if farthest_source and trunk_pred_by > 0:
             trunk_source[mjid] = farthest_source
-            trunk_by[mjid] = deepest_by
+            trunk_by[mjid] = trunk_pred_by
 
     # Classify edges into skip (not routed) and index_exclude
     # (routed as branches but excluded from gap indexing)

--- a/src/nf_metro/render/animate.py
+++ b/src/nf_metro/render/animate.py
@@ -10,6 +10,7 @@ import re
 import drawsvg as draw
 
 from nf_metro.layout.routing import RoutedPath
+from nf_metro.layout.routing.common import point_on_polyline
 from nf_metro.layout.routing.corners import resolve_curve_radii
 from nf_metro.parser.model import MetroGraph
 from nf_metro.render.constants import (
@@ -124,11 +125,11 @@ def _build_line_motion_paths(
     TrimGalore). Returns list of (line_id, d_attr) pairs -- a line_id
     may appear multiple times when it has forking branches.
     """
-    # Index routes by (source, target, line_id) for lookup
-    route_by_edge: dict[tuple[str, str, str], RoutedPath] = {}
+    # Single offset-applied polyline per route, reused below.
+    route_polylines: dict[tuple[str, str, str], list[tuple[float, float]]] = {}
     for route in routes:
         key = (route.edge.source, route.edge.target, route.line_id)
-        route_by_edge[key] = route
+        route_polylines[key] = apply_route_offsets(route, station_offsets)
 
     # Group edges by line
     edges_by_line: dict[str, list] = {}
@@ -163,18 +164,22 @@ def _build_line_motion_paths(
         if not all_paths:
             continue
 
-        for path_edges in all_paths:
-            all_points = _chain_edge_points(
-                path_edges,
-                route_by_edge,
-                station_offsets,
-            )
-            if len(all_points) < 2:
-                continue
+        line_polylines = [
+            pts for key, pts in route_polylines.items() if key[2] == line_id
+        ]
 
-            d_attr = _points_to_svg_path(all_points, curve_radius)
-            if d_attr:
-                result.append((line_id, d_attr))
+        for path_edges in all_paths:
+            chunks = _chain_edge_points(
+                path_edges,
+                route_polylines,
+                line_polylines,
+            )
+            for chunk in chunks:
+                if len(chunk) < 2:
+                    continue
+                d_attr = _points_to_svg_path(chunk, curve_radius)
+                if d_attr:
+                    result.append((line_id, d_attr))
 
     return result
 
@@ -272,35 +277,108 @@ def _variant_path(
 
 def _chain_edge_points(
     edges: list,
-    route_by_edge: dict[tuple[str, str, str], RoutedPath],
-    station_offsets: dict[tuple[str, str], float],
-) -> list[tuple[float, float]]:
-    """Chain edge routes into one continuous list of waypoints."""
-    all_points: list[tuple[float, float]] = []
+    route_polylines: dict[tuple[str, str, str], list[tuple[float, float]]],
+    line_polylines: list[list[tuple[float, float]]],
+) -> list[list[tuple[float, float]]]:
+    """Chain edge route polylines into contiguous waypoint chunks.
 
-    for edge in edges:
-        route = route_by_edge.get(
-            (edge.source, edge.target, edge.line_id),
-        )
-        if not route:
+    When consecutive edges' route endpoints don't coincide -- a
+    merge-junction branch route terminates on the trunk bundle rather
+    than at the junction station -- the gap is bridged using
+    sibling-route geometry on the same line so the motion path stays
+    on rendered geometry instead of cutting an off-piste diagonal.
+    The bridge may consume the next edge as well, since the stub from
+    merge junction to entry port is often already covered by the trunk.
+    """
+    chunks: list[list[tuple[float, float]]] = []
+    current: list[tuple[float, float]] = []
+
+    i = 0
+    while i < len(edges):
+        edge = edges[i]
+        pts = route_polylines.get((edge.source, edge.target, edge.line_id))
+        if not pts:
+            i += 1
             continue
 
-        pts = apply_route_offsets(route, station_offsets)
+        if not current:
+            current = list(pts)
+            i += 1
+            continue
 
-        if not all_points:
-            all_points.extend(pts)
-        elif pts:
-            last = all_points[-1]
-            first = pts[0]
-            if (
-                abs(last[0] - first[0]) < EDGE_CONNECT_TOLERANCE
-                and abs(last[1] - first[1]) < EDGE_CONNECT_TOLERANCE
-            ):
-                all_points.extend(pts[1:])
-            else:
-                all_points.extend(pts)
+        if _points_match(current[-1], pts[0]):
+            current.extend(pts[1:])
+            i += 1
+            continue
 
-    return all_points
+        bridge = _find_bridge(current[-1], pts[0], line_polylines)
+        if bridge is not None:
+            current.extend(bridge[1:])
+            current.extend(pts[1:])
+            i += 1
+            continue
+
+        # Try skipping a stub edge whose geometry the trunk already covered.
+        if i + 1 < len(edges):
+            n = edges[i + 1]
+            next_pts = route_polylines.get((n.source, n.target, n.line_id))
+            if next_pts:
+                if _points_match(current[-1], next_pts[0]):
+                    current.extend(next_pts[1:])
+                    i += 2
+                    continue
+                bridge = _find_bridge(current[-1], next_pts[0], line_polylines)
+                if bridge is not None:
+                    current.extend(bridge[1:])
+                    current.extend(next_pts[1:])
+                    i += 2
+                    continue
+
+        chunks.append(current)
+        current = list(pts)
+        i += 1
+
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _points_match(a: tuple[float, float], b: tuple[float, float]) -> bool:
+    return (
+        abs(a[0] - b[0]) < EDGE_CONNECT_TOLERANCE
+        and abs(a[1] - b[1]) < EDGE_CONNECT_TOLERANCE
+    )
+
+
+def _find_bridge(
+    from_pt: tuple[float, float],
+    to_pt: tuple[float, float],
+    polylines: list[list[tuple[float, float]]],
+    tol: float = 2.0,
+) -> list[tuple[float, float]] | None:
+    """Return a sub-polyline from from_pt to to_pt along a sibling route."""
+    for pts in polylines:
+        from_loc = point_on_polyline(from_pt, pts, tol)
+        if from_loc is None:
+            continue
+        to_loc = point_on_polyline(to_pt, pts, tol)
+        if to_loc is None:
+            continue
+        from_idx, from_t = from_loc
+        to_idx, to_t = to_loc
+        if to_idx < from_idx or (to_idx == from_idx and to_t < from_t):
+            continue
+        bridge: list[tuple[float, float]] = [from_pt]
+        for j in range(from_idx + 1, to_idx + 1):
+            bridge.append(pts[j])
+        bridge.append(to_pt)
+        cleaned: list[tuple[float, float]] = [bridge[0]]
+        for p in bridge[1:]:
+            if not _points_match(cleaned[-1], p):
+                cleaned.append(p)
+        if len(cleaned) >= 2:
+            return cleaned
+    return None
 
 
 def _points_to_svg_path(

--- a/tests/fixtures/genomeassembly_organellar.mmd
+++ b/tests/fixtures/genomeassembly_organellar.mmd
@@ -1,0 +1,105 @@
+%%metro title: sanger-tol/genomeassembly
+%%metro style: dark
+%%metro line: long_reads | Long reads | #3d95fd
+%%metro line: hic_reads | Hi-C reads | #FA6863
+%%metro line: i10x_reads | 10X reads | #EB7AEB
+%%metro line: assemblies | Assembly | #24B064
+%%metro file: input_long_reads | FASTX
+%%metro file: input_long_reads_organelle | FASTX
+%%metro file: input_hic_reads | CRAM
+%%metro file: input_10x_reads | FASTQ
+%%metro grid: raw_asm | 0, 0, 2
+%%metro grid: purging | 1, 0, 2
+%%metro grid: polishing | 2, 0, 2
+%%metro grid: scaffolding | 3, 0, 4
+%%metro grid: genome_statistics | 4, 0, 4
+%%metro grid: organellar_assembly | 1, 4, 2
+%%metro line_order: span
+%%metro compact_offsets: true
+%%metro legend: bl
+
+graph LR
+    subgraph raw_asm [Raw assembly]
+        %%metro exit: bottom | hic_reads
+        %%metro exit: right | assemblies,long_reads
+        input_long_reads[ ]
+        input_hic_reads[ ]
+        hifiasm[hifiasm]
+        input_long_reads -->|long_reads| hifiasm
+        input_hic_reads -->|hic_reads| hifiasm
+    end
+
+    subgraph purging [Purging]
+        %%metro entry: left | assemblies,long_reads
+        %%metro exit: right | assemblies
+        purging_minimap2[minimap2]
+        purge_dups[purge_dups]
+        purging_minimap2 -->|assemblies,long_reads| purge_dups
+    end
+
+    subgraph polishing [Polishing]
+        %%metro entry: left | assemblies
+        %%metro exit: right | assemblies
+        input_10x_reads[ ]
+        longranger[Longranger]
+        freebayes[FreeBayes]
+        input_10x_reads -->|i10x_reads| longranger
+        longranger -->|i10x_reads,assemblies| freebayes
+    end
+
+    subgraph scaffolding [Scaffolding]
+        %%metro entry: left | assemblies
+        %%metro entry: bottom | hic_reads
+        %%metro exit: right | assemblies
+        scaffolding_bwamem2[bwa-mem2]
+        scaffolding_minimap2[minimap2]
+        yahs[YaHS]
+        pretextmap[PretextMap]
+        juicer[Juicer]
+        cooler[Cooler]
+        scaffolding_bwamem2 -->|assemblies,hic_reads| yahs
+        scaffolding_minimap2 -->|assemblies,hic_reads| yahs
+        yahs -->|assemblies,hic_reads| pretextmap
+        yahs -->|assemblies,hic_reads| juicer
+        yahs -->|assemblies,hic_reads| cooler
+    end
+
+    subgraph genome_statistics [Genome QC]
+        %%metro entry: left | assemblies
+        asmstats[asmstats]
+        gfastats[GFAStats]
+        busco[BUSCO]
+        merquryfk[MerquryFK]
+        asmstats -->|assemblies| gfastats
+        asmstats -->|assemblies| busco
+        asmstats -->|assemblies| merquryfk
+    end
+
+    subgraph organellar_assembly [Organellar assembly]
+        %%metro entry: left | assemblies, long_reads
+        input_long_reads_organelle[ ]
+        mitohifi[MitoHiFi]
+        oatk[oatk]
+
+        input_long_reads_organelle -->|long_reads| mitohifi
+        input_long_reads_organelle -->|long_reads| oatk
+    end
+
+    %% Inter-section edges
+    hifiasm -->|assemblies,long_reads| purging_minimap2
+    hifiasm -->|hic_reads| scaffolding_bwamem2
+    hifiasm -->|hic_reads| scaffolding_minimap2
+    hifiasm -->|assemblies| longranger
+    hifiasm -->|assemblies| scaffolding_bwamem2
+    hifiasm -->|assemblies| scaffolding_minimap2
+    purge_dups -->|assemblies| longranger
+    purge_dups -->|assemblies| scaffolding_bwamem2
+    purge_dups -->|assemblies| scaffolding_minimap2
+    freebayes -->|assemblies| scaffolding_bwamem2
+    freebayes -->|assemblies| scaffolding_minimap2
+    hifiasm -->|assemblies| asmstats
+    purge_dups -->|assemblies| asmstats
+    freebayes -->|assemblies| asmstats
+    yahs -->|assemblies| asmstats
+    hifiasm -->|assemblies| mitohifi
+

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -1,0 +1,152 @@
+"""Animation motion path invariants.
+
+Every line segment in a motion path must lie along a rendered
+metro-line segment for the same line.  An animation polyline that
+strays off the visible track produces a ball that flies off-piste.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.animate import _build_line_motion_paths
+from nf_metro.themes import THEMES
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+TOPOLOGIES_DIR = Path(__file__).parent / "fixtures" / "topologies"
+
+# Fixtures that exercise the merge-junction routing introduced in #207
+# along with a couple of standard examples as regression guards.
+ANIMATION_FIXTURES = [
+    EXAMPLES_DIR / "genomeassembly.mmd",
+    EXAMPLES_DIR / "rnaseq_sections.mmd",
+    EXAMPLES_DIR / "epitopeprediction.mmd",
+    EXAMPLES_DIR / "hlatyping.mmd",
+    TOPOLOGIES_DIR / "fan_in_merge.mmd",
+    TOPOLOGIES_DIR / "wide_fan_in.mmd",
+    TOPOLOGIES_DIR / "section_diamond.mmd",
+]
+ANIMATION_FIXTURE_IDS = [p.stem for p in ANIMATION_FIXTURES]
+
+
+def _build(fixture: Path):
+    """Parse, layout, route, and build animation motion paths for a fixture."""
+    graph = parse_metro_mermaid(fixture.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    theme = THEMES["nfcore"]
+    motion_paths = _build_line_motion_paths(graph, routes, offsets, theme)
+    return graph, routes, offsets, motion_paths
+
+
+_NUMBER = r"-?\d+(?:\.\d+)?"
+_TOKEN_RE = re.compile(rf"[MLQ]|{_NUMBER}")
+
+
+def _parse_motion_path(d_attr: str) -> list[tuple[str, list[tuple[float, float]]]]:
+    """Parse an SVG motion path 'd' attribute into segments.
+
+    Returns a list of (command, points) where command is one of 'M', 'L',
+    'Q' and points is the segment's coordinate tuples.  The 'Q' segment
+    keeps the (control, end) pair.
+    """
+    tokens = _TOKEN_RE.findall(d_attr)
+    out: list[tuple[str, list[tuple[float, float]]]] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in ("M", "L"):
+            x = float(tokens[i + 1])
+            y = float(tokens[i + 2])
+            out.append((tok, [(x, y)]))
+            i += 3
+        elif tok == "Q":
+            cx = float(tokens[i + 1])
+            cy = float(tokens[i + 2])
+            ex = float(tokens[i + 3])
+            ey = float(tokens[i + 4])
+            out.append(("Q", [(cx, cy), (ex, ey)]))
+            i += 5
+        else:
+            i += 1
+    return out
+
+
+def _end_point(segment: tuple[str, list[tuple[float, float]]]) -> tuple[float, float]:
+    """Return the on-curve endpoint of a parsed segment."""
+    cmd, pts = segment
+    if cmd == "Q":
+        return pts[1]
+    return pts[0]
+
+
+@pytest.mark.parametrize("fixture", ANIMATION_FIXTURES, ids=ANIMATION_FIXTURE_IDS)
+def test_motion_path_segments_lie_on_rendered_geometry(fixture: Path):
+    """Every L/Q segment of every motion path must coincide with a
+    rendered metro-line segment of the same line."""
+    from nf_metro.layout.routing.common import point_on_polyline
+    from nf_metro.render.svg import apply_route_offsets
+
+    graph, routes, offsets, motion_paths = _build(fixture)
+
+    polylines_by_line: dict[str, list[list[tuple[float, float]]]] = {}
+    for r in routes:
+        polylines_by_line.setdefault(r.line_id, []).append(
+            apply_route_offsets(r, offsets)
+        )
+
+    tol = 1.5  # absorb curve-approximation rounding
+
+    def _segment_covered(
+        a: tuple[float, float],
+        b: tuple[float, float],
+        line_id: str,
+    ) -> bool:
+        for pts in polylines_by_line.get(line_id, []):
+            a_loc = point_on_polyline(a, pts, tol)
+            if a_loc is None:
+                continue
+            b_loc = point_on_polyline(b, pts, tol)
+            if b_loc is None:
+                continue
+            # Same segment or adjacent segments along the polyline are fine;
+            # the test is whether both points sit on the same polyline.
+            return True
+        return False
+
+    offences: list[str] = []
+    for line_id, d_attr in motion_paths:
+        parsed = _parse_motion_path(d_attr)
+        if not parsed:
+            continue
+        prev_end = _end_point(parsed[0])
+        for seg in parsed[1:]:
+            cmd, pts = seg
+            end = _end_point(seg)
+            if cmd == "L":
+                if not _segment_covered(prev_end, end, line_id):
+                    offences.append(f"L {prev_end} -> {end} on line {line_id!r}")
+            elif cmd == "Q":
+                # Curve smoothing at a station corner: accept if either the
+                # control leg or the chord lies on the rendered polyline.
+                control = pts[0]
+                if not (
+                    _segment_covered(prev_end, control, line_id)
+                    or _segment_covered(prev_end, end, line_id)
+                ):
+                    offences.append(
+                        f"Q {prev_end} -> {control} -> {end} on line {line_id!r}"
+                    )
+            prev_end = end
+
+    assert not offences, (
+        f"{fixture.name}: motion path contains off-piste segments not on "
+        f"any rendered metro-line edge:\n  " + "\n  ".join(offences[:5])
+    )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -208,3 +208,59 @@ def test_bypass_routing_around_intervening_sections():
         f"No waypoint below intervening sections (bottom={max_section_bottom}). "
         f"Waypoint Ys: {waypoint_ys}"
     )
+
+
+def _route_endpoint_attached(point, station, sibling_polylines, tol=2.0):
+    """True if *point* coincides with *station* or any sibling polyline."""
+    import math
+
+    from nf_metro.layout.routing.common import point_on_polyline
+
+    if (
+        station is not None
+        and math.hypot(point[0] - station.x, point[1] - station.y) < 5.0
+    ):
+        return True
+    return any(
+        point_on_polyline(point, pts, tol) is not None for pts in sibling_polylines
+    )
+
+
+def test_merge_branch_lands_on_trunk_y():
+    """Merge-junction branch routes must terminate on the trunk bundle Y
+    (or on a sibling polyline) -- not hanging in mid-air between rows."""
+    from nf_metro.render.svg import apply_route_offsets
+
+    fp = Path(__file__).parent / "fixtures" / "genomeassembly_organellar.mmd"
+    graph = parse_metro_mermaid(fp.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    by_line: dict[str, list[list[tuple[float, float]]]] = {}
+    for r in routes:
+        by_line.setdefault(r.line_id, []).append(apply_route_offsets(r, offsets))
+
+    offences = []
+    for r in routes:
+        pts = apply_route_offsets(r, offsets)
+        if len(pts) < 2:
+            continue
+        siblings = [p for p in by_line[r.line_id] if p is not pts]
+        src = graph.stations.get(r.edge.source)
+        tgt = graph.stations.get(r.edge.target)
+        if not _route_endpoint_attached(pts[0], src, siblings):
+            offences.append(
+                f"{r.edge.source}->{r.edge.target} on {r.line_id!r}: "
+                f"src {pts[0]} disconnected"
+            )
+        if not _route_endpoint_attached(pts[-1], tgt, siblings):
+            offences.append(
+                f"{r.edge.source}->{r.edge.target} on {r.line_id!r}: "
+                f"tgt {pts[-1]} disconnected"
+            )
+
+    assert not offences, (
+        f"{fp.name}: route endpoints hanging in mid-air (not on a "
+        f"station marker or sibling route segment):\n  " + "\n  ".join(offences[:5])
+    )


### PR DESCRIPTION
## Summary

Two related fixes against merge-junction routing, both surfaced by the
sanger-tol/genomeassembly diagram with an organellar_assembly section.

- **Routing**: `_classify_merge_edges` stored `trunk_by[mjid] = deepest_by`,
  the deepest `bypass_bottom_y` across all merge-junction predecessors. But
  the trunk's own route uses its own `bypass_bottom_y`, which can be
  shallower when the cap-at-midpoint guard fires for the trunk's wider
  column span but not the closer branches'. Branches then landed at the
  deeper Y while the trunk ran shallower — visible stubs hanging in
  mid-air. Now `trunk_by` is the trunk source's own `bypass_bottom_y`.

- **Animation**: `_chain_edge_points` blindly concatenated edge polylines,
  so when a merge-branch route ended on the trunk bundle and the next
  edge started at the merge junction station, the ball cut a straight
  diagonal between them. Now the chain bridges those gaps using
  sibling-route geometry on the same line (the trunk typically covers
  it), optionally skipping a stub edge whose geometry the trunk already
  includes. When no bridge is available the chain breaks into a fresh
  motion path instead of inventing one.

- Adds a shared `point_on_polyline` helper in `routing/common.py`, used
  by both the animation builder and the new invariant tests.

Fixes #251

## Test plan

- [x] `pytest` passes (1644 passed, 4 xfailed)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] `tests/test_animation.py` (new): parametrised across genomeassembly,
      rnaseq_sections, epitopeprediction, hlatyping, fan_in_merge,
      wide_fan_in, section_diamond. Pins motion-path segments to rendered
      metro-line geometry. Fails on pre-fix code.
- [x] `tests/test_routing.py::test_merge_branch_lands_on_trunk_y` (new):
      uses `tests/fixtures/genomeassembly_organellar.mmd` which exercises
      the cap-at-midpoint asymmetry. Fails on pre-fix code.
- [ ] Visual review via [render preview](https://pinin4fjords.github.io/nf-metro/_pr/<PR>/)
- [ ] Render-preview verdict captured

Generated with Claude Code