### PR TITLE
refactor(layout): rename second Phase 13k to Phase 13k2

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -547,11 +547,9 @@ Guard bodies live at the top of `engine.py` (lines 83-275).
 - **Invariants preserved**: Busy sibling Y. Bundle Y.
 - **Related tests**: `test_lines_dont_cross_non_consumer_markers`,
   `test_no_icon_overlaps_line_path`.
-- **Notes**: Shares the "13k" tag with the lower-row tighten phase
-  above. **UNCLEAR / collision.**
 
 ### Phase 13l: push lower rows after bbox grow (engine.py:802-806)
-- **Purpose**: Companion to 13k - when 13k grew a section's bbox
+- **Purpose**: Companion to 13k2 - when 13k2 grew a section's bbox
   downward, push lower-row sections down to keep
   `section_y_gap`.
 - **Helper**: `_push_lower_rows_after_bbox_grow` (engine.py:2698).

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -532,12 +532,8 @@ Guard bodies live at the top of `engine.py` (lines 83-275).
   filled their full row claim).
 - **Invariants preserved**: Within-row trunk Ys. Bbox heights of
   upper rows.
-- **Notes**: Phase tag in code shadowed - there are two "Phase 13k"
-  comments (engine.py:789 and engine.py:796). Engine numbering is
-  unique by helper, but the comment labels collide; **UNCLEAR
-  structural debt - the two 13k entries should be renumbered.**
 
-### Phase 13k (second, sparse loop shift) (engine.py:796-800)
+### Phase 13k2: shift sparse loop stations to clear bundle (engine.py:796-800)
 - **Purpose**: Shift sparse loop-side stations (one inbound, one
   outbound, single-line consumer) onto a half-pitch Y when sharing
   the full-row Y with a busier sibling whose inbound bundle would
@@ -559,7 +555,7 @@ Guard bodies live at the top of `engine.py` (lines 83-275).
   downward, push lower-row sections down to keep
   `section_y_gap`.
 - **Helper**: `_push_lower_rows_after_bbox_grow` (engine.py:2698).
-- **Precondition**: Phase 13k may have grown some bboxes.
+- **Precondition**: Phase 13k2 may have grown some bboxes.
 - **Postcondition**: Row gaps preserved across the bbox grow.
 - **Invariants preserved**: Within-row Ys.
 - **Related tests**: `test_row_gap_accommodates_bypass`.
@@ -581,9 +577,11 @@ Guard bodies live at the top of `engine.py` (lines 83-275).
 The following observations came up while writing this doc. Each one is
 a candidate for a follow-up cleanup PR.
 
-1. **Two "Phase 13k" comments** (engine.py:789 and engine.py:796) refer
+1. ~~**Two "Phase 13k" comments** (engine.py:789 and engine.py:796) refer
    to entirely different helpers. The phase numbering scheme has
-   collided and should be renumbered.
+   collided and should be renumbered.~~ **Resolved**: the second
+   `_shift_sparse_loop_stations_to_clear_bundle` block is now labelled
+   `Phase 13k2`.
 2. **Phase 13d3 has more conditional logic than the rest** - it's
    gated on `center_ports` and tracks state on
    `_half_grid_station_ids` to coordinate with Phase 13e. That

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1121,13 +1121,15 @@ def _compute_section_layout(
     # claim; multi-row layouts with content-filled rows are untouched.
     _tighten_lower_rows_after_shrink(graph, section_y_gap)
 
-    # Phase 13k: Shift sparse loop-side stations (e.g. ``grea`` -- one
+    # Phase 13k2: Shift sparse loop-side stations (e.g. ``grea`` -- one
     # incoming, one outgoing, single-line consumer) onto a half-grid Y
     # when sharing the full-row Y with a busier sibling whose inbound
     # bundle would otherwise cross the sparse station's marker bbox.
+    # (Distinct from Phase 13k above; renamed to disambiguate after the
+    # numbering collision flagged in src/nf_metro/layout/CONTRACT.md.)
     _shift_sparse_loop_stations_to_clear_bundle(graph, y_spacing, section_y_padding)
 
-    # Phase 13l: When Phase 13k grew a section's bbox downward, push
+    # Phase 13l: When Phase 13k2 grew a section's bbox downward, push
     # sections in lower rows down so they don't crowd the grown bbox.
     # ``_tighten_lower_rows_after_shrink`` only closes slack (pulls
     # rows up); the inverse push happens here.
@@ -3037,7 +3039,7 @@ def _shift_sparse_loop_stations_to_clear_bundle(
 def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) -> None:
     """Push lower-row sections down when an upper-row bbox grows.
 
-    ``_shift_sparse_loop_stations_to_clear_bundle`` (Phase 13k) can
+    ``_shift_sparse_loop_stations_to_clear_bundle`` (Phase 13k2) can
     grow a section's ``bbox_h`` downward when shifting a sparse loop
     station like ``grea`` past the original bbox bottom.  Row offsets
     were fixed earlier by ``_compute_section_offsets`` from pre-shift


### PR DESCRIPTION
## Summary

Resolves the first structural-debt signal listed in `src/nf_metro/layout/CONTRACT.md`: two distinct phases were both labelled "Phase 13k" in engine.py comments.

- engine.py:789 was `_tighten_lower_rows_after_shrink` (Phase 13k).
- engine.py:796 was `_shift_sparse_loop_stations_to_clear_bundle` (also labelled Phase 13k).

The second is now `Phase 13k2`. Updated cross-references in:
- the inline comment at engine.py:796
- Phase 13l's comment block ("When Phase 13k grew..." -> "When Phase 13k2 grew...")
- the `_push_lower_rows_after_bbox_grow` docstring
- `CONTRACT.md` section heading
- the structural-debt-signals list (signal #1 marked resolved)

Pure comment / docstring rename. No semantic change.

## Tests / lint / render

- `pytest tests/`: 2015 passed, 34 xfailed.
- `ruff check src/ tests/`: clean.
- `ruff format --check`: clean.
- Render-diff against the #340 rollup baseline: empty (exit 2).

## Base

Stacked on top of #340. Re-target to `main` after #340 merges.

## Test plan

- [ ] Skim the engine.py comment changes and the CONTRACT.md update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)