### PR TITLE
fix(layout): keep TOP/BOTTOM ports on bbox edge during row compact

### DIFF
--- a/.claude/skills/nf-metro-layout-triage/build_review.py
+++ b/.claude/skills/nf-metro-layout-triage/build_review.py
@@ -938,9 +938,7 @@ def collect_failures_via_pytest(worktree: Path, target: str) -> str:
     """Run pytest -rfX --tb=no -q against ``target`` inside ``worktree``
     and return its stdout. Failures don't abort us - the report is the goal."""
     env = os.environ.copy()
-    env["PYTHONPATH"] = (
-        f"{worktree / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}"
-    )
+    env["PYTHONPATH"] = f"{worktree / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}"
     cmd = ["pytest", target, "-rfX", "--tb=no", "-q", "--no-header"]
     proc = subprocess.run(
         cmd,
@@ -1050,9 +1048,7 @@ def main() -> int:
                     )
             except Exception as e:  # noqa: BLE001
                 bbox_fallback += 1
-                violator_err = (
-                    f"violator extraction error: {type(e).__name__}: {e}"
-                )
+                violator_err = f"violator extraction error: {type(e).__name__}: {e}"
 
         if base_svg is None:
             annotated_svg = None
@@ -1090,9 +1086,7 @@ def main() -> int:
     print(f"Wrote {out} ({out.stat().st_size:,} bytes)", file=sys.stderr)
 
     if render_failed:
-        print(
-            f"CAVEAT: {render_failed} fixture(s) failed to render", file=sys.stderr
-        )
+        print(f"CAVEAT: {render_failed} fixture(s) failed to render", file=sys.stderr)
     return 0
 
 
@@ -1250,8 +1244,7 @@ def _build_explanation_blocks(invariant: str, violators: list[dict]) -> str:
                     if len(info["parents"]) == 1:
                         p, py = info["parents"][0]
                         parent_part = (
-                            f"parent <code>{esc(p)}</code> "
-                            f"(y=<code>{py:.1f}</code>)"
+                            f"parent <code>{esc(p)}</code> (y=<code>{py:.1f}</code>)"
                         )
                     else:
                         parent_part = (
@@ -1420,8 +1413,7 @@ def _build_explanation_blocks(invariant: str, violators: list[dict]) -> str:
                 "flag Ambiguous.",
             ),
             "test_off_track_inputs_above_consumer": (
-                "An off-track input station does not sit above the "
-                "station it feeds.",
+                "An off-track input station does not sit above the station it feeds.",
                 "Find off-track inputs whose feed arrow points up instead "
                 "of down. If the layout intentionally puts the input "
                 "below, flag Ambiguous.",
@@ -1480,20 +1472,16 @@ def build_html(rows: list[dict]) -> str:
             violator_summary = (
                 f'<div class="violator-list"><strong>{len(r["violators"])} '
                 f"violator(s) highlighted:</strong><ul>"
-                + "".join(
-                    f"<li>{esc(v.get('note', ''))}</li>" for v in r["violators"]
-                )
+                + "".join(f"<li>{esc(v.get('note', ''))}</li>" for v in r["violators"])
                 + "</ul></div>"
             )
         elif v_err:
-            violator_summary = (
-                f'<div class="violator-note"><em>{esc(v_err)}</em></div>'
-            )
+            violator_summary = f'<div class="violator-note"><em>{esc(v_err)}</em></div>'
 
         if svg is None:
             img_block = (
                 f'<div class="render-fail">render failed: '
-                f'{esc(rdr_err or "unknown")}</div>'
+                f"{esc(rdr_err or 'unknown')}</div>"
             )
         else:
             b64 = base64.b64encode(svg.encode("utf-8")).decode("ascii")

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -231,9 +231,7 @@ PIPELINE_ENTRIES: list[tuple[str, str, str, str]] = [
 _manifest: dict[str, str] = {}
 
 
-def render_mmd(
-    mmd_path: Path, svg_path: Path, *, debug: bool = DEBUG_RENDERS
-) -> None:
+def render_mmd(mmd_path: Path, svg_path: Path, *, debug: bool = DEBUG_RENDERS) -> None:
     """Parse, layout, and render a .mmd file to SVG."""
     text = mmd_path.read_text()
     graph = parse_metro_mermaid(text)

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1954,26 +1954,24 @@ def _compact_row_content_to_bbox_top(
 
             if delta >= 0.5:
                 for section in group:
-                    # bbox_y is preserved across compact; only bbox_h shrinks.
-                    # Clamp TOP/BOTTOM ports to the resulting top/bottom edge
-                    # so the shift doesn't push edge-pinned ports outside
-                    # the bbox (e.g. a TOP port at bbox_y getting pushed to
-                    # bbox_y - delta).
-                    new_top = section.bbox_y
+                    # bbox_y is preserved; only bbox_h shrinks.  Clamp
+                    # edge-pinned ports so the shift doesn't push them
+                    # outside the (now-shorter) bbox.
                     new_bottom = section.bbox_y + max(0.0, section.bbox_h - delta)
                     for sid in section.station_ids:
                         st = graph.stations.get(sid)
                         if st is None:
                             continue
-                        port = graph.ports.get(sid)
                         new_y = st.y - delta
-                        if port is not None and port.side == PortSide.TOP:
-                            new_y = max(new_y, new_top)
-                        elif port is not None and port.side == PortSide.BOTTOM:
-                            new_y = min(new_y, new_bottom)
-                        st.y = new_y
-                        if port:
-                            port.y = new_y
+                        port = graph.ports.get(sid)
+                        if port is not None:
+                            if port.side == PortSide.TOP:
+                                new_y = max(new_y, section.bbox_y)
+                            elif port.side == PortSide.BOTTOM:
+                                new_y = min(new_y, new_bottom)
+                            _set_port_y(graph, sid, new_y)
+                        else:
+                            st.y = new_y
                     section.bbox_h = max(0.0, section.bbox_h - delta)
 
             for section in group:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1954,14 +1954,26 @@ def _compact_row_content_to_bbox_top(
 
             if delta >= 0.5:
                 for section in group:
+                    # bbox_y is preserved across compact; only bbox_h shrinks.
+                    # Clamp TOP/BOTTOM ports to the resulting top/bottom edge
+                    # so the shift doesn't push edge-pinned ports outside
+                    # the bbox (e.g. a TOP port at bbox_y getting pushed to
+                    # bbox_y - delta).
+                    new_top = section.bbox_y
+                    new_bottom = section.bbox_y + max(0.0, section.bbox_h - delta)
                     for sid in section.station_ids:
                         st = graph.stations.get(sid)
                         if st is None:
                             continue
-                        st.y -= delta
                         port = graph.ports.get(sid)
+                        new_y = st.y - delta
+                        if port is not None and port.side == PortSide.TOP:
+                            new_y = max(new_y, new_top)
+                        elif port is not None and port.side == PortSide.BOTTOM:
+                            new_y = min(new_y, new_bottom)
+                        st.y = new_y
                         if port:
-                            port.y -= delta
+                            port.y = new_y
                     section.bbox_h = max(0.0, section.bbox_h - delta)
 
             for section in group:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2841,8 +2841,10 @@ def test_ports_on_section_boundary(fixture):
     the full fixture corpus so a regression on any single pipeline trips
     the test rather than only ``validate=True`` runs.
     """
+    from nf_metro.layout.constants import GUARD_TOLERANCE
+
     graph = _layout(fixture)
-    tol = 5.0  # GUARD_TOLERANCE from layout.constants
+    tol = GUARD_TOLERANCE
 
     offenders: list[str] = []
     for pid, port in graph.ports.items():

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2827,6 +2827,47 @@ def test_routes_dont_loop_backwards(fixture):
     assert not offenders, f"{fixture}: " + "; ".join(offenders[:3])
 
 
+# ---------------------------------------------------------------------------
+# Ports must sit on a section bbox edge, and Port/Station registries must
+# agree on the port's coordinates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_ports_on_section_boundary(fixture):
+    """Every port station must sit on its section's bbox edge.
+
+    Mirrors the runtime ``_guard_ports_on_boundaries`` check but exercises
+    the full fixture corpus so a regression on any single pipeline trips
+    the test rather than only ``validate=True`` runs.
+    """
+    graph = _layout(fixture)
+    tol = 5.0  # GUARD_TOLERANCE from layout.constants
+
+    offenders: list[str] = []
+    for pid, port in graph.ports.items():
+        st = graph.stations.get(pid)
+        if st is None:
+            continue
+        sec = graph.sections.get(st.section_id or "")
+        if sec is None or sec.bbox_w == 0 or sec.bbox_h == 0:
+            continue
+        on_left = abs(st.x - sec.bbox_x) <= tol
+        on_right = abs(st.x - (sec.bbox_x + sec.bbox_w)) <= tol
+        on_top = abs(st.y - sec.bbox_y) <= tol
+        on_bottom = abs(st.y - (sec.bbox_y + sec.bbox_h)) <= tol
+        if not (on_left or on_right or on_top or on_bottom):
+            offenders.append(
+                f"port {pid!r} (side={port.side.name}) at "
+                f"({st.x:.1f}, {st.y:.1f}) not on any edge of section "
+                f"{st.section_id!r} bbox "
+                f"({sec.bbox_x:.1f}, {sec.bbox_y:.1f}, "
+                f"w={sec.bbox_w:.1f}, h={sec.bbox_h:.1f})"
+            )
+
+    assert not offenders, f"{fixture}: " + "; ".join(offenders[:3])
+
+
 def _resolve_section_col_for_station(graph, station):
     """Resolve a station's grid column.  For ports, use the section.
     For junctions, follow an incoming edge back to a real station.


### PR DESCRIPTION
## Summary

- `_compact_row_content_to_bbox_top` shifts content up to be flush with `section_y_padding` below `bbox_y`, then shrinks `bbox_h`. `bbox_y` itself is preserved.
- The shift loop was applying the same delta to ports, taking TOP-side ports from `y == bbox_y` to `y == bbox_y - delta` (above the unchanged top edge). `_guard_ports_on_boundaries(validate=True)` caught this on `variantbenchmarking{,_auto}.mmd`.
- Fix: clamp TOP/BOTTOM ports to the (possibly-shrunk) bbox edge during the shift so edge-pinned ports stay on the boundary.
- Adds `test_ports_on_section_boundary` parametrized over all gallery fixtures so this regression class is caught broadly, not only when `validate=True` runs.

Fixes #347

## Test plan
- [x] `pytest` passes (1991 passed, 4 pre-existing xfails)
- [x] `ruff check src/ tests/` and `ruff format --check src/ tests/` clean (CI's scope)
- [x] Runtime validator already existed (`_guard_ports_on_boundaries`); now usable with `validate=True` on the variantbenchmarking gallery entries.
- [ ] Visual review of the [render preview](https://pinin4fjords.github.io/nf-metro/_pr/) once CI completes
- [ ] Render-preview verdict captured