### PR TITLE
refactor(layout): Phase-13x bisection guards in validate=True (#346)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -51,9 +51,18 @@ Phases split into three regimes:
 | after Phase 4 | finite coords, stations-in-sections, bboxes-positive |
 | after Phase 5 | ports-on-boundaries |
 | after top-align (Phase 9) | ports-on-boundaries |
-| after Phase 12 (final) | finite coords, bboxes-positive, stations-in-sections, ports-on-boundaries, no-station-overlap, no-line-crosses-non-consumer |
+| after each Phase 13x (bisection) | finite coords, bboxes-positive, stations-in-sections, ports-on-boundaries, no-station-overlap, no-line-crosses-non-consumer, station-x-column-drift |
+| after Phase 12 (final) | bisection set + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
-Guard bodies live at the top of `engine.py` (lines 83-275).
+Bisection checkpoints fire after every Phase-13x sub-phase
+(see the `# Phase 13...` comments in `_compute_section_layout`).
+Three guards are excluded from the bisection set because they are
+legitimately transient between sub-phases; the
+`_run_phase13_guards` docstring (engine.py) is the authoritative
+list and rationale.
+
+Guard bodies live at the top of `engine.py` (lines 83-275); the
+bisection runner is `_run_phase13_guards`.
 
 ## Phase table
 
@@ -573,40 +582,30 @@ Guard bodies live at the top of `engine.py` (lines 83-275).
 ## Unclear / structural-debt signals
 
 The following observations came up while writing this doc. Each one is
-a candidate for a follow-up cleanup PR.
+a candidate for a follow-up cleanup PR. Items are removed as they are
+resolved; refer to the relevant tracking issue or PR for history.
 
-1. ~~**Two "Phase 13k" comments** (engine.py:789 and engine.py:796) refer
-   to entirely different helpers. The phase numbering scheme has
-   collided and should be renumbered.~~ **Resolved**: the second
-   `_shift_sparse_loop_stations_to_clear_bundle` block is now labelled
-   `Phase 13k2`.
-2. **Phase 13d3 has more conditional logic than the rest** - it's
+1. **Phase 13d3 has more conditional logic than the rest** - it's
    gated on `center_ports` and tracks state on
    `_half_grid_station_ids` to coordinate with Phase 13e. That
    cross-phase coupling is hard to follow; the half-grid marker
    pattern would benefit from a dedicated discussion in the doc /
    code.
-3. **Pass B is described as "single pass"** in the function docstring,
+2. **Pass B is described as "single pass"** in the function docstring,
    but Phase 11 expands bboxes (`_expand_bbox_for_y`) and Phase 11c
    immediately re-runs top-align to undo the resulting bbox-top
    drift. Naming-wise, "single pass" is misleading.
-4. **Phase 13h triggers further phases** (`_reanchor_off_track_to_consumer`
+3. **Phase 13h triggers further phases** (`_reanchor_off_track_to_consumer`
    and `_top_align_row_bboxes_only`) inside its `if center_ports:`
    block. These are effectively unnumbered sub-phases hiding in
    a conditional - they don't appear as `# Phase 13h.something`
    comments but are real graph-mutating passes.
-5. **Phase 13 (off-track lift) calls `_shift_graph_into_canvas`**,
+4. **Phase 13 (off-track lift) calls `_shift_graph_into_canvas`**,
    which globally translates every station / port / junction / bbox.
    That's a Phase 4-style transformation hiding inside a Phase 13
    helper; if any later phase assumed Phase 4's global-coord origin
    was stable, the assumption is wrong.
-6. **`compute_layout(validate=True)` runs `_guard_no_station_overlap`
-   and `_guard_no_line_crosses_non_consumer` only at "after Phase 12
-   (final)" - i.e. at the *end* of layout.** Many of the 13-suffixed
-   phases exist precisely to fix overlap or breeze-past issues. A
-   binary search bisecting which phase first introduces overlap is
-   currently a manual exercise.
-7. **Phase 11d/11da symmetrically fan content using a stale port Y**;
+5. **Phase 11d/11da symmetrically fan content using a stale port Y**;
    Phase 13h re-centers using the final trunk Y. The two-pass pattern
    is necessary because Phase 11da runs before snap-to-grid, but it
    means the early pass's output is partially-discarded work.
@@ -617,7 +616,8 @@ When adding a new phase to `_compute_section_layout`, document the
 following before merging:
 
 1. **Phase tag**: pick a new tag matching the position in the pipeline.
-   Avoid suffix collisions (see structural debt #1 above).
+   Avoid suffix collisions (the `Phase 13k` -> `Phase 13k2` rename in
+   PR #342 is what happens when you don't).
 2. **Helper location**: top-level function in `engine.py` (or a new
    module if it's substantial). Phase comments in the function body
    must reference the helper.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -197,12 +197,15 @@ def _station_marker_bbox(
     return (st.x - radius, cy - half_h, st.x + radius, cy + half_h)
 
 
-def _guard_no_station_overlap(graph: MetroGraph, phase: str) -> None:
+def _guard_no_station_overlap(
+    graph: MetroGraph, phase: str, *, offsets: dict | None = None
+) -> None:
     """Final-phase: no two station marker bboxes may overlap at render
     time, else one station hides another in the SVG."""
-    from nf_metro.layout.routing import compute_station_offsets
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
 
-    offsets = compute_station_offsets(graph)
+        offsets = compute_station_offsets(graph)
     boxes: list[tuple[str, tuple[float, float, float, float]]] = []
     for sid in graph.stations:
         b = _station_marker_bbox(graph, sid, offsets=offsets)
@@ -219,7 +222,13 @@ def _guard_no_station_overlap(graph: MetroGraph, phase: str) -> None:
                 )
 
 
-def _guard_no_line_crosses_non_consumer(graph: MetroGraph, phase: str) -> None:
+def _guard_no_line_crosses_non_consumer(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict | None = None,
+    routes: list | None = None,
+) -> None:
     """Final-phase: no rendered line segment may pass through a
     station marker whose station neither consumes nor produces that
     line.
@@ -233,14 +242,19 @@ def _guard_no_line_crosses_non_consumer(graph: MetroGraph, phase: str) -> None:
     sharing its trunk-Y row with a busier sibling whose inbound
     bundle traverses the sparse consumer's column.
     """
-    from nf_metro.layout.routing import compute_station_offsets, route_edges
     from nf_metro.render.svg import apply_route_offsets
 
-    offsets = compute_station_offsets(graph)
-    try:
-        routes = route_edges(graph, station_offsets=offsets)
-    except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
-        return
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
+
+        offsets = compute_station_offsets(graph)
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+            return
 
     consumed_by: dict[str, set[str]] = {}
     produced_by: dict[str, set[str]] = {}
@@ -601,6 +615,64 @@ def _guard_station_x_column_drift(graph: MetroGraph, phase: str) -> None:
                         f"{abs(x - median_x):.1f} > X_SPACING={X_SPACING:.1f} "
                         f"from median={median_x:.1f}"
                     )
+
+
+def _run_phase13_guards(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict | None = None,
+    routes: list | None = None,
+) -> tuple[dict, list | None]:
+    """Bisection guards run after every Phase-13x sub-phase boundary in
+    ``validate=True`` mode.
+
+    The Phase 13 tidy-up pipeline is a sequence of ~20 mutating passes
+    over a shared graph; before this helper, ``validate=True`` only
+    sampled the final state, so a regression introduced at e.g. Phase
+    13h surfaced as ``after Phase 12 (final): ...`` with no way to
+    bisect.  Running the same overlap / breeze-past / column-drift
+    checks at each boundary localises the culprit to a single phase.
+
+    Excluded from the bisection set (transient between sub-phases or
+    only meaningful at the final boundary):
+
+    * ``_guard_off_track_inputs_above_consumer`` -- Phase 13e's snap-
+      to-grid shifts the on-track consumer Y by up to half a pitch
+      before Phase 13g re-anchors the off-track input.
+    * ``_guard_row_trunk_cy_consistent`` -- the row trunk Y is only
+      finalised once Phase 13h has re-centred ``center_ports`` graphs.
+    * ``_guard_inter_section_routes_in_row_band`` -- row-band height
+      tolerance assumes final bboxes, which Phase 13j/k may still be
+      shrinking.
+
+    The final guard block (``after Phase 12 (final)``) composes this
+    helper with the three excluded guards above, sharing
+    ``offsets``/``routes`` for a single computation per checkpoint.
+    Returns the computed ``(offsets, routes)`` so callers (e.g. the
+    final block) can pass them on to the remaining guards.
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    if offsets is None:
+        offsets = compute_station_offsets(graph)
+    if routes is None:
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+            routes = None
+
+    _guard_coordinates_finite(graph, phase)
+    _guard_section_bboxes_positive(graph, phase)
+    _guard_stations_in_sections(graph, phase)
+    _guard_ports_on_boundaries(graph, phase)
+    _guard_no_station_overlap(graph, phase, offsets=offsets)
+    if routes is not None:
+        _guard_no_line_crosses_non_consumer(
+            graph, phase, offsets=offsets, routes=routes
+        )
+    _guard_station_x_column_drift(graph, phase)
+    return offsets, routes
 
 
 def compute_min_y_spacing(
@@ -989,6 +1061,8 @@ def _compute_section_layout(
     # Phase 13: Lift off_track stations above their section's top track.
     # Runs last so it operates on finalised station Ys and bboxes.
     _lift_off_track_stations(graph, y_spacing, section_y_padding)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13")
 
     # Phase 13a: Re-align bbox tops within each grid row after off-track
     # lifting expanded some sections upward.  Unlike Phase 9/11c which
@@ -996,12 +1070,16 @@ def _compute_section_layout(
     # the empty input-band space lines up across the row.  Station Ys
     # in unlifted sections are preserved.
     _top_align_row_bboxes_only(graph)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13a")
 
     # Phase 13b: Compact row-mate sections so content sits just inside
     # the bbox top edge.  Shifts an entire row's column group up by the
     # smallest above-content slack, preserving trunk alignment.  Bbox
     # heights shrink correspondingly so the empty top space disappears.
     _compact_row_content_to_bbox_top(graph, section_y_padding, y_spacing)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13b")
 
     # Phase 13c: Snap inter-section LR/RL port pairs to a common Y so
     # the trunk bundle stays perfectly horizontal across boundaries.
@@ -1012,6 +1090,8 @@ def _compute_section_layout(
     # may have moved the exit port since then.
     _snap_inter_section_port_pairs(graph)
     _position_junctions(graph)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13c")
 
     # Phase 13d: Fan a section's free content upward when the row's
     # compaction left visible empty space at the bbox top.  Only fires
@@ -1019,6 +1099,8 @@ def _compute_section_layout(
     # (no off-track band) and whose trunk Y sits below the bbox top
     # padding by more than one ``y_spacing`` slot.
     _fan_free_content_upward(graph, section_y_padding, y_spacing)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13d")
 
     # Phase 13d2: Companion to 13d for source-stack sections.  When the
     # entry column has a single full-bundle trunk plus subset-bundle
@@ -1026,6 +1108,8 @@ def _compute_section_layout(
     # nearest-to-trunk sources into the empty top band so the section
     # is bottom- and top-weighted instead of stacked below the trunk.
     _fan_source_inputs_upward(graph, y_spacing)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13d2")
 
     # Phase 13d3: For sections that contain exactly a 2-branch
     # symmetric fan (and no off-track or other constraining content),
@@ -1036,6 +1120,8 @@ def _compute_section_layout(
     # grid pass doesn't immediately undo the compaction.
     if graph.center_ports:
         _apply_half_grid_2branch_symfan(graph, y_spacing, section_y_padding)
+        if validate:
+            _run_phase13_guards(graph, "after Phase 13d3")
 
     # Phase 13e: Snap all station/port Ys to a per-section y_spacing
     # grid.  Trunk-Y align, port-snap, and the row compaction/fan
@@ -1043,12 +1129,16 @@ def _compute_section_layout(
     # coordinates at fractional Ys (e.g. 298.785 when the pitch is 55).
     # This final pass restores clean grid positions before validation.
     _snap_all_y_to_grid(graph, y_spacing)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13e")
 
     # Phase 13f: Grow TB-section bbox bottoms so they align with the
     # downstream LR section's bbox bottom.  Without this the TB
     # section's bbox ends right at the inter-section exit port Y,
     # making the line look pinned to the section edge.
     _align_tb_section_bbox_bottoms(graph)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13f")
 
     # Phase 13g: Re-anchor off-track inputs to their consumer's final
     # (snapped) Y.  Phase 13's lift placed them relative to pre-snap
@@ -1058,6 +1148,8 @@ def _compute_section_layout(
     # consumer.y - n*y_spacing on the final grid and grows the bbox
     # upward if the new position rises above the padding zone.
     _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13g")
 
     # Phase 13h: Re-center full-bundle columns around the row's final
     # trunk Y.  ``_redistribute_full_bundle_columns`` runs early when
@@ -1083,12 +1175,16 @@ def _compute_section_layout(
         # bbox tops up to match so the section row stays flush along
         # its top edge.
         _top_align_row_bboxes_only(graph)
+        if validate:
+            _run_phase13_guards(graph, "after Phase 13h")
 
     # Phase 13i: After fan-re-centering, single-station downstream
     # columns (e.g. terminus file icons) may have stayed at their
     # pre-fan Y while their sole upstream moved to the trunk.  Pin
     # them back onto the source Y so the connection stays horizontal.
     _align_terminus_to_upstream(graph)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13i")
 
     # Phase 13i2: Auto-balance pass.  For sections whose final layout
     # still leaves an empty band above the trunk while more siblings
@@ -1097,6 +1193,8 @@ def _compute_section_layout(
     # Runs after re-centering and terminus-Y pinning so it sees the
     # final trunk Y.  U-turn-safe and bbox-bounded.
     _balance_section_content_around_trunk(graph, section_y_padding, y_spacing)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13i2")
 
     # Phase 13h3: Recenter fan-out side stations on their loop midpoint.
     # The layer-based X assignment places off-trunk siblings (e.g. propd,
@@ -1107,12 +1205,16 @@ def _compute_section_layout(
     # Reposition each side station to the midpoint of the two diagonal
     # corner Xs derived from the actual routing geometry.
     _recenter_loop_side_stations(graph)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13h3")
 
     # Phase 13j: Shrink rowspan / row-mate bboxes whose content moved
     # up after compact (e.g. ``_fan_source_inputs_upward`` lifted the
     # bottom rows away from the bbox bottom).  Bottom-only shrink, so
     # trunk alignment is unaffected.
     _shrink_bboxes_to_content_bottom(graph, section_y_padding)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13j")
 
     # Phase 13k: Close vertical slack that the pre-shrink row-height
     # estimate (in ``_compute_section_offsets``) left between row ``r``
@@ -1120,6 +1222,8 @@ def _compute_section_layout(
     # Only fires when a rowspan section's content fell short of its row
     # claim; multi-row layouts with content-filled rows are untouched.
     _tighten_lower_rows_after_shrink(graph, section_y_gap)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13k")
 
     # Phase 13k2: Shift sparse loop-side stations (e.g. ``grea`` -- one
     # incoming, one outgoing, single-line consumer) onto a half-grid Y
@@ -1128,12 +1232,16 @@ def _compute_section_layout(
     # (Distinct from Phase 13k above; renamed to disambiguate after the
     # numbering collision flagged in src/nf_metro/layout/CONTRACT.md.)
     _shift_sparse_loop_stations_to_clear_bundle(graph, y_spacing, section_y_padding)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13k2")
 
     # Phase 13l: When Phase 13k2 grew a section's bbox downward, push
     # sections in lower rows down so they don't crowd the grown bbox.
     # ``_tighten_lower_rows_after_shrink`` only closes slack (pulls
     # rows up); the inverse push happens here.
     _push_lower_rows_after_bbox_grow(graph, section_y_gap)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13l")
 
     # Phase 13m: Pad vertical spacing between stacked file-input icons
     # whose under-icon captions would otherwise overlap the next icon
@@ -1141,25 +1249,18 @@ def _compute_section_layout(
     # captioned icon's vertical extent (~44 px), so columns of source
     # inputs in DA-style sections need a slightly wider pitch.
     _pad_stacked_captioned_file_icons(graph, y_spacing, section_y_padding)
+    if validate:
+        _run_phase13_guards(graph, "after Phase 13m")
 
     if validate:
-        from nf_metro.layout.routing import compute_station_offsets, route_edges
-
         phase = "after Phase 12 (final)"
-        offsets = compute_station_offsets(graph)
-        routes = route_edges(graph, station_offsets=offsets)
-        _guard_coordinates_finite(graph, phase)
-        _guard_section_bboxes_positive(graph, phase)
-        _guard_stations_in_sections(graph, phase)
-        _guard_ports_on_boundaries(graph, phase)
-        _guard_no_station_overlap(graph, phase)
-        _guard_no_line_crosses_non_consumer(graph, phase)
+        offsets, routes = _run_phase13_guards(graph, phase)
         _guard_row_trunk_cy_consistent(graph, phase, offsets=offsets)
         _guard_off_track_inputs_above_consumer(graph, phase)
-        _guard_station_x_column_drift(graph, phase)
-        _guard_inter_section_routes_in_row_band(
-            graph, phase, offsets=offsets, routes=routes
-        )
+        if routes is not None:
+            _guard_inter_section_routes_in_row_band(
+                graph, phase, offsets=offsets, routes=routes
+            )
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1677,3 +1677,84 @@ class TestPhaseGuards:
         )
         # validate=True should be harmless for flat layout
         compute_layout(graph, validate=True)
+
+
+class TestPhase13Bisection:
+    """Bisection guards fired at each Phase-13x boundary must identify the
+    offending sub-phase, not the catch-all 'after Phase 12 (final)' label.
+
+    Without bisection, a regression introduced by e.g. Phase 13k2 surfaces
+    as ``after Phase 12 (final): position clash: ...``; the maintainer
+    must manually bisect by toggling phases to find the culprit.  With
+    bisection, the same regression surfaces immediately as
+    ``after Phase 13k2: position clash: ...``.
+    """
+
+    # One representative fixture per check: simple two-station section
+    # with no off-track inputs so the corruption-induced overlap is the
+    # first guard violation encountered, regardless of which phase is
+    # being tested.
+    _MMD = (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro line: alt | Alt | #00ff00\n"
+        "graph LR\n"
+        "    subgraph s1 [S1]\n"
+        "        a[A]\n"
+        "        a2[A2]\n"
+        "        a -->|main| a2\n"
+        "    end\n"
+        "    subgraph s2 [S2]\n"
+        "        b[B]\n"
+        "        b2[B2]\n"
+        "        b -->|main| b2\n"
+        "    end\n"
+        "    a2 -->|main,alt| b\n"
+    )
+
+    @pytest.mark.parametrize(
+        "phase_label,helper_name",
+        [
+            ("after Phase 13", "_lift_off_track_stations"),
+            ("after Phase 13a", "_top_align_row_bboxes_only"),
+            ("after Phase 13b", "_compact_row_content_to_bbox_top"),
+            ("after Phase 13e", "_snap_all_y_to_grid"),
+            ("after Phase 13i", "_align_terminus_to_upstream"),
+            ("after Phase 13j", "_shrink_bboxes_to_content_bottom"),
+            ("after Phase 13m", "_pad_stacked_captioned_file_icons"),
+        ],
+    )
+    def test_overlap_localises_to_phase(self, monkeypatch, phase_label, helper_name):
+        from nf_metro.layout import engine
+
+        original = getattr(engine, helper_name)
+
+        def corrupt(graph, *args, **kwargs):
+            result = original(graph, *args, **kwargs)
+            # Move 'a' to land on 'a2', producing an overlap that
+            # ``_guard_no_station_overlap`` must catch at the very
+            # next bisection checkpoint.
+            a = graph.stations.get("a")
+            a2 = graph.stations.get("a2")
+            if a is not None and a2 is not None:
+                a.x = a2.x
+                a.y = a2.y
+            return result
+
+        monkeypatch.setattr(engine, helper_name, corrupt)
+
+        graph = parse_metro_mermaid(self._MMD)
+        with pytest.raises(engine.PhaseInvariantError) as excinfo:
+            compute_layout(graph, validate=True)
+
+        msg = str(excinfo.value)
+        assert msg.startswith(phase_label + ":"), (
+            f"Expected bisection to identify {phase_label!r}, but error was: {msg!r}"
+        )
+
+    def test_clean_layout_does_not_fire_bisection_guards(self):
+        """Sanity check: an unpatched layout must pass all bisection
+        checkpoints, confirming the guard set is genuinely empty-render-
+        diff for the gallery's normal-shape topologies.
+        """
+        graph = parse_metro_mermaid(self._MMD)
+        compute_layout(graph, validate=True)


### PR DESCRIPTION
## Summary

- Run the overlap / breeze-past / column-drift guards after every Phase-13x sub-phase (`Phase 13, 13a, 13b, ... 13m`) so a regression in a 13-suffix phase points directly at the offending sub-phase instead of surfacing generically as `after Phase 12 (final): ...`.
- New `_run_phase13_guards(graph, phase)` helper composes the bisection set (finite coords, bboxes-positive, stations-in-sections, ports-on-boundaries, no-station-overlap, no-line-crosses-non-consumer, station-x-column-drift). The final guard block reuses the same helper plus the three legitimately-transient guards (off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band), sharing one `compute_station_offsets` / `route_edges` pair per checkpoint.
- `TestPhase13Bisection` parametrises a corruption-injection over 7 representative phases and asserts the error message names the right phase; the test fails on `main` and passes here.
- CONTRACT.md gains a "bisection" row in the validate-mode checkpoints table; structural-debt signal #6 is removed (commits hold the history).

`validate=False` is the production default, so renders are unchanged. The bisection cost is contained to the test suite (28-fixture `TestPhaseGuards` runtime: 0.24s -> 0.55s).

Fixes #346.

## Test plan

- [x] `pytest` passes (1999 + 4 xfail, including new `TestPhase13Bisection` parametrisation)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean (CI scope)
- [x] Bisection test fails on `main` baseline, confirming the test is meaningful
- [ ] Render preview verdict: no visual changes expected (validate=False path unchanged)

Generated with Claude Code