### PR TITLE
refactor(layout): number Phase 13h hidden sub-phases (#346)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -464,19 +464,43 @@ bisection runner is `_run_phase13_guards`.
 - **Invariants preserved**: On-track station Y.
 - **Related tests**: `test_off_track_inputs_above_consumer`.
 
-### Phase 13h: re-center full-bundle columns (engine.py:734-757)
+### Phase 13h: re-center full-bundle columns (engine.py)
 - **Purpose**: Re-fan full-bundle columns around the row's final trunk
   Y (Phase 11da used the local port Y which may now be stale).
-  Re-anchors off-track inputs and re-runs row-top-align afterwards.
   Gated on `center_ports`.
-- **Helper**: `_recenter_full_bundle_columns` (engine.py:3578),
-  then `_reanchor_off_track_to_consumer`, then
-  `_top_align_row_bboxes_only`.
+- **Helper**: `_recenter_full_bundle_columns`.
 - **Precondition**: Final inter-section trunk Y known (post-snap).
 - **Postcondition**: Full-bundle columns are symmetric around the
-  row's final trunk Y, with off-track inputs re-pinned to their
-  consumers' new Ys and row bboxes still flush at the top.
-- **Invariants preserved**: Bbox tops (after the row re-top-align).
+  row's final trunk Y.
+- **Invariants preserved**: Off-track Y anchoring (re-established by
+  Phase 13h.1) and bbox-top alignment (re-established by Phase 13h.2)
+  are temporarily broken; both are restored before leaving the
+  `if center_ports:` block.
+
+### Phase 13h.1: re-anchor off-track after recenter (engine.py)
+- **Purpose**: The Phase 13h recenter moves consumers to the final
+  trunk-anchored Y, leaving off-track icons stranded at the old
+  consumer Y (and overlapping the consumer station). Re-pin each
+  off-track at `consumer.y - n*y_spacing` on the post-recenter grid.
+  Gated on `center_ports`.
+- **Helper**: `_reanchor_off_track_to_consumer` (same helper as Phase
+  13g; called again here on the post-recenter Ys).
+- **Precondition**: Phase 13h has re-centred full-bundle columns.
+- **Postcondition**: Off-track inputs sit one or more pitches above
+  their post-recenter consumer. Section bboxes grow upward when
+  lifted bands move above the existing top padding.
+- **Invariants preserved**: Row top-alignment may be broken when a
+  bbox grew upward; Phase 13h.2 restores it.
+
+### Phase 13h.2: re-run row top-align (engine.py)
+- **Purpose**: A Phase 13h.1 bbox grow can leave the grown section's
+  bbox top above its row mates'. Pull row mates' bbox tops up to
+  match so the section row stays flush along its top edge. Gated on
+  `center_ports`.
+- **Helper**: `_top_align_row_bboxes_only` (same helper as Phase 13a).
+- **Precondition**: Phase 13h.1 has re-anchored off-track inputs.
+- **Postcondition**: Row bboxes flush at the top across all row mates.
+- **Invariants preserved**: Station Ys (only bbox tops move).
 
 ### Phase 13i: align terminus to upstream (engine.py:759-763)
 - **Purpose**: After 13h re-pitched fanned columns, a single-station
@@ -595,17 +619,12 @@ resolved; refer to the relevant tracking issue or PR for history.
    but Phase 11 expands bboxes (`_expand_bbox_for_y`) and Phase 11c
    immediately re-runs top-align to undo the resulting bbox-top
    drift. Naming-wise, "single pass" is misleading.
-3. **Phase 13h triggers further phases** (`_reanchor_off_track_to_consumer`
-   and `_top_align_row_bboxes_only`) inside its `if center_ports:`
-   block. These are effectively unnumbered sub-phases hiding in
-   a conditional - they don't appear as `# Phase 13h.something`
-   comments but are real graph-mutating passes.
-4. **Phase 13 (off-track lift) calls `_shift_graph_into_canvas`**,
+3. **Phase 13 (off-track lift) calls `_shift_graph_into_canvas`**,
    which globally translates every station / port / junction / bbox.
    That's a Phase 4-style transformation hiding inside a Phase 13
    helper; if any later phase assumed Phase 4's global-coord origin
    was stable, the assumption is wrong.
-5. **Phase 11d/11da symmetrically fan content using a stale port Y**;
+4. **Phase 11d/11da symmetrically fan content using a stale port Y**;
    Phase 13h re-centers using the final trunk Y. The two-pass pattern
    is necessary because Phase 11da runs before snap-to-grid, but it
    means the early pass's output is partially-discarded work.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1160,23 +1160,29 @@ def _compute_section_layout(
     # one below).  This re-center uses the final inter-section bundle
     # Y as the anchor so the trunk row stays empty in each fanned
     # column.
+    #
+    # Phase 13h.1 and Phase 13h.2 below restore invariants the recenter
+    # breaks; ``.N`` is used (not bare ``13h2``) so the suffix doesn't
+    # collide with the standalone Phase 13h3 further below.
     if graph.center_ports:
         _recenter_full_bundle_columns(graph, y_spacing)
-        # Re-anchor off-track inputs again: ``_recenter`` moves
-        # their consumers to the final trunk-anchored Y, which can
-        # leave the off-track icon stranded at the old consumer Y
-        # (overlapping the consumer station instead of sitting one
-        # row above it).  This second reanchor uses each consumer's
-        # post-recenter Y as the new anchor and grows the section
-        # bbox upward when the lifted band moves above its current top.
+
+        # Phase 13h.1: Re-anchor off-track inputs after the recenter.
+        # The recenter moves consumers to the final trunk-anchored Y,
+        # which can leave the off-track icon stranded at the old
+        # consumer Y (overlapping the consumer station instead of
+        # sitting one row above it).  Uses each consumer's post-
+        # recenter Y as the new anchor and grows the section bbox
+        # upward when the lifted band moves above its current top.
         _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
-        # Re-run the row top-align: a reanchor-driven bbox grow leaves
-        # the section's bbox above its row mates'.  Pull row mates'
-        # bbox tops up to match so the section row stays flush along
-        # its top edge.
+
+        # Phase 13h.2: Re-run row top-align.  A Phase 13h.1 reanchor-
+        # driven bbox grow leaves the section's bbox above its row
+        # mates'; pull row mates' bbox tops up to match so the section
+        # row stays flush along its top edge.
         _top_align_row_bboxes_only(graph)
         if validate:
-            _run_phase13_guards(graph, "after Phase 13h")
+            _run_phase13_guards(graph, "after Phase 13h.2")
 
     # Phase 13i: After fan-re-centering, single-station downstream
     # columns (e.g. terminus file icons) may have stayed at their

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1758,3 +1758,68 @@ class TestPhase13Bisection:
         """
         graph = parse_metro_mermaid(self._MMD)
         compute_layout(graph, validate=True)
+
+    # Minimal center_ports fixture: enters the `if graph.center_ports:`
+    # block at Phase 13h so the "after Phase 13h.2" checkpoint actually
+    # fires.  Plain enough not to need full-bundle reanchoring, so the
+    # helpers there are effective no-ops and the checkpoint is reached
+    # cleanly.
+    _MMD_CENTER_PORTS = (
+        "%%metro center_ports: true\n"
+        "%%metro line: main | Main | #ff0000\n"
+        "graph LR\n"
+        "    subgraph s1 [S1]\n"
+        "        a[A]\n"
+        "        a2[A2]\n"
+        "        a -->|main| a2\n"
+        "    end\n"
+        "    subgraph s2 [S2]\n"
+        "        b[B]\n"
+        "    end\n"
+        "    a2 -->|main| b\n"
+    )
+
+    def test_phase_13h_subphase_checkpoint_fires_on_center_ports(self, monkeypatch):
+        """Phase 13h.2's bisection checkpoint surfaces a regression
+        introduced by ``_top_align_row_bboxes_only`` inside the
+        ``if center_ports:`` branch.
+
+        This exercises a code path the default ``_MMD`` fixture (no
+        ``center_ports``) cannot reach.  The corruption runs *after*
+        the Phase 13a checkpoint to avoid a false positive there: we
+        corrupt only on the second invocation of
+        ``_top_align_row_bboxes_only``, which lands inside Phase 13h.2.
+        """
+        from nf_metro.layout import engine
+
+        original = engine._top_align_row_bboxes_only
+        call_count = {"n": 0}
+
+        def corrupt(graph, *args, **kwargs):
+            result = original(graph, *args, **kwargs)
+            call_count["n"] += 1
+            # First call is Phase 13a (always runs); second is Phase 13h.2
+            # (only on center_ports graphs).  Corrupt only on the second
+            # to hit the Phase 13h.2 checkpoint specifically.
+            if call_count["n"] >= 2:
+                a = graph.stations.get("a")
+                a2 = graph.stations.get("a2")
+                if a is not None and a2 is not None:
+                    a.x = a2.x
+                    a.y = a2.y
+            return result
+
+        monkeypatch.setattr(engine, "_top_align_row_bboxes_only", corrupt)
+
+        graph = parse_metro_mermaid(self._MMD_CENTER_PORTS)
+        with pytest.raises(engine.PhaseInvariantError) as excinfo:
+            compute_layout(graph, validate=True)
+
+        msg = str(excinfo.value)
+        assert msg.startswith("after Phase 13h.2:"), (
+            f"Expected bisection to identify Phase 13h.2, but error was: {msg!r}"
+        )
+        assert call_count["n"] == 2, (
+            f"Expected exactly 2 calls to _top_align_row_bboxes_only "
+            f"(Phase 13a + Phase 13h.2), got {call_count['n']}"
+        )


### PR DESCRIPTION
## Summary

- Two graph-mutating passes inside Phase 13h's `if graph.center_ports:` block are now numbered as **Phase 13h.1** (`_reanchor_off_track_to_consumer`) and **Phase 13h.2** (`_top_align_row_bboxes_only`).
- The `.N` suffix avoids colliding with the standalone **Phase 13h3** (`_recenter_loop_side_stations`) further down the pipeline.
- The existing single bisection checkpoint at the end of the block is now labelled `after Phase 13h.2` so the label matches the state it actually samples.
- `CONTRACT.md` gains dedicated rows for Phase 13h.1 and Phase 13h.2 with their own pre/postconditions and the "broken/restored invariant" relationship between them.
- Signal #3 is removed from CONTRACT.md's structural-debt list.
- New test `test_phase_13h_subphase_checkpoint_fires_on_center_ports` exercises the Phase 13h.2 label specifically (the existing `test_overlap_localises_to_phase` parametrisation cannot reach the `if center_ports:` block).

Fixes #346 (signal #3).

## Test plan

- [x] `pytest` passes (2000 + 4 xfail) including the new Phase 13h.2 test
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] New test fails on `main` (label is `after Phase 13h`), passes here
- [ ] Render preview verdict: no visual changes expected (validate=False path unchanged; new bisection label runs only under validate=True)

Generated with Claude Code