### PR TITLE
fix(layout): phase-gate transient bisection guards (#346)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -51,15 +51,24 @@ Phases split into three regimes:
 | after Phase 4 | finite coords, stations-in-sections, bboxes-positive |
 | after Phase 5 | ports-on-boundaries |
 | after top-align (Phase 9) | ports-on-boundaries |
-| after each Phase 13x (bisection) | finite coords, bboxes-positive, stations-in-sections, ports-on-boundaries, no-station-overlap, no-line-crosses-non-consumer, station-x-column-drift |
-| after Phase 12 (final) | bisection set + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
+| after each Phase 13x (bisection) | finite coords, bboxes-positive, ports-on-boundaries, station-x-column-drift, plus three phase-gated guards (see below) |
+| after Phase 12 (final) | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
-Bisection checkpoints fire after every Phase-13x sub-phase
-(see the `# Phase 13...` comments in `_compute_section_layout`).
-Three guards are excluded from the bisection set because they are
-legitimately transient between sub-phases; the
-`_run_phase13_guards` docstring (engine.py) is the authoritative
-list and rationale.
+Bisection checkpoints fire after every Phase-13x sub-phase (see the
+`# Phase 13...` comments in `_compute_section_layout`). Three guards
+hold continuously only from a specific checkpoint onward, and the
+bisection runner skips them earlier; see `_BISECTION_FIRST_VALID` in
+`engine.py` for the threshold table:
+
+| Guard | First valid checkpoint | Transient because |
+|---|---|---|
+| `_guard_stations_in_sections` | after Phase 13a | Phase 13's off-track lift moves stations above the section bbox; Phase 13a grows the bbox to enclose them. |
+| `_guard_no_station_overlap` | after Phase 13g | Phase 13e's snap-to-grid can land an off-track terminus icon on its on-track column-mate's Y; Phase 13g re-anchors the off-track above its consumer. |
+| `_guard_no_line_crosses_non_consumer` | after Phase 13k2 | A sparse loop-side station sits on the trunk Y until Phase 13k2 shifts it to a half-grid offset; before that, sibling line bundles pass through its marker bbox. |
+
+Three further guards are excluded from the bisection set entirely
+(meaningful only at the final boundary); the `_run_phase13_guards`
+docstring in `engine.py` is the authoritative list.
 
 Guard bodies live at the top of `engine.py` (lines 83-275); the
 bisection runner is `_run_phase13_guards`.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -617,6 +617,70 @@ def _guard_station_x_column_drift(graph: MetroGraph, phase: str) -> None:
                     )
 
 
+_PHASE_13_ORDER: tuple[str, ...] = (
+    "after Phase 13",
+    "after Phase 13a",
+    "after Phase 13b",
+    "after Phase 13c",
+    "after Phase 13d",
+    "after Phase 13d2",
+    "after Phase 13d3",
+    "after Phase 13e",
+    "after Phase 13f",
+    "after Phase 13g",
+    "after Phase 13h.2",
+    "after Phase 13i",
+    "after Phase 13i2",
+    "after Phase 13h3",
+    "after Phase 13j",
+    "after Phase 13k",
+    "after Phase 13k2",
+    "after Phase 13l",
+    "after Phase 13m",
+)
+"""Ordered Phase-13x bisection checkpoints, used by
+``_run_phase13_guards`` to gate guards whose invariants only become
+valid mid-pipeline.  Update when adding or removing a Phase-13x
+checkpoint in ``_compute_section_layout``.
+"""
+
+# Each entry: bisection-runnable guard -> first checkpoint at which its
+# invariant must hold.  Before that checkpoint, the guard is skipped in
+# bisection mode; the final guard block (phase ``"after Phase 12
+# (final)"``, which is not in ``_PHASE_13_ORDER``) always runs it.
+#
+# - stations_in_sections: Phase 13 lifts off-track stations above their
+#   section's pre-grow bbox top; Phase 13a's row top-align grows the
+#   bbox upward to enclose them.
+# - no_station_overlap: Phase 13e's snap-to-grid can place an off-track
+#   terminus icon at the same coordinates as an on-track column-mate;
+#   Phase 13g's re-anchor lifts the off-track back above its consumer.
+# - no_line_crosses_non_consumer: a sparse loop-side station (single
+#   line in, single line out, full-bundle row-mates) sits on the trunk
+#   Y until Phase 13k2 shifts it to a half-grid offset; before that,
+#   the sibling line bundle's route passes through its marker bbox.
+_BISECTION_FIRST_VALID: dict[str, str] = {
+    "_guard_stations_in_sections": "after Phase 13a",
+    "_guard_no_station_overlap": "after Phase 13g",
+    "_guard_no_line_crosses_non_consumer": "after Phase 13k2",
+}
+
+
+def _bisection_should_run(guard_name: str, phase: str) -> bool:
+    """True if ``guard_name`` should run at bisection checkpoint ``phase``.
+
+    Returns True for the final guard block (``phase`` outside
+    ``_PHASE_13_ORDER``) so the final invariant set stays complete.
+    """
+    threshold = _BISECTION_FIRST_VALID.get(guard_name)
+    if threshold is None:
+        return True
+    try:
+        return _PHASE_13_ORDER.index(phase) >= _PHASE_13_ORDER.index(threshold)
+    except ValueError:
+        return True
+
+
 def _run_phase13_guards(
     graph: MetroGraph,
     phase: str,
@@ -634,8 +698,12 @@ def _run_phase13_guards(
     bisect.  Running the same overlap / breeze-past / column-drift
     checks at each boundary localises the culprit to a single phase.
 
-    Excluded from the bisection set (transient between sub-phases or
-    only meaningful at the final boundary):
+    Guards transient through specific Phase-13x sub-phases are gated
+    by ``_BISECTION_FIRST_VALID`` and skipped before they're valid.
+    See that table for the per-guard transient windows.
+
+    Always excluded from the bisection set (only meaningful at the
+    final boundary):
 
     * ``_guard_off_track_inputs_above_consumer`` -- Phase 13e's snap-
       to-grid shifts the on-track consumer Y by up to half a pitch
@@ -664,10 +732,14 @@ def _run_phase13_guards(
 
     _guard_coordinates_finite(graph, phase)
     _guard_section_bboxes_positive(graph, phase)
-    _guard_stations_in_sections(graph, phase)
+    if _bisection_should_run("_guard_stations_in_sections", phase):
+        _guard_stations_in_sections(graph, phase)
     _guard_ports_on_boundaries(graph, phase)
-    _guard_no_station_overlap(graph, phase, offsets=offsets)
-    if routes is not None:
+    if _bisection_should_run("_guard_no_station_overlap", phase):
+        _guard_no_station_overlap(graph, phase, offsets=offsets)
+    if routes is not None and _bisection_should_run(
+        "_guard_no_line_crosses_non_consumer", phase
+    ):
         _guard_no_line_crosses_non_consumer(
             graph, phase, offsets=offsets, routes=routes
         )

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1657,6 +1657,14 @@ class TestPhaseGuards:
         if path.exists():
             self._layout_validated(path.read_text())
 
+    def test_differentialabundance(self):
+        """``differentialabundance.mmd`` is the only gallery fixture that
+        combines ``center_ports: true`` with off-track terminus inputs
+        and a sparse loop-side station; exercises the bisection guard
+        phase-gating policy.
+        """
+        self._layout_validated((EXAMPLES_DIR / "differentialabundance.mmd").read_text())
+
     def test_simple_two_sections(self):
         self._layout_validated(
             "%%metro line: main | Main | #ff0000\n"
@@ -1711,28 +1719,38 @@ class TestPhase13Bisection:
         "    a2 -->|main,alt| b\n"
     )
 
+    # Corruption-phase -> expected surfacing checkpoint.  When the
+    # corruption phase is at or after the overlap-guard's first valid
+    # checkpoint (``after Phase 13g``), bisection localises to the
+    # corruption phase itself.  Otherwise the overlap regression
+    # surfaces at ``after Phase 13g`` (the first un-gated overlap
+    # check), which is the accepted trade-off for letting the bisection
+    # set tolerate the off-track-stranded-on-consumer transient at
+    # Phase 13e/13f (see ``_BISECTION_FIRST_VALID`` in engine.py).
     @pytest.mark.parametrize(
-        "phase_label,helper_name",
+        "corruption_helper,expected_phase",
         [
-            ("after Phase 13", "_lift_off_track_stations"),
-            ("after Phase 13a", "_top_align_row_bboxes_only"),
-            ("after Phase 13b", "_compact_row_content_to_bbox_top"),
-            ("after Phase 13e", "_snap_all_y_to_grid"),
-            ("after Phase 13i", "_align_terminus_to_upstream"),
-            ("after Phase 13j", "_shrink_bboxes_to_content_bottom"),
-            ("after Phase 13m", "_pad_stacked_captioned_file_icons"),
+            ("_lift_off_track_stations", "after Phase 13g"),
+            ("_top_align_row_bboxes_only", "after Phase 13g"),
+            ("_compact_row_content_to_bbox_top", "after Phase 13g"),
+            ("_snap_all_y_to_grid", "after Phase 13g"),
+            ("_align_terminus_to_upstream", "after Phase 13i"),
+            ("_shrink_bboxes_to_content_bottom", "after Phase 13j"),
+            ("_pad_stacked_captioned_file_icons", "after Phase 13m"),
         ],
     )
-    def test_overlap_localises_to_phase(self, monkeypatch, phase_label, helper_name):
+    def test_overlap_localises_to_phase(
+        self, monkeypatch, corruption_helper, expected_phase
+    ):
         from nf_metro.layout import engine
 
-        original = getattr(engine, helper_name)
+        original = getattr(engine, corruption_helper)
 
         def corrupt(graph, *args, **kwargs):
             result = original(graph, *args, **kwargs)
             # Move 'a' to land on 'a2', producing an overlap that
-            # ``_guard_no_station_overlap`` must catch at the very
-            # next bisection checkpoint.
+            # ``_guard_no_station_overlap`` must catch at the next
+            # un-gated bisection checkpoint.
             a = graph.stations.get("a")
             a2 = graph.stations.get("a2")
             if a is not None and a2 is not None:
@@ -1740,15 +1758,16 @@ class TestPhase13Bisection:
                 a.y = a2.y
             return result
 
-        monkeypatch.setattr(engine, helper_name, corrupt)
+        monkeypatch.setattr(engine, corruption_helper, corrupt)
 
         graph = parse_metro_mermaid(self._MMD)
         with pytest.raises(engine.PhaseInvariantError) as excinfo:
             compute_layout(graph, validate=True)
 
         msg = str(excinfo.value)
-        assert msg.startswith(phase_label + ":"), (
-            f"Expected bisection to identify {phase_label!r}, but error was: {msg!r}"
+        assert msg.startswith(expected_phase + ":"), (
+            f"Expected bisection to surface at {expected_phase!r}, "
+            f"but error was: {msg!r}"
         )
 
     def test_clean_layout_does_not_fire_bisection_guards(self):
@@ -1822,4 +1841,72 @@ class TestPhase13Bisection:
         assert call_count["n"] == 2, (
             f"Expected exactly 2 calls to _top_align_row_bboxes_only "
             f"(Phase 13a + Phase 13h.2), got {call_count['n']}"
+        )
+
+    def test_gated_overlap_guard_fires_at_later_bisection_checkpoints(
+        self, monkeypatch
+    ):
+        """An overlap injected at Phase 13m must surface at the
+        ``after Phase 13m`` bisection checkpoint (not deferred to the
+        final block).
+
+        Confirms ``_BISECTION_FIRST_VALID`` only delays a guard's
+        first valid checkpoint -- once past the threshold (``after
+        Phase 13g`` for the overlap guard), the guard fires at every
+        subsequent bisection checkpoint.
+        """
+        from nf_metro.layout import engine
+
+        original = engine._pad_stacked_captioned_file_icons
+
+        def corrupt(graph, *args, **kwargs):
+            result = original(graph, *args, **kwargs)
+            a = graph.stations.get("a")
+            a2 = graph.stations.get("a2")
+            if a is not None and a2 is not None:
+                a.x = a2.x
+                a.y = a2.y
+            return result
+
+        monkeypatch.setattr(engine, "_pad_stacked_captioned_file_icons", corrupt)
+
+        graph = parse_metro_mermaid(self._MMD)
+        with pytest.raises(engine.PhaseInvariantError) as excinfo:
+            compute_layout(graph, validate=True)
+
+        msg = str(excinfo.value)
+        assert msg.startswith("after Phase 13m:"), (
+            f"Expected bisection to surface at 'after Phase 13m' "
+            f"(overlap guard runs at every checkpoint from Phase 13g "
+            f"onward), but error was: {msg!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "guard_name,first_valid",
+        [
+            ("_guard_stations_in_sections", "after Phase 13a"),
+            ("_guard_no_station_overlap", "after Phase 13g"),
+            ("_guard_no_line_crosses_non_consumer", "after Phase 13k2"),
+        ],
+    )
+    def test_bisection_first_valid_threshold(self, guard_name, first_valid):
+        """``_BISECTION_FIRST_VALID`` thresholds must reference real
+        Phase-13x checkpoints; ``_bisection_should_run`` must skip the
+        guard at the preceding checkpoint and run it at the threshold.
+        """
+        from nf_metro.layout import engine
+
+        assert first_valid in engine._PHASE_13_ORDER, (
+            f"Threshold {first_valid!r} not a known Phase-13x checkpoint"
+        )
+        assert engine._BISECTION_FIRST_VALID[guard_name] == first_valid
+
+        idx = engine._PHASE_13_ORDER.index(first_valid)
+        assert engine._bisection_should_run(guard_name, first_valid) is True
+        if idx > 0:
+            prev_phase = engine._PHASE_13_ORDER[idx - 1]
+            assert engine._bisection_should_run(guard_name, prev_phase) is False
+        # Final-block phase is not in _PHASE_13_ORDER; guard always runs.
+        assert (
+            engine._bisection_should_run(guard_name, "after Phase 12 (final)") is True
         )


### PR DESCRIPTION
## Summary

PR #356 wired bisection guards after every Phase-13x checkpoint, but three of those guards are transient through specific Phase-13 sub-phases - they trip mid-pipeline even though the final layout is correct. CI didn't catch this because `TestPhaseGuards` globs `examples/topologies/*.mmd` + `rnaseq_*.mmd`, none of which combines `center_ports: true` + off-track terminus inputs + a sparse loop-side station. `examples/differentialabundance.mmd` does, and wasn't in the loop.

This PR:

1. **Phase-gates each transient guard** at its first-valid checkpoint via `_BISECTION_FIRST_VALID` and a new `_bisection_should_run` helper:
   - `_guard_stations_in_sections` -> valid from **Phase 13a** (Phase 13 lifts off-track stations above the section bbox; Phase 13a grows the bbox upward to enclose them).
   - `_guard_no_station_overlap` -> valid from **Phase 13g** (Phase 13e's snap-to-grid can land an off-track terminus on its on-track column-mate's Y; Phase 13g re-anchors above the consumer).
   - `_guard_no_line_crosses_non_consumer` -> valid from **Phase 13k2** (sparse loop stations sit on the trunk Y until Phase 13k2 shifts them to a half-grid offset).

   The `after Phase 12 (final)` block continues to run the full guard set unconditionally.

2. **Adds `examples/differentialabundance.mmd` to `TestPhaseGuards`** so the gating policy is exercised in CI.

3. **Adds regression tests**:
   - `test_gated_overlap_guard_fires_at_later_bisection_checkpoints` - past the threshold, gated guards still fire at every checkpoint (not just at the final block).
   - `test_bisection_first_valid_threshold` - pure-unit consistency check that every `_BISECTION_FIRST_VALID` value is a real Phase-13x checkpoint.

Updates `CONTRACT.md` validate-mode-guards section to document the gating policy.

Fixes #346 signal (newly-discovered fragility).

## Test plan

- [x] `pytest` passes (2005 + 4 xfail) including new `test_differentialabundance` in `TestPhaseGuards` and three new bisection regression tests
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] `test_differentialabundance` fails on `main` engine baseline (verified by stash + run), passes here
- [ ] Render-preview verdict: no visual changes expected (validate=False path unchanged; the new gating is test-mode-only)

Generated with Claude Code