### PR TITLE
refactor(layout): hoist _shift_graph_into_canvas out of helpers (#346)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -349,16 +349,18 @@ bisection runner is `_run_phase13_guards`.
   `max(pred.x) + JUNCTION_MARGIN, entry_port.y`.
 - **Invariants preserved**: Real stations, ports.
 
-### Phase 13: lift off-track stations (engine.py:661-663)
+### Phase 13: lift off-track stations (engine.py)
 - **Purpose**: Lift off-track file-input stations to the row above
   their consumer, stacking when multiple inputs share one consumer.
   Grow bbox upward; nudge same-section TOP ports back to new edge.
-- **Helper**: `_lift_off_track_stations` (engine.py:6582).
+- **Helper**: `_lift_off_track_stations`.
 - **Precondition**: Phase 12 complete; all on-track Ys final.
 - **Postcondition**: Each off-track station sits at
   `consumer.y - n*y_spacing` (n = stack rank). Section bbox extends
-  upward to fit. Canvas Y-offset increases if needed
-  (`_shift_graph_into_canvas`).
+  upward to fit.  May leave the topmost section above the canvas
+  margin -- ``_shift_graph_into_canvas`` runs immediately afterwards
+  to restore the margin (called explicitly by the caller, not by
+  the helper).
 - **Invariants preserved**: On-track station Y. Other sections' Ys
   (only the canvas Y-offset may shift the world uniformly).
 - **Related tests**: `test_off_track_inputs_above_consumer`,
@@ -462,14 +464,16 @@ bisection runner is `_run_phase13_guards`.
   `tb.bbox_y + tb.bbox_h >= target.bbox_y + target.bbox_h`.
 - **Invariants preserved**: All station and port Ys. Other bboxes.
 
-### Phase 13g: reanchor off-track to consumer (engine.py:725-732)
+### Phase 13g: reanchor off-track to consumer (engine.py)
 - **Purpose**: Re-pin each off-track input at `consumer.y - n*y_spacing`
   using the consumer's final snapped Y (Phase 13 used pre-snap Ys).
   Grow bbox upward if needed.
-- **Helper**: `_reanchor_off_track_to_consumer` (engine.py:6624).
+- **Helper**: `_reanchor_off_track_to_consumer`.
 - **Precondition**: Phase 13e snapped consumers to grid.
 - **Postcondition**: Off-track inputs sit `n * y_spacing` above their
-  consumer's final Y.
+  consumer's final Y.  May leave the topmost section above the
+  canvas margin -- ``_shift_graph_into_canvas`` runs immediately
+  afterwards (called explicitly by the caller, not by the helper).
 - **Invariants preserved**: On-track station Y.
 - **Related tests**: `test_off_track_inputs_above_consumer`.
 
@@ -491,7 +495,9 @@ bisection runner is `_run_phase13_guards`.
   trunk-anchored Y, leaving off-track icons stranded at the old
   consumer Y (and overlapping the consumer station). Re-pin each
   off-track at `consumer.y - n*y_spacing` on the post-recenter grid.
-  Gated on `center_ports`.
+  Followed by ``_shift_graph_into_canvas`` to handle bbox grow that
+  pushed the topmost section above the canvas margin.  Gated on
+  `center_ports`.
 - **Helper**: `_reanchor_off_track_to_consumer` (same helper as Phase
   13g; called again here on the post-recenter Ys).
 - **Precondition**: Phase 13h has re-centred full-bundle columns.
@@ -624,12 +630,7 @@ resolved; refer to the relevant tracking issue or PR for history.
    cross-phase coupling is hard to follow; the half-grid marker
    pattern would benefit from a dedicated discussion in the doc /
    code.
-2. **Phase 13 (off-track lift) calls `_shift_graph_into_canvas`**,
-   which globally translates every station / port / junction / bbox.
-   That's a Phase 4-style transformation hiding inside a Phase 13
-   helper; if any later phase assumed Phase 4's global-coord origin
-   was stable, the assumption is wrong.
-3. **Phase 11d/11da symmetrically fan content using a stale port Y**;
+2. **Phase 11d/11da symmetrically fan content using a stale port Y**;
    Phase 13h re-centers using the final trunk Y. The two-pass pattern
    is necessary because Phase 11da runs before snap-to-grid, but it
    means the early pass's output is partially-discarded work.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1175,6 +1175,10 @@ def _compute_section_layout(
     # Phase 13: Lift off_track stations above their section's top track.
     # Runs last so it operates on finalised station Ys and bboxes.
     _lift_off_track_stations(graph, y_spacing, section_y_padding)
+    # The upward bbox growth above can push the topmost section above
+    # the canvas top margin set by Phase 3b; shift the whole graph
+    # down to restore the margin.  No-op when no section overflowed.
+    _shift_graph_into_canvas(graph, section_y_padding)
     if validate:
         _run_phase13_guards(graph, "after Phase 13")
 
@@ -1262,6 +1266,9 @@ def _compute_section_layout(
     # consumer.y - n*y_spacing on the final grid and grows the bbox
     # upward if the new position rises above the padding zone.
     _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
+    # Same canvas-fit safeguard as after Phase 13: a reanchor-driven
+    # bbox grow can push the topmost section above the canvas top.
+    _shift_graph_into_canvas(graph, section_y_padding)
     if validate:
         _run_phase13_guards(graph, "after Phase 13g")
 
@@ -1289,6 +1296,10 @@ def _compute_section_layout(
         # recenter Y as the new anchor and grows the section bbox
         # upward when the lifted band moves above its current top.
         _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
+        # Same canvas-fit safeguard as Phase 13 / Phase 13g: a
+        # reanchor-driven bbox grow can push the topmost section
+        # above the canvas top.
+        _shift_graph_into_canvas(graph, section_y_padding)
 
         # Phase 13h.2: Re-run row top-align.  A Phase 13h.1 reanchor-
         # driven bbox grow leaves the section's bbox above its row
@@ -7185,6 +7196,10 @@ def _lift_off_track_stations(
     as its anchor.  After placement, the section bbox grows upward to
     fit the highest lifted input, and same-section TOP ports are
     nudged back to the new top edge.
+
+    Caller is responsible for invoking ``_shift_graph_into_canvas``
+    afterwards: the upward bbox growth here can push the topmost
+    section above the canvas top margin set by Phase 3b.
     """
     groups = _off_track_groups(graph)
     if not groups:
@@ -7202,10 +7217,6 @@ def _lift_off_track_stations(
         new_bbox_top = highest_y - section_y_padding
         if new_bbox_top < section.bbox_y:
             _grow_section_bbox_upward(graph, section, new_bbox_top)
-
-    # Phase 3b ran before our lift, so y_offset doesn't account for the
-    # new bbox tops.
-    _shift_graph_into_canvas(graph, section_y_padding)
 
 
 def _reanchor_off_track_to_consumer(
@@ -7226,13 +7237,14 @@ def _reanchor_off_track_to_consumer(
     the time.  If a re-anchor moves an off-track above the current bbox
     top minus padding, expand the bbox upward so the lifted input still
     sits inside the section's padding zone.  Same-section TOP ports
-    follow the new top edge.  When the growth pushes any section bbox
-    above the canvas top margin, shift the whole graph down so the
-    topmost section keeps its ``section_y_padding`` margin from the
-    canvas edge (mirrors the safeguard in ``_lift_off_track_stations``).
+    follow the new top edge.
+
+    Caller is responsible for invoking ``_shift_graph_into_canvas``
+    afterwards: the upward bbox growth here can push the topmost
+    section above the canvas top margin (mirrors the same caller
+    contract as ``_lift_off_track_stations``).
     """
     groups = _off_track_groups(graph)
-    grew = False
     for sec_id, (fallback_id, by_consumer) in groups.items():
         highest_y = _place_off_track_above_consumers(
             graph, y_spacing, sec_id, fallback_id, by_consumer
@@ -7245,10 +7257,6 @@ def _reanchor_off_track_to_consumer(
         desired_top = highest_y - section_y_padding
         if desired_top < section.bbox_y - 0.5:
             _grow_section_bbox_upward(graph, section, desired_top)
-            grew = True
-
-    if grew:
-        _shift_graph_into_canvas(graph, section_y_padding)
 
 
 def _required_captioned_icon_pitch(y_spacing: float) -> float:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1687,6 +1687,70 @@ class TestPhaseGuards:
         compute_layout(graph, validate=True)
 
 
+class TestShiftGraphIntoCanvas:
+    """Behavioural invariants of ``_shift_graph_into_canvas``.
+
+    The helper is called explicitly from three Phase-13 sub-step
+    sites in ``_compute_section_layout``.  Each call must be safe
+    regardless of whether the preceding bbox-growing helper actually
+    grew anything; the helper's own no-op guard makes the call
+    idempotent.
+    """
+
+    def test_idempotent_when_already_in_canvas(self):
+        from nf_metro.layout import engine
+        from nf_metro.parser.model import MetroGraph, Section, Station
+
+        # Section already sits above its padding zone; the shift is a no-op.
+        graph = MetroGraph()
+        graph.sections["s1"] = Section(
+            id="s1", name="S1", bbox_x=0, bbox_y=200, bbox_w=100, bbox_h=80
+        )
+        graph.stations["a"] = Station(id="a", label="A", x=10, y=220)
+
+        engine._shift_graph_into_canvas(graph, section_y_padding=20.0)
+
+        # No shift applied, coords unchanged.
+        assert graph.stations["a"].y == 220
+        assert graph.sections["s1"].bbox_y == 200
+
+    def test_shifts_overflowing_section_down_to_padding(self):
+        from nf_metro.layout import engine
+        from nf_metro.parser.model import MetroGraph, Section, Station
+
+        graph = MetroGraph()
+        graph.sections["s1"] = Section(
+            id="s1", name="S1", bbox_x=0, bbox_y=-30, bbox_w=100, bbox_h=80
+        )
+        graph.stations["a"] = Station(id="a", label="A", x=10, y=10)
+
+        engine._shift_graph_into_canvas(graph, section_y_padding=20.0)
+
+        # bbox_y was -30, padding 20 -> shift = 20 - (-30) = 50.
+        assert graph.sections["s1"].bbox_y == 20
+        assert graph.stations["a"].y == 60
+
+    def test_double_call_is_safe(self):
+        from nf_metro.layout import engine
+        from nf_metro.parser.model import MetroGraph, Section, Station
+
+        graph = MetroGraph()
+        graph.sections["s1"] = Section(
+            id="s1", name="S1", bbox_x=0, bbox_y=-30, bbox_w=100, bbox_h=80
+        )
+        graph.stations["a"] = Station(id="a", label="A", x=10, y=10)
+
+        engine._shift_graph_into_canvas(graph, section_y_padding=20.0)
+        first_bbox_y = graph.sections["s1"].bbox_y
+        first_station_y = graph.stations["a"].y
+
+        engine._shift_graph_into_canvas(graph, section_y_padding=20.0)
+
+        # Second call is a no-op (section is now in canvas).
+        assert graph.sections["s1"].bbox_y == first_bbox_y
+        assert graph.stations["a"].y == first_station_y
+
+
 class TestPhase13Bisection:
     """Bisection guards fired at each Phase-13x boundary must identify the
     offending sub-phase, not the catch-all 'after Phase 12 (final)' label.


### PR DESCRIPTION
## Summary

`_lift_off_track_stations` and `_reanchor_off_track_to_consumer` both ended with a hidden call to `_shift_graph_into_canvas` - a whole-graph translation that moves every station / port / section bbox. The side effect made the global-coord origin appear to shift inside Phase 13 / Phase 13g / Phase 13h.1 with no visible call site in `_compute_section_layout`.

This PR:

- **Removes the hidden calls** from both helpers; each now stops at its bbox grow step and documents the caller's canvas-fit responsibility.
- **Adds explicit `_shift_graph_into_canvas` calls** at Phase 13 / Phase 13g / Phase 13h.1 in `_compute_section_layout`, each with a one-line comment explaining the rationale.
- **Drops the `if grew:` gating** inside `_reanchor_off_track_to_consumer` - the helper's existing min-top guard makes each unconditional call a no-op when nothing overflowed.
- **Adds idempotence unit tests**: already-in-canvas leaves coords alone; shift-then-shift is stable.
- **CONTRACT.md** loses the corresponding bullet from its structural-debt list. Phase 13 / 13g / 13h.1 entries now point at the explicit caller-side call.

Pure call-site visibility refactor; same operations happen at the same logical points.

Fixes #346 signal (orig #5).

## Test plan

- [x] `pytest` passes (2008 + 4 xfail) including new `TestShiftGraphIntoCanvas` class
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [ ] Render-preview verdict: no visual changes expected (call-site move only)

Generated with Claude Code