### PR TITLE
refactor(model): promote _half_grid_station_ids to public field (#346)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -427,26 +427,30 @@ bisection runner is `_run_phase13_guards`.
   trunk row instead of stacked below it.
 - **Invariants preserved**: Trunk station Y.
 
-### Phase 13d3: 2-branch symfan half-grid compaction (engine.py:702-710)
+### Phase 13d3: 2-branch symfan half-grid compaction (engine.py)
 - **Purpose**: Sections containing exactly a 2-branch symmetric fan
   (no off-track / constraining content) collapse onto half-pitch
-  offsets so the section is 1 grid-unit tall instead of 2. Marks
-  stations in `_half_grid_station_ids` so Phase 13e leaves them alone.
-  Gated on `center_ports`.
-- **Helper**: `_apply_half_grid_2branch_symfan` (engine.py:3266).
+  offsets so the section is 1 grid-unit tall instead of 2. Records
+  the placed stations on the public `MetroGraph.half_grid_station_ids`
+  field so Phase 13e leaves them alone -- this is the only cross-
+  phase channel for half-grid placement. Gated on `center_ports`.
+- **Helper**: `_apply_half_grid_2branch_symfan`.
 - **Precondition**: 13d/13d2 done; symfan classification stable
   (`_section_symfan_uses_half_grid`).
 - **Postcondition**: Eligible symfan pairs share half-pitch offsets
-  from the trunk Y.
+  from the trunk Y. `graph.half_grid_station_ids` contains their IDs.
 - **Invariants preserved**: Trunk station Y. Other sections.
 - **Related tests**: `test_symfan_pairs_share_y`.
 
-### Phase 13e: snap all Y to grid (engine.py:712-717)
+### Phase 13e: snap all Y to grid (engine.py)
 - **Purpose**: Final pass snapping every station and port Y to the
   nearest row-wide grid slot, removing fractional Ys left by earlier
-  shifts. Half-grid stations from 13d3 are skipped.
-- **Helper**: `_snap_all_y_to_grid` (engine.py:2882).
-- **Precondition**: All semantic Y shifts done.
+  shifts. Stations listed in `graph.half_grid_station_ids` (populated
+  by Phase 13d3) are skipped so they keep their intentional half-pitch
+  Y.
+- **Helper**: `_snap_all_y_to_grid`.
+- **Precondition**: All semantic Y shifts done. If Phase 13d3 ran,
+  `graph.half_grid_station_ids` is populated.
 - **Postcondition**: Every station and port Y is a grid slot of the
   per-section / per-row pitch (except marked half-grid stations).
 - **Invariants preserved**: X coordinates (tested by
@@ -624,13 +628,7 @@ The following observations came up while writing this doc. Each one is
 a candidate for a follow-up cleanup PR. Items are removed as they are
 resolved; refer to the relevant tracking issue or PR for history.
 
-1. **Phase 13d3 has more conditional logic than the rest** - it's
-   gated on `center_ports` and tracks state on
-   `_half_grid_station_ids` to coordinate with Phase 13e. That
-   cross-phase coupling is hard to follow; the half-grid marker
-   pattern would benefit from a dedicated discussion in the doc /
-   code.
-2. **Phase 11d/11da symmetrically fan content using a stale port Y**;
+1. **Phase 11d/11da symmetrically fan content using a stale port Y**;
    Phase 13h re-centers using the final trunk Y. The two-pass pattern
    is necessary because Phase 11da runs before snap-to-grid, but it
    means the early pass's output is partially-discarded work.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1233,9 +1233,9 @@ def _compute_section_layout(
     # symmetric fan (and no off-track or other constraining content),
     # collapse the fan onto half-pitch offsets so the section consumes
     # one vertical grid unit instead of two.  Marks the branch stations
-    # in ``_half_grid_station_ids`` so the next snap pass leaves them
-    # alone.  Runs before ``_snap_all_y_to_grid`` so the snap-to-row-
-    # grid pass doesn't immediately undo the compaction.
+    # in ``graph.half_grid_station_ids`` so the next snap pass leaves
+    # them alone.  Runs before ``_snap_all_y_to_grid`` so the snap-to-
+    # row-grid pass doesn't immediately undo the compaction.
     if graph.center_ports:
         _apply_half_grid_2branch_symfan(graph, y_spacing, section_y_padding)
         if validate:
@@ -3532,7 +3532,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
         # consumer is preserved) but don't influence the origin.
         residues: Counter[float] = Counter()
         per_section_ports: dict[str, set[str]] = {}
-        half_grid_ids = getattr(graph, "_half_grid_station_ids", set()) or set()
+        half_grid_ids = graph.half_grid_station_ids
         for sec_id in sec_ids:
             section = graph.sections.get(sec_id)
             if section is None or section.bbox_h <= 0:
@@ -3869,7 +3869,7 @@ def _apply_half_grid_2branch_symfan(
       2. LR/RL exit port Y.
       3. Midpoint of the two branch stations' current Ys.
 
-    The branches are marked in ``_half_grid_station_ids`` so the
+    The branches are marked in ``graph.half_grid_station_ids`` so the
     subsequent ``_snap_all_y_to_grid`` pass leaves their half-pitch
     offsets intact (and ignores them when computing the row grid
     origin).
@@ -3929,7 +3929,7 @@ def _apply_half_grid_2branch_symfan(
         branches.sort(key=lambda s: s.y)
         branches[0].y = trunk_y - 0.5 * y_spacing
         branches[1].y = trunk_y + 0.5 * y_spacing
-        graph._half_grid_station_ids.update(b.id for b in branches)
+        graph.half_grid_station_ids.update(b.id for b in branches)
 
         # Half-grid branches consume half a y_spacing above and below
         # the trunk instead of a full slot.  Shrink the bbox top to match
@@ -3972,7 +3972,7 @@ def _section_symfan_uses_half_grid(graph: MetroGraph, section: Section) -> bool:
 
     Trunk Y itself is unchanged.  The branches sit at half-pitch
     relative to the row grid; ``_snap_all_y_to_grid`` skips them via
-    ``graph._half_grid_station_ids``.
+    ``graph.half_grid_station_ids``.
     """
     port_ids = set(section.entry_ports) | set(section.exit_ports)
     branches: list[Station] = []

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -196,10 +196,12 @@ class MetroGraph:
     _station_lines_cache: dict[str, list[str]] | None = field(default=None, repr=False)
     # Grid alignment metadata (populated by Phase 2.5 _align_row_y_grids)
     _row_y_grid_info: dict = field(default_factory=dict, repr=False)
-    # Station IDs placed at half-pitch offsets relative to the row grid by the
-    # 2-branch symmetric-fan placement.  Tracked so that ``_snap_all_y_to_grid``
-    # leaves them alone (they intentionally sit on the half-grid).
-    _half_grid_station_ids: set[str] = field(default_factory=set, repr=False)
+    # Cross-phase channel: station IDs placed at half-pitch offsets
+    # relative to the row grid by Phase 13d3
+    # (``_apply_half_grid_2branch_symfan``) for 2-branch symfan sections.
+    # Phase 13e (``_snap_all_y_to_grid``) reads this set and skips those
+    # stations so they keep their intentional half-grid Y.
+    half_grid_station_ids: set[str] = field(default_factory=set, repr=False)
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1722,7 +1722,7 @@ def test_all_stations_snap_to_grid(fixture):
 
     Half-grid placement (``trunk_y +/- 0.5 * y_spacing``) is reserved
     for the auto-half-grid 2-branch symmetric fan feature: stations
-    registered in ``graph._half_grid_station_ids`` whose section
+    registered in ``graph.half_grid_station_ids`` whose section
     satisfies ``_section_symfan_uses_half_grid`` and has exactly two
     on-track branches.  Any other half-grid station is a regression.
     """
@@ -1732,7 +1732,7 @@ def test_all_stations_snap_to_grid(fixture):
     tol = 1.0
     graph = _layout(fixture, y_spacing=y_spacing)
 
-    half_grid_ids = getattr(graph, "_half_grid_station_ids", set()) or set()
+    half_grid_ids = graph.half_grid_station_ids
     port_ids: set[str] = set()
     for sec in graph.sections.values():
         port_ids.update(sec.entry_ports)


### PR DESCRIPTION
## Summary

Phase 13d3 (`_apply_half_grid_2branch_symfan`) places 2-branch symfan stations at half-pitch offsets and records their IDs on a set attribute of `MetroGraph`. Phase 13e (`_snap_all_y_to_grid`) reads that set and skips those stations so they keep their half-grid Y. Until now the attribute was named with a leading underscore (`_half_grid_station_ids`) and accessed via defensive `getattr(graph, "_half_grid_station_ids", set())`, which hid an intentional cross-phase data channel as a private side-effect.

This PR:

- Renames the field to `half_grid_station_ids` (no underscore) on `MetroGraph` and documents it as the canonical Phase 13d3 -> Phase 13e channel.
- Drops the defensive `getattr` (the dataclass field always exists; the helper now uses direct attribute access).
- Updates all 8 references: 2 code call sites (write + read), 1 test, 5 docstring/comment references.
- CONTRACT.md: Phase 13d3 and Phase 13e entries point at the public field; structural-debt list loses the corresponding bullet.

Rename + documentation only; no behaviour change. The signal asked for "a dedicated discussion / typed-encapsulated container instead of a side-channel attribute" - making it a properly-named, documented public field with direct attribute access is the lighter-touch resolution that doesn't introduce a wrapper class for what is effectively a set of IDs.

Fixes #346 signal (orig #2).

## Test plan

- [x] `pytest` passes (2008 + 4 xfail)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [ ] Render-preview verdict: no visual changes expected (field rename + doc only)

Generated with Claude Code