### PR TITLE
docs(layout): document the 11da / 13h pairing as load-bearing (#346)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -326,16 +326,24 @@ bisection runner is `_run_phase13_guards`.
   structures, and file inputs are left in place.
 - **Invariants preserved**: Trunk station Y. Off-track stations.
 
-### Phase 11da: redistribute full-bundle columns (engine.py:650-653)
+### Phase 11da: redistribute full-bundle columns (engine.py)
 - **Purpose**: When a column has no unique trunk (every station
   carries the full bundle - e.g. Reporting's Shiny + Quarto),
   symmetrically fan stations around the local LR port Y. Gated on
   `center_ports`.
-- **Helper**: `_redistribute_full_bundle_columns` (engine.py:3424).
+- **Helper**: `_redistribute_full_bundle_columns`.
 - **Precondition**: Phase 11d ran.
 - **Postcondition**: Full-bundle columns sit symmetric around the
-  LR port Y. Re-centered later by Phase 13h once final trunk Y is
-  known.
+  LR port Y.
+- **Why both this and Phase 13h**: Phase 13h
+  (``_recenter_full_bundle_columns``) re-fans the same columns
+  using the final trunk Y, which can have drifted from 11da's
+  port-Y anchor.  Phase 11da's output is *not* redundant: the
+  intermediate symmetric layout is read by Phase 13's bbox-growth
+  and compaction passes (an empty trunk row in fanned columns lets
+  13b/13j shrink the section bbox to the compact extent).
+  Skipping 11da changes intermediate bbox sizes and is not empty-
+  render-diff -- the two passes are load-bearing in combination.
 - **Invariants preserved**: Other columns.
 
 ### Phase 12: position junctions (engine.py:658-659)
@@ -624,14 +632,8 @@ bisection runner is `_run_phase13_guards`.
 
 ## Unclear / structural-debt signals
 
-The following observations came up while writing this doc. Each one is
-a candidate for a follow-up cleanup PR. Items are removed as they are
-resolved; refer to the relevant tracking issue or PR for history.
-
-1. **Phase 11d/11da symmetrically fan content using a stale port Y**;
-   Phase 13h re-centers using the final trunk Y. The two-pass pattern
-   is necessary because Phase 11da runs before snap-to-grid, but it
-   means the early pass's output is partially-discarded work.
+No open signals at this time. Add new entries here when phase
+pre/postconditions reveal a candidate for cleanup.
 
 ## Adding a new phase: checklist
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1160,6 +1160,15 @@ def _compute_section_layout(
     # Phase 11da: Symmetrically fan a column of full-bundle stations
     # around the trunk Y when no unique trunk exists (e.g. Reporting's
     # Shiny app + Quarto report, both carrying the full bundle).
+    #
+    # Why both 11da and Phase 13h's recenter: 11da's symmetric layout
+    # is read by Phase 13's bbox-growth, compaction, and snap-to-grid
+    # passes (an empty trunk row in fanned columns lets 13b/13j shrink
+    # the section bbox to the compact extent).  Phase 13h then re-fans
+    # the same columns using the post-row-alignment trunk Y, which can
+    # have drifted from 11da's port-Y anchor.  Skipping 11da changes
+    # intermediate bbox sizes and is not empty-render-diff; the two
+    # passes are load-bearing in combination.
     _redistribute_full_bundle_columns(graph, y_spacing)
 
     # ---- Pass C: Junction positioning & Phase 13 finalisation ----------


### PR DESCRIPTION
## Summary

Phase 11da (`_redistribute_full_bundle_columns`) and Phase 13h (`_recenter_full_bundle_columns`) look like duplicate work - both fan full-bundle station columns around a trunk Y, with 11da using the local LR port Y and 13h using the post-row-alignment trunk Y. The intuitive cleanup would be to drop 11da and rely on 13h.

**Experiment**: skipping 11da's call changes the canvas height on `differentialabundance.mmd` by ~50px. 11da's symmetric layout is read by Phase 13's bbox-growth and compaction passes - an empty trunk row in fanned columns lets 13b/13j shrink the section bbox to its compact extent. Without 11da, those passes see a different column layout and produce different bbox sizes. The two passes are load-bearing in combination.

This PR documents the load-bearing pairing:

- **CONTRACT.md Phase 11da entry**: adds a "Why both this and Phase 13h" explanation noting that 11da's output is read by Phase 13's bbox-growth/compaction passes, and that skipping is not empty-render-diff.
- **Inline comment at the 11da call site** in `_compute_section_layout`: same explanation in the engine code.
- **Structural-debt list**: removed the bullet - the two-pass pattern is now documented rather than "unclear". The structural-debt list is empty.

Pure docs change; no behaviour difference.

Fixes #346 signal (orig #7) and closes out #346.

## Test plan

- [x] `pytest` passes (2008 + 4 xfail)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] Confirmed empirically: skipping 11da changes `differentialabundance.mmd` canvas height by ~50px (NOT empty-render-diff)
- [ ] Render-preview verdict: no visual changes expected (docs only)

Generated with Claude Code