### PR TITLE
chore(simplify): retrospective /simplify pass over 0.6.1..main

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -2106,7 +2106,7 @@ def _classify_section_station_ys(
             continue
         if st.is_port:
             ports.append(st.y)
-        elif getattr(st, "off_track", False):
+        elif st.off_track:
             off_track.append(st.y)
         else:
             on_track.append(st.y)
@@ -2248,7 +2248,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
     branch below runs unconditionally because it only moves the entry
     port (not the exit), preserving the auto-layout fan-in convergence.
     """
-    explicit_grid = bool(getattr(graph, "_explicit_grid", None))
+    explicit_grid = bool(graph._explicit_grid)
     junction_ids = set(graph.junctions)
     moved = False
 
@@ -2356,7 +2356,7 @@ def _fan_free_content_upward(
     Scoped to pipelines using explicit ``%%metro grid:`` directives so
     the auto-layout path is unaffected.
     """
-    if not getattr(graph, "_explicit_grid", None):
+    if not graph._explicit_grid:
         return
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
@@ -2444,16 +2444,8 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
     path is unaffected.  U-turn risk is nil because sources have no
     upstream feeders by definition.
     """
-    if not getattr(graph, "_explicit_grid", None):
+    if not graph._explicit_grid:
         return
-
-    # Reverse-adjacency built once: avoids scanning graph.edges for every
-    # source candidate's "no inbound edges" check.
-    in_edges: dict[str, set[str]] = {}
-    out_edges: dict[str, set[str]] = {}
-    for e in graph.edges:
-        in_edges.setdefault(e.target, set()).add(e.source)
-        out_edges.setdefault(e.source, set()).add(e.target)
 
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
@@ -2494,7 +2486,7 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
             if s != trunk_sid
             and graph.station_lines(s)
             and set(graph.station_lines(s)) < bundle
-            and not in_edges.get(s)
+            and not graph.edges_to(s)
             and graph.stations[s].y > trunk_y - 0.5
         ]
         if len(sources) < 2:
@@ -2525,13 +2517,13 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
             cur = src
             src_lines = set(graph.station_lines(src))
             while True:
-                outs = out_edges.get(cur, set())
+                outs = {e.target for e in graph.edges_from(cur)}
                 if len(outs) != 1:
                     break
                 nxt = next(iter(outs))
                 if nxt not in internal_set:
                     break
-                if len(in_edges.get(nxt, set())) != 1:
+                if len({e.source for e in graph.edges_to(nxt)}) != 1:
                     break
                 if set(graph.station_lines(nxt)) != src_lines:
                     break
@@ -2575,26 +2567,25 @@ def _balance_direct_external_feeder_ys(
     junction_ids = set(graph.junctions)
     feeder_ys: list[float] = []
     seen: set[tuple[str, str]] = set()
-    stack: list[tuple[str, str]] = []
-    for edge in graph.edges:
-        if edge.target == station_id:
-            stack.append((edge.source, edge.line_id))
+    stack: list[tuple[str, str]] = [
+        (edge.source, edge.line_id) for edge in graph.edges_to(station_id)
+    ]
     while stack:
         cur_id, lid = stack.pop()
         if (cur_id, lid) in seen:
             continue
         seen.add((cur_id, lid))
         if cur_id in junction_ids:
-            for edge in graph.edges:
-                if edge.target == cur_id and edge.line_id == lid:
+            for edge in graph.edges_to(cur_id):
+                if edge.line_id == lid:
                     stack.append((edge.source, lid))
             continue
         src = graph.stations.get(cur_id)
         if src is None:
             continue
         if src.is_port:
-            for edge in graph.edges:
-                if edge.target == cur_id and edge.line_id == lid:
+            for edge in graph.edges_to(cur_id):
+                if edge.line_id == lid:
                     stack.append((edge.source, lid))
             continue
         if src.section_id == section_id:
@@ -2626,7 +2617,7 @@ def _balance_section_content_around_trunk(
     safety prevents lifts that would force the line to climb past the
     trunk and double back.
     """
-    if not getattr(graph, "_explicit_grid", None):
+    if not graph._explicit_grid:
         return
     if not graph.center_ports:
         return
@@ -3429,9 +3420,7 @@ def _lift_would_cause_uturn(
     feeder_ys: list[float] = []
 
     def _collect(node_id: str) -> None:
-        for edge in graph.edges:
-            if edge.target != node_id:
-                continue
+        for edge in graph.edges_to(node_id):
             src_id = edge.source
             if src_id in seen:
                 continue
@@ -3540,7 +3529,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
                     # design; don't let them shift the row's grid origin.
                     continue
                 st = graph.stations.get(sid)
-                if st is None or getattr(st, "off_track", False):
+                if st is None or st.off_track:
                     continue
                 residues[round(st.y % pitch, 3)] += 1
         if not residues:
@@ -3591,7 +3580,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
     # new midpoint so a fan-in still visually converges symmetrically.
     for target_id, src_ids in convergence_sources.items():
         st = graph.stations.get(target_id)
-        if st is None or getattr(st, "off_track", False):
+        if st is None or st.off_track:
             continue
         # Convergence sources whose snap displaced them away from their
         # original Y may break the midpoint relationship; recompute
@@ -3620,9 +3609,7 @@ def _convergence_source_ys(graph: MetroGraph) -> dict[str, list[str]]:
     for edge in graph.edges:
         src_id = edge.source
         if src_id in junction_ids:
-            for e2 in graph.edges:
-                if e2.target != src_id:
-                    continue
+            for e2 in graph.edges_to(src_id):
                 pre = graph.stations.get(e2.source)
                 if pre is None or pre.is_port:
                     continue
@@ -3716,20 +3703,6 @@ def _section_bundle_lines(graph: MetroGraph, section: Section) -> set[str]:
             continue
         bundle.update(graph.station_lines(pid))
     return bundle
-
-
-def _section_columns_by_x(
-    graph: MetroGraph, section: Section
-) -> dict[float, list[str]]:
-    """Group a section's non-port stations by their (rounded) X column."""
-    port_ids = set(section.entry_ports) | set(section.exit_ports)
-    cols: dict[float, list[str]] = defaultdict(list)
-    for sid in section.station_ids:
-        if sid in port_ids:
-            continue
-        if (st := graph.stations.get(sid)) is not None:
-            cols[round(st.x, 3)].append(sid)
-    return cols
 
 
 def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
@@ -6120,14 +6093,11 @@ def _align_tb_section_bbox_bottoms(graph: MetroGraph) -> None:
     def _downstream_section_ids(tb_section: Section) -> set[str]:
         out: set[str] = set()
         for pid in tb_section.exit_ports:
-            for edge in graph.edges:
-                if edge.source != pid:
-                    continue
+            for edge in graph.edges_from(pid):
                 candidates: list[str] = []
                 if edge.target in junction_ids:
-                    for e2 in graph.edges:
-                        if e2.source == edge.target:
-                            candidates.append(e2.target)
+                    for e2 in graph.edges_from(edge.target):
+                        candidates.append(e2.target)
                 else:
                     candidates.append(edge.target)
                 for tid in candidates:
@@ -6297,7 +6267,7 @@ def _space_ports_from_termini(
             # from being pushed away (and dragging the upstream port via
             # junction propagation) for a conflict that won't exist by
             # render time.
-            if getattr(st, "off_track", False):
+            if st.off_track:
                 continue
             preds = predecessors.get(sid, set())
             succs = successors.get(sid, set())
@@ -6673,8 +6643,6 @@ def _compute_fork_join_gaps(
     divergences are suppressed because there are no diagonal transitions
     and the extra spacing is purely wasteful.
     """
-    from collections import defaultdict
-
     out_targets: dict[str, set[str]] = defaultdict(set)
     in_sources: dict[str, set[str]] = defaultdict(set)
 
@@ -7021,9 +6989,8 @@ def _bump_off_track_clear_of_trunks(
     if y_spacing <= 0:
         return candidate_y
 
-    # Match the renderer's terminus icon height (32 px default; half=16)
-    # and add a small margin so the icon's stroke doesn't touch a track.
-    ICON_HALF = 16.0
+    # Match the renderer's terminus icon height and add a small margin
+    # so the icon's stroke doesn't touch a track.
     MARGIN = 2.0
     # Limit lift attempts so a pathological column doesn't pull the
     # icon off-canvas.
@@ -7067,16 +7034,16 @@ def _bump_off_track_clear_of_trunks(
         return candidate_y
 
     def _overlaps(y: float) -> bool:
-        top = y - ICON_HALF - MARGIN
-        bot = y + ICON_HALF + MARGIN
+        top = y - ICON_HALF_HEIGHT - MARGIN
+        bot = y + ICON_HALF_HEIGHT + MARGIN
         for tl_y_lo, tl_y_hi in zip(trunk_offsets_at_x[::2], trunk_offsets_at_x[1::2]):
             if not (bot < tl_y_lo or tl_y_hi < top):
                 return True
-        # Sibling clearance: keep at least 2 * ICON_HALF + MARGIN between
+        # Sibling clearance: keep at least 2 * ICON_HALF_HEIGHT + MARGIN between
         # icon centres in the same column so the icon bboxes don't
         # touch.
         for sy in sib_ys:
-            if abs(sy - y) < 2 * ICON_HALF + MARGIN:
+            if abs(sy - y) < 2 * ICON_HALF_HEIGHT + MARGIN:
                 return True
         return False
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -78,7 +78,7 @@ class PhaseInvariantError(Exception):
 
 def _guard_coordinates_finite(graph: MetroGraph, phase: str) -> None:
     """After Phase 4+: all laid-out stations must have finite coordinates."""
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     for sid, st in graph.stations.items():
         if st.section_id and not st.is_port and sid not in junction_ids:
             if math.isnan(st.x) or math.isnan(st.y):
@@ -104,7 +104,7 @@ def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
     height) spill above the bbox top while still being technically "in" the
     section.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     tol = GUARD_TOLERANCE
     for sid, st in graph.stations.items():
         sec = graph.sections.get(st.section_id or "")
@@ -338,7 +338,7 @@ def _guard_row_trunk_cy_consistent(
         if not port_ys:
             return None
         port_y = port_ys[0]
-        port_set = set(sec.entry_ports) | set(sec.exit_ports)
+        port_set = sec.port_ids
         best: tuple[float, float, float, float] | None = None
         for sid in sec.station_ids:
             if sid in port_set:
@@ -486,7 +486,7 @@ def _guard_off_track_inputs_above_consumer(graph: MetroGraph, phase: str) -> Non
     least ``GUARD_TOLERANCE`` above (smaller Y than) their on-track
     consumer.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     consumer_of: dict[str, str] = {}
     for edge in graph.edges:
         src = graph.stations.get(edge.source)
@@ -561,7 +561,7 @@ def _guard_station_x_column_drift(graph: MetroGraph, phase: str) -> None:
     for sec in graph.sections.values():
         if sec.bbox_h <= 0 or sec.direction not in ("LR", "RL"):
             continue
-        port_ids = set(sec.entry_ports) | set(sec.exit_ports)
+        port_ids = sec.port_ids
         layer_xs: dict[int, list[tuple[str, float]]] = {}
         for sid in sec.station_ids:
             if sid in port_ids:
@@ -1942,7 +1942,7 @@ def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
     bundle = _section_bundle_lines(graph, section)
     if not bundle:
         return None
-    port_ids = set(section.entry_ports) | set(section.exit_ports)
+    port_ids = section.port_ids
     internal_ids = set(section.station_ids) - port_ids
     trunk_ys: set[float] = set()
     for pid in port_ids:
@@ -2041,7 +2041,7 @@ def _align_row_trunk_ys(graph: MetroGraph) -> None:
             for section in group:
                 if section.id not in shifted:
                     continue
-                port_set = set(section.entry_ports) | set(section.exit_ports)
+                port_set = section.port_ids
                 internal_ids = set(section.station_ids) - port_set
                 for pid in port_set:
                     p = graph.ports.get(pid)
@@ -2228,7 +2228,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
     port (not the exit), preserving the auto-layout fan-in convergence.
     """
     explicit_grid = bool(graph._explicit_grid)
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     for port_id, port in graph.ports.items():
         if port.is_entry:
@@ -2274,7 +2274,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
         # keep their centred-midpoint convergence Y, so don't move the
         # exit port itself.  Instead, snap the downstream entry port
         # to the exit port's Y so the inter-section trunk stays flat.
-        port_set = set(section.entry_ports) | set(section.exit_ports)
+        port_set = section.port_ids
         src_ys: set[float] = set()
         for edge in graph.edges_to(port_id):
             src = graph.stations.get(edge.source)
@@ -2340,7 +2340,7 @@ def _fan_free_content_upward(
             for sid in section.station_ids
         ):
             continue
-        port_set = set(section.entry_ports) | set(section.exit_ports)
+        port_set = section.port_ids
         internal_ids = [
             sid
             for sid in section.station_ids
@@ -2429,7 +2429,7 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
             for sid in section.station_ids
         ):
             continue
-        port_set = set(section.entry_ports) | set(section.exit_ports)
+        port_set = section.port_ids
         internal_ids = [
             sid
             for sid in section.station_ids
@@ -2538,7 +2538,7 @@ def _balance_direct_external_feeder_ys(
     by line means transit-only stations feeding the same shared port
     on a different line are not counted.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     feeder_ys: list[float] = []
     seen: set[tuple[str, str]] = set()
     stack: list[tuple[str, str]] = [
@@ -2602,7 +2602,7 @@ def _balance_section_content_around_trunk(
         bundle = _section_bundle_lines(graph, section)
         if not bundle:
             continue
-        port_set = set(section.entry_ports) | set(section.exit_ports)
+        port_set = section.port_ids
         internal_ids = [
             sid
             for sid in section.station_ids
@@ -2891,7 +2891,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
             continue
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
         # Each side station: not a port, not hidden, has exactly one
         # incoming edge and one outgoing edge, both endpoints sit on
         # the section trunk Y (single source / single target on-trunk).
@@ -2984,7 +2984,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
             continue
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
         # Determine the section's trunk Y from a horizontal port.
         trunk_y: float | None = None
         for pid in section.entry_ports + section.exit_ports:
@@ -3133,7 +3133,7 @@ def _shift_sparse_loop_stations_to_clear_bundle(
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
             continue
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
         # Trunk Y from the LR/RL ports.
         trunk_y: float | None = None
         for pid in section.entry_ports + section.exit_ports:
@@ -3376,7 +3376,7 @@ def _lift_would_cause_uturn(
     Returns False when there's no risk (no feeders, single feeder, or
     any feeder sits above the anchor giving the bundle a reason to climb).
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     seen: set[str] = set()
     feeder_ys: list[float] = []
 
@@ -3480,7 +3480,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
             section = graph.sections.get(sec_id)
             if section is None or section.bbox_h <= 0:
                 continue
-            port_ids = set(section.entry_ports) | set(section.exit_ports)
+            port_ids = section.port_ids
             per_section_ports[sec_id] = port_ids
             for sid in section.station_ids:
                 if sid in port_ids:
@@ -3565,7 +3565,7 @@ def _convergence_source_ys(graph: MetroGraph) -> dict[str, list[str]]:
     Walks one step back through junctions to identify the real
     predecessors so fan-in via a single junction is still detected.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     inbound: dict[str, set[str]] = defaultdict(set)
     for edge in graph.edges:
         src_id = edge.source
@@ -3617,7 +3617,7 @@ def _divergence_target_ys(graph: MetroGraph) -> set[str]:
     Walks one step forward through junctions to identify the real
     successors so fan-out via a single junction is still detected.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     outbound: dict[str, set[str]] = defaultdict(set)
     for edge in graph.edges:
         tgt_id = edge.target
@@ -3715,7 +3715,7 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
         bundle = _section_bundle_lines(graph, section)
         if not bundle:
             continue
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
 
         # Group non-port, on-track stations by column x.  Off-track
         # stations (file inputs lifted above their consumer) are placed
@@ -3799,7 +3799,7 @@ def _apply_half_grid_2branch_symfan(
         if not _section_symfan_uses_half_grid(graph, section):
             continue
 
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
         branches: list[Station] = []
         for sid in section.station_ids:
             if sid in port_ids:
@@ -3891,7 +3891,7 @@ def _section_symfan_uses_half_grid(graph: MetroGraph, section: Section) -> bool:
     relative to the row grid; ``_snap_all_y_to_grid`` skips them via
     ``graph.half_grid_station_ids``.
     """
-    port_ids = set(section.entry_ports) | set(section.exit_ports)
+    port_ids = section.port_ids
     branches: list[Station] = []
     has_off_track = False
     by_col: dict[float, int] = defaultdict(int)
@@ -3963,7 +3963,7 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
         bundle = _section_bundle_lines(graph, section)
         if not bundle:
             continue
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
 
         cols: dict[float, list[str]] = defaultdict(list)
         for sid in section.station_ids:
@@ -4103,7 +4103,7 @@ def _recenter_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
         bundle = _section_bundle_lines(graph, section)
         if not bundle:
             continue
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
 
         cols: dict[float, list[str]] = defaultdict(list)
         for sid in section.station_ids:
@@ -4765,14 +4765,13 @@ def _adjust_tb_entry_shifts(
         port = graph.ports.get(pid)
         if not port or port.side != PortSide.TOP:
             continue
-        for edge in graph.edges:
-            if edge.target == pid:
-                src = graph.stations.get(edge.source)
-                if src and src.section_id:
-                    src_sec = graph.sections.get(src.section_id)
-                    if src_sec and src_sec.grid_col != section.grid_col:
-                        has_cross_col_top_entry = True
-                        break
+        for edge in graph.edges_to(pid):
+            src = graph.stations.get(edge.source)
+            if src and src.section_id:
+                src_sec = graph.sections.get(src.section_id)
+                if src_sec and src_sec.grid_col != section.grid_col:
+                    has_cross_col_top_entry = True
+                    break
         if has_cross_col_top_entry:
             break
     if has_cross_col_top_entry:
@@ -4814,9 +4813,7 @@ def _adjust_lr_entry_inset(
         if graph.ports[pid].side != flow_side:
             continue
         targets = {
-            e.target
-            for e in graph.edges
-            if e.source == pid and e.target in section.station_ids
+            e.target for e in graph.edges_from(pid) if e.target in section.station_ids
         }
         if len(targets) > 1:
             entry_inset = x_spacing * EXIT_GAP_MULTIPLIER
@@ -4866,8 +4863,10 @@ def _adjust_lr_exit_gap(
     # marker, but the diagonal still terminates at a visible station.
     feeder_ys: set[float] = set()
     real_ids = set(sub.stations)
-    for edge in graph.edges:
-        if edge.target in flow_exit_port_ids and edge.source in real_ids:
+    for pid in flow_exit_port_ids:
+        for edge in graph.edges_to(pid):
+            if edge.source not in real_ids:
+                continue
             src_id = edge.source
             if src_id.startswith("__bypass_"):
                 pred_y = None
@@ -4996,7 +4995,7 @@ def _adjust_terminus_icon_clearance(
         needed = _terminus_icon_clearance(n_icons, station.terminus_names)
 
         # Determine source vs sink from the full graph's edges
-        is_source = not any(e.target == station.id for e in graph.edges)
+        is_source = not graph.edges_to(station.id)
 
         section_dir = section.direction or "LR"
 
@@ -5055,7 +5054,7 @@ def _shift_lr_perp_entry_stations(
             continue
 
         # Collect internal station X positions
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
         internal_xs: list[float] = []
         for sid in section.station_ids:
             if sid in port_ids:
@@ -5291,7 +5290,7 @@ def _align_entry_ports(graph: MetroGraph) -> None:
     LEFT/RIGHT ports: align Y for straight horizontal runs.
     TOP/BOTTOM ports: align X for vertical drops or Y for cross-column.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     for port_id, port in graph.ports.items():
         if not port.is_entry:
@@ -5490,7 +5489,7 @@ def _align_ports_to_downstream(graph: MetroGraph) -> None:
     Only applies to non-fold LR/RL sections without fan-out junctions
     (fold/TB sections are handled by ``_align_exit_ports``).
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     for port_id, port in graph.ports.items():
         if port.is_entry:
@@ -5634,7 +5633,7 @@ def _snap_sole_layer_stations_to_ports(graph: MetroGraph) -> None:
         if section.id in grid_group_secs:
             continue
 
-        port_ids = set(section.entry_ports) | set(section.exit_ports)
+        port_ids = section.port_ids
         internal_ids = set(section.station_ids) - port_ids
 
         # Skip single-station sections: the station is already centred
@@ -5792,7 +5791,7 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
     if not grid_group_secs:
         return
 
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     for port_id, port in graph.ports.items():
         if port.is_entry:
@@ -5901,7 +5900,7 @@ def _align_exit_ports(graph: MetroGraph) -> None:
     section's entry may be at a different Y. Aligning ensures a straight
     horizontal inter-section connection.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     for port_id, port in graph.ports.items():
         if port.is_entry:
@@ -6049,7 +6048,7 @@ def _align_tb_section_bbox_bottoms(graph: MetroGraph) -> None:
     Skipped for TB sections with BOTTOM-side exit ports (TB->TB flow)
     so the bottom-edge port placement invariant continues to hold.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     def _downstream_section_ids(tb_section: Section) -> set[str]:
         out: set[str] = set()
@@ -6288,7 +6287,7 @@ def _push_ports_from_termini(
     when multiple ports in the same section conflict with the same
     terminus.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     section_port_set = set(port_ids)
 
     for pid in port_ids:
@@ -6409,7 +6408,7 @@ def _push_termini_from_port(
     """
     # Collect existing station Y values in the section (excluding ports
     # and the termini being moved) as candidate snap targets.
-    port_ids = set(section.entry_ports) | set(section.exit_ports)
+    port_ids = section.port_ids
     tid_set = set(terminus_ids)
     section_ys: set[float] = set()
     for sid in section.station_ids:
@@ -6470,7 +6469,7 @@ def _build_section_subgraph(graph: MetroGraph, section: Section) -> MetroGraph:
     sub.diamond_style = graph.diamond_style
 
     # Collect port IDs for this section
-    port_ids = set(section.entry_ports) | set(section.exit_ports)
+    port_ids = section.port_ids
 
     # Add only real (non-port) stations belonging to this section
     real_station_ids: set[str] = set()
@@ -6537,9 +6536,10 @@ def _insert_phantom_pass_throughs(
 
     # Find lines entering from entry ports to deep-layer internal stations.
     entry_targets: dict[str, set[str]] = {}
-    for edge in graph.edges:
-        if edge.source in entry_port_ids and edge.target in sub.stations:
-            entry_targets.setdefault(edge.line_id, set()).add(edge.target)
+    for pid in entry_port_ids:
+        for edge in graph.edges_from(pid):
+            if edge.target in sub.stations:
+                entry_targets.setdefault(edge.line_id, set()).add(edge.target)
 
     for line_id, targets in entry_targets.items():
         target_layers = [layers.get(t, min_layer) for t in targets]
@@ -6798,7 +6798,7 @@ def _off_track_groups(
     that consumer.  ``fallback_consumer_id`` is the topmost on-track
     station in the section, used as the anchor for the ``""`` bucket.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     by_section: dict[str, list[Station]] = defaultdict(list)
     for sid, st in graph.stations.items():
@@ -6809,18 +6809,18 @@ def _off_track_groups(
         by_section[st.section_id].append(st)
 
     consumer_of: dict[str, str] = {}
-    for edge in graph.edges:
-        src = graph.stations.get(edge.source)
-        tgt = graph.stations.get(edge.target)
-        if src is None or tgt is None:
-            continue
-        if not src.off_track or src.is_port or src.id in junction_ids:
-            continue
-        if tgt.is_port or tgt.id in junction_ids or tgt.off_track:
-            continue
-        if src.section_id != tgt.section_id:
-            continue
-        consumer_of.setdefault(src.id, tgt.id)
+    for off_stations in by_section.values():
+        for off_st in off_stations:
+            for edge in graph.edges_from(off_st.id):
+                tgt = graph.stations.get(edge.target)
+                if tgt is None:
+                    continue
+                if tgt.is_port or tgt.id in junction_ids or tgt.off_track:
+                    continue
+                if off_st.section_id != tgt.section_id:
+                    continue
+                consumer_of.setdefault(off_st.id, tgt.id)
+                break
 
     result: dict[str, tuple[str, dict[str, list[Station]]]] = {}
     for sec_id, off_stations in by_section.items():
@@ -6868,7 +6868,7 @@ def _place_off_track_above_consumers(
     """
     section = graph.sections.get(section_id)
     sec_dir = section.direction if section is not None else "LR"
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     # Track already-placed off-track Ys per column so a bumped icon
     # doesn't crash into a sibling off-track already at the desired Y.
@@ -7197,7 +7197,7 @@ def _pad_stacked_captioned_file_icons(
     if pitch <= y_spacing + 0.5:
         return
 
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     grew_sections: list[Section] = []
 
     for section in graph.sections.values():

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -256,12 +256,6 @@ def _guard_no_line_crosses_non_consumer(
         except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
             return
 
-    consumed_by: dict[str, set[str]] = {}
-    produced_by: dict[str, set[str]] = {}
-    for e in graph.edges:
-        consumed_by.setdefault(e.target, set()).add(e.line_id)
-        produced_by.setdefault(e.source, set()).add(e.line_id)
-
     def _segment_crosses_bbox(
         p1: tuple[float, float],
         p2: tuple[float, float],
@@ -289,7 +283,7 @@ def _guard_no_line_crosses_non_consumer(
         bbox = _station_marker_bbox(graph, sid, offsets=offsets)
         if bbox is None:
             continue
-        station_lines = consumed_by.get(sid, set()) | produced_by.get(sid, set())
+        station_lines = set(graph.station_lines(sid))
         for r in routes:
             if r.line_id in station_lines:
                 continue
@@ -3732,9 +3726,7 @@ def _section_bundle_lines(graph: MetroGraph, section: Section) -> set[str]:
         port = graph.ports.get(pid)
         if port is None or port.side not in (PortSide.LEFT, PortSide.RIGHT):
             continue
-        for edge in graph.edges:
-            if edge.source == pid or edge.target == pid:
-                bundle.add(edge.line_id)
+        bundle.update(graph.station_lines(pid))
     return bundle
 
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -321,19 +321,8 @@ def _guard_row_trunk_cy_consistent(
 
         offsets = compute_station_offsets(graph)
 
-    def _section_full_bundle(sec) -> set[str]:
-        port_lines: set[str] = set()
-        has_lr_port = False
-        for pid in list(sec.entry_ports) + list(sec.exit_ports):
-            port = graph.ports.get(pid)
-            if port is None or port.side not in (PortSide.LEFT, PortSide.RIGHT):
-                continue
-            has_lr_port = True
-            port_lines.update(graph.station_lines(pid))
-        return port_lines if (has_lr_port and port_lines) else set()
-
     def _section_trunk_info(sec) -> tuple[float, float, float, set[str]] | None:
-        bundle = _section_full_bundle(sec)
+        bundle = _section_bundle_lines(graph, sec)
         if not bundle:
             return None
         port_ys: list[float] = []
@@ -770,8 +759,9 @@ def compute_min_y_spacing(
     clearance = ICON_STACK_LABEL_CLEARANCE
 
     pitch_icon_icon = icon_above + icon_below + clearance
+    # icon_over_label uses icon_below (the larger extent), so it
+    # subsumes the label-over-icon case which uses icon_above.
     pitch_icon_over_label = icon_below + label_extent + clearance
-    pitch_label_over_icon = label_extent + icon_above + clearance
 
     required = floor
     if not graph.sections:
@@ -797,7 +787,7 @@ def compute_min_y_spacing(
         if captioned >= 2:
             required = max(required, pitch_icon_icon)
         if captioned >= 1 and labeled >= 1:
-            required = max(required, pitch_icon_over_label, pitch_label_over_icon)
+            required = max(required, pitch_icon_over_label)
 
     return required
 
@@ -2213,7 +2203,7 @@ def _compact_row_content_to_bbox_top(
                     section.bbox_h = max(0.0, new_h)
 
 
-def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
+def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
     """Snap exit/entry port pairs in the same row to a shared Y.
 
     For each LEFT/RIGHT exit port that connects (directly or via a
@@ -2239,7 +2229,6 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
     """
     explicit_grid = bool(graph._explicit_grid)
     junction_ids = set(graph.junctions)
-    moved = False
 
     for port_id, port in graph.ports.items():
         if port.is_entry:
@@ -2313,15 +2302,11 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
                     if ep_st is None or abs(ep_st.y - port_st.y) < 0.5:
                         continue
                     _set_port_y(graph, eid, port_st.y)
-                    moved = True
             continue
 
         if not explicit_grid:
             continue
         _set_port_y(graph, port_id, target_y)
-        moved = True
-
-    return moved
 
 
 def _fan_free_content_upward(
@@ -4886,10 +4871,10 @@ def _adjust_lr_exit_gap(
             src_id = edge.source
             if src_id.startswith("__bypass_"):
                 pred_y = None
-                for pe in graph.edges:
-                    if pe.target == src_id and pe.source in real_ids:
+                for pe in graph.edges_to(src_id):
+                    if pe.source in real_ids and not pe.source.startswith("__bypass_"):
                         ps = sub.stations.get(pe.source)
-                        if ps is not None and not pe.source.startswith("__bypass_"):
+                        if ps is not None:
                             pred_y = ps.y
                             break
                 if pred_y is None:
@@ -7212,12 +7197,6 @@ def _pad_stacked_captioned_file_icons(
     if pitch <= y_spacing + 0.5:
         return
 
-    in_edges: dict[str, set[str]] = {}
-    out_edges: dict[str, set[str]] = {}
-    for e in graph.edges:
-        in_edges.setdefault(e.target, set()).add(e.source)
-        out_edges.setdefault(e.source, set()).add(e.target)
-
     junction_ids = set(graph.junctions)
     grew_sections: list[Section] = []
 
@@ -7247,13 +7226,13 @@ def _pad_stacked_captioned_file_icons(
             src_lines = set(graph.station_lines(src))
             visited: set[str] = {src}
             while True:
-                outs = out_edges.get(cur, set())
+                outs = {e.target for e in graph.edges_from(cur)}
                 if len(outs) != 1:
                     break
                 nxt = next(iter(outs))
                 if nxt in visited or nxt not in internal_set:
                     break
-                if len(in_edges.get(nxt, set())) != 1:
+                if len({e.source for e in graph.edges_to(nxt)}) != 1:
                     break
                 if set(graph.station_lines(nxt)) != src_lines:
                     break

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -527,12 +527,7 @@ def _guard_off_track_inputs_above_consumer(graph: MetroGraph, phase: str) -> Non
             )
 
 
-def is_loop_side_branch_station(
-    graph: MetroGraph,
-    sid: str,
-    in_by_tgt: dict[str, list],
-    out_by_src: dict[str, list],
-) -> bool:
+def is_loop_side_branch_station(graph: MetroGraph, sid: str) -> bool:
     """Mirror ``_recenter_loop_side_stations``'s precondition: a station
     with exactly one in-edge and one out-edge, whose predecessor and
     successor share Y, sitting off the trunk Y between them in X.
@@ -546,8 +541,8 @@ def is_loop_side_branch_station(
     st = graph.stations.get(sid)
     if st is None:
         return False
-    ins = in_by_tgt.get(sid, [])
-    outs = out_by_src.get(sid, [])
+    ins = graph.edges_to(sid)
+    outs = graph.edges_from(sid)
     if len(ins) != 1 or len(outs) != 1:
         return False
     src = graph.stations.get(ins[0].source)
@@ -574,12 +569,6 @@ def _guard_station_x_column_drift(graph: MetroGraph, phase: str) -> None:
     """
     import statistics
 
-    in_by_tgt: dict[str, list] = {}
-    out_by_src: dict[str, list] = {}
-    for e in graph.edges:
-        in_by_tgt.setdefault(e.target, []).append(e)
-        out_by_src.setdefault(e.source, []).append(e)
-
     for sec in graph.sections.values():
         if sec.bbox_h <= 0 or sec.direction not in ("LR", "RL"):
             continue
@@ -593,7 +582,7 @@ def _guard_station_x_column_drift(graph: MetroGraph, phase: str) -> None:
                 continue
             if st.off_track:
                 continue
-            if is_loop_side_branch_station(graph, sid, in_by_tgt, out_by_src):
+            if is_loop_side_branch_station(graph, sid):
                 continue
             layer_xs.setdefault(st.layer, []).append((sid, st.x))
         for layer, members in layer_xs.items():
@@ -2896,17 +2885,11 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
     skipped when shifting would leave fewer than ``DIAGONAL_RUN`` worth
     of horizontal room on either side.
     """
-    # Index edges by source/target for O(1) loop detection.
-    # Single pass: index edges by endpoint and accumulate distinct
-    # successors/predecessors for fork/join detection (mirroring
-    # routing's label-clearance logic).
-    out_by_src: dict[str, list[Edge]] = defaultdict(list)
-    in_by_tgt: dict[str, list[Edge]] = defaultdict(list)
+    # Single pass over graph.edges to accumulate fork/join sets.
+    # (Adjacency itself is served by graph.edges_from / edges_to.)
     fork_targets: dict[str, set[str]] = defaultdict(set)
     join_sources: dict[str, set[str]] = defaultdict(set)
     for e in graph.edges:
-        out_by_src[e.source].append(e)
-        in_by_tgt[e.target].append(e)
         fork_targets[e.source].add(e.target)
         join_sources[e.target].add(e.source)
     fork_stations = {sid for sid, t in fork_targets.items() if len(t) > 1}
@@ -2933,8 +2916,8 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
             st = graph.stations.get(sid)
             if st is None or st.is_port or st.is_hidden:
                 continue
-            ins = in_by_tgt.get(sid, [])
-            outs = out_by_src.get(sid, [])
+            ins = graph.edges_to(sid)
+            outs = graph.edges_from(sid)
             if len(ins) != 1 or len(outs) != 1:
                 continue
             src_id = ins[0].source
@@ -2973,8 +2956,8 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                     continue
                 if abs(other.y - trunk_y) < 0.5:
                     continue  # on-trunk co-loopers don't establish a fan
-                other_ins = in_by_tgt.get(other_sid, [])
-                other_outs = out_by_src.get(other_sid, [])
+                other_ins = graph.edges_to(other_sid)
+                other_outs = graph.edges_from(other_sid)
                 other_srcs = {e.source for e in other_ins}
                 other_tgts = {e.target for e in other_outs}
                 if other_srcs == {src_id} and other_tgts == {tgt_id}:
@@ -3039,7 +3022,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
         def _column_key(sid: str) -> tuple[float, float] | None:
             pred_x: float | None = None
             succ_x: float | None = None
-            for e in in_by_tgt.get(sid, []):
+            for e in graph.edges_to(sid):
                 p = graph.stations.get(e.source)
                 if p is None or p.is_hidden:
                     continue
@@ -3051,7 +3034,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                     or (section.direction == "RL" and p.x < pred_x)
                 ):
                     pred_x = p.x
-            for e in out_by_src.get(sid, []):
+            for e in graph.edges_from(sid):
                 t = graph.stations.get(e.target)
                 if t is None or t.is_hidden:
                     continue
@@ -3100,7 +3083,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                 # single-in/single-out filter pass-1 uses.
                 visible_ins = [
                     e
-                    for e in in_by_tgt.get(sid, [])
+                    for e in graph.edges_to(sid)
                     if (
                         (gs := graph.stations.get(e.source)) is not None
                         and not gs.is_hidden
@@ -3108,7 +3091,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                 ]
                 visible_outs = [
                     e
-                    for e in out_by_src.get(sid, [])
+                    for e in graph.edges_from(sid)
                     if (
                         (gs := graph.stations.get(e.target)) is not None
                         and not gs.is_hidden
@@ -3159,15 +3142,8 @@ def _shift_sparse_loop_stations_to_clear_bundle(
     if y_spacing <= 0:
         return
 
-    in_by_tgt: dict[str, list[Edge]] = defaultdict(list)
-    out_by_src: dict[str, list[Edge]] = defaultdict(list)
-    for e in graph.edges:
-        in_by_tgt[e.target].append(e)
-        out_by_src[e.source].append(e)
-
-    consumed_by: dict[str, set[str]] = defaultdict(set)
-    for e in graph.edges:
-        consumed_by[e.target].add(e.line_id)
+    def _consumed_lines(sid: str) -> set[str]:
+        return {e.line_id for e in graph.edges_to(sid)}
 
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
@@ -3194,8 +3170,8 @@ def _shift_sparse_loop_stations_to_clear_bundle(
             st = graph.stations.get(sid)
             if st is None or st.is_port or st.is_hidden or st.off_track:
                 continue
-            ins = in_by_tgt.get(sid, [])
-            outs = out_by_src.get(sid, [])
+            ins = graph.edges_to(sid)
+            outs = graph.edges_from(sid)
             if len(ins) != 1 or len(outs) != 1:
                 continue
             src = graph.stations.get(ins[0].source)
@@ -3210,7 +3186,7 @@ def _shift_sparse_loop_stations_to_clear_bundle(
             dy = st.y - trunk_y
             if abs(dy) < 0.5:
                 continue
-            s_lines = consumed_by.get(sid, set())
+            s_lines = _consumed_lines(sid)
             sibling: Station | None = None
             for sib_id in section.station_ids:
                 if sib_id == sid or sib_id in port_ids:
@@ -3226,7 +3202,7 @@ def _shift_sparse_loop_stations_to_clear_bundle(
                     continue
                 if abs(sib.y - st.y) > 0.5:
                     continue
-                sib_lines = consumed_by.get(sib_id, set())
+                sib_lines = _consumed_lines(sib_id)
                 if len(sib_lines) > len(s_lines):
                     sibling = sib
                     break

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -2266,17 +2266,13 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
 
         # Find downstream entry port(s) in the same row.
         targets: list[float] = []
-        for edge in graph.edges:
-            if edge.source != port_id:
-                continue
+        for edge in graph.edges_from(port_id):
             entry_candidates: list[str] = []
             tgt_port = graph.ports.get(edge.target)
             if tgt_port and tgt_port.is_entry:
                 entry_candidates.append(edge.target)
             elif edge.target in junction_ids:
-                for e2 in graph.edges:
-                    if e2.source != edge.target:
-                        continue
+                for e2 in graph.edges_from(edge.target):
                     tp2 = graph.ports.get(e2.target)
                     if tp2 and tp2.is_entry:
                         entry_candidates.append(e2.target)
@@ -2302,24 +2298,18 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> bool:
         # to the exit port's Y so the inter-section trunk stays flat.
         port_set = set(section.entry_ports) | set(section.exit_ports)
         src_ys: set[float] = set()
-        for edge in graph.edges:
-            if edge.target != port_id:
-                continue
+        for edge in graph.edges_to(port_id):
             src = graph.stations.get(edge.source)
             if src and not src.is_port and edge.source not in port_set:
                 src_ys.add(round(src.y, 1))
         if len(src_ys) >= 2:
-            for edge in graph.edges:
-                if edge.source != port_id:
-                    continue
+            for edge in graph.edges_from(port_id):
                 entry_candidates: list[str] = []
                 tgt_port = graph.ports.get(edge.target)
                 if tgt_port and tgt_port.is_entry:
                     entry_candidates.append(edge.target)
                 elif edge.target in junction_ids:
-                    for e2 in graph.edges:
-                        if e2.source != edge.target:
-                            continue
+                    for e2 in graph.edges_from(edge.target):
                         tp2 = graph.ports.get(e2.target)
                         if tp2 and tp2.is_entry:
                             entry_candidates.append(e2.target)
@@ -2714,13 +2704,13 @@ def _balance_section_content_around_trunk(
             cur = src
             src_lines = set(graph.station_lines(src))
             while True:
-                outs = {e.target for e in graph.edges if e.source == cur}
+                outs = {e.target for e in graph.edges_from(cur)}
                 if len(outs) != 1:
                     break
                 nxt = next(iter(outs))
                 if nxt not in section_internal_set:
                     break
-                in_srcs = {e.source for e in graph.edges if e.target == nxt}
+                in_srcs = {e.source for e in graph.edges_to(nxt)}
                 if len(in_srcs) != 1:
                     break
                 if set(graph.station_lines(nxt)) != src_lines:
@@ -3781,12 +3771,6 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
     if not grid_sec_ids:
         return
 
-    import networkx as nx
-
-    G = nx.DiGraph()
-    for edge in graph.edges:
-        G.add_edge(edge.source, edge.target)
-
     for section in graph.sections.values():
         if (
             section.id not in grid_sec_ids
@@ -3834,7 +3818,7 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
                 if s != trunk_sid
                 and set(graph.station_lines(s))
                 and set(graph.station_lines(s)) < bundle
-                and (s in G and any(True for _ in G.predecessors(s)))
+                and graph.edges_to(s)
             ]
             if not siblings:
                 continue
@@ -4035,12 +4019,6 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
     if not grid_sec_ids:
         return
 
-    import networkx as nx
-
-    G = nx.DiGraph()
-    for edge in graph.edges:
-        G.add_edge(edge.source, edge.target)
-
     for section in graph.sections.values():
         if (
             section.id not in grid_sec_ids
@@ -4066,7 +4044,7 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
             cols[round(st.x, 3)].append(sid)
 
         def _has_pred(sid: str) -> bool:
-            return sid in G and next(iter(G.predecessors(sid)), None) is not None
+            return bool(graph.edges_to(sid))
 
         full_by_col = {
             x: [s for s in sids if set(graph.station_lines(s)) == bundle]
@@ -4181,12 +4159,6 @@ def _recenter_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
     if not grid_sec_ids:
         return
 
-    import networkx as nx
-
-    G = nx.DiGraph()
-    for edge in graph.edges:
-        G.add_edge(edge.source, edge.target)
-
     for section in graph.sections.values():
         if (
             section.id not in grid_sec_ids
@@ -4209,7 +4181,7 @@ def _recenter_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
             cols[round(st.x, 3)].append(sid)
 
         def _has_pred(sid: str) -> bool:
-            return sid in G and next(iter(G.predecessors(sid)), None) is not None
+            return bool(graph.edges_to(sid))
 
         full_by_col = {
             x: [s for s in sids if set(graph.station_lines(s)) == bundle]
@@ -4469,10 +4441,8 @@ def _align_terminus_to_upstream(graph: MetroGraph) -> None:
                 continue
             preds = {
                 e.source
-                for e in graph.edges
-                if e.target == sid
-                and e.source in sec_sids
-                and not graph.stations[e.source].is_port
+                for e in graph.edges_to(sid)
+                if e.source in sec_sids and not graph.stations[e.source].is_port
             }
             if len(preds) != 1:
                 continue
@@ -5332,9 +5302,7 @@ def _resolve_source_xy(
 
     # Junction: find the feeding exit port and compute placement.
     chained: list[str] = []
-    for e in graph.edges:
-        if e.target != edge_source:
-            continue
+    for e in graph.edges_to(edge_source):
         if e.source in junction_ids:
             chained.append(e.source)
             continue
@@ -6672,18 +6640,14 @@ def _align_phantom_pass_throughs(
     track keeps the trunk horizontal so the optional branch visually
     "bubbles" away from it.
     """
-    import networkx as nx
-
-    G = nx.DiGraph()
-    for edge in sub.edges:
-        G.add_edge(edge.source, edge.target)
-
     for sid, station in sub.stations.items():
-        if not station.is_hidden or sid not in tracks or sid not in G:
+        if not station.is_hidden or sid not in tracks:
             continue
-        succs = list(G.successors(sid))
-        if len(succs) == 1 and succs[0] in tracks:
-            tracks[succs[0]] = tracks[sid]
+        succs = {e.target for e in sub.edges_from(sid)}
+        if len(succs) == 1:
+            succ = next(iter(succs))
+            if succ in tracks:
+                tracks[succ] = tracks[sid]
 
 
 def _compute_fork_join_gaps(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -57,7 +57,7 @@ from nf_metro.layout.constants import (
 from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.layers import assign_layers
 from nf_metro.layout.ordering import assign_tracks
-from nf_metro.parser.model import Edge, MetroGraph, PortSide, Section, Station
+from nf_metro.parser.model import Edge, MetroGraph, Port, PortSide, Section, Station
 
 # ---------------------------------------------------------------------------
 # Phase-boundary guards
@@ -1611,9 +1611,13 @@ def _align_row_y_grids(
         # crowding and should not inflate spacing for the entire row.
         #
         max_lines = 0
+        section_class: dict[str, tuple[dict[int, list[float]], set[float]]] = {
+            sec_id: _classify_multi_station_ys(section_subgraphs[sec_id])
+            for sec_id in sec_ids
+        }
         for sec_id in sec_ids:
             sub = section_subgraphs[sec_id]
-            _, _multi_ys = _classify_multi_station_ys(sub)
+            _multi_ys = section_class[sec_id][1]
             for st in sub.stations.values():
                 if not st.is_port and st.y in _multi_ys:
                     max_lines = max(max_lines, len(graph.station_lines(st.id)))
@@ -1637,7 +1641,7 @@ def _align_row_y_grids(
             sub = section_subgraphs[sec_id]
             section = graph.sections[sec_id]
 
-            layer_stations, multi_layer_ys = _classify_multi_station_ys(sub)
+            layer_stations, multi_layer_ys = section_class[sec_id]
 
             # Remap multi-station-layer Y values first.
             if multi_layer_ys:
@@ -1966,16 +1970,14 @@ def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
         p = graph.ports.get(pid)
         if p is None or p.side not in (PortSide.LEFT, PortSide.RIGHT):
             continue
-        for edge in graph.edges:
-            other_id = (
-                edge.target
-                if edge.source == pid and edge.target in internal_ids
-                else edge.source
-                if edge.target == pid and edge.source in internal_ids
-                else None
-            )
-            if other_id is None:
-                continue
+        candidates: list[str] = []
+        for edge in graph.edges_from(pid):
+            if edge.target in internal_ids:
+                candidates.append(edge.target)
+        for edge in graph.edges_to(pid):
+            if edge.source in internal_ids:
+                candidates.append(edge.source)
+        for other_id in candidates:
             st = graph.stations.get(other_id)
             if (
                 st
@@ -2074,16 +2076,14 @@ def _align_row_trunk_ys(graph: MetroGraph) -> None:
                         continue
                     connected_ys: set[float] = set()
                     target_aligned = False
-                    for edge in graph.edges:
-                        other_id = (
-                            edge.target
-                            if edge.source == pid and edge.target in internal_ids
-                            else edge.source
-                            if edge.target == pid and edge.source in internal_ids
-                            else None
-                        )
-                        if other_id is None:
-                            continue
+                    neighbours: list[str] = []
+                    for edge in graph.edges_from(pid):
+                        if edge.target in internal_ids:
+                            neighbours.append(edge.target)
+                    for edge in graph.edges_to(pid):
+                        if edge.source in internal_ids:
+                            neighbours.append(edge.source)
+                    for other_id in neighbours:
                         st = graph.stations.get(other_id)
                         if st and not st.is_port:
                             connected_ys.add(round(st.y, 1))
@@ -3684,9 +3684,7 @@ def _divergence_target_ys(graph: MetroGraph) -> set[str]:
     for edge in graph.edges:
         tgt_id = edge.target
         if tgt_id in junction_ids:
-            for e2 in graph.edges:
-                if e2.source != tgt_id:
-                    continue
+            for e2 in graph.edges_from(tgt_id):
                 post = graph.stations.get(e2.target)
                 if post is None or post.is_port:
                     continue
@@ -4498,6 +4496,19 @@ def _align_terminus_to_upstream(graph: MetroGraph) -> None:
             st.y = src.y
 
 
+def _has_horizontal_predecessor_section(graph: MetroGraph, section: Section) -> bool:
+    """True if any entry-port predecessor lives in an LR/RL section."""
+    for pid in section.entry_ports:
+        for edge in graph.edges_to(pid):
+            src_port = graph.ports.get(edge.source)
+            if not src_port:
+                continue
+            src_sec = graph.sections.get(src_port.section_id)
+            if src_sec and src_sec.direction in ("LR", "RL"):
+                return True
+    return False
+
+
 def _layout_single_section(
     graph: MetroGraph,
     section: Section,
@@ -4527,19 +4538,10 @@ def _layout_single_section(
     # horizontal (LR/RL), so the entry-connected station stays at the
     # top and aligns with the upstream exit station (#165).  Skip for
     # TB predecessors where vertical entry makes top-biasing inappropriate.
-    entry_top = False
-    if section.entry_ports and section.direction in ("LR", "RL"):
-        for pid in section.entry_ports:
-            for edge in graph.edges:
-                if edge.target == pid:
-                    src_port = graph.ports.get(edge.source)
-                    if src_port:
-                        src_sec = graph.sections.get(src_port.section_id)
-                        if src_sec and src_sec.direction in ("LR", "RL"):
-                            entry_top = True
-                            break
-            if entry_top:
-                break
+    entry_top = section.direction in (
+        "LR",
+        "RL",
+    ) and _has_horizontal_predecessor_section(graph, section)
 
     tracks = assign_tracks(sub, layers, entry_top=entry_top)
 
@@ -5212,17 +5214,16 @@ def _position_junctions(graph: MetroGraph) -> None:
         successor_ports: list[Station] = []
         exit_port_id: str | None = None
 
-        for edge in graph.edges:
-            if edge.target == jid:
-                src = graph.stations.get(edge.source)
-                if src:
-                    predecessors.append(src)
-                    if src.is_port:
-                        exit_port_id = edge.source
-            if edge.source == jid:
-                tgt = graph.stations.get(edge.target)
-                if tgt and tgt.is_port:
-                    successor_ports.append(tgt)
+        for edge in graph.edges_to(jid):
+            src = graph.stations.get(edge.source)
+            if src:
+                predecessors.append(src)
+                if src.is_port:
+                    exit_port_id = edge.source
+        for edge in graph.edges_from(jid):
+            tgt = graph.stations.get(edge.target)
+            if tgt and tgt.is_port:
+                successor_ports.append(tgt)
 
         # Merge junction: N>1 predecessors, 1 entry port successor
         if len(predecessors) > 1 and len(successor_ports) == 1:
@@ -5294,12 +5295,11 @@ def _resolve_source_section_id(
         return None
     src_section_id = src.section_id
     if edge_source in junction_ids:
-        for e2 in graph.edges:
-            if e2.target == edge_source:
-                s2 = graph.stations.get(e2.source)
-                if s2 and s2.section_id:
-                    src_section_id = s2.section_id
-                    break
+        for e2 in graph.edges_to(edge_source):
+            s2 = graph.stations.get(e2.source)
+            if s2 and s2.section_id:
+                src_section_id = s2.section_id
+                break
     return src_section_id
 
 
@@ -5408,14 +5408,12 @@ def _align_entry_ports(graph: MetroGraph) -> None:
 def _align_lr_entry_port(
     graph: MetroGraph,
     port_id: str,
-    port,
+    port: Port,
     entry_section: Section,
     junction_ids: set[str],
 ) -> None:
     """Align a LEFT/RIGHT entry port's Y with its incoming source."""
-    for edge in graph.edges:
-        if edge.target != port_id:
-            continue
+    for edge in graph.edges_to(port_id):
         src = graph.stations.get(edge.source)
         if not src or not (src.is_port or edge.source in junction_ids):
             continue
@@ -5472,7 +5470,7 @@ def _align_lr_entry_port(
 def _align_tb_entry_port(
     graph: MetroGraph,
     port_id: str,
-    port,
+    port: Port,
     entry_section: Section,
     junction_ids: set[str],
 ) -> None:
@@ -5480,9 +5478,7 @@ def _align_tb_entry_port(
     # Collect all incoming sources.  Coordinates are derived via
     # _resolve_source_xy so junctions don't need to be pre-positioned.
     sources: list[tuple[float, float, str | None]] = []
-    for edge in graph.edges:
-        if edge.target != port_id:
-            continue
+    for edge in graph.edges_to(port_id):
         src = graph.stations.get(edge.source)
         if not src or not (src.is_port or edge.source in junction_ids):
             continue
@@ -5611,9 +5607,7 @@ def _align_ports_to_downstream(graph: MetroGraph) -> None:
 
         # Find the single target entry port (skip fan-out via junctions)
         target_entry_id: str | None = None
-        for edge in graph.edges:
-            if edge.source != port_id:
-                continue
+        for edge in graph.edges_from(port_id):
             if edge.target in junction_ids:
                 # Fan-out to junction -- don't override
                 target_entry_id = None
@@ -5663,8 +5657,8 @@ def _align_ports_to_downstream(graph: MetroGraph) -> None:
             - set(entry_section.exit_ports)
         )
         downstream_ys: list[float] = []
-        for edge in graph.edges:
-            if edge.source == target_entry_id and edge.target in internal_ids:
+        for edge in graph.edges_from(target_entry_id):
+            if edge.target in internal_ids:
                 downstream_ys.append(graph.stations[edge.target].y)
         if not downstream_ys:
             continue
@@ -5688,8 +5682,8 @@ def _align_ports_to_downstream(graph: MetroGraph) -> None:
                 - set(exit_section.exit_ports)
             )
             upstream_ys: list[float] = []
-            for edge in graph.edges:
-                if edge.target == port_id and edge.source in exit_internal_ids:
+            for edge in graph.edges_to(port_id):
+                if edge.source in exit_internal_ids:
                     upstream_ys.append(graph.stations[edge.source].y)
             if upstream_ys:
                 upstream_y = sum(upstream_ys) / len(upstream_ys)
@@ -5769,10 +5763,11 @@ def _snap_sole_layer_stations_to_ports(graph: MetroGraph) -> None:
 
             # Collect the distinct internal stations connected to this port.
             connected: set[str] = set()
-            for edge in graph.edges:
-                if edge.source == pid and edge.target in internal_ids:
+            for edge in graph.edges_from(pid):
+                if edge.target in internal_ids:
                     connected.add(edge.target)
-                elif edge.target == pid and edge.source in internal_ids:
+            for edge in graph.edges_to(pid):
+                if edge.source in internal_ids:
                     connected.add(edge.source)
 
             # Only snap when exactly one station connects to the port
@@ -5792,10 +5787,8 @@ def _snap_sole_layer_stations_to_ports(graph: MetroGraph) -> None:
             # means internal stations feed into it, so snapping would
             # create a diagonal on those connections.
             has_internal_pred = any(
-                edge.target == current
-                and edge.source != pid
-                and edge.source in internal_ids
-                for edge in graph.edges
+                edge.source != pid and edge.source in internal_ids
+                for edge in graph.edges_to(current)
             )
             if has_internal_pred:
                 continue
@@ -5822,11 +5815,12 @@ def _snap_sole_layer_stations_to_ports(graph: MetroGraph) -> None:
                 # Follow to the next singleton: successors for entry
                 # ports (walking inward), predecessors for exit ports.
                 nexts: set[str] = set()
-                for edge in graph.edges:
-                    if is_entry and edge.source == current:
+                if is_entry:
+                    for edge in graph.edges_from(current):
                         if edge.target in internal_ids:
                             nexts.add(edge.target)
-                    elif not is_entry and edge.target == current:
+                else:
+                    for edge in graph.edges_to(current):
                         if edge.source in internal_ids:
                             nexts.add(edge.source)
                 current = next(iter(nexts)) if len(nexts) == 1 else None
@@ -5867,9 +5861,7 @@ def _snap_grid_group_entry_ports(graph: MetroGraph) -> None:
 
         # Find the first non-port station connected to this port.
         target_y = None
-        for edge in graph.edges:
-            if edge.source != port_id:
-                continue
+        for edge in graph.edges_from(port_id):
             tgt = graph.stations.get(edge.target)
             if tgt and not tgt.is_port and tgt.section_id == section.id:
                 target_y = tgt.y
@@ -5920,9 +5912,7 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
         # line ids carried by the exit edges in a single edge pass.
         source_ys: list[float] = []
         exit_lines: set[str] = set()
-        for edge in graph.edges:
-            if edge.target != port_id:
-                continue
+        for edge in graph.edges_to(port_id):
             exit_lines.add(edge.line_id)
             src = graph.stations.get(edge.source)
             if src and not src.is_port and src.section_id == section.id:
@@ -5979,9 +5969,7 @@ def _resolve_downstream_entry_y(
         return None
 
     entry_ys: list[float] = []
-    for edge in graph.edges:
-        if edge.source != exit_port_id:
-            continue
+    for edge in graph.edges_from(exit_port_id):
         # Direct exit -> entry connection
         dp = graph.ports.get(edge.target)
         if dp and dp.is_entry:
@@ -5991,9 +5979,7 @@ def _resolve_downstream_entry_y(
             continue
         # Via junction
         if edge.target in junction_ids:
-            for e2 in graph.edges:
-                if e2.source != edge.target:
-                    continue
+            for e2 in graph.edges_from(edge.target):
                 dp2 = graph.ports.get(e2.target)
                 if dp2 and dp2.is_entry:
                     ds_st = graph.stations.get(e2.target)
@@ -6032,14 +6018,12 @@ def _align_exit_ports(graph: MetroGraph) -> None:
 def _align_lr_exit_port(
     graph: MetroGraph,
     port_id: str,
-    port,
+    port: Port,
     exit_section: Section,
     junction_ids: set[str],
 ) -> None:
     """Align a LEFT/RIGHT exit port's Y with its target entry port."""
-    for edge in graph.edges:
-        if edge.source != port_id:
-            continue
+    for edge in graph.edges_from(port_id):
         tgt = graph.stations.get(edge.target)
         if not tgt:
             continue
@@ -6073,7 +6057,7 @@ def _align_lr_exit_port(
 
 def _resolve_tb_exit_y(
     graph: MetroGraph,
-    port,
+    port: Port,
     tgt: Station,
     exit_section: Section,
 ) -> float:

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 __all__ = ["LabelPlacement", "label_text_width", "place_labels"]
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
     CHAR_WIDTH,
@@ -26,6 +27,9 @@ from nf_metro.layout.constants import (
     TB_PILL_EDGE_OFFSET,
 )
 from nf_metro.parser.model import MetroGraph
+
+if TYPE_CHECKING:
+    from nf_metro.layout.routing.common import RoutedPath
 
 
 def label_text_width(label: str) -> float:
@@ -408,7 +412,7 @@ def place_labels(
     label_offset: float = LABEL_OFFSET,
     station_offsets: dict[tuple[str, str], float] | None = None,
     icon_obstacles: list[tuple[float, float, float, float]] | None = None,
-    routes: list | None = None,
+    routes: list["RoutedPath"] | None = None,
 ) -> list[LabelPlacement]:
     """Place horizontal labels alternating above/below stations.
 
@@ -744,7 +748,7 @@ def _segment_intersects_bbox(
 def _avoid_diagonal_routes(
     placements: list[LabelPlacement],
     graph: MetroGraph,
-    routes: list,
+    routes: list["RoutedPath"],
     station_offsets: dict[tuple[str, str], float] | None,
 ) -> None:
     """Flip labels overlapping a non-horizontal route segment.
@@ -758,8 +762,8 @@ def _avoid_diagonal_routes(
     """
     diag: list[tuple[float, float, float, float]] = []
     for route in routes:
-        pts = list(getattr(route, "points", []))
-        if station_offsets and not getattr(route, "offsets_applied", False) and pts:
+        pts = list(route.points)
+        if station_offsets and not route.offsets_applied and pts:
             so = station_offsets.get((route.edge.source, route.line_id), 0.0)
             to = station_offsets.get((route.edge.target, route.line_id), 0.0)
             pts[0] = (pts[0][0], pts[0][1] + so)

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -261,11 +261,10 @@ def line_source_y_at_port(
     and returns the source station's Y position for each line.
     """
     line_y: dict[str, float] = {}
-    for edge in graph.edges:
-        if edge.target == port_id:
-            src = graph.stations.get(edge.source)
-            if src and not src.is_port:
-                line_y[edge.line_id] = src.y
+    for edge in graph.edges_to(port_id):
+        src = graph.stations.get(edge.source)
+        if src and not src.is_port:
+            line_y[edge.line_id] = src.y
     return line_y
 
 
@@ -374,24 +373,3 @@ def bypass_bottom_y(
                     candidate = (row_bottom + header_top) / 2
 
     return candidate
-
-
-def line_incoming_y_at_entry_port(
-    port_id: str,
-    graph: MetroGraph,
-    exit_offsets: dict[tuple[str, str], float],
-) -> dict[str, float]:
-    """Map line_id -> effective Y of incoming connection at an entry port.
-
-    Uses the source station's Y + its already-computed station offset
-    for the line, so the entry port ordering matches the bundle ordering
-    from the source section.
-    """
-    line_y: dict[str, float] = {}
-    for edge in graph.edges:
-        if edge.target == port_id:
-            src = graph.stations.get(edge.source)
-            if src and src.is_port:
-                src_off = exit_offsets.get((edge.source, edge.line_id), 0)
-                line_y[edge.line_id] = src.y + src_off
-    return line_y

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -343,9 +343,7 @@ def bypass_bottom_y(
         for s in graph.sections.values()
         if s.bbox_w > 0 and lo < s.grid_col < hi and _in_row(s)
     ]
-    max_intervening = max(
-        (s.bbox_y + s.bbox_h for s in intervening), default=0.0
-    )
+    max_intervening = max((s.bbox_y + s.bbox_h for s in intervening), default=0.0)
 
     if max_intervening > 0:
         candidate = max_intervening + clearance

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -269,19 +269,6 @@ def line_source_y_at_port(
     return line_y
 
 
-def adjacent_column_gap_x(
-    graph: MetroGraph,
-    col_a: int,
-    col_b: int,
-) -> float:
-    """X midpoint between two adjacent columns.
-
-    Finds the right edge of col_a and left edge of col_b (assuming
-    col_a < col_b) and returns the midpoint.
-    """
-    return column_gap_midpoint(graph, col_a, col_b)
-
-
 def point_on_polyline(
     point: tuple[float, float],
     pts: list[tuple[float, float]],
@@ -356,10 +343,8 @@ def bypass_bottom_y(
         for s in graph.sections.values()
         if s.bbox_w > 0 and lo < s.grid_col < hi and _in_row(s)
     ]
-    max_intervening = (
-        max((s.bbox_y + s.bbox_h for s in intervening), default=0.0)
-        if intervening
-        else 0.0
+    max_intervening = max(
+        (s.bbox_y + s.bbox_h for s in intervening), default=0.0
     )
 
     if max_intervening > 0:

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -564,22 +564,13 @@ def _route_inter_section(
     # columns the standard L-shape naturally drops in the inter-column
     # gap and going "away from target" would route backward through a
     # neighbouring section.
-    src_col_for_special = (
-        _resolve_section_col(graph, src)
-        if edge.source in ctx.junction_ids
-        else None
-    )
-    tgt_col_for_special = _resolve_section_col(graph, tgt)
-    same_col_special = (
-        src_col_for_special is not None
-        and tgt_col_for_special is not None
-        and src_col_for_special == tgt_col_for_special
-    )
     if (
         edge.source in ctx.junction_ids
         and abs(dx) <= JUNCTION_MARGIN + COORD_TOLERANCE
         and abs(dy) > abs(dx) * 3
-        and same_col_special
+        and (src_col_for_special := _resolve_section_col(graph, src)) is not None
+        and (tgt_col_for_special := _resolve_section_col(graph, tgt)) is not None
+        and src_col_for_special == tgt_col_for_special
     ):
         delta, r_first, r_second = l_shape_radii(
             i,

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -205,6 +205,12 @@ def _classify_merge_edges(
     trunk_by: dict[str, float] = {}
     entry_port_for: dict[str, str] = {}
 
+    def _col_for_id(sid: str) -> int | None:
+        st = graph.stations.get(sid)
+        if st is None:
+            return None
+        return _resolve_section_col(graph, st)
+
     for mjid in junctions:
         mst = graph.stations.get(mjid)
         if not mst:
@@ -214,12 +220,11 @@ def _classify_merge_edges(
             continue
 
         # Resolve entry port (successor of merge junction)
-        for e in graph.edges:
-            if e.source == mjid:
-                ep = graph.ports.get(e.target)
-                if ep and ep.is_entry:
-                    entry_port_for[mjid] = e.target
-                    break
+        for e in graph.edges_from(mjid):
+            ep = graph.ports.get(e.target)
+            if ep and ep.is_entry:
+                entry_port_for[mjid] = e.target
+                break
 
         # Find farthest bypass predecessor (trunk carrier).  Branches
         # must land on the trunk's own bypass_bottom_y -- the value the
@@ -230,9 +235,7 @@ def _classify_merge_edges(
         farthest_source: str | None = None
         farthest_span = 0
         trunk_pred_by = 0.0
-        for edge in graph.edges:
-            if edge.target != mjid:
-                continue
+        for edge in graph.edges_to(mjid):
             pred = graph.stations.get(edge.source)
             if not pred:
                 continue
@@ -265,10 +268,7 @@ def _classify_merge_edges(
     index_exclude: set[_EdgeKey] = set()
 
     for mjid, trunk_src in trunk_source.items():
-        m_col = _resolve_section_col(
-            graph,
-            graph.stations.get(mjid),  # type: ignore[arg-type]
-        )
+        m_col = _col_for_id(mjid)
 
         # Check for adjacent JUNCTION predecessors whose stubs need
         # the merge -> entry edge to cross the full gap.  Adjacent
@@ -276,35 +276,27 @@ def _classify_merge_edges(
         # redundant for them.
         has_adjacent_junction_pred = False
         if m_col is not None:
-            for e2 in graph.edges:
-                if e2.target != mjid or e2.source == trunk_src:
+            for e2 in graph.edges_to(mjid):
+                if e2.source == trunk_src or e2.source not in junction_ids:
                     continue
-                p = graph.stations.get(e2.source)
-                if not p or e2.source not in junction_ids:
-                    continue
-                p_col = _resolve_section_col(graph, p)
+                p_col = _col_for_id(e2.source)
                 if p_col is not None and abs(m_col - p_col) <= 1:
                     has_adjacent_junction_pred = True
                     break
 
-        for edge in graph.edges:
-            # merge -> entry: skip unless adjacent junction pred needs it
-            if edge.source == mjid and not has_adjacent_junction_pred:
+        # merge -> entry: skip unless adjacent junction pred needs it
+        if not has_adjacent_junction_pred:
+            for edge in graph.edges_from(mjid):
                 ep = graph.ports.get(edge.target)
                 if ep and ep.is_entry:
                     skip_edges.add((edge.source, edge.target, edge.line_id))
-            # Non-trunk bypass junction -> merge: exclude from indexing
-            # (truncated branches shouldn't occupy bundle slots)
-            if (
-                edge.target == mjid
-                and edge.source != trunk_src
-                and edge.source in junction_ids
-                and m_col is not None
-            ):
-                src_col = _resolve_section_col(
-                    graph,
-                    graph.stations.get(edge.source),  # type: ignore[arg-type]
-                )
+        # Non-trunk bypass junction -> merge: exclude from indexing
+        # (truncated branches shouldn't occupy bundle slots)
+        if m_col is not None:
+            for edge in graph.edges_to(mjid):
+                if edge.source == trunk_src or edge.source not in junction_ids:
+                    continue
+                src_col = _col_for_id(edge.source)
                 if src_col is not None and abs(m_col - src_col) > 1:
                     index_exclude.add((edge.source, edge.target, edge.line_id))
 
@@ -557,7 +549,7 @@ def _route_inter_section(
                 return _route_merge_trunk(
                     edge, src, tgt, i, src_col, tgt_col, ctx, src_row
                 )
-            return _route_merge_branch(edge, src, ctx, src_col, tgt_col)
+            return _route_merge_branch(edge, src, ctx, src_col)
         return _route_bypass(edge, src, tgt, i, src_col, tgt_col, ctx, src_row)
 
     # Near-vertical: junction to same-column entry with tiny horizontal
@@ -682,7 +674,6 @@ def _route_merge_branch(
     src: Station,
     ctx: _RoutingCtx,
     src_col: int,
-    tgt_col: int,
 ) -> RoutedPath:
     """Truncated L-shape descent from a junction to the trunk level.
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -322,7 +322,7 @@ def _build_routing_context(
     station_offsets: dict[tuple[str, str], float] | None,
 ) -> _RoutingCtx:
     """Pre-compute all shared state for edge routing."""
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     # Fold edge: max X across all stations
     all_x = [s.x for s in graph.stations.values()]
@@ -1660,7 +1660,7 @@ def _route_entry_runway(
         return None
 
     # Find the earliest internal station between entry port and target.
-    port_ids = set(section.entry_ports) | set(section.exit_ports)
+    port_ids = section.port_ids
     first_x: float | None = None
     for sid in section.station_ids:
         if sid == edge.target or sid in port_ids:
@@ -2589,9 +2589,7 @@ def _compute_junction_fan_info(
         outgoing: list[Edge] = []
         has_lshape = False
         has_bypass = False
-        for edge in graph.edges:
-            if edge.source != jid:
-                continue
+        for edge in graph.edges_from(jid):
             if (edge.source, edge.target, edge.line_id) in _skip:
                 continue
             tgt = graph.stations.get(edge.target)

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -32,10 +32,10 @@ from nf_metro.layout.constants import (
 from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.routing.common import (
     RoutedPath,
-    adjacent_column_gap_x,
     bypass_bottom_y,
     col_left_edge,
     col_right_edge,
+    column_gap_midpoint,
     compute_bundle_info,
     inter_column_channel_x,
     row_bottom_edge,
@@ -209,7 +209,7 @@ def _classify_merge_edges(
         mst = graph.stations.get(mjid)
         if not mst:
             continue
-        tgt_col = _resolve_section_col(graph, mst, junction_ids)
+        tgt_col = _resolve_section_col(graph, mst)
         if tgt_col is None:
             continue
 
@@ -236,8 +236,8 @@ def _classify_merge_edges(
             pred = graph.stations.get(edge.source)
             if not pred:
                 continue
-            pred_col = _resolve_section_col(graph, pred, junction_ids)
-            pred_row = _resolve_section_row(graph, pred, junction_ids)
+            pred_col = _resolve_section_col(graph, pred)
+            pred_row = _resolve_section_row(graph, pred)
             if (
                 pred_col is not None
                 and abs(tgt_col - pred_col) > 1
@@ -268,7 +268,6 @@ def _classify_merge_edges(
         m_col = _resolve_section_col(
             graph,
             graph.stations.get(mjid),  # type: ignore[arg-type]
-            junction_ids,
         )
 
         # Check for adjacent JUNCTION predecessors whose stubs need
@@ -283,7 +282,7 @@ def _classify_merge_edges(
                 p = graph.stations.get(e2.source)
                 if not p or e2.source not in junction_ids:
                     continue
-                p_col = _resolve_section_col(graph, p, junction_ids)
+                p_col = _resolve_section_col(graph, p)
                 if p_col is not None and abs(m_col - p_col) <= 1:
                     has_adjacent_junction_pred = True
                     break
@@ -305,7 +304,6 @@ def _classify_merge_edges(
                 src_col = _resolve_section_col(
                     graph,
                     graph.stations.get(edge.source),  # type: ignore[arg-type]
-                    junction_ids,
                 )
                 if src_col is not None and abs(m_col - src_col) > 1:
                     index_exclude.add((edge.source, edge.target, edge.line_id))
@@ -510,9 +508,9 @@ def _route_inter_section(
     )
 
     # Resolve section columns and row for bypass detection
-    src_col = _resolve_section_col(graph, src, ctx.junction_ids)
-    tgt_col = _resolve_section_col(graph, tgt, ctx.junction_ids)
-    src_row = _resolve_section_row(graph, src, ctx.junction_ids)
+    src_col = _resolve_section_col(graph, src)
+    tgt_col = _resolve_section_col(graph, tgt)
+    src_row = _resolve_section_row(graph, src)
     needs_bypass = (
         src_col is not None
         and tgt_col is not None
@@ -575,11 +573,11 @@ def _route_inter_section(
     # gap and going "away from target" would route backward through a
     # neighbouring section.
     src_col_for_special = (
-        _resolve_section_col(graph, src, ctx.junction_ids)
+        _resolve_section_col(graph, src)
         if edge.source in ctx.junction_ids
         else None
     )
-    tgt_col_for_special = _resolve_section_col(graph, tgt, ctx.junction_ids)
+    tgt_col_for_special = _resolve_section_col(graph, tgt)
     same_col_special = (
         src_col_for_special is not None
         and tgt_col_for_special is not None
@@ -796,7 +794,7 @@ def _route_bypass(
     else:
         nest_offset = max(i, g2_j) * ctx.offset_step
     # Resolve target row to detect cross-row bypasses.
-    tgt_row = _resolve_section_row(graph, tgt, ctx.junction_ids)
+    tgt_row = _resolve_section_row(graph, tgt)
     cross_row = src_row is not None and tgt_row is not None and src_row != tgt_row
     base_y = bypass_bottom_y(
         graph,
@@ -860,7 +858,7 @@ def _route_bypass(
             gap1_x = fan_mid_x + fan_delta
         else:
             gap1_base = (
-                adjacent_column_gap_x(graph, src_col, src_col + 1) - base_bypass_offset
+                column_gap_midpoint(graph, src_col, src_col + 1) - base_bypass_offset
             )
             gap1_limit = sx + ctx.curve_radius
             if gap1_base - (g1_n - 1) * ctx.offset_step < gap1_limit:
@@ -870,7 +868,7 @@ def _route_bypass(
             gap1_x = gap1_mid + delta1
 
         gap2_base = (
-            adjacent_column_gap_x(graph, tgt_col - 1, tgt_col) + base_bypass_offset
+            column_gap_midpoint(graph, tgt_col - 1, tgt_col) + base_bypass_offset
         )
         gap2_limit = effective_tx - ctx.curve_radius
         if gap2_base + (g2_n - 1) * ctx.offset_step > gap2_limit:
@@ -892,7 +890,7 @@ def _route_bypass(
             gap1_x = fan_mid_x + fan_delta
         else:
             gap1_base = (
-                adjacent_column_gap_x(graph, src_col - 1, src_col) + base_bypass_offset
+                column_gap_midpoint(graph, src_col - 1, src_col) + base_bypass_offset
             )
             gap1_limit = sx - ctx.curve_radius
             if gap1_base + (g1_n - 1) * ctx.offset_step > gap1_limit:
@@ -902,7 +900,7 @@ def _route_bypass(
             gap1_x = gap1_mid + delta1
 
         gap2_base = (
-            adjacent_column_gap_x(graph, tgt_col, tgt_col + 1) - base_bypass_offset
+            column_gap_midpoint(graph, tgt_col, tgt_col + 1) - base_bypass_offset
         )
         gap2_limit = effective_tx + ctx.curve_radius
         if gap2_base - (g2_n - 1) * ctx.offset_step < gap2_limit:
@@ -1132,10 +1130,10 @@ def _route_right_entry_wrap(
     # Detect cross-row case: use bypass-style Y just below the source
     # row's sections so the line runs horizontally under the adjacent
     # section before dropping to the target row.
-    src_row = _resolve_section_row(ctx.graph, src, ctx.junction_ids)
-    tgt_row = _resolve_section_row(ctx.graph, tgt, ctx.junction_ids)
-    src_col = _resolve_section_col(ctx.graph, src, ctx.junction_ids)
-    tgt_col = _resolve_section_col(ctx.graph, tgt, ctx.junction_ids)
+    src_row = _resolve_section_row(ctx.graph, src)
+    tgt_row = _resolve_section_row(ctx.graph, tgt)
+    src_col = _resolve_section_col(ctx.graph, src)
+    tgt_col = _resolve_section_col(ctx.graph, tgt)
 
     cross_row = (
         src_row is not None
@@ -1238,24 +1236,22 @@ def _resolve_section(
         return graph.sections.get(station.section_id)
 
     if prefer_upstream:
-        # Check incoming edges first (upstream preference)
-        for e in graph.edges:
-            if e.target == station.id:
-                other = graph.stations.get(e.source)
-                if other and other.section_id:
-                    sec = graph.sections.get(other.section_id)
-                    if sec:
-                        return sec
-        # Fall back to outgoing edges
-        for e in graph.edges:
-            if e.source == station.id:
-                other = graph.stations.get(e.target)
-                if other and other.section_id:
-                    sec = graph.sections.get(other.section_id)
-                    if sec:
-                        return sec
+        for e in graph.edges_to(station.id):
+            other = graph.stations.get(e.source)
+            if other and other.section_id:
+                sec = graph.sections.get(other.section_id)
+                if sec:
+                    return sec
+        for e in graph.edges_from(station.id):
+            other = graph.stations.get(e.target)
+            if other and other.section_id:
+                sec = graph.sections.get(other.section_id)
+                if sec:
+                    return sec
     else:
-        # Scan both directions in one pass (no preference)
+        # Preserve original graph.edges insertion order: callers depend on
+        # the first incident edge winning when a junction has neighbours
+        # in multiple sections.
         for e in graph.edges:
             other_id = None
             if e.source == station.id:
@@ -2441,11 +2437,7 @@ def _center_bubble_stations(routes: list[RoutedPath], graph: MetroGraph) -> None
 # ---------------------------------------------------------------------------
 
 
-def _resolve_section_col(
-    graph: MetroGraph,
-    station: Station,
-    junction_ids: set[str],
-) -> int | None:
+def _resolve_section_col(graph: MetroGraph, station: Station) -> int | None:
     """Resolve the grid column for a port or junction station."""
     sec = _resolve_section(graph, station, prefer_upstream=False)
     if sec and sec.grid_col >= 0:
@@ -2453,11 +2445,7 @@ def _resolve_section_col(
     return None
 
 
-def _resolve_section_row(
-    graph: MetroGraph,
-    station: Station,
-    junction_ids: set[str],
-) -> int | None:
+def _resolve_section_row(graph: MetroGraph, station: Station) -> int | None:
     """Resolve the grid row for a port or junction station."""
     sec = _resolve_section(graph, station, prefer_upstream=False)
     if sec and sec.grid_row >= 0:
@@ -2522,9 +2510,9 @@ def _compute_bypass_gap_indices(
         if not is_inter:
             continue
 
-        src_col = _resolve_section_col(graph, src, junction_ids)
-        tgt_col = _resolve_section_col(graph, tgt, junction_ids)
-        src_row = _resolve_section_row(graph, src, junction_ids)
+        src_col = _resolve_section_col(graph, src)
+        tgt_col = _resolve_section_col(graph, tgt)
+        src_row = _resolve_section_row(graph, src)
         if (
             src_col is None
             or tgt_col is None
@@ -2610,10 +2598,10 @@ def _compute_junction_fan_info(
         jst = graph.stations.get(jid)
         if not jst:
             continue
-        src_col = _resolve_section_col(graph, jst, junction_ids)
+        src_col = _resolve_section_col(graph, jst)
         if src_col is None:
             continue
-        src_row = _resolve_section_row(graph, jst, junction_ids)
+        src_row = _resolve_section_row(graph, jst)
 
         # Collect all outgoing inter-section edges (excluding skipped)
         outgoing: list[Edge] = []
@@ -2627,7 +2615,7 @@ def _compute_junction_fan_info(
             tgt = graph.stations.get(edge.target)
             if not tgt or not (tgt.is_port or edge.target in junction_ids):
                 continue
-            tgt_col = _resolve_section_col(graph, tgt, junction_ids)
+            tgt_col = _resolve_section_col(graph, tgt)
             if tgt_col is None:
                 continue
             is_bypass = abs(tgt_col - src_col) > 1 and _has_intervening_sections(

--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -22,6 +22,8 @@ is NEVER variable beyond the line's position within the bundle.
 
 from __future__ import annotations
 
+import math
+
 from nf_metro.layout.constants import CURVE_RADIUS, OFFSET_STEP
 
 # ---------------------------------------------------------------------------
@@ -74,13 +76,8 @@ def resolve_curve_radii(
         )
 
         prev, curr, nxt = points[i - 1], points[i], points[i + 1]
-        dx1 = curr[0] - prev[0]
-        dy1 = curr[1] - prev[1]
-        len1 = (dx1**2 + dy1**2) ** 0.5
-
-        dx2 = nxt[0] - curr[0]
-        dy2 = nxt[1] - curr[1]
-        len2 = (dx2**2 + dy2**2) ** 0.5
+        len1 = math.hypot(curr[0] - prev[0], curr[1] - prev[1])
+        len2 = math.hypot(nxt[0] - curr[0], nxt[1] - curr[1])
 
         # Proportional allocation for segments shared between adjacent corners.
         if i > 1:

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -955,12 +955,15 @@ def _align_junction_to_entry_port(ctx: _OffsetCtx) -> None:
         j_lines = list(graph.station_lines(jid))
         if len(j_lines) < 2:
             continue
+        # Group outbound edges by line once, then check each line has a
+        # single target downstream.
+        line_targets: dict[str, list[str]] = {}
+        for edge in graph.edges_from(jid):
+            line_targets.setdefault(edge.line_id, []).append(edge.target)
         line_to_target: dict[str, str] = {}
         ok = True
         for lid in j_lines:
-            targets = [
-                edge.target for edge in graph.edges_from(jid) if edge.line_id == lid
-            ]
+            targets = line_targets.get(lid, [])
             if len(targets) != 1:
                 ok = False
                 break

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -223,9 +223,7 @@ def _reindex_section_local(ctx: _OffsetCtx) -> None:
             continue
         line_feeder: dict[str, str] = {}
         for pid in section.entry_ports:
-            for edge in graph.edges:
-                if edge.target != pid:
-                    continue
+            for edge in graph.edges_to(pid):
                 src = graph.stations.get(edge.source)
                 if not src:
                     continue
@@ -233,8 +231,8 @@ def _reindex_section_local(ctx: _OffsetCtx) -> None:
                 if src.is_port:
                     feeder_sec = src.section_id
                 elif edge.source in graph.junctions:
-                    for je in graph.edges:
-                        if je.target == edge.source and je.line_id == edge.line_id:
+                    for je in graph.edges_to(edge.source):
+                        if je.line_id == edge.line_id:
                             js = graph.stations.get(je.source)
                             if js and js.is_port:
                                 feeder_sec = js.section_id
@@ -500,13 +498,12 @@ def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
         if port_obj.side not in (PortSide.LEFT, PortSide.RIGHT):
             continue
         internal_offs: dict[str, float] = {}
-        for edge in graph.edges:
-            if edge.target == port_id:
-                src_st = graph.stations.get(edge.source)
-                if src_st and not src_st.is_port:
-                    internal_offs[edge.line_id] = ctx.offsets.get(
-                        (edge.source, edge.line_id), 0.0
-                    )
+        for edge in graph.edges_to(port_id):
+            src_st = graph.stations.get(edge.source)
+            if src_st and not src_st.is_port:
+                internal_offs[edge.line_id] = ctx.offsets.get(
+                    (edge.source, edge.line_id), 0.0
+                )
         if internal_offs:
             max_int = max(internal_offs.values())
             for lid, ioff in internal_offs.items():
@@ -523,13 +520,12 @@ def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
         # line's "average Y" off the trunk: the kink belongs at the side
         # branch, not at the bundle's exit.
         line_feeders: dict[str, list[tuple[str, float]]] = {}
-        for edge in graph.edges:
-            if edge.target == port_id:
-                src_st = graph.stations.get(edge.source)
-                if src_st and not src_st.is_port:
-                    line_feeders.setdefault(edge.line_id, []).append(
-                        (edge.source, src_st.y)
-                    )
+        for edge in graph.edges_to(port_id):
+            src_st = graph.stations.get(edge.source)
+            if src_st and not src_st.is_port:
+                line_feeders.setdefault(edge.line_id, []).append(
+                    (edge.source, src_st.y)
+                )
         if len(line_feeders) < 2:
             continue
         port_lines = set(line_feeders.keys())
@@ -585,15 +581,14 @@ def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
 
         # Propagate to upstream hub stations
         feeder_ids: set[str] = set()
-        for edge in graph.edges:
-            if edge.target == port_id:
-                src_st = graph.stations.get(edge.source)
-                if src_st and not src_st.is_port:
-                    feeder_ids.add(edge.source)
+        for edge in graph.edges_to(port_id):
+            src_st = graph.stations.get(edge.source)
+            if src_st and not src_st.is_port:
+                feeder_ids.add(edge.source)
         if len(feeder_ids) >= 2:
             hub_candidates: set[str] = set()
-            for edge in graph.edges:
-                if edge.target in feeder_ids:
+            for feeder_id in feeder_ids:
+                for edge in graph.edges_to(feeder_id):
                     hub_candidates.add(edge.source)
             for hub_id in hub_candidates:
                 hub_lines = graph.station_lines(hub_id)
@@ -611,16 +606,15 @@ def _propagate_to_junctions(ctx: _OffsetCtx) -> None:
     """
     graph = ctx.graph
     for jid in graph.junctions:
-        for edge in graph.edges:
-            if edge.target == jid:
-                src = graph.stations.get(edge.source)
-                port_obj = graph.ports.get(edge.source)
-                if src and src.is_port and port_obj and not port_obj.is_entry:
-                    for lid in graph.station_lines(jid):
-                        port_off = ctx.offsets.get((edge.source, lid))
-                        if port_off is not None:
-                            ctx.offsets[(jid, lid)] = port_off
-                    break
+        for edge in graph.edges_to(jid):
+            src = graph.stations.get(edge.source)
+            port_obj = graph.ports.get(edge.source)
+            if src and src.is_port and port_obj and not port_obj.is_entry:
+                for lid in graph.station_lines(jid):
+                    port_off = ctx.offsets.get((edge.source, lid))
+                    if port_off is not None:
+                        ctx.offsets[(jid, lid)] = port_off
+                break
 
 
 def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
@@ -649,9 +643,7 @@ def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
     for port_id, port_obj in graph.ports.items():
         if not port_obj.is_entry or port_obj.side != PortSide.TOP:
             continue
-        for edge in graph.edges:
-            if edge.target != port_id:
-                continue
+        for edge in graph.edges_to(port_id):
             src = graph.stations.get(edge.source)
             if not src or not src.is_port:
                 continue
@@ -687,9 +679,7 @@ def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
         if port_obj.side not in (PortSide.LEFT, PortSide.RIGHT):
             continue
         feeding_exit_ports: set[str] = set()
-        for edge in graph.edges:
-            if edge.target != port_id:
-                continue
+        for edge in graph.edges_to(port_id):
             src = graph.stations.get(edge.source)
             if not src or not src.is_port:
                 continue
@@ -713,15 +703,14 @@ def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
                 ctx.offsets[(port_id, lid)] = exit_off
                 entry_offs[lid] = exit_off
         if len(entry_offs) >= 2:
-            for e2 in graph.edges:
-                if e2.source == port_id:
-                    tgt_st = graph.stations.get(e2.target)
-                    if tgt_st and not tgt_st.is_port:
-                        tgt_lines = graph.station_lines(e2.target)
-                        overlap = [lid for lid in tgt_lines if lid in entry_offs]
-                        if len(overlap) >= 2:
-                            for lid in overlap:
-                                ctx.offsets[(e2.target, lid)] = entry_offs[lid]
+            for e2 in graph.edges_from(port_id):
+                tgt_st = graph.stations.get(e2.target)
+                if tgt_st and not tgt_st.is_port:
+                    tgt_lines = graph.station_lines(e2.target)
+                    overlap = [lid for lid in tgt_lines if lid in entry_offs]
+                    if len(overlap) >= 2:
+                        for lid in overlap:
+                            ctx.offsets[(e2.target, lid)] = entry_offs[lid]
 
     # --- Compact entry port offset separation ---
     if ctx.compact:
@@ -749,8 +738,8 @@ def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
                 for pid in section.entry_ports:
                     if lid in graph.station_lines(pid):
                         ctx.offsets[(pid, lid)] = off
-                        for edge in graph.edges:
-                            if edge.target == pid and edge.line_id == lid:
+                        for edge in graph.edges_to(pid):
+                            if edge.line_id == lid:
                                 src_port = graph.ports.get(edge.source)
                                 if src_port and not src_port.is_entry:
                                     ctx.offsets[(edge.source, lid)] = off
@@ -969,10 +958,9 @@ def _align_junction_to_entry_port(ctx: _OffsetCtx) -> None:
         line_to_target: dict[str, str] = {}
         ok = True
         for lid in j_lines:
-            targets: list[str] = []
-            for edge in graph.edges:
-                if edge.source == jid and edge.line_id == lid:
-                    targets.append(edge.target)
+            targets = [
+                edge.target for edge in graph.edges_from(jid) if edge.line_id == lid
+            ]
             if len(targets) != 1:
                 ok = False
                 break
@@ -1006,9 +994,7 @@ def _align_junction_to_entry_port(ctx: _OffsetCtx) -> None:
 
         feeding_exit: str | None = None
         single_exit = True
-        for edge in graph.edges:
-            if edge.target != jid:
-                continue
+        for edge in graph.edges_to(jid):
             src_port = graph.ports.get(edge.source)
             if src_port and not src_port.is_entry:
                 if feeding_exit is None:

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -37,7 +37,7 @@ def _build_offset_ctx(graph: MetroGraph, offset_step: float) -> _OffsetCtx:
     line_order = list(graph.lines.keys())
     line_priority = {lid: i for i, lid in enumerate(line_order)}
     max_priority = len(line_order) - 1 if line_order else 0
-    compact = getattr(graph, "compact_offsets", False)
+    compact = graph.compact_offsets
 
     inbound: dict[str, set[str]] = {sid: set() for sid in graph.stations}
     outbound: dict[str, set[str]] = {sid: set() for sid in graph.stations}

--- a/src/nf_metro/layout/routing/reversal.py
+++ b/src/nf_metro/layout/routing/reversal.py
@@ -31,7 +31,7 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
     """
     tb_sections = {sid for sid, s in graph.sections.items() if s.direction == "TB"}
     reversed_secs: set[str] = set()
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
 
     # Phase 1a: detect sections directly fed by TB BOTTOM exits
     for sec_id, section in graph.sections.items():
@@ -39,23 +39,25 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
             port = graph.ports.get(port_id)
             if not port or port.side != PortSide.TOP:
                 continue
-            for edge in graph.edges:
-                if edge.target == port_id:
-                    src = graph.stations.get(edge.source)
-                    if not src or not src.is_port:
-                        continue
-                    src_port = graph.ports.get(edge.source)
-                    if (
-                        src_port
-                        and not src_port.is_entry
-                        and src_port.side == PortSide.BOTTOM
-                        and src.section_id in tb_sections
-                    ):
-                        reversed_secs.add(sec_id)
+            for edge in graph.edges_to(port_id):
+                src = graph.stations.get(edge.source)
+                if not src or not src.is_port:
+                    continue
+                src_port = graph.ports.get(edge.source)
+                if (
+                    src_port
+                    and not src_port.is_entry
+                    and src_port.side == PortSide.BOTTOM
+                    and src.section_id in tb_sections
+                ):
+                    reversed_secs.add(sec_id)
 
     # Build section adjacency from inter-section edges (used by
-    # propagation phases below).
+    # propagation phases below).  Also pre-compute the section-pair set
+    # for which the inter-section edge runs between LEFT/RIGHT ports on
+    # both sides (a direction-preserving continuation).
     sec_successors: dict[str, set[str]] = {}
+    horizontal_succ_pairs: set[tuple[str, str]] = set()
     for edge in graph.edges:
         src = graph.stations.get(edge.source)
         tgt = graph.stations.get(edge.target)
@@ -63,16 +65,6 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
             continue
         if src.section_id and tgt.section_id and src.section_id != tgt.section_id:
             sec_successors.setdefault(src.section_id, set()).add(tgt.section_id)
-
-    def _is_horizontal_successor(sec_id: str, succ_id: str) -> bool:
-        """Check if succ_id is reached via a horizontal port connection."""
-        for edge in graph.edges:
-            src = graph.stations.get(edge.source)
-            tgt = graph.stations.get(edge.target)
-            if not src or not tgt:
-                continue
-            if src.section_id != sec_id or tgt.section_id != succ_id:
-                continue
             src_port = graph.ports.get(edge.source)
             tgt_port = graph.ports.get(edge.target)
             if (
@@ -83,8 +75,7 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
                 and tgt_port.is_entry
                 and tgt_port.side in (PortSide.LEFT, PortSide.RIGHT)
             ):
-                return True
-        return False
+                horizontal_succ_pairs.add((src.section_id, tgt.section_id))
 
     def _propagate_along_rows() -> bool:
         """Propagate reversal to horizontal successors.
@@ -115,8 +106,9 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
                     succ = graph.sections.get(succ_id)
                     if not succ:
                         continue
-                    if succ.grid_row == section.grid_row or _is_horizontal_successor(
-                        sec_id, succ_id
+                    if (
+                        succ.grid_row == section.grid_row
+                        or (sec_id, succ_id) in horizontal_succ_pairs
                     ):
                         reversed_secs.add(succ_id)
                         changed = True
@@ -170,26 +162,23 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
                     PortSide.RIGHT,
                 ):
                     continue
-                for edge in graph.edges:
+                for edge in graph.edges_to(port_id):
                     if added:
                         break
-                    if edge.target != port_id:
-                        continue
                     src = graph.stations.get(edge.source)
                     if not src:
                         continue
                     matched = False
                     if edge.source in junction_ids:
                         # Look through junction to find upstream exit port
-                        for e2 in graph.edges:
-                            if e2.target == edge.source:
-                                s2 = graph.stations.get(e2.source)
-                                if not s2 or not s2.is_port:
-                                    continue
-                                s2_port = graph.ports.get(e2.source)
-                                if _is_tb_lr_exit_nonreversed(s2_port):
-                                    matched = True
-                                    break
+                        for e2 in graph.edges_to(edge.source):
+                            s2 = graph.stations.get(e2.source)
+                            if not s2 or not s2.is_port:
+                                continue
+                            s2_port = graph.ports.get(e2.source)
+                            if _is_tb_lr_exit_nonreversed(s2_port):
+                                matched = True
+                                break
                     elif src.is_port:
                         src_port = graph.ports.get(edge.source)
                         matched = _is_tb_lr_exit_nonreversed(src_port)

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -339,7 +339,7 @@ def _count_lines_between_columns(
     ports and junctions) to find how many lines will need to route through
     the gap between *col_a* and *col_b*.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     lines: set[str] = set()
 
     for edge in graph.edges:
@@ -420,7 +420,7 @@ def _has_merge_routing_in_gap(
     if not merge_ids:
         return False
 
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     lo, hi = min(col_a, col_b), max(col_a, col_b)
 
     for mjid in merge_ids:
@@ -730,7 +730,7 @@ def _find_downstream_bundle_y(
     fits inside this section's bbox, otherwise None so the caller can
     fall back to the local-internal centre.
     """
-    junction_ids = set(graph.junctions)
+    junction_ids = graph.junction_ids
     ports = graph.ports
     stations = graph.stations
     sections = graph.sections

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -736,11 +736,6 @@ def _find_downstream_bundle_y(
     sections = graph.sections
     same_row = section.grid_row
 
-    # Index edges by source once: every other lookup is by source.
-    edges_by_source: dict[str, list] = {}
-    for edge in graph.edges:
-        edges_by_source.setdefault(edge.source, []).append(edge)
-
     # Fan-in exits stay centred: 2+ distinct internal source Ys means
     # the visual convergence is meaningful and downstream anchoring
     # would collapse the bundle onto one source.
@@ -749,7 +744,7 @@ def _find_downstream_bundle_y(
     )
     src_ys: set[float] = set()
     for sid in internal_ids:
-        for edge in edges_by_source.get(sid, ()):
+        for edge in graph.edges_from(sid):
             if edge.target != exit_port_id:
                 continue
             st = stations.get(sid)
@@ -760,12 +755,12 @@ def _find_downstream_bundle_y(
                 break
 
     entry_ids: list[str] = []
-    for edge in edges_by_source.get(exit_port_id, ()):
+    for edge in graph.edges_from(exit_port_id):
         tgt = edge.target
         if tgt in ports and ports[tgt].is_entry:
             entry_ids.append(tgt)
         elif tgt in junction_ids:
-            for e2 in edges_by_source.get(tgt, ()):
+            for e2 in graph.edges_from(tgt):
                 if e2.target in ports and ports[e2.target].is_entry:
                     entry_ids.append(e2.target)
     if not entry_ids:
@@ -781,7 +776,7 @@ def _find_downstream_bundle_y(
             continue
         ds_internal = set(ds.station_ids) - set(ds.entry_ports) - set(ds.exit_ports)
         targets: dict[str, set[str]] = {}
-        for edge in edges_by_source.get(eid, ()):
+        for edge in graph.edges_from(eid):
             if edge.target not in ds_internal:
                 continue
             st = stations.get(edge.target)
@@ -821,14 +816,11 @@ def _find_connected_internal_coord(
         set(section.station_ids) - set(section.entry_ports) - set(section.exit_ports)
     )
     vals: list[float] = []
-    for edge in graph.edges:
-        if edge.source == port_id and edge.target in internal_ids:
-            if edge.target.startswith("__bypass_"):
-                continue
+    for edge in graph.edges_from(port_id):
+        if edge.target in internal_ids and not edge.target.startswith("__bypass_"):
             vals.append(getattr(graph.stations[edge.target], axis))
-        if edge.target == port_id and edge.source in internal_ids:
-            if edge.source.startswith("__bypass_"):
-                continue
+    for edge in graph.edges_to(port_id):
+        if edge.source in internal_ids and not edge.source.startswith("__bypass_"):
             vals.append(getattr(graph.stations[edge.source], axis))
     if vals:
         return sum(vals) / len(vals)

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -380,11 +380,10 @@ def _station_column(
         return col_assign[station.section_id]
     # Junction: trace back to its source port's section
     if station.id in junction_ids:
-        for edge in graph.edges:
-            if edge.target == station.id:
-                src = graph.stations.get(edge.source)
-                if src and src.section_id and src.section_id in col_assign:
-                    return col_assign[src.section_id]
+        for edge in graph.edges_to(station.id):
+            src = graph.stations.get(edge.source)
+            if src and src.section_id and src.section_id in col_assign:
+                return col_assign[src.section_id]
     return None
 
 
@@ -430,9 +429,7 @@ def _has_merge_routing_in_gap(
             continue
         tgt_col = col_assign.get(mst.section_id, -1) if mst.section_id else -1
         # Check if any bypass predecessor crosses this gap
-        for edge in graph.edges:
-            if edge.target != mjid:
-                continue
+        for edge in graph.edges_to(mjid):
             src_col = _station_column(
                 graph,
                 graph.stations.get(edge.source),

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -1122,8 +1122,6 @@ def _insert_merge_junctions(graph: MetroGraph) -> None:
 
     # Apply edge rewrites
     kept = [
-        e
-        for e in graph.edges
-        if (e.source, e.target, e.line_id) not in edges_to_remove
+        e for e in graph.edges if (e.source, e.target, e.line_id) not in edges_to_remove
     ]
     graph.replace_edges(kept + new_edges)

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -996,7 +996,7 @@ def _rewrite_edges_with_junctions(
             port_counter += 1
             junction = Station(id=junction_id, label="", is_port=True, section_id=None)
             graph.add_station(junction)
-            graph.junctions.append(junction_id)
+            graph.add_junction(junction_id)
 
             all_line_ids_set: set[str] = set()
             for edges in entry_targets.values():
@@ -1110,7 +1110,7 @@ def _insert_merge_junctions(graph: MetroGraph) -> None:
             section_id=entry_port.section_id,
         )
         graph.add_station(merge_station)
-        graph.junctions.append(merge_id)
+        graph.add_junction(merge_id)
 
         # Rewrite: each source -> merge junction
         for edge in edges:

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -544,7 +544,9 @@ def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
         graph.register_station(st)
 
     if edges_to_remove:
-        graph.edges = [e for i, e in enumerate(graph.edges) if i not in edges_to_remove]
+        graph.replace_edges(
+            [e for i, e in enumerate(graph.edges) if i not in edges_to_remove]
+        )
     for edge in new_edges:
         graph.add_edge(edge)
 
@@ -763,7 +765,9 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
         graph.register_station(st)
 
     if edges_to_remove:
-        graph.edges = [e for i, e in enumerate(graph.edges) if i not in edges_to_remove]
+        graph.replace_edges(
+            [e for i, e in enumerate(graph.edges) if i not in edges_to_remove]
+        )
     for edge in new_edges:
         graph.add_edge(edge)
 
@@ -1023,8 +1027,7 @@ def _rewrite_edges_with_junctions(
         if key not in seen:
             seen.add(key)
             deduped.append(edge)
-    graph.edges = deduped
-    graph._invalidate_edge_caches()
+    graph.replace_edges(deduped)
 
 
 def _create_ports_and_junctions(
@@ -1118,7 +1121,9 @@ def _insert_merge_junctions(graph: MetroGraph) -> None:
         new_edges.append(Edge(source=merge_id, target=entry_port_id, line_id=line_id))
 
     # Apply edge rewrites
-    graph.edges = [
-        e for e in graph.edges if (e.source, e.target, e.line_id) not in edges_to_remove
-    ] + new_edges
-    graph._invalidate_edge_caches()
+    kept = [
+        e
+        for e in graph.edges
+        if (e.source, e.target, e.line_id) not in edges_to_remove
+    ]
+    graph.replace_edges(kept + new_edges)

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -125,6 +125,12 @@ class Section:
     internal_edges: list[Edge] = field(default_factory=list)
     entry_ports: list[str] = field(default_factory=list)  # port IDs
     exit_ports: list[str] = field(default_factory=list)  # port IDs
+
+    @property
+    def port_ids(self) -> set[str]:
+        """Set of all entry- and exit-port IDs on this section."""
+        return set(self.entry_ports).union(self.exit_ports)
+
     # Hints from %%metro entry/exit directives: list of (side, [line_ids])
     exit_hints: list[tuple[PortSide, list[str]]] = field(default_factory=list)
     entry_hints: list[tuple[PortSide, list[str]]] = field(default_factory=list)
@@ -196,6 +202,8 @@ class MetroGraph:
     _station_lines_cache: dict[str, list[str]] | None = field(default=None, repr=False)
     _edges_from_cache: dict[str, list[Edge]] | None = field(default=None, repr=False)
     _edges_to_cache: dict[str, list[Edge]] | None = field(default=None, repr=False)
+    # Lazy set view of `junctions`, invalidated on junction mutation.
+    _junction_ids_cache: set[str] | None = field(default=None, repr=False)
     # Grid alignment metadata (populated by Phase 2.5 _align_row_y_grids)
     _row_y_grid_info: dict = field(default_factory=dict, repr=False)
     # Cross-phase channel: station IDs placed at half-pitch offsets
@@ -231,6 +239,18 @@ class MetroGraph:
         """Replace the entire edge list and invalidate dependent caches."""
         self.edges = new_edges
         self._invalidate_edge_caches()
+
+    def add_junction(self, junction_id: str) -> None:
+        """Append a junction ID and invalidate the junction-set cache."""
+        self.junctions.append(junction_id)
+        self._junction_ids_cache = None
+
+    @property
+    def junction_ids(self) -> set[str]:
+        """Set view of ``self.junctions`` for O(1) membership checks."""
+        if self._junction_ids_cache is None:
+            self._junction_ids_cache = set(self.junctions)
+        return self._junction_ids_cache
 
     def add_section(self, section: Section) -> None:
         self.sections[section.id] = section

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -192,8 +192,10 @@ class MetroGraph:
     _pending_terminus: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
     # Pending off-track marks: station_ids to lift above section top track
     _pending_off_track: list[str] = field(default_factory=list)
-    # Lazy cache for station_lines(); invalidated on edge mutation
+    # Lazy caches keyed off the edge list; invalidated on edge mutation.
     _station_lines_cache: dict[str, list[str]] | None = field(default=None, repr=False)
+    _edges_from_cache: dict[str, list[Edge]] | None = field(default=None, repr=False)
+    _edges_to_cache: dict[str, list[Edge]] | None = field(default=None, repr=False)
     # Grid alignment metadata (populated by Phase 2.5 _align_row_y_grids)
     _row_y_grid_info: dict = field(default_factory=dict, repr=False)
     # Cross-phase channel: station IDs placed at half-pitch offsets
@@ -206,6 +208,8 @@ class MetroGraph:
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""
         self._station_lines_cache = None
+        self._edges_from_cache = None
+        self._edges_to_cache = None
 
     def add_line(self, line: MetroLine) -> None:
         self.lines[line.id] = line
@@ -221,6 +225,11 @@ class MetroGraph:
 
     def add_edge(self, edge: Edge) -> None:
         self.edges.append(edge)
+        self._invalidate_edge_caches()
+
+    def replace_edges(self, new_edges: list[Edge]) -> None:
+        """Replace the entire edge list and invalidate dependent caches."""
+        self.edges = new_edges
         self._invalidate_edge_caches()
 
     def add_section(self, section: Section) -> None:
@@ -261,6 +270,24 @@ class MetroGraph:
             self._station_lines_cache = {sid: sorted(lids) for sid, lids in idx.items()}
         return self._station_lines_cache.get(station_id, [])
 
+    def edges_from(self, station_id: str) -> list[Edge]:
+        """Return edges whose ``source`` is *station_id* (lazy adjacency cache)."""
+        if self._edges_from_cache is None:
+            idx: dict[str, list[Edge]] = {}
+            for e in self.edges:
+                idx.setdefault(e.source, []).append(e)
+            self._edges_from_cache = idx
+        return self._edges_from_cache.get(station_id, [])
+
+    def edges_to(self, station_id: str) -> list[Edge]:
+        """Return edges whose ``target`` is *station_id* (lazy adjacency cache)."""
+        if self._edges_to_cache is None:
+            idx: dict[str, list[Edge]] = {}
+            for e in self.edges:
+                idx.setdefault(e.target, []).append(e)
+            self._edges_to_cache = idx
+        return self._edges_to_cache.get(station_id, [])
+
     def line_stations(self, line_id: str) -> list[str]:
         """Return station IDs on a line, in edge order."""
         stations = []
@@ -274,16 +301,6 @@ class MetroGraph:
                     stations.append(edge.target)
                     seen.add(edge.target)
         return stations
-
-    def inter_section_edges(self) -> list[Edge]:
-        """Return edges that cross section boundaries."""
-        result = []
-        for edge in self.edges:
-            src_section = self.section_for_station(edge.source)
-            tgt_section = self.section_for_station(edge.target)
-            if src_section and tgt_section and src_section != tgt_section:
-                result.append(edge)
-        return result
 
     def section_for_station(self, station_id: str) -> str | None:
         """Return the section ID containing a station, or None."""

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -236,3 +236,11 @@ STROKE_DASHARRAY: dict[str, str] = {
     "dotted": "2,4",
 }
 """SVG stroke-dasharray values for non-solid line styles."""
+
+
+def line_style_kwargs(style: str) -> dict[str, str]:
+    """Return extra SVG kwargs for a metro line style (dashed/dotted)."""
+    dasharray = STROKE_DASHARRAY.get(style)
+    if dasharray:
+        return {"stroke_dasharray": dasharray}
+    return {}

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -216,7 +216,7 @@ FOLDER_TAB_WIDTH_RATIO: float = 0.4
 # ---------------------------------------------------------------------------
 # Animation styling
 # ---------------------------------------------------------------------------
-ANIMATION_BALL_OPACITY: str = "0.9"
+ANIMATION_BALL_OPACITY: float = 0.9
 """Opacity of animated balls traveling along lines."""
 
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -16,8 +16,8 @@ from nf_metro.render.constants import (
     LEGEND_TEXT_GAP,
     LOGO_GAP,
     LOGO_SCALE_FACTOR,
-    STROKE_DASHARRAY,
     TEXT_VCENTER_DY,
+    line_style_kwargs,
 )
 from nf_metro.render.style import Theme
 
@@ -137,10 +137,7 @@ def render_legend(
         entry_y = y + padding + i * line_height + line_height / 2
 
         # Color swatch (line segment)
-        dash_kw = {}
-        dasharray = STROKE_DASHARRAY.get(metro_line.style)
-        if dasharray:
-            dash_kw["stroke_dasharray"] = dasharray
+        dash_kw = line_style_kwargs(metro_line.style)
         d.append(
             draw.Line(
                 x + padding + logo_offset,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -53,7 +53,6 @@ from nf_metro.render.constants import (
     SECTION_NUM_FONT_SIZE,
     SECTION_NUM_Y_OFFSET,
     SECTION_STROKE_WIDTH,
-    STROKE_DASHARRAY,
     SVG_CURVE_RADIUS,
     TERMINUS_FONT_COLOR,
     TEXT_VCENTER_DY,
@@ -61,6 +60,7 @@ from nf_metro.render.constants import (
     WATERMARK_FONT_SIZE,
     WATERMARK_PADDING_RATIO,
     WATERMARK_Y_INSET,
+    line_style_kwargs,
 )
 from nf_metro.render.icons import (
     render_file_icon,
@@ -69,14 +69,6 @@ from nf_metro.render.icons import (
 )
 from nf_metro.render.legend import compute_legend_dimensions, render_legend
 from nf_metro.render.style import Theme
-
-
-def _line_style_kwargs(style: str) -> dict:
-    """Return extra SVG kwargs for a metro line style (dashed/dotted)."""
-    dasharray = STROKE_DASHARRAY.get(style)
-    if dasharray:
-        return {"stroke_dasharray": dasharray}
-    return {}
 
 
 def apply_route_offsets(
@@ -232,11 +224,7 @@ def _compute_icon_obstacles(
         r = theme.station_radius
 
         # Determine if source (no incoming edges) or sink
-        is_source = True
-        for edge in graph.edges:
-            if edge.target == station.id:
-                is_source = False
-                break
+        is_source = not graph.edges_to(station.id)
 
         section = graph.sections.get(station.section_id) if station.section_id else None
         section_dir = section.direction if section else "LR"
@@ -641,7 +629,7 @@ def _render_edges(
     for route in routes:
         line = graph.lines.get(route.line_id)
         color = line.color if line else FALLBACK_LINE_COLOR
-        style_kw = _line_style_kwargs(line.style) if line else {}
+        style_kw = line_style_kwargs(line.style) if line else {}
         class_name = f"metro-line-{route.line_id}"
 
         pts = apply_route_offsets(route, station_offsets)
@@ -854,14 +842,7 @@ def _render_terminus_icons(
         graph.sections.get(station.section_id) if station.section_id else None
     )
     # Detect if station is a source (no incoming edges) or sink.
-    # Check graph.edges (not section.internal_edges) because the latter
-    # is populated before inter-section edge rewriting and doesn't
-    # include port-to-station edges.
-    is_source = True
-    for edge in graph.edges:
-        if edge.target == station.id:
-            is_source = False
-            break
+    is_source = not graph.edges_to(station.id)
     # Place icons on the "outside" of the flow
     icon_gap = r + ICON_STATION_GAP
     icon_half_w = theme.terminus_width / 2

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2712,11 +2712,6 @@ def test_station_x_within_column_tolerance(fixture):
 
     x_spacing = X_SPACING
     graph = _layout(fixture, x_spacing=x_spacing)
-    in_by_tgt: dict[str, list] = defaultdict(list)
-    out_by_src: dict[str, list] = defaultdict(list)
-    for e in graph.edges:
-        in_by_tgt[e.target].append(e)
-        out_by_src[e.source].append(e)
 
     offenders: list[str] = []
     for sec in graph.sections.values():
@@ -2732,7 +2727,7 @@ def test_station_x_within_column_tolerance(fixture):
                 continue
             if st.off_track:
                 continue
-            if is_loop_side_branch_station(graph, sid, in_by_tgt, out_by_src):
+            if is_loop_side_branch_station(graph, sid):
                 continue
             layer_xs[st.layer].append((sid, st.x))
         for layer, members in layer_xs.items():


### PR DESCRIPTION
## Summary

Retrospective `/simplify` pass over everything merged since release 0.6.1 (218 commits, ~10k src lines). Reviewed in six commit-window chunks with three review agents per chunk (reuse / quality / efficiency), then a second-pass aggregate review caught residual cross-chunk inconsistencies.

**Net result: -220 lines across 14 files. All 2008 tests pass. Ruff lint + format clean.**

## What changed

### New shared infrastructure on the data model

- **`MetroGraph.edges_from(station_id)` / `edges_to(station_id)`** — lazy adjacency caches mirroring the existing `station_lines` cache, invalidated by the same `_invalidate_edge_caches` hook.
- **`MetroGraph.replace_edges(new_edges)`** — wraps `self.edges = ...` plus cache invalidation. Used at the four sites that previously assigned `graph.edges` directly (two of which were silently relying on a later `add_edge` to invalidate the cache).
- **`MetroGraph.junction_ids`** — lazy frozen set view of `self.junctions`, invalidated via new `add_junction(id)` helper. Replaces 22 sites of `set(graph.junctions)`.
- **`Section.port_ids`** — derived property returning the union of entry- and exit-port IDs. Replaces 22 sites of `set(section.entry_ports) | set(section.exit_ports)`.
- **`render.constants.line_style_kwargs(style)`** — shared style-kwargs builder so `render/legend.py` no longer reimplements the dashed/dotted lookup from `render/svg.py`.

### Adjacency-cache adoption (50+ sites)

Replaced `for edge in graph.edges: if edge.target == X` (or `.source == X`) patterns across the engine, routing, parser, and renderer with `graph.edges_to(X)` / `graph.edges_from(X)`. Highlights:

- `_classify_merge_edges` — 4 scans collapsed; introduced `_col_for_id` helper to drop three `# type: ignore[arg-type]` markers.
- `_position_junctions`, `_align_ports_to_downstream`, `_snap_*` family.
- `_resolve_source_xy`, `_resolve_source_section_id`, `_resolve_section`'s prefer_upstream=True path (the `prefer_upstream=False` branch keeps the ordered scan because callers rely on graph.edges insertion order).
- `_section_trunk_y`, `_align_row_trunk_ys`, `_balance_section_content_around_trunk._shift_chain`, `_fan_source_inputs_upward._shift_chain`, `_pad_stacked_captioned_file_icons._shift_chain` (also dropped each function's locally-built `in_edges`/`out_edges` adjacency dicts).
- `_recenter_loop_side_stations`, `_shift_sparse_loop_stations_to_clear_bundle`, `_adjust_lr_exit_gap`, `_lift_would_cause_uturn`, `_balance_direct_external_feeder_ys`, `_convergence_source_ys`, `_divergence_target_ys`, `_align_tb_section_bbox_bottoms._downstream_section_ids`.
- `_align_terminus_to_upstream`, `_find_downstream_bundle_y`, `_find_connected_internal_coord`, `_has_merge_routing_in_gap`.
- Two `is_source = True; for edge in graph.edges: ...` patterns in `svg.py` and one in `engine.py` collapse to `is_source = not graph.edges_to(station.id)`.
- All four `routing/reversal.py` adjacency scans, plus a pre-computed `horizontal_succ_pairs` set that turns the O(I·N·M·E) propagation while-loop into O(I·N·M).
- `routing/common.py:line_source_y_at_port`, `_compute_junction_fan_info` inner scan.
- `_adjust_tb_entry_inset`, `_adjust_lr_entry_inset`, `_insert_phantom_pass_throughs`, `_off_track_groups`.

### NetworkX DiGraph rebuilds removed

Four functions imported `networkx` and rebuilt a full DiGraph from `graph.edges` per call:

- `_redistribute_fanout_siblings` / `_redistribute_full_bundle_columns` / `_recenter_full_bundle_columns` rebuilt the DiGraph only to call `G.predecessors(sid)` — now `bool(graph.edges_to(sid))`.
- `_align_phantom_pass_throughs` rebuilt it only for `G.successors(sid)` — now a set comprehension over `sub.edges_from(sid)`.

### Dead code removed

- `MetroGraph.inter_section_edges` method (helper unused; 5+ inline copies of its body in the parser).
- `_section_columns_by_x` helper added in chunk 4 but never wired up.
- `adjacent_column_gap_x` forwarder (pure passthrough to `column_gap_midpoint`).
- `_section_full_bundle` inner helper in `_guard_row_trunk_cy_consistent` (duplicate of `_section_bundle_lines`).
- `routing/common.py:line_incoming_y_at_entry_port` — zero callers anywhere.
- `_snap_inter_section_port_pairs` returned a `bool` that the sole caller discarded.
- `pitch_label_over_icon` in `compute_min_y_spacing` (provably never the max because `icon_below > icon_above` by construction).
- Function-scope `from collections import defaultdict` shadowing the module-level import.
- Local `ICON_HALF = 16.0` in `_bump_off_track_clear_of_trunks` shadowing the imported `ICON_HALF_HEIGHT`.
- `_resolve_section_col` / `_resolve_section_row` dead `junction_ids` parameter (16 call sites).
- `_route_merge_branch` dead `tgt_col` parameter.

### Defensive `getattr` removed where the dataclass field has a default

- `getattr(graph, "_explicit_grid", None)` → `graph._explicit_grid` (3 sites).
- `getattr(graph, "compact_offsets", False)` → `graph.compact_offsets`.
- `getattr(st, "off_track", False)` → `st.off_track` (3 sites where `st` was already known non-None; the two sites where the argument is `graph.stations.get(sid)` and may legitimately be None are kept).

### Other quality fixes

- Used `math.hypot` in `resolve_curve_radii` corner-length calc.
- Dropped redundant `if iter else 0.0` around `max(..., default=0.0)` in `bypass_bottom_y`.
- `ANIMATION_BALL_OPACITY: str = "0.9"` → `float = 0.9` (was preventing arithmetic; the f-string consumes either).
- `_layout_single_section`'s entry_top detection (4-level nested loop with flag-and-break) extracted into `_has_horizontal_predecessor_section` helper using `any(...)` over a flat generator.
- `_align_row_y_grids` was calling `_classify_multi_station_ys(sub)` twice per section; precompute once and reuse.
- `_align_junction_to_entry_port` precomputes a line→targets dict once per junction instead of scanning per line.
- `_route_inter_section`: fold `_resolve_section_col` resolution into the if-guard walrus so the col lookup only fires when the cheap geometric predicate already holds.
- Proper `port: Port` annotations on `_align_lr_entry_port` / `_align_tb_entry_port` / `_align_lr_exit_port` / `_resolve_tb_exit_y` (were bare `port,`).
- Type `routes: list` → `routes: list[RoutedPath]` in `place_labels` / `_avoid_diagonal_routes` (via TYPE_CHECKING import to avoid the routing/core → labels cycle); drop the corresponding `getattr(route, ...)` defensiveness.
- `is_loop_side_branch_station` dropped its `(in_by_tgt, out_by_src)` parameters and uses `graph.edges_to` / `edges_from` internally; updates the test mirror in `test_layout_invariants.py`.

## Deferred to follow-up issues

The aggregate review surfaced two larger refactors with different risk profiles that warrant their own PRs:

- **#367** — consolidate the three `_shift_chain` closures (only differ in cycle-guard flag).
- **#368** — replace the genuinely-quadratic `_guard_no_station_overlap` (O(N²)) and `_guard_no_line_crosses_non_consumer` (sampling-based segment-vs-bbox) with spatial indexing and closed-form intersection.

Other agent findings deliberately left for later (broader refactors, beyond a /simplify pass):
- enum migrations for section direction / line style / icon type
- `_lift_off_track_stations` / `_reanchor_off_track_to_consumer` near-duplicates
- `_redistribute_full_bundle_columns` / `_recenter_full_bundle_columns` ~80% structural duplication

## Test plan

- [x] `pytest` from worktree: 2008 passed, 4 xfailed (same set as origin/main baseline)
- [x] `ruff check src/ tests/` clean, `ruff format --check src/ tests/` clean
- [x] CI test matrix (Python 3.10-3.13) green
- [ ] Render-diff preview will appear at the usual `_pr/366/` path; visual review is the authoritative check for this kind of refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)