### PR TITLE
feat(engine): add C13 row-gap runtime invariant guard

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -169,6 +169,48 @@ def _guard_section_bboxes_positive(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _guard_row_gaps(graph: MetroGraph, phase: str, *, section_y_gap: float) -> None:
+    """Final phase: column-overlapping adjacent-row section pairs must
+    keep at least ``section_y_gap`` between the upper section's bbox
+    bottom and the lower section's bbox top.
+
+    Sections that don't share horizontal extent are unconstrained --
+    their vertical proximity has no visual impact.
+    """
+    tol = 0.5
+    sections_by_row_start: dict[int, list[tuple[str, Section]]] = defaultdict(list)
+    for sid, sec in graph.sections.items():
+        if sec.bbox_w <= 0 or sec.bbox_h <= 0:
+            continue
+        sections_by_row_start[sec.grid_row].append((sid, sec))
+    if not sections_by_row_start:
+        return
+
+    deepest: tuple[float, float, str, str] | None = None
+    for usid, us in graph.sections.items():
+        if us.bbox_w <= 0 or us.bbox_h <= 0:
+            continue
+        next_row = us.grid_row + us.grid_row_span
+        for lsid, ls in sections_by_row_start.get(next_row, []):
+            if not (
+                us.bbox_x < ls.bbox_x + ls.bbox_w and ls.bbox_x < us.bbox_x + us.bbox_w
+            ):
+                continue
+            gap = ls.bbox_y - (us.bbox_y + us.bbox_h)
+            deficit = section_y_gap - gap
+            if deficit > tol and (deepest is None or deficit > deepest[0]):
+                deepest = (deficit, gap, usid, lsid)
+    if deepest is None:
+        return
+    deficit, gap, usid, lsid = deepest
+    raise PhaseInvariantError(
+        f"{phase}: row gap below required: sections {usid!r} (bottom) "
+        f"and {lsid!r} (top) overlap horizontally and are {gap:.1f}px "
+        f"apart, expected >= {section_y_gap:.1f}px "
+        f"(deficit {deficit:.1f}px)"
+    )
+
+
 def _station_marker_bbox(
     graph: MetroGraph,
     sid: str,
@@ -1368,6 +1410,7 @@ def _compute_section_layout(
         offsets, routes = _run_phase13_guards(graph, phase)
         _guard_row_trunk_cy_consistent(graph, phase, offsets=offsets)
         _guard_off_track_inputs_above_consumer(graph, phase)
+        _guard_row_gaps(graph, phase, section_y_gap=section_y_gap)
         if routes is not None:
             _guard_inter_section_routes_in_row_band(
                 graph, phase, offsets=offsets, routes=routes

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from nf_metro.layout.constants import SECTION_Y_GAP
 from nf_metro.layout.engine import compute_layout, is_loop_side_branch_station
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -940,6 +941,38 @@ def test_section_bbox_contains_all_content(fixture, params):
                 f"Section {sec_id}: station {sid} bottom={bot} "
                 f"(y={st.y}, half={half}) overflows bbox bottom "
                 f"y={section.bbox_y + section.bbox_h}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Adjacent-row sections that overlap horizontally must keep the configured
+# section_y_gap between upper bbox bottom and lower bbox top
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_row_gap_between_adjacent_rows(fixture):
+    """For every section pair in adjacent grid rows that share horizontal
+    extent, the bbox-to-bbox vertical gap must be at least
+    ``SECTION_Y_GAP``.
+    """
+    graph = _layout(fixture)
+    for usid, us in graph.sections.items():
+        if us.bbox_w <= 0 or us.bbox_h <= 0:
+            continue
+        next_row = us.grid_row + us.grid_row_span
+        for lsid, ls in graph.sections.items():
+            if ls.bbox_w <= 0 or ls.bbox_h <= 0 or ls.grid_row != next_row:
+                continue
+            if not (
+                us.bbox_x < ls.bbox_x + ls.bbox_w and ls.bbox_x < us.bbox_x + us.bbox_w
+            ):
+                continue
+            gap = ls.bbox_y - (us.bbox_y + us.bbox_h)
+            assert gap >= SECTION_Y_GAP - 0.5, (
+                f"row gap below required: {usid!r} (bottom) and {lsid!r} "
+                f"(top) overlap horizontally and are {gap:.1f}px apart, "
+                f"expected >= {SECTION_Y_GAP:.1f}px"
             )
 
 


### PR DESCRIPTION
## Summary

Adds the C13 row-gap inequality as a runtime invariant in
`compute_layout(validate=True)` and as a parametrised invariant test
across the full gallery.

- `_guard_row_gaps` in `src/nf_metro/layout/engine.py` raises
  `PhaseInvariantError` if any column-overlapping adjacent-row section
  pair has bbox-to-bbox vertical clearance below `section_y_gap`.
  The error names the deepest offending pair with observed and expected
  gaps.
- Wired into the final post-Phase-13m guard block alongside the
  existing trunk-cy / off-track / row-band guards.
- `test_row_gap_between_adjacent_rows` in
  `tests/test_layout_invariants.py` parametrises the same check over
  all 55 gallery fixtures; the test currently passes everywhere.

Fixes #354.

## Test plan

- [x] `pytest` (2120 passed, 4 pre-existing xfail, no regressions)
- [x] `ruff check src/ tests/` clean
- [x] New `test_row_gap_between_adjacent_rows` passes on all 55 gallery fixtures
- [x] Manual injection test: artificially shifting `plots.bbox_y` into `functional` on `da_pipeline.mmd` raises `PhaseInvariantError` with the expected (deepest pair, gap, deficit) message
- [ ] Render-preview verdict: no visual changes expected (guard is read-only)

Generated with Claude Code