### PR TITLE
fix(convert): accept unquoted labels and disambiguate duplicate process IDs (#249)

### DIFF
--- a/src/nf_metro/convert.py
+++ b/src/nf_metro/convert.py
@@ -72,11 +72,12 @@ _NF_SUBGRAPH = re.compile(
 # Also handle unquoted: subgraph " "
 _NF_SUBGRAPH_SPACE = re.compile(r'^subgraph\s+" "\s*$')
 
-# Stadium node: v1(["LABEL"])
-_NF_STADIUM = re.compile(r'^(v\d+)\(\["([^"]*?)"\]\)\s*$')
+# Stadium node: v1(["LABEL"]) or v1([LABEL]).
+# Nextflow <= 22 emitted quoted labels; 23+ emits unquoted ones.
+_NF_STADIUM = re.compile(r'^(v\d+)\(\["?([^"\]]*?)"?\]\)\s*$')
 
-# Square bracket node: v1["LABEL"]
-_NF_SQUARE = re.compile(r'^(v\d+)\["([^"]*?)"\]\s*$')
+# Square bracket node: v1["LABEL"] or v1[LABEL] (same quoting drift).
+_NF_SQUARE = re.compile(r'^(v\d+)\["?([^"\]]*?)"?\]\s*$')
 
 # Circle node: v1(( )) or v1(( label ))
 _NF_CIRCLE = re.compile(r"^(v\d+)\(\(\s*(.*?)\s*\)\)\s*$")
@@ -324,6 +325,34 @@ def _sanitize_id(name: str) -> str:
     return re.sub(r"[^a-z0-9_]", "_", name.lower()).strip("_")
 
 
+def _allocate_station_ids(
+    section_order: list[str],
+    section_node_order: dict[str, list[str]],
+    nodes: dict[str, _NfNode],
+) -> dict[str, str]:
+    """Assign a unique station ID to every kept Nextflow node.
+
+    Two `_NfNode`s can share a label (e.g. `SAMTOOLS_SORT` reused across
+    several subworkflows). Sanitising the label alone collapses them onto
+    one station ID, producing duplicate declarations and self-loop edges
+    that crash layout. Walk sections in topological order and suffix
+    subsequent occurrences (`samtools_sort`, `samtools_sort_2`, ...).
+    """
+    used: set[str] = set()
+    station_ids: dict[str, str] = {}
+    for sec_key in section_order:
+        for nid in section_node_order.get(sec_key, []):
+            base = _sanitize_id(nodes[nid].label) or "node"
+            candidate = base
+            suffix = 2
+            while candidate in used:
+                candidate = f"{base}_{suffix}"
+                suffix += 1
+            used.add(candidate)
+            station_ids[nid] = candidate
+    return station_ids
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -525,6 +554,11 @@ def convert_nextflow_dag(text: str, title: str = "") -> str:
                 ordered.append(n)
         section_node_order[sec_key] = ordered
 
+    # Assign one unique station ID per kept node so duplicate labels across
+    # sections (e.g. SAMTOOLS_SORT reused in several subworkflows) don't
+    # collide.
+    station_ids = _allocate_station_ids(section_order, section_node_order, dag.nodes)
+
     # Infer title
     if not title:
         if len(section_names) == 1 and "__pipeline" in section_names:
@@ -567,19 +601,18 @@ def convert_nextflow_dag(text: str, title: str = "") -> str:
         # Station declarations
         for nid in ordered_nodes:
             node = dag.nodes[nid]
-            station_id = _sanitize_id(node.label)
             label = _humanize_label(node.label)
-            out.append(f"        {station_id}([{label}])")
+            out.append(f"        {station_ids[nid]}([{label}])")
 
         # Intra-section edges
         sec_edges = intra_edges.get(sec_key, [])
         if sec_edges:
             out.append("")
             for src, tgt in sec_edges:
-                src_label = _sanitize_id(dag.nodes[src].label)
-                tgt_label = _sanitize_id(dag.nodes[tgt].label)
                 lid = edge_line.get((src, tgt), main_line_id)
-                out.append(f"        {src_label} -->|{lid}| {tgt_label}")
+                out.append(
+                    f"        {station_ids[src]} -->|{lid}| {station_ids[tgt]}"
+                )
 
         out.append("    end")
         out.append("")
@@ -592,10 +625,8 @@ def convert_nextflow_dag(text: str, title: str = "") -> str:
     if all_inter:
         out.append("    %% Inter-section edges")
         for src, tgt in all_inter:
-            src_label = _sanitize_id(dag.nodes[src].label)
-            tgt_label = _sanitize_id(dag.nodes[tgt].label)
             lid = edge_line.get((src, tgt), main_line_id)
-            out.append(f"    {src_label} -->|{lid}| {tgt_label}")
+            out.append(f"    {station_ids[src]} -->|{lid}| {station_ids[tgt]}")
 
     # Ensure trailing newline
     return "\n".join(out) + "\n"

--- a/src/nf_metro/convert.py
+++ b/src/nf_metro/convert.py
@@ -554,9 +554,6 @@ def convert_nextflow_dag(text: str, title: str = "") -> str:
                 ordered.append(n)
         section_node_order[sec_key] = ordered
 
-    # Assign one unique station ID per kept node so duplicate labels across
-    # sections (e.g. SAMTOOLS_SORT reused in several subworkflows) don't
-    # collide.
     station_ids = _allocate_station_ids(section_order, section_node_order, dag.nodes)
 
     # Infer title

--- a/src/nf_metro/convert.py
+++ b/src/nf_metro/convert.py
@@ -607,9 +607,7 @@ def convert_nextflow_dag(text: str, title: str = "") -> str:
             out.append("")
             for src, tgt in sec_edges:
                 lid = edge_line.get((src, tgt), main_line_id)
-                out.append(
-                    f"        {station_ids[src]} -->|{lid}| {station_ids[tgt]}"
-                )
+                out.append(f"        {station_ids[src]} -->|{lid}| {station_ids[tgt]}")
 
         out.append("    end")
         out.append("")

--- a/tests/fixtures/nextflow/duplicate_processes.mmd
+++ b/tests/fixtures/nextflow/duplicate_processes.mmd
@@ -5,20 +5,14 @@ flowchart TB
     subgraph "NFCORE_RNASEQ:BAM_SORT_STATS_SAMTOOLS [BAM_SORT_STATS_SAMTOOLS]"
     v1(["SAMTOOLS_SORT"])
     v2(["SAMTOOLS_INDEX"])
-    v3(["SAMTOOLS_STATS"])
     end
     subgraph "NFCORE_RNASEQ:BAM_SORT_STATS_SAMTOOLS_UNFILTERED [BAM_SORT_STATS_SAMTOOLS_UNFILTERED]"
-    v4(["SAMTOOLS_SORT"])
-    v5(["SAMTOOLS_INDEX"])
-    v6(["SAMTOOLS_STATS"])
+    v3(["SAMTOOLS_SORT"])
+    v4(["SAMTOOLS_INDEX"])
     end
-    v7(["MULTIQC"])
+    v5(["MULTIQC"])
     v0 --> v1
     v1 --> v2
-    v1 --> v3
-    v2 --> v4
+    v2 --> v3
+    v3 --> v4
     v4 --> v5
-    v4 --> v6
-    v5 --> v7
-    v6 --> v7
-    v3 --> v7

--- a/tests/fixtures/nextflow/duplicate_processes.mmd
+++ b/tests/fixtures/nextflow/duplicate_processes.mmd
@@ -1,0 +1,24 @@
+flowchart TB
+    subgraph " "
+    v0["Channel.of"]
+    end
+    subgraph "NFCORE_RNASEQ:BAM_SORT_STATS_SAMTOOLS [BAM_SORT_STATS_SAMTOOLS]"
+    v1(["SAMTOOLS_SORT"])
+    v2(["SAMTOOLS_INDEX"])
+    v3(["SAMTOOLS_STATS"])
+    end
+    subgraph "NFCORE_RNASEQ:BAM_SORT_STATS_SAMTOOLS_UNFILTERED [BAM_SORT_STATS_SAMTOOLS_UNFILTERED]"
+    v4(["SAMTOOLS_SORT"])
+    v5(["SAMTOOLS_INDEX"])
+    v6(["SAMTOOLS_STATS"])
+    end
+    v7(["MULTIQC"])
+    v0 --> v1
+    v1 --> v2
+    v1 --> v3
+    v2 --> v4
+    v4 --> v5
+    v4 --> v6
+    v5 --> v7
+    v6 --> v7
+    v3 --> v7

--- a/tests/fixtures/nextflow/unquoted_labels.mmd
+++ b/tests/fixtures/nextflow/unquoted_labels.mmd
@@ -1,0 +1,27 @@
+flowchart TB
+    subgraph " "
+    v0["Channel.of"]
+    v1["Channel.of"]
+    end
+    v2([FASTQC])
+    subgraph " "
+    v3[" "]
+    v12[" "]
+    end
+    v4([TRIM_READS])
+    v6([ALIGN])
+    v7([SORT_BAM])
+    v11([MULTIQC])
+    v5(( ))
+    v8(( ))
+    v0 --> v2
+    v0 --> v4
+    v1 --> v5
+    v2 --> v3
+    v2 --> v8
+    v4 --> v6
+    v5 --> v6
+    v6 --> v7
+    v7 --> v8
+    v8 --> v11
+    v11 --> v12

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -349,16 +349,12 @@ class TestDuplicateProcessLabels:
         text = (FIXTURES / "duplicate_processes.mmd").read_text()
         result = convert_nextflow_dag(text)
         decls = re.findall(r"^\s+([a-z0-9_]+)\(\[", result, re.MULTILINE)
-        assert len(decls) == len(set(decls)), (
-            f"Duplicate station declarations: {decls}"
-        )
+        assert len(decls) == len(set(decls)), f"Duplicate station declarations: {decls}"
 
     def test_no_self_loops(self):
         text = (FIXTURES / "duplicate_processes.mmd").read_text()
         result = convert_nextflow_dag(text)
-        for m in re.finditer(
-            r"([a-z0-9_]+)\s*-->\|[^|]+\|\s*([a-z0-9_]+)", result
-        ):
+        for m in re.finditer(r"([a-z0-9_]+)\s*-->\|[^|]+\|\s*([a-z0-9_]+)", result):
             assert m.group(1) != m.group(2), f"Self-loop edge: {m.group(0)}"
 
     def test_duplicates_lay_out(self):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -297,10 +298,118 @@ class TestConvertNextflowDag:
 
 
 # ---------------------------------------------------------------------------
+# Regression: unquoted labels (issue #249, Nextflow 23.x+)
+# ---------------------------------------------------------------------------
+class TestUnquotedLabels:
+    """Nextflow 23.x+ emits v1([LABEL]) without surrounding quotes.
+
+    Prior to issue #249, the stadium regex required quotes, so every process
+    node failed to match and convert silently returned an empty pipeline.
+    """
+
+    def test_unquoted_stadium_parses(self):
+        text = (
+            "flowchart TB\n"
+            '    v1["input"]\n'
+            "    v2([PROCESS_A])\n"
+            "    v3([PROCESS_B])\n"
+            '    v4[" "]\n'
+            "    v1 --> v2\n"
+            "    v2 --> v3\n"
+            "    v3 --> v4\n"
+        )
+        dag = _parse_nextflow_mermaid(text)
+        process_nodes = [n for n in dag.nodes.values() if n.shape == "stadium"]
+        assert len(process_nodes) == 2
+        assert {n.label for n in process_nodes} == {"PROCESS_A", "PROCESS_B"}
+
+    def test_unquoted_convert_non_empty(self):
+        text = (FIXTURES / "unquoted_labels.mmd").read_text()
+        result = convert_nextflow_dag(text)
+        assert "Empty Pipeline" not in result
+        assert "fastqc" in result
+        assert "trim_reads" in result
+        assert "multiqc" in result
+
+    def test_mixed_quoted_and_unquoted(self):
+        text = (
+            "flowchart TB\n"
+            '    v1(["QUOTED_PROC"])\n'
+            "    v2([UNQUOTED_PROC])\n"
+            "    v1 --> v2\n"
+        )
+        dag = _parse_nextflow_mermaid(text)
+        labels = {n.label for n in dag.nodes.values() if n.shape == "stadium"}
+        assert labels == {"QUOTED_PROC", "UNQUOTED_PROC"}
+
+
+# ---------------------------------------------------------------------------
+# Regression: duplicate process labels across subworkflows (issue #249)
+# ---------------------------------------------------------------------------
+class TestDuplicateProcessLabels:
+    """When two `_NfNode`s share a label, station IDs must stay distinct.
+
+    Prior to issue #249, `_sanitize_id(node.label)` collapsed both into one
+    station ID, producing duplicate declarations and self-loop edges that
+    crashed layout with NetworkXUnfeasible.
+    """
+
+    def test_no_duplicate_station_declarations(self):
+        text = (FIXTURES / "duplicate_processes.mmd").read_text()
+        result = convert_nextflow_dag(text)
+        decls = re.findall(r"^\s+([a-z0-9_]+)\(\[", result, re.MULTILINE)
+        assert len(decls) == len(set(decls)), (
+            f"Duplicate station declarations: {decls}"
+        )
+
+    def test_no_self_loops(self):
+        text = (FIXTURES / "duplicate_processes.mmd").read_text()
+        result = convert_nextflow_dag(text)
+        for m in re.finditer(
+            r"([a-z0-9_]+)\s*-->\|[^|]+\|\s*([a-z0-9_]+)", result
+        ):
+            assert m.group(1) != m.group(2), f"Self-loop edge: {m.group(0)}"
+
+    def test_duplicates_lay_out(self):
+        from nf_metro.layout import compute_layout
+        from nf_metro.parser import parse_metro_mermaid
+
+        text = (FIXTURES / "duplicate_processes.mmd").read_text()
+        mmd = convert_nextflow_dag(text)
+        graph = parse_metro_mermaid(mmd)
+        compute_layout(graph, x_spacing=60.0, y_spacing=40.0)
+
+    def test_unnamed_subgraph_duplicates_disambiguated(self):
+        text = (
+            "flowchart TB\n"
+            '    subgraph " "\n'
+            "    v1([PROC])\n"
+            "    end\n"
+            '    subgraph " "\n'
+            "    v2([PROC])\n"
+            "    end\n"
+            "    v1 --> v2\n"
+        )
+        result = convert_nextflow_dag(text)
+        decls = re.findall(r"^\s+([a-z0-9_]+)\(\[", result, re.MULTILINE)
+        assert len(decls) == 2 and len(set(decls)) == 2, (
+            f"Expected two distinct stations, got {decls}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Roundtrip: convert then parse through nf-metro
 # ---------------------------------------------------------------------------
 class TestRoundtrip:
-    @pytest.fixture(params=["flat_pipeline", "with_subworkflows", "variant_calling"])
+    @pytest.fixture(
+        params=[
+            "flat_pipeline",
+            "with_subworkflows",
+            "variant_calling",
+            "unquoted_labels",
+            "duplicate_processes",
+        ]
+    )
     def fixture_name(self, request):
         return request.param
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -301,11 +301,7 @@ class TestConvertNextflowDag:
 # Regression: unquoted labels (issue #249, Nextflow 23.x+)
 # ---------------------------------------------------------------------------
 class TestUnquotedLabels:
-    """Nextflow 23.x+ emits v1([LABEL]) without surrounding quotes.
-
-    Prior to issue #249, the stadium regex required quotes, so every process
-    node failed to match and convert silently returned an empty pipeline.
-    """
+    """Stadium nodes parse whether or not labels are wrapped in quotes."""
 
     def test_unquoted_stadium_parses(self):
         text = (
@@ -347,12 +343,7 @@ class TestUnquotedLabels:
 # Regression: duplicate process labels across subworkflows (issue #249)
 # ---------------------------------------------------------------------------
 class TestDuplicateProcessLabels:
-    """When two `_NfNode`s share a label, station IDs must stay distinct.
-
-    Prior to issue #249, `_sanitize_id(node.label)` collapsed both into one
-    station ID, producing duplicate declarations and self-loop edges that
-    crashed layout with NetworkXUnfeasible.
-    """
+    """Distinct nodes that share a label get distinct station IDs."""
 
     def test_no_duplicate_station_declarations(self):
         text = (FIXTURES / "duplicate_processes.mmd").read_text()


### PR DESCRIPTION
## Summary

- Loosen `_NF_STADIUM` and `_NF_SQUARE` regexes in `nf_metro/convert.py` to accept both quoted (`v1([\"LABEL\"])`) and unquoted (`v1([LABEL])`) labels. Nextflow 23.x+ emits the unquoted form, which the old regex rejected, so every process node failed to match and `nf-metro convert` silently returned `%%metro title: Empty Pipeline`.
- Allocate one unique station ID per kept Nextflow node via a new `_allocate_station_ids` helper. When the same process label appears in multiple subworkflows (e.g. `SAMTOOLS_SORT` reused across `BAM_SORT_STATS_SAMTOOLS` / `BAM_SORT_STATS_SAMTOOLS_UNFILTERED`), `_sanitize_id(node.label)` previously collapsed them into a single station ID, producing duplicate declarations and self-loop edges that crashed layout with `NetworkXUnfeasible`. Subsequent occurrences are now suffixed (`samtools_sort`, `samtools_sort_2`, ...).
- Add two regression fixtures (`unquoted_labels.mmd`, `duplicate_processes.mmd`) plus a `TestUnquotedLabels` and `TestDuplicateProcessLabels` suite, and extend the roundtrip parametrization to cover them.

Fixes #249

## Test plan
- [x] pytest passes (2133 tests, 4 known xfails)
- [x] ruff check + ruff format clean on src/ and tests/ (CI's lint scope)
- [x] Issue's minimal reproducer now produces a non-empty pipeline
- [x] Multi-subworkflow duplicate-process pipeline now lays out without raising

Generated with Claude Code