### PR TITLE
refactor(layout): introduce six-stage grouping and flat Stage X.Y naming

### DIFF
--- a/docs/dev/layout_pipeline.md
+++ b/docs/dev/layout_pipeline.md
@@ -1,0 +1,234 @@
+# Layout pipeline
+
+A reader-friendly walkthrough of how nf-metro turns a parsed metro graph
+into placed coordinates.  If you're hunting a layout bug, fixing a
+visual regression, or adding a new transformation pass, start here.
+
+For the rigorous per-sub-stage contract (preconditions,
+postconditions, invariants preserved, related tests), see
+[`src/nf_metro/layout/CONTRACT.md`](https://github.com/pinin4fjords/nf-metro/blob/main/src/nf_metro/layout/CONTRACT.md).
+For the source itself, the orchestrator is `_compute_section_layout`
+in `src/nf_metro/layout/engine.py`.
+
+## What "layout" means here
+
+Parsing produces a `MetroGraph` with sections, stations, edges, lines,
+and ports - but with no coordinates yet (other than the optional
+`%%metro grid:` directives).  The layout pipeline assigns every station,
+port, junction, and section bbox an `(x, y)` on the canvas, subject to:
+
+- Sections don't overlap each other.
+- Stations sit inside their section's bbox.
+- Ports sit on their section's bbox edge.
+- Lines route between connected stations without crossing unrelated
+  station markers.
+- Same-row sections share a trunk Y so the inter-section bundle stays
+  horizontal across boundaries.
+- A bunch of other invariants documented in
+  `tests/test_layout_invariants.py`.
+
+Achieving all of this in one pass is intractable - some constraints are
+naturally local (each section's internal layout) and some are global
+(trunk Y alignment across an entire row).  The pipeline solves this by
+chaining many small passes, each of which mutates the graph and
+preserves the invariants of preceding passes.
+
+## The six stages
+
+The pipeline groups into six stages.  Stage boundaries align with
+coord-regime transitions (when station coordinates become global,
+when ports become positioned) and with the traditional Pass A / Pass B
+/ Pass C divisions referenced throughout the codebase.
+
+### Stage 1 - Section construction (local coords)
+
+Lay out each section's internal stations on its own private coordinate
+system, then place the sections on the global grid (still local-coord).
+
+- **Stage 1.1**: Lay out each section independently via layer / track
+  assignment (real stations only; ports and junctions stay
+  unpositioned).
+- **Stage 1.2**: Snap same-row, same-direction sections to a shared Y
+  grid so they agree on pitch and slot count.
+- **Stage 1.3**: Place sections on the canvas grid by topological
+  layering of the section DAG.
+- **Stage 1.4**: Renumber sections by visual reading order (column
+  first, then row) so the legend numbering follows the eye.
+- **Stage 1.5**: Grow `x_offset` / `y_offset` if section local extents
+  overshoot the canvas origin.
+
+At the end of Stage 1, every section has a `(local_x, local_y, w, h)`
+bbox and an `(offset_x, offset_y)` placement.  No global coords yet.
+
+### Stage 2 - Globalise (local -> global coords)
+
+A single-step coord-regime transition.
+
+- **Stage 2.1**: Translate every real station's `(x, y)` and every
+  section's bbox into global canvas coordinates.
+
+After this, all subsequent stages operate in global coords.  Ports and
+junctions still have no positions.
+
+### Stage 3 - Pass A: port initialisation & section geometry
+
+Ports first appear on bbox edges, then get aligned with their incoming /
+outgoing connections, then the section layout is adjusted to accommodate
+them.
+
+- **Stage 3.1**: Position every port on its section's bbox edge at the
+  edge midpoint.
+- **Stage 3.2**: Align LEFT / RIGHT entry ports to the incoming source
+  Y so the inter-section horizontal run is straight; align TOP / BOTTOM
+  entry ports analogously.
+- **Stage 3.3**: For LR / RL sections with perpendicular (TOP / BOTTOM)
+  entry, shift internal stations' X so the entry port has runway
+  before stations begin.
+- **Stage 3.4**: Align LEFT / RIGHT exit ports on row-spanning (fold)
+  sections with the target section's Y.
+- **Stage 3.5**: Top-align sections within each grid row so contiguous
+  column groups share their bbox tops.
+
+Pass A leaves ports on bbox edges with first-approximation alignment.
+Subsequent passes refine.
+
+### Stage 4 - Pass B: downstream alignment & trunk-Y consolidation
+
+Pull ports toward downstream stations to remove unnecessary detours;
+consolidate the inter-section trunk Y across each row; redistribute
+fan-out and full-bundle columns around the trunk.
+
+- **Stage 4.1**: For non-fold LR / RL sections, pull exit-entry port
+  pairs toward the downstream section's connected station Y.
+- **Stages 4.2 to 4.4**: Snap port pairs to grid-group / sole-layer
+  station Ys so port-to-station connections are horizontal.
+- **Stage 4.5**: Ensure ports maintain at least `y_spacing` from
+  terminus stations so file icons don't overlap routed lines.
+  (May expand bboxes.)
+- **Stages 4.6 to 4.7**: Recompute grid-group bboxes; re-run row
+  top-align after the Stage 4.5 expansions.
+- **Stage 4.8**: Align trunk Ys across same-row sections.  Shifts
+  shallower sections' content down so the inter-section bundle passes
+  through at a single Y per row.
+- **Stages 4.9 to 4.10**: Redistribute fan-out siblings and full-bundle
+  columns symmetrically around the trunk.  Both gated on `center_ports`.
+
+By the end of Pass B, all port Ys are final.
+
+### Stage 5 - Pass C: junctions & off-track lift
+
+Position junctions for the first time, lift off-track file inputs above
+their consumers, then a few post-lift fixups.
+
+- **Stage 5.1**: Position every junction station in the inter-section
+  gap.  Fan-out junctions sit at the exit port's Y; merge junctions sit
+  near the entry port.
+- **Stage 5.2**: Lift off-track stations (file inputs that should sit
+  above the trunk, not on it) to the row above their consumer, growing
+  bboxes upward.
+- **Stages 5.3 to 5.4**: Re-align row bbox tops to match the lifted
+  sections, then compact each row's content to its bbox top.
+- **Stage 5.5**: Snap inter-section LR / RL port pairs to a shared Y
+  (the compaction in Stage 5.4 may have drifted them) and re-position
+  junctions to follow.
+
+### Stage 6 - Pass C: vertical settling & finishing
+
+The long settle.  17 sub-stages clean up the consequences of Stages 1
+through 5, snap everything to the grid, restore invariants broken by
+each cleanup pass, then handle the final geometric details (loop-side
+X recenter, bbox shrink, captioned-icon spacing).
+
+- **Stages 6.1 to 6.3**: Fan free content / source inputs upward into
+  empty top bands; collapse 2-branch symmetric fans onto half-grid
+  offsets (gated on `center_ports`).
+- **Stage 6.4**: Snap every station and port Y to the row's grid
+  pitch, removing fractional drift from earlier passes.
+- **Stages 6.5 to 6.6**: Grow TB-section bbox bottoms to match
+  downstream LR / RL targets; re-anchor off-track inputs to their
+  consumers' post-snap Y.
+- **Stages 6.7 to 6.9**: Re-center full-bundle columns around the
+  row's final trunk Y; restore the off-track-above-consumer and row
+  top-align invariants that the recenter breaks.  All gated on
+  `center_ports`.
+- **Stages 6.10 to 6.12**: Pin single-station downstream columns to
+  their unique upstream Y; auto-balance content around the trunk;
+  re-center loop-side stations on their loop midpoint (X-axis pass).
+- **Stages 6.13 to 6.16**: Shrink bbox bottoms to content, close
+  vertical slack between rows; shift sparse loop-side stations onto
+  half-pitch Ys to clear bundle pass-throughs; push lower rows down
+  when those shifts grew a bbox.
+- **Stage 6.17**: Pad stacked captioned file-icon columns so
+  under-icon captions don't overlap the icon below.
+
+Stage 6 is where most of the historical organic-suffix sprawl (the old
+13d / 13d2 / 13h.1 / 13k2 names) lived.  The flat Stage.N scheme makes
+the sequence walkable; the per-sub-stage CONTRACT.md entries explain
+each one's necessity.
+
+## Passes vs stages
+
+The codebase has two overlapping group labels.  They are not redundant
+- they encode different axes of the structure:
+
+- **Stage** (1-6) groups by **what kind of mutation** the pass
+  performs: section construction, globalisation, port positioning,
+  port refinement, junctions / off-track lift, vertical settling.
+- **Pass** (A / B / C) groups by **how much of the layout is final**
+  when the pass runs.  Pass A operates on a fresh station layout to
+  position ports.  Pass B refines ports on a fixed station layout.
+  Pass C operates on finalised stations and ports.
+
+The Stage and Pass labels line up cleanly:
+
+| Pass | Stages |
+|---|---|
+| Pre-pass setup | 1, 2 |
+| Pass A | 3 |
+| Pass B | 4 |
+| Pass C | 5, 6 |
+
+## When something breaks
+
+Common scenarios and where to start looking:
+
+- **A station moved when it shouldn't have**: which stage's
+  postcondition does it violate?  Run `pytest tests/test_layout_invariants.py`
+  - the failing invariant's "related tests" entry in CONTRACT.md
+  names the stage that establishes the relevant property.
+- **A guard fired with `after Stage X.Y: ...` at `validate=True`**:
+  Stage X.Y is the *latest* sub-stage where the invariant could
+  still have been broken.  Bisect by toggling preceding sub-stages.
+- **A guard fired with `after final: ...`**: the invariant only
+  holds at the very end, so the regression could be anywhere in
+  Pass C.  Run with `validate=True` and use the per-checkpoint
+  bisection (`_run_pass_c_guards`) to localise.
+- **A new fixture lays out badly**: render it with `nf-metro render`,
+  inspect the SVG against the stage descriptions above to guess
+  which stage handles the problem area, then read the corresponding
+  sub-stage entry in CONTRACT.md.
+
+## Why so many sub-stages
+
+The Pass C tail (Stages 6.1 to 6.17) looks excessive at first glance.
+Each sub-stage exists because:
+
+1. A bug was found in some real-world fixture.
+2. A targeted helper was written to fix it.
+3. The helper was placed at the point in the pipeline where it has
+   the inputs it needs and won't disrupt earlier-established
+   invariants.
+
+Some sub-stages exist purely to **restore** an invariant that an
+earlier sub-stage broke (e.g. Stages 6.8 and 6.9 restore the
+off-track-above-consumer and row-top-align invariants that Stage 6.7's
+full-bundle recenter breaks).  These "repair-only" sub-stages are
+candidates for being folded back into the breaking stage, but each
+fold is per-pair investigation and risks regressing other pipelines.
+
+The flat Stage.N numbering replaces an earlier organic suffix tree
+(`Phase 13`, `13a`, `13d2`, `13h.1`, `13k2`, ...) that grew suffixes
+each time a sub-stage was inserted between two existing ones.  The new
+scheme keeps the same ordering but makes the sequence walkable; the
+historical context lives in the git log and in the "Adding a new stage"
+section of CONTRACT.md.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,3 +42,5 @@ nav:
   - Nextflow Import: nextflow.md
   - nf-core Pipelines: pipelines/index.md
   - Gallery: gallery/index.md
+  - Internals:
+    - Layout pipeline: dev/layout_pipeline.md

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -52,7 +52,7 @@ Stages split into three regimes:
 | after Stage 2.1 | finite coords, stations-in-sections, bboxes-positive |
 | after Stage 3.1 | ports-on-boundaries |
 | after top-align (Stage 3.5) | ports-on-boundaries |
-| after each Stage 5.2x (bisection) | finite coords, bboxes-positive, ports-on-boundaries, station-x-column-drift, plus three phase-gated guards (see below) |
+| after each Pass C sub-stage (bisection) | finite coords, bboxes-positive, ports-on-boundaries, station-x-column-drift, plus three phase-gated guards (see below) |
 | after final | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
 Bisection checkpoints fire after every Pass C sub-stage (see the
@@ -77,25 +77,13 @@ bisection runner is `_run_pass_c_guards`.
 
 ## Stage overview
 
-The pipeline groups into six stages.  Stage boundaries align with the
-coord-regime transitions and the Pass A / Pass B / Pass C divisions
-referenced throughout this doc.
-
-1. **Stage 1 - Section construction (local coords)**: Stages 1.1
-   through 1.5.
-2. **Stage 2 - Globalise (local -> global coords)**: Stage 2.1.
-3. **Stage 3 - Pass A: port initialisation & section geometry**:
-   Stages 3.1 through 3.5.
-4. **Stage 4 - Pass B: downstream alignment & trunk-Y consolidation**:
-   Stages 4.1 through 4.10.
-5. **Stage 5 - Pass C: junctions & off-track lift**: Stages 5.1
-   through 5.5.
-6. **Stage 6 - Pass C: vertical settling & finishing**: Stages 6.1
-   through 6.17.
-
-The matching `# ---- Stage N - ... ----` comment dividers in
-`_compute_section_layout` mark each stage's start in the source.
-Stage-table entries below appear in pipeline order.
+The pipeline groups into six stages aligned with the coord-regime
+transitions and the Pass A / Pass B / Pass C divisions used throughout
+this doc.  See [`docs/dev/layout_pipeline.md`](../../../docs/dev/layout_pipeline.md)
+for a prose walkthrough of each stage; the matching
+`# ---- Stage N - ... ----` comment dividers in `_compute_section_layout`
+mark each stage's start in the source.  Stage-table entries below appear
+in pipeline order.
 
 ## Stage table
 
@@ -276,7 +264,7 @@ Stage-table entries below appear in pipeline order.
 - **Related tests**: `test_section_entry_hub_on_grid` (downstream).
 
 ### Stage 4.3: snap grid-group entry ports (engine.py:611-615)
-- **Purpose**: For grid-group sections (skipped by 10b), snap entry
+- **Purpose**: For grid-group sections (skipped by Stage 4.2), snap entry
   ports to the connected first-internal-station Y - straight
   port-to-station connection.
 - **Helper**: `_snap_grid_group_entry_ports` (engine.py:5237).
@@ -286,10 +274,10 @@ Stage-table entries below appear in pipeline order.
 - **Invariants preserved**: Internal station Y. Exit ports.
 
 ### Stage 4.4: snap grid-group exit ports (engine.py:617-621)
-- **Purpose**: Mirror of 10c for exit ports - snap to the downstream
-  entry port's Y (which 10c just snapped to a grid station).
+- **Purpose**: Mirror of Stage 4.3 for exit ports - snap to the downstream
+  entry port's Y (which Stage 4.3 just snapped to a grid station).
 - **Helper**: `_snap_grid_group_exit_ports` (engine.py:5284).
-- **Precondition**: 10c complete (downstream entry ports snapped).
+- **Precondition**: Stage 4.3 complete (downstream entry ports snapped).
 - **Postcondition**: Grid-group exit ports share Y with their
   downstream entry port (i.e. with the downstream's connected
   station).
@@ -299,7 +287,7 @@ Stage-table entries below appear in pipeline order.
 - **Purpose**: Push ports away from terminus stations so a routed
   line clears any file-icon caption / label by at least `y_spacing`.
 - **Helper**: `_space_ports_from_termini` (engine.py:5695).
-- **Precondition**: Port Ys settled by Phases 10-10d.
+- **Precondition**: Port Ys settled by Stages 4.1 to 4.4.
 - **Postcondition**: For every (port, terminus) pair in the same
   section, `|port.y - terminus.y| >= y_spacing` (modulo bbox bounds).
   Bboxes may expand via `_expand_bbox_for_y` to keep ports on edges.
@@ -320,7 +308,7 @@ Stage-table entries below appear in pipeline order.
 - **Purpose**: Repeat Stage 3.5 after Stage 4.5 expanded bboxes via
   `_expand_bbox_for_y`.
 - **Helper**: `_top_align_row_sections` (re-invoked).
-- **Precondition**: Stage 4.5/11b complete.
+- **Precondition**: Stages 4.5 / 4.6 complete.
 - **Postcondition**: As Stage 3.5.
 - **Invariants preserved**: As Stage 3.5.
 
@@ -358,13 +346,13 @@ Stage-table entries below appear in pipeline order.
   LR port Y.
 - **Why both this and Stage 6.7**: Stage 6.7
   (``_recenter_full_bundle_columns``) re-fans the same columns
-  using the final trunk Y, which can have drifted from 11da's
+  using the final trunk Y, which can have drifted from Stage 4.10's
   port-Y anchor.  Stage 4.10's output is *not* redundant: the
-  intermediate symmetric layout is read by Stage 5.2's bbox-growth
+  intermediate symmetric layout is read by Pass C's bbox-growth
   and compaction passes (an empty trunk row in fanned columns lets
-  13b/13j shrink the section bbox to the compact extent).
-  Skipping 11da changes intermediate bbox sizes and is not empty-
-  render-diff -- the two passes are load-bearing in combination.
+  Stages 5.4 / 6.13 shrink the section bbox to the compact extent).
+  Skipping Stage 4.10 changes intermediate bbox sizes and is not
+  empty-render-diff -- the two passes are load-bearing in combination.
 - **Invariants preserved**: Other columns.
 
 ### Stage 5.1: position junctions (engine.py:658-659)
@@ -447,11 +435,11 @@ Stage-table entries below appear in pipeline order.
   `test_section1_input_above_trunk`.
 
 ### Stage 6.2: fan source inputs upward (engine.py:695-700)
-- **Purpose**: Companion to 13d for source-stack sections (single
+- **Purpose**: Companion to Stage 6.1 for source-stack sections (single
   full-bundle trunk + subset-bundle file inputs at the entry column).
   Lift trunk-nearest source inputs into the empty top band.
 - **Helper**: `_fan_source_inputs_upward` (engine.py:1852).
-- **Precondition**: 13d done.
+- **Precondition**: Stage 6.1 done.
 - **Postcondition**: Section is top- and bottom-weighted around the
   trunk row instead of stacked below it.
 - **Invariants preserved**: Trunk station Y.
@@ -464,7 +452,7 @@ Stage-table entries below appear in pipeline order.
   field so Stage 6.4 leaves them alone -- this is the only cross-
   phase channel for half-grid placement. Gated on `center_ports`.
 - **Helper**: `_apply_half_grid_2branch_symfan`.
-- **Precondition**: 13d/13d2 done; symfan classification stable
+- **Precondition**: Stages 6.1 / 6.2 done; symfan classification stable
   (`_section_symfan_uses_half_grid`).
 - **Postcondition**: Eligible symfan pairs share half-pitch offsets
   from the trunk Y. `graph.half_grid_station_ids` contains their IDs.
@@ -551,7 +539,7 @@ Stage-table entries below appear in pipeline order.
 - **Invariants preserved**: Station Ys (only bbox tops move).
 
 ### Stage 6.10: align terminus to upstream (engine.py:759-763)
-- **Purpose**: After 13h re-pitched fanned columns, a single-station
+- **Purpose**: After Stage 6.7 re-pitched fanned columns, a single-station
   downstream column (e.g. a `file` terminus) may have stayed at its
   pre-fan Y. Pin it back onto its sole upstream's Y.
 - **Helper**: `_align_terminus_to_upstream` (engine.py:3860).
@@ -605,9 +593,9 @@ Stage-table entries below appear in pipeline order.
 ### Stage 6.14: tighten lower rows after shrink (engine.py:789-794)
 - **Purpose**: Pull lower-row sections up to close vertical slack left
   by the pre-shrink row-height estimate when rowspan sections
-  collapsed via 13j.
+  collapsed via Stage 6.13.
 - **Helper**: `_tighten_lower_rows_after_shrink` (engine.py:3802).
-- **Precondition**: 13j shrank some rowspan sections.
+- **Precondition**: Stage 6.13 shrank some rowspan sections.
 - **Postcondition**: For each row pair, the row gap is
   `section_y_gap` (no more, no less, except where rowspan sections
   filled their full row claim).
@@ -630,7 +618,7 @@ Stage-table entries below appear in pipeline order.
   `test_no_icon_overlaps_line_path`.
 
 ### Stage 6.16: push lower rows after bbox grow (engine.py:802-806)
-- **Purpose**: Companion to 13k2 - when 13k2 grew a section's bbox
+- **Purpose**: Companion to Stage 6.15 - when Stage 6.15 grew a section's bbox
   downward, push lower-row sections down to keep
   `section_y_gap`.
 - **Helper**: `_push_lower_rows_after_bbox_grow` (engine.py:2698).

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -1,44 +1,45 @@
-# Layout Phase Contract
+# Layout Stage Contract
 
-Per-phase pre/postconditions for `_compute_section_layout` in
+Per-stage pre/postconditions for `_compute_section_layout` in
 `src/nf_metro/layout/engine.py`. The pipeline is a long chain of mutating
 passes over a shared `MetroGraph`; this doc records what each pass assumes
-and what it guarantees, so that adding or reordering a phase doesn't
+and what it guarantees, so that adding or reordering a stage doesn't
 silently violate a downstream pass's expectations.
 
 ## How to read this doc
 
-- **Phase tag** matches the `# Phase N[suffix]` comments inside
-  `_compute_section_layout`. Suffixes (`13d2`, `13ca`, ...) reflect
-  organic history; treat them as opaque identifiers, not a hierarchy.
-- **Lines** point at the entry comment of the phase in `engine.py` at the
-  current HEAD. Re-grep `# Phase N` if the file shifts.
-- **Precondition** = what the helper assumes. Pass-A phases assume
-  global coordinates and ports on bbox edges; Pass-C phases assume
+- **Stage tag** matches the `# Stage X.Y:` comments inside
+  `_compute_section_layout`. The first digit is the stage number (1-6,
+  see "Stage overview" below); the second is sequential within the
+  stage.
+- **Lines** point at the entry comment of the stage in `engine.py` at the
+  current HEAD. Re-grep `# Stage ` if the file shifts.
+- **Precondition** = what the helper assumes. Pass-A stages assume
+  global coordinates and ports on bbox edges; Pass-C stages assume
   finalised station Ys.
-- **Postcondition** = the property the phase establishes (and that
-  later phases may depend on).
-- **Invariants preserved** = state the phase does NOT touch. Useful when
-  asking "can I move this phase earlier?"
+- **Postcondition** = the property the stage establishes (and that
+  later stages may depend on).
+- **Invariants preserved** = state the stage does NOT touch. Useful when
+  asking "can I move this stage earlier?"
 - **Related tests** = invariants in `tests/test_layout_invariants.py`
   that exercise the postcondition. Many tests are full-pipeline
-  end-to-end checks (no single phase owns them outright); the mapping is
-  "this phase is the one that establishes the property the test
-  asserts," not "this test fails iff this phase regresses."
+  end-to-end checks (no single stage owns them outright); the mapping is
+  "this stage is the one that establishes the property the test
+  asserts," not "this test fails iff this stage regresses."
 
-A phase whose purpose isn't crisp here is a structural-debt signal -
+A stage whose purpose isn't crisp here is a structural-debt signal -
 those rows are flagged "UNCLEAR" in the Notes column. Don't paper over
-them; investigate before adding another phase next to them.
+them; investigate before adding another stage next to them.
 
 ## Coordinate-system convention
 
-Phases split into three regimes:
+Stages split into three regimes:
 
-1. **Pre-Phase-4**: stations have section-local coordinates. Bboxes are
+1. **Pre-Stage-2.1**: stations have section-local coordinates. Bboxes are
    in local coordinates.
-2. **Post-Phase-4**: stations and bboxes are in global canvas
+2. **Post-Stage-2.1**: stations and bboxes are in global canvas
    coordinates. Ports do not yet exist on bbox edges.
-3. **Post-Phase-5**: ports sit on bbox edges (validated by
+3. **Post-Stage-3.1**: ports sit on bbox edges (validated by
    `_guard_ports_on_boundaries`).
 
 ## Validate-mode guards
@@ -47,60 +48,58 @@ Phases split into three regimes:
 
 | Checkpoint | Guards |
 |---|---|
-| after Phase 2 | `_guard_section_bboxes_positive` |
-| after Phase 4 | finite coords, stations-in-sections, bboxes-positive |
-| after Phase 5 | ports-on-boundaries |
-| after top-align (Phase 9) | ports-on-boundaries |
-| after each Phase 13x (bisection) | finite coords, bboxes-positive, ports-on-boundaries, station-x-column-drift, plus three phase-gated guards (see below) |
-| after Phase 12 (final) | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
+| after Stage 1.1 | `_guard_section_bboxes_positive` |
+| after Stage 2.1 | finite coords, stations-in-sections, bboxes-positive |
+| after Stage 3.1 | ports-on-boundaries |
+| after top-align (Stage 3.5) | ports-on-boundaries |
+| after each Stage 5.2x (bisection) | finite coords, bboxes-positive, ports-on-boundaries, station-x-column-drift, plus three phase-gated guards (see below) |
+| after final | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
-Bisection checkpoints fire after every Phase-13x sub-phase (see the
-`# Phase 13...` comments in `_compute_section_layout`). Three guards
+Bisection checkpoints fire after every Pass C sub-stage (see the
+`# Stage 5.2:` through `# Stage 6.17:` comments in
+`_compute_section_layout`). Three guards
 hold continuously only from a specific checkpoint onward, and the
 bisection runner skips them earlier; see `_BISECTION_FIRST_VALID` in
 `engine.py` for the threshold table:
 
 | Guard | First valid checkpoint | Transient because |
 |---|---|---|
-| `_guard_stations_in_sections` | after Phase 13a | Phase 13's off-track lift moves stations above the section bbox; Phase 13a grows the bbox to enclose them. |
-| `_guard_no_station_overlap` | after Phase 13g | Phase 13e's snap-to-grid can land an off-track terminus icon on its on-track column-mate's Y; Phase 13g re-anchors the off-track above its consumer. |
-| `_guard_no_line_crosses_non_consumer` | after Phase 13k2 | A sparse loop-side station sits on the trunk Y until Phase 13k2 shifts it to a half-grid offset; before that, sibling line bundles pass through its marker bbox. |
+| `_guard_stations_in_sections` | after Stage 5.3 | Stage 5.2's off-track lift moves stations above the section bbox; Stage 5.3 grows the bbox to enclose them. |
+| `_guard_no_station_overlap` | after Stage 6.6 | Stage 6.4's snap-to-grid can land an off-track terminus icon on its on-track column-mate's Y; Stage 6.6 re-anchors the off-track above its consumer. |
+| `_guard_no_line_crosses_non_consumer` | after Stage 6.15 | A sparse loop-side station sits on the trunk Y until Stage 6.15 shifts it to a half-grid offset; before that, sibling line bundles pass through its marker bbox. |
 
 Three further guards are excluded from the bisection set entirely
-(meaningful only at the final boundary); the `_run_phase13_guards`
+(meaningful only at the final boundary); the `_run_pass_c_guards`
 docstring in `engine.py` is the authoritative list.
 
 Guard bodies live at the top of `engine.py` (lines 83-275); the
-bisection runner is `_run_phase13_guards`.
+bisection runner is `_run_pass_c_guards`.
 
 ## Stage overview
 
-The phase pipeline groups into six stages.  Stage boundaries align with
-the coord-regime transitions and the Pass A / Pass B / Pass C
-divisions referenced throughout this doc.
+The pipeline groups into six stages.  Stage boundaries align with the
+coord-regime transitions and the Pass A / Pass B / Pass C divisions
+referenced throughout this doc.
 
-1. **Stage 1 - Section construction (local coords)**: Phases 2, 2.5,
-   3, 3a, 3b.
-2. **Stage 2 - Globalise (local -> global coords)**: Phase 4.
+1. **Stage 1 - Section construction (local coords)**: Stages 1.1
+   through 1.5.
+2. **Stage 2 - Globalise (local -> global coords)**: Stage 2.1.
 3. **Stage 3 - Pass A: port initialisation & section geometry**:
-   Phases 5, 6, 7, 8, 9.
+   Stages 3.1 through 3.5.
 4. **Stage 4 - Pass B: downstream alignment & trunk-Y consolidation**:
-   Phases 10, 10b, 10c, 10d, 11, 11b, 11c, 11ca, 11d, 11da.
-5. **Stage 5 - Pass C: junctions & off-track lift**: Phases 12, 13,
-   13a, 13b, 13c.
-6. **Stage 6 - Pass C: vertical settling & finishing**: Phases 13d,
-   13d2, 13d3, 13e, 13f, 13g, 13h, 13h.1, 13h.2, 13i, 13i2, 13h3, 13j,
-   13k, 13k2, 13l, 13m.
+   Stages 4.1 through 4.10.
+5. **Stage 5 - Pass C: junctions & off-track lift**: Stages 5.1
+   through 5.5.
+6. **Stage 6 - Pass C: vertical settling & finishing**: Stages 6.1
+   through 6.17.
 
 The matching `# ---- Stage N - ... ----` comment dividers in
 `_compute_section_layout` mark each stage's start in the source.
-Phase-table entries below appear in pipeline order; stage boundaries
-fall between Phase 3b/4, Phase 4/5, Phase 9/10, Phase 11da/12, and
-Phase 13c/13d.
+Stage-table entries below appear in pipeline order.
 
-## Phase table
+## Stage table
 
-### Phase 2: internal section layout (engine.py:483-490)
+### Stage 1.1: internal section layout (engine.py:483-490)
 - **Purpose**: Lay out each section's real stations in section-local
   coordinates via layer/track assignment.
 - **Helper**: `_layout_single_section` (engine.py:3917).
@@ -117,15 +116,15 @@ Phase 13c/13d.
 - **Related tests**: `test_section_bbox_contains_all_content`,
   `test_loop_column_stations_share_x`.
 
-### Phase 2.5: align row Y grids (engine.py:495-496)
+### Stage 1.2: align row Y grids (engine.py:495-496)
 - **Purpose**: Snap station Ys to a shared row-wide grid so same-row
   same-direction sections agree on grid pitch and slot count.
 - **Helper**: `_align_row_y_grids` (engine.py:958).
-- **Precondition**: Phase 2 complete; sections still in local
+- **Precondition**: Stage 1.1 complete; sections still in local
   coordinates; section subgraphs available.
 - **Postcondition**: Within each `(grid_row, direction)` group, all
   multi-station layers share one Y grid. Bbox `w/h` unchanged from
-  Phase 2 (only station Ys shift). `graph._row_y_grid_info` stores
+  Stage 1.1 (only station Ys shift). `graph._row_y_grid_info` stores
   grid metadata for the debug overlay.
 - **Invariants preserved**: Isolated stations (sole layer occupants
   with off-grid Y) keep original Y - hub centering survives. Section
@@ -133,18 +132,18 @@ Phase 13c/13d.
 - **Related tests**: `test_row_trunk_marker_cy_consistent`,
   `test_all_stations_snap_to_grid`.
 
-### Phase 3: section placement (engine.py:498-499)
+### Stage 1.3: section placement (engine.py:498-499)
 - **Purpose**: Place sections on the canvas grid via topological
   layering of the section DAG.
 - **Helper**: `place_sections` in `section_placement.py`.
-- **Precondition**: Sections have bboxes from Phase 2 and grid
+- **Precondition**: Sections have bboxes from Stage 1.1 and grid
   positions from `auto_layout`. Still all local-coord.
 - **Postcondition**: Every section has `offset_x`, `offset_y` set such
   that `(local + offset)` lands sections on a non-overlapping grid.
 - **Invariants preserved**: Station local coords unchanged. Bboxes
   still local-coord.
 
-### Phase 3a: renumber sections (engine.py:501-502)
+### Stage 1.4: renumber sections (engine.py:501-502)
 - **Purpose**: Renumber sections by visual reading order (sweep, col,
   row) so legend / debug numbering follows the eye.
 - **Helper**: `_renumber_sections_by_grid` (engine.py:824).
@@ -155,10 +154,10 @@ Phase 13c/13d.
   edges. Pure metadata pass.
 - **Related tests**: none directly (cosmetic / debug-only).
 
-### Phase 3b: offset overshoot correction (engine.py:504-535)
+### Stage 1.5: offset overshoot correction (engine.py:504-535)
 - **Purpose**: Grow `x_offset`/`y_offset` when section local extents
   reach left/above the canvas origin, so global coords stay positive
-  after Phase 4.
+  after Stage 2.1.
 - **Helper**: inline.
 - **Precondition**: Section `offset_x/y` and local `bbox_x/y` set.
 - **Postcondition**: For every laid-out section, `offset_{x,y} +
@@ -166,11 +165,11 @@ Phase 13c/13d.
 - **Invariants preserved**: Section bboxes (local), station local
   coords, grid layout.
 
-### Phase 4: local-to-global translation (engine.py:537-557)
+### Stage 2.1: local-to-global translation (engine.py:537-557)
 - **Purpose**: Translate every real station and section bbox into
   global canvas coordinates.
 - **Helper**: inline.
-- **Precondition**: Phase 3 / 3b complete; `section.offset_{x,y}`,
+- **Precondition**: Stage 1.3 / 3b complete; `section.offset_{x,y}`,
   `x_offset`, `y_offset` final.
 - **Postcondition**: Every real station's `x, y` and every section's
   `bbox_x, bbox_y` are global. `bbox_w, bbox_h` unchanged. Section
@@ -182,11 +181,11 @@ Phase 13c/13d.
 - **Related tests**: `test_section_bbox_contains_all_content` (the
   containment invariant first holds here).
 
-### Phase 5: position ports on section boundaries (engine.py:565-570)
+### Stage 3.1: position ports on section boundaries (engine.py:565-570)
 - **Purpose**: Place every port on its section's bbox edge at the
   section's nominal centre line for its side.
 - **Helper**: `position_ports` in `section_placement.py`.
-- **Precondition**: Section bboxes in global coords (Phase 4).
+- **Precondition**: Section bboxes in global coords (Stage 2.1).
 - **Postcondition**: Every port station's `(x, y)` lies on the bbox
   edge corresponding to its side, within `GUARD_TOLERANCE`. Ports
   start at the bbox-edge midpoint for their side.
@@ -194,16 +193,13 @@ Phase 13c/13d.
   junctions.
 - **Validate guard after**: `_guard_ports_on_boundaries`.
 
-### Phase 5b: (none) - placeholder
-- No 5b phase exists; numbering jumps to Phase 6.
-
-### Phase 6: align LR entry ports (engine.py:572-576)
+### Stage 3.2: align LR entry ports (engine.py:572-576)
 - **Purpose**: For LEFT/RIGHT entry ports, set Y to the incoming
   source's Y so the inter-section horizontal run is straight; for
   TOP/BOTTOM entry ports, set X / Y accordingly.
 - **Helper**: `_align_entry_ports` (engine.py:4788), dispatching to
   `_align_lr_entry_port` and `_align_tb_entry_port`.
-- **Precondition**: Phase 5 placed ports on bbox edges. Junction
+- **Precondition**: Stage 3.1 placed ports on bbox edges. Junction
   positions are unknown - the helper uses `_resolve_source_xy` to
   derive junction coords on-the-fly.
 - **Postcondition**: Each entry port's coordinate on the axis along
@@ -214,12 +210,12 @@ Phase 13c/13d.
 - **Related tests**: `test_no_kink_at_section_boundary` (the
   straight-run property this phase establishes).
 
-### Phase 7: shift LR/RL perp-entry internal stations (engine.py:578-582)
+### Stage 3.3: shift LR/RL perp-entry internal stations (engine.py:578-582)
 - **Purpose**: When an LR/RL section has a TOP or BOTTOM (perpendicular)
   entry port, shift internal stations' X so the entry port has
   in-section runway before stations begin.
 - **Helper**: `_shift_lr_perp_entry_stations` (engine.py:4520).
-- **Precondition**: Phase 6 finalised LR/RL entry-port X for perp
+- **Precondition**: Stage 3.2 finalised LR/RL entry-port X for perp
   entries.
 - **Postcondition**: Internal stations in such sections sit at least
   `x_spacing` away from the perp entry port X.
@@ -228,35 +224,35 @@ Phase 13c/13d.
 - **Related tests**: `test_terminus_not_directly_after_diagonal`,
   `test_no_kink_at_section_boundary` (entry-side geometry).
 
-### Phase 8: align fold-section exit ports (engine.py:584-588)
+### Stage 3.4: align fold-section exit ports (engine.py:584-588)
 - **Purpose**: For row-spanning (fold) and TB-direction sections,
   shift LEFT/RIGHT exit ports to the target section's entry Y. May
   push the target section down via `_resolve_tb_exit_y`.
 - **Helper**: `_align_exit_ports` (engine.py:5410), dispatching to
   `_align_lr_exit_port`.
-- **Precondition**: Entry ports aligned (Phase 6); target sections
-  positioned (Phase 3/4).
+- **Precondition**: Entry ports aligned (Stage 3.2); target sections
+  positioned (Stage 1.3/4).
 - **Postcondition**: Exit ports on fold/TB sections sit at the same Y
   as their target section's entry port (within section bbox extent).
 - **Invariants preserved**: Real station coords. Entry-port Ys
-  (Phase 9's top-align corrects any bbox push-down).
+  (Stage 3.5's top-align corrects any bbox push-down).
 - **Related tests**: `test_no_kink_at_section_boundary`,
   `test_inter_section_route_y_stays_within_row_band`.
 
-### Phase 9: top-align sections within each grid row (engine.py:590-594)
+### Stage 3.5: top-align sections within each grid row (engine.py:590-594)
 - **Purpose**: Shift sections up so contiguous column groups within a
   row share the same `bbox_y`.
 - **Helper**: `_top_align_row_sections` (engine.py:1275).
-- **Precondition**: All Phase-8 bbox shifts settled.
+- **Precondition**: All Stage-3.4 bbox shifts settled.
 - **Postcondition**: Same-row contiguous-column sections share
   `bbox_y` (and station/port Y shifts by the same delta, preserving
-  Phase 6 alignment).
+  Stage 3.2 alignment).
 - **Invariants preserved**: Relative station-to-section position
   inside each shifted section. Bbox heights.
 - **Validate guard after**: `_guard_ports_on_boundaries` (top-align
   preserves port-on-edge by shifting ports with stations).
 
-### Phase 10: align ports to downstream (engine.py:603-605)
+### Stage 4.1: align ports to downstream (engine.py:603-605)
 - **Purpose**: For non-fold LR/RL sections, pull exit-entry port
   pairs toward the downstream section's internal stations so lines
   flow without detour.
@@ -265,31 +261,31 @@ Phase 13c/13d.
 - **Postcondition**: Each non-fold LR/RL exit-entry pair Y sits near
   the downstream section's connected station Y.
 - **Invariants preserved**: Section bboxes (movement is bbox-bounded,
-  Phase 11b/c recompute bboxes where needed). Real stations.
+  Stage 4.6/c recompute bboxes where needed). Real stations.
 - **Related tests**: `test_no_kink_at_section_boundary`.
 
-### Phase 10b: snap sole-layer stations to ports (engine.py:607-609)
+### Stage 4.2: snap sole-layer stations to ports (engine.py:607-609)
 - **Purpose**: When a port-connected station is the only occupant of
   its layer, snap it to the port Y so the connection is horizontal.
 - **Helper**: `_snap_sole_layer_stations_to_ports` (engine.py:5120).
-- **Precondition**: Phase 10 settled port Ys.
+- **Precondition**: Stage 4.1 settled port Ys.
 - **Postcondition**: Sole-layer port-connected stations share Y with
   their port. Multi-station layers are skipped (would risk collision).
 - **Invariants preserved**: Multi-station layer Ys. Shared row-Y grid
-  is not respected here (Phase 13e re-snaps).
+  is not respected here (Stage 6.4 re-snaps).
 - **Related tests**: `test_section_entry_hub_on_grid` (downstream).
 
-### Phase 10c: snap grid-group entry ports (engine.py:611-615)
+### Stage 4.3: snap grid-group entry ports (engine.py:611-615)
 - **Purpose**: For grid-group sections (skipped by 10b), snap entry
   ports to the connected first-internal-station Y - straight
   port-to-station connection.
 - **Helper**: `_snap_grid_group_entry_ports` (engine.py:5237).
-- **Precondition**: Phase 10b complete.
+- **Precondition**: Stage 4.2 complete.
 - **Postcondition**: Grid-group entry ports share Y with their first
   connected internal station.
 - **Invariants preserved**: Internal station Y. Exit ports.
 
-### Phase 10d: snap grid-group exit ports (engine.py:617-621)
+### Stage 4.4: snap grid-group exit ports (engine.py:617-621)
 - **Purpose**: Mirror of 10c for exit ports - snap to the downstream
   entry port's Y (which 10c just snapped to a grid station).
 - **Helper**: `_snap_grid_group_exit_ports` (engine.py:5284).
@@ -299,7 +295,7 @@ Phase 13c/13d.
   station).
 - **Invariants preserved**: Internal stations.
 
-### Phase 11: space ports from termini (engine.py:623-625)
+### Stage 4.5: space ports from termini (engine.py:623-625)
 - **Purpose**: Push ports away from terminus stations so a routed
   line clears any file-icon caption / label by at least `y_spacing`.
 - **Helper**: `_space_ports_from_termini` (engine.py:5695).
@@ -310,68 +306,68 @@ Phase 13c/13d.
 - **Invariants preserved**: Real non-terminus station Y. Other
   sections.
 
-### Phase 11b: recompute grid-group bboxes (engine.py:627-632)
+### Stage 4.6: recompute grid-group bboxes (engine.py:627-632)
 - **Purpose**: Reset grid-group bboxes to symmetric `max_y_pad`
   padding around final non-port station Y range, then expand for any
   ports outside.
 - **Helper**: `_recompute_grid_group_bboxes` (engine.py:1232).
-- **Precondition**: Port Ys final (Phase 11).
+- **Precondition**: Port Ys final (Stage 4.5).
 - **Postcondition**: Each grid-group section bbox snugly bounds its
   content with consistent top/bottom padding.
 - **Invariants preserved**: Station and port Ys.
 
-### Phase 11c: re-run top-align (engine.py:634-637)
-- **Purpose**: Repeat Phase 9 after Phase 11 expanded bboxes via
+### Stage 4.7: re-run top-align (engine.py:634-637)
+- **Purpose**: Repeat Stage 3.5 after Stage 4.5 expanded bboxes via
   `_expand_bbox_for_y`.
 - **Helper**: `_top_align_row_sections` (re-invoked).
-- **Precondition**: Phase 11/11b complete.
-- **Postcondition**: As Phase 9.
-- **Invariants preserved**: As Phase 9.
+- **Precondition**: Stage 4.5/11b complete.
+- **Postcondition**: As Stage 3.5.
+- **Invariants preserved**: As Stage 3.5.
 
-### Phase 11ca: align row trunk Ys (engine.py:639-642)
+### Stage 4.8: align row trunk Ys (engine.py:639-642)
 - **Purpose**: Within each row, shift content downward in shallower
   sections so the inter-section trunk bundle passes through at a
   single Y. Bbox tops preserved (heights grow downward).
 - **Helper**: `_align_row_trunk_ys` (engine.py:1414).
-- **Precondition**: Phase 11c done.
+- **Precondition**: Stage 4.7 done.
 - **Postcondition**: For sections in a row's contiguous column run,
   the trunk Y is the row's deepest pre-pass trunk Y. Row-spanning
   sections are skipped.
 - **Invariants preserved**: Bbox tops. Row-spanning sections.
 
-### Phase 11d: redistribute fan-out siblings (engine.py:644-648)
+### Stage 4.9: redistribute fan-out siblings (engine.py:644-648)
 - **Purpose**: For each fan-out column with a unique trunk junction
   (one station carrying the full bundle plus >=2 side branches),
   redistribute side stations symmetrically around the trunk Y. Gated
   on `graph.center_ports`.
 - **Helper**: `_redistribute_fanout_siblings` (engine.py:3163).
-- **Precondition**: Trunk Ys aligned (Phase 11ca).
+- **Precondition**: Trunk Ys aligned (Stage 4.8).
 - **Postcondition**: In qualifying columns, fan-out siblings sit
   symmetrically around the trunk station's Y. Linear chains, fan-in
   structures, and file inputs are left in place.
 - **Invariants preserved**: Trunk station Y. Off-track stations.
 
-### Phase 11da: redistribute full-bundle columns (engine.py)
+### Stage 4.10: redistribute full-bundle columns (engine.py)
 - **Purpose**: When a column has no unique trunk (every station
   carries the full bundle - e.g. Reporting's Shiny + Quarto),
   symmetrically fan stations around the local LR port Y. Gated on
   `center_ports`.
 - **Helper**: `_redistribute_full_bundle_columns`.
-- **Precondition**: Phase 11d ran.
+- **Precondition**: Stage 4.9 ran.
 - **Postcondition**: Full-bundle columns sit symmetric around the
   LR port Y.
-- **Why both this and Phase 13h**: Phase 13h
+- **Why both this and Stage 6.7**: Stage 6.7
   (``_recenter_full_bundle_columns``) re-fans the same columns
   using the final trunk Y, which can have drifted from 11da's
-  port-Y anchor.  Phase 11da's output is *not* redundant: the
-  intermediate symmetric layout is read by Phase 13's bbox-growth
+  port-Y anchor.  Stage 4.10's output is *not* redundant: the
+  intermediate symmetric layout is read by Stage 5.2's bbox-growth
   and compaction passes (an empty trunk row in fanned columns lets
   13b/13j shrink the section bbox to the compact extent).
   Skipping 11da changes intermediate bbox sizes and is not empty-
   render-diff -- the two passes are load-bearing in combination.
 - **Invariants preserved**: Other columns.
 
-### Phase 12: position junctions (engine.py:658-659)
+### Stage 5.1: position junctions (engine.py:658-659)
 - **Purpose**: Place each junction station in the inter-section gap
   at the exit port's Y (fan-out) or near the entry port (merge).
 - **Helper**: `_position_junctions` (engine.py:4596).
@@ -382,12 +378,12 @@ Phase 13c/13d.
   `max(pred.x) + JUNCTION_MARGIN, entry_port.y`.
 - **Invariants preserved**: Real stations, ports.
 
-### Phase 13: lift off-track stations (engine.py)
+### Stage 5.2: lift off-track stations (engine.py)
 - **Purpose**: Lift off-track file-input stations to the row above
   their consumer, stacking when multiple inputs share one consumer.
   Grow bbox upward; nudge same-section TOP ports back to new edge.
 - **Helper**: `_lift_off_track_stations`.
-- **Precondition**: Phase 12 complete; all on-track Ys final.
+- **Precondition**: Stage 5.1 complete; all on-track Ys final.
 - **Postcondition**: Each off-track station sits at
   `consumer.y - n*y_spacing` (n = stack rank). Section bbox extends
   upward to fit.  May leave the topmost section above the canvas
@@ -399,22 +395,22 @@ Phase 13c/13d.
 - **Related tests**: `test_off_track_inputs_above_consumer`,
   `test_off_track_icons_ordered_by_consumer_y`.
 
-### Phase 13a: re-align row bbox tops only (engine.py:665-670)
-- **Purpose**: After Phase 13 grew some bboxes upward, grow other
+### Stage 5.3: re-align row bbox tops only (engine.py:665-670)
+- **Purpose**: After Stage 5.2 grew some bboxes upward, grow other
   same-row bboxes upward to match. Station Ys in unlifted sections
   preserved.
 - **Helper**: `_top_align_row_bboxes_only` (engine.py:1348).
-- **Precondition**: Phase 13 may have lifted some bboxes.
+- **Precondition**: Stage 5.2 may have lifted some bboxes.
 - **Postcondition**: Within each row's contiguous column group, all
   bboxes share `bbox_y` (heights extended upward as needed).
 - **Invariants preserved**: All station / port Ys.
 
-### Phase 13b: compact row content to bbox top (engine.py:672-676)
+### Stage 5.4: compact row content to bbox top (engine.py:672-676)
 - **Purpose**: Shift each row's column-group up by the smallest
   above-content slack, then shrink bbox heights to remove the empty
   band. Preserves trunk alignment.
 - **Helper**: `_compact_row_content_to_bbox_top` (engine.py:1540).
-- **Precondition**: Bbox tops aligned (Phase 13a).
+- **Precondition**: Bbox tops aligned (Stage 5.3).
 - **Postcondition**: Each row's contiguous column group's bbox top
   sits at `min(content_top) - section_y_padding`. Stations shift up
   by the same delta as their bbox.
@@ -422,9 +418,9 @@ Phase 13c/13d.
   each section. Trunk Y stays aligned across the row.
 - **Related tests**: `test_section_bbox_has_bottom_padding`.
 
-### Phase 13c: snap inter-section port pairs + reposition junctions (engine.py:678-686)
+### Stage 5.5: snap inter-section port pairs + reposition junctions (engine.py:678-686)
 - **Purpose**: Snap exit/entry port pairs in the same row to a shared
-  Y (the entry's), then re-run Phase 12 to put junctions back on the
+  Y (the entry's), then re-run Stage 5.1 to put junctions back on the
   exit port.
 - **Helper**: `_snap_inter_section_port_pairs` (engine.py:1641) then
   `_position_junctions`.
@@ -436,13 +432,13 @@ Phase 13c/13d.
 - **Related tests**: `test_no_kink_at_section_boundary`,
   `test_inter_section_route_y_stays_within_row_band`.
 
-### Phase 13d: fan free content upward (engine.py:688-693)
+### Stage 6.1: fan free content upward (engine.py:688-693)
 - **Purpose**: When the row's compaction leaves visible empty top
   band but the section has trunk-candidate sibling stations,
   fan those upward into the empty band.
 - **Helper**: `_fan_free_content_upward` (engine.py:1762).
-- **Precondition**: Trunk Y aligned (Phase 11ca). Compaction done
-  (Phase 13b).
+- **Precondition**: Trunk Y aligned (Stage 4.8). Compaction done
+  (Stage 5.4).
 - **Postcondition**: Eligible sections fan stations upward by at most
   one `y_spacing` slot, balancing content above/below trunk.
 - **Invariants preserved**: Trunk station Y. Off-track stations
@@ -450,7 +446,7 @@ Phase 13c/13d.
 - **Related tests**: `test_section_top_band_filled`,
   `test_section1_input_above_trunk`.
 
-### Phase 13d2: fan source inputs upward (engine.py:695-700)
+### Stage 6.2: fan source inputs upward (engine.py:695-700)
 - **Purpose**: Companion to 13d for source-stack sections (single
   full-bundle trunk + subset-bundle file inputs at the entry column).
   Lift trunk-nearest source inputs into the empty top band.
@@ -460,12 +456,12 @@ Phase 13c/13d.
   trunk row instead of stacked below it.
 - **Invariants preserved**: Trunk station Y.
 
-### Phase 13d3: 2-branch symfan half-grid compaction (engine.py)
+### Stage 6.3: 2-branch symfan half-grid compaction (engine.py)
 - **Purpose**: Sections containing exactly a 2-branch symmetric fan
   (no off-track / constraining content) collapse onto half-pitch
   offsets so the section is 1 grid-unit tall instead of 2. Records
   the placed stations on the public `MetroGraph.half_grid_station_ids`
-  field so Phase 13e leaves them alone -- this is the only cross-
+  field so Stage 6.4 leaves them alone -- this is the only cross-
   phase channel for half-grid placement. Gated on `center_ports`.
 - **Helper**: `_apply_half_grid_2branch_symfan`.
 - **Precondition**: 13d/13d2 done; symfan classification stable
@@ -475,14 +471,14 @@ Phase 13c/13d.
 - **Invariants preserved**: Trunk station Y. Other sections.
 - **Related tests**: `test_symfan_pairs_share_y`.
 
-### Phase 13e: snap all Y to grid (engine.py)
+### Stage 6.4: snap all Y to grid (engine.py)
 - **Purpose**: Final pass snapping every station and port Y to the
   nearest row-wide grid slot, removing fractional Ys left by earlier
   shifts. Stations listed in `graph.half_grid_station_ids` (populated
-  by Phase 13d3) are skipped so they keep their intentional half-pitch
+  by Stage 6.3) are skipped so they keep their intentional half-pitch
   Y.
 - **Helper**: `_snap_all_y_to_grid`.
-- **Precondition**: All semantic Y shifts done. If Phase 13d3 ran,
+- **Precondition**: All semantic Y shifts done. If Stage 6.3 ran,
   `graph.half_grid_station_ids` is populated.
 - **Postcondition**: Every station and port Y is a grid slot of the
   per-section / per-row pitch (except marked half-grid stations).
@@ -491,7 +487,7 @@ Phase 13c/13d.
 - **Related tests**: `test_all_stations_snap_to_grid`,
   `test_grid_snap_does_not_mutate_x`.
 
-### Phase 13f: align TB-section bbox bottoms (engine.py:719-723)
+### Stage 6.5: align TB-section bbox bottoms (engine.py:719-723)
 - **Purpose**: Extend TB-section bbox bottom to match downstream
   LR/RL section's bbox bottom so the line doesn't look pinned to the
   TB bbox edge.
@@ -501,12 +497,12 @@ Phase 13c/13d.
   `tb.bbox_y + tb.bbox_h >= target.bbox_y + target.bbox_h`.
 - **Invariants preserved**: All station and port Ys. Other bboxes.
 
-### Phase 13g: reanchor off-track to consumer (engine.py)
+### Stage 6.6: reanchor off-track to consumer (engine.py)
 - **Purpose**: Re-pin each off-track input at `consumer.y - n*y_spacing`
-  using the consumer's final snapped Y (Phase 13 used pre-snap Ys).
+  using the consumer's final snapped Y (Stage 5.2 used pre-snap Ys).
   Grow bbox upward if needed.
 - **Helper**: `_reanchor_off_track_to_consumer`.
-- **Precondition**: Phase 13e snapped consumers to grid.
+- **Precondition**: Stage 6.4 snapped consumers to grid.
 - **Postcondition**: Off-track inputs sit `n * y_spacing` above their
   consumer's final Y.  May leave the topmost section above the
   canvas margin -- ``_shift_graph_into_canvas`` runs immediately
@@ -514,58 +510,58 @@ Phase 13c/13d.
 - **Invariants preserved**: On-track station Y.
 - **Related tests**: `test_off_track_inputs_above_consumer`.
 
-### Phase 13h: re-center full-bundle columns (engine.py)
+### Stage 6.7: re-center full-bundle columns (engine.py)
 - **Purpose**: Re-fan full-bundle columns around the row's final trunk
-  Y (Phase 11da used the local port Y which may now be stale).
+  Y (Stage 4.10 used the local port Y which may now be stale).
   Gated on `center_ports`.
 - **Helper**: `_recenter_full_bundle_columns`.
 - **Precondition**: Final inter-section trunk Y known (post-snap).
 - **Postcondition**: Full-bundle columns are symmetric around the
   row's final trunk Y.
 - **Invariants preserved**: Off-track Y anchoring (re-established by
-  Phase 13h.1) and bbox-top alignment (re-established by Phase 13h.2)
+  Stage 6.8) and bbox-top alignment (re-established by Stage 6.9)
   are temporarily broken; both are restored before leaving the
   `if center_ports:` block.
 
-### Phase 13h.1: re-anchor off-track after recenter (engine.py)
-- **Purpose**: The Phase 13h recenter moves consumers to the final
+### Stage 6.8: re-anchor off-track after recenter (engine.py)
+- **Purpose**: The Stage 6.7 recenter moves consumers to the final
   trunk-anchored Y, leaving off-track icons stranded at the old
   consumer Y (and overlapping the consumer station). Re-pin each
   off-track at `consumer.y - n*y_spacing` on the post-recenter grid.
   Followed by ``_shift_graph_into_canvas`` to handle bbox grow that
   pushed the topmost section above the canvas margin.  Gated on
   `center_ports`.
-- **Helper**: `_reanchor_off_track_to_consumer` (same helper as Phase
-  13g; called again here on the post-recenter Ys).
-- **Precondition**: Phase 13h has re-centred full-bundle columns.
+- **Helper**: `_reanchor_off_track_to_consumer` (same helper as
+  Stage 6.6; called again here on the post-recenter Ys).
+- **Precondition**: Stage 6.7 has re-centred full-bundle columns.
 - **Postcondition**: Off-track inputs sit one or more pitches above
   their post-recenter consumer. Section bboxes grow upward when
   lifted bands move above the existing top padding.
 - **Invariants preserved**: Row top-alignment may be broken when a
-  bbox grew upward; Phase 13h.2 restores it.
+  bbox grew upward; Stage 6.9 restores it.
 
-### Phase 13h.2: re-run row top-align (engine.py)
-- **Purpose**: A Phase 13h.1 bbox grow can leave the grown section's
+### Stage 6.9: re-run row top-align (engine.py)
+- **Purpose**: A Stage 6.8 bbox grow can leave the grown section's
   bbox top above its row mates'. Pull row mates' bbox tops up to
   match so the section row stays flush along its top edge. Gated on
   `center_ports`.
-- **Helper**: `_top_align_row_bboxes_only` (same helper as Phase 13a).
-- **Precondition**: Phase 13h.1 has re-anchored off-track inputs.
+- **Helper**: `_top_align_row_bboxes_only` (same helper as Stage 5.3).
+- **Precondition**: Stage 6.8 has re-anchored off-track inputs.
 - **Postcondition**: Row bboxes flush at the top across all row mates.
 - **Invariants preserved**: Station Ys (only bbox tops move).
 
-### Phase 13i: align terminus to upstream (engine.py:759-763)
+### Stage 6.10: align terminus to upstream (engine.py:759-763)
 - **Purpose**: After 13h re-pitched fanned columns, a single-station
   downstream column (e.g. a `file` terminus) may have stayed at its
   pre-fan Y. Pin it back onto its sole upstream's Y.
 - **Helper**: `_align_terminus_to_upstream` (engine.py:3860).
-- **Precondition**: Phase 13h re-centered fans.
+- **Precondition**: Stage 6.7 re-centered fans.
 - **Postcondition**: Single-station downstream columns share Y with
   their unique upstream.
 - **Invariants preserved**: Multi-station columns.
 - **Related tests**: `test_terminus_not_directly_after_diagonal`.
 
-### Phase 13i2: balance section content around trunk (engine.py:765-771)
+### Stage 6.11: balance section content around trunk (engine.py:765-771)
 - **Purpose**: Auto-balance pass. For sections whose final layout
   still has an empty band above the trunk while more siblings sit
   below than above, lift bottommost movable siblings into the empty
@@ -578,7 +574,7 @@ Phase 13c/13d.
   balance are left alone.
 - **Related tests**: `test_section_top_band_filled`.
 
-### Phase 13h3: recenter loop side stations (engine.py:773-781)
+### Stage 6.12: recenter loop side stations (engine.py:773-781)
 - **Purpose**: Recompute the X of fan-out side stations (one trunk
   predecessor, one trunk successor - "loop side" stations like propd,
   dream, DESeq2 around limma) to the midpoint of their actual diagonal
@@ -593,7 +589,7 @@ Phase 13c/13d.
   `test_loop_recenter_only_for_pure_side_branches`,
   `test_loop_column_stations_share_x`.
 
-### Phase 13j: shrink bbox to content bottom (engine.py:783-787)
+### Stage 6.13: shrink bbox to content bottom (engine.py:783-787)
 - **Purpose**: Shrink each section's bbox bottom to
   `max_content_y + section_y_padding` after earlier phases lifted
   bottom rows.
@@ -606,7 +602,7 @@ Phase 13c/13d.
 - **Related tests**: `test_section_bbox_has_bottom_padding`,
   `test_section_bbox_matches_content_extent`.
 
-### Phase 13k: tighten lower rows after shrink (engine.py:789-794)
+### Stage 6.14: tighten lower rows after shrink (engine.py:789-794)
 - **Purpose**: Pull lower-row sections up to close vertical slack left
   by the pre-shrink row-height estimate when rowspan sections
   collapsed via 13j.
@@ -618,7 +614,7 @@ Phase 13c/13d.
 - **Invariants preserved**: Within-row trunk Ys. Bbox heights of
   upper rows.
 
-### Phase 13k2: shift sparse loop stations to clear bundle (engine.py:796-800)
+### Stage 6.15: shift sparse loop stations to clear bundle (engine.py:796-800)
 - **Purpose**: Shift sparse loop-side stations (one inbound, one
   outbound, single-line consumer) onto a half-pitch Y when sharing
   the full-row Y with a busier sibling whose inbound bundle would
@@ -633,17 +629,17 @@ Phase 13c/13d.
 - **Related tests**: `test_lines_dont_cross_non_consumer_markers`,
   `test_no_icon_overlaps_line_path`.
 
-### Phase 13l: push lower rows after bbox grow (engine.py:802-806)
+### Stage 6.16: push lower rows after bbox grow (engine.py:802-806)
 - **Purpose**: Companion to 13k2 - when 13k2 grew a section's bbox
   downward, push lower-row sections down to keep
   `section_y_gap`.
 - **Helper**: `_push_lower_rows_after_bbox_grow` (engine.py:2698).
-- **Precondition**: Phase 13k2 may have grown some bboxes.
+- **Precondition**: Stage 6.15 may have grown some bboxes.
 - **Postcondition**: Row gaps preserved across the bbox grow.
 - **Invariants preserved**: Within-row Ys.
 - **Related tests**: `test_row_gap_accommodates_bypass`.
 
-### Phase 13m: pad stacked captioned file icons (engine.py:808-813)
+### Stage 6.17: pad stacked captioned file icons (engine.py:808-813)
 - **Purpose**: Pad vertical spacing between stacked file-input icons
   whose under-icon captions would overlap the icon below at default
   `y_spacing`.
@@ -660,31 +656,35 @@ Phase 13c/13d.
 No open signals at this time. Add new entries here when phase
 pre/postconditions reveal a candidate for cleanup.
 
-## Adding a new phase: checklist
+## Adding a new stage: checklist
 
-When adding a new phase to `_compute_section_layout`, document the
+When adding a new stage to `_compute_section_layout`, document the
 following before merging:
 
-1. **Phase tag**: pick a new tag matching the position in the pipeline.
-   Avoid suffix collisions (the `Phase 13k` -> `Phase 13k2` rename in
-   PR #342 is what happens when you don't).
+1. **Stage tag**: pick the next sequential number within the
+   appropriate stage (e.g. a new Stage 6.x sub-step gets the next
+   integer after Stage 6.17).  Historical note: the organic phase
+   suffix tree (`13d2`, `13k2`, the `Phase 13k` -> `Phase 13k2`
+   rename in PR #342) is what the flat Stage.N scheme is designed to
+   prevent.
 2. **Helper location**: top-level function in `engine.py` (or a new
-   module if it's substantial). Phase comments in the function body
+   module if it's substantial). Stage comments in the function body
    must reference the helper.
 3. **Precondition**: what state on the graph the helper assumes.
    Mention coordinate-system regime (local vs global), whether ports
    are positioned, whether junctions are positioned, and whether
    trunks/grids are final.
-4. **Postcondition**: the property the phase guarantees. Be concrete -
+4. **Postcondition**: the property the stage guarantees. Be concrete -
    "Y values are snapped to the row grid" not "Y values look nice".
-5. **Invariants preserved**: what the phase does NOT change. Crucial
+5. **Invariants preserved**: what the stage does NOT change. Crucial
    for reasoning about reorder safety. Bboxes? Other sections?
    Off-track stations? Half-grid marker set?
 6. **Related tests**: which invariants in `tests/test_layout_invariants.py`
-   defend the postcondition. If none, add one - phases without test
-   coverage are how the 13-suffix sprawl happened.
-7. **Validate-mode coverage**: if the phase introduces a new property
+   defend the postcondition. If none, add one - stages without test
+   coverage are how the Phase-13-suffix sprawl happened in the first
+   place.
+7. **Validate-mode coverage**: if the stage introduces a new property
    that should hold permanently, add a `_guard_*` helper and call it
    from `validate=True` mode.
-8. **Update this doc**: extend the per-phase table above and call out
-   any cross-phase coupling in the structural-debt section.
+8. **Update this doc**: extend the per-stage table above and call out
+   any cross-stage coupling in the structural-debt section.

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -73,6 +73,31 @@ docstring in `engine.py` is the authoritative list.
 Guard bodies live at the top of `engine.py` (lines 83-275); the
 bisection runner is `_run_phase13_guards`.
 
+## Stage overview
+
+The phase pipeline groups into six stages.  Stage boundaries align with
+the coord-regime transitions and the Pass A / Pass B / Pass C
+divisions referenced throughout this doc.
+
+1. **Stage 1 - Section construction (local coords)**: Phases 2, 2.5,
+   3, 3a, 3b.
+2. **Stage 2 - Globalise (local -> global coords)**: Phase 4.
+3. **Stage 3 - Pass A: port initialisation & section geometry**:
+   Phases 5, 6, 7, 8, 9.
+4. **Stage 4 - Pass B: downstream alignment & trunk-Y consolidation**:
+   Phases 10, 10b, 10c, 10d, 11, 11b, 11c, 11ca, 11d, 11da.
+5. **Stage 5 - Pass C: junctions & off-track lift**: Phases 12, 13,
+   13a, 13b, 13c.
+6. **Stage 6 - Pass C: vertical settling & finishing**: Phases 13d,
+   13d2, 13d3, 13e, 13f, 13g, 13h, 13h.1, 13h.2, 13i, 13i2, 13h3, 13j,
+   13k, 13k2, 13l, 13m.
+
+The matching `# ---- Stage N - ... ----` comment dividers in
+`_compute_section_layout` mark each stage's start in the source.
+Phase-table entries below appear in pipeline order; stage boundaries
+fall between Phase 3b/4, Phase 4/5, Phase 9/10, Phase 11da/12, and
+Phase 13c/13d.
+
 ## Phase table
 
 ### Phase 2: internal section layout (engine.py:483-490)

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -194,7 +194,7 @@ ENTRY_INSET_LR: float = 0.3
 ENTRY_SHIFT_LR: float = 0.5
 """Station shift multiplier for LR/RL sections with perpendicular entry.
 
-Applied after port positioning (Phase 9+) so that internal stations move
+Applied after port positioning (Stage 3.5+) so that internal stations move
 inward while ports stay put, creating a gap between the perpendicular
 entry port and the first internal station.  Mirrors ENTRY_SHIFT_TB."""
 
@@ -335,7 +335,7 @@ Used by bubble-centering post-processing to distinguish moved stations
 from untouched ones when checking column-companion consensus."""
 
 # ---------------------------------------------------------------------------
-# Phase-boundary guards
+# Stage-boundary guards
 # ---------------------------------------------------------------------------
 GUARD_TOLERANCE: float = 5.0
-"""Tolerance for phase-boundary invariant checks (port-on-boundary, etc.)."""
+"""Tolerance for stage-boundary invariant checks (port-on-boundary, etc.)."""

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -61,11 +61,11 @@ from nf_metro.layout.ordering import assign_tracks
 from nf_metro.parser.model import Edge, MetroGraph, Port, PortSide, Section, Station
 
 # ---------------------------------------------------------------------------
-# Phase-boundary guards
+# Stage-boundary guards
 # ---------------------------------------------------------------------------
 
 _VALIDATE_DEFAULT = False
-"""Set to True to enable phase-boundary invariant checks.
+"""Set to True to enable stage-boundary invariant checks.
 
 Controlled by the ``validate`` parameter on ``compute_layout``.
 Tests pass ``validate=True`` to catch cross-phase corruption that would
@@ -78,7 +78,7 @@ class PhaseInvariantError(Exception):
 
 
 def _guard_coordinates_finite(graph: MetroGraph, phase: str) -> None:
-    """After Phase 4+: all laid-out stations must have finite coordinates."""
+    """After Stage 2.1+: all laid-out stations must have finite coordinates."""
     junction_ids = graph.junction_ids
     for sid, st in graph.stations.items():
         if st.section_id and not st.is_port and sid not in junction_ids:
@@ -94,7 +94,7 @@ def _guard_coordinates_finite(graph: MetroGraph, phase: str) -> None:
 
 
 def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
-    """After Phase 4+: rendered station markers (and terminus icons) must
+    """After Stage 2.1+: rendered station markers (and terminus icons) must
     be fully within their section bbox.
 
     Tightened from station-centre containment to marker-edge containment:
@@ -137,7 +137,7 @@ def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
 
 
 def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:
-    """After Phase 5+: ports must sit on their section's bounding box edge."""
+    """After Stage 3.1+: ports must sit on their section's bounding box edge."""
     tolerance = GUARD_TOLERANCE
     for pid, port in graph.ports.items():
         st = graph.stations.get(pid)
@@ -158,7 +158,7 @@ def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:
 
 
 def _guard_section_bboxes_positive(graph: MetroGraph, phase: str) -> None:
-    """After Phase 2+: non-empty sections must have positive-size bboxes."""
+    """After Stage 1.1+: non-empty sections must have positive-size bboxes."""
     for sid, sec in graph.sections.items():
         if not sec.station_ids:
             continue
@@ -522,7 +522,7 @@ def _guard_inter_section_routes_in_row_band(
 
 
 def _guard_off_track_inputs_above_consumer(graph: MetroGraph, phase: str) -> None:
-    """After Phase 11 and final: off-track input stations must sit at
+    """After Stage 4.5 and final: off-track input stations must sit at
     least ``GUARD_TOLERANCE`` above (smaller Y than) their on-track
     consumer.
     """
@@ -629,52 +629,52 @@ def _guard_station_x_column_drift(graph: MetroGraph, phase: str) -> None:
                     )
 
 
-_PHASE_13_ORDER: tuple[str, ...] = (
-    "after Phase 13",
-    "after Phase 13a",
-    "after Phase 13b",
-    "after Phase 13c",
-    "after Phase 13d",
-    "after Phase 13d2",
-    "after Phase 13d3",
-    "after Phase 13e",
-    "after Phase 13f",
-    "after Phase 13g",
-    "after Phase 13h.2",
-    "after Phase 13i",
-    "after Phase 13i2",
-    "after Phase 13h3",
-    "after Phase 13j",
-    "after Phase 13k",
-    "after Phase 13k2",
-    "after Phase 13l",
-    "after Phase 13m",
+_PASS_C_BISECTION_ORDER: tuple[str, ...] = (
+    "after Stage 5.2",
+    "after Stage 5.3",
+    "after Stage 5.4",
+    "after Stage 5.5",
+    "after Stage 6.1",
+    "after Stage 6.2",
+    "after Stage 6.3",
+    "after Stage 6.4",
+    "after Stage 6.5",
+    "after Stage 6.6",
+    "after Stage 6.9",
+    "after Stage 6.10",
+    "after Stage 6.11",
+    "after Stage 6.12",
+    "after Stage 6.13",
+    "after Stage 6.14",
+    "after Stage 6.15",
+    "after Stage 6.16",
+    "after Stage 6.17",
 )
-"""Ordered Phase-13x bisection checkpoints, used by
-``_run_phase13_guards`` to gate guards whose invariants only become
-valid mid-pipeline.  Update when adding or removing a Phase-13x
+"""Ordered Pass C bisection checkpoints, used by
+``_run_pass_c_guards`` to gate guards whose invariants only become
+valid mid-pipeline.  Update when adding or removing a Pass C
 checkpoint in ``_compute_section_layout``.
 """
 
 # Each entry: bisection-runnable guard -> first checkpoint at which its
 # invariant must hold.  Before that checkpoint, the guard is skipped in
-# bisection mode; the final guard block (phase ``"after Phase 12
-# (final)"``, which is not in ``_PHASE_13_ORDER``) always runs it.
+# bisection mode; the final guard block (phase ``"after Stage 5.1
+# (final)"``, which is not in ``_PASS_C_BISECTION_ORDER``) always runs it.
 #
-# - stations_in_sections: Phase 13 lifts off-track stations above their
-#   section's pre-grow bbox top; Phase 13a's row top-align grows the
+# - stations_in_sections: Stage 5.2 lifts off-track stations above their
+#   section's pre-grow bbox top; Stage 5.3's row top-align grows the
 #   bbox upward to enclose them.
-# - no_station_overlap: Phase 13e's snap-to-grid can place an off-track
+# - no_station_overlap: Stage 6.4's snap-to-grid can place an off-track
 #   terminus icon at the same coordinates as an on-track column-mate;
-#   Phase 13g's re-anchor lifts the off-track back above its consumer.
+#   Stage 6.6's re-anchor lifts the off-track back above its consumer.
 # - no_line_crosses_non_consumer: a sparse loop-side station (single
 #   line in, single line out, full-bundle row-mates) sits on the trunk
-#   Y until Phase 13k2 shifts it to a half-grid offset; before that,
+#   Y until Stage 6.15 shifts it to a half-grid offset; before that,
 #   the sibling line bundle's route passes through its marker bbox.
 _BISECTION_FIRST_VALID: dict[str, str] = {
-    "_guard_stations_in_sections": "after Phase 13a",
-    "_guard_no_station_overlap": "after Phase 13g",
-    "_guard_no_line_crosses_non_consumer": "after Phase 13k2",
+    "_guard_stations_in_sections": "after Stage 5.3",
+    "_guard_no_station_overlap": "after Stage 6.6",
+    "_guard_no_line_crosses_non_consumer": "after Stage 6.15",
 }
 
 
@@ -682,51 +682,53 @@ def _bisection_should_run(guard_name: str, phase: str) -> bool:
     """True if ``guard_name`` should run at bisection checkpoint ``phase``.
 
     Returns True for the final guard block (``phase`` outside
-    ``_PHASE_13_ORDER``) so the final invariant set stays complete.
+    ``_PASS_C_BISECTION_ORDER``) so the final invariant set stays complete.
     """
     threshold = _BISECTION_FIRST_VALID.get(guard_name)
     if threshold is None:
         return True
     try:
-        return _PHASE_13_ORDER.index(phase) >= _PHASE_13_ORDER.index(threshold)
+        phase_idx = _PASS_C_BISECTION_ORDER.index(phase)
+        threshold_idx = _PASS_C_BISECTION_ORDER.index(threshold)
+        return phase_idx >= threshold_idx
     except ValueError:
         return True
 
 
-def _run_phase13_guards(
+def _run_pass_c_guards(
     graph: MetroGraph,
     phase: str,
     *,
     offsets: dict | None = None,
     routes: list | None = None,
 ) -> tuple[dict, list | None]:
-    """Bisection guards run after every Phase-13x sub-phase boundary in
+    """Bisection guards run after every Pass C sub-phase boundary in
     ``validate=True`` mode.
 
-    The Phase 13 tidy-up pipeline is a sequence of ~20 mutating passes
+    The Stage 5.2 tidy-up pipeline is a sequence of ~20 mutating passes
     over a shared graph; before this helper, ``validate=True`` only
-    sampled the final state, so a regression introduced at e.g. Phase
-    13h surfaced as ``after Phase 12 (final): ...`` with no way to
+    sampled the final state, so a regression introduced at e.g.
+    Stage 6.7 surfaced as ``after final: ...`` with no way to
     bisect.  Running the same overlap / breeze-past / column-drift
     checks at each boundary localises the culprit to a single phase.
 
-    Guards transient through specific Phase-13x sub-phases are gated
+    Guards transient through specific Pass C sub-phases are gated
     by ``_BISECTION_FIRST_VALID`` and skipped before they're valid.
     See that table for the per-guard transient windows.
 
     Always excluded from the bisection set (only meaningful at the
     final boundary):
 
-    * ``_guard_off_track_inputs_above_consumer`` -- Phase 13e's snap-
+    * ``_guard_off_track_inputs_above_consumer`` -- Stage 6.4's snap-
       to-grid shifts the on-track consumer Y by up to half a pitch
-      before Phase 13g re-anchors the off-track input.
+      before Stage 6.6 re-anchors the off-track input.
     * ``_guard_row_trunk_cy_consistent`` -- the row trunk Y is only
-      finalised once Phase 13h has re-centred ``center_ports`` graphs.
+      finalised once Stage 6.7 has re-centred ``center_ports`` graphs.
     * ``_guard_inter_section_routes_in_row_band`` -- row-band height
-      tolerance assumes final bboxes, which Phase 13j/k may still be
+      tolerance assumes final bboxes, which Stage 6.13/k may still be
       shrinking.
 
-    The final guard block (``after Phase 12 (final)``) composes this
+    The final guard block (``after final``) composes this
     helper with the three excluded guards above, sharing
     ``offsets``/``routes`` for a single computation per checkpoint.
     Returns the computed ``(offsets, routes)`` so callers (e.g. the
@@ -853,7 +855,7 @@ def compute_layout(
     captioned icons and labelled stations automatically.  Pass an
     explicit numeric value to override.
 
-    When *validate* is True, phase-boundary invariant checks run after
+    When *validate* is True, stage-boundary invariant checks run after
     key phases.  Violations raise ``PhaseInvariantError`` instead of
     silently producing broken layouts.
     """
@@ -942,74 +944,40 @@ def _compute_section_layout(
 ) -> None:
     """Section-first layout pipeline.
 
-    See ``CONTRACT.md`` for each phase's pre/postconditions; this
-    docstring is a quick map of the pipeline's structure.
+    Quick map of the pipeline's structure.  See ``CONTRACT.md`` for the
+    full per-sub-stage table with pre/postconditions and invariant
+    coverage, and ``docs/dev/layout_pipeline.md`` for the human-facing
+    overview.
 
-    Phase 1 (parse & partition) is already done by the parser.  The
-    pipeline below splits into six stages.  Stages 1-2 leave content in
-    local coordinates and then translate to canvas coordinates; Stages
-    3-4 are Pass A and Pass B (port positioning and refinement on a
-    fixed station layout); Stages 5-6 are Pass C, split into the
-    junction + off-track-lift block and the long vertical-settling /
-    finishing block.
+    Parsing & partition is already done by the parser.  Six stages
+    follow:
 
-    Stage 1 - Section construction (local coords):
-      Phase 2:   Internal section layout (per section, real stations only)
-      Phase 2.5: Align Y grids across same-row, same-direction sections
-      Phase 3:   Section placement (meta-graph)
-      Phase 3a:  Renumber sections by visual reading order
-      Phase 3b:  Adapt x/y_offset for left/top overshoot
+    1. **Section construction** (Stages 1.1 to 1.5).  Lay out each
+       section internally, snap row Y grids, place on the canvas grid,
+       renumber by reading order, correct left/top overshoot.  Coords
+       stay local.
+    2. **Globalise** (Stage 2.1).  Single-stage coord-regime
+       transition: translate stations and bboxes to canvas coordinates.
+    3. **Pass A - port positioning** (Stages 3.1 to 3.5).  Place ports
+       on bbox edges, align entry ports, shift LR/RL perp-entry
+       stations, align fold-section exit ports, top-align rows.
+    4. **Pass B - downstream alignment & trunk-Y consolidation**
+       (Stages 4.1 to 4.10).  Pull ports toward downstream content,
+       snap to grid-group stations, space from termini, recompute
+       bboxes, align trunk Ys, redistribute fan-out and full-bundle
+       columns.
+    5. **Pass C - junctions & off-track lift** (Stages 5.1 to 5.5).
+       Position junctions, lift off-track stations, re-align row bbox
+       tops, compact, snap inter-section port pairs.
+    6. **Pass C - vertical settling & finishing** (Stages 6.1 to 6.17).
+       Fan content upward, snap to grid, re-anchor off-track, recenter
+       full-bundle columns and restore their invariants, balance content
+       around trunk, loop-side X recenter, bbox shrink + row tighten /
+       push, captioned-icon pad.
 
-    Stage 2 - Globalise (local -> global coords):
-      Phase 4:   Translate stations and bboxes to canvas coordinates
-
-    Stage 3 - Pass A: Port initialisation & section geometry:
-      Phase 5:  Port positioning on section boundaries
-      Phase 6:  Align entry ports to incoming source Y/X
-      Phase 7:  Shift LR/RL perp-entry internal stations (X only)
-      Phase 8:  Align fold-section exit ports (may push target sections)
-      Phase 9:  Top-align sections within each grid row
-
-    Stage 4 - Pass B: Downstream alignment & trunk-Y consolidation:
-      Phase 10:  Align exit-entry port pairs to downstream stations
-      Phase 10b: Snap sole-layer stations to port Y
-      Phase 10c: Snap grid-group entry ports to first-station Y
-      Phase 10d: Mirror of 10c for exit ports
-      Phase 11:  Space ports from terminus stations (may expand bboxes)
-      Phase 11b: Recompute bboxes for grid-aligned sections
-      Phase 11c: Re-run top-align (undo the bbox-top drift Phase 11 may
-                 introduce via ``_expand_bbox_for_y``)
-      Phase 11ca: Align trunk Ys across same-row sections
-      Phase 11d:  Redistribute fan-out siblings around trunk
-                  (center_ports only)
-      Phase 11da: Redistribute full-bundle columns around trunk
-                  (center_ports only)
-
-    Stage 5 - Pass C: Junctions & off-track lift:
-      Phase 12:    Position junction stations in inter-section gaps
-      Phase 13:    Lift off-track stations above section's top track
-      Phase 13a:   Re-align bbox tops within each row (bbox-only)
-      Phase 13b:   Compact row content to bbox top
-      Phase 13c:   Snap inter-section LR/RL port pairs + re-position junctions
-
-    Stage 6 - Pass C: Vertical settling & finishing:
-      Phase 13d:   Fan free content upward
-      Phase 13d2:  Fan source inputs upward
-      Phase 13d3:  Half-grid 2-branch symfan (center_ports only)
-      Phase 13e:   Snap all Ys to per-section grid
-      Phase 13f:   Grow TB-section bbox bottoms
-      Phase 13g:   Re-anchor off-track to consumer's final Y
-      Phase 13h:   Re-center full-bundle columns (center_ports only)
-        Phase 13h.1: Re-anchor off-track after recenter
-        Phase 13h.2: Re-run row top-align after 13h.1 bbox grow
-      Phase 13i:   Align terminus to upstream
-      Phase 13i2:  Balance section content around trunk
-      Phase 13h3:  Recenter loop side stations
-      Phase 13j:   Shrink bboxes to content bottom
-      Phase 13k:   Tighten lower rows after shrink
-      Phase 13k2:  Shift sparse loop stations to clear bundle
-      Phase 13l:   Push lower rows after bbox grow
-      Phase 13m:   Pad stacked captioned file icons
+    Inline ``# ---- Stage N - ... ----`` dividers below mark each
+    stage's start; ``# Stage X.Y:`` comments above each helper call
+    name the sub-stage.
     """
     from nf_metro.layout.section_placement import place_sections, position_ports
 
@@ -1018,7 +986,7 @@ def _compute_section_layout(
     # the canvas grid, renumber by reading order, correct left/top
     # overshoot.  All work in section-local coordinates.
 
-    # Phase 2: Lay out each section independently (real stations only, no ports)
+    # Stage 1.1: Lay out each section independently (real stations only, no ports)
     section_subgraphs: dict[str, MetroGraph] = {}
     for sec_id, section in graph.sections.items():
         sub = _layout_single_section(
@@ -1028,18 +996,18 @@ def _compute_section_layout(
             section_subgraphs[sec_id] = sub
 
     if validate:
-        _guard_section_bboxes_positive(graph, "after Phase 2")
+        _guard_section_bboxes_positive(graph, "after Stage 1.1")
 
-    # Phase 2.5: Align Y grids across same-row, same-direction sections
+    # Stage 1.2: Align Y grids across same-row, same-direction sections
     _align_row_y_grids(graph, section_subgraphs, y_spacing, section_y_padding)
 
-    # Phase 3: Place sections on the canvas
+    # Stage 1.3: Place sections on the canvas
     place_sections(graph, section_x_gap, section_y_gap)
 
-    # Phase 3a: Renumber sections by visual reading order (row, col)
+    # Stage 1.4: Renumber sections by visual reading order (row, col)
     _renumber_sections_by_grid(graph)
 
-    # Phase 3b: Adapt x/y_offset for left/top overshoot.
+    # Stage 1.5: Adapt x/y_offset for left/top overshoot.
     # Section bboxes extend left of the local origin by at least
     # section_x_padding; x_offset normally absorbs this with margin to
     # spare (standard margin = x_offset - section_x_padding).  When
@@ -1073,10 +1041,10 @@ def _compute_section_layout(
             y_offset += standard_margin - global_top
 
     # ---- Stage 2 - Globalise (local -> global coords) ------------------
-    # The coord-regime transition.  Owns the post-Phase-4 guard
+    # The coord-regime transition.  Owns the post-Stage-2.1 guard
     # checkpoint (finite coords, stations-in-sections, bboxes-positive).
 
-    # Phase 4: Translate local coords to global coords (real stations)
+    # Stage 2.1: Translate local coords to global coords (real stations)
     for sec_id, section in graph.sections.items():
         sub = section_subgraphs.get(sec_id)
         if not sub:
@@ -1094,9 +1062,9 @@ def _compute_section_layout(
         section.bbox_y += section.offset_y + y_offset
 
     if validate:
-        _guard_coordinates_finite(graph, "after Phase 4")
-        _guard_stations_in_sections(graph, "after Phase 4")
-        _guard_section_bboxes_positive(graph, "after Phase 4")
+        _guard_coordinates_finite(graph, "after Stage 2.1")
+        _guard_stations_in_sections(graph, "after Stage 2.1")
+        _guard_section_bboxes_positive(graph, "after Stage 2.1")
 
     # ---- Stage 3 - Pass A: Port initialisation & section geometry --------
     # Position ports on bbox edges, align entry ports, shift internal
@@ -1104,34 +1072,34 @@ def _compute_section_layout(
     # Top-align runs last so it corrects any bbox shifts from fold-exit
     # alignment.
 
-    # Phase 5: Position ports on section boundaries (after bbox is in global coords)
+    # Stage 3.1: Position ports on section boundaries (after bbox is in global coords)
     for sec_id, section in graph.sections.items():
         position_ports(section, graph)
 
     if validate:
-        _guard_ports_on_boundaries(graph, "after Phase 5")
+        _guard_ports_on_boundaries(graph, "after Stage 3.1")
 
-    # Phase 6: Align LEFT/RIGHT entry ports with their incoming
+    # Stage 3.2: Align LEFT/RIGHT entry ports with their incoming
     # connection's Y so inter-section horizontal runs are straight.
     # Uses _resolve_source_xy() to derive junction coordinates
     # on-the-fly, removing the dependency on pre-positioned junctions.
     _align_entry_ports(graph)
 
-    # Phase 7: Shift internal stations in LR/RL sections with
+    # Stage 3.3: Shift internal stations in LR/RL sections with
     # perpendicular (TOP/BOTTOM) entry away from the port.  Needs the
-    # aligned port X from Phase 6; only moves internal station X, not
+    # aligned port X from Stage 3.2; only moves internal station X, not
     # ports or bboxes.
     _shift_lr_perp_entry_stations(graph, x_spacing)
 
-    # Phase 8: Align LEFT/RIGHT exit ports on row-spanning (fold)
+    # Stage 3.4: Align LEFT/RIGHT exit ports on row-spanning (fold)
     # sections with their target's Y so the exit is at the return row.
     # May push target sections down (via _resolve_tb_exit_y), which
     # top-align in the next step corrects.
     _align_exit_ports(graph)
 
-    # Phase 9: Top-align sections within each grid row.
+    # Stage 3.5: Top-align sections within each grid row.
     # Runs after fold-exit alignment so it corrects any bbox_y shifts
-    # from Phase 8's target-section push.  Same-row port pairs shift
+    # from Stage 3.4's target-section push.  Same-row port pairs shift
     # by the same delta, preserving entry-port alignment.
     _top_align_row_sections(graph)
 
@@ -1139,66 +1107,66 @@ def _compute_section_layout(
         _guard_ports_on_boundaries(graph, "after top-align")
 
     # ---- Stage 4 - Pass B: Downstream alignment & trunk-Y consolidation -
-    # Phase 11's port-terminus spacing can expand bboxes via
-    # ``_expand_bbox_for_y``; Phase 11c re-runs row top-align to undo
+    # Stage 4.5's port-terminus spacing can expand bboxes via
+    # ``_expand_bbox_for_y``; Stage 4.7 re-runs row top-align to undo
     # the resulting bbox-top drift.  Phases 11d / 11da run only on
     # ``center_ports`` graphs.
 
-    # Phase 10: For non-fold LR/RL sections, pull exit-entry port pairs
+    # Stage 4.1: For non-fold LR/RL sections, pull exit-entry port pairs
     # toward the downstream section's stations so lines flow directly.
     _align_ports_to_downstream(graph)
 
-    # Phase 10b: When a port-connected station is the sole occupant of its
+    # Stage 4.2: When a port-connected station is the sole occupant of its
     # layer, snap it to the port Y so the connection is horizontal.
     _snap_sole_layer_stations_to_ports(graph)
 
-    # Phase 10c: For grid-group sections (where 10b is skipped), snap
+    # Stage 4.3: For grid-group sections (where 10b is skipped), snap
     # entry ports to the Y of their first connected internal station.
     # This produces a straight horizontal port-to-station connection
     # instead of a diagonal from the upstream junction Y.
     _snap_grid_group_entry_ports(graph)
 
-    # Phase 10d: Mirror of 10c for exit ports.  Move exit ports of
+    # Stage 4.4: Mirror of 10c for exit ports.  Move exit ports of
     # grid-group sections to the Y of the downstream entry port (which
     # 10c already snapped to a grid station).  This eliminates detours
     # where lines leave at the section midpoint then route back.
     _snap_grid_group_exit_ports(graph)
 
-    # Phase 11: Ensure ports maintain at least y_spacing from terminus
+    # Stage 4.5: Ensure ports maintain at least y_spacing from terminus
     # stations in their section so file icons don't overlap routed lines.
     _space_ports_from_termini(graph, y_spacing)
 
-    # Phase 11b: Recompute bboxes for grid-aligned sections.  Earlier
+    # Stage 4.6: Recompute bboxes for grid-aligned sections.  Earlier
     # phases (6, 8, 11) may have expanded bboxes for temporary port
-    # positions that were later corrected (e.g. Phase 10 pulls ports
+    # positions that were later corrected (e.g. Stage 4.1 pulls ports
     # back toward downstream stations).  Recompute with symmetric
     # padding around the final non-port station range.
     _recompute_grid_group_bboxes(graph)
 
-    # Phase 11c: Re-run top-align after Phase 11 may have shifted
+    # Stage 4.7: Re-run top-align after Stage 4.5 may have shifted
     # individual section bbox_y values (via _expand_bbox_for_y) so
     # bbox tops within each row stay flush after port-terminus spacing.
     _top_align_row_sections(graph)
 
-    # Phase 11ca: Align trunk Ys across same-row sections.  Shifts
+    # Stage 4.8: Align trunk Ys across same-row sections.  Shifts
     # content downward in shallower sections so the inter-section bundle
     # passes through at a single Y per row.  Bbox tops are preserved.
     _align_row_trunk_ys(graph)
 
-    # Phase 11d: When --center-ports is on, redistribute fan-out siblings
+    # Stage 4.9: When --center-ports is on, redistribute fan-out siblings
     # of a section's trunk junction symmetrically around the trunk Y.
     # Scoped to fan-out side branches only: linear chains, fan-in
     # structures, and file inputs are left in place.
     _redistribute_fanout_siblings(graph, y_spacing)
 
-    # Phase 11da: Symmetrically fan a column of full-bundle stations
+    # Stage 4.10: Symmetrically fan a column of full-bundle stations
     # around the trunk Y when no unique trunk exists (e.g. Reporting's
     # Shiny app + Quarto report, both carrying the full bundle).
     #
-    # Why both 11da and Phase 13h's recenter: 11da's symmetric layout
-    # is read by Phase 13's bbox-growth, compaction, and snap-to-grid
+    # Why both 11da and Stage 6.7's recenter: 11da's symmetric layout
+    # is read by Stage 5.2's bbox-growth, compaction, and snap-to-grid
     # passes (an empty trunk row in fanned columns lets 13b/13j shrink
-    # the section bbox to the compact extent).  Phase 13h then re-fans
+    # the section bbox to the compact extent).  Stage 6.7 then re-fans
     # the same columns using the post-row-alignment trunk Y, which can
     # have drifted from 11da's port-Y anchor.  Skipping 11da changes
     # intermediate bbox sizes and is not empty-render-diff; the two
@@ -1206,53 +1174,53 @@ def _compute_section_layout(
     _redistribute_full_bundle_columns(graph, y_spacing)
 
     # ---- Stage 5 - Pass C: Junctions & off-track lift ------------------
-    # All port positions are now final; Phase 12 positions junctions
-    # once.  Phase 13 lifts off-track stations; 13a-13c then re-align
+    # All port positions are now final; Stage 5.1 positions junctions
+    # once.  Stage 5.2 lifts off-track stations; 13a-13c then re-align
     # row bbox tops, compact, and re-snap inter-section port pairs
-    # (re-running Phase 12 for the junctions that move with them).
+    # (re-running Stage 5.1 for the junctions that move with them).
     # Stage 6 below handles the rest of Pass C.
 
-    # Phase 12: Position junction stations in the inter-section gap.
+    # Stage 5.1: Position junction stations in the inter-section gap.
     _position_junctions(graph)
 
-    # Phase 13: Lift off_track stations above their section's top track.
+    # Stage 5.2: Lift off_track stations above their section's top track.
     # Runs last so it operates on finalised station Ys and bboxes.
     _lift_off_track_stations(graph, y_spacing, section_y_padding)
     # The upward bbox growth above can push the topmost section above
-    # the canvas top margin set by Phase 3b; shift the whole graph
+    # the canvas top margin set by Stage 1.5; shift the whole graph
     # down to restore the margin.  No-op when no section overflowed.
     _shift_graph_into_canvas(graph, section_y_padding)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13")
+        _run_pass_c_guards(graph, "after Stage 5.2")
 
-    # Phase 13a: Re-align bbox tops within each grid row after off-track
-    # lifting expanded some sections upward.  Unlike Phase 9/11c which
+    # Stage 5.3: Re-align bbox tops within each grid row after off-track
+    # lifting expanded some sections upward.  Unlike Stage 3.5/11c which
     # shifts stations with the bbox, this only grows the bbox upward so
     # the empty input-band space lines up across the row.  Station Ys
     # in unlifted sections are preserved.
     _top_align_row_bboxes_only(graph)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13a")
+        _run_pass_c_guards(graph, "after Stage 5.3")
 
-    # Phase 13b: Compact row-mate sections so content sits just inside
+    # Stage 5.4: Compact row-mate sections so content sits just inside
     # the bbox top edge.  Shifts an entire row's column group up by the
     # smallest above-content slack, preserving trunk alignment.  Bbox
     # heights shrink correspondingly so the empty top space disappears.
     _compact_row_content_to_bbox_top(graph, section_y_padding, y_spacing)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13b")
+        _run_pass_c_guards(graph, "after Stage 5.4")
 
-    # Phase 13c: Snap inter-section LR/RL port pairs to a common Y so
+    # Stage 5.5: Snap inter-section LR/RL port pairs to a common Y so
     # the trunk bundle stays perfectly horizontal across boundaries.
     # Picks the downstream entry port's Y as the anchor since it sits
     # on the row's aligned trunk grid.  Junctions are re-positioned
-    # afterwards: Phase 12 fixed their Y to the pre-compaction exit
+    # afterwards: Stage 5.1 fixed their Y to the pre-compaction exit
     # port Y, and either the snap pass or ``_compact_row_content_to_bbox_top``
     # may have moved the exit port since then.
     _snap_inter_section_port_pairs(graph)
     _position_junctions(graph)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13c")
+        _run_pass_c_guards(graph, "after Stage 5.5")
 
     # ---- Stage 6 - Pass C: Vertical settling & finishing ---------------
     # The long settle: fan free / source content upward, half-grid
@@ -1263,25 +1231,25 @@ def _compute_section_layout(
     # phases here run unconditionally; a few are gated on
     # ``center_ports`` or on a specific topology (see each comment).
 
-    # Phase 13d: Fan a section's free content upward when the row's
+    # Stage 6.1: Fan a section's free content upward when the row's
     # compaction left visible empty space at the bbox top.  Only fires
     # for sections whose internal stations have no upward dependency
     # (no off-track band) and whose trunk Y sits below the bbox top
     # padding by more than one ``y_spacing`` slot.
     _fan_free_content_upward(graph, section_y_padding, y_spacing)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13d")
+        _run_pass_c_guards(graph, "after Stage 6.1")
 
-    # Phase 13d2: Companion to 13d for source-stack sections.  When the
+    # Stage 6.2: Companion to 13d for source-stack sections.  When the
     # entry column has a single full-bundle trunk plus subset-bundle
     # source inputs (file icons with no inbound edges), lift the
     # nearest-to-trunk sources into the empty top band so the section
     # is bottom- and top-weighted instead of stacked below the trunk.
     _fan_source_inputs_upward(graph, y_spacing)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13d2")
+        _run_pass_c_guards(graph, "after Stage 6.2")
 
-    # Phase 13d3: For sections that contain exactly a 2-branch
+    # Stage 6.3: For sections that contain exactly a 2-branch
     # symmetric fan (and no off-track or other constraining content),
     # collapse the fan onto half-pitch offsets so the section consumes
     # one vertical grid unit instead of two.  Marks the branch stations
@@ -1291,40 +1259,40 @@ def _compute_section_layout(
     if graph.center_ports:
         _apply_half_grid_2branch_symfan(graph, y_spacing, section_y_padding)
         if validate:
-            _run_phase13_guards(graph, "after Phase 13d3")
+            _run_pass_c_guards(graph, "after Stage 6.3")
 
-    # Phase 13e: Snap all station/port Ys to a per-section y_spacing
+    # Stage 6.4: Snap all station/port Ys to a per-section y_spacing
     # grid.  Trunk-Y align, port-snap, and the row compaction/fan
     # phases compute shifts that don't respect the grid pitch, leaving
     # coordinates at fractional Ys (e.g. 298.785 when the pitch is 55).
     # This final pass restores clean grid positions before validation.
     _snap_all_y_to_grid(graph, y_spacing)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13e")
+        _run_pass_c_guards(graph, "after Stage 6.4")
 
-    # Phase 13f: Grow TB-section bbox bottoms so they align with the
+    # Stage 6.5: Grow TB-section bbox bottoms so they align with the
     # downstream LR section's bbox bottom.  Without this the TB
     # section's bbox ends right at the inter-section exit port Y,
     # making the line look pinned to the section edge.
     _align_tb_section_bbox_bottoms(graph)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13f")
+        _run_pass_c_guards(graph, "after Stage 6.5")
 
-    # Phase 13g: Re-anchor off-track inputs to their consumer's final
-    # (snapped) Y.  Phase 13's lift placed them relative to pre-snap
+    # Stage 6.6: Re-anchor off-track inputs to their consumer's final
+    # (snapped) Y.  Stage 5.2's lift placed them relative to pre-snap
     # consumer Ys; snapping the consumer to the grid can shift it by
     # up to half a pitch, which would collapse the y_spacing gap above
     # off-track.  Recomputing here pins each off-track at
     # consumer.y - n*y_spacing on the final grid and grows the bbox
     # upward if the new position rises above the padding zone.
     _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
-    # Same canvas-fit safeguard as after Phase 13: a reanchor-driven
+    # Same canvas-fit safeguard as after Stage 5.2: a reanchor-driven
     # bbox grow can push the topmost section above the canvas top.
     _shift_graph_into_canvas(graph, section_y_padding)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13g")
+        _run_pass_c_guards(graph, "after Stage 6.6")
 
-    # Phase 13h: Re-center full-bundle columns around the row's final
+    # Stage 6.7: Re-center full-bundle columns around the row's final
     # trunk Y.  ``_redistribute_full_bundle_columns`` runs early when
     # only local port Ys are available; for terminal sections whose
     # port Y differs from the row's eventual trunk Y, the symmetric
@@ -1334,13 +1302,13 @@ def _compute_section_layout(
     # Y as the anchor so the trunk row stays empty in each fanned
     # column.
     #
-    # Phase 13h.1 and Phase 13h.2 below restore invariants the recenter
+    # Stage 6.8 and Stage 6.9 below restore invariants the recenter
     # breaks; ``.N`` is used (not bare ``13h2``) so the suffix doesn't
-    # collide with the standalone Phase 13h3 further below.
+    # collide with the standalone Stage 6.12 further below.
     if graph.center_ports:
         _recenter_full_bundle_columns(graph, y_spacing)
 
-        # Phase 13h.1: Re-anchor off-track inputs after the recenter.
+        # Stage 6.8: Re-anchor off-track inputs after the recenter.
         # The recenter moves consumers to the final trunk-anchored Y,
         # which can leave the off-track icon stranded at the old
         # consumer Y (overlapping the consumer station instead of
@@ -1348,28 +1316,28 @@ def _compute_section_layout(
         # recenter Y as the new anchor and grows the section bbox
         # upward when the lifted band moves above its current top.
         _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
-        # Same canvas-fit safeguard as Phase 13 / Phase 13g: a
+        # Same canvas-fit safeguard as Stage 5.2 / Stage 6.6: a
         # reanchor-driven bbox grow can push the topmost section
         # above the canvas top.
         _shift_graph_into_canvas(graph, section_y_padding)
 
-        # Phase 13h.2: Re-run row top-align.  A Phase 13h.1 reanchor-
+        # Stage 6.9: Re-run row top-align.  A Stage 6.8 reanchor-
         # driven bbox grow leaves the section's bbox above its row
         # mates'; pull row mates' bbox tops up to match so the section
         # row stays flush along its top edge.
         _top_align_row_bboxes_only(graph)
         if validate:
-            _run_phase13_guards(graph, "after Phase 13h.2")
+            _run_pass_c_guards(graph, "after Stage 6.9")
 
-    # Phase 13i: After fan-re-centering, single-station downstream
+    # Stage 6.10: After fan-re-centering, single-station downstream
     # columns (e.g. terminus file icons) may have stayed at their
     # pre-fan Y while their sole upstream moved to the trunk.  Pin
     # them back onto the source Y so the connection stays horizontal.
     _align_terminus_to_upstream(graph)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13i")
+        _run_pass_c_guards(graph, "after Stage 6.10")
 
-    # Phase 13i2: Auto-balance pass.  For sections whose final layout
+    # Stage 6.11: Auto-balance pass.  For sections whose final layout
     # still leaves an empty band above the trunk while more siblings
     # sit below than above, lift bottommost movable siblings into the
     # empty top band so content sits symmetrically around the trunk.
@@ -1377,9 +1345,9 @@ def _compute_section_layout(
     # final trunk Y.  U-turn-safe and bbox-bounded.
     _balance_section_content_around_trunk(graph, section_y_padding, y_spacing)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13i2")
+        _run_pass_c_guards(graph, "after Stage 6.11")
 
-    # Phase 13h3: Recenter fan-out side stations on their loop midpoint.
+    # Stage 6.12: Recenter fan-out side stations on their loop midpoint.
     # The layer-based X assignment places off-trunk siblings (e.g. propd,
     # dream, DESeq2 fanned off limma between section entry and annotate
     # results) at a fixed offset from the section entry that ignores how
@@ -1389,55 +1357,55 @@ def _compute_section_layout(
     # corner Xs derived from the actual routing geometry.
     _recenter_loop_side_stations(graph)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13h3")
+        _run_pass_c_guards(graph, "after Stage 6.12")
 
-    # Phase 13j: Shrink rowspan / row-mate bboxes whose content moved
+    # Stage 6.13: Shrink rowspan / row-mate bboxes whose content moved
     # up after compact (e.g. ``_fan_source_inputs_upward`` lifted the
     # bottom rows away from the bbox bottom).  Bottom-only shrink, so
     # trunk alignment is unaffected.
     _shrink_bboxes_to_content_bottom(graph, section_y_padding)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13j")
+        _run_pass_c_guards(graph, "after Stage 6.13")
 
-    # Phase 13k: Close vertical slack that the pre-shrink row-height
+    # Stage 6.14: Close vertical slack that the pre-shrink row-height
     # estimate (in ``_compute_section_offsets``) left between row ``r``
     # and row ``r + 1`` once 13j has collapsed bboxes to their content.
     # Only fires when a rowspan section's content fell short of its row
     # claim; multi-row layouts with content-filled rows are untouched.
     _tighten_lower_rows_after_shrink(graph, section_y_gap)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13k")
+        _run_pass_c_guards(graph, "after Stage 6.14")
 
-    # Phase 13k2: Shift sparse loop-side stations (e.g. ``grea`` -- one
+    # Stage 6.15: Shift sparse loop-side stations (e.g. ``grea`` -- one
     # incoming, one outgoing, single-line consumer) onto a half-grid Y
     # when sharing the full-row Y with a busier sibling whose inbound
     # bundle would otherwise cross the sparse station's marker bbox.
-    # (Distinct from Phase 13k above; renamed to disambiguate after the
+    # (Distinct from Stage 6.14 above; renamed to disambiguate after the
     # numbering collision flagged in src/nf_metro/layout/CONTRACT.md.)
     _shift_sparse_loop_stations_to_clear_bundle(graph, y_spacing, section_y_padding)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13k2")
+        _run_pass_c_guards(graph, "after Stage 6.15")
 
-    # Phase 13l: When Phase 13k2 grew a section's bbox downward, push
+    # Stage 6.16: When Stage 6.15 grew a section's bbox downward, push
     # sections in lower rows down so they don't crowd the grown bbox.
     # ``_tighten_lower_rows_after_shrink`` only closes slack (pulls
     # rows up); the inverse push happens here.
     _push_lower_rows_after_bbox_grow(graph, section_y_gap)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13l")
+        _run_pass_c_guards(graph, "after Stage 6.16")
 
-    # Phase 13m: Pad vertical spacing between stacked file-input icons
+    # Stage 6.17: Pad vertical spacing between stacked file-input icons
     # whose under-icon captions would otherwise overlap the next icon
     # below.  The default ``y_spacing`` grid (40 px) is smaller than a
     # captioned icon's vertical extent (~44 px), so columns of source
     # inputs in DA-style sections need a slightly wider pitch.
     _pad_stacked_captioned_file_icons(graph, y_spacing, section_y_padding)
     if validate:
-        _run_phase13_guards(graph, "after Phase 13m")
+        _run_pass_c_guards(graph, "after Stage 6.17")
 
     if validate:
-        phase = "after Phase 12 (final)"
-        offsets, routes = _run_phase13_guards(graph, phase)
+        phase = "after final"
+        offsets, routes = _run_pass_c_guards(graph, phase)
         _guard_row_trunk_cy_consistent(graph, phase, offsets=offsets)
         _guard_off_track_inputs_above_consumer(graph, phase)
         _guard_row_gaps(graph, phase, section_y_gap=section_y_gap)
@@ -1599,16 +1567,16 @@ def _align_row_y_grids(
        value not found at any multi-station layer) keep their original Y.
        This preserves hub-station centering (e.g. bench_hub).
     2. **Bbox dimensions** (bbox_w, bbox_h) are unchanged.  Stations may
-       shift within their bbox but the box itself keeps its Phase-2 size.
+       shift within their bbox but the box itself keeps its Stage-1.1 size.
     3. **y_pad compensation**: a uniform shift of ``max_y_pad - y_pad``
-       is applied to every station so that after Phase 9 top-aligns
+       is applied to every station so that after Stage 3.5 top-aligns
        bbox_y, the first-station Y matches across sections despite
        differing ``_multiline_label_padding``.
 
     Stores grid metadata on ``graph._row_y_grid_info`` for the debug
     overlay to render shared Y grid lines.
 
-    Runs between Phase 2 and Phase 3, operating in local coordinates.
+    Runs between Stage 1.1 and Stage 1.3, operating in local coordinates.
     """
     from nf_metro.layout.section_placement import _assign_grid_layout
 
@@ -1842,7 +1810,7 @@ def _align_row_y_grids(
 
             # y_pad compensation: shift all stations so that the
             # distance from the top of the Y range to the first
-            # station equals max_y_pad.  After Phase 9 top-aligns
+            # station equals max_y_pad.  After Stage 3.5 top-aligns
             # bbox_y, this makes first_station_y consistent across
             # sections with different multiline label padding.
             y_pad = section_y_padding + _multiline_label_padding(sub)
@@ -2175,7 +2143,7 @@ def _compact_row_content_to_bbox_top(
        station (on-track or off-track) stays inside the bbox padding
        zone.  The uniform shift applied to the group is the minimum
        allowable shift across same-row sections; that preserves the
-       trunk-Y alignment established by Phase 11ca.  Both on-track and
+       trunk-Y alignment established by Stage 4.8.  Both on-track and
        off-track stations move together so the gap between each
        off-track input and its consumer is preserved.
     2. Shrink each section's ``bbox_h`` so the bottom slack matches
@@ -2280,7 +2248,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
     For each LEFT/RIGHT exit port that connects (directly or via a
     junction) to a same-row LEFT/RIGHT entry port, picks the entry's Y
     as the shared anchor.  This eliminates the small Y kinks left by
-    sections whose trunk Y couldn't be aligned via Phase 11ca (e.g.
+    sections whose trunk Y couldn't be aligned via Stage 4.8 (e.g.
     row-spanning sections that the trunk aligner skips); the inside-
     section link from the internal source to the port may bend by a
     pixel or two but the inter-section bundle stays perfectly
@@ -3300,7 +3268,7 @@ def _shift_sparse_loop_stations_to_clear_bundle(
 def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) -> None:
     """Push lower-row sections down when an upper-row bbox grows.
 
-    ``_shift_sparse_loop_stations_to_clear_bundle`` (Phase 13k2) can
+    ``_shift_sparse_loop_stations_to_clear_bundle`` (Stage 6.15) can
     grow a section's ``bbox_h`` downward when shifting a sparse loop
     station like ``grea`` past the original bbox bottom.  Row offsets
     were fixed earlier by ``_compute_section_offsets`` from pre-shift
@@ -3544,7 +3512,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
         half = pitch / 2.0
         # Collect non-port, on-track station Ys across the whole group
         # to estimate the row's shared grid offset.  Off-track stations
-        # were lifted by Phase 13 relative to their consumers; they
+        # were lifted by Stage 5.2 relative to their consumers; they
         # snap to the same grid (so the y_spacing gap above the
         # consumer is preserved) but don't influence the origin.
         residues: Counter[float] = Counter()
@@ -4288,7 +4256,7 @@ def _shrink_bboxes_to_content_bottom(
     this section's bbox vertical range, OR which shares at least one
     grid-row index (accounting for ``grid_row_span``).  Trimming below
     such a row-mate's bottom would undo intentional bottom alignment
-    performed by ``_align_tb_section_bbox_bottoms`` (Phase 13f) or by
+    performed by ``_align_tb_section_bbox_bottoms`` (Stage 6.5) or by
     row-spanning TB sections that share a visual bottom edge with
     row-mates one or more grid rows lower.
     """
@@ -4534,7 +4502,7 @@ def _layout_single_section(
     # the vertical spread.  Gaps larger than LINE_GAP get capped so
     # distant line base tracks don't create excessive whitespace.
     # Off-track stations carry a placeholder track that will be
-    # overwritten by Phase 13's lift-to-consumer pass, so they must not
+    # overwritten by Stage 5.2's lift-to-consumer pass, so they must not
     # influence the rank compaction of the on-track stations.
     unique_tracks = sorted(
         {tracks[sid] for sid in tracks if not sub.stations[sid].off_track}
@@ -4562,7 +4530,7 @@ def _layout_single_section(
     for sid, station in sub.stations.items():
         station.layer = layers.get(sid, 0)
         station.track = tracks.get(sid, 0)
-        # Off-track stations get rank 0 here as a placeholder; Phase 13
+        # Off-track stations get rank 0 here as a placeholder; Stage 5.2
         # overwrites their Y to ``consumer.y - n*y_spacing``.  On-track
         # stations must have a track that made it into the rank map.
         if not station.off_track:
@@ -5101,10 +5069,10 @@ def _shift_lr_perp_entry_stations(
     """Shift internal stations in LR/RL sections with perpendicular entry.
 
     Mirrors ``_adjust_tb_entry_shifts`` for horizontal-flow sections.
-    In TB sections the station shift is applied in Phase 2, and entry-port
+    In TB sections the station shift is applied in Stage 1.1, and entry-port
     alignment later overrides the port Y with the upstream source Y,
     creating a gap.  For LR/RL sections no such port-X override exists,
-    so we shift stations after port initialisation (Phase 5) while ports
+    so we shift stations after port initialisation (Stage 3.1) while ports
     stay put and internal stations move inward.
 
     The shift is only applied when the gap between the perpendicular entry
@@ -5156,7 +5124,7 @@ def _shift_lr_perp_entry_stations(
             continue  # gap is already sufficient
 
         # Shift internal stations away from the entry side.
-        # Phase 2 (_adjust_lr_entry_inset) already reserved bbox space
+        # Stage 1.1 (_adjust_lr_entry_inset) already reserved bbox space
         # for this shift, so no bbox expansion is needed here.
         for sid in section.station_ids:
             if sid in port_ids:
@@ -5693,7 +5661,7 @@ def _snap_sole_layer_stations_to_ports(graph: MetroGraph) -> None:
     to the port Y without colliding with layer-siblings.
     """
     # Build set of section IDs that participated in grid alignment.
-    # Phase 10b must not override the shared Y grid for these sections.
+    # Stage 4.2 must not override the shared Y grid for these sections.
     grid_group_secs = _grid_group_section_ids(graph)
 
     for section in graph.sections.values():
@@ -5804,8 +5772,8 @@ def _snap_sole_layer_stations_to_ports(graph: MetroGraph) -> None:
 def _snap_grid_group_entry_ports(graph: MetroGraph) -> None:
     """Snap entry ports of grid-group sections to their connected station Y.
 
-    Phase 6 aligns entry ports to the upstream junction Y (e.g. the
-    midpoint of two exit stations in the source section).  When Phase 10b
+    Stage 3.2 aligns entry ports to the upstream junction Y (e.g. the
+    midpoint of two exit stations in the source section).  When Stage 4.2
     is skipped for grid-group sections, the internal station stays on the
     grid but the port keeps the junction-derived Y, creating a diagonal.
 
@@ -5849,7 +5817,7 @@ def _snap_grid_group_entry_ports(graph: MetroGraph) -> None:
 def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
     """Snap exit ports of grid-group sections to their connected station Y.
 
-    Mirrors Phase 10c (entry port snap) for exit ports.  When a
+    Mirrors Stage 4.3 (entry port snap) for exit ports.  When a
     grid-group section's exit port is at a midpoint between internal
     stations (the default centering), move it to the Y of the connected
     internal station that feeds into it.  This eliminates midpoint
@@ -6296,7 +6264,7 @@ def _space_ports_from_termini(
             if not st or not st.is_terminus or st.is_port:
                 continue
             # Off-track stations get lifted above the topmost line track
-            # later (Phase 13), so they no longer share a Y with the
+            # later (Stage 5.2), so they no longer share a Y with the
             # inter-section bundle.  Excluding them here prevents ports
             # from being pushed away (and dragging the upstream port via
             # junction propagation) for a conflict that won't exist by
@@ -7150,7 +7118,7 @@ def _lift_off_track_stations(
 
     Caller is responsible for invoking ``_shift_graph_into_canvas``
     afterwards: the upward bbox growth here can push the topmost
-    section above the canvas top margin set by Phase 3b.
+    section above the canvas top margin set by Stage 1.5.
     """
     groups = _off_track_groups(graph)
     if not groups:
@@ -7177,14 +7145,14 @@ def _reanchor_off_track_to_consumer(
 ) -> None:
     """Re-place off-track inputs relative to consumer Ys after final snap.
 
-    Phase 13 placed each off-track input at ``consumer.y - n*y_spacing``
+    Stage 5.2 placed each off-track input at ``consumer.y - n*y_spacing``
     using the consumer's pre-snap Y.  Later phases (compaction, grid
     snap, fan re-centering) may shift the consumer, which would
     collapse or shrink the gap between the off-track input and its
     consumer.  This pass re-pins each off-track at
     ``consumer.y - n*y_spacing`` on the consumer's final snapped Y.
 
-    Bboxes were grown in Phase 13 based on the off-track positions at
+    Bboxes were grown in Stage 5.2 based on the off-track positions at
     the time.  If a re-anchor moves an off-track above the current bbox
     top minus padding, expand the bbox upward so the lifted input still
     sits inside the section's padding zone.  Same-section TOP ports

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -705,7 +705,7 @@ def _run_pass_c_guards(
     """Bisection guards run after every Pass C sub-phase boundary in
     ``validate=True`` mode.
 
-    The Stage 5.2 tidy-up pipeline is a sequence of ~20 mutating passes
+    The Pass C tidy-up pipeline is a sequence of ~20 mutating passes
     over a shared graph; before this helper, ``validate=True`` only
     sampled the final state, so a regression introduced at e.g.
     Stage 6.7 surfaced as ``after final: ...`` with no way to
@@ -725,7 +725,7 @@ def _run_pass_c_guards(
     * ``_guard_row_trunk_cy_consistent`` -- the row trunk Y is only
       finalised once Stage 6.7 has re-centred ``center_ports`` graphs.
     * ``_guard_inter_section_routes_in_row_band`` -- row-band height
-      tolerance assumes final bboxes, which Stage 6.13/k may still be
+      tolerance assumes final bboxes, which Stages 6.13 / 6.14 may still be
       shrinking.
 
     The final guard block (``after final``) composes this
@@ -1109,7 +1109,7 @@ def _compute_section_layout(
     # ---- Stage 4 - Pass B: Downstream alignment & trunk-Y consolidation -
     # Stage 4.5's port-terminus spacing can expand bboxes via
     # ``_expand_bbox_for_y``; Stage 4.7 re-runs row top-align to undo
-    # the resulting bbox-top drift.  Phases 11d / 11da run only on
+    # the resulting bbox-top drift.  Stages 4.9 / 4.10 run only on
     # ``center_ports`` graphs.
 
     # Stage 4.1: For non-fold LR/RL sections, pull exit-entry port pairs
@@ -1120,15 +1120,15 @@ def _compute_section_layout(
     # layer, snap it to the port Y so the connection is horizontal.
     _snap_sole_layer_stations_to_ports(graph)
 
-    # Stage 4.3: For grid-group sections (where 10b is skipped), snap
+    # Stage 4.3: For grid-group sections (where Stage 4.2 is skipped), snap
     # entry ports to the Y of their first connected internal station.
     # This produces a straight horizontal port-to-station connection
     # instead of a diagonal from the upstream junction Y.
     _snap_grid_group_entry_ports(graph)
 
-    # Stage 4.4: Mirror of 10c for exit ports.  Move exit ports of
+    # Stage 4.4: Mirror of Stage 4.3 for exit ports.  Move exit ports of
     # grid-group sections to the Y of the downstream entry port (which
-    # 10c already snapped to a grid station).  This eliminates detours
+    # Stage 4.3 already snapped to a grid station).  This eliminates detours
     # where lines leave at the section midpoint then route back.
     _snap_grid_group_exit_ports(graph)
 
@@ -1137,7 +1137,7 @@ def _compute_section_layout(
     _space_ports_from_termini(graph, y_spacing)
 
     # Stage 4.6: Recompute bboxes for grid-aligned sections.  Earlier
-    # phases (6, 8, 11) may have expanded bboxes for temporary port
+    # stages (3.2, 3.4, 4.5) may have expanded bboxes for temporary port
     # positions that were later corrected (e.g. Stage 4.1 pulls ports
     # back toward downstream stations).  Recompute with symmetric
     # padding around the final non-port station range.
@@ -1163,22 +1163,23 @@ def _compute_section_layout(
     # around the trunk Y when no unique trunk exists (e.g. Reporting's
     # Shiny app + Quarto report, both carrying the full bundle).
     #
-    # Why both 11da and Stage 6.7's recenter: 11da's symmetric layout
-    # is read by Stage 5.2's bbox-growth, compaction, and snap-to-grid
-    # passes (an empty trunk row in fanned columns lets 13b/13j shrink
-    # the section bbox to the compact extent).  Stage 6.7 then re-fans
-    # the same columns using the post-row-alignment trunk Y, which can
-    # have drifted from 11da's port-Y anchor.  Skipping 11da changes
-    # intermediate bbox sizes and is not empty-render-diff; the two
-    # passes are load-bearing in combination.
+    # Why both Stage 4.10 and Stage 6.7's recenter: Stage 4.10's
+    # symmetric layout is read by Stage 5.2's bbox-growth, compaction,
+    # and snap-to-grid passes (an empty trunk row in fanned columns
+    # lets Stages 5.4 / 6.13 shrink the section bbox to the compact
+    # extent).  Stage 6.7 then re-fans the same columns using the
+    # post-row-alignment trunk Y, which can have drifted from Stage
+    # 4.10's port-Y anchor.  Skipping Stage 4.10 changes intermediate
+    # bbox sizes and is not empty-render-diff; the two passes are
+    # load-bearing in combination.
     _redistribute_full_bundle_columns(graph, y_spacing)
 
     # ---- Stage 5 - Pass C: Junctions & off-track lift ------------------
     # All port positions are now final; Stage 5.1 positions junctions
-    # once.  Stage 5.2 lifts off-track stations; 13a-13c then re-align
-    # row bbox tops, compact, and re-snap inter-section port pairs
-    # (re-running Stage 5.1 for the junctions that move with them).
-    # Stage 6 below handles the rest of Pass C.
+    # once.  Stage 5.2 lifts off-track stations; Stages 5.3 to 5.5
+    # then re-align row bbox tops, compact, and re-snap inter-section
+    # port pairs (re-running Stage 5.1 for the junctions that move
+    # with them).  Stage 6 below handles the rest of Pass C.
 
     # Stage 5.1: Position junction stations in the inter-section gap.
     _position_junctions(graph)
@@ -1194,7 +1195,7 @@ def _compute_section_layout(
         _run_pass_c_guards(graph, "after Stage 5.2")
 
     # Stage 5.3: Re-align bbox tops within each grid row after off-track
-    # lifting expanded some sections upward.  Unlike Stage 3.5/11c which
+    # lifting expanded some sections upward.  Unlike Stages 3.5 / 4.7 which
     # shifts stations with the bbox, this only grows the bbox upward so
     # the empty input-band space lines up across the row.  Station Ys
     # in unlifted sections are preserved.
@@ -1240,7 +1241,7 @@ def _compute_section_layout(
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.1")
 
-    # Stage 6.2: Companion to 13d for source-stack sections.  When the
+    # Stage 6.2: Companion to Stage 6.1 for source-stack sections.  When the
     # entry column has a single full-bundle trunk plus subset-bundle
     # source inputs (file icons with no inbound edges), lift the
     # nearest-to-trunk sources into the empty top band so the section
@@ -1303,8 +1304,7 @@ def _compute_section_layout(
     # column.
     #
     # Stage 6.8 and Stage 6.9 below restore invariants the recenter
-    # breaks; ``.N`` is used (not bare ``13h2``) so the suffix doesn't
-    # collide with the standalone Stage 6.12 further below.
+    # breaks.
     if graph.center_ports:
         _recenter_full_bundle_columns(graph, y_spacing)
 
@@ -1369,7 +1369,7 @@ def _compute_section_layout(
 
     # Stage 6.14: Close vertical slack that the pre-shrink row-height
     # estimate (in ``_compute_section_offsets``) left between row ``r``
-    # and row ``r + 1`` once 13j has collapsed bboxes to their content.
+    # and row ``r + 1`` once Stage 6.13 has collapsed bboxes to their content.
     # Only fires when a rowspan section's content fell short of its row
     # claim; multi-row layouts with content-filled rows are untouched.
     _tighten_lower_rows_after_shrink(graph, section_y_gap)
@@ -1380,8 +1380,6 @@ def _compute_section_layout(
     # incoming, one outgoing, single-line consumer) onto a half-grid Y
     # when sharing the full-row Y with a busier sibling whose inbound
     # bundle would otherwise cross the sparse station's marker bbox.
-    # (Distinct from Stage 6.14 above; renamed to disambiguate after the
-    # numbering collision flagged in src/nf_metro/layout/CONTRACT.md.)
     _shift_sparse_loop_stations_to_clear_bundle(graph, y_spacing, section_y_padding)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.15")

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -945,22 +945,32 @@ def _compute_section_layout(
     See ``CONTRACT.md`` for each phase's pre/postconditions; this
     docstring is a quick map of the pipeline's structure.
 
-    Phase 1: Parse & partition (already done by parser)
-    Phase 2: Internal section layout (per section, real stations only)
-    Phase 2.5: Align Y grids across same-row, same-direction sections
-    Phase 3: Section placement (meta-graph)
-    Phase 3a: Renumber sections by visual reading order
-    Phase 3b: Adapt x/y_offset for left/top overshoot
-    Phase 4: Global coordinate mapping
+    Phase 1 (parse & partition) is already done by the parser.  The
+    pipeline below splits into six stages.  Stages 1-2 leave content in
+    local coordinates and then translate to canvas coordinates; Stages
+    3-4 are Pass A and Pass B (port positioning and refinement on a
+    fixed station layout); Stages 5-6 are Pass C, split into the
+    junction + off-track-lift block and the long vertical-settling /
+    finishing block.
 
-    Pass A - Port initialisation & section geometry:
+    Stage 1 - Section construction (local coords):
+      Phase 2:   Internal section layout (per section, real stations only)
+      Phase 2.5: Align Y grids across same-row, same-direction sections
+      Phase 3:   Section placement (meta-graph)
+      Phase 3a:  Renumber sections by visual reading order
+      Phase 3b:  Adapt x/y_offset for left/top overshoot
+
+    Stage 2 - Globalise (local -> global coords):
+      Phase 4:   Translate stations and bboxes to canvas coordinates
+
+    Stage 3 - Pass A: Port initialisation & section geometry:
       Phase 5:  Port positioning on section boundaries
       Phase 6:  Align entry ports to incoming source Y/X
       Phase 7:  Shift LR/RL perp-entry internal stations (X only)
       Phase 8:  Align fold-section exit ports (may push target sections)
       Phase 9:  Top-align sections within each grid row
 
-    Pass B - Downstream alignment & trunk-Y consolidation:
+    Stage 4 - Pass B: Downstream alignment & trunk-Y consolidation:
       Phase 10:  Align exit-entry port pairs to downstream stations
       Phase 10b: Snap sole-layer stations to port Y
       Phase 10c: Snap grid-group entry ports to first-station Y
@@ -975,12 +985,14 @@ def _compute_section_layout(
       Phase 11da: Redistribute full-bundle columns around trunk
                   (center_ports only)
 
-    Pass C - Junction positioning & Phase 13 finalisation:
+    Stage 5 - Pass C: Junctions & off-track lift:
       Phase 12:    Position junction stations in inter-section gaps
       Phase 13:    Lift off-track stations above section's top track
       Phase 13a:   Re-align bbox tops within each row (bbox-only)
       Phase 13b:   Compact row content to bbox top
       Phase 13c:   Snap inter-section LR/RL port pairs + re-position junctions
+
+    Stage 6 - Pass C: Vertical settling & finishing:
       Phase 13d:   Fan free content upward
       Phase 13d2:  Fan source inputs upward
       Phase 13d3:  Half-grid 2-branch symfan (center_ports only)
@@ -1000,6 +1012,11 @@ def _compute_section_layout(
       Phase 13m:   Pad stacked captioned file icons
     """
     from nf_metro.layout.section_placement import place_sections, position_ports
+
+    # ---- Stage 1 - Section construction (local coords) ------------------
+    # Lay out each section internally, snap row Y grids, place sections on
+    # the canvas grid, renumber by reading order, correct left/top
+    # overshoot.  All work in section-local coordinates.
 
     # Phase 2: Lay out each section independently (real stations only, no ports)
     section_subgraphs: dict[str, MetroGraph] = {}
@@ -1055,6 +1072,10 @@ def _compute_section_layout(
             standard_margin = y_offset - section_y_padding
             y_offset += standard_margin - global_top
 
+    # ---- Stage 2 - Globalise (local -> global coords) ------------------
+    # The coord-regime transition.  Owns the post-Phase-4 guard
+    # checkpoint (finite coords, stations-in-sections, bboxes-positive).
+
     # Phase 4: Translate local coords to global coords (real stations)
     for sec_id, section in graph.sections.items():
         sub = section_subgraphs.get(sec_id)
@@ -1077,7 +1098,7 @@ def _compute_section_layout(
         _guard_stations_in_sections(graph, "after Phase 4")
         _guard_section_bboxes_positive(graph, "after Phase 4")
 
-    # ---- Pass A: Port initialisation & section geometry adjustments ------
+    # ---- Stage 3 - Pass A: Port initialisation & section geometry --------
     # Position ports on bbox edges, align entry ports, shift internal
     # stations for perp entries, align fold exits, then top-align.
     # Top-align runs last so it corrects any bbox shifts from fold-exit
@@ -1117,7 +1138,7 @@ def _compute_section_layout(
     if validate:
         _guard_ports_on_boundaries(graph, "after top-align")
 
-    # ---- Pass B: Downstream alignment & trunk-Y consolidation ----------
+    # ---- Stage 4 - Pass B: Downstream alignment & trunk-Y consolidation -
     # Phase 11's port-terminus spacing can expand bboxes via
     # ``_expand_bbox_for_y``; Phase 11c re-runs row top-align to undo
     # the resulting bbox-top drift.  Phases 11d / 11da run only on
@@ -1184,12 +1205,12 @@ def _compute_section_layout(
     # passes are load-bearing in combination.
     _redistribute_full_bundle_columns(graph, y_spacing)
 
-    # ---- Pass C: Junction positioning & Phase 13 finalisation ----------
+    # ---- Stage 5 - Pass C: Junctions & off-track lift ------------------
     # All port positions are now final; Phase 12 positions junctions
-    # once.  Phase 13 lifts off-track stations; the 13a..13m sub-phases
-    # then settle bboxes, ports, junctions, and Ys to their final
-    # values (some conditional on ``center_ports`` or sparse-loop
-    # topology - see each phase's comment for the precondition).
+    # once.  Phase 13 lifts off-track stations; 13a-13c then re-align
+    # row bbox tops, compact, and re-snap inter-section port pairs
+    # (re-running Phase 12 for the junctions that move with them).
+    # Stage 6 below handles the rest of Pass C.
 
     # Phase 12: Position junction stations in the inter-section gap.
     _position_junctions(graph)
@@ -1232,6 +1253,15 @@ def _compute_section_layout(
     _position_junctions(graph)
     if validate:
         _run_phase13_guards(graph, "after Phase 13c")
+
+    # ---- Stage 6 - Pass C: Vertical settling & finishing ---------------
+    # The long settle: fan free / source content upward, half-grid
+    # symfan, snap to grid, bbox-bottom and off-track-reanchor
+    # post-snap fixups, full-bundle recenter + its invariant-restore
+    # sub-phases, terminus pin / auto-balance, loop-side X recenter,
+    # bbox shrink + row tighten / push, captioned-icon pad.  Most
+    # phases here run unconditionally; a few are gated on
+    # ``center_ports`` or on a specific topology (see each comment).
 
     # Phase 13d: Fan a section's free content upward when the row's
     # compaction left visible empty space at the bbox top.  Only fires

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -72,7 +72,7 @@ def assign_tracks(
         line_base[lid] = i * line_gap
 
     # Step 3: Group nodes by (layer, primary_line).  Off-track stations
-    # are excluded from grouping: their Y is overwritten by the Phase 13
+    # are excluded from grouping: their Y is overwritten by the Stage 5.2
     # off-track lift (anchored to the consumer station), so letting them
     # participate in fan-out placement here would only distort the trunk
     # track assignment for siblings and downstream stations.

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -134,7 +134,7 @@ def _compute_section_offsets(
 
     # Right reach re-anchored to the standard left edge so that bbox_x
     # pushed further left (e.g. by terminus-icon clearance) doesn't
-    # inflate the column.  Phase 3b of compute_layout absorbs the
+    # inflate the column.  Stage 1.5 of compute_layout absorbs the
     # leftward overhang via a global x_offset bump.
     def _effective_width(section: Section) -> float:
         return section.bbox_x + section.bbox_w + SECTION_X_PADDING

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -204,12 +204,12 @@ class MetroGraph:
     _edges_to_cache: dict[str, list[Edge]] | None = field(default=None, repr=False)
     # Lazy set view of `junctions`, invalidated on junction mutation.
     _junction_ids_cache: set[str] | None = field(default=None, repr=False)
-    # Grid alignment metadata (populated by Phase 2.5 _align_row_y_grids)
+    # Grid alignment metadata (populated by Stage 1.2 _align_row_y_grids)
     _row_y_grid_info: dict = field(default_factory=dict, repr=False)
     # Cross-phase channel: station IDs placed at half-pitch offsets
-    # relative to the row grid by Phase 13d3
+    # relative to the row grid by Stage 6.3
     # (``_apply_half_grid_2branch_symfan``) for 2-branch symfan sections.
-    # Phase 13e (``_snap_all_y_to_grid``) reads this set and skips those
+    # Stage 6.4 (``_snap_all_y_to_grid``) reads this set and skips those
     # stations so they keep their intentional half-grid Y.
     half_grid_station_ids: set[str] = field(default_factory=set, repr=False)
 

--- a/tests/test_grid_alignment.py
+++ b/tests/test_grid_alignment.py
@@ -1,4 +1,4 @@
-"""Regression tests for shared Y grid alignment (Phase 2.5).
+"""Regression tests for shared Y grid alignment (Stage 1.2).
 
 These tests verify the grid alignment behaviour across real pipeline
 examples.  They cover the issues fixed on the feat/shared-y-grid-alignment
@@ -135,7 +135,7 @@ class TestGridInvariants:
 
 
 class TestIssueK:
-    """Phase 10d must not drag exit ports away from matching downstream entry."""
+    """Stage 4.4 must not drag exit ports away from matching downstream entry."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -155,7 +155,7 @@ class TestIssueK:
 
 
 class TestIssueL:
-    """Phase 10d must preserve straight alignment->variant_calling connection."""
+    """Stage 4.4 must preserve straight alignment->variant_calling connection."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -251,7 +251,7 @@ class TestIssueN:
 
 
 class TestFanInExitPreservation:
-    """Phase 10d must keep centered midpoint for 3+ source fan-in exits."""
+    """Stage 4.4 must keep centered midpoint for 3+ source fan-in exits."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -366,7 +366,7 @@ class TestVariantbenchmarkingSpacing:
 
 
 # ---------------------------------------------------------------------------
-# Inter-section port pair snap (final-polish phase 13c)
+# Inter-section port pair snap (final-polish Stage 5.5)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1791,7 +1791,7 @@ class TestPassCBisection:
     # surfaces at ``after Stage 6.6`` (the first un-gated overlap
     # check), which is the accepted trade-off for letting the bisection
     # set tolerate the off-track-stranded-on-consumer transient at
-    # Stage 6.4/13f (see ``_BISECTION_FIRST_VALID`` in engine.py).
+    # Stages 6.4 / 6.5 (see ``_BISECTION_FIRST_VALID`` in engine.py).
     @pytest.mark.parametrize(
         "corruption_helper,expected_phase",
         [

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -374,8 +374,8 @@ def test_section_content_y_stable_under_neutral_layout():
 
 
 def test_rowspan_trim_doesnt_misalign_tb_bbox_bottom():
-    """``_shrink_bboxes_to_content_bottom`` (Phase 13j) must not undo
-    ``_align_tb_section_bbox_bottoms`` (Phase 13f), nor trim a
+    """``_shrink_bboxes_to_content_bottom`` (Stage 6.13) must not undo
+    ``_align_tb_section_bbox_bottoms`` (Stage 6.5), nor trim a
     row-spanning TB section's bbox bottom above a known row-mate it
     visually shares a bottom edge with.
 
@@ -1379,7 +1379,7 @@ def test_label_text_width_empty():
     assert label_text_width("") == 0
 
 
-# --- Port-terminus spacing (Phase 7c) ---
+# --- Port-terminus spacing (Stage 4.5) ---
 
 
 def test_port_terminus_spacing_basic():
@@ -1436,7 +1436,7 @@ def test_port_terminus_spacing_basic():
 
 
 def test_port_terminus_spacing_no_station_as_elbow():
-    """Phase 7c must not introduce station-as-elbow violations.
+    """Stage 4.5 must not introduce station-as-elbow violations.
 
     Uses the variant_calling_tuned example which triggered the original
     icon overlap issue, and checks that the fix doesn't create new
@@ -1452,7 +1452,7 @@ def test_port_terminus_spacing_no_station_as_elbow():
 
     violations = check_station_as_elbow(graph)
     errors = [v for v in violations if v.severity == Severity.ERROR]
-    assert not errors, "station-as-elbow violations after Phase 7c:\n" + "\n".join(
+    assert not errors, "station-as-elbow violations after Stage 4.5:\n" + "\n".join(
         v.message for v in errors
     )
 
@@ -1627,7 +1627,7 @@ def test_port_terminus_spacing_multi_terminus():
 
 
 # ---------------------------------------------------------------------------
-# Phase-boundary guard tests
+# Stage-boundary guard tests
 # ---------------------------------------------------------------------------
 
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
@@ -1690,7 +1690,7 @@ class TestPhaseGuards:
 class TestShiftGraphIntoCanvas:
     """Behavioural invariants of ``_shift_graph_into_canvas``.
 
-    The helper is called explicitly from three Phase-13 sub-step
+    The helper is called explicitly from three Pass C sub-step
     sites in ``_compute_section_layout``.  Each call must be safe
     regardless of whether the preceding bbox-growing helper actually
     grew anything; the helper's own no-op guard makes the call
@@ -1751,15 +1751,16 @@ class TestShiftGraphIntoCanvas:
         assert graph.stations["a"].y == first_station_y
 
 
-class TestPhase13Bisection:
-    """Bisection guards fired at each Phase-13x boundary must identify the
-    offending sub-phase, not the catch-all 'after Phase 12 (final)' label.
+class TestPassCBisection:
+    """Bisection guards fired at each Pass C bisection boundary must
+    identify the offending sub-stage, not the catch-all 'after final'
+    label.
 
-    Without bisection, a regression introduced by e.g. Phase 13k2 surfaces
-    as ``after Phase 12 (final): position clash: ...``; the maintainer
+    Without bisection, a regression introduced by e.g. Stage 6.15 surfaces
+    as ``after final: position clash: ...``; the maintainer
     must manually bisect by toggling phases to find the culprit.  With
     bisection, the same regression surfaces immediately as
-    ``after Phase 13k2: position clash: ...``.
+    ``after Stage 6.15: position clash: ...``.
     """
 
     # One representative fixture per check: simple two-station section
@@ -1785,22 +1786,22 @@ class TestPhase13Bisection:
 
     # Corruption-phase -> expected surfacing checkpoint.  When the
     # corruption phase is at or after the overlap-guard's first valid
-    # checkpoint (``after Phase 13g``), bisection localises to the
+    # checkpoint (``after Stage 6.6``), bisection localises to the
     # corruption phase itself.  Otherwise the overlap regression
-    # surfaces at ``after Phase 13g`` (the first un-gated overlap
+    # surfaces at ``after Stage 6.6`` (the first un-gated overlap
     # check), which is the accepted trade-off for letting the bisection
     # set tolerate the off-track-stranded-on-consumer transient at
-    # Phase 13e/13f (see ``_BISECTION_FIRST_VALID`` in engine.py).
+    # Stage 6.4/13f (see ``_BISECTION_FIRST_VALID`` in engine.py).
     @pytest.mark.parametrize(
         "corruption_helper,expected_phase",
         [
-            ("_lift_off_track_stations", "after Phase 13g"),
-            ("_top_align_row_bboxes_only", "after Phase 13g"),
-            ("_compact_row_content_to_bbox_top", "after Phase 13g"),
-            ("_snap_all_y_to_grid", "after Phase 13g"),
-            ("_align_terminus_to_upstream", "after Phase 13i"),
-            ("_shrink_bboxes_to_content_bottom", "after Phase 13j"),
-            ("_pad_stacked_captioned_file_icons", "after Phase 13m"),
+            ("_lift_off_track_stations", "after Stage 6.6"),
+            ("_top_align_row_bboxes_only", "after Stage 6.6"),
+            ("_compact_row_content_to_bbox_top", "after Stage 6.6"),
+            ("_snap_all_y_to_grid", "after Stage 6.6"),
+            ("_align_terminus_to_upstream", "after Stage 6.10"),
+            ("_shrink_bboxes_to_content_bottom", "after Stage 6.13"),
+            ("_pad_stacked_captioned_file_icons", "after Stage 6.17"),
         ],
     )
     def test_overlap_localises_to_phase(
@@ -1843,7 +1844,7 @@ class TestPhase13Bisection:
         compute_layout(graph, validate=True)
 
     # Minimal center_ports fixture: enters the `if graph.center_ports:`
-    # block at Phase 13h so the "after Phase 13h.2" checkpoint actually
+    # block at Stage 6.7 so the "after Stage 6.9" checkpoint actually
     # fires.  Plain enough not to need full-bundle reanchoring, so the
     # helpers there are effective no-ops and the checkpoint is reached
     # cleanly.
@@ -1863,15 +1864,15 @@ class TestPhase13Bisection:
     )
 
     def test_phase_13h_subphase_checkpoint_fires_on_center_ports(self, monkeypatch):
-        """Phase 13h.2's bisection checkpoint surfaces a regression
+        """Stage 6.9's bisection checkpoint surfaces a regression
         introduced by ``_top_align_row_bboxes_only`` inside the
         ``if center_ports:`` branch.
 
         This exercises a code path the default ``_MMD`` fixture (no
         ``center_ports``) cannot reach.  The corruption runs *after*
-        the Phase 13a checkpoint to avoid a false positive there: we
+        the Stage 5.3 checkpoint to avoid a false positive there: we
         corrupt only on the second invocation of
-        ``_top_align_row_bboxes_only``, which lands inside Phase 13h.2.
+        ``_top_align_row_bboxes_only``, which lands inside Stage 6.9.
         """
         from nf_metro.layout import engine
 
@@ -1881,9 +1882,9 @@ class TestPhase13Bisection:
         def corrupt(graph, *args, **kwargs):
             result = original(graph, *args, **kwargs)
             call_count["n"] += 1
-            # First call is Phase 13a (always runs); second is Phase 13h.2
+            # First call is Stage 5.3 (always runs); second is Stage 6.9
             # (only on center_ports graphs).  Corrupt only on the second
-            # to hit the Phase 13h.2 checkpoint specifically.
+            # to hit the Stage 6.9 checkpoint specifically.
             if call_count["n"] >= 2:
                 a = graph.stations.get("a")
                 a2 = graph.stations.get("a2")
@@ -1899,24 +1900,24 @@ class TestPhase13Bisection:
             compute_layout(graph, validate=True)
 
         msg = str(excinfo.value)
-        assert msg.startswith("after Phase 13h.2:"), (
-            f"Expected bisection to identify Phase 13h.2, but error was: {msg!r}"
+        assert msg.startswith("after Stage 6.9:"), (
+            f"Expected bisection to identify Stage 6.9, but error was: {msg!r}"
         )
         assert call_count["n"] == 2, (
             f"Expected exactly 2 calls to _top_align_row_bboxes_only "
-            f"(Phase 13a + Phase 13h.2), got {call_count['n']}"
+            f"(Stage 5.3 + Stage 6.9), got {call_count['n']}"
         )
 
     def test_gated_overlap_guard_fires_at_later_bisection_checkpoints(
         self, monkeypatch
     ):
-        """An overlap injected at Phase 13m must surface at the
-        ``after Phase 13m`` bisection checkpoint (not deferred to the
+        """An overlap injected at Stage 6.17 must surface at the
+        ``after Stage 6.17`` bisection checkpoint (not deferred to the
         final block).
 
         Confirms ``_BISECTION_FIRST_VALID`` only delays a guard's
         first valid checkpoint -- once past the threshold (``after
-        Phase 13g`` for the overlap guard), the guard fires at every
+        Stage 6.6`` for the overlap guard), the guard fires at every
         subsequent bisection checkpoint.
         """
         from nf_metro.layout import engine
@@ -1939,38 +1940,39 @@ class TestPhase13Bisection:
             compute_layout(graph, validate=True)
 
         msg = str(excinfo.value)
-        assert msg.startswith("after Phase 13m:"), (
-            f"Expected bisection to surface at 'after Phase 13m' "
-            f"(overlap guard runs at every checkpoint from Phase 13g "
+        assert msg.startswith("after Stage 6.17:"), (
+            f"Expected bisection to surface at 'after Stage 6.17' "
+            f"(overlap guard runs at every checkpoint from Stage 6.6 "
             f"onward), but error was: {msg!r}"
         )
 
     @pytest.mark.parametrize(
         "guard_name,first_valid",
         [
-            ("_guard_stations_in_sections", "after Phase 13a"),
-            ("_guard_no_station_overlap", "after Phase 13g"),
-            ("_guard_no_line_crosses_non_consumer", "after Phase 13k2"),
+            ("_guard_stations_in_sections", "after Stage 5.3"),
+            ("_guard_no_station_overlap", "after Stage 6.6"),
+            ("_guard_no_line_crosses_non_consumer", "after Stage 6.15"),
         ],
     )
     def test_bisection_first_valid_threshold(self, guard_name, first_valid):
         """``_BISECTION_FIRST_VALID`` thresholds must reference real
-        Phase-13x checkpoints; ``_bisection_should_run`` must skip the
-        guard at the preceding checkpoint and run it at the threshold.
+        Pass C bisection checkpoints; ``_bisection_should_run`` must
+        skip the guard at the preceding checkpoint and run it at the
+        threshold.
         """
         from nf_metro.layout import engine
 
-        assert first_valid in engine._PHASE_13_ORDER, (
-            f"Threshold {first_valid!r} not a known Phase-13x checkpoint"
+        assert first_valid in engine._PASS_C_BISECTION_ORDER, (
+            f"Threshold {first_valid!r} not a known Pass C checkpoint"
         )
         assert engine._BISECTION_FIRST_VALID[guard_name] == first_valid
 
-        idx = engine._PHASE_13_ORDER.index(first_valid)
+        idx = engine._PASS_C_BISECTION_ORDER.index(first_valid)
         assert engine._bisection_should_run(guard_name, first_valid) is True
         if idx > 0:
-            prev_phase = engine._PHASE_13_ORDER[idx - 1]
+            prev_phase = engine._PASS_C_BISECTION_ORDER[idx - 1]
             assert engine._bisection_should_run(guard_name, prev_phase) is False
-        # Final-block phase is not in _PHASE_13_ORDER; guard always runs.
+        # Final-block phase is not in _PASS_C_BISECTION_ORDER; guard always runs.
         assert (
-            engine._bisection_should_run(guard_name, "after Phase 12 (final)") is True
+            engine._bisection_should_run(guard_name, "after final") is True
         )

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1973,6 +1973,4 @@ class TestPassCBisection:
             prev_phase = engine._PASS_C_BISECTION_ORDER[idx - 1]
             assert engine._bisection_should_run(guard_name, prev_phase) is False
         # Final-block phase is not in _PASS_C_BISECTION_ORDER; guard always runs.
-        assert (
-            engine._bisection_should_run(guard_name, "after final") is True
-        )
+        assert engine._bisection_should_run(guard_name, "after final") is True

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2054,7 +2054,7 @@ def test_loop_column_stations_share_x(fixture):
 
 
 # ---------------------------------------------------------------------------
-# Section bbox bottom padding (Phase 13k post-shift padding)
+# Section bbox bottom padding (Stage 6.14 post-shift padding)
 # ---------------------------------------------------------------------------
 
 
@@ -2071,7 +2071,7 @@ def test_section_bbox_has_bottom_padding(fixture):
     edge, so the invariant is ``bbox_bot >= max(station.y) +
     section_y_padding``.
 
-    ``_shift_sparse_loop_stations_to_clear_bundle`` (Phase 13k) can
+    ``_shift_sparse_loop_stations_to_clear_bundle`` (Stage 6.14) can
     move a sparse loop station like ``grea`` further down without
     restoring this padding.  Catches the v116 regression where
     section 3's bbox sat ~5px below ``grea``'s centre instead of
@@ -2113,7 +2113,7 @@ def test_section_bbox_has_bottom_padding(fixture):
 
 
 # ---------------------------------------------------------------------------
-# Inter-row gap accommodates grown bboxes from Phase 13k shifts
+# Inter-row gap accommodates grown bboxes from Stage 6.14 shifts
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Replaces the organic `Phase N[suffix]` tree (`Phase 13`, `13a`, `13d2`, `13h.1`, `13k2`, ...) inside `_compute_section_layout` with a flat **Stage X.Y** scheme grouped into six named stages.  The old names encoded insertion history; the new names walk the pipeline in order.  Comments and markdown only; no pipeline behaviour change.

### The six stages

| Stage | Sub-stages | Owns |
|---|---|---|
| 1. Section construction (local coords) | 1.1 to 1.5 | Internal section layout, row Y-grid snap, canvas placement, reading-order renumber, overshoot fixup |
| 2. Globalise (local -> global coords) | 2.1 | Local-to-global coord translation |
| 3. Pass A: port init & section geometry | 3.1 to 3.5 | Port positioning, entry/exit alignment, perp-entry shifts, top-align |
| 4. Pass B: downstream alignment & trunk-Y consolidation | 4.1 to 4.10 | Port pull, grid-group snap, terminus spacing, trunk-Y align, fan redistribution |
| 5. Pass C: junctions & off-track lift | 5.1 to 5.5 | Junction positioning, off-track lift, row top-align, compaction, port-pair snap |
| 6. Pass C: vertical settling & finishing | 6.1 to 6.17 | Fan-up, snap to grid, off-track re-anchor, full-bundle recenter, balance, bbox shrink/tighten, icon padding |

### What changed

- **44 phase identifiers renamed** to flat `Stage X.Y` form (`Phase 2` -> `Stage 1.1`, ..., `Phase 13m` -> `Stage 6.17`).  728 replacements across 11 files.
- **6 `# ---- Stage N - ... ----` dividers** in `_compute_section_layout` matching a new `## Stage overview` section in `CONTRACT.md`.
- **`_compute_section_layout` docstring shrunk** from a 70-line per-sub-stage enumeration to a 35-line stage-level summary.  `CONTRACT.md` retains the authoritative per-sub-stage table.
- **`_run_phase13_guards` -> `_run_pass_c_guards`**, **`_PHASE_13_ORDER` -> `_PASS_C_BISECTION_ORDER`**, **`TestPhase13Bisection` -> `TestPassCBisection`**, **`"after Phase 12 (final)"` -> `"after final"`** (the `12` was a misleading historical label - the catch-all checkpoint runs after the entire pipeline, not after the old Phase 12).
- **New `docs/dev/layout_pipeline.md`**: prose walkthrough of the six stages, the Stage / Pass relationship, common debugging scenarios, and why so many sub-stages exist.  Wired into the mkdocs site nav under "Internals".
- **`CONTRACT.md` cleanup**: re-titled "Layout Stage Contract"; "Adding a new stage" checklist updated for the flat-numbering convention; the `Phase 5b: (none)` placeholder deleted (no equivalent under flat numbering); body text uniformly references `Stage X.Y`.  The deliberate historical annotation about the `Phase 13k` -> `Phase 13k2` rename in PR #342 is retained as the record of why the new scheme exists.

### What's NOT in this PR

- **Repair-phase audit**: folding invariant-restoring sub-stages (6.8 / 6.9, 6.14 / 6.13, 6.15 / 6.16) back into their breakers is filed as #376 for follow-up.  Each fold is per-pair investigation with gallery-diff vetting and is a behaviour change, not cosmetic.
- **Any pipeline reordering or logic change**.

## Test plan

- [x] `pytest -q` - 2240 passed, 7 pre-existing xfails unchanged (issues #318, #348)
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [ ] CI green on the final commit
- [ ] Gallery render diff confirmed empty (comment-only change, no possible visual delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)