### PR TITLE
refactor(layout): fold repair-only Stage 6 sub-stages (#376)

### DIFF
--- a/docs/dev/layout_pipeline.md
+++ b/docs/dev/layout_pipeline.md
@@ -134,7 +134,7 @@ their consumers, then a few post-lift fixups.
 
 ### Stage 6 - Pass C: vertical settling & finishing
 
-The long settle.  16 sub-stages clean up the consequences of Stages 1
+The long settle.  15 sub-stages clean up the consequences of Stages 1
 through 5, snap everything to the grid, restore invariants broken by
 each cleanup pass, then handle the final geometric details (loop-side
 X recenter, bbox shrink, captioned-icon spacing).
@@ -154,11 +154,12 @@ X recenter, bbox shrink, captioned-icon spacing).
 - **Stages 6.10 to 6.12**: Pin single-station downstream columns to
   their unique upstream Y; auto-balance content around the trunk;
   re-center loop-side stations on their loop midpoint (X-axis pass).
-- **Stages 6.13 to 6.15**: Shrink bbox bottoms to content, close
-  vertical slack between rows; shift sparse loop-side stations onto
-  half-pitch Ys to clear bundle pass-throughs (the same helper pushes
-  lower rows down internally when a shift grew a bbox).
-- **Stage 6.16**: Pad stacked captioned file-icon columns so
+- **Stages 6.13 to 6.14**: Shrink bbox bottoms to content and close
+  vertical slack between rows in one two-phase helper; shift sparse
+  loop-side stations onto half-pitch Ys to clear bundle
+  pass-throughs (the same helper pushes lower rows down internally
+  when a shift grew a bbox).
+- **Stage 6.15**: Pad stacked captioned file-icon columns so
   under-icon captions don't overlap the icon below.
 
 Stage 6 is where most of the historical organic-suffix sprawl (the old
@@ -210,7 +211,7 @@ Common scenarios and where to start looking:
 
 ## Why so many sub-stages
 
-The Pass C tail (Stages 6.1 to 6.16) looks excessive at first glance.
+The Pass C tail (Stages 6.1 to 6.15) looks excessive at first glance.
 Each sub-stage exists because:
 
 1. A bug was found in some real-world fixture.

--- a/docs/dev/layout_pipeline.md
+++ b/docs/dev/layout_pipeline.md
@@ -134,7 +134,7 @@ their consumers, then a few post-lift fixups.
 
 ### Stage 6 - Pass C: vertical settling & finishing
 
-The long settle.  17 sub-stages clean up the consequences of Stages 1
+The long settle.  16 sub-stages clean up the consequences of Stages 1
 through 5, snap everything to the grid, restore invariants broken by
 each cleanup pass, then handle the final geometric details (loop-side
 X recenter, bbox shrink, captioned-icon spacing).
@@ -154,11 +154,11 @@ X recenter, bbox shrink, captioned-icon spacing).
 - **Stages 6.10 to 6.12**: Pin single-station downstream columns to
   their unique upstream Y; auto-balance content around the trunk;
   re-center loop-side stations on their loop midpoint (X-axis pass).
-- **Stages 6.13 to 6.16**: Shrink bbox bottoms to content, close
+- **Stages 6.13 to 6.15**: Shrink bbox bottoms to content, close
   vertical slack between rows; shift sparse loop-side stations onto
-  half-pitch Ys to clear bundle pass-throughs; push lower rows down
-  when those shifts grew a bbox.
-- **Stage 6.17**: Pad stacked captioned file-icon columns so
+  half-pitch Ys to clear bundle pass-throughs (the same helper pushes
+  lower rows down internally when a shift grew a bbox).
+- **Stage 6.16**: Pad stacked captioned file-icon columns so
   under-icon captions don't overlap the icon below.
 
 Stage 6 is where most of the historical organic-suffix sprawl (the old
@@ -210,7 +210,7 @@ Common scenarios and where to start looking:
 
 ## Why so many sub-stages
 
-The Pass C tail (Stages 6.1 to 6.17) looks excessive at first glance.
+The Pass C tail (Stages 6.1 to 6.16) looks excessive at first glance.
 Each sub-stage exists because:
 
 1. A bug was found in some real-world fixture.

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -56,7 +56,7 @@ Stages split into three regimes:
 | after final | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
 Bisection checkpoints fire after every Pass C sub-stage (see the
-`# Stage 5.2:` through `# Stage 6.16:` comments in
+`# Stage 5.2:` through `# Stage 6.15:` comments in
 `_compute_section_layout`). Three guards
 hold continuously only from a specific checkpoint onward, and the
 bisection runner skips them earlier; see `_BISECTION_FIRST_VALID` in
@@ -66,7 +66,7 @@ bisection runner skips them earlier; see `_BISECTION_FIRST_VALID` in
 |---|---|---|
 | `_guard_stations_in_sections` | after Stage 5.3 | Stage 5.2's off-track lift moves stations above the section bbox; Stage 5.3 grows the bbox to enclose them. |
 | `_guard_no_station_overlap` | after Stage 6.6 | Stage 6.4's snap-to-grid can land an off-track terminus icon on its on-track column-mate's Y; Stage 6.6 re-anchors the off-track above its consumer. |
-| `_guard_no_line_crosses_non_consumer` | after Stage 6.15 | A sparse loop-side station sits on the trunk Y until Stage 6.15 shifts it to a half-grid offset; before that, sibling line bundles pass through its marker bbox. |
+| `_guard_no_line_crosses_non_consumer` | after Stage 6.14 | A sparse loop-side station sits on the trunk Y until Stage 6.14 shifts it to a half-grid offset; before that, sibling line bundles pass through its marker bbox. |
 
 Three further guards are excluded from the bisection set entirely
 (meaningful only at the final boundary); the `_run_pass_c_guards`
@@ -577,32 +577,31 @@ in pipeline order.
   `test_loop_recenter_only_for_pure_side_branches`,
   `test_loop_column_stations_share_x`.
 
-### Stage 6.13: shrink bbox to content bottom (engine.py:783-787)
+### Stage 6.13: shrink and tighten rows (engine.py:783-794)
 - **Purpose**: Shrink each section's bbox bottom to
-  `max_content_y + section_y_padding` after earlier phases lifted
-  bottom rows.
-- **Helper**: `_shrink_bboxes_to_content_bottom` (engine.py:3708).
+  `max_content_y + section_y_padding` (phase 1), then pull lower-row
+  sections up to close any vertical slack the shrink revealed
+  (phase 2).  Phase 1 handles bbox bottoms that drifted after earlier
+  passes lifted content; phase 2 handles the pre-shrink row-height
+  overestimate when a rowspan section collapses to less than its
+  row claim.  Phase 2 must run as a second pass over the graph so
+  every section's shrink is finalised before row-gap deficits are
+  measured.
+- **Helper**: `_shrink_and_tighten_rows` (orchestrates
+  `_shrink_bboxes_to_content_bottom` then
+  `_tighten_lower_rows_after_shrink`).
 - **Precondition**: All content Ys final.
 - **Postcondition**: Section bbox bottoms sit `section_y_padding`
-  below the deepest content. Trunk alignment unaffected (only bottom
-  shrinks).
-- **Invariants preserved**: Bbox tops. Station / port / junction Ys.
+  below the deepest content (trunk alignment unaffected -- only
+  bottom shrinks).  For each row pair, the row gap is `section_y_gap`
+  (no more, no less, except where rowspan sections filled their full
+  row claim).
+- **Invariants preserved**: Bbox tops. Within-row trunk Ys. Bbox
+  heights of upper rows.
 - **Related tests**: `test_section_bbox_has_bottom_padding`,
   `test_section_bbox_matches_content_extent`.
 
-### Stage 6.14: tighten lower rows after shrink (engine.py:789-794)
-- **Purpose**: Pull lower-row sections up to close vertical slack left
-  by the pre-shrink row-height estimate when rowspan sections
-  collapsed via Stage 6.13.
-- **Helper**: `_tighten_lower_rows_after_shrink` (engine.py:3802).
-- **Precondition**: Stage 6.13 shrank some rowspan sections.
-- **Postcondition**: For each row pair, the row gap is
-  `section_y_gap` (no more, no less, except where rowspan sections
-  filled their full row claim).
-- **Invariants preserved**: Within-row trunk Ys. Bbox heights of
-  upper rows.
-
-### Stage 6.15: shift and propagate loop stations (engine.py:796-806)
+### Stage 6.14: shift and propagate loop stations (engine.py:796-806)
 - **Purpose**: Shift sparse loop-side stations (one inbound, one
   outbound, single-line consumer) onto a half-pitch Y when sharing
   the full-row Y with a busier sibling whose inbound bundle would
@@ -622,7 +621,7 @@ in pipeline order.
   `test_no_icon_overlaps_line_path`,
   `test_row_gap_accommodates_bypass`.
 
-### Stage 6.16: pad stacked captioned file icons (engine.py:808-813)
+### Stage 6.15: pad stacked captioned file icons (engine.py:808-813)
 - **Purpose**: Pad vertical spacing between stacked file-input icons
   whose under-icon captions would overlap the icon below at default
   `y_spacing`.
@@ -646,7 +645,7 @@ following before merging:
 
 1. **Stage tag**: pick the next sequential number within the
    appropriate stage (e.g. a new Stage 6.x sub-step gets the next
-   integer after Stage 6.16).  Historical note: the organic phase
+   integer after Stage 6.15).  Historical note: the organic phase
    suffix tree (`13d2`, `13k2`, the `Phase 13k` -> `Phase 13k2`
    rename in PR #342) is what the flat Stage.N scheme is designed to
    prevent.

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -56,7 +56,7 @@ Stages split into three regimes:
 | after final | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
 Bisection checkpoints fire after every Pass C sub-stage (see the
-`# Stage 5.2:` through `# Stage 6.17:` comments in
+`# Stage 5.2:` through `# Stage 6.16:` comments in
 `_compute_section_layout`). Three guards
 hold continuously only from a specific checkpoint onward, and the
 bisection runner skips them earlier; see `_BISECTION_FIRST_VALID` in
@@ -602,32 +602,27 @@ in pipeline order.
 - **Invariants preserved**: Within-row trunk Ys. Bbox heights of
   upper rows.
 
-### Stage 6.15: shift sparse loop stations to clear bundle (engine.py:796-800)
+### Stage 6.15: shift and propagate loop stations (engine.py:796-806)
 - **Purpose**: Shift sparse loop-side stations (one inbound, one
   outbound, single-line consumer) onto a half-pitch Y when sharing
   the full-row Y with a busier sibling whose inbound bundle would
-  otherwise breeze-past the sparse station's marker.
-- **Helper**: `_shift_sparse_loop_stations_to_clear_bundle`
-  (engine.py:2563).
+  otherwise breeze-past the sparse station's marker.  When a shift
+  grows a section's bbox downward, push lower-row sections down
+  internally to restore `section_y_gap`.
+- **Helper**: `_shift_and_propagate_loop_stations`
+  (calls `_push_lower_rows_after_bbox_grow` when any bbox grew).
 - **Precondition**: Bundle Ys final.
 - **Postcondition**: Sparse single-line loop stations whose row Y
   conflicts with a busier sibling's bundle move to a half-pitch
-  offset. May grow bbox downward.
-- **Invariants preserved**: Busy sibling Y. Bundle Y.
+  offset (may grow bbox downward).  Row gaps preserved across any
+  bbox grow.
+- **Invariants preserved**: Busy sibling Y. Bundle Y. Within-row Ys
+  of unaffected sections.
 - **Related tests**: `test_lines_dont_cross_non_consumer_markers`,
-  `test_no_icon_overlaps_line_path`.
+  `test_no_icon_overlaps_line_path`,
+  `test_row_gap_accommodates_bypass`.
 
-### Stage 6.16: push lower rows after bbox grow (engine.py:802-806)
-- **Purpose**: Companion to Stage 6.15 - when Stage 6.15 grew a section's bbox
-  downward, push lower-row sections down to keep
-  `section_y_gap`.
-- **Helper**: `_push_lower_rows_after_bbox_grow` (engine.py:2698).
-- **Precondition**: Stage 6.15 may have grown some bboxes.
-- **Postcondition**: Row gaps preserved across the bbox grow.
-- **Invariants preserved**: Within-row Ys.
-- **Related tests**: `test_row_gap_accommodates_bypass`.
-
-### Stage 6.17: pad stacked captioned file icons (engine.py:808-813)
+### Stage 6.16: pad stacked captioned file icons (engine.py:808-813)
 - **Purpose**: Pad vertical spacing between stacked file-input icons
   whose under-icon captions would overlap the icon below at default
   `y_spacing`.
@@ -651,7 +646,7 @@ following before merging:
 
 1. **Stage tag**: pick the next sequential number within the
    appropriate stage (e.g. a new Stage 6.x sub-step gets the next
-   integer after Stage 6.17).  Historical note: the organic phase
+   integer after Stage 6.16).  Historical note: the organic phase
    suffix tree (`13d2`, `13k2`, the `Phase 13k` -> `Phase 13k2`
    rename in PR #342) is what the flat Stage.N scheme is designed to
    prevent.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -648,7 +648,6 @@ _PASS_C_BISECTION_ORDER: tuple[str, ...] = (
     "after Stage 6.14",
     "after Stage 6.15",
     "after Stage 6.16",
-    "after Stage 6.17",
 )
 """Ordered Pass C bisection checkpoints, used by
 ``_run_pass_c_guards`` to gate guards whose invariants only become
@@ -969,7 +968,7 @@ def _compute_section_layout(
     5. **Pass C - junctions & off-track lift** (Stages 5.1 to 5.5).
        Position junctions, lift off-track stations, re-align row bbox
        tops, compact, snap inter-section port pairs.
-    6. **Pass C - vertical settling & finishing** (Stages 6.1 to 6.17).
+    6. **Pass C - vertical settling & finishing** (Stages 6.1 to 6.16).
        Fan content upward, snap to grid, re-anchor off-track, recenter
        full-bundle columns and restore their invariants, balance content
        around trunk, loop-side X recenter, bbox shrink + row tighten /
@@ -1380,26 +1379,24 @@ def _compute_section_layout(
     # incoming, one outgoing, single-line consumer) onto a half-grid Y
     # when sharing the full-row Y with a busier sibling whose inbound
     # bundle would otherwise cross the sparse station's marker bbox.
-    _shift_sparse_loop_stations_to_clear_bundle(graph, y_spacing, section_y_padding)
+    # When the shift grows a section's bbox downward, the helper also
+    # pushes lower-row sections down internally to restore
+    # ``section_y_gap`` (the row-propagation step formerly tracked as
+    # a separate Stage 6.16).
+    _shift_and_propagate_loop_stations(
+        graph, y_spacing, section_y_padding, section_y_gap
+    )
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.15")
 
-    # Stage 6.16: When Stage 6.15 grew a section's bbox downward, push
-    # sections in lower rows down so they don't crowd the grown bbox.
-    # ``_tighten_lower_rows_after_shrink`` only closes slack (pulls
-    # rows up); the inverse push happens here.
-    _push_lower_rows_after_bbox_grow(graph, section_y_gap)
-    if validate:
-        _run_pass_c_guards(graph, "after Stage 6.16")
-
-    # Stage 6.17: Pad vertical spacing between stacked file-input icons
+    # Stage 6.16: Pad vertical spacing between stacked file-input icons
     # whose under-icon captions would otherwise overlap the next icon
     # below.  The default ``y_spacing`` grid (40 px) is smaller than a
     # captioned icon's vertical extent (~44 px), so columns of source
     # inputs in DA-style sections need a slightly wider pitch.
     _pad_stacked_captioned_file_icons(graph, y_spacing, section_y_padding)
     if validate:
-        _run_pass_c_guards(graph, "after Stage 6.17")
+        _run_pass_c_guards(graph, "after Stage 6.16")
 
     if validate:
         phase = "after final"
@@ -3135,13 +3132,14 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                 graph.stations[sid].x = target_x
 
 
-def _shift_sparse_loop_stations_to_clear_bundle(
+def _shift_and_propagate_loop_stations(
     graph: MetroGraph,
     y_spacing: float,
     section_y_padding: float = SECTION_Y_PADDING,
+    section_y_gap: float = SECTION_Y_GAP,
 ) -> None:
-    """Shift single-line loop side stations onto a half-pitch Y when
-    their full-row Y collides with a busier sibling's inbound bundle.
+    """Shift sparse loop-side stations onto a half-pitch Y, then
+    propagate any bbox growth to lower rows.
 
     The bypass virtual station mechanism (``_insert_bypass_stations``)
     covers the pred -> exit_port case (e.g. ``annotate`` between limma
@@ -3158,14 +3156,17 @@ def _shift_sparse_loop_stations_to_clear_bundle(
         sibling T in the same section, and
       * shares the same Y row as that sibling,
 
-    shift S vertically by half a ``y_spacing`` away from the trunk
-    (i.e. ``trunk_y +- y_spacing / 2`` on the side S is already on)
-    so its marker bbox sits clear of the sibling's bundle Y range.
-    The shift is reverted if it would push S above or below the
-    section bbox.
+    shift S vertically by one full ``y_spacing`` away from the trunk
+    on the side it already sits on, so its marker bbox sits clear of
+    the sibling's bundle Y range.  Growing the section bbox downward
+    can then leave the lower-row gap below ``section_y_gap``; once all
+    shifts are applied, the helper pushes lower rows down to restore
+    that gap (the row-propagation step formerly handled by
+    ``_push_lower_rows_after_bbox_grow`` as a separate stage).
     """
     if y_spacing <= 0:
         return
+    any_bbox_grew = False
 
     def _consumed_lines(sid: str) -> set[str]:
         return {e.line_id for e in graph.edges_to(sid)}
@@ -3257,20 +3258,27 @@ def _shift_sparse_loop_stations_to_clear_bundle(
                 grow = sec_top + edge_pad - new_y
                 section.bbox_y -= grow
                 section.bbox_h += grow
+                any_bbox_grew = True
             elif new_y > sec_bottom - edge_pad:
                 grow = new_y - (sec_bottom - edge_pad)
                 section.bbox_h += grow
+                any_bbox_grew = True
             st.y = new_y
+
+    if any_bbox_grew:
+        _push_lower_rows_after_bbox_grow(graph, section_y_gap)
 
 
 def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) -> None:
     """Push lower-row sections down when an upper-row bbox grows.
 
-    ``_shift_sparse_loop_stations_to_clear_bundle`` (Stage 6.15) can
-    grow a section's ``bbox_h`` downward when shifting a sparse loop
-    station like ``grea`` past the original bbox bottom.  Row offsets
-    were fixed earlier by ``_compute_section_offsets`` from pre-shift
-    bbox heights, so the section below the grown one ends up sitting
+    Shared helper called by stages that may grow a section's
+    ``bbox_h`` downward after row offsets are already fixed:
+    ``_shift_and_propagate_loop_stations`` (Stage 6.15, sparse loop
+    station shift) and ``_pad_stacked_captioned_file_icons`` (Stage
+    6.16, captioned-icon pitch padding).  Row offsets were fixed
+    earlier by ``_compute_section_offsets`` from pre-grow bbox
+    heights, so the section below a grown one can end up sitting
     closer than ``section_y_gap`` from the new bbox bottom.
 
     For each row ``r >= 1``, measure the deficit between the lowest

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -3126,11 +3126,31 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
 def _shift_and_propagate_loop_stations(
     graph: MetroGraph,
     y_spacing: float,
-    section_y_padding: float = SECTION_Y_PADDING,
-    section_y_gap: float = SECTION_Y_GAP,
+    section_y_padding: float,
+    section_y_gap: float,
 ) -> None:
     """Shift sparse loop-side stations onto a half-pitch Y, then
     propagate any bbox growth to lower rows.
+
+    Two-phase unified helper.  Phase 1 shifts sparse single-line loop
+    stations clear of busier siblings' inbound bundles (and may grow
+    the section bbox downward).  Phase 2 propagates any bbox growth
+    to lower rows so ``section_y_gap`` is preserved; it is a no-op
+    when phase 1 didn't grow anything.
+    """
+    _shift_sparse_loop_stations_to_clear_bundle(graph, y_spacing, section_y_padding)
+    _push_lower_rows_after_bbox_grow(graph, section_y_gap)
+
+
+def _shift_sparse_loop_stations_to_clear_bundle(
+    graph: MetroGraph,
+    y_spacing: float,
+    section_y_padding: float = SECTION_Y_PADDING,
+) -> None:
+    """Phase 1 of :func:`_shift_and_propagate_loop_stations`.
+
+    Shift single-line loop side stations onto a half-pitch Y when
+    their full-row Y collides with a busier sibling's inbound bundle.
 
     The bypass virtual station mechanism (``_insert_bypass_stations``)
     covers the pred -> exit_port case (e.g. ``annotate`` between limma
@@ -3149,15 +3169,11 @@ def _shift_and_propagate_loop_stations(
 
     shift S vertically by one full ``y_spacing`` away from the trunk
     on the side it already sits on, so its marker bbox sits clear of
-    the sibling's bundle Y range.  Growing the section bbox downward
-    can then leave the lower-row gap below ``section_y_gap``; once all
-    shifts are applied, the helper pushes lower rows down to restore
-    that gap (the row-propagation step formerly handled by
-    ``_push_lower_rows_after_bbox_grow`` as a separate stage).
+    the sibling's bundle Y range.  The section bbox is grown when
+    necessary; phase 2 then closes the row gap that growth opened.
     """
     if y_spacing <= 0:
         return
-    any_bbox_grew = False
 
     def _consumed_lines(sid: str) -> set[str]:
         return {e.line_id for e in graph.edges_to(sid)}
@@ -3249,15 +3265,10 @@ def _shift_and_propagate_loop_stations(
                 grow = sec_top + edge_pad - new_y
                 section.bbox_y -= grow
                 section.bbox_h += grow
-                any_bbox_grew = True
             elif new_y > sec_bottom - edge_pad:
                 grow = new_y - (sec_bottom - edge_pad)
                 section.bbox_h += grow
-                any_bbox_grew = True
             st.y = new_y
-
-    if any_bbox_grew:
-        _push_lower_rows_after_bbox_grow(graph, section_y_gap)
 
 
 def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) -> None:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -647,7 +647,6 @@ _PASS_C_BISECTION_ORDER: tuple[str, ...] = (
     "after Stage 6.13",
     "after Stage 6.14",
     "after Stage 6.15",
-    "after Stage 6.16",
 )
 """Ordered Pass C bisection checkpoints, used by
 ``_run_pass_c_guards`` to gate guards whose invariants only become
@@ -668,12 +667,12 @@ checkpoint in ``_compute_section_layout``.
 #   Stage 6.6's re-anchor lifts the off-track back above its consumer.
 # - no_line_crosses_non_consumer: a sparse loop-side station (single
 #   line in, single line out, full-bundle row-mates) sits on the trunk
-#   Y until Stage 6.15 shifts it to a half-grid offset; before that,
+#   Y until Stage 6.14 shifts it to a half-grid offset; before that,
 #   the sibling line bundle's route passes through its marker bbox.
 _BISECTION_FIRST_VALID: dict[str, str] = {
     "_guard_stations_in_sections": "after Stage 5.3",
     "_guard_no_station_overlap": "after Stage 6.6",
-    "_guard_no_line_crosses_non_consumer": "after Stage 6.15",
+    "_guard_no_line_crosses_non_consumer": "after Stage 6.14",
 }
 
 
@@ -968,7 +967,7 @@ def _compute_section_layout(
     5. **Pass C - junctions & off-track lift** (Stages 5.1 to 5.5).
        Position junctions, lift off-track stations, re-align row bbox
        tops, compact, snap inter-section port pairs.
-    6. **Pass C - vertical settling & finishing** (Stages 6.1 to 6.16).
+    6. **Pass C - vertical settling & finishing** (Stages 6.1 to 6.15).
        Fan content upward, snap to grid, re-anchor off-track, recenter
        full-bundle columns and restore their invariants, balance content
        around trunk, loop-side X recenter, bbox shrink + row tighten /
@@ -1360,43 +1359,35 @@ def _compute_section_layout(
 
     # Stage 6.13: Shrink rowspan / row-mate bboxes whose content moved
     # up after compact (e.g. ``_fan_source_inputs_upward`` lifted the
-    # bottom rows away from the bbox bottom).  Bottom-only shrink, so
-    # trunk alignment is unaffected.
-    _shrink_bboxes_to_content_bottom(graph, section_y_padding)
+    # bottom rows away from the bbox bottom), then pull lower rows up
+    # to close the slack the shrink revealed.  Bottom-only shrink, so
+    # trunk alignment is unaffected; tighten only fires where a rowspan
+    # section's content fell short of its row claim.
+    _shrink_and_tighten_rows(graph, section_y_padding, section_y_gap)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.13")
 
-    # Stage 6.14: Close vertical slack that the pre-shrink row-height
-    # estimate (in ``_compute_section_offsets``) left between row ``r``
-    # and row ``r + 1`` once Stage 6.13 has collapsed bboxes to their content.
-    # Only fires when a rowspan section's content fell short of its row
-    # claim; multi-row layouts with content-filled rows are untouched.
-    _tighten_lower_rows_after_shrink(graph, section_y_gap)
-    if validate:
-        _run_pass_c_guards(graph, "after Stage 6.14")
-
-    # Stage 6.15: Shift sparse loop-side stations (e.g. ``grea`` -- one
+    # Stage 6.14: Shift sparse loop-side stations (e.g. ``grea`` -- one
     # incoming, one outgoing, single-line consumer) onto a half-grid Y
     # when sharing the full-row Y with a busier sibling whose inbound
     # bundle would otherwise cross the sparse station's marker bbox.
     # When the shift grows a section's bbox downward, the helper also
     # pushes lower-row sections down internally to restore
-    # ``section_y_gap`` (the row-propagation step formerly tracked as
-    # a separate Stage 6.16).
+    # ``section_y_gap``.
     _shift_and_propagate_loop_stations(
         graph, y_spacing, section_y_padding, section_y_gap
     )
     if validate:
-        _run_pass_c_guards(graph, "after Stage 6.15")
+        _run_pass_c_guards(graph, "after Stage 6.14")
 
-    # Stage 6.16: Pad vertical spacing between stacked file-input icons
+    # Stage 6.15: Pad vertical spacing between stacked file-input icons
     # whose under-icon captions would otherwise overlap the next icon
     # below.  The default ``y_spacing`` grid (40 px) is smaller than a
     # captioned icon's vertical extent (~44 px), so columns of source
     # inputs in DA-style sections need a slightly wider pitch.
     _pad_stacked_captioned_file_icons(graph, y_spacing, section_y_padding)
     if validate:
-        _run_pass_c_guards(graph, "after Stage 6.16")
+        _run_pass_c_guards(graph, "after Stage 6.15")
 
     if validate:
         phase = "after final"
@@ -3274,9 +3265,9 @@ def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) ->
 
     Shared helper called by stages that may grow a section's
     ``bbox_h`` downward after row offsets are already fixed:
-    ``_shift_and_propagate_loop_stations`` (Stage 6.15, sparse loop
+    ``_shift_and_propagate_loop_stations`` (Stage 6.14, sparse loop
     station shift) and ``_pad_stacked_captioned_file_icons`` (Stage
-    6.16, captioned-icon pitch padding).  Row offsets were fixed
+    6.15, captioned-icon pitch padding).  Row offsets were fixed
     earlier by ``_compute_section_offsets`` from pre-grow bbox
     heights, so the section below a grown one can end up sitting
     closer than ``section_y_gap`` from the new bbox bottom.
@@ -4241,30 +4232,57 @@ def _recenter_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
                 graph.stations[sid].y = anchor_y + off * y_spacing
 
 
+def _shrink_and_tighten_rows(
+    graph: MetroGraph,
+    section_y_padding: float,
+    section_y_gap: float,
+) -> None:
+    """Shrink section bbox bottoms to content, then pull lower rows up
+    to close any slack the shrink revealed.
+
+    Two-phase unified helper:
+
+    Phase 1 - shrink:
+      Resize each section's ``bbox_h`` so the bottom sits
+      ``section_y_padding`` below the bottom-most station / port,
+      shrinking when content rose during earlier passes
+      (``_fan_source_inputs_upward``, ``_recenter_full_bundle_columns``)
+      and growing when ``_snap_all_y_to_grid`` snapped a station
+      downward.  Station Ys are unchanged so trunk alignment is
+      preserved.  Never trims past the maximum bbox bottom of any
+      row-mate (another section whose bbox vertical range overlaps
+      this one's, OR which shares at least one grid-row index
+      accounting for ``grid_row_span``); trimming below would undo
+      intentional bottom alignment from Stage 6.5 or rowspan TB
+      sections.
+
+    Phase 2 - tighten:
+      ``_compute_section_offsets`` sizes ``row_heights[r]`` from the
+      pre-shrink bbox heights, and a rowspan section that ends at row
+      ``r`` inflates the height further to fit its (then-tall) bbox.
+      Once phase 1 collapses bbox bottoms to actual content, row
+      ``r + 1`` can sit below empty space.  For each row pair, close
+      any slack beyond ``section_y_gap`` by shifting lower rows
+      (sections + stations + ports) upward.  The tighten step needs
+      every row's shrink to finish first so the row-gap deficit is
+      measurable against the final bbox bottoms, which is why this
+      runs as a second pass over the same graph rather than per
+      section.
+    """
+    _shrink_bboxes_to_content_bottom(graph, section_y_padding)
+    _tighten_lower_rows_after_shrink(graph, section_y_gap)
+
+
 def _shrink_bboxes_to_content_bottom(
     graph: MetroGraph, section_y_padding: float
 ) -> None:
-    """Resize bbox bottoms so they sit ``section_y_padding`` below content.
+    """Phase 1 of :func:`_shrink_and_tighten_rows`.
 
-    ``_compact_row_content_to_bbox_top`` shrinks the bottom slack to
-    ``section_y_padding`` once, but later phases
-    (``_fan_source_inputs_upward``, ``_recenter_full_bundle_columns``)
-    can pull content further up, leaving fresh empty space below the
-    last station; conversely ``_snap_all_y_to_grid`` can snap a station
-    downward, eating into the existing padding.  Re-size each section's
-    ``bbox_h`` so the bottom sits ``section_y_padding`` below the
-    bottom-most station/port -- shrinking when content rose, growing
-    when content snapped down.  Station Ys are unchanged, so trunk
-    alignment is preserved.
-
-    Never trims past the maximum bbox bottom of any row-mate.  A
-    row-mate is any other section whose bbox vertical range overlaps
-    this section's bbox vertical range, OR which shares at least one
-    grid-row index (accounting for ``grid_row_span``).  Trimming below
-    such a row-mate's bottom would undo intentional bottom alignment
-    performed by ``_align_tb_section_bbox_bottoms`` (Stage 6.5) or by
-    row-spanning TB sections that share a visual bottom edge with
-    row-mates one or more grid rows lower.
+    Resize each section's ``bbox_h`` so the bottom sits
+    ``section_y_padding`` below the bottom-most station / port.  See
+    the parent helper's docstring for the full contract; this
+    function is split out so the runtime guard at "after Stage 6.13"
+    still bisects to a meaningful intermediate state.
     """
 
     def _row_mate_bottoms(section: Section) -> list[float]:
@@ -4336,27 +4354,19 @@ def _shrink_bboxes_to_content_bottom(
 
 
 def _tighten_lower_rows_after_shrink(graph: MetroGraph, section_y_gap: float) -> None:
-    """Pull lower-row sections up to close slack left by rowspan claims.
+    """Phase 2 of :func:`_shrink_and_tighten_rows`.
 
-    ``_compute_section_offsets`` sizes ``row_heights[r]`` from pre-shrink
-    bbox heights, and a rowspan section that ends at row ``r`` inflates
-    the height further to fit its (then-tall) bbox.  After
-    ``_shrink_bboxes_to_content_bottom`` collapses bbox bottoms to
-    actual content, row ``r+1`` sits below empty space when the only
-    section "filling" row ``r`` was the rowspanned one (whose own bbox
-    now ends well above the row bottom).
-
-    For each row ``r >= 1``, this measures the gap between row ``r``'s
-    current top and the max bbox bottom of sections that *end* at row
-    ``r - 1`` (single-row sections in row ``r - 1`` plus rowspan
-    sections that terminate there).  Rowspan sections that *extend
-    into* row ``r`` are excluded: their bbox bottom is now content-
-    bounded, not row-bounded, so they no longer constrain row ``r``'s
-    top.  Any slack beyond ``section_y_gap`` is closed by shifting
-    sections in row ``r`` and below (along with their stations and
-    ports) upward by that amount.  Junctions live in inter-section
-    space and routing recomputes after layout, so their positions are
-    left alone.
+    Pull lower-row sections up to close the slack revealed once
+    phase 1 collapsed bbox bottoms.  For each row ``r >= 1``, measure
+    the gap between row ``r``'s current top and the max bbox bottom
+    of sections that *end* at row ``r - 1``.  Rowspan sections that
+    *extend into* row ``r`` are excluded -- their bbox bottom is now
+    content-bounded, not row-bounded, so they no longer constrain
+    row ``r``'s top.  Any slack beyond ``section_y_gap`` is closed
+    by shifting sections in row ``r`` and below (along with their
+    stations and ports) upward by that amount.  Junctions live in
+    inter-section space and routing recomputes after layout, so
+    their positions are left alone.
     """
     if not graph.sections:
         return

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1801,7 +1801,7 @@ class TestPassCBisection:
             ("_snap_all_y_to_grid", "after Stage 6.6"),
             ("_align_terminus_to_upstream", "after Stage 6.10"),
             ("_shrink_bboxes_to_content_bottom", "after Stage 6.13"),
-            ("_pad_stacked_captioned_file_icons", "after Stage 6.17"),
+            ("_pad_stacked_captioned_file_icons", "after Stage 6.16"),
         ],
     )
     def test_overlap_localises_to_phase(
@@ -1911,8 +1911,8 @@ class TestPassCBisection:
     def test_gated_overlap_guard_fires_at_later_bisection_checkpoints(
         self, monkeypatch
     ):
-        """An overlap injected at Stage 6.17 must surface at the
-        ``after Stage 6.17`` bisection checkpoint (not deferred to the
+        """An overlap injected at Stage 6.16 must surface at the
+        ``after Stage 6.16`` bisection checkpoint (not deferred to the
         final block).
 
         Confirms ``_BISECTION_FIRST_VALID`` only delays a guard's
@@ -1940,8 +1940,8 @@ class TestPassCBisection:
             compute_layout(graph, validate=True)
 
         msg = str(excinfo.value)
-        assert msg.startswith("after Stage 6.17:"), (
-            f"Expected bisection to surface at 'after Stage 6.17' "
+        assert msg.startswith("after Stage 6.16:"), (
+            f"Expected bisection to surface at 'after Stage 6.16' "
             f"(overlap guard runs at every checkpoint from Stage 6.6 "
             f"onward), but error was: {msg!r}"
         )

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1756,11 +1756,11 @@ class TestPassCBisection:
     identify the offending sub-stage, not the catch-all 'after final'
     label.
 
-    Without bisection, a regression introduced by e.g. Stage 6.15 surfaces
+    Without bisection, a regression introduced by e.g. Stage 6.14 surfaces
     as ``after final: position clash: ...``; the maintainer
     must manually bisect by toggling phases to find the culprit.  With
     bisection, the same regression surfaces immediately as
-    ``after Stage 6.15: position clash: ...``.
+    ``after Stage 6.14: position clash: ...``.
     """
 
     # One representative fixture per check: simple two-station section
@@ -1801,7 +1801,7 @@ class TestPassCBisection:
             ("_snap_all_y_to_grid", "after Stage 6.6"),
             ("_align_terminus_to_upstream", "after Stage 6.10"),
             ("_shrink_bboxes_to_content_bottom", "after Stage 6.13"),
-            ("_pad_stacked_captioned_file_icons", "after Stage 6.16"),
+            ("_pad_stacked_captioned_file_icons", "after Stage 6.15"),
         ],
     )
     def test_overlap_localises_to_phase(
@@ -1911,8 +1911,8 @@ class TestPassCBisection:
     def test_gated_overlap_guard_fires_at_later_bisection_checkpoints(
         self, monkeypatch
     ):
-        """An overlap injected at Stage 6.16 must surface at the
-        ``after Stage 6.16`` bisection checkpoint (not deferred to the
+        """An overlap injected at Stage 6.15 must surface at the
+        ``after Stage 6.15`` bisection checkpoint (not deferred to the
         final block).
 
         Confirms ``_BISECTION_FIRST_VALID`` only delays a guard's
@@ -1940,8 +1940,8 @@ class TestPassCBisection:
             compute_layout(graph, validate=True)
 
         msg = str(excinfo.value)
-        assert msg.startswith("after Stage 6.16:"), (
-            f"Expected bisection to surface at 'after Stage 6.16' "
+        assert msg.startswith("after Stage 6.15:"), (
+            f"Expected bisection to surface at 'after Stage 6.15' "
             f"(overlap guard runs at every checkpoint from Stage 6.6 "
             f"onward), but error was: {msg!r}"
         )
@@ -1951,7 +1951,7 @@ class TestPassCBisection:
         [
             ("_guard_stations_in_sections", "after Stage 5.3"),
             ("_guard_no_station_overlap", "after Stage 6.6"),
-            ("_guard_no_line_crosses_non_consumer", "after Stage 6.15"),
+            ("_guard_no_line_crosses_non_consumer", "after Stage 6.14"),
         ],
     )
     def test_bisection_first_valid_threshold(self, guard_name, first_valid):

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2071,7 +2071,7 @@ def test_section_bbox_has_bottom_padding(fixture):
     edge, so the invariant is ``bbox_bot >= max(station.y) +
     section_y_padding``.
 
-    ``_shift_and_propagate_loop_stations`` (Stage 6.15) can
+    ``_shift_and_propagate_loop_stations`` (Stage 6.14) can
     move a sparse loop station like ``grea`` further down without
     restoring this padding.  Catches the v116 regression where
     section 3's bbox sat ~5px below ``grea``'s centre instead of
@@ -2113,7 +2113,7 @@ def test_section_bbox_has_bottom_padding(fixture):
 
 
 # ---------------------------------------------------------------------------
-# Inter-row gap accommodates grown bboxes from Stage 6.15 shifts
+# Inter-row gap accommodates grown bboxes from Stage 6.14 shifts
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2071,7 +2071,7 @@ def test_section_bbox_has_bottom_padding(fixture):
     edge, so the invariant is ``bbox_bot >= max(station.y) +
     section_y_padding``.
 
-    ``_shift_sparse_loop_stations_to_clear_bundle`` (Stage 6.14) can
+    ``_shift_and_propagate_loop_stations`` (Stage 6.15) can
     move a sparse loop station like ``grea`` further down without
     restoring this padding.  Catches the v116 regression where
     section 3's bbox sat ~5px below ``grea``'s centre instead of
@@ -2113,7 +2113,7 @@ def test_section_bbox_has_bottom_padding(fixture):
 
 
 # ---------------------------------------------------------------------------
-# Inter-row gap accommodates grown bboxes from Stage 6.14 shifts
+# Inter-row gap accommodates grown bboxes from Stage 6.15 shifts
 # ---------------------------------------------------------------------------
 
 
@@ -2123,7 +2123,7 @@ def test_row_gap_accommodates_bypass(fixture):
     row ``r + 1`` sections' bbox tops must be at least
     ``section_y_gap`` for every column-overlapping pair.
 
-    When ``_shift_sparse_loop_stations_to_clear_bundle`` grows an
+    When ``_shift_and_propagate_loop_stations`` grows an
     upper-row section's bbox downward (e.g. section 3 in the
     differentialabundance pipeline, around ``grea``), the row offset
     computed by ``_compute_section_offsets`` from the pre-shift bbox


### PR DESCRIPTION
## Summary

Folds two pairs of repair-only Pass C sub-stages into combined helpers, shrinking the Pass C tail from 17 sub-stages to 15 with no behaviour change.

**Fold 1**: Stage 6.16 (push lower rows after bbox grow) is folded into Stage 6.15 (shift sparse loop stations). New helper `_shift_and_propagate_loop_stations` is a thin two-call orchestrator over the existing phase functions `_shift_sparse_loop_stations_to_clear_bundle` then `_push_lower_rows_after_bbox_grow`. The propagator is shared with the captioned-icon pitch pass so it stays public.

**Fold 2**: Stage 6.14 (tighten lower rows after shrink) is folded into Stage 6.13 (shrink bbox bottoms). New helper `_shrink_and_tighten_rows` is a thin orchestrator over `_shrink_bboxes_to_content_bottom` then `_tighten_lower_rows_after_shrink`. Two-phase structure is required because row-gap deficits are only measurable once every section's shrink is finalised.

**Fold 3** (6.8 + 6.9 into 6.7) is deliberately deferred. The shared helpers it would consume (`_top_align_row_bboxes_only`, `_reanchor_off_track_to_consumer`, `_shift_graph_into_canvas`) are called from multiple stages; bundling them into a wrapper saves no operations and loses bisection granularity. Restructuring `_recenter_full_bundle_columns` to preserve the invariants internally is the real simplification, but it's gated on `center_ports`, hard, and high-risk; the issue explicitly says this is reasonable to leave unfolded.

Renumber `Stage 6.17` -> `Stage 6.15` across `engine.py`, `CONTRACT.md`, `layout_pipeline.md`, and the test files. Sequence 6.1..6.15 is contiguous after renumbering.

Fixes #376

## Test plan

- [x] `pytest -x -q tests/` passes (2240 passed, 7 xfailed, same as main)
- [x] `ruff check src/ tests/` clean
- [x] Local before/after render diff: byte-identical SVG on all 53 fixtures (examples/ + tests/fixtures/)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/PR_NUMBER/) - expect "No visual changes detected" since local diff is empty

Generated with Claude Code