### PR TITLE
fix(render): emit per-column debug-overlay row separators across folds (#316)

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1084,6 +1084,87 @@ def _render_labels(
             )
 
 
+def _grid_bbox_bounds(
+    sections: list[Section],
+) -> tuple[dict[int, tuple[float, float]], dict[int, tuple[float, float]]]:
+    """Collect per-column X bounds and per-row Y bounds from section bboxes.
+
+    Spanning sections (``grid_col_span > 1`` or ``grid_row_span > 1``) are
+    excluded from the corresponding axis - their extent across multiple
+    cells would distort a single-cell measurement.
+    """
+    col_bounds: dict[int, tuple[float, float]] = {}
+    row_bounds: dict[int, tuple[float, float]] = {}
+    for sec in sections:
+        c, r = sec.grid_col, sec.grid_row
+        x0, x1 = sec.bbox_x, sec.bbox_x + sec.bbox_w
+        y0, y1 = sec.bbox_y, sec.bbox_y + sec.bbox_h
+        if sec.grid_col_span == 1:
+            if c not in col_bounds:
+                col_bounds[c] = (x0, x1)
+            else:
+                col_bounds[c] = (
+                    min(col_bounds[c][0], x0),
+                    max(col_bounds[c][1], x1),
+                )
+        if sec.grid_row_span == 1:
+            if r not in row_bounds:
+                row_bounds[r] = (y0, y1)
+            else:
+                row_bounds[r] = (
+                    min(row_bounds[r][0], y0),
+                    max(row_bounds[r][1], y1),
+                )
+    return col_bounds, row_bounds
+
+
+def _compute_col_boundary_xs(
+    col_bounds: dict[int, tuple[float, float]],
+) -> list[tuple[int, int, float]]:
+    """Return ``(col_a, col_b, mid_x)`` triples for consecutive grid columns
+    whose bbox X ranges don't overlap.
+
+    A debug-overlay column separator is only meaningful when the columns
+    are visually separable; if they overlap (e.g. a wide section in col i
+    extends past col i+1's left edge) the midpoint would fall inside one
+    of their bboxes, so the pair is skipped.
+    """
+    result: list[tuple[int, int, float]] = []
+    sorted_cols = sorted(col_bounds)
+    for i in range(len(sorted_cols) - 1):
+        ca, cb = sorted_cols[i], sorted_cols[i + 1]
+        right = col_bounds[ca][1]
+        left = col_bounds[cb][0]
+        if right >= left:
+            continue
+        result.append((ca, cb, (right + left) / 2))
+    return result
+
+
+def _compute_row_boundary_ys(
+    row_bounds: dict[int, tuple[float, float]],
+) -> list[tuple[int, int, float]]:
+    """Return ``(row_a, row_b, mid_y)`` triples for consecutive grid rows
+    whose bbox Y ranges don't overlap.
+
+    When a fold extends a row's bbox into the next row's band (so the
+    upper row's ``bbox_y + bbox_h`` exceeds the lower row's ``bbox_y``),
+    no horizontal line can sit cleanly between them - the midpoint would
+    cut through both bboxes.  Such pairs are dropped from the overlay
+    rather than drawn at a misleading Y.
+    """
+    result: list[tuple[int, int, float]] = []
+    sorted_rows = sorted(row_bounds)
+    for i in range(len(sorted_rows) - 1):
+        ra, rb = sorted_rows[i], sorted_rows[i + 1]
+        bottom = row_bounds[ra][1]
+        top = row_bounds[rb][0]
+        if bottom >= top:
+            continue
+        result.append((ra, rb, (bottom + top) / 2))
+    return result
+
+
 def _render_debug_overlay(
     d: draw.Drawing,
     graph: MetroGraph,
@@ -1141,32 +1222,7 @@ def _render_debug_overlay(
     # Grid lines: dashed lines at boundaries between grid rows/columns
     sections = list(graph.sections.values())
     if sections:
-        # Collect column and row boundaries from section bboxes
-        col_bounds: dict[int, tuple[float, float]] = {}
-        row_bounds: dict[int, tuple[float, float]] = {}
-        for sec in sections:
-            c, r = sec.grid_col, sec.grid_row
-            x0, x1 = sec.bbox_x, sec.bbox_x + sec.bbox_w
-            y0, y1 = sec.bbox_y, sec.bbox_y + sec.bbox_h
-            # Skip spanning sections for column/row bounds - they distort
-            # single-column measurements by assigning their full width to
-            # one column.
-            if sec.grid_col_span == 1:
-                if c not in col_bounds:
-                    col_bounds[c] = (x0, x1)
-                else:
-                    col_bounds[c] = (
-                        min(col_bounds[c][0], x0),
-                        max(col_bounds[c][1], x1),
-                    )
-            if sec.grid_row_span == 1:
-                if r not in row_bounds:
-                    row_bounds[r] = (y0, y1)
-                else:
-                    row_bounds[r] = (
-                        min(row_bounds[r][0], y0),
-                        max(row_bounds[r][1], y1),
-                    )
+        col_bounds, row_bounds = _grid_bbox_bounds(sections)
 
         # Global extents (fall back to col/row bounds or section bboxes)
         if not col_bounds or not row_bounds:
@@ -1182,12 +1238,7 @@ def _render_debug_overlay(
             all_y1 = max(b[1] for b in row_bounds.values()) + 20
         grid_color = "rgba(255, 255, 0, 0.5)"
 
-        # Vertical lines between columns
-        sorted_cols = sorted(col_bounds.keys())
-        for i in range(len(sorted_cols) - 1):
-            right = col_bounds[sorted_cols[i]][1]
-            left = col_bounds[sorted_cols[i + 1]][0]
-            mid_x = (right + left) / 2
+        for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds):
             d.append(
                 draw.Line(
                     mid_x,
@@ -1201,7 +1252,7 @@ def _render_debug_overlay(
             )
             d.append(
                 draw.Text(
-                    f"col {sorted_cols[i]}|{sorted_cols[i + 1]}",
+                    f"col {ca}|{cb}",
                     debug_font_size,
                     mid_x,
                     all_y0 - 4,
@@ -1211,12 +1262,7 @@ def _render_debug_overlay(
                 )
             )
 
-        # Horizontal lines between rows
-        sorted_rows = sorted(row_bounds.keys())
-        for i in range(len(sorted_rows) - 1):
-            bottom = row_bounds[sorted_rows[i]][1]
-            top = row_bounds[sorted_rows[i + 1]][0]
-            mid_y = (bottom + top) / 2
+        for ra, rb, mid_y in _compute_row_boundary_ys(row_bounds):
             d.append(
                 draw.Line(
                     all_x0,
@@ -1230,7 +1276,7 @@ def _render_debug_overlay(
             )
             d.append(
                 draw.Text(
-                    f"row {sorted_rows[i]}|{sorted_rows[i + 1]}",
+                    f"row {ra}|{rb}",
                     debug_font_size,
                     all_x0 - 4,
                     mid_y,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1162,34 +1162,28 @@ def _compute_row_boundary_segments(
     return segments
 
 
-def _compute_col_boundary_segments(
-    sections: list[Section],
-    row_bounds: dict[int, tuple[float, float]],
-) -> list[tuple[int, int, float, float, float]]:
-    """Return per-row column-boundary segments as
-    ``(col_a, col_b, y_start, y_end, x)`` tuples.
+def _compute_col_boundary_xs(
+    col_bounds: dict[int, tuple[float, float]],
+) -> list[tuple[int, int, float]]:
+    """Return ``(col_a, col_b, mid_x)`` triples for consecutive grid columns
+    whose bbox X ranges don't overlap.
 
-    Mirrors :func:`_compute_row_boundary_segments` along the other
-    axis - per-row vertical segments at the local midpoint between
-    horizontally adjacent sections, skipped where bboxes locally
-    overlap in X.
+    Columns very rarely overlap in practice (sections in the same column
+    share an X range by construction), so this stays a single full-height
+    line per pair; the overlap guard is preserved as a precaution.  The
+    horizontal counterpart needs per-column segmentation because folds
+    routinely make rows overlap in Y; columns don't.
     """
-    sec_by_cell = _sections_by_grid_cell(sections)
-    cols = sorted({c for c, _ in sec_by_cell})
-    segments: list[tuple[int, int, float, float, float]] = []
-    for j in range(len(cols) - 1):
-        ca, cb = cols[j], cols[j + 1]
-        for r, (y_start, y_end) in row_bounds.items():
-            sa = sec_by_cell.get((ca, r))
-            sb = sec_by_cell.get((cb, r))
-            if sa is None or sb is None:
-                continue
-            a_right = sa.bbox_x + sa.bbox_w
-            b_left = sb.bbox_x
-            if a_right >= b_left:
-                continue
-            segments.append((ca, cb, y_start, y_end, (a_right + b_left) / 2))
-    return segments
+    result: list[tuple[int, int, float]] = []
+    sorted_cols = sorted(col_bounds)
+    for i in range(len(sorted_cols) - 1):
+        ca, cb = sorted_cols[i], sorted_cols[i + 1]
+        right = col_bounds[ca][1]
+        left = col_bounds[cb][0]
+        if right >= left:
+            continue
+        result.append((ca, cb, (right + left) / 2))
+    return result
 
 
 def _render_debug_overlay(
@@ -1251,45 +1245,40 @@ def _render_debug_overlay(
     if sections:
         col_bounds, row_bounds = _grid_bbox_bounds(sections)
 
-        # Label anchors (top-of-canvas for col labels, left for row labels).
-        # All sections spanning means no single-cell bounds exist - fall
-        # back to raw bboxes for label placement only.
+        # Global extents for full-canvas column lines and row label anchor.
         if not col_bounds or not row_bounds:
             all_x0 = min(s.bbox_x for s in sections) - 20
             all_y0 = min(s.bbox_y for s in sections) - 20
+            all_y1 = max(s.bbox_y + s.bbox_h for s in sections) + 20
         else:
             all_x0 = min(b[0] for b in col_bounds.values()) - 20
             all_y0 = min(b[0] for b in row_bounds.values()) - 20
+            all_y1 = max(b[1] for b in row_bounds.values()) + 20
         grid_color = "rgba(255, 255, 0, 0.5)"
 
-        labelled_col_pairs: set[tuple[int, int]] = set()
-        for ca, cb, y_start, y_end, x in _compute_col_boundary_segments(
-            sections, row_bounds
-        ):
+        for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds):
             d.append(
                 draw.Line(
-                    x,
-                    y_start,
-                    x,
-                    y_end,
+                    mid_x,
+                    all_y0,
+                    mid_x,
+                    all_y1,
                     stroke=grid_color,
                     stroke_width=1,
                     stroke_dasharray="6,4",
                 )
             )
-            if (ca, cb) not in labelled_col_pairs:
-                d.append(
-                    draw.Text(
-                        f"col {ca}|{cb}",
-                        debug_font_size,
-                        x,
-                        all_y0 - 4,
-                        fill=grid_color,
-                        font_family=debug_font,
-                        text_anchor="middle",
-                    )
+            d.append(
+                draw.Text(
+                    f"col {ca}|{cb}",
+                    debug_font_size,
+                    mid_x,
+                    all_y0 - 4,
+                    fill=grid_color,
+                    font_family=debug_font,
+                    text_anchor="middle",
                 )
-                labelled_col_pairs.add((ca, cb))
+            )
 
         labelled_row_pairs: set[tuple[int, int]] = set()
         for ra, rb, x_start, x_end, y in _compute_row_boundary_segments(

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1132,10 +1132,10 @@ def _compute_row_boundary_segments(
        above min bbox-top of row b), use the global midpoint - the
        natural row separator that sits below every section in the
        upper row and above every section in the lower row.
-    2. Otherwise pick the median of per-column local midpoints (cells
-       where both rows have a non-spanning section that don't locally
-       overlap).  Fold sections produce visible gaps where the line
-       would cut their bboxes.
+    2. Otherwise (a fold extends one row into the other's band), emit
+       one per-column segment at each cell's local midpoint, dropping
+       cells where the bboxes locally overlap.  Fold columns and
+       columns missing one of the two rows produce visible gaps.
     """
     if not col_bounds:
         return []
@@ -1186,11 +1186,9 @@ def _compute_col_boundary_xs(
     """Return ``(col_a, col_b, mid_x)`` triples for consecutive grid columns
     whose bbox X ranges don't overlap.
 
-    Columns very rarely overlap in practice (sections in the same column
-    share an X range by construction), so this stays a single full-height
-    line per pair; the overlap guard is preserved as a precaution.  The
-    horizontal counterpart needs per-column segmentation because folds
-    routinely make rows overlap in Y; columns don't.
+    Columns don't overlap like rows do (there's no column-axis analogue
+    of a fold), so a single canvas-spanning line per pair suffices; the
+    overlap guard is defensive.
     """
     result: list[tuple[int, int, float]] = []
     sorted_cols = sorted(col_bounds)

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1122,23 +1122,29 @@ def _compute_row_boundary_segments(
     sections: list[Section],
     col_bounds: dict[int, tuple[float, float]],
 ) -> list[tuple[int, int, float, float, float]]:
-    """Return per-column row-boundary segments as
-    ``(row_a, row_b, x_start, x_end, y)`` tuples.
+    """Return row-boundary segments as ``(row_a, row_b, x_start, x_end, y)``.
 
-    For each pair of consecutive grid rows and each column where both
-    rows have a non-spanning section, emit a horizontal segment at the
-    local midpoint between the upper section's bottom and the lower
-    section's top.  If a fold extends the upper section's bbox past
-    the lower section's top (local overlap), no segment is emitted for
-    that column - the row boundary visibly breaks at the fold column
-    instead of being plotted at a Y that would cut through bboxes.
+    For each consecutive grid-row pair, choose a representative
+    boundary Y from the per-column midpoints (median across columns
+    where both rows have a non-spanning section and don't locally
+    overlap), then draw a horizontal line at that Y spanning the
+    canvas - broken only around bboxes the line would otherwise cut.
+    Fold sections that extend past their row produce gaps in the line,
+    so the separator is visibly absent at fold columns but still
+    extends under all other sections (including columns where only one
+    of the two rows has a section).
     """
+    if not col_bounds:
+        return []
     sec_by_cell = _sections_by_grid_cell(sections)
     rows = sorted({r for _, r in sec_by_cell})
+    canvas_x0 = min(b[0] for b in col_bounds.values()) - 20
+    canvas_x1 = max(b[1] for b in col_bounds.values()) + 20
     segments: list[tuple[int, int, float, float, float]] = []
     for i in range(len(rows) - 1):
         ra, rb = rows[i], rows[i + 1]
-        for c, (x_start, x_end) in col_bounds.items():
+        anchor_ys: list[float] = []
+        for c in col_bounds:
             sa = sec_by_cell.get((c, ra))
             sb = sec_by_cell.get((c, rb))
             if sa is None or sb is None:
@@ -1147,7 +1153,31 @@ def _compute_row_boundary_segments(
             b_top = sb.bbox_y
             if a_bot >= b_top:
                 continue
-            segments.append((ra, rb, x_start, x_end, (a_bot + b_top) / 2))
+            anchor_ys.append((a_bot + b_top) / 2)
+        if not anchor_ys:
+            continue
+        anchor_ys.sort()
+        y = anchor_ys[len(anchor_ys) // 2]
+        cut_ranges: list[tuple[float, float]] = []
+        for sec in sections:
+            if sec.grid_row_span != 1 or sec.grid_row not in (ra, rb):
+                continue
+            if sec.bbox_y < y < sec.bbox_y + sec.bbox_h:
+                cut_ranges.append((sec.bbox_x, sec.bbox_x + sec.bbox_w))
+        cut_ranges.sort()
+        merged: list[tuple[float, float]] = []
+        for x0, x1 in cut_ranges:
+            if merged and x0 <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], x1))
+            else:
+                merged.append((x0, x1))
+        cursor = canvas_x0
+        for x0, x1 in merged:
+            if cursor < x0:
+                segments.append((ra, rb, cursor, x0, y))
+            cursor = max(cursor, x1)
+        if cursor < canvas_x1:
+            segments.append((ra, rb, cursor, canvas_x1, y))
     return segments
 
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1118,51 +1118,78 @@ def _grid_bbox_bounds(
     return col_bounds, row_bounds
 
 
-def _compute_col_boundary_xs(
+def _sections_by_grid_cell(
+    sections: list[Section],
+) -> dict[tuple[int, int], Section]:
+    """Index non-spanning sections by ``(grid_col, grid_row)``."""
+    out: dict[tuple[int, int], Section] = {}
+    for sec in sections:
+        if sec.grid_col_span == 1 and sec.grid_row_span == 1:
+            out[(sec.grid_col, sec.grid_row)] = sec
+    return out
+
+
+def _compute_row_boundary_segments(
+    sections: list[Section],
     col_bounds: dict[int, tuple[float, float]],
-) -> list[tuple[int, int, float]]:
-    """Return ``(col_a, col_b, mid_x)`` triples for consecutive grid columns
-    whose bbox X ranges don't overlap.
+) -> list[tuple[int, int, float, float, float]]:
+    """Return per-column row-boundary segments as
+    ``(row_a, row_b, x_start, x_end, y)`` tuples.
 
-    A debug-overlay column separator is only meaningful when the columns
-    are visually separable; if they overlap (e.g. a wide section in col i
-    extends past col i+1's left edge) the midpoint would fall inside one
-    of their bboxes, so the pair is skipped.
+    For each pair of consecutive grid rows and each column where both
+    rows have a non-spanning section, emit a horizontal segment at the
+    local midpoint between the upper section's bottom and the lower
+    section's top.  If a fold extends the upper section's bbox past
+    the lower section's top (local overlap), no segment is emitted for
+    that column - the row boundary visibly breaks at the fold column
+    instead of being plotted at a Y that would cut through bboxes.
     """
-    result: list[tuple[int, int, float]] = []
-    sorted_cols = sorted(col_bounds)
-    for i in range(len(sorted_cols) - 1):
-        ca, cb = sorted_cols[i], sorted_cols[i + 1]
-        right = col_bounds[ca][1]
-        left = col_bounds[cb][0]
-        if right >= left:
-            continue
-        result.append((ca, cb, (right + left) / 2))
-    return result
+    sec_by_cell = _sections_by_grid_cell(sections)
+    rows = sorted({r for _, r in sec_by_cell})
+    segments: list[tuple[int, int, float, float, float]] = []
+    for i in range(len(rows) - 1):
+        ra, rb = rows[i], rows[i + 1]
+        for c, (x_start, x_end) in col_bounds.items():
+            sa = sec_by_cell.get((c, ra))
+            sb = sec_by_cell.get((c, rb))
+            if sa is None or sb is None:
+                continue
+            a_bot = sa.bbox_y + sa.bbox_h
+            b_top = sb.bbox_y
+            if a_bot >= b_top:
+                continue
+            segments.append((ra, rb, x_start, x_end, (a_bot + b_top) / 2))
+    return segments
 
 
-def _compute_row_boundary_ys(
+def _compute_col_boundary_segments(
+    sections: list[Section],
     row_bounds: dict[int, tuple[float, float]],
-) -> list[tuple[int, int, float]]:
-    """Return ``(row_a, row_b, mid_y)`` triples for consecutive grid rows
-    whose bbox Y ranges don't overlap.
+) -> list[tuple[int, int, float, float, float]]:
+    """Return per-row column-boundary segments as
+    ``(col_a, col_b, y_start, y_end, x)`` tuples.
 
-    When a fold extends a row's bbox into the next row's band (so the
-    upper row's ``bbox_y + bbox_h`` exceeds the lower row's ``bbox_y``),
-    no horizontal line can sit cleanly between them - the midpoint would
-    cut through both bboxes.  Such pairs are dropped from the overlay
-    rather than drawn at a misleading Y.
+    Mirrors :func:`_compute_row_boundary_segments` along the other
+    axis - per-row vertical segments at the local midpoint between
+    horizontally adjacent sections, skipped where bboxes locally
+    overlap in X.
     """
-    result: list[tuple[int, int, float]] = []
-    sorted_rows = sorted(row_bounds)
-    for i in range(len(sorted_rows) - 1):
-        ra, rb = sorted_rows[i], sorted_rows[i + 1]
-        bottom = row_bounds[ra][1]
-        top = row_bounds[rb][0]
-        if bottom >= top:
-            continue
-        result.append((ra, rb, (bottom + top) / 2))
-    return result
+    sec_by_cell = _sections_by_grid_cell(sections)
+    cols = sorted({c for c, _ in sec_by_cell})
+    segments: list[tuple[int, int, float, float, float]] = []
+    for j in range(len(cols) - 1):
+        ca, cb = cols[j], cols[j + 1]
+        for r, (y_start, y_end) in row_bounds.items():
+            sa = sec_by_cell.get((ca, r))
+            sb = sec_by_cell.get((cb, r))
+            if sa is None or sb is None:
+                continue
+            a_right = sa.bbox_x + sa.bbox_w
+            b_left = sb.bbox_x
+            if a_right >= b_left:
+                continue
+            segments.append((ca, cb, y_start, y_end, (a_right + b_left) / 2))
+    return segments
 
 
 def _render_debug_overlay(
@@ -1224,67 +1251,74 @@ def _render_debug_overlay(
     if sections:
         col_bounds, row_bounds = _grid_bbox_bounds(sections)
 
-        # Global extents (fall back to col/row bounds or section bboxes)
+        # Label anchors (top-of-canvas for col labels, left for row labels).
+        # All sections spanning means no single-cell bounds exist - fall
+        # back to raw bboxes for label placement only.
         if not col_bounds or not row_bounds:
-            # All sections are spanning - use raw section bboxes
             all_x0 = min(s.bbox_x for s in sections) - 20
-            all_x1 = max(s.bbox_x + s.bbox_w for s in sections) + 20
             all_y0 = min(s.bbox_y for s in sections) - 20
-            all_y1 = max(s.bbox_y + s.bbox_h for s in sections) + 20
         else:
             all_x0 = min(b[0] for b in col_bounds.values()) - 20
-            all_x1 = max(b[1] for b in col_bounds.values()) + 20
             all_y0 = min(b[0] for b in row_bounds.values()) - 20
-            all_y1 = max(b[1] for b in row_bounds.values()) + 20
         grid_color = "rgba(255, 255, 0, 0.5)"
 
-        for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds):
+        labelled_col_pairs: set[tuple[int, int]] = set()
+        for ca, cb, y_start, y_end, x in _compute_col_boundary_segments(
+            sections, row_bounds
+        ):
             d.append(
                 draw.Line(
-                    mid_x,
-                    all_y0,
-                    mid_x,
-                    all_y1,
+                    x,
+                    y_start,
+                    x,
+                    y_end,
                     stroke=grid_color,
                     stroke_width=1,
                     stroke_dasharray="6,4",
                 )
             )
-            d.append(
-                draw.Text(
-                    f"col {ca}|{cb}",
-                    debug_font_size,
-                    mid_x,
-                    all_y0 - 4,
-                    fill=grid_color,
-                    font_family=debug_font,
-                    text_anchor="middle",
+            if (ca, cb) not in labelled_col_pairs:
+                d.append(
+                    draw.Text(
+                        f"col {ca}|{cb}",
+                        debug_font_size,
+                        x,
+                        all_y0 - 4,
+                        fill=grid_color,
+                        font_family=debug_font,
+                        text_anchor="middle",
+                    )
                 )
-            )
+                labelled_col_pairs.add((ca, cb))
 
-        for ra, rb, mid_y in _compute_row_boundary_ys(row_bounds):
+        labelled_row_pairs: set[tuple[int, int]] = set()
+        for ra, rb, x_start, x_end, y in _compute_row_boundary_segments(
+            sections, col_bounds
+        ):
             d.append(
                 draw.Line(
-                    all_x0,
-                    mid_y,
-                    all_x1,
-                    mid_y,
+                    x_start,
+                    y,
+                    x_end,
+                    y,
                     stroke=grid_color,
                     stroke_width=1,
                     stroke_dasharray="6,4",
                 )
             )
-            d.append(
-                draw.Text(
-                    f"row {ra}|{rb}",
-                    debug_font_size,
-                    all_x0 - 4,
-                    mid_y,
-                    fill=grid_color,
-                    font_family=debug_font,
-                    text_anchor="end",
+            if (ra, rb) not in labelled_row_pairs:
+                d.append(
+                    draw.Text(
+                        f"row {ra}|{rb}",
+                        debug_font_size,
+                        all_x0 - 4,
+                        y,
+                        fill=grid_color,
+                        font_family=debug_font,
+                        text_anchor="end",
+                    )
                 )
-            )
+                labelled_row_pairs.add((ra, rb))
 
     # Shared Y grid lines: horizontal lines at each grid slot position
     # within each row group (populated by _align_row_y_grids in engine.py).

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1157,41 +1157,26 @@ def _compute_row_boundary_segments(
         max_bottom = max(s.bbox_y + s.bbox_h for s in row_a_secs)
         min_top = min(s.bbox_y for s in row_b_secs)
         if max_bottom < min_top:
+            # Rows are globally separable: one canvas-wide line at the
+            # natural midpoint (below every row a section, above every
+            # row b section).  No bbox is cut by construction.
             y = (max_bottom + min_top) / 2
-        else:
-            anchor_ys: list[float] = []
-            for c in col_bounds:
-                sa = sec_by_cell.get((c, ra))
-                sb = sec_by_cell.get((c, rb))
-                if sa is None or sb is None:
-                    continue
-                a_bot = sa.bbox_y + sa.bbox_h
-                b_top = sb.bbox_y
-                if a_bot >= b_top:
-                    continue
-                anchor_ys.append((a_bot + b_top) / 2)
-            if not anchor_ys:
+            segments.append((ra, rb, canvas_x0, canvas_x1, y))
+            continue
+        # Rows overlap (a fold extends one row into the other's band).
+        # Emit per-column segments only at cells where both rows have
+        # a non-spanning section and the sections don't locally overlap,
+        # so the line appears only where the boundary is unambiguous.
+        for c, (x_start, x_end) in col_bounds.items():
+            sa = sec_by_cell.get((c, ra))
+            sb = sec_by_cell.get((c, rb))
+            if sa is None or sb is None:
                 continue
-            anchor_ys.sort()
-            y = anchor_ys[len(anchor_ys) // 2]
-        cut_ranges: list[tuple[float, float]] = []
-        for sec in row_a_secs + row_b_secs:
-            if sec.bbox_y < y < sec.bbox_y + sec.bbox_h:
-                cut_ranges.append((sec.bbox_x, sec.bbox_x + sec.bbox_w))
-        cut_ranges.sort()
-        merged: list[tuple[float, float]] = []
-        for x0, x1 in cut_ranges:
-            if merged and x0 <= merged[-1][1]:
-                merged[-1] = (merged[-1][0], max(merged[-1][1], x1))
-            else:
-                merged.append((x0, x1))
-        cursor = canvas_x0
-        for x0, x1 in merged:
-            if cursor < x0:
-                segments.append((ra, rb, cursor, x0, y))
-            cursor = max(cursor, x1)
-        if cursor < canvas_x1:
-            segments.append((ra, rb, cursor, canvas_x1, y))
+            a_bot = sa.bbox_y + sa.bbox_h
+            b_top = sb.bbox_y
+            if a_bot >= b_top:
+                continue
+            segments.append((ra, rb, x_start, x_end, (a_bot + b_top) / 2))
     return segments
 
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1124,44 +1124,58 @@ def _compute_row_boundary_segments(
 ) -> list[tuple[int, int, float, float, float]]:
     """Return row-boundary segments as ``(row_a, row_b, x_start, x_end, y)``.
 
-    For each consecutive grid-row pair, choose a representative
-    boundary Y from the per-column midpoints (median across columns
-    where both rows have a non-spanning section and don't locally
-    overlap), then draw a horizontal line at that Y spanning the
-    canvas - broken only around bboxes the line would otherwise cut.
-    Fold sections that extend past their row produce gaps in the line,
-    so the separator is visibly absent at fold columns but still
-    extends under all other sections (including columns where only one
-    of the two rows has a section).
+    For each consecutive grid-row pair, pick a boundary Y and draw a
+    canvas-wide horizontal line at that Y, broken around bboxes the
+    line would cut:
+
+    1. If rows don't overlap globally (max bbox-bottom of row a is
+       above min bbox-top of row b), use the global midpoint - the
+       natural row separator that sits below every section in the
+       upper row and above every section in the lower row.
+    2. Otherwise pick the median of per-column local midpoints (cells
+       where both rows have a non-spanning section that don't locally
+       overlap).  Fold sections produce visible gaps where the line
+       would cut their bboxes.
     """
     if not col_bounds:
         return []
     sec_by_cell = _sections_by_grid_cell(sections)
-    rows = sorted({r for _, r in sec_by_cell})
     canvas_x0 = min(b[0] for b in col_bounds.values()) - 20
     canvas_x1 = max(b[1] for b in col_bounds.values()) + 20
+    sections_by_row: dict[int, list[Section]] = {}
+    for sec in sections:
+        if sec.grid_row_span == 1:
+            sections_by_row.setdefault(sec.grid_row, []).append(sec)
+    rows = sorted(sections_by_row)
     segments: list[tuple[int, int, float, float, float]] = []
     for i in range(len(rows) - 1):
         ra, rb = rows[i], rows[i + 1]
-        anchor_ys: list[float] = []
-        for c in col_bounds:
-            sa = sec_by_cell.get((c, ra))
-            sb = sec_by_cell.get((c, rb))
-            if sa is None or sb is None:
-                continue
-            a_bot = sa.bbox_y + sa.bbox_h
-            b_top = sb.bbox_y
-            if a_bot >= b_top:
-                continue
-            anchor_ys.append((a_bot + b_top) / 2)
-        if not anchor_ys:
+        row_a_secs = sections_by_row.get(ra, [])
+        row_b_secs = sections_by_row.get(rb, [])
+        if not row_a_secs or not row_b_secs:
             continue
-        anchor_ys.sort()
-        y = anchor_ys[len(anchor_ys) // 2]
-        cut_ranges: list[tuple[float, float]] = []
-        for sec in sections:
-            if sec.grid_row_span != 1 or sec.grid_row not in (ra, rb):
+        max_bottom = max(s.bbox_y + s.bbox_h for s in row_a_secs)
+        min_top = min(s.bbox_y for s in row_b_secs)
+        if max_bottom < min_top:
+            y = (max_bottom + min_top) / 2
+        else:
+            anchor_ys: list[float] = []
+            for c in col_bounds:
+                sa = sec_by_cell.get((c, ra))
+                sb = sec_by_cell.get((c, rb))
+                if sa is None or sb is None:
+                    continue
+                a_bot = sa.bbox_y + sa.bbox_h
+                b_top = sb.bbox_y
+                if a_bot >= b_top:
+                    continue
+                anchor_ys.append((a_bot + b_top) / 2)
+            if not anchor_ys:
                 continue
+            anchor_ys.sort()
+            y = anchor_ys[len(anchor_ys) // 2]
+        cut_ranges: list[tuple[float, float]] = []
+        for sec in row_a_secs + row_b_secs:
             if sec.bbox_y < y < sec.bbox_y + sec.bbox_h:
                 cut_ranges.append((sec.bbox_x, sec.bbox_x + sec.bbox_w))
         cut_ranges.sort()

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1096,25 +1096,14 @@ def _grid_bbox_bounds(
     col_bounds: dict[int, tuple[float, float]] = {}
     row_bounds: dict[int, tuple[float, float]] = {}
     for sec in sections:
-        c, r = sec.grid_col, sec.grid_row
         x0, x1 = sec.bbox_x, sec.bbox_x + sec.bbox_w
         y0, y1 = sec.bbox_y, sec.bbox_y + sec.bbox_h
         if sec.grid_col_span == 1:
-            if c not in col_bounds:
-                col_bounds[c] = (x0, x1)
-            else:
-                col_bounds[c] = (
-                    min(col_bounds[c][0], x0),
-                    max(col_bounds[c][1], x1),
-                )
+            cx0, cx1 = col_bounds.get(sec.grid_col, (x0, x1))
+            col_bounds[sec.grid_col] = (min(cx0, x0), max(cx1, x1))
         if sec.grid_row_span == 1:
-            if r not in row_bounds:
-                row_bounds[r] = (y0, y1)
-            else:
-                row_bounds[r] = (
-                    min(row_bounds[r][0], y0),
-                    max(row_bounds[r][1], y1),
-                )
+            ry0, ry1 = row_bounds.get(sec.grid_row, (y0, y1))
+            row_bounds[sec.grid_row] = (min(ry0, y0), max(ry1, y1))
     return col_bounds, row_bounds
 
 
@@ -1280,10 +1269,8 @@ def _render_debug_overlay(
                 )
             )
 
-        labelled_row_pairs: set[tuple[int, int]] = set()
-        for ra, rb, x_start, x_end, y in _compute_row_boundary_segments(
-            sections, col_bounds
-        ):
+        row_segments = _compute_row_boundary_segments(sections, col_bounds)
+        for _ra, _rb, x_start, x_end, y in row_segments:
             d.append(
                 draw.Line(
                     x_start,
@@ -1295,19 +1282,22 @@ def _render_debug_overlay(
                     stroke_dasharray="6,4",
                 )
             )
-            if (ra, rb) not in labelled_row_pairs:
-                d.append(
-                    draw.Text(
-                        f"row {ra}|{rb}",
-                        debug_font_size,
-                        all_x0 - 4,
-                        y,
-                        fill=grid_color,
-                        font_family=debug_font,
-                        text_anchor="end",
-                    )
+        # One label per row pair, anchored at the first segment's Y.
+        row_pair_label_ys: dict[tuple[int, int], float] = {}
+        for ra, rb, _xs, _xe, y in row_segments:
+            row_pair_label_ys.setdefault((ra, rb), y)
+        for (ra, rb), y in row_pair_label_ys.items():
+            d.append(
+                draw.Text(
+                    f"row {ra}|{rb}",
+                    debug_font_size,
+                    all_x0 - 4,
+                    y,
+                    fill=grid_color,
+                    font_family=debug_font,
+                    text_anchor="end",
                 )
-                labelled_row_pairs.add((ra, rb))
+            )
 
     # Shared Y grid lines: horizontal lines at each grid slot position
     # within each row group (populated by _align_row_y_grids in engine.py).

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -3108,3 +3108,55 @@ def _resolve_section_col_for_station(graph, station):
                     if sec and sec.grid_col >= 0:
                         return sec.grid_col
     return None
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_debug_grid_overlay_boundaries_outside_section_bboxes(fixture):
+    """Debug-overlay row/column separator lines must not cut through any
+    section bbox.
+
+    The overlay draws a single horizontal line "between" each pair of
+    consecutive grid rows (and vertical lines for columns), placed at
+    the midpoint between row i's max bbox bottom and row i+1's min bbox
+    top.  When a fold extends a section's bbox into the next row's band
+    the rows overlap in Y, and the midpoint lands inside both rows'
+    bboxes - misleading the reader of the overlay.  The helper must
+    drop such pairs rather than emit a line at a meaningless Y.
+
+    Bug: https://github.com/pinin4fjords/nf-metro/issues/316
+    """
+    from nf_metro.render.svg import (
+        _compute_col_boundary_xs,
+        _compute_row_boundary_ys,
+        _grid_bbox_bounds,
+    )
+
+    graph = _layout(fixture)
+    sections = list(graph.sections.values())
+    if not sections:
+        pytest.skip("no sections")
+    col_bounds, row_bounds = _grid_bbox_bounds(sections)
+
+    offenders: list[str] = []
+    for ra, rb, mid_y in _compute_row_boundary_ys(row_bounds):
+        for sec in sections:
+            if sec.grid_row_span != 1:
+                continue
+            y0, y1 = sec.bbox_y, sec.bbox_y + sec.bbox_h
+            if y0 < mid_y < y1:
+                offenders.append(
+                    f"row {ra}|{rb} mid_y={mid_y:.1f} cuts {sec.id!r} "
+                    f"(row={sec.grid_row}, y={y0:.1f}..{y1:.1f})"
+                )
+    for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds):
+        for sec in sections:
+            if sec.grid_col_span != 1:
+                continue
+            x0, x1 = sec.bbox_x, sec.bbox_x + sec.bbox_w
+            if x0 < mid_x < x1:
+                offenders.append(
+                    f"col {ca}|{cb} mid_x={mid_x:.1f} cuts {sec.id!r} "
+                    f"(col={sec.grid_col}, x={x0:.1f}..{x1:.1f})"
+                )
+
+    assert not offenders, f"{fixture}: " + "; ".join(offenders[:5])

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -3112,22 +3112,22 @@ def _resolve_section_col_for_station(graph, station):
 
 @pytest.mark.parametrize("fixture", ALL_FIXTURES)
 def test_debug_grid_overlay_boundaries_outside_section_bboxes(fixture):
-    """Debug-overlay row/column separator lines must not cut through any
-    section bbox.
+    """Debug-overlay row/column separator segments must not cut through
+    any section bbox.
 
-    The overlay draws a single horizontal line "between" each pair of
-    consecutive grid rows (and vertical lines for columns), placed at
-    the midpoint between row i's max bbox bottom and row i+1's min bbox
-    top.  When a fold extends a section's bbox into the next row's band
-    the rows overlap in Y, and the midpoint lands inside both rows'
-    bboxes - misleading the reader of the overlay.  The helper must
-    drop such pairs rather than emit a line at a meaningless Y.
+    The overlay draws per-column horizontal segments between consecutive
+    grid rows (and per-row vertical segments between consecutive columns).
+    Each segment sits at the local midpoint between two adjacent
+    sections' bboxes; when a fold extends a section past its row's
+    natural extent the local midpoint would land inside a bbox, so the
+    segment for that column is dropped.  This test asserts no emitted
+    segment cuts any section bbox in the rows/columns it joins.
 
     Bug: https://github.com/pinin4fjords/nf-metro/issues/316
     """
     from nf_metro.render.svg import (
-        _compute_col_boundary_xs,
-        _compute_row_boundary_ys,
+        _compute_col_boundary_segments,
+        _compute_row_boundary_segments,
         _grid_bbox_bounds,
     )
 
@@ -3138,25 +3138,33 @@ def test_debug_grid_overlay_boundaries_outside_section_bboxes(fixture):
     col_bounds, row_bounds = _grid_bbox_bounds(sections)
 
     offenders: list[str] = []
-    for ra, rb, mid_y in _compute_row_boundary_ys(row_bounds):
+    for ra, rb, x_start, x_end, y in _compute_row_boundary_segments(
+        sections, col_bounds
+    ):
         for sec in sections:
-            if sec.grid_row_span != 1:
+            if sec.grid_row_span != 1 or sec.grid_row not in (ra, rb):
                 continue
             y0, y1 = sec.bbox_y, sec.bbox_y + sec.bbox_h
-            if y0 < mid_y < y1:
+            x0, x1 = sec.bbox_x, sec.bbox_x + sec.bbox_w
+            x_overlaps = max(x_start, x0) < min(x_end, x1)
+            if x_overlaps and y0 < y < y1:
                 offenders.append(
-                    f"row {ra}|{rb} mid_y={mid_y:.1f} cuts {sec.id!r} "
-                    f"(row={sec.grid_row}, y={y0:.1f}..{y1:.1f})"
+                    f"row {ra}|{rb} segment y={y:.1f} x={x_start:.0f}..{x_end:.0f} "
+                    f"cuts {sec.id!r} (row={sec.grid_row}, y={y0:.1f}..{y1:.1f})"
                 )
-    for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds):
+    for ca, cb, y_start, y_end, x in _compute_col_boundary_segments(
+        sections, row_bounds
+    ):
         for sec in sections:
-            if sec.grid_col_span != 1:
+            if sec.grid_col_span != 1 or sec.grid_col not in (ca, cb):
                 continue
             x0, x1 = sec.bbox_x, sec.bbox_x + sec.bbox_w
-            if x0 < mid_x < x1:
+            y0, y1 = sec.bbox_y, sec.bbox_y + sec.bbox_h
+            y_overlaps = max(y_start, y0) < min(y_end, y1)
+            if y_overlaps and x0 < x < x1:
                 offenders.append(
-                    f"col {ca}|{cb} mid_x={mid_x:.1f} cuts {sec.id!r} "
-                    f"(col={sec.grid_col}, x={x0:.1f}..{x1:.1f})"
+                    f"col {ca}|{cb} segment x={x:.1f} y={y_start:.0f}..{y_end:.0f} "
+                    f"cuts {sec.id!r} (col={sec.grid_col}, x={x0:.1f}..{x1:.1f})"
                 )
 
     assert not offenders, f"{fixture}: " + "; ".join(offenders[:5])

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -3126,7 +3126,7 @@ def test_debug_grid_overlay_boundaries_outside_section_bboxes(fixture):
     Bug: https://github.com/pinin4fjords/nf-metro/issues/316
     """
     from nf_metro.render.svg import (
-        _compute_col_boundary_segments,
+        _compute_col_boundary_xs,
         _compute_row_boundary_segments,
         _grid_bbox_bounds,
     )
@@ -3152,19 +3152,15 @@ def test_debug_grid_overlay_boundaries_outside_section_bboxes(fixture):
                     f"row {ra}|{rb} segment y={y:.1f} x={x_start:.0f}..{x_end:.0f} "
                     f"cuts {sec.id!r} (row={sec.grid_row}, y={y0:.1f}..{y1:.1f})"
                 )
-    for ca, cb, y_start, y_end, x in _compute_col_boundary_segments(
-        sections, row_bounds
-    ):
+    for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds):
         for sec in sections:
-            if sec.grid_col_span != 1 or sec.grid_col not in (ca, cb):
+            if sec.grid_col_span != 1:
                 continue
             x0, x1 = sec.bbox_x, sec.bbox_x + sec.bbox_w
-            y0, y1 = sec.bbox_y, sec.bbox_y + sec.bbox_h
-            y_overlaps = max(y_start, y0) < min(y_end, y1)
-            if y_overlaps and x0 < x < x1:
+            if x0 < mid_x < x1:
                 offenders.append(
-                    f"col {ca}|{cb} segment x={x:.1f} y={y_start:.0f}..{y_end:.0f} "
-                    f"cuts {sec.id!r} (col={sec.grid_col}, x={x0:.1f}..{x1:.1f})"
+                    f"col {ca}|{cb} mid_x={mid_x:.1f} cuts {sec.id!r} "
+                    f"(col={sec.grid_col}, x={x0:.1f}..{x1:.1f})"
                 )
 
     assert not offenders, f"{fixture}: " + "; ".join(offenders[:5])


### PR DESCRIPTION
## Summary

In `--debug` mode the dotted row separator previously sat at the midpoint between row i's max bbox bottom and row i+1's min bbox top. In fold-heavy renders (`fold_double`, `rnaseq_lite`, `u_turn_fold`) a fold extends an upper section's bbox into the next row's band, the rows overlap in Y, and the midpoint lands inside both rows' bboxes - the separator visibly cuts through row markers.

- For each consecutive grid-row pair:
  - If the rows don't overlap globally (max bbox-bottom of row a is above min bbox-top of row b), draw a single canvas-wide horizontal line at the global midpoint - the natural row separator below every section in row a and above every section in row b.
  - If they overlap (fold case), emit per-column segments at the local midpoint, one per column where both rows have a non-spanning section and the local Y ranges don't overlap. Columns with a fold-extending section or missing one of the two rows produce gaps, so the divider only appears where the boundary is unambiguous.
- Column separators remain a single full-height line per consecutive-column pair (overlap guard preserved as a precaution).
- Extract `_grid_bbox_bounds`, `_sections_by_grid_cell`, `_compute_row_boundary_segments`, `_compute_col_boundary_xs` as testable helpers. Row labels emit in a second pass keyed by unique row pairs.

Parametrized invariant `test_debug_grid_overlay_boundaries_outside_section_bboxes` over all 55 fixtures asserts that no emitted row segment cuts any section bbox in the rows it joins and no column line cuts any section bbox in its columns.

Debug-only render path. No impact on non-`--debug` output.

Fixes #316

## Test plan

- [x] pytest passes including the new invariant test (2292 passed, 3 skipped, 7 xfailed)
- [x] `ruff check src/ tests/` and `ruff format --check src/ tests/` clean
- [x] Local debug renders verified:
  - `02_sections`, `rnaseq_sections`, `mismatched_tracks`: row separator is a canvas-wide line at the natural midpoint between rows
  - `fold_double`, `rnaseq_lite`, `u_turn_fold`: row separator appears as per-column segments under paired non-fold cells
- [ ] Render-preview verdict captured

Generated with Claude Code
