### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.6.1"
+version = "0.7.0"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Bump version from 0.6.1 to 0.7.0 in `pyproject.toml` and `src/nf_metro/__init__.py`.

This is a substantial minor release (228 commits since 0.6.1). All changes are backward-compatible at the `.mmd` input level - existing pipelines render without modification, the new directives and CLI flags are additive.

## What's new in 0.7.0

### New features

- `--format html` for interactive embeddable maps (#374)
- `%%metro off_track:` directive to lift file inputs above line tracks (#265)
- `%%metro center_ports:` directive / `--center-ports` flag to centre inter-section ports on the shorter section (#320)
- `%%metro legend_min_height:` directive for minimum legend content height
- Dashed and dotted line styles for optional pipeline paths
- Stacked-files and folder icon types (#175), with optional caption names on file/files/dir directives (#269)
- Sections renumbered by visual reading order (#217)
- Fan-in merge junctions with trunk routing (#207)
- New gallery entries: differentialabundance (#319), genomeassembly, upward_bypass and mismatched_tracks topologies
- nf-core Pipelines gallery page on the docs site (#239)

### Layout & routing fixes

- Major layout-engine fragility rework: invariants, fixtures, clearance unification, runtime guards, layout contract, solver spike (#340)
- Phase-boundary invariant guards (`compute_layout(validate=True)`)
- C13 row-gap runtime invariant guard (#371)
- Animated balls no longer fly off-piste at merge junctions (#251)
- Per-column debug-overlay row separators across folds (#316)
- Many fan-in / fan-out / bypass / off-track routing fixes (#125, #240, #244, #247, #259, #260, #261, #266, #267, #268, #270, #275, #276, #277, #278, #281, #284, #285, #287, #288, #289, #290, #293, #298, #299, #300, #301, #302, #303, #304, #305, #307, #327, #329, #334, #335, #336, #338, #344, #352)
- Backward-L segments prevented in cross-column junction routes (#338)
- Consistent line z-order via per-line path grouping (#305)
- TOP/BOTTOM ports kept on bbox edge during row compact (#352)

### Performance

- Spatial-index validation guards and closed-form intersection (#368)
- Cached `station_lines()` on `MetroGraph` (~40 call sites, O(1) amortised)
- Pre-computed diamond groups and track occupancy for O(1) lookups
- Compute offsets and routes once in `validate_layout`

### Internal refactors

- Six-stage Phase grouping with flat Stage X.Y naming (#375)
- Repair-only Stage 6 sub-stages (#376)
- Phase-13x bisection guards under `validate=True` (#356, #357)
- Consolidated `_shift_chain` helpers (#367)
- Promoted `_half_grid_station_ids` to public field (#346)
- Centralised corner-radius math in `corner_radius()` (#212)
- Split large functions: `_center_bubble_stations`, `compute_station_offsets`, `compute_layout`
- Deduplicated `_resolve_section` / `_resolve_junction_section`
- Unified diagonal routing, shared `resolve_curve_radii` for routing + rendering
- Grid-query helpers to deduplicate section iteration
- Moved icon constants to layout (fixed backward render->layout dependency)
- Derived `SVG_CURVE_RADIUS`, `ANIMATION_CURVE_RADIUS`, `MIN_INTER_SECTION_GAP` from `CURVE_RADIUS`
- Extracted magic numbers to named constants
- Retrospective `/simplify` pass over `0.6.1..main` (#366)

### Testing

- Programmatic layout-quality validators with known-defect xfails (#252)
- Full-corpus parametrisation of layout invariants (#326)
- Visually-grounded label and stack-X predicates (#348)
- 83 SVG path validation tests for edge routing
- 36 regression tests for shared Y grid alignment
- Edge-section crossing validator
- Topology fixtures expanded: upward bypass, fan_in_merge, and more

### Docs & tooling

- `CONTRIBUTING.md` covering visual review, invariant ratchet, git hygiene (#341)
- Layout `CONTRACT.md` documenting phase preconditions, postconditions, invariants
- New Claude Code skills: `nf-metro-layout-fix`, `pipeline-metro-diagram`, `pipeline-metro-setup`, `pr-chain-vet`, `nf-metro-layout-triage` (#311, #312, #313, #343)
- Expanded `fix-issue` skill with diagnostic and PR-hygiene rigor (#325)
- Render diff page grouped by section, reviewer instructions, timestamp
- CLI options and reference tables synced across README/guide

## Test plan

- [ ] CI green on the PR (lint, tests, gallery render diff)
- [ ] Gallery render diff shows no unexpected regressions vs main