### PR TITLE
fix(layout): predict bypass route depth in inter-row gap

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -3309,9 +3309,7 @@ def _predicted_bypass_bottom_in_row(
         visited.add(node_id)
         sec = _node_section(node_id)
         if sec is None:
-            edges = (
-                graph.edges_to(node_id) if upstream else graph.edges_from(node_id)
-            )
+            edges = graph.edges_to(node_id) if upstream else graph.edges_from(node_id)
             for e in edges:
                 nb = e.source if upstream else e.target
                 sec = _resolve(nb, upstream, visited)
@@ -4506,9 +4504,7 @@ def _tighten_lower_rows_after_shrink(graph: MetroGraph, section_y_gap: float) ->
         # Bypass routes dip below intervening bboxes into the inter-row
         # gap; tightening must not pull lower rows up into them.
         bypass_spans = _aggregate_bypass_spans(graph, ending_at_prev)
-        effective_floor = max(
-            max_above_bot, max(bypass_spans.values(), default=0.0)
-        )
+        effective_floor = max(max_above_bot, max(bypass_spans.values(), default=0.0))
         current_top = min(s.bbox_y for s in lower)
         slack = current_top - (effective_floor + section_y_gap)
         if slack <= 0.5:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -3274,65 +3274,52 @@ def _shift_sparse_loop_stations_to_clear_bundle(
 
 def _predicted_bypass_bottom_in_row(
     graph: MetroGraph, row: int
-) -> tuple[float, dict[tuple[int, int], float]]:
-    """Predict the deepest Y a bypass route may reach in *row*.
+) -> dict[tuple[int, int], float]:
+    """Predict bypass U-route bottom Ys for edges anchored in *row*.
 
-    A bypass U-route is emitted at routing time when an edge spans
-    two or more columns AND has same-row intervening sections (see
-    ``layout.routing.core._has_intervening_sections`` and the
-    ``needs_bypass`` check).  This pre-routing prediction mirrors
-    that condition, walking junction predecessors/successors to
-    resolve the effective source/target column for edges that pass
-    through junction stations, and computes the same bottom Y
-    formula used in ``layout.routing.common.bypass_bottom_y``: the
-    deepest intervening section bottom plus ``BYPASS_CLEARANCE``.
-
-    Returns ``(row_max, per_col_max)``:
-
-    * ``row_max``: the deepest bypass bottom across the row (0.0 when
-      no bypass is expected).
-    * ``per_col_max``: mapping ``(lo, hi) -> bottom`` for each bypass
-      column span observed, so callers can scope the floor to lower
-      sections that the bypass actually passes over.
+    Mirrors ``layout.routing.common.bypass_bottom_y`` for layout-time
+    prediction: returns ``{(lo, hi): max(intervening_bottoms) + BYPASS_CLEARANCE}``
+    for each edge whose endpoints (after walking junctions) resolve to
+    same-row sections spanning more than one column with at least one
+    intervening section.  Empty when *row* has no bypass-eligible edges.
     """
     sections_in_row = [
         s for s in graph.sections.values() if s.grid_row == row and s.bbox_w > 0
     ]
     if not sections_in_row:
-        return 0.0, {}
-
-    successors: dict[str, list[str]] = defaultdict(list)
-    predecessors: dict[str, list[str]] = defaultdict(list)
-    for e in graph.edges:
-        successors[e.source].append(e.target)
-        predecessors[e.target].append(e.source)
+        return {}
 
     def _node_section(node_id: str):
         st = graph.stations.get(node_id) or graph.ports.get(node_id)
         if st is None:
             return None
         sec_id = getattr(st, "section_id", None)
-        if sec_id:
-            return graph.sections.get(sec_id)
-        return None
+        return graph.sections.get(sec_id) if sec_id else None
+
+    resolve_cache: dict[tuple[str, bool], Section | None] = {}
 
     def _resolve(node_id: str, upstream: bool, visited: set[str] | None = None):
+        key = (node_id, upstream)
+        if key in resolve_cache:
+            return resolve_cache[key]
         if visited is None:
             visited = set()
         if node_id in visited:
             return None
         visited.add(node_id)
         sec = _node_section(node_id)
-        if sec is not None:
-            return sec
-        neighbors = predecessors[node_id] if upstream else successors[node_id]
-        for nb in neighbors:
-            sec = _resolve(nb, upstream, visited)
-            if sec is not None:
-                return sec
-        return None
+        if sec is None:
+            edges = (
+                graph.edges_to(node_id) if upstream else graph.edges_from(node_id)
+            )
+            for e in edges:
+                nb = e.source if upstream else e.target
+                sec = _resolve(nb, upstream, visited)
+                if sec is not None:
+                    break
+        resolve_cache[key] = sec
+        return sec
 
-    row_max = 0.0
     per_span: dict[tuple[int, int], float] = {}
     for edge in graph.edges:
         src_sec = _resolve(edge.source, upstream=True)
@@ -3348,12 +3335,28 @@ def _predicted_bypass_bottom_in_row(
         if not intervening:
             continue
         bot = max(s.bbox_y + s.bbox_h for s in intervening) + BYPASS_CLEARANCE
-        if bot > row_max:
-            row_max = bot
-        prev = per_span.get((lo, hi), 0.0)
-        if bot > prev:
+        if bot > per_span.get((lo, hi), 0.0):
             per_span[(lo, hi)] = bot
-    return row_max, per_span
+    return per_span
+
+
+def _aggregate_bypass_spans(
+    graph: MetroGraph, upper_sections: list[Section]
+) -> dict[tuple[int, int], float]:
+    """Aggregate bypass span->bottom predictions across upper sections.
+
+    A row-spanning section carries its bypass routes from its start row
+    down to the row below its end row, so the prediction must key off
+    ``grid_row`` (start), not the end row.
+    """
+    combined: dict[tuple[int, int], float] = {}
+    for upper_start_row in {s.grid_row for s in upper_sections}:
+        for span, bot in _predicted_bypass_bottom_in_row(
+            graph, upper_start_row
+        ).items():
+            if bot > combined.get(span, 0.0):
+                combined[span] = bot
+    return combined
 
 
 def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) -> None:
@@ -3407,20 +3410,7 @@ def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) ->
         ]
         if not ending_at_prev:
             continue
-        # Cross-column edges in the upper rows with intervening sections
-        # route below those intervening bboxes, landing in the inter-row
-        # gap.  Aggregate bypass predictions from every upper-row start
-        # row whose sections end at ``r - 1`` -- a row-spanning section
-        # (e.g. ``scaffolding`` with grid_row=0 and grid_row_span=4)
-        # carries its bypass routes from its start row down to the row
-        # below its end row, so the prediction must key off the start
-        # row, not ``r - 1``.
-        bypass_by_span: dict[tuple[int, int], float] = {}
-        for upper_start_row in {s.grid_row for s in ending_at_prev}:
-            _, spans = _predicted_bypass_bottom_in_row(graph, upper_start_row)
-            for span, bot in spans.items():
-                if bot > bypass_by_span.get(span, 0.0):
-                    bypass_by_span[span] = bot
+        bypass_by_span = _aggregate_bypass_spans(graph, ending_at_prev)
 
         # Only consider column-overlapping (upper, lower) pairs for
         # deficit computation: a tall upper-row bbox that lives in a
@@ -4513,18 +4503,12 @@ def _tighten_lower_rows_after_shrink(graph: MetroGraph, section_y_gap: float) ->
         if not lower or not ending_at_prev:
             continue
         max_above_bot = max(s.bbox_y + s.bbox_h for s in ending_at_prev)
-        # Cross-column bypass routes in the upper rows dip below
-        # intervening bboxes into the inter-row gap.  A bypass keys off
-        # its endpoints' start row, not ``r - 1``, so query each upper-
-        # row start to find the deepest predicted bypass.  Use it as an
-        # additional floor so tightening does not pull the lower row up
-        # into a bypass route.
-        bypass_row_max = 0.0
-        for upper_start_row in {s.grid_row for s in ending_at_prev}:
-            bp, _ = _predicted_bypass_bottom_in_row(graph, upper_start_row)
-            if bp > bypass_row_max:
-                bypass_row_max = bp
-        effective_floor = max(max_above_bot, bypass_row_max)
+        # Bypass routes dip below intervening bboxes into the inter-row
+        # gap; tightening must not pull lower rows up into them.
+        bypass_spans = _aggregate_bypass_spans(graph, ending_at_prev)
+        effective_floor = max(
+            max_above_bot, max(bypass_spans.values(), default=0.0)
+        )
         current_top = min(s.bbox_y for s in lower)
         slack = current_top - (effective_floor + section_y_gap)
         if slack <= 0.5:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -11,6 +11,7 @@ import math
 from collections import Counter, defaultdict
 
 from nf_metro.layout.constants import (
+    BYPASS_CLEARANCE,
     CURVE_RADIUS,
     DESCENDER_CLEARANCE,
     DIAGONAL_RUN,
@@ -3271,6 +3272,90 @@ def _shift_sparse_loop_stations_to_clear_bundle(
             st.y = new_y
 
 
+def _predicted_bypass_bottom_in_row(
+    graph: MetroGraph, row: int
+) -> tuple[float, dict[tuple[int, int], float]]:
+    """Predict the deepest Y a bypass route may reach in *row*.
+
+    A bypass U-route is emitted at routing time when an edge spans
+    two or more columns AND has same-row intervening sections (see
+    ``layout.routing.core._has_intervening_sections`` and the
+    ``needs_bypass`` check).  This pre-routing prediction mirrors
+    that condition, walking junction predecessors/successors to
+    resolve the effective source/target column for edges that pass
+    through junction stations, and computes the same bottom Y
+    formula used in ``layout.routing.common.bypass_bottom_y``: the
+    deepest intervening section bottom plus ``BYPASS_CLEARANCE``.
+
+    Returns ``(row_max, per_col_max)``:
+
+    * ``row_max``: the deepest bypass bottom across the row (0.0 when
+      no bypass is expected).
+    * ``per_col_max``: mapping ``(lo, hi) -> bottom`` for each bypass
+      column span observed, so callers can scope the floor to lower
+      sections that the bypass actually passes over.
+    """
+    sections_in_row = [
+        s for s in graph.sections.values() if s.grid_row == row and s.bbox_w > 0
+    ]
+    if not sections_in_row:
+        return 0.0, {}
+
+    successors: dict[str, list[str]] = defaultdict(list)
+    predecessors: dict[str, list[str]] = defaultdict(list)
+    for e in graph.edges:
+        successors[e.source].append(e.target)
+        predecessors[e.target].append(e.source)
+
+    def _node_section(node_id: str):
+        st = graph.stations.get(node_id) or graph.ports.get(node_id)
+        if st is None:
+            return None
+        sec_id = getattr(st, "section_id", None)
+        if sec_id:
+            return graph.sections.get(sec_id)
+        return None
+
+    def _resolve(node_id: str, upstream: bool, visited: set[str] | None = None):
+        if visited is None:
+            visited = set()
+        if node_id in visited:
+            return None
+        visited.add(node_id)
+        sec = _node_section(node_id)
+        if sec is not None:
+            return sec
+        neighbors = predecessors[node_id] if upstream else successors[node_id]
+        for nb in neighbors:
+            sec = _resolve(nb, upstream, visited)
+            if sec is not None:
+                return sec
+        return None
+
+    row_max = 0.0
+    per_span: dict[tuple[int, int], float] = {}
+    for edge in graph.edges:
+        src_sec = _resolve(edge.source, upstream=True)
+        tgt_sec = _resolve(edge.target, upstream=False)
+        if src_sec is None or tgt_sec is None:
+            continue
+        if src_sec.grid_row != row or tgt_sec.grid_row != row:
+            continue
+        if abs(src_sec.grid_col - tgt_sec.grid_col) <= 1:
+            continue
+        lo, hi = sorted((src_sec.grid_col, tgt_sec.grid_col))
+        intervening = [s for s in sections_in_row if lo < s.grid_col < hi]
+        if not intervening:
+            continue
+        bot = max(s.bbox_y + s.bbox_h for s in intervening) + BYPASS_CLEARANCE
+        if bot > row_max:
+            row_max = bot
+        prev = per_span.get((lo, hi), 0.0)
+        if bot > prev:
+            per_span[(lo, hi)] = bot
+    return row_max, per_span
+
+
 def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) -> None:
     """Push lower-row sections down when an upper-row bbox grows.
 
@@ -3322,6 +3407,21 @@ def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) ->
         ]
         if not ending_at_prev:
             continue
+        # Cross-column edges in the upper rows with intervening sections
+        # route below those intervening bboxes, landing in the inter-row
+        # gap.  Aggregate bypass predictions from every upper-row start
+        # row whose sections end at ``r - 1`` -- a row-spanning section
+        # (e.g. ``scaffolding`` with grid_row=0 and grid_row_span=4)
+        # carries its bypass routes from its start row down to the row
+        # below its end row, so the prediction must key off the start
+        # row, not ``r - 1``.
+        bypass_by_span: dict[tuple[int, int], float] = {}
+        for upper_start_row in {s.grid_row for s in ending_at_prev}:
+            _, spans = _predicted_bypass_bottom_in_row(graph, upper_start_row)
+            for span, bot in spans.items():
+                if bot > bypass_by_span.get(span, 0.0):
+                    bypass_by_span[span] = bot
+
         # Only consider column-overlapping (upper, lower) pairs for
         # deficit computation: a tall upper-row bbox that lives in a
         # different column from the lower-row content does not need
@@ -3336,6 +3436,20 @@ def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) ->
                 upper_bot = us.bbox_y + us.bbox_h
                 lower_top = ls.bbox_y
                 d = (upper_bot + section_y_gap) - lower_top
+                if d > deficit:
+                    deficit = d
+        # Bypass routes do not need column overlap with the upper-row
+        # endpoint bbox; they only need column overlap with the lower
+        # section they would otherwise crowd against.
+        for (lo, hi), bypass_bot in bypass_by_span.items():
+            for ls in lower:
+                if ls.bbox_h <= 0:
+                    continue
+                ls_lo = ls.grid_col
+                ls_hi = ls.grid_col + ls.grid_col_span - 1
+                if ls_hi < lo or ls_lo > hi:
+                    continue
+                d = (bypass_bot + section_y_gap) - ls.bbox_y
                 if d > deficit:
                     deficit = d
         if deficit <= 0.5:
@@ -4399,8 +4513,20 @@ def _tighten_lower_rows_after_shrink(graph: MetroGraph, section_y_gap: float) ->
         if not lower or not ending_at_prev:
             continue
         max_above_bot = max(s.bbox_y + s.bbox_h for s in ending_at_prev)
+        # Cross-column bypass routes in the upper rows dip below
+        # intervening bboxes into the inter-row gap.  A bypass keys off
+        # its endpoints' start row, not ``r - 1``, so query each upper-
+        # row start to find the deepest predicted bypass.  Use it as an
+        # additional floor so tightening does not pull the lower row up
+        # into a bypass route.
+        bypass_row_max = 0.0
+        for upper_start_row in {s.grid_row for s in ending_at_prev}:
+            bp, _ = _predicted_bypass_bottom_in_row(graph, upper_start_row)
+            if bp > bypass_row_max:
+                bypass_row_max = bp
+        effective_floor = max(max_above_bot, bypass_row_max)
         current_top = min(s.bbox_y for s in lower)
-        slack = current_top - (max_above_bot + section_y_gap)
+        slack = current_top - (effective_floor + section_y_gap)
         if slack <= 0.5:
             continue
 

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -10,6 +10,7 @@ from nf_metro.layout.constants import (
     COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
     DEFAULT_LINE_PRIORITY,
+    HEADER_CLEARANCE,
     SECTION_HEADER_PROTRUSION,
 )
 from nf_metro.parser.model import Edge, MetroGraph, Section
@@ -362,14 +363,24 @@ def bypass_bottom_y(
     # When row-filtering is active, the candidate may land in the
     # inter-row gap too close to a section header in another row.
     # The header (number badge + label) extends ~26px above bbox_y.
-    # Cap the bypass at the midpoint of the gap to keep equal spacing.
+    # Keep the bypass at least HEADER_CLEARANCE above any next-row
+    # header_top so the stacked-line bundle does not visually crowd
+    # the badge.  If the inter-row gap is too tight to satisfy both
+    # the upper-bbox clearance and the header clearance, fall back to
+    # the midpoint as a last resort -- but the section-placement-side
+    # bypass floor (``layout.engine._predicted_bypass_bottom_in_row``)
+    # should normally widen the gap enough that the fallback never
+    # fires.
     if src_row is not None:
         for s in graph.sections.values():
             if s.bbox_w > 0 and lo <= s.grid_col <= hi and s.grid_row != src_row:
                 header_top = s.bbox_y - SECTION_HEADER_PROTRUSION
-                if candidate > header_top:
-                    # Place bypass at midpoint between row bottom and header top
-                    row_bottom = candidate - clearance
-                    candidate = (row_bottom + header_top) / 2
+                row_bottom = candidate - clearance
+                safe_cap = header_top - HEADER_CLEARANCE
+                if candidate > safe_cap:
+                    if safe_cap >= row_bottom:
+                        candidate = safe_cap
+                    else:
+                        candidate = (row_bottom + header_top) / 2
 
     return candidate

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -360,17 +360,10 @@ def bypass_bottom_y(
         else:
             return clearance
 
-    # When row-filtering is active, the candidate may land in the
-    # inter-row gap too close to a section header in another row.
-    # The header (number badge + label) extends ~26px above bbox_y.
-    # Keep the bypass at least HEADER_CLEARANCE above any next-row
-    # header_top so the stacked-line bundle does not visually crowd
-    # the badge.  If the inter-row gap is too tight to satisfy both
-    # the upper-bbox clearance and the header clearance, fall back to
-    # the midpoint as a last resort -- but the section-placement-side
-    # bypass floor (``layout.engine._predicted_bypass_bottom_in_row``)
-    # should normally widen the gap enough that the fallback never
-    # fires.
+    # Keep the bypass at least HEADER_CLEARANCE above any different-row
+    # section header_top; the stacked-line bundle otherwise crowds the
+    # badge.  Midpoint fallback for inter-row gaps too tight to satisfy
+    # both clearances (layout placement should normally prevent this).
     if src_row is not None:
         for s in graph.sections.values():
             if s.bbox_w > 0 and lo <= s.grid_col <= hi and s.grid_row != src_row:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from nf_metro.layout.constants import SECTION_Y_GAP
+from nf_metro.layout.constants import SECTION_HEADER_PROTRUSION, SECTION_Y_GAP
 from nf_metro.layout.engine import compute_layout, is_loop_side_branch_station
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -2471,6 +2471,77 @@ def test_bypass_clearance_from_lower_section(fixture):
                 f"effective_bot={effective_bot:.1f}, gap={gap:.1f} "
                 f"< SECTION_Y_GAP={SECTION_Y_GAP}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Inter-section routed paths must clear next-row section headers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_routed_paths_clear_next_row_headers(fixture):
+    """Every horizontal-or-near-horizontal segment of an inter-section
+    routed path must stay clear of any next-row section header.
+
+    Bypass routes (cross-column edges with intervening same-row sections)
+    dip into the inter-row gap below the intervening bbox bottom.  When
+    the next row's section header (number badge + label) protrudes
+    ``SECTION_HEADER_PROTRUSION`` above its bbox, an inter-row routed
+    segment passing through the same column range can visually crowd the
+    badge.  The section-placement-side ``_predicted_bypass_bottom_in_row``
+    floor exists specifically to keep these from colliding.
+    """
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    # Collect (header_top_y, x_lo, x_hi, section_id) for every section
+    # whose header could be crowded from above.
+    headers: list[tuple[float, float, float, str]] = []
+    for sid, sec in graph.sections.items():
+        if sec.bbox_h <= 0 or sec.bbox_w <= 0:
+            continue
+        header_top = sec.bbox_y - SECTION_HEADER_PROTRUSION
+        headers.append((header_top, sec.bbox_x, sec.bbox_x + sec.bbox_w, sid))
+
+    # Minimum required clearance between a routed segment and a header
+    # below it.  Chosen to catch the v0.7.0 differentialabundance
+    # regression where the bottom-most line of a 4-line bypass bundle
+    # sat ~7.5px above the Plots header, while still accommodating
+    # TOP-entry channel routes that legitimately route at HEADER_CLEARANCE
+    # distance from the badge (~14px once badge protrusion is netted).
+    min_clearance = 12.0
+    h_axis_tol = 2.0  # treat as horizontal when |dy| <= 2px
+    for r in routes:
+        if not r.is_inter_section:
+            continue
+        pts = r.points
+        if len(pts) < 2:
+            continue
+        for i in range(len(pts) - 1):
+            x1, y1 = pts[i]
+            x2, y2 = pts[i + 1]
+            if abs(y2 - y1) > h_axis_tol:
+                continue
+            seg_y = (y1 + y2) / 2
+            seg_x_lo = min(x1, x2)
+            seg_x_hi = max(x1, x2)
+            for header_top, hx_lo, hx_hi, hsid in headers:
+                if seg_x_hi <= hx_lo or seg_x_lo >= hx_hi:
+                    continue
+                # Only consider headers strictly below this segment.
+                if header_top <= seg_y:
+                    continue
+                gap = header_top - seg_y
+                assert gap + 0.5 >= min_clearance, (
+                    f"{fixture}: inter-section routed segment "
+                    f"({x1:.1f},{y1:.1f})->({x2:.1f},{y2:.1f}) "
+                    f"of edge {r.edge.source!r}->{r.edge.target!r} "
+                    f"sits {gap:.1f}px above header of section "
+                    f"{hsid!r} (header_top={header_top:.1f}), "
+                    f"below required clearance "
+                    f"{min_clearance:.1f}px"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2504,14 +2504,11 @@ def test_routed_paths_clear_next_row_headers(fixture):
         header_top = sec.bbox_y - SECTION_HEADER_PROTRUSION
         headers.append((header_top, sec.bbox_x, sec.bbox_x + sec.bbox_w, sid))
 
-    # Minimum required clearance between a routed segment and a header
-    # below it.  Chosen to catch the v0.7.0 differentialabundance
-    # regression where the bottom-most line of a 4-line bypass bundle
-    # sat ~7.5px above the Plots header, while still accommodating
-    # TOP-entry channel routes that legitimately route at HEADER_CLEARANCE
-    # distance from the badge (~14px once badge protrusion is netted).
+    # Must exceed the stacked-bundle half-width (~6px for 4 lines at
+    # OFFSET_STEP=3) while staying under TOP-entry channel routes that
+    # legitimately sit ~14px above the badge.
     min_clearance = 12.0
-    h_axis_tol = 2.0  # treat as horizontal when |dy| <= 2px
+    h_axis_tol = 2.0
     for r in routes:
         if not r.is_inter_section:
             continue


### PR DESCRIPTION
## Summary
- Cross-column bypass routes (e.g. limma -> reporting in differentialabundance) descend below intervening sections into the inter-row gap. v0.7.0 placed the bottom-most line ~6px above the next row's section header (the Plots badge in DA), with similar crowding in `genomeassembly_organellar` and `complex_multipath`. Section placement only considered bbox bottoms, so the gap was sized without accounting for the bypass.
- Adds `_predicted_bypass_bottom_in_row` and wires it into both `_tighten_lower_rows_after_shrink` (Stage 6.13) and `_push_lower_rows_after_bbox_grow` (Stages 6.14 / 6.15) so the row gap is widened by `section_y_gap` relative to the bypass low point, not just the bbox bottom. Keyed on the upper-row **start** row so row-spanning sections (e.g. `scaffolding` with `grid_row_span=4`) push down the section below their **end** row.
- Tightens `bypass_bottom_y`'s cap-at-midpoint guard to enforce a minimum `HEADER_CLEARANCE` above the next-row `header_top` when the gap allows. Midpoint fallback only fires when both upper and lower clearances cannot be satisfied (rare now that placement is bypass-aware).
- Adds `test_routed_paths_clear_next_row_headers` parametrised over the full corpus (55 fixtures, all passing): every horizontal inter-section segment must sit at least 12px above any next-row section header it crosses.

This restores and extends the unmerged commit 1f7359f from the `differentialabundance` branch, which fixed the same DA pipeline issue but never landed on `main`. See https://github.com/nf-core/differentialabundance/blob/8c83c9d9bfcc669a750f308ba1a524c318b32e7e/docs/images/nf-core-differentialabundance_metro_map_animated.svg for the v0.7.0 regression that prompted this PR.

## Visual impact
- `differentialabundance`, `differentialabundance_default`, `da_pipeline`, `genomeassembly_organellar`, `complex_multipath`: viewBox grows by 25px to accommodate the bypass; bypass lines now sit clearly above the next-row header.
- All 41 other gallery / topology / guide fixtures byte-identical.

## Test plan
- [x] `pytest -x -q` -- 2347 passed, 3 skipped, 7 xfailed
- [x] `ruff check src/ tests/` -- clean
- [x] Visual review on DA, DA_default, genomeassembly_organellar, complex_multipath -- all four fixtures now show clear separation between bypass routes and downstream section headers
- [ ] CI gallery render preview