### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.7.0"
+version = "0.7.1"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Patch release: bump version from 0.7.0 to 0.7.1 in `pyproject.toml` and `src/nf_metro/__init__.py`.

## What's in 0.7.1

Single fix: **#380 fix(layout): predict bypass route depth in inter-row gap**

In v0.7.0, cross-column bypass routes that descend below intervening sections could land in the inter-row gap close enough to the next row's section header that the stacked-line bundle visually crowded the badge. Reproduced in the [nf-core/differentialabundance metro map](https://github.com/nf-core/differentialabundance/blob/8c83c9d9bfcc669a750f308ba1a524c318b32e7e/docs/images/nf-core-differentialabundance_metro_map_animated.svg) (bypass sat ~6px above the Plots header) and in `genomeassembly_organellar` / `complex_multipath` fixtures.

The fix restores and extends commit 1f7359f from the `differentialabundance` branch (which fixed the same DA issue but never landed on `main`):

- `_predicted_bypass_bottom_in_row` in `layout/engine.py` is wired into both `_tighten_lower_rows_after_shrink` (Stage 6.13) and `_push_lower_rows_after_bbox_grow` (Stages 6.14 / 6.15), keyed off the upper-row start so row-spanning sections push down the section below their end row.
- `bypass_bottom_y` in `routing/common.py` tightens its cap-at-midpoint guard to enforce `HEADER_CLEARANCE` above next-row `header_top` when the gap allows.
- New parametrised invariant `test_routed_paths_clear_next_row_headers` over the full corpus.

Only `differentialabundance`, `differentialabundance_default`, `da_pipeline`, `genomeassembly_organellar`, and `complex_multipath` change visually (each gains 25px height to fit the bypass). The other 41 gallery / topology / guide fixtures are byte-identical.

## Test plan

- [ ] CI green on the PR (lint, tests, gallery render diff)
- [ ] Gallery render diff confirms the five affected fixtures look better and no regressions elsewhere