### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.7.1"
+version = "0.7.2"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Patch release: bump version from 0.7.1 to 0.7.2 in `pyproject.toml` and `src/nf_metro/__init__.py`.

## What's in 0.7.2

Single fix: **#382 fix(layout): shrink past stale-Y row-mates in LR/RL sections**

In v0.7.1, `_fan_source_inputs_upward` (Stage 6.2) lifts source-input chains above the trunk to fill empty top space, but Stage 6.13's `_shrink_bboxes_to_content_bottom` couldn't then trim the bbox bottom: its row-mate predicate counted any Y-overlapping section as a mate, which made the bug self-protecting. An LR/RL section that declares `grid_row_span > 1` but whose content fits in one row had its pre-shrink bbox extend into the claimed-but-unfilled lower rows, Y-overlap a row-r+1 neighbour, and the neighbour then pinned the bottom — blocking the very shrink that would remove the overlap.

Visibly affected nf-core/differentialabundance, where section 1 (data_prep, rowspan=2) ended mid-air between row 0 and row 1.

The fix splits `_row_mate_bottoms` by direction:

- **TB sections** keep the Y-overlap check (section placement grows TB bbox_h by `section_y_gap` so fold-style TB sections visually span into their row-r+1 target).
- **LR/RL sections** match on the starting grid row only (with the other section's rowspan respected). Y-overlap is dropped for LR/RL.

The grid-row reservation from `rowspan>1` is preserved — auto-placed sections in the same column still skip the claimed rows; only bbox sizing is corrected.

Only 3 of 54 gallery fixtures change visually:

- `differentialabundance`: data_prep bbox_h 508.8 → 392.0
- `differentialabundance_default`: data_prep bbox_h 508.8 → 392.0
- `genomeassembly_staggered`: scaffolding bbox_h 196.3 → 188.2

All changes are pure bbox shrinks (no station/edge movement). The other 51 fixtures are byte-identical.

## Test plan

- [ ] CI green on the PR (lint, tests, gallery render diff)
- [ ] Gallery render diff confirms the three affected fixtures look cleaner and no regressions elsewhere