### PR TITLE
ci: share gh-pages concurrency group across all workflows that push it

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ permissions:
   pages: write
 
 concurrency:
-  group: docs
+  group: gh-pages
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-renders.yml
+++ b/.github/workflows/pr-renders.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-renders-${{ github.event.number }}
+  group: gh-pages
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Three workflows push to the \`gh-pages\` branch:

| Workflow | Triggered by | Old concurrency group |
|---|---|---|
| \`docs.yml\` | push to main, release published | \`docs\` |
| \`pr-renders.yml\` | PR opened/updated | \`pr-renders-\${{ github.event.number }}\` |
| \`pr-cleanup.yml\` | PR closed | (none) |

Each workflow serialised against itself but not against the others, so back-to-back events raced for the \`gh-pages\` ref and the loser failed with \`! [rejected] gh-pages -> gh-pages (fetch first)\`.

## Concrete failure

For the 0.7.2 release:

| Time (UTC) | Event | Result |
|---|---|---|
| 11:11:36 | PR #383 merged | – |
| 11:11:40 | \`docs.yml\` push-to-main run starts (run 26029895495) | – |
| 11:11:47 | \`pr-cleanup.yml\` pushes \`Clean up render preview for PR #383\` to gh-pages | ✅ |
| 11:12:05 | \`docs.yml\` mike push to gh-pages rejected | ❌ |

Same pattern reproduced on the 0.7.1 release flow.

## Fix

Promote all three workflows to a single shared concurrency group \`gh-pages\` with \`cancel-in-progress: false\` so any job pushing to that ref waits for the in-flight one to finish.

\`pr-renders.yml\` loses its per-PR parallelism, but a render-diff run is ~30s — queueing on the gh-pages-push step is cheap compared to flaky release deploys.

## Test plan

- [ ] CI green on the PR
- [ ] Next push to main / next release deploy produces a single ✅ \`Deploy docs\` run (not the usual one ✅ + one ❌)

🤖 Generated with [Claude Code](https://claude.com/claude-code)