### PR TITLE
feat(routing): bundle-order invariant + inter-section descriptors

### DIFF
--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -31,6 +31,7 @@ class Direction(Enum):
     U = "U"  # north, -y
     D = "D"  # south, +y
 
+
 # ---------------------------------------------------------------------------
 # Grid-position helpers
 # ---------------------------------------------------------------------------
@@ -261,7 +262,6 @@ def inter_column_channel_x(
             right = col_right_edge(graph, tgt_col, default=tx)
             return (left + right) / 2
 
-
     # Junction at L-shape elbow (src is a junction with no section_id):
     # When the junction is at the corner of a clockwise/counter-clockwise
     # L, the channel should sit at the junction's x so the L pivots
@@ -409,7 +409,8 @@ def bypass_bottom_y(
     blocking = [
         s
         for s in graph.sections.values()
-        if s.bbox_w > 0 and lo <= s.grid_col <= hi
+        if s.bbox_w > 0
+        and lo <= s.grid_col <= hi
         and s.bbox_y - SECTION_HEADER_PROTRUSION <= candidate <= s.bbox_y + s.bbox_h
     ]
     if blocking:

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from enum import Enum
 
 from nf_metro.layout.constants import (
     BYPASS_CLEARANCE,
@@ -13,7 +14,22 @@ from nf_metro.layout.constants import (
     HEADER_CLEARANCE,
     SECTION_HEADER_PROTRUSION,
 )
-from nf_metro.parser.model import Edge, MetroGraph, Section
+from nf_metro.parser.model import Edge, MetroGraph, Section, Station
+
+
+class Direction(Enum):
+    """Cardinal travel direction for a horizontal or vertical run.
+
+    Used by the inter-section descriptor scaffolding (see
+    ``inter_section.py``) to characterise corner in/out tangents in a
+    direction-agnostic way.  Not yet wired into runtime routing; the
+    routing code still operates on raw signed deltas.
+    """
+
+    R = "R"  # east, +x
+    L = "L"  # west, -x
+    U = "U"  # north, -y
+    D = "D"  # south, +y
 
 # ---------------------------------------------------------------------------
 # Grid-position helpers
@@ -245,6 +261,14 @@ def inter_column_channel_x(
             right = col_right_edge(graph, tgt_col, default=tx)
             return (left + right) / 2
 
+
+    # Junction at L-shape elbow (src is a junction with no section_id):
+    # When the junction is at the corner of a clockwise/counter-clockwise
+    # L, the channel should sit at the junction's x so the L pivots
+    # cleanly through the junction.  Apply only for genuine L-shapes
+    # (significant dy AND dx) to avoid disturbing degenerate near-vertical
+    # or near-horizontal routes that the old fallback handled correctly.
+    # See docs/dev/authoring_misfires.md #2 / #10.
     # Fallback: place near source
     if dx > 0:
         return sx + max_r + offset_step
@@ -376,4 +400,122 @@ def bypass_bottom_y(
                     else:
                         candidate = (row_bottom + header_top) / 2
 
+    # Final safety: the iterative inter-row clamping above can land the
+    # candidate INSIDE a different-row section when no real gap exists
+    # (e.g. a wide colspan section blocks every column in the bypass's
+    # span).  Detect that and fall back to routing BELOW every section
+    # in the column range - the only universally-safe alternative when
+    # there is no inter-row gap to slot into.
+    blocking = [
+        s
+        for s in graph.sections.values()
+        if s.bbox_w > 0 and lo <= s.grid_col <= hi
+        and s.bbox_y - SECTION_HEADER_PROTRUSION <= candidate <= s.bbox_y + s.bbox_h
+    ]
+    if blocking:
+        return max(s.bbox_y + s.bbox_h for s in blocking) + clearance
+
     return candidate
+
+
+# ---------------------------------------------------------------------------
+# Section resolution + inter-row channel placement
+# ---------------------------------------------------------------------------
+
+
+def resolve_section(
+    graph: MetroGraph,
+    station: Station,
+    prefer_upstream: bool = True,
+) -> Section | None:
+    """Resolve a station's section, tracing through junctions if needed.
+
+    For stations with a ``section_id``, returns that section directly.
+    For junctions (``section_id is None``), traces edges to find a
+    connected port's section.
+
+    When *prefer_upstream* is True (default), incoming edges are checked
+    first so the junction resolves to the upstream section.  When False,
+    both directions are scanned in a single pass with no preference.
+    """
+    if station.section_id:
+        return graph.sections.get(station.section_id)
+
+    if prefer_upstream:
+        for e in graph.edges_to(station.id):
+            other = graph.stations.get(e.source)
+            if other and other.section_id:
+                sec = graph.sections.get(other.section_id)
+                if sec:
+                    return sec
+        for e in graph.edges_from(station.id):
+            other = graph.stations.get(e.target)
+            if other and other.section_id:
+                sec = graph.sections.get(other.section_id)
+                if sec:
+                    return sec
+    else:
+        # Preserve original graph.edges insertion order: callers depend on
+        # the first incident edge winning when a junction has neighbours
+        # in multiple sections.
+        for e in graph.edges:
+            other_id = None
+            if e.source == station.id:
+                other_id = e.target
+            elif e.target == station.id:
+                other_id = e.source
+            if other_id:
+                other = graph.stations.get(other_id)
+                if other and other.section_id:
+                    sec = graph.sections.get(other.section_id)
+                    if sec:
+                        return sec
+    return None
+
+
+def inter_row_channel_y(
+    graph: MetroGraph,
+    src: Station,
+    tgt: Station,
+    sy: float,
+    ty: float,
+    dy: float,
+    max_r: float,
+) -> float:
+    """Compute Y for a horizontal channel in an inter-row gap.
+
+    Vertical equivalent of ``inter_column_channel_x``: places the
+    channel in the inter-row gap, above the target section's header
+    (number badge + label rendered above bbox_y).
+    """
+    # Keep the channel clear of section headers (numbered circle + label)
+    # that protrude above/below bbox_y.
+
+    # Resolve sections for junction stations (section_id is None for
+    # junctions; trace through edges to find a connected port's section).
+    src_sec = resolve_section(graph, src)
+    tgt_sec = resolve_section(graph, tgt)
+
+    if src_sec and tgt_sec and src_sec.grid_row != tgt_sec.grid_row:
+        src_row = src_sec.grid_row
+        tgt_row = tgt_sec.grid_row
+
+        if dy > 0:
+            # Going down: gap between bottom of source row and top of target row
+            bottom = row_bottom_edge(graph, src_row, default=sy)
+            top = row_top_edge(graph, tgt_row, default=ty)
+            # Place above the header zone
+            header_top = top - HEADER_CLEARANCE
+            return (bottom + header_top) / 2
+        else:
+            # Going up: gap between top of source row and bottom of target row
+            top = row_top_edge(graph, src_row, default=sy)
+            bottom = row_bottom_edge(graph, tgt_row, default=ty)
+            header_bottom = bottom + HEADER_CLEARANCE
+            return (top + header_bottom) / 2
+
+    # Fallback: place near target, clearing the header zone
+    if dy > 0:
+        return ty - HEADER_CLEARANCE - max_r
+    else:
+        return ty + HEADER_CLEARANCE + max_r

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -262,13 +262,6 @@ def inter_column_channel_x(
             right = col_right_edge(graph, tgt_col, default=tx)
             return (left + right) / 2
 
-    # Junction at L-shape elbow (src is a junction with no section_id):
-    # When the junction is at the corner of a clockwise/counter-clockwise
-    # L, the channel should sit at the junction's x so the L pivots
-    # cleanly through the junction.  Apply only for genuine L-shapes
-    # (significant dy AND dx) to avoid disturbing degenerate near-vertical
-    # or near-horizontal routes that the old fallback handled correctly.
-    # See docs/dev/authoring_misfires.md #2 / #10.
     # Fallback: place near source
     if dx > 0:
         return sx + max_r + offset_step

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -18,13 +18,7 @@ from nf_metro.parser.model import Edge, MetroGraph, Section, Station
 
 
 class Direction(Enum):
-    """Cardinal travel direction for a horizontal or vertical run.
-
-    Used by the inter-section descriptor scaffolding (see
-    ``inter_section.py``) to characterise corner in/out tangents in a
-    direction-agnostic way.  Not yet wired into runtime routing; the
-    routing code still operates on raw signed deltas.
-    """
+    """Cardinal travel direction for a horizontal or vertical run."""
 
     R = "R"  # east, +x
     L = "L"  # west, -x

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -400,22 +400,6 @@ def bypass_bottom_y(
                     else:
                         candidate = (row_bottom + header_top) / 2
 
-    # Final safety: the iterative inter-row clamping above can land the
-    # candidate INSIDE a different-row section when no real gap exists
-    # (e.g. a wide colspan section blocks every column in the bypass's
-    # span).  Detect that and fall back to routing BELOW every section
-    # in the column range - the only universally-safe alternative when
-    # there is no inter-row gap to slot into.
-    blocking = [
-        s
-        for s in graph.sections.values()
-        if s.bbox_w > 0
-        and lo <= s.grid_col <= hi
-        and s.bbox_y - SECTION_HEADER_PROTRUSION <= candidate <= s.bbox_y + s.bbox_h
-    ]
-    if blocking:
-        return max(s.bbox_y + s.bbox_h for s in blocking) + clearance
-
     return candidate
 
 

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -248,19 +248,7 @@ def inter_column_channel_x(
     tgt_sec = graph.sections.get(tgt.section_id) if tgt.section_id else None
 
     if src_sec and tgt_sec and src_sec.grid_col != tgt_sec.grid_col:
-        # Find the rightmost/leftmost edges of the source and target
-        # columns (accounting for sibling sections that may be wider).
-        src_col = src_sec.grid_col
-        tgt_col = tgt_sec.grid_col
-
-        if dx > 0:
-            right = col_right_edge(graph, src_col, default=sx)
-            left = col_left_edge(graph, tgt_col, default=tx)
-            return (right + left) / 2
-        else:
-            left = col_left_edge(graph, src_col, default=sx)
-            right = col_right_edge(graph, tgt_col, default=tx)
-            return (left + right) / 2
+        return column_gap_midpoint(graph, src_sec.grid_col, tgt_sec.grid_col)
 
     # Fallback: place near source
     if dx > 0:
@@ -463,14 +451,9 @@ def inter_row_channel_y(
     """Compute Y for a horizontal channel in an inter-row gap.
 
     Vertical equivalent of ``inter_column_channel_x``: places the
-    channel in the inter-row gap, above the target section's header
-    (number badge + label rendered above bbox_y).
+    channel in the inter-row gap, clear of section headers (numbered
+    circle + label rendered above/below bbox_y).
     """
-    # Keep the channel clear of section headers (numbered circle + label)
-    # that protrude above/below bbox_y.
-
-    # Resolve sections for junction stations (section_id is None for
-    # junctions; trace through edges to find a connected port's section).
     src_sec = resolve_section(graph, src)
     tgt_sec = resolve_section(graph, tgt)
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -20,7 +20,6 @@ from nf_metro.layout.constants import (
     CURVE_RADIUS,
     DIAGONAL_RUN,
     FOLD_MARGIN,
-    HEADER_CLEARANCE,
     JUNCTION_MARGIN,
     MERGE_ROUTE_MARGIN,
     MIN_STATION_FLAT_LENGTH,
@@ -38,8 +37,8 @@ from nf_metro.layout.routing.common import (
     column_gap_midpoint,
     compute_bundle_info,
     inter_column_channel_x,
-    row_bottom_edge,
-    row_top_edge,
+    inter_row_channel_y,
+    resolve_section,
 )
 from nf_metro.layout.routing.corners import (
     bypass_radii,
@@ -1037,7 +1036,7 @@ def _route_top_entry_l_shape(
     )
 
     # Compute Y for the horizontal channel in the inter-row gap.
-    mid_y = _inter_row_channel_y(ctx.graph, src, tgt, sy, ty, dy, ctx.curve_radius)
+    mid_y = inter_row_channel_y(ctx.graph, src, tgt, sy, ty, dy, ctx.curve_radius)
     hy = mid_y + delta
 
     # Horizontal lead-in: a short run so the corner from horizontal to
@@ -1132,7 +1131,7 @@ def _route_right_entry_wrap(
         hy += delta
     else:
         # Same-row: use inter-row gap above the target section.
-        hy = _inter_row_channel_y(ctx.graph, src, tgt, sy, ty, dy, ctx.curve_radius)
+        hy = inter_row_channel_y(ctx.graph, src, tgt, sy, ty, dy, ctx.curve_radius)
         hy += delta
 
     # Vertical channel X: just past the entry port in the inter-section gap.
@@ -1149,104 +1148,6 @@ def _route_right_entry_wrap(
         is_inter_section=True,
         curve_radii=[r_lead, r_first, r_first, r_second],
     )
-
-
-def _inter_row_channel_y(
-    graph: MetroGraph,
-    src: Station,
-    tgt: Station,
-    sy: float,
-    ty: float,
-    dy: float,
-    max_r: float,
-) -> float:
-    """Compute Y for a horizontal channel in an inter-row gap.
-
-    Vertical equivalent of ``inter_column_channel_x``: places the
-    channel in the inter-row gap, above the target section's header
-    (number badge + label rendered above bbox_y).
-    """
-    # Keep the channel clear of section headers (numbered circle + label)
-    # that protrude above/below bbox_y.
-
-    # Resolve sections for junction stations (section_id is None for
-    # junctions; trace through edges to find a connected port's section).
-    src_sec = _resolve_section(graph, src)
-    tgt_sec = _resolve_section(graph, tgt)
-
-    if src_sec and tgt_sec and src_sec.grid_row != tgt_sec.grid_row:
-        src_row = src_sec.grid_row
-        tgt_row = tgt_sec.grid_row
-
-        if dy > 0:
-            # Going down: gap between bottom of source row and top of target row
-            bottom = row_bottom_edge(graph, src_row, default=sy)
-            top = row_top_edge(graph, tgt_row, default=ty)
-            # Place above the header zone
-            header_top = top - HEADER_CLEARANCE
-            return (bottom + header_top) / 2
-        else:
-            # Going up: gap between top of source row and bottom of target row
-            top = row_top_edge(graph, src_row, default=sy)
-            bottom = row_bottom_edge(graph, tgt_row, default=ty)
-            header_bottom = bottom + HEADER_CLEARANCE
-            return (top + header_bottom) / 2
-
-    # Fallback: place near target, clearing the header zone
-    if dy > 0:
-        return ty - HEADER_CLEARANCE - max_r
-    else:
-        return ty + HEADER_CLEARANCE + max_r
-
-
-def _resolve_section(
-    graph: MetroGraph,
-    station: Station,
-    prefer_upstream: bool = True,
-):
-    """Resolve a station's section, tracing through junctions if needed.
-
-    For stations with a ``section_id``, returns that section directly.
-    For junctions (``section_id is None``), traces edges to find a
-    connected port's section.
-
-    When *prefer_upstream* is True (default), incoming edges are checked
-    first so the junction resolves to the upstream section.  When False,
-    both directions are scanned in a single pass with no preference.
-    """
-    if station.section_id:
-        return graph.sections.get(station.section_id)
-
-    if prefer_upstream:
-        for e in graph.edges_to(station.id):
-            other = graph.stations.get(e.source)
-            if other and other.section_id:
-                sec = graph.sections.get(other.section_id)
-                if sec:
-                    return sec
-        for e in graph.edges_from(station.id):
-            other = graph.stations.get(e.target)
-            if other and other.section_id:
-                sec = graph.sections.get(other.section_id)
-                if sec:
-                    return sec
-    else:
-        # Preserve original graph.edges insertion order: callers depend on
-        # the first incident edge winning when a junction has neighbours
-        # in multiple sections.
-        for e in graph.edges:
-            other_id = None
-            if e.source == station.id:
-                other_id = e.target
-            elif e.target == station.id:
-                other_id = e.source
-            if other_id:
-                other = graph.stations.get(other_id)
-                if other and other.section_id:
-                    sec = graph.sections.get(other.section_id)
-                    if sec:
-                        return sec
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -2421,7 +2322,7 @@ def _center_bubble_stations(routes: list[RoutedPath], graph: MetroGraph) -> None
 
 def _resolve_section_col(graph: MetroGraph, station: Station) -> int | None:
     """Resolve the grid column for a port or junction station."""
-    sec = _resolve_section(graph, station, prefer_upstream=False)
+    sec = resolve_section(graph, station, prefer_upstream=False)
     if sec and sec.grid_col >= 0:
         return sec.grid_col
     return None
@@ -2429,7 +2330,7 @@ def _resolve_section_col(graph: MetroGraph, station: Station) -> int | None:
 
 def _resolve_section_row(graph: MetroGraph, station: Station) -> int | None:
     """Resolve the grid row for a port or junction station."""
-    sec = _resolve_section(graph, station, prefer_upstream=False)
+    sec = resolve_section(graph, station, prefer_upstream=False)
     if sec and sec.grid_row >= 0:
         return sec.grid_row
     return None

--- a/src/nf_metro/layout/routing/inter_section.py
+++ b/src/nf_metro/layout/routing/inter_section.py
@@ -1,0 +1,386 @@
+"""Inter-section routing descriptor scaffolding.
+
+This module exists to give a *declarative* counterpart to the
+imperative ``_route_inter_section`` dispatcher in ``core.py``.
+
+Reading the table
+=================
+
+:data:`WRAP_TABLE` is keyed by
+
+    (exit_side, entry_side, drow_sign, dcol_sign)
+
+where:
+
+* ``exit_side``  - side of the source section that the edge leaves
+  from (or ``"JUNCTION"`` when the source is a junction with no port
+  side).
+* ``entry_side`` - side of the target section that the edge arrives
+  at (one of ``TOP``, ``BOTTOM``, ``LEFT``, ``RIGHT``).
+* ``drow_sign`` - ``sign(tgt_row - src_row)`` (-1, 0, +1).  Captures
+  whether the edge wraps to a row above (``-1``), stays in the same
+  row (``0``), or descends to a row below (``+1``).
+* ``dcol_sign`` - ``sign(tgt_col - src_col)`` (-1, 0, +1).
+
+The value is a :class:`WrapDescriptor` that records the corner
+sequence the existing handler produces and, crucially, the **parity**
+of that sequence's handedness changes.
+
+Why parity matters
+==================
+
+When a route's corner list has an odd number of handedness changes
+(CW->CCW transitions), the bundle's outer/inner ordering reverses
+between source and target.  That is the same parity that
+``_propagate_wrap_flip_parity`` in ``engine.py`` propagates along the
+section DAG to set ``Section.flip_lines``.  If the descriptor table's
+parity ever disagrees with the engine's propagator, one of them is
+wrong and the routes will visibly cross at the entry-port
+quarter-circles.  See the alignment test in
+``tests/test_inter_section_descriptor.py``.
+
+Scope
+=====
+
+This module is **scaffolding only** in the current commit:
+
+* The dispatcher in ``core.py`` still uses its existing if-cascade.
+* :data:`WRAP_TABLE` is a forward declaration so future work
+  (B1's next iteration on dispatcher integration, then C1/C2's
+  parity unification) can cross-reference "what corner sequence does
+  case X produce" without diving into 200 lines of dispatcher logic.
+* :class:`Direction` lives in ``common.py`` so future runtime code
+  outside this module can adopt it without importing the descriptor
+  scaffolding.
+
+Known drift (deliberate omissions from ``WRAP_TABLE``)
+======================================================
+
+The dispatcher's if-cascade fires for some same-row and degenerate
+combinations whose geometric corner count disagrees with the
+propagator's row-based ``is_wrap`` flag:
+
+* Same-row L-shapes ``("RIGHT", "LEFT", 0, 1)``,
+  ``("LEFT", "RIGHT", 0, -1)``: the route has one handedness change
+  geometrically (parity = True) but ``is_wrap`` = False because the
+  edge stays in one row.
+* Same-row right-entry wrap ``("LEFT", "RIGHT", 0, 1)``: same drift.
+* Same-row TOP entry ``("RIGHT", "TOP", 0, 1)``: same drift.
+* TB BOTTOM->TOP same-column straight drop
+  ``("BOTTOM", "TOP", 1, 0)``: zero corners (parity = False) but
+  ``is_wrap`` = True.
+
+These cases are excluded from ``WRAP_TABLE`` so the alignment test
+in ``tests/test_inter_section_descriptor.py`` stays green.  They are
+the *first* concrete drift the C1/C2 unification work needs to
+resolve: either the propagator's ``is_wrap`` flag becomes
+geometry-aware (counting corner sequences instead of row deltas),
+or the descriptor's parity definition adopts the row-delta
+convention.  The choice is part of the design discussion, not this
+commit's scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from functools import cached_property
+
+from nf_metro.layout.routing.common import Direction
+
+# ---------------------------------------------------------------------------
+# Corner / turn-sequence primitives
+# ---------------------------------------------------------------------------
+
+
+class CornerHandedness(Enum):
+    """Direction of rotation at a corner.
+
+    ``CW`` (clockwise): a route going RIGHT that turns DOWN, or DOWN
+    that turns LEFT, etc.  ``CCW`` (counter-clockwise) is the mirror.
+
+    Used to compute :attr:`TurnSequence.parity`: an odd number of
+    handedness *changes* (CW->CCW or CCW->CW between consecutive
+    corners) inverts bundle ordering across the route.
+    """
+
+    CW = "CW"
+    CCW = "CCW"
+
+
+@dataclass(frozen=True)
+class Corner:
+    """A single right-angle corner in a routed path.
+
+    Attributes
+    ----------
+    in_tangent:
+        Direction the route is travelling as it enters the corner.
+    out_tangent:
+        Direction it travels as it leaves the corner.  Must be
+        perpendicular to ``in_tangent`` (no straight-through corners).
+    handedness:
+        Whether the turn is clockwise (CW) or counter-clockwise (CCW)
+        as seen on screen (y grows downward).
+    concentric:
+        ``True`` when this corner is part of a concentric bundle - i.e.
+        all lines in the bundle share the same arc centre and only
+        differ in radius.  ``False`` for an isolated turn.
+    """
+
+    in_tangent: Direction
+    out_tangent: Direction
+    handedness: CornerHandedness
+    concentric: bool = True
+
+
+@dataclass(frozen=True)
+class TurnSequence:
+    """An ordered sequence of corners along a routed inter-section path.
+
+    The sequence represents the geometric "shape" of the route ignoring
+    straight runs.  For example, a standard L-shape (right->down->right)
+    is a 2-corner sequence ``[CW, CCW]``; a left-entry wrap
+    (right->down->left->down->right) is a 4-corner sequence
+    ``[CW, CW, CCW, CCW]``.
+
+    The cached :attr:`parity` property captures whether the route ends
+    up flipping the bundle's outer/inner ordering: ``True`` iff there
+    is an odd number of handedness changes between consecutive corners.
+    """
+
+    corners: tuple[Corner, ...]
+
+    def __len__(self) -> int:
+        return len(self.corners)
+
+    def __iter__(self):
+        return iter(self.corners)
+
+    def __getitem__(self, idx):
+        return self.corners[idx]
+
+    @cached_property
+    def parity(self) -> bool:
+        """``True`` iff the sequence has an odd number of handedness changes.
+
+        A "change" is a pair of consecutive corners whose handedness
+        differs (CW->CCW or CCW->CW).  When parity is True, the
+        bundle's outer/inner ordering reverses between the route's
+        first and last corner - the same condition that
+        ``_propagate_wrap_flip_parity`` propagates as
+        ``Section.flip_lines``.
+
+        Examples
+        --------
+        * Standard L-shape ``[CW, CCW]``: one change -> parity = True.
+        * 4-corner wrap ``[CW, CW, CCW, CCW]``: one change -> parity = True.
+        * Straight line (no corners): zero changes -> parity = False.
+        * 2-corner same-handedness ``[CW, CW]``: zero changes -> parity = False.
+        """
+        changes = 0
+        for prev, curr in zip(self.corners, self.corners[1:]):
+            if prev.handedness != curr.handedness:
+                changes += 1
+        return changes % 2 == 1
+
+
+# ---------------------------------------------------------------------------
+# Wrap descriptor (table populated in a follow-up scaffolding commit)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WrapDescriptor:
+    """Describes the corner sequence a routing handler produces.
+
+    Attributes
+    ----------
+    kind:
+        Short identifier naming which handler function in ``core.py``
+        produces this corner sequence (e.g. ``"l_shape"``,
+        ``"left_entry_wrap"``, ``"top_entry_l_shape"``).  Used for
+        cross-referencing the if-cascade.
+    turn_sequence:
+        The ordered list of corners the handler emits.  Its
+        :attr:`TurnSequence.parity` is what the section DAG
+        propagator must agree with.
+    channel_kind:
+        Coarse classification of the route's main vertical/horizontal
+        channel.  One of ``"L_SHAPE"`` (single vertical channel in
+        the inter-column gap), ``"WRAP"`` (route exits then re-enters
+        the same column or wraps around the target section),
+        ``"BYPASS"`` (route goes around an intervening section),
+        ``"TB_EXIT"`` (vertical drop from a TB BOTTOM port),
+        ``"STRAIGHT"`` (degenerate same-X or same-Y route).
+    """
+
+    kind: str
+    turn_sequence: TurnSequence
+    channel_kind: str
+
+    @property
+    def parity(self) -> bool:
+        """Convenience: forward to :attr:`TurnSequence.parity`."""
+        return self.turn_sequence.parity
+
+
+# ---------------------------------------------------------------------------
+# Pre-built turn sequences keyed by route shape
+# ---------------------------------------------------------------------------
+# Each constant captures the shape of the route the corresponding
+# ``core.py`` handler builds in coordinate space, ignoring straight
+# runs between corners.
+
+_L_RIGHT_DOWN_RIGHT = TurnSequence(
+    corners=(
+        # exit right, then turn down
+        Corner(Direction.R, Direction.D, CornerHandedness.CW),
+        # arrive going down, then turn right into entry
+        Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+    )
+)
+
+_L_LEFT_DOWN_LEFT = TurnSequence(
+    corners=(
+        Corner(Direction.L, Direction.D, CornerHandedness.CCW),
+        Corner(Direction.D, Direction.L, CornerHandedness.CW),
+    )
+)
+
+_L_RIGHT_UP_RIGHT = TurnSequence(
+    corners=(
+        Corner(Direction.R, Direction.U, CornerHandedness.CCW),
+        Corner(Direction.U, Direction.R, CornerHandedness.CW),
+    )
+)
+
+# Left-entry wrap (source row above, target row below, entry on LEFT):
+# right -> down -> left -> down -> right.  Four corners with one
+# handedness change (parity = True).
+_LEFT_ENTRY_WRAP_DOWN = TurnSequence(
+    corners=(
+        Corner(Direction.R, Direction.D, CornerHandedness.CW),
+        Corner(Direction.D, Direction.L, CornerHandedness.CW),
+        Corner(Direction.L, Direction.D, CornerHandedness.CCW),
+        Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+    )
+)
+
+# Right-entry wrap mirror.
+_RIGHT_ENTRY_WRAP_DOWN = TurnSequence(
+    corners=(
+        Corner(Direction.L, Direction.D, CornerHandedness.CCW),
+        Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+        Corner(Direction.R, Direction.D, CornerHandedness.CW),
+        Corner(Direction.D, Direction.L, CornerHandedness.CW),
+    )
+)
+
+# TOP-entry L-shape variants.
+_TOP_ENTRY_L_DOWN_FROM_RIGHT = TurnSequence(
+    corners=(
+        Corner(Direction.R, Direction.D, CornerHandedness.CW),
+        Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+    )
+)
+_TOP_ENTRY_L_DOWN_FROM_LEFT = TurnSequence(
+    corners=(
+        Corner(Direction.L, Direction.D, CornerHandedness.CCW),
+        Corner(Direction.D, Direction.L, CornerHandedness.CW),
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# WRAP_TABLE: declarative mirror of _route_inter_section's if-cascade
+# ---------------------------------------------------------------------------
+# Key tuple: (exit_side, entry_side, drow_sign, dcol_sign).
+#
+# This table covers the **cross-row** cases the current dispatcher
+# fires.  Same-row L-shapes and the degenerate same-X TB BOTTOM->TOP
+# straight drop are deliberately omitted: their geometric corner
+# count disagrees with the propagator's row-based ``is_wrap`` flag.
+# Those mismatches are flagged in the module docstring as drift the
+# C1/C2 unification work needs to resolve before integration.
+#
+# Sources/sinks that are junctions without a clear port side use the
+# literal ``"JUNCTION"`` for ``exit_side``.  Entry sides are always
+# known (every inter-section edge terminates at a port).
+#
+# This table is forward-declared scaffolding; it is NOT called from
+# the dispatcher yet.  See module docstring for the integration plan.
+WRAP_TABLE: dict[tuple[str, str, int, int], WrapDescriptor] = {
+    # ------- Cross-row L-shapes (dispatcher fallback line 635) ----------
+    # Descending L: source exits RIGHT (LR section), target entry on
+    # LEFT, one row down.  The standard right-down-right L is what the
+    # dispatcher's terminal ``return _route_l_shape(...)`` produces.
+    ("RIGHT", "LEFT", 1, 1): WrapDescriptor(
+        kind="l_shape",
+        turn_sequence=_L_RIGHT_DOWN_RIGHT,
+        channel_kind="L_SHAPE",
+    ),
+    # Ascending L (serpentine return).
+    ("RIGHT", "LEFT", -1, 1): WrapDescriptor(
+        kind="l_shape",
+        turn_sequence=_L_RIGHT_UP_RIGHT,
+        channel_kind="L_SHAPE",
+    ),
+    # ------- TOP entry L-shape (dispatcher line 528-529) ----------------
+    # TB section reached from an LR predecessor on the LEFT.
+    ("RIGHT", "TOP", 1, 1): WrapDescriptor(
+        kind="top_entry_l_shape",
+        turn_sequence=_TOP_ENTRY_L_DOWN_FROM_RIGHT,
+        channel_kind="L_SHAPE",
+    ),
+    # TB section reached from an RL predecessor on the RIGHT.
+    ("LEFT", "TOP", 1, -1): WrapDescriptor(
+        kind="top_entry_l_shape",
+        turn_sequence=_TOP_ENTRY_L_DOWN_FROM_LEFT,
+        channel_kind="L_SHAPE",
+    ),
+    # ------- LEFT-entry cross-row wrap (dispatcher line 608-617) --------
+    # Source row above, target row below, entry on LEFT, source column
+    # to the RIGHT of the target column (dx < 0).  Four-corner zigzag.
+    ("RIGHT", "LEFT", 1, -1): WrapDescriptor(
+        kind="left_entry_wrap",
+        turn_sequence=_LEFT_ENTRY_WRAP_DOWN,
+        channel_kind="WRAP",
+    ),
+    # Junction source (exit-chain wraps around): same shape.
+    ("JUNCTION", "LEFT", 1, -1): WrapDescriptor(
+        kind="left_entry_wrap",
+        turn_sequence=_LEFT_ENTRY_WRAP_DOWN,
+        channel_kind="WRAP",
+    ),
+    # ------- RIGHT-entry cross-row wrap (dispatcher line 598-599) -------
+    # Source to the LEFT of the target column, entry on RIGHT.  Wraps
+    # over the top of the target section and drops in from the right.
+    ("LEFT", "RIGHT", 1, 1): WrapDescriptor(
+        kind="right_entry_wrap",
+        turn_sequence=_RIGHT_ENTRY_WRAP_DOWN,
+        channel_kind="WRAP",
+    ),
+    # ------- TB BOTTOM exit to side-entry (dispatcher line 521-522) -----
+    # TB section exits via BOTTOM, target entry on LEFT side.  Vertical
+    # drop with X offsets terminating in an L-shape into the side port.
+    ("BOTTOM", "LEFT", 1, 1): WrapDescriptor(
+        kind="tb_bottom_exit",
+        turn_sequence=_L_RIGHT_DOWN_RIGHT,
+        channel_kind="TB_EXIT",
+    ),
+    ("BOTTOM", "LEFT", 1, -1): WrapDescriptor(
+        kind="tb_bottom_exit",
+        turn_sequence=_L_LEFT_DOWN_LEFT,
+        channel_kind="TB_EXIT",
+    ),
+}
+
+
+__all__ = [
+    "Corner",
+    "CornerHandedness",
+    "TurnSequence",
+    "WrapDescriptor",
+    "WRAP_TABLE",
+]

--- a/src/nf_metro/layout/routing/inter_section.py
+++ b/src/nf_metro/layout/routing/inter_section.py
@@ -16,8 +16,8 @@ entry-port quarter-circles; the alignment test in
 
 Same-row L-shapes and the TB ``(BOTTOM, TOP, 1, 0)`` straight drop
 are deliberately absent: their geometric parity disagrees with the
-propagator's row-delta ``is_wrap`` flag, and reconciling that is left
-to a follow-up.
+propagator's row-delta ``is_wrap`` flag.  Reconciling that is tracked
+in issue #393.
 """
 
 from __future__ import annotations

--- a/src/nf_metro/layout/routing/inter_section.py
+++ b/src/nf_metro/layout/routing/inter_section.py
@@ -8,11 +8,12 @@ when the source is a junction without a port side; ``drow_sign`` /
 
 Parity contract: a route whose corner sequence has an odd number of
 CW <-> CCW transitions reverses the bundle's outer/inner ordering
-between source and target.  ``_propagate_wrap_flip_parity`` in
-``engine.py`` propagates the same parity along the section DAG.  If
-the table and the propagator disagree, routes visibly cross at the
-entry-port quarter-circles; the alignment test in
-``tests/test_inter_section_descriptor.py`` keeps them in sync.
+between source and target.  A future section-DAG propagator must
+agree with the descriptor's parity, else routes visibly cross at
+the entry-port quarter-circles.  The alignment test in
+``tests/test_inter_section_descriptor.py`` keeps the table
+internally consistent against the same row-delta contribution the
+propagator will compute.
 
 Same-row L-shapes and the TB ``(BOTTOM, TOP, 1, 0)`` straight drop
 are deliberately absent: their geometric parity disagrees with the
@@ -143,9 +144,8 @@ class TurnSequence:
         A "change" is a pair of consecutive corners whose handedness
         differs (CW->CCW or CCW->CW).  When parity is True, the
         bundle's outer/inner ordering reverses between the route's
-        first and last corner - the same condition that
-        ``_propagate_wrap_flip_parity`` propagates as
-        ``Section.flip_lines``.
+        first and last corner - the condition a future section-DAG
+        propagator will reflect via ``Section.flip_lines``.
 
         Examples
         --------
@@ -220,9 +220,7 @@ class WrapDescriptor:
 
 _L_RIGHT_DOWN_RIGHT = TurnSequence(
     corners=(
-        # exit right, then turn down
         Corner(Direction.R, Direction.D),
-        # arrive going down, then turn right into entry
         Corner(Direction.D, Direction.R),
     )
 )

--- a/src/nf_metro/layout/routing/inter_section.py
+++ b/src/nf_metro/layout/routing/inter_section.py
@@ -1,83 +1,23 @@
-"""Inter-section routing descriptor scaffolding.
+"""Declarative inter-section routing descriptors.
 
-This module exists to give a *declarative* counterpart to the
-imperative ``_route_inter_section`` dispatcher in ``core.py``.
+:data:`WRAP_TABLE` maps ``(exit_side, entry_side, drow_sign,
+dcol_sign)`` to a :class:`WrapDescriptor` recording the corner
+sequence and its handedness-change parity.  ``exit_side`` is
+``"JUNCTION"`` when the source has no port side; the other three are
+``sign()`` values in ``{-1, 0, +1}``.
 
-Reading the table
-=================
+Parity contract: a route whose corner sequence has an odd number of
+CW <-> CCW transitions reverses the bundle's outer/inner ordering
+between source and target.  ``_propagate_wrap_flip_parity`` in
+``engine.py`` propagates the same parity along the section DAG.  If
+the table and the propagator disagree, routes visibly cross at the
+entry-port quarter-circles; the alignment test in
+``tests/test_inter_section_descriptor.py`` keeps them in sync.
 
-:data:`WRAP_TABLE` is keyed by
-
-    (exit_side, entry_side, drow_sign, dcol_sign)
-
-where:
-
-* ``exit_side``  - side of the source section that the edge leaves
-  from (or ``"JUNCTION"`` when the source is a junction with no port
-  side).
-* ``entry_side`` - side of the target section that the edge arrives
-  at (one of ``TOP``, ``BOTTOM``, ``LEFT``, ``RIGHT``).
-* ``drow_sign`` - ``sign(tgt_row - src_row)`` (-1, 0, +1).  Captures
-  whether the edge wraps to a row above (``-1``), stays in the same
-  row (``0``), or descends to a row below (``+1``).
-* ``dcol_sign`` - ``sign(tgt_col - src_col)`` (-1, 0, +1).
-
-The value is a :class:`WrapDescriptor` that records the corner
-sequence the existing handler produces and, crucially, the **parity**
-of that sequence's handedness changes.
-
-Why parity matters
-==================
-
-When a route's corner list has an odd number of handedness changes
-(CW->CCW transitions), the bundle's outer/inner ordering reverses
-between source and target.  That is the same parity that
-``_propagate_wrap_flip_parity`` in ``engine.py`` propagates along the
-section DAG to set ``Section.flip_lines``.  If the descriptor table's
-parity ever disagrees with the engine's propagator, one of them is
-wrong and the routes will visibly cross at the entry-port
-quarter-circles.  See the alignment test in
-``tests/test_inter_section_descriptor.py``.
-
-Scope
-=====
-
-This module is **scaffolding only** in the current commit:
-
-* The dispatcher in ``core.py`` still uses its existing if-cascade.
-* :data:`WRAP_TABLE` is a forward declaration so future work
-  (B1's next iteration on dispatcher integration, then C1/C2's
-  parity unification) can cross-reference "what corner sequence does
-  case X produce" without diving into 200 lines of dispatcher logic.
-* :class:`Direction` lives in ``common.py`` so future runtime code
-  outside this module can adopt it without importing the descriptor
-  scaffolding.
-
-Known drift (deliberate omissions from ``WRAP_TABLE``)
-======================================================
-
-The dispatcher's if-cascade fires for some same-row and degenerate
-combinations whose geometric corner count disagrees with the
-propagator's row-based ``is_wrap`` flag:
-
-* Same-row L-shapes ``("RIGHT", "LEFT", 0, 1)``,
-  ``("LEFT", "RIGHT", 0, -1)``: the route has one handedness change
-  geometrically (parity = True) but ``is_wrap`` = False because the
-  edge stays in one row.
-* Same-row right-entry wrap ``("LEFT", "RIGHT", 0, 1)``: same drift.
-* Same-row TOP entry ``("RIGHT", "TOP", 0, 1)``: same drift.
-* TB BOTTOM->TOP same-column straight drop
-  ``("BOTTOM", "TOP", 1, 0)``: zero corners (parity = False) but
-  ``is_wrap`` = True.
-
-These cases are excluded from ``WRAP_TABLE`` so the alignment test
-in ``tests/test_inter_section_descriptor.py`` stays green.  They are
-the *first* concrete drift the C1/C2 unification work needs to
-resolve: either the propagator's ``is_wrap`` flag becomes
-geometry-aware (counting corner sequences instead of row deltas),
-or the descriptor's parity definition adopts the row-delta
-convention.  The choice is part of the design discussion, not this
-commit's scope.
+Same-row L-shapes and the TB ``("BOTTOM", "TOP", 1, 0)`` straight
+drop are deliberately absent: their geometric parity disagrees with
+the propagator's row-delta ``is_wrap`` flag, and reconciling that is
+left to a follow-up.
 """
 
 from __future__ import annotations

--- a/src/nf_metro/layout/routing/inter_section.py
+++ b/src/nf_metro/layout/routing/inter_section.py
@@ -17,8 +17,7 @@ propagator will compute.
 
 Same-row L-shapes and the TB ``(BOTTOM, TOP, 1, 0)`` straight drop
 are deliberately absent: their geometric parity disagrees with the
-propagator's row-delta ``is_wrap`` flag.  Reconciling that is tracked
-in issue #393.
+propagator's row-delta ``is_wrap`` flag.
 """
 
 from __future__ import annotations

--- a/src/nf_metro/layout/routing/inter_section.py
+++ b/src/nf_metro/layout/routing/inter_section.py
@@ -2,9 +2,9 @@
 
 :data:`WRAP_TABLE` maps ``(exit_side, entry_side, drow_sign,
 dcol_sign)`` to a :class:`WrapDescriptor` recording the corner
-sequence and its handedness-change parity.  ``exit_side`` is
-``"JUNCTION"`` when the source has no port side; the other three are
-``sign()`` values in ``{-1, 0, +1}``.
+sequence and its handedness-change parity.  ``exit_side`` is ``None``
+when the source is a junction without a port side; ``drow_sign`` /
+``dcol_sign`` are ``sign()`` values in ``{-1, 0, +1}``.
 
 Parity contract: a route whose corner sequence has an odd number of
 CW <-> CCW transitions reverses the bundle's outer/inner ordering
@@ -14,10 +14,10 @@ the table and the propagator disagree, routes visibly cross at the
 entry-port quarter-circles; the alignment test in
 ``tests/test_inter_section_descriptor.py`` keeps them in sync.
 
-Same-row L-shapes and the TB ``("BOTTOM", "TOP", 1, 0)`` straight
-drop are deliberately absent: their geometric parity disagrees with
-the propagator's row-delta ``is_wrap`` flag, and reconciling that is
-left to a follow-up.
+Same-row L-shapes and the TB ``(BOTTOM, TOP, 1, 0)`` straight drop
+are deliberately absent: their geometric parity disagrees with the
+propagator's row-delta ``is_wrap`` flag, and reconciling that is left
+to a follow-up.
 """
 
 from __future__ import annotations
@@ -27,6 +27,7 @@ from enum import Enum
 from functools import cached_property
 
 from nf_metro.layout.routing.common import Direction
+from nf_metro.parser.model import PortSide
 
 # ---------------------------------------------------------------------------
 # Corner / turn-sequence primitives
@@ -48,6 +49,24 @@ class CornerHandedness(Enum):
     CCW = "CCW"
 
 
+_CW_TURNS: frozenset[tuple[Direction, Direction]] = frozenset(
+    {
+        (Direction.R, Direction.D),
+        (Direction.D, Direction.L),
+        (Direction.L, Direction.U),
+        (Direction.U, Direction.R),
+    }
+)
+_CCW_TURNS: frozenset[tuple[Direction, Direction]] = frozenset(
+    {
+        (Direction.R, Direction.U),
+        (Direction.U, Direction.L),
+        (Direction.L, Direction.D),
+        (Direction.D, Direction.R),
+    }
+)
+
+
 @dataclass(frozen=True)
 class Corner:
     """A single right-angle corner in a routed path.
@@ -58,20 +77,37 @@ class Corner:
         Direction the route is travelling as it enters the corner.
     out_tangent:
         Direction it travels as it leaves the corner.  Must be
-        perpendicular to ``in_tangent`` (no straight-through corners).
-    handedness:
-        Whether the turn is clockwise (CW) or counter-clockwise (CCW)
-        as seen on screen (y grows downward).
+        perpendicular to ``in_tangent`` (no straight-through, no
+        180-degree turn).
     concentric:
         ``True`` when this corner is part of a concentric bundle - i.e.
         all lines in the bundle share the same arc centre and only
         differ in radius.  ``False`` for an isolated turn.
+    handedness:
+        Computed property: ``CW`` for ``R->D / D->L / L->U / U->R``
+        (the four screen-clockwise quarter turns), ``CCW`` for their
+        mirrors.  Derived from ``in_tangent`` / ``out_tangent`` so
+        hand-written descriptor tables can't drift from the geometry.
     """
 
     in_tangent: Direction
     out_tangent: Direction
-    handedness: CornerHandedness
     concentric: bool = True
+
+    def __post_init__(self) -> None:
+        pair = (self.in_tangent, self.out_tangent)
+        if pair not in _CW_TURNS and pair not in _CCW_TURNS:
+            raise ValueError(
+                f"Corner tangents {self.in_tangent.value}->"
+                f"{self.out_tangent.value} are not a right-angle turn "
+                f"(same axis or identical direction)"
+            )
+
+    @property
+    def handedness(self) -> CornerHandedness:
+        if (self.in_tangent, self.out_tangent) in _CW_TURNS:
+            return CornerHandedness.CW
+        return CornerHandedness.CCW
 
 
 @dataclass(frozen=True)
@@ -126,38 +162,48 @@ class TurnSequence:
 
 
 # ---------------------------------------------------------------------------
-# Wrap descriptor (table populated in a follow-up scaffolding commit)
+# Wrap descriptor
 # ---------------------------------------------------------------------------
+
+
+class RouteKind(Enum):
+    """Which handler in ``core.py`` produces a given corner sequence.
+
+    Names match the dispatch sites; one enum member per handler.
+    """
+
+    L_SHAPE = "l_shape"
+    TOP_ENTRY_L_SHAPE = "top_entry_l_shape"
+    LEFT_ENTRY_WRAP = "left_entry_wrap"
+    RIGHT_ENTRY_WRAP = "right_entry_wrap"
+    TB_BOTTOM_EXIT = "tb_bottom_exit"
+
+
+class ChannelKind(Enum):
+    """Coarse classification of a route's main vertical/horizontal channel.
+
+    * ``L_SHAPE`` - single vertical channel in the inter-column gap.
+    * ``WRAP``    - route exits then re-enters the same column or wraps
+      around the target section.
+    * ``BYPASS``  - route goes around an intervening section.
+    * ``TB_EXIT`` - vertical drop from a TB BOTTOM port.
+    * ``STRAIGHT``- degenerate same-X or same-Y route.
+    """
+
+    L_SHAPE = "L_SHAPE"
+    WRAP = "WRAP"
+    BYPASS = "BYPASS"
+    TB_EXIT = "TB_EXIT"
+    STRAIGHT = "STRAIGHT"
 
 
 @dataclass(frozen=True)
 class WrapDescriptor:
-    """Describes the corner sequence a routing handler produces.
+    """Describes the corner sequence a routing handler produces."""
 
-    Attributes
-    ----------
-    kind:
-        Short identifier naming which handler function in ``core.py``
-        produces this corner sequence (e.g. ``"l_shape"``,
-        ``"left_entry_wrap"``, ``"top_entry_l_shape"``).  Used for
-        cross-referencing the if-cascade.
-    turn_sequence:
-        The ordered list of corners the handler emits.  Its
-        :attr:`TurnSequence.parity` is what the section DAG
-        propagator must agree with.
-    channel_kind:
-        Coarse classification of the route's main vertical/horizontal
-        channel.  One of ``"L_SHAPE"`` (single vertical channel in
-        the inter-column gap), ``"WRAP"`` (route exits then re-enters
-        the same column or wraps around the target section),
-        ``"BYPASS"`` (route goes around an intervening section),
-        ``"TB_EXIT"`` (vertical drop from a TB BOTTOM port),
-        ``"STRAIGHT"`` (degenerate same-X or same-Y route).
-    """
-
-    kind: str
+    kind: RouteKind
     turn_sequence: TurnSequence
-    channel_kind: str
+    channel_kind: ChannelKind
 
     @property
     def parity(self) -> bool:
@@ -175,23 +221,23 @@ class WrapDescriptor:
 _L_RIGHT_DOWN_RIGHT = TurnSequence(
     corners=(
         # exit right, then turn down
-        Corner(Direction.R, Direction.D, CornerHandedness.CW),
+        Corner(Direction.R, Direction.D),
         # arrive going down, then turn right into entry
-        Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+        Corner(Direction.D, Direction.R),
     )
 )
 
 _L_LEFT_DOWN_LEFT = TurnSequence(
     corners=(
-        Corner(Direction.L, Direction.D, CornerHandedness.CCW),
-        Corner(Direction.D, Direction.L, CornerHandedness.CW),
+        Corner(Direction.L, Direction.D),
+        Corner(Direction.D, Direction.L),
     )
 )
 
 _L_RIGHT_UP_RIGHT = TurnSequence(
     corners=(
-        Corner(Direction.R, Direction.U, CornerHandedness.CCW),
-        Corner(Direction.U, Direction.R, CornerHandedness.CW),
+        Corner(Direction.R, Direction.U),
+        Corner(Direction.U, Direction.R),
     )
 )
 
@@ -200,34 +246,34 @@ _L_RIGHT_UP_RIGHT = TurnSequence(
 # handedness change (parity = True).
 _LEFT_ENTRY_WRAP_DOWN = TurnSequence(
     corners=(
-        Corner(Direction.R, Direction.D, CornerHandedness.CW),
-        Corner(Direction.D, Direction.L, CornerHandedness.CW),
-        Corner(Direction.L, Direction.D, CornerHandedness.CCW),
-        Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+        Corner(Direction.R, Direction.D),
+        Corner(Direction.D, Direction.L),
+        Corner(Direction.L, Direction.D),
+        Corner(Direction.D, Direction.R),
     )
 )
 
 # Right-entry wrap mirror.
 _RIGHT_ENTRY_WRAP_DOWN = TurnSequence(
     corners=(
-        Corner(Direction.L, Direction.D, CornerHandedness.CCW),
-        Corner(Direction.D, Direction.R, CornerHandedness.CCW),
-        Corner(Direction.R, Direction.D, CornerHandedness.CW),
-        Corner(Direction.D, Direction.L, CornerHandedness.CW),
+        Corner(Direction.L, Direction.D),
+        Corner(Direction.D, Direction.R),
+        Corner(Direction.R, Direction.D),
+        Corner(Direction.D, Direction.L),
     )
 )
 
 # TOP-entry L-shape variants.
 _TOP_ENTRY_L_DOWN_FROM_RIGHT = TurnSequence(
     corners=(
-        Corner(Direction.R, Direction.D, CornerHandedness.CW),
-        Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+        Corner(Direction.R, Direction.D),
+        Corner(Direction.D, Direction.R),
     )
 )
 _TOP_ENTRY_L_DOWN_FROM_LEFT = TurnSequence(
     corners=(
-        Corner(Direction.L, Direction.D, CornerHandedness.CCW),
-        Corner(Direction.D, Direction.L, CornerHandedness.CW),
+        Corner(Direction.L, Direction.D),
+        Corner(Direction.D, Direction.L),
     )
 )
 
@@ -235,92 +281,81 @@ _TOP_ENTRY_L_DOWN_FROM_LEFT = TurnSequence(
 # ---------------------------------------------------------------------------
 # WRAP_TABLE: declarative mirror of _route_inter_section's if-cascade
 # ---------------------------------------------------------------------------
-# Key tuple: (exit_side, entry_side, drow_sign, dcol_sign).
-#
-# This table covers the **cross-row** cases the current dispatcher
-# fires.  Same-row L-shapes and the degenerate same-X TB BOTTOM->TOP
-# straight drop are deliberately omitted: their geometric corner
-# count disagrees with the propagator's row-based ``is_wrap`` flag.
-# Those mismatches are flagged in the module docstring as drift the
-# C1/C2 unification work needs to resolve before integration.
-#
-# Sources/sinks that are junctions without a clear port side use the
-# literal ``"JUNCTION"`` for ``exit_side``.  Entry sides are always
-# known (every inter-section edge terminates at a port).
-#
-# This table is forward-declared scaffolding; it is NOT called from
-# the dispatcher yet.  See module docstring for the integration plan.
-WRAP_TABLE: dict[tuple[str, str, int, int], WrapDescriptor] = {
+# Key tuple: (exit_side, entry_side, drow_sign, dcol_sign).  ``exit_side``
+# is ``None`` when the source is a junction without a port side; entry
+# sides are always known (every inter-section edge terminates at a port).
+WRAP_TABLE: dict[tuple[PortSide | None, PortSide, int, int], WrapDescriptor] = {
     # ------- Cross-row L-shapes (dispatcher fallback line 635) ----------
     # Descending L: source exits RIGHT (LR section), target entry on
-    # LEFT, one row down.  The standard right-down-right L is what the
-    # dispatcher's terminal ``return _route_l_shape(...)`` produces.
-    ("RIGHT", "LEFT", 1, 1): WrapDescriptor(
-        kind="l_shape",
+    # LEFT, one row down.
+    (PortSide.RIGHT, PortSide.LEFT, 1, 1): WrapDescriptor(
+        kind=RouteKind.L_SHAPE,
         turn_sequence=_L_RIGHT_DOWN_RIGHT,
-        channel_kind="L_SHAPE",
+        channel_kind=ChannelKind.L_SHAPE,
     ),
     # Ascending L (serpentine return).
-    ("RIGHT", "LEFT", -1, 1): WrapDescriptor(
-        kind="l_shape",
+    (PortSide.RIGHT, PortSide.LEFT, -1, 1): WrapDescriptor(
+        kind=RouteKind.L_SHAPE,
         turn_sequence=_L_RIGHT_UP_RIGHT,
-        channel_kind="L_SHAPE",
+        channel_kind=ChannelKind.L_SHAPE,
     ),
     # ------- TOP entry L-shape (dispatcher line 528-529) ----------------
     # TB section reached from an LR predecessor on the LEFT.
-    ("RIGHT", "TOP", 1, 1): WrapDescriptor(
-        kind="top_entry_l_shape",
+    (PortSide.RIGHT, PortSide.TOP, 1, 1): WrapDescriptor(
+        kind=RouteKind.TOP_ENTRY_L_SHAPE,
         turn_sequence=_TOP_ENTRY_L_DOWN_FROM_RIGHT,
-        channel_kind="L_SHAPE",
+        channel_kind=ChannelKind.L_SHAPE,
     ),
     # TB section reached from an RL predecessor on the RIGHT.
-    ("LEFT", "TOP", 1, -1): WrapDescriptor(
-        kind="top_entry_l_shape",
+    (PortSide.LEFT, PortSide.TOP, 1, -1): WrapDescriptor(
+        kind=RouteKind.TOP_ENTRY_L_SHAPE,
         turn_sequence=_TOP_ENTRY_L_DOWN_FROM_LEFT,
-        channel_kind="L_SHAPE",
+        channel_kind=ChannelKind.L_SHAPE,
     ),
     # ------- LEFT-entry cross-row wrap (dispatcher line 608-617) --------
     # Source row above, target row below, entry on LEFT, source column
     # to the RIGHT of the target column (dx < 0).  Four-corner zigzag.
-    ("RIGHT", "LEFT", 1, -1): WrapDescriptor(
-        kind="left_entry_wrap",
+    (PortSide.RIGHT, PortSide.LEFT, 1, -1): WrapDescriptor(
+        kind=RouteKind.LEFT_ENTRY_WRAP,
         turn_sequence=_LEFT_ENTRY_WRAP_DOWN,
-        channel_kind="WRAP",
+        channel_kind=ChannelKind.WRAP,
     ),
     # Junction source (exit-chain wraps around): same shape.
-    ("JUNCTION", "LEFT", 1, -1): WrapDescriptor(
-        kind="left_entry_wrap",
+    (None, PortSide.LEFT, 1, -1): WrapDescriptor(
+        kind=RouteKind.LEFT_ENTRY_WRAP,
         turn_sequence=_LEFT_ENTRY_WRAP_DOWN,
-        channel_kind="WRAP",
+        channel_kind=ChannelKind.WRAP,
     ),
     # ------- RIGHT-entry cross-row wrap (dispatcher line 598-599) -------
     # Source to the LEFT of the target column, entry on RIGHT.  Wraps
     # over the top of the target section and drops in from the right.
-    ("LEFT", "RIGHT", 1, 1): WrapDescriptor(
-        kind="right_entry_wrap",
+    (PortSide.LEFT, PortSide.RIGHT, 1, 1): WrapDescriptor(
+        kind=RouteKind.RIGHT_ENTRY_WRAP,
         turn_sequence=_RIGHT_ENTRY_WRAP_DOWN,
-        channel_kind="WRAP",
+        channel_kind=ChannelKind.WRAP,
     ),
     # ------- TB BOTTOM exit to side-entry (dispatcher line 521-522) -----
     # TB section exits via BOTTOM, target entry on LEFT side.  Vertical
     # drop with X offsets terminating in an L-shape into the side port.
-    ("BOTTOM", "LEFT", 1, 1): WrapDescriptor(
-        kind="tb_bottom_exit",
+    (PortSide.BOTTOM, PortSide.LEFT, 1, 1): WrapDescriptor(
+        kind=RouteKind.TB_BOTTOM_EXIT,
         turn_sequence=_L_RIGHT_DOWN_RIGHT,
-        channel_kind="TB_EXIT",
+        channel_kind=ChannelKind.TB_EXIT,
     ),
-    ("BOTTOM", "LEFT", 1, -1): WrapDescriptor(
-        kind="tb_bottom_exit",
+    (PortSide.BOTTOM, PortSide.LEFT, 1, -1): WrapDescriptor(
+        kind=RouteKind.TB_BOTTOM_EXIT,
         turn_sequence=_L_LEFT_DOWN_LEFT,
-        channel_kind="TB_EXIT",
+        channel_kind=ChannelKind.TB_EXIT,
     ),
 }
 
 
 __all__ = [
+    "ChannelKind",
     "Corner",
     "CornerHandedness",
+    "RouteKind",
     "TurnSequence",
-    "WrapDescriptor",
     "WRAP_TABLE",
+    "WrapDescriptor",
 ]

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -1,0 +1,249 @@
+"""Runtime invariants on the output of :func:`route_edges`.
+
+:func:`check_bundle_order_preserved` asserts that for any pair of
+routes sharing ``(edge.source, edge.target)``, the lines' relative
+side (left vs right of travel) is CONSTANT across the parallel
+waypoint walk.  A flip is a visible line crossing.
+
+Why pairwise-index walk?  Bundled routes share a waypoint count and
+the same sequence of cardinal tangents, so segment k of A and
+segment k of B are "the same segment, parallel-offset".  Corner-xy
+clustering fails: per-line offsets put each line's corners at
+slightly different xy, so tight tolerance misses real bugs while
+loose tolerance flags every concentric corner.
+
+Wired into :func:`compute_layout(graph, validate=True)` via
+``_guard_bundle_order_preserved`` in ``engine.py``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+from nf_metro.layout.constants import COORD_TOLERANCE_FINE
+from nf_metro.layout.routing.common import Direction, RoutedPath
+
+# Segments shorter than this are sub-pixel artefacts of per-line
+# offsets and carry no meaningful direction of travel.
+_MIN_SEGMENT_LENGTH = 1.0
+
+
+class Side:
+    """Sentinel-string namespace: ``LEFT`` / ``RIGHT`` / ``COINCIDENT``."""
+
+    LEFT = "LEFT"
+    RIGHT = "RIGHT"
+    COINCIDENT = "COINCIDENT"
+
+
+def _segment_direction(
+    p1: tuple[float, float], p2: tuple[float, float]
+) -> Direction | None:
+    """Cardinal direction (STRICT off-axis tolerance); helper for unit tests."""
+    dx = p2[0] - p1[0]
+    dy = p2[1] - p1[1]
+    horizontal = abs(dx) > abs(dy) and abs(dy) <= COORD_TOLERANCE_FINE
+    vertical = abs(dy) > abs(dx) and abs(dx) <= COORD_TOLERANCE_FINE
+    if horizontal:
+        return Direction.R if dx > 0 else Direction.L
+    if vertical:
+        return Direction.D if dy > 0 else Direction.U
+    return None
+
+
+def _left_of(tangent: Direction) -> Direction:
+    """Cardinal direction 90 deg CCW from *tangent* (screen coords)."""
+    return {
+        Direction.R: Direction.U,
+        Direction.U: Direction.L,
+        Direction.L: Direction.D,
+        Direction.D: Direction.R,
+    }[tangent]
+
+
+def _relative_side(
+    a_xy: tuple[float, float],
+    b_xy: tuple[float, float],
+    side_direction: Direction,
+) -> str:
+    """LEFT iff ``(a - b) . side_direction > 0``, else RIGHT / COINCIDENT."""
+    ax, ay = a_xy
+    bx, by = b_xy
+    if side_direction is Direction.U:
+        delta = by - ay
+    elif side_direction is Direction.D:
+        delta = ay - by
+    elif side_direction is Direction.R:
+        delta = ax - bx
+    elif side_direction is Direction.L:
+        delta = bx - ax
+    else:  # pragma: no cover - exhausted by Direction
+        return Side.COINCIDENT
+    if abs(delta) <= COORD_TOLERANCE_FINE:
+        return Side.COINCIDENT
+    return Side.LEFT if delta > 0 else Side.RIGHT
+
+
+@dataclass(frozen=True)
+class BundleOrderViolation:
+    """One bundle-order violation.  ``corner_xy`` = waypoint where the
+    flip was first observed on line A; ``in_tangent`` / ``out_tangent``
+    = travel directions before / on the offending segment;
+    ``segment_index`` = the offending segment's index in line A's
+    points list (``points[k]`` -> ``points[k+1]``).
+    """
+
+    edge_source: str
+    edge_target: str
+    line_a: str
+    line_b: str
+    corner_xy: tuple[float, float]
+    in_tangent: Direction
+    out_tangent: Direction
+    before: str
+    after: str
+    segment_index: int = -1
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        cx, cy = self.corner_xy
+        return (
+            f"bundle {self.edge_source!r}->{self.edge_target!r} "
+            f"corner ({cx:.1f},{cy:.1f}) "
+            f"in={self.in_tangent.value} out={self.out_tangent.value} "
+            f"segment={self.segment_index}: "
+            f"expected line {self.line_a!r} on {self.before} of "
+            f"line {self.line_b!r} (matching incoming run); "
+            f"observed {self.line_a!r} on {self.after} of "
+            f"line {self.line_b!r} on outgoing run"
+        )
+
+
+def _segment_unit_perp(
+    p1: tuple[float, float], p2: tuple[float, float]
+) -> tuple[float, float] | None:
+    """Unit perpendicular ``(-dy, dx)/|seg|``; ``None`` for sub-pixel segments."""
+    dx = p2[0] - p1[0]
+    dy = p2[1] - p1[1]
+    length = (dx * dx + dy * dy) ** 0.5
+    if length < _MIN_SEGMENT_LENGTH:
+        return None
+    return (-dy / length, dx / length)
+
+
+def _side_sign(
+    a_p1: tuple[float, float],
+    b_p1: tuple[float, float],
+    perp: tuple[float, float],
+) -> int:
+    """Sign of ``(A - B) . perp``: +1 LEFT, -1 RIGHT, 0 COINCIDENT."""
+    dxp = a_p1[0] - b_p1[0]
+    dyp = a_p1[1] - b_p1[1]
+    proj = dxp * perp[0] + dyp * perp[1]
+    if abs(proj) <= COORD_TOLERANCE_FINE:
+        return 0
+    return 1 if proj > 0 else -1
+
+
+def _segment_cardinal(
+    p1: tuple[float, float], p2: tuple[float, float]
+) -> Direction | None:
+    """Cardinal direction with GENEROUS off-axis tolerance; ``None`` if degenerate."""
+    dx = p2[0] - p1[0]
+    dy = p2[1] - p1[1]
+    if abs(dx) < _MIN_SEGMENT_LENGTH and abs(dy) < _MIN_SEGMENT_LENGTH:
+        return None
+    if abs(dx) >= abs(dy):
+        return Direction.R if dx > 0 else Direction.L
+    return Direction.D if dy > 0 else Direction.U
+
+
+def check_bundle_order_preserved(
+    routes: list[RoutedPath],
+) -> list[BundleOrderViolation]:
+    """Return one :class:`BundleOrderViolation` per bundled pair whose
+    relative side flips along the parallel waypoint walk.
+
+    Routes are grouped by ``(edge.source, edge.target)``.  For each
+    pair ``(A, B)`` in a bundle with matching waypoint counts, side
+    sign of A relative to B is sampled at each segment's midpoint;
+    the invariant is that the sign is CONSTANT across all
+    non-coincident segments.  Skipped: single-line bundles, pairs
+    with mismatched waypoint counts, sub-pixel / coincident segments.
+    """
+    violations: list[BundleOrderViolation] = []
+
+    bundles: dict[tuple[str, str], list[RoutedPath]] = defaultdict(list)
+    for r in routes:
+        bundles[(r.edge.source, r.edge.target)].append(r)
+
+    for (src_id, tgt_id), bundle in bundles.items():
+        if len(bundle) < 2:
+            continue
+        for ai in range(len(bundle)):
+            for bi in range(ai + 1, len(bundle)):
+                v = _check_pair(src_id, tgt_id, bundle[ai], bundle[bi])
+                if v is not None:
+                    violations.append(v)
+
+    return violations
+
+
+def _check_pair(
+    src_id: str,
+    tgt_id: str,
+    a_route: RoutedPath,
+    b_route: RoutedPath,
+) -> BundleOrderViolation | None:
+    """Walk two bundled routes in parallel; return the first sign flip.
+
+    The bundle's travel direction per segment is the routes' midpoint
+    tangent (parallel by construction; averaged against per-line
+    nudges).  The side sign is sampled at each segment's MIDPOINT to
+    average out per-line corner displacement at L-shape endpoints; at
+    a true crossing the midpoint sign disagrees with its neighbour's.
+    """
+    if len(a_route.points) != len(b_route.points) or len(a_route.points) < 2:
+        return None
+
+    last_sign = 0
+    last_dir: Direction | None = None
+    for k in range(len(a_route.points) - 1):
+        a_p1, a_p2 = a_route.points[k], a_route.points[k + 1]
+        b_p1, b_p2 = b_route.points[k], b_route.points[k + 1]
+        mid_p1 = ((a_p1[0] + b_p1[0]) * 0.5, (a_p1[1] + b_p1[1]) * 0.5)
+        mid_p2 = ((a_p2[0] + b_p2[0]) * 0.5, (a_p2[1] + b_p2[1]) * 0.5)
+        perp = _segment_unit_perp(mid_p1, mid_p2)
+        if perp is None:
+            continue
+        a_mid = ((a_p1[0] + a_p2[0]) * 0.5, (a_p1[1] + a_p2[1]) * 0.5)
+        b_mid = ((b_p1[0] + b_p2[0]) * 0.5, (b_p1[1] + b_p2[1]) * 0.5)
+        sign = _side_sign(a_mid, b_mid, perp)
+        if sign == 0:
+            continue
+        cur_dir = _segment_cardinal(mid_p1, mid_p2)
+        if last_sign != 0 and sign != last_sign:
+            return BundleOrderViolation(
+                edge_source=src_id,
+                edge_target=tgt_id,
+                line_a=a_route.line_id,
+                line_b=b_route.line_id,
+                corner_xy=a_p1,
+                in_tangent=last_dir if last_dir is not None else Direction.R,
+                out_tangent=cur_dir if cur_dir is not None else Direction.R,
+                before=Side.LEFT if last_sign > 0 else Side.RIGHT,
+                after=Side.LEFT if sign > 0 else Side.RIGHT,
+                segment_index=k,
+            )
+        last_sign = sign
+        last_dir = cur_dir
+
+    return None
+
+
+__all__ = [
+    "BundleOrderViolation",
+    "Side",
+    "check_bundle_order_preserved",
+]

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -37,54 +37,6 @@ class Side:
     COINCIDENT = "COINCIDENT"
 
 
-def _segment_direction(
-    p1: tuple[float, float], p2: tuple[float, float]
-) -> Direction | None:
-    """Cardinal direction (STRICT off-axis tolerance); helper for unit tests."""
-    dx = p2[0] - p1[0]
-    dy = p2[1] - p1[1]
-    horizontal = abs(dx) > abs(dy) and abs(dy) <= COORD_TOLERANCE_FINE
-    vertical = abs(dy) > abs(dx) and abs(dx) <= COORD_TOLERANCE_FINE
-    if horizontal:
-        return Direction.R if dx > 0 else Direction.L
-    if vertical:
-        return Direction.D if dy > 0 else Direction.U
-    return None
-
-
-def _left_of(tangent: Direction) -> Direction:
-    """Cardinal direction 90 deg CCW from *tangent* (screen coords)."""
-    return {
-        Direction.R: Direction.U,
-        Direction.U: Direction.L,
-        Direction.L: Direction.D,
-        Direction.D: Direction.R,
-    }[tangent]
-
-
-def _relative_side(
-    a_xy: tuple[float, float],
-    b_xy: tuple[float, float],
-    side_direction: Direction,
-) -> str:
-    """LEFT iff ``(a - b) . side_direction > 0``, else RIGHT / COINCIDENT."""
-    ax, ay = a_xy
-    bx, by = b_xy
-    if side_direction is Direction.U:
-        delta = by - ay
-    elif side_direction is Direction.D:
-        delta = ay - by
-    elif side_direction is Direction.R:
-        delta = ax - bx
-    elif side_direction is Direction.L:
-        delta = bx - ax
-    else:  # pragma: no cover - exhausted by Direction
-        return Side.COINCIDENT
-    if abs(delta) <= COORD_TOLERANCE_FINE:
-        return Side.COINCIDENT
-    return Side.LEFT if delta > 0 else Side.RIGHT
-
-
 @dataclass(frozen=True)
 class BundleOrderViolation:
     """One bundle-order violation.  ``corner_xy`` = waypoint where the

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from enum import Enum
 
 from nf_metro.layout.constants import COORD_TOLERANCE_FINE
 from nf_metro.layout.routing.common import Direction, RoutedPath
@@ -29,8 +30,8 @@ from nf_metro.layout.routing.common import Direction, RoutedPath
 _MIN_SEGMENT_LENGTH = 1.0
 
 
-class Side:
-    """Sentinel-string namespace: ``LEFT`` / ``RIGHT`` / ``COINCIDENT``."""
+class Side(Enum):
+    """Side of a line relative to its bundle mate's trajectory."""
 
     LEFT = "LEFT"
     RIGHT = "RIGHT"
@@ -53,8 +54,8 @@ class BundleOrderViolation:
     corner_xy: tuple[float, float]
     in_tangent: Direction
     out_tangent: Direction
-    before: str
-    after: str
+    before: Side
+    after: Side
     segment_index: int = -1
 
     def message(self) -> str:
@@ -65,9 +66,9 @@ class BundleOrderViolation:
             f"corner ({cx:.1f},{cy:.1f}) "
             f"in={self.in_tangent.value} out={self.out_tangent.value} "
             f"segment={self.segment_index}: "
-            f"expected line {self.line_a!r} on {self.before} of "
+            f"expected line {self.line_a!r} on {self.before.value} of "
             f"line {self.line_b!r} (matching incoming run); "
-            f"observed {self.line_a!r} on {self.after} of "
+            f"observed {self.line_a!r} on {self.after.value} of "
             f"line {self.line_b!r} on outgoing run"
         )
 

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -12,8 +12,10 @@ clustering fails: per-line offsets put each line's corners at
 slightly different xy, so tight tolerance misses real bugs while
 loose tolerance flags every concentric corner.
 
-Wired into :func:`compute_layout(graph, validate=True)` via
-``_guard_bundle_order_preserved`` in ``engine.py``.
+Returns a list of :class:`BundleOrderViolation`; the caller decides
+whether to log, raise, or ignore.  Tests in
+``tests/test_bundle_order_invariant.py`` exercise it against every
+gallery example and topology fixture.
 """
 
 from __future__ import annotations
@@ -177,14 +179,19 @@ def _check_pair(
             continue
         cur_dir = _segment_cardinal(mid_p1, mid_p2)
         if last_sign != 0 and sign != last_sign:
+            # ``last_dir`` and ``cur_dir`` are non-None whenever we reach
+            # here: both were set on iterations that already passed the
+            # ``perp is None`` / ``sign == 0`` gates, which require the
+            # same >= 1px segment length ``_segment_cardinal`` does.
+            assert last_dir is not None and cur_dir is not None
             return BundleOrderViolation(
                 edge_source=src_id,
                 edge_target=tgt_id,
                 line_a=a_route.line_id,
                 line_b=b_route.line_id,
                 corner_xy=a_p1,
-                in_tangent=last_dir if last_dir is not None else Direction.R,
-                out_tangent=cur_dir if cur_dir is not None else Direction.R,
+                in_tangent=last_dir,
+                out_tangent=cur_dir,
                 before=Side.LEFT if last_sign > 0 else Side.RIGHT,
                 after=Side.LEFT if sign > 0 else Side.RIGHT,
                 segment_index=k,

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -151,6 +151,12 @@ class Section:
     offset_y: float = 0.0
     # Implicit sections are auto-created for loose stations; no visible box
     is_implicit: bool = False
+    # When True, this section's line-track order is reversed relative to
+    # graph.lines' definition order.  Used for sections entered via a
+    # cross-row wrap, where the wrap's natural zigzag inverts bundle
+    # ordering and section internals must follow to avoid crossings at
+    # the entry corner.
+    flip_lines: bool = False
 
 
 @dataclass

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -151,11 +151,9 @@ class Section:
     offset_y: float = 0.0
     # Implicit sections are auto-created for loose stations; no visible box
     is_implicit: bool = False
-    # Reserved manual override: when True, the section's line-track order
-    # is reversed relative to graph.lines' definition order, to match a
-    # cross-row wrap entry whose zigzag inverts bundle ordering.  Not yet
-    # read by the layout engine; a future DAG propagator (see issue #393)
-    # will populate it automatically.
+    # Manual override that reverses the section's line-track order
+    # relative to graph.lines' definition order, to match a cross-row
+    # wrap entry whose zigzag inverts bundle ordering.
     flip_lines: bool = False
 
 

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -151,11 +151,11 @@ class Section:
     offset_y: float = 0.0
     # Implicit sections are auto-created for loose stations; no visible box
     is_implicit: bool = False
-    # When True, this section's line-track order is reversed relative to
-    # graph.lines' definition order.  Used for sections entered via a
-    # cross-row wrap, where the wrap's natural zigzag inverts bundle
-    # ordering and section internals must follow to avoid crossings at
-    # the entry corner.
+    # Reserved manual override: when True, the section's line-track order
+    # is reversed relative to graph.lines' definition order, to match a
+    # cross-row wrap entry whose zigzag inverts bundle ordering.  Not yet
+    # read by the layout engine; a future DAG propagator (see issue #393)
+    # will populate it automatically.
     flip_lines: bool = False
 
 

--- a/tests/test_bundle_order_invariant.py
+++ b/tests/test_bundle_order_invariant.py
@@ -156,9 +156,7 @@ def test_relative_side(a, b, side_dir, expected) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _synthetic_route(
-    line_id: str, points: list[tuple[float, float]]
-) -> RoutedPath:
+def _synthetic_route(line_id: str, points: list[tuple[float, float]]) -> RoutedPath:
     """Build a ``RoutedPath`` from a points list for testing.
 
     Source/target IDs are fixed (``'__src__'``, ``'__tgt__'``) so the
@@ -232,9 +230,7 @@ def test_synthetic_flipped_corner_is_caught() -> None:
     ]
     routes = [_synthetic_route("A", a_pts), _synthetic_route("B", b_pts)]
     violations = check_bundle_order_preserved(routes)
-    assert violations, (
-        "expected a synthetic bundle-order violation; got an empty list"
-    )
+    assert violations, "expected a synthetic bundle-order violation; got an empty list"
     v = violations[0]
     assert v.line_a == "A" and v.line_b == "B"
     assert v.in_tangent is Direction.R

--- a/tests/test_bundle_order_invariant.py
+++ b/tests/test_bundle_order_invariant.py
@@ -1,0 +1,266 @@
+"""Tests for the bundle-order-preservation invariant.
+
+Covers:
+
+* Happy-path: every gallery fixture and example yields zero violations
+  when passed through :func:`check_bundle_order_preserved`.
+* Helper-level negative: the per-pair side-relation primitive returns
+  the expected LEFT / RIGHT / COINCIDENT verdicts for hand-built
+  inputs.
+* Route-level negative: a synthetic ``RoutedPath`` pair with a
+  hand-crafted flipped corner correctly surfaces as a violation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.common import Direction, RoutedPath
+from nf_metro.layout.routing.invariants import (
+    BundleOrderViolation,
+    Side,
+    _left_of,
+    _relative_side,
+    _segment_direction,
+    check_bundle_order_preserved,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import Edge
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOPOLOGIES = REPO_ROOT / "tests" / "fixtures" / "topologies"
+EXAMPLES = REPO_ROOT / "examples"
+
+# Fixtures with KNOWN bundle-order violations that the criterion
+# correctly surfaces.  These are real bugs we xfail rather than blunt
+# the criterion to hide them.
+_KNOWN_VIOLATION_FIXTURES: frozenset[str] = frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: every fixture and example must pass the invariant
+# ---------------------------------------------------------------------------
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = []
+    paths.extend(sorted(TOPOLOGIES.glob("*.mmd")))
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    return paths
+
+
+@pytest.mark.parametrize(
+    "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
+)
+def test_no_bundle_order_violations_in_gallery(path: Path) -> None:
+    """Every shipped topology and example must route without a
+    bundle-order violation.
+
+    This is the corpus-level happy-path check.  A regression to a
+    routing handler that creates a flipped concentric bundle would
+    cause exactly one fixture to start failing here.
+
+    Fixtures listed in :data:`_KNOWN_VIOLATION_FIXTURES` are
+    xfailed: they have real bundle-order bugs at the Plots-entry
+    corner that the criterion correctly catches, and we'd rather
+    track those as known failures than silently blunt the criterion.
+    """
+    if path.name in _KNOWN_VIOLATION_FIXTURES:
+        pytest.xfail(
+            f"{path.name} has a known bundle-order violation at the "
+            "Plots-entry corner; the criterion correctly catches it."
+        )
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    violations = check_bundle_order_preserved(routes)
+    assert violations == [], (
+        f"{path.name}: {len(violations)} bundle-order violation(s); "
+        f"first: {violations[0].message() if violations else ''}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "p1, p2, expected",
+    [
+        ((0.0, 0.0), (10.0, 0.0), Direction.R),
+        ((10.0, 0.0), (0.0, 0.0), Direction.L),
+        ((0.0, 0.0), (0.0, 10.0), Direction.D),
+        ((0.0, 10.0), (0.0, 0.0), Direction.U),
+        ((0.0, 0.0), (10.0, 10.0), None),  # diagonal, not cardinal
+        ((0.0, 0.0), (0.0, 0.0), None),  # degenerate
+    ],
+)
+def test_segment_direction(p1, p2, expected) -> None:
+    """``_segment_direction`` returns the cardinal direction for an
+    axis-aligned segment and ``None`` otherwise.
+
+    The fine-tolerance test is implicit in the inputs: a segment with
+    any non-trivial off-axis component returns ``None``.
+    """
+    assert _segment_direction(p1, p2) is expected
+
+
+@pytest.mark.parametrize(
+    "tangent, expected_left",
+    [
+        (Direction.R, Direction.U),
+        (Direction.U, Direction.L),
+        (Direction.L, Direction.D),
+        (Direction.D, Direction.R),
+    ],
+)
+def test_left_of_is_quarter_turn_ccw(
+    tangent: Direction, expected_left: Direction
+) -> None:
+    """``_left_of`` is a quarter-turn anti-clockwise in screen coords."""
+    assert _left_of(tangent) is expected_left
+
+
+@pytest.mark.parametrize(
+    "a, b, side_dir, expected",
+    [
+        # +x axis (R): A LEFT iff A.x > B.x
+        ((5.0, 0.0), (0.0, 0.0), Direction.R, Side.LEFT),
+        ((0.0, 0.0), (5.0, 0.0), Direction.R, Side.RIGHT),
+        ((0.0, 0.0), (0.0, 0.0), Direction.R, Side.COINCIDENT),
+        # -y axis (U): A LEFT iff A.y < B.y
+        ((0.0, 0.0), (0.0, 5.0), Direction.U, Side.LEFT),
+        ((0.0, 5.0), (0.0, 0.0), Direction.U, Side.RIGHT),
+        # +y axis (D): A LEFT iff A.y > B.y
+        ((0.0, 5.0), (0.0, 0.0), Direction.D, Side.LEFT),
+        # -x axis (L): A LEFT iff A.x < B.x
+        ((0.0, 0.0), (5.0, 0.0), Direction.L, Side.LEFT),
+    ],
+)
+def test_relative_side(a, b, side_dir, expected) -> None:
+    """``_relative_side`` projects ``a - b`` onto the unit vector
+    pointing in ``side_dir`` and returns LEFT for positive projection,
+    RIGHT for negative, COINCIDENT when within tolerance.
+    """
+    assert _relative_side(a, b, side_dir) == expected
+
+
+# ---------------------------------------------------------------------------
+# Route-level negative test: a synthetic flipped corner is caught
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_route(
+    line_id: str, points: list[tuple[float, float]]
+) -> RoutedPath:
+    """Build a ``RoutedPath`` from a points list for testing.
+
+    Source/target IDs are fixed (``'__src__'``, ``'__tgt__'``) so the
+    paths share a bundle key.  The ``Edge`` carries the line id; the
+    rest of the routing metadata is irrelevant to
+    :func:`check_bundle_order_preserved`.
+    """
+    return RoutedPath(
+        edge=Edge(source="__src__", target="__tgt__", line_id=line_id),
+        line_id=line_id,
+        points=points,
+        is_inter_section=True,
+        offsets_applied=True,
+    )
+
+
+def test_check_skips_clean_bundle() -> None:
+    """Two paths that share waypoints exactly produce zero violations:
+    the COINCIDENT path-pair has nothing to compare on either side.
+    """
+    pts = [(0.0, 0.0), (100.0, 0.0), (100.0, 100.0), (200.0, 100.0)]
+    routes = [_synthetic_route("A", pts), _synthetic_route("B", pts)]
+    assert check_bundle_order_preserved(routes) == []
+
+
+def test_check_skips_single_line_bundle() -> None:
+    """A bundle with only one line has no pairs to compare; no
+    violation is possible.
+    """
+    pts = [(0.0, 0.0), (100.0, 0.0), (100.0, 100.0), (200.0, 100.0)]
+    routes = [_synthetic_route("A", pts)]
+    assert check_bundle_order_preserved(routes) == []
+
+
+def test_synthetic_flipped_corner_is_caught() -> None:
+    """A hand-crafted bundle with a deliberate flip at a near-shared
+    corner surfaces as a :class:`BundleOrderViolation`.
+
+    Construction: two L-shape routes whose corners sit within
+    ``_CLUSTER_TOLERANCE`` (= ``COORD_TOLERANCE``, 1 px) of each
+    other - tight enough that real bundles (offset by
+    ``OFFSET_STEP`` = 3 px) never cluster together, loose enough
+    that this sub-pixel-offset synthetic case does.
+
+    Line A's elbow is at ``(100, 100)``, line B's is at
+    ``(100.5, 100.5)``.  The approach segments are both R (going
+    east, dy=0 at the elbow); the exit segments are both D (going
+    south, dx=0).  Because the elbows differ in *both* x and y by
+    half a pixel, A and B sit on opposite sides of each other on
+    the incoming run (B is below A) AND opposite sides on the
+    outgoing run (B is right of A).
+
+    The expected verdict per ``_left_of`` semantics:
+
+    * incoming R, left = U (smaller y is LEFT): A.y=100 < B.y=100.5
+      so A is LEFT before.
+    * outgoing D, left = R (larger x is LEFT): A.x=100 < B.x=100.5
+      so A is RIGHT after.
+
+    LEFT->RIGHT is exactly the flip the invariant exists to catch.
+    """
+    a_pts = [
+        (0.0, 100.0),
+        (100.0, 100.0),
+        (100.0, 200.0),
+    ]
+    b_pts = [
+        (0.0, 100.5),
+        (100.5, 100.5),
+        (100.5, 200.0),
+    ]
+    routes = [_synthetic_route("A", a_pts), _synthetic_route("B", b_pts)]
+    violations = check_bundle_order_preserved(routes)
+    assert violations, (
+        "expected a synthetic bundle-order violation; got an empty list"
+    )
+    v = violations[0]
+    assert v.line_a == "A" and v.line_b == "B"
+    assert v.in_tangent is Direction.R
+    assert v.out_tangent is Direction.D
+    assert {v.before, v.after} == {Side.LEFT, Side.RIGHT}, v.message()
+
+
+def test_violation_message_self_describing() -> None:
+    """The violation's ``message()`` includes the corner xy, line ids,
+    tangent directions, and the offending before/after sides - the
+    fields downstream callers (the engine guard and CI logs) rely on
+    for diagnosis.
+    """
+    v = BundleOrderViolation(
+        edge_source="src",
+        edge_target="tgt",
+        line_a="alpha",
+        line_b="beta",
+        corner_xy=(100.0, 200.0),
+        in_tangent=Direction.D,
+        out_tangent=Direction.L,
+        before=Side.LEFT,
+        after=Side.RIGHT,
+    )
+    msg = v.message()
+    assert "100.0" in msg and "200.0" in msg
+    assert "alpha" in msg and "beta" in msg
+    assert "D" in msg and "L" in msg
+    assert "LEFT" in msg and "RIGHT" in msg

--- a/tests/test_bundle_order_invariant.py
+++ b/tests/test_bundle_order_invariant.py
@@ -23,9 +23,6 @@ from nf_metro.layout.routing.common import Direction, RoutedPath
 from nf_metro.layout.routing.invariants import (
     BundleOrderViolation,
     Side,
-    _left_of,
-    _relative_side,
-    _segment_direction,
     check_bundle_order_preserved,
 )
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -88,67 +85,6 @@ def test_no_bundle_order_violations_in_gallery(path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Helper-level unit tests
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "p1, p2, expected",
-    [
-        ((0.0, 0.0), (10.0, 0.0), Direction.R),
-        ((10.0, 0.0), (0.0, 0.0), Direction.L),
-        ((0.0, 0.0), (0.0, 10.0), Direction.D),
-        ((0.0, 10.0), (0.0, 0.0), Direction.U),
-        ((0.0, 0.0), (10.0, 10.0), None),  # diagonal, not cardinal
-        ((0.0, 0.0), (0.0, 0.0), None),  # degenerate
-    ],
-)
-def test_segment_direction(p1, p2, expected) -> None:
-    """``_segment_direction`` returns the cardinal direction for an
-    axis-aligned segment and ``None`` otherwise.
-
-    The fine-tolerance test is implicit in the inputs: a segment with
-    any non-trivial off-axis component returns ``None``.
-    """
-    assert _segment_direction(p1, p2) is expected
-
-
-@pytest.mark.parametrize(
-    "tangent, expected_left",
-    [
-        (Direction.R, Direction.U),
-        (Direction.U, Direction.L),
-        (Direction.L, Direction.D),
-        (Direction.D, Direction.R),
-    ],
-)
-def test_left_of_is_quarter_turn_ccw(
-    tangent: Direction, expected_left: Direction
-) -> None:
-    """``_left_of`` is a quarter-turn anti-clockwise in screen coords."""
-    assert _left_of(tangent) is expected_left
-
-
-@pytest.mark.parametrize(
-    "a, b, side_dir, expected",
-    [
-        # +x axis (R): A LEFT iff A.x > B.x
-        ((5.0, 0.0), (0.0, 0.0), Direction.R, Side.LEFT),
-        ((0.0, 0.0), (5.0, 0.0), Direction.R, Side.RIGHT),
-        ((0.0, 0.0), (0.0, 0.0), Direction.R, Side.COINCIDENT),
-        # -y axis (U): A LEFT iff A.y < B.y
-        ((0.0, 0.0), (0.0, 5.0), Direction.U, Side.LEFT),
-        ((0.0, 5.0), (0.0, 0.0), Direction.U, Side.RIGHT),
-        # +y axis (D): A LEFT iff A.y > B.y
-        ((0.0, 5.0), (0.0, 0.0), Direction.D, Side.LEFT),
-        # -x axis (L): A LEFT iff A.x < B.x
-        ((0.0, 0.0), (5.0, 0.0), Direction.L, Side.LEFT),
-    ],
-)
-def test_relative_side(a, b, side_dir, expected) -> None:
-    """``_relative_side`` projects ``a - b`` onto the unit vector
-    pointing in ``side_dir`` and returns LEFT for positive projection,
-    RIGHT for negative, COINCIDENT when within tolerance.
-    """
-    assert _relative_side(a, b, side_dir) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bundle_order_invariant.py
+++ b/tests/test_bundle_order_invariant.py
@@ -4,9 +4,6 @@ Covers:
 
 * Happy-path: every gallery fixture and example yields zero violations
   when passed through :func:`check_bundle_order_preserved`.
-* Helper-level negative: the per-pair side-relation primitive returns
-  the expected LEFT / RIGHT / COINCIDENT verdicts for hand-built
-  inputs.
 * Route-level negative: a synthetic ``RoutedPath`` pair with a
   hand-crafted flipped corner correctly surfaces as a violation.
 """
@@ -83,11 +80,6 @@ def test_no_bundle_order_violations_in_gallery(path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Helper-level unit tests
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
 # Route-level negative test: a synthetic flipped corner is caught
 # ---------------------------------------------------------------------------
 
@@ -131,28 +123,10 @@ def test_synthetic_flipped_corner_is_caught() -> None:
     """A hand-crafted bundle with a deliberate flip at a near-shared
     corner surfaces as a :class:`BundleOrderViolation`.
 
-    Construction: two L-shape routes whose corners sit within
-    ``_CLUSTER_TOLERANCE`` (= ``COORD_TOLERANCE``, 1 px) of each
-    other - tight enough that real bundles (offset by
-    ``OFFSET_STEP`` = 3 px) never cluster together, loose enough
-    that this sub-pixel-offset synthetic case does.
-
-    Line A's elbow is at ``(100, 100)``, line B's is at
-    ``(100.5, 100.5)``.  The approach segments are both R (going
-    east, dy=0 at the elbow); the exit segments are both D (going
-    south, dx=0).  Because the elbows differ in *both* x and y by
-    half a pixel, A and B sit on opposite sides of each other on
-    the incoming run (B is below A) AND opposite sides on the
-    outgoing run (B is right of A).
-
-    The expected verdict per ``_left_of`` semantics:
-
-    * incoming R, left = U (smaller y is LEFT): A.y=100 < B.y=100.5
-      so A is LEFT before.
-    * outgoing D, left = R (larger x is LEFT): A.x=100 < B.x=100.5
-      so A is RIGHT after.
-
-    LEFT->RIGHT is exactly the flip the invariant exists to catch.
+    Two L-shape routes whose elbows are half a pixel apart on both
+    axes: A is on the LEFT of B going east, then on the RIGHT going
+    south.  LEFT -> RIGHT is exactly the flip the invariant exists to
+    catch.
     """
     a_pts = [
         (0.0, 100.0),

--- a/tests/test_inter_section_descriptor.py
+++ b/tests/test_inter_section_descriptor.py
@@ -1,0 +1,171 @@
+"""Tests for the inter-section routing descriptor scaffolding.
+
+These tests pin down the parity contract of :class:`TurnSequence`
+and check that every entry in :data:`WRAP_TABLE` agrees with the
+parity ``_propagate_wrap_flip_parity`` would assign to a section
+reached by the corresponding edge.
+
+The parity alignment test is the load-bearing one: it is the early
+warning that catches descriptor/propagator drift before C1/C2
+unifies them into a single source of truth.
+"""
+
+from __future__ import annotations
+
+from nf_metro.layout.routing.common import Direction
+from nf_metro.layout.routing.inter_section import (
+    WRAP_TABLE,
+    Corner,
+    CornerHandedness,
+    TurnSequence,
+    WrapDescriptor,
+)
+
+# ---------------------------------------------------------------------------
+# TurnSequence.parity unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_left_entry_wrap_parity_is_true():
+    """The 4-corner left-entry wrap has odd handedness changes.
+
+    Shape: right -> down -> left -> down -> right.
+
+    Corner handednesses: ``[CW, CW, CCW, CCW]``.  Adjacent pairs:
+    CW->CW (no change), CW->CCW (change), CCW->CCW (no change).
+    One change overall -> parity = True.
+    """
+    seq = TurnSequence(
+        corners=(
+            Corner(Direction.R, Direction.D, CornerHandedness.CW),
+            Corner(Direction.D, Direction.L, CornerHandedness.CW),
+            Corner(Direction.L, Direction.D, CornerHandedness.CCW),
+            Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+        )
+    )
+    assert seq.parity is True
+    # Sanity: len works and iteration yields the corners in order
+    assert len(seq) == 4
+    assert [c.handedness for c in seq] == [
+        CornerHandedness.CW,
+        CornerHandedness.CW,
+        CornerHandedness.CCW,
+        CornerHandedness.CCW,
+    ]
+
+
+def test_l_shape_parity_is_true():
+    """Standard L-shape (right -> down -> right) has one handedness change.
+
+    Shape: ``[CW, CCW]`` -> exactly one change -> parity = True.
+    """
+    seq = TurnSequence(
+        corners=(
+            Corner(Direction.R, Direction.D, CornerHandedness.CW),
+            Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+        )
+    )
+    assert seq.parity is True
+
+
+def test_empty_turn_sequence_has_parity_false():
+    """A degenerate straight route has no corners and parity = False."""
+    seq = TurnSequence(corners=())
+    assert seq.parity is False
+    assert len(seq) == 0
+
+
+def test_same_handedness_pair_parity_is_false():
+    """Two consecutive corners with the same handedness: zero changes.
+
+    A spiral-like ``[CW, CW]`` (the front half of a four-corner wrap)
+    has zero handedness changes -> parity False.
+    """
+    seq = TurnSequence(
+        corners=(
+            Corner(Direction.R, Direction.D, CornerHandedness.CW),
+            Corner(Direction.D, Direction.L, CornerHandedness.CW),
+        )
+    )
+    assert seq.parity is False
+
+
+def test_wrap_descriptor_parity_delegates_to_turn_sequence():
+    """WrapDescriptor.parity is a thin shim over TurnSequence.parity."""
+    seq = TurnSequence(
+        corners=(
+            Corner(Direction.R, Direction.D, CornerHandedness.CW),
+            Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+        )
+    )
+    desc = WrapDescriptor(
+        kind="test", turn_sequence=seq, channel_kind="L_SHAPE"
+    )
+    assert desc.parity == seq.parity is True
+
+
+# ---------------------------------------------------------------------------
+# WRAP_TABLE alignment check
+# ---------------------------------------------------------------------------
+#
+# The propagator's rule (see ``_propagate_wrap_flip_parity`` in
+# ``engine.py``): each section's flip parity is
+#
+#     flip[tgt] = flip[src] XOR is_wrap
+#
+# where ``is_wrap`` is ``True`` iff the connecting edge spans
+# different grid rows (drow_sign != 0).  Roots default to
+# ``flip = False``.
+#
+# For a fresh section reached via a single edge from a root predecessor,
+# the propagator's parity contribution is therefore exactly
+# ``drow_sign != 0``.  Each descriptor's :attr:`TurnSequence.parity`
+# must agree with that contribution: a route that crosses rows must
+# emit a corner sequence with odd handedness changes, and a same-row
+# route must emit one with even changes.  Drift in either direction
+# will eventually manifest as visible line crossings at the entry-port
+# quarter-circles.
+
+
+def test_wrap_table_parity_matches_propagator_contribution():
+    """Every WRAP_TABLE entry's parity matches what the propagator yields.
+
+    For an edge with ``drow_sign = D``, the propagator contributes
+    ``D != 0`` to the target section's flip flag.  Each descriptor's
+    ``TurnSequence.parity`` must equal that contribution.
+    """
+    mismatches: list[str] = []
+    for key, descriptor in WRAP_TABLE.items():
+        _exit_side, _entry_side, drow_sign, _dcol_sign = key
+        propagator_contribution = drow_sign != 0
+        if descriptor.parity != propagator_contribution:
+            mismatches.append(
+                f"{key} ({descriptor.kind}): descriptor.parity = "
+                f"{descriptor.parity}, propagator_contribution = "
+                f"{propagator_contribution}"
+            )
+    assert not mismatches, "WRAP_TABLE / propagator drift:\n  " + "\n  ".join(
+        mismatches
+    )
+
+
+def test_wrap_table_keys_are_well_formed():
+    """Sanity: keys use legal exit/entry sides and -1/0/+1 signs."""
+    legal_exit = {"LEFT", "RIGHT", "TOP", "BOTTOM", "JUNCTION"}
+    legal_entry = {"LEFT", "RIGHT", "TOP", "BOTTOM"}
+    for key in WRAP_TABLE:
+        exit_side, entry_side, drow_sign, dcol_sign = key
+        assert exit_side in legal_exit, f"bad exit_side: {key}"
+        assert entry_side in legal_entry, f"bad entry_side: {key}"
+        assert drow_sign in (-1, 0, 1), f"bad drow_sign: {key}"
+        assert dcol_sign in (-1, 0, 1), f"bad dcol_sign: {key}"
+
+
+def test_wrap_table_is_non_empty():
+    """WRAP_TABLE must cover at least the genuine wrap cases.
+
+    Catches accidental deletions during refactors.  If you legitimately
+    want to remove every entry (e.g. moving the table elsewhere), update
+    this test to reflect the new home.
+    """
+    assert len(WRAP_TABLE) >= 4, "WRAP_TABLE shrank below the wrap-handler floor"

--- a/tests/test_inter_section_descriptor.py
+++ b/tests/test_inter_section_descriptor.py
@@ -98,9 +98,7 @@ def test_wrap_descriptor_parity_delegates_to_turn_sequence():
             Corner(Direction.D, Direction.R, CornerHandedness.CCW),
         )
     )
-    desc = WrapDescriptor(
-        kind="test", turn_sequence=seq, channel_kind="L_SHAPE"
-    )
+    desc = WrapDescriptor(kind="test", turn_sequence=seq, channel_kind="L_SHAPE")
     assert desc.parity == seq.parity is True
 
 

--- a/tests/test_inter_section_descriptor.py
+++ b/tests/test_inter_section_descriptor.py
@@ -15,11 +15,14 @@ from __future__ import annotations
 from nf_metro.layout.routing.common import Direction
 from nf_metro.layout.routing.inter_section import (
     WRAP_TABLE,
+    ChannelKind,
     Corner,
     CornerHandedness,
+    RouteKind,
     TurnSequence,
     WrapDescriptor,
 )
+from nf_metro.parser.model import PortSide
 
 # ---------------------------------------------------------------------------
 # TurnSequence.parity unit tests
@@ -37,10 +40,10 @@ def test_left_entry_wrap_parity_is_true():
     """
     seq = TurnSequence(
         corners=(
-            Corner(Direction.R, Direction.D, CornerHandedness.CW),
-            Corner(Direction.D, Direction.L, CornerHandedness.CW),
-            Corner(Direction.L, Direction.D, CornerHandedness.CCW),
-            Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+            Corner(Direction.R, Direction.D),
+            Corner(Direction.D, Direction.L),
+            Corner(Direction.L, Direction.D),
+            Corner(Direction.D, Direction.R),
         )
     )
     assert seq.parity is True
@@ -61,8 +64,8 @@ def test_l_shape_parity_is_true():
     """
     seq = TurnSequence(
         corners=(
-            Corner(Direction.R, Direction.D, CornerHandedness.CW),
-            Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+            Corner(Direction.R, Direction.D),
+            Corner(Direction.D, Direction.R),
         )
     )
     assert seq.parity is True
@@ -83,8 +86,8 @@ def test_same_handedness_pair_parity_is_false():
     """
     seq = TurnSequence(
         corners=(
-            Corner(Direction.R, Direction.D, CornerHandedness.CW),
-            Corner(Direction.D, Direction.L, CornerHandedness.CW),
+            Corner(Direction.R, Direction.D),
+            Corner(Direction.D, Direction.L),
         )
     )
     assert seq.parity is False
@@ -94,11 +97,15 @@ def test_wrap_descriptor_parity_delegates_to_turn_sequence():
     """WrapDescriptor.parity is a thin shim over TurnSequence.parity."""
     seq = TurnSequence(
         corners=(
-            Corner(Direction.R, Direction.D, CornerHandedness.CW),
-            Corner(Direction.D, Direction.R, CornerHandedness.CCW),
+            Corner(Direction.R, Direction.D),
+            Corner(Direction.D, Direction.R),
         )
     )
-    desc = WrapDescriptor(kind="test", turn_sequence=seq, channel_kind="L_SHAPE")
+    desc = WrapDescriptor(
+        kind=RouteKind.L_SHAPE,
+        turn_sequence=seq,
+        channel_kind=ChannelKind.L_SHAPE,
+    )
     assert desc.parity == seq.parity is True
 
 
@@ -149,12 +156,12 @@ def test_wrap_table_parity_matches_propagator_contribution():
 
 def test_wrap_table_keys_are_well_formed():
     """Sanity: keys use legal exit/entry sides and -1/0/+1 signs."""
-    legal_exit = {"LEFT", "RIGHT", "TOP", "BOTTOM", "JUNCTION"}
-    legal_entry = {"LEFT", "RIGHT", "TOP", "BOTTOM"}
     for key in WRAP_TABLE:
         exit_side, entry_side, drow_sign, dcol_sign = key
-        assert exit_side in legal_exit, f"bad exit_side: {key}"
-        assert entry_side in legal_entry, f"bad entry_side: {key}"
+        assert exit_side is None or isinstance(exit_side, PortSide), (
+            f"bad exit_side: {key}"
+        )
+        assert isinstance(entry_side, PortSide), f"bad entry_side: {key}"
         assert drow_sign in (-1, 0, 1), f"bad drow_sign: {key}"
         assert dcol_sign in (-1, 0, 1), f"bad dcol_sign: {key}"
 

--- a/tests/test_inter_section_descriptor.py
+++ b/tests/test_inter_section_descriptor.py
@@ -2,12 +2,9 @@
 
 These tests pin down the parity contract of :class:`TurnSequence`
 and check that every entry in :data:`WRAP_TABLE` agrees with the
-parity ``_propagate_wrap_flip_parity`` would assign to a section
-reached by the corresponding edge.
-
-The parity alignment test is the load-bearing one: it is the early
-warning that catches descriptor/propagator drift before C1/C2
-unifies them into a single source of truth.
+row-delta parity contribution a future section-DAG propagator will
+assign.  Catches descriptor/propagator drift before the table is
+wired into the dispatcher.
 """
 
 from __future__ import annotations
@@ -113,31 +110,20 @@ def test_wrap_descriptor_parity_delegates_to_turn_sequence():
 # WRAP_TABLE alignment check
 # ---------------------------------------------------------------------------
 #
-# The propagator's rule (see ``_propagate_wrap_flip_parity`` in
-# ``engine.py``): each section's flip parity is
-#
-#     flip[tgt] = flip[src] XOR is_wrap
-#
-# where ``is_wrap`` is ``True`` iff the connecting edge spans
-# different grid rows (drow_sign != 0).  Roots default to
-# ``flip = False``.
-#
-# For a fresh section reached via a single edge from a root predecessor,
-# the propagator's parity contribution is therefore exactly
-# ``drow_sign != 0``.  Each descriptor's :attr:`TurnSequence.parity`
-# must agree with that contribution: a route that crosses rows must
-# emit a corner sequence with odd handedness changes, and a same-row
-# route must emit one with even changes.  Drift in either direction
-# will eventually manifest as visible line crossings at the entry-port
-# quarter-circles.
+# The future section-DAG propagator will set each section's flip parity as
+# ``flip[tgt] = flip[src] XOR (drow_sign != 0)``, with roots at
+# ``flip = False``.  For a fresh section reached from a root predecessor,
+# the parity contribution is therefore exactly ``drow_sign != 0``.  Every
+# descriptor's :attr:`TurnSequence.parity` must equal that contribution
+# or routes visibly cross at the entry-port quarter-circles.
 
 
 def test_wrap_table_parity_matches_propagator_contribution():
-    """Every WRAP_TABLE entry's parity matches what the propagator yields.
+    """Every WRAP_TABLE entry's parity matches the row-delta contribution.
 
-    For an edge with ``drow_sign = D``, the propagator contributes
-    ``D != 0`` to the target section's flip flag.  Each descriptor's
-    ``TurnSequence.parity`` must equal that contribution.
+    For an edge with ``drow_sign = D``, the future propagator
+    contributes ``D != 0`` to the target section's flip flag.  Each
+    descriptor's ``TurnSequence.parity`` must equal that contribution.
     """
     mismatches: list[str] = []
     for key, descriptor in WRAP_TABLE.items():


### PR DESCRIPTION
## Summary

Adds bundle-order runtime invariant + declarative inter-section routing descriptors. Pure infrastructure: no visual changes.

- **`routing/invariants.py`** — `check_bundle_order_preserved()` walks parallel waypoints in routed bundles and reports any pair whose side-of-trajectory sign flips between segments. A flip = a visible line crossing. `Side` is an `Enum`.
- **`routing/inter_section.py`** — `Corner`, `TurnSequence`, `WrapDescriptor` dataclasses plus `WRAP_TABLE` keyed by `(PortSide | None, PortSide, int, int)` (None for junction-source). `Corner.handedness` is derived from `(in_tangent, out_tangent)` so descriptor entries can't drift from geometry; `__post_init__` rejects degenerate turn pairs. `RouteKind` and `ChannelKind` enums replace the previous raw-string `kind` / `channel_kind` fields.
- **`routing/common.py`** — `Direction` enum used by the descriptors; `inter_row_channel_y` and `resolve_section` lifted from `core.py` (originals deleted, all call sites use the public names).
- **`parser/model.py`** — `Section.flip_lines: bool = False`, reserved as a future manual override.

## Why

Earlier wrap-routing fixes had no way to assert "the bundle order survived this corner sequence". The runtime invariant catches such regressions at routing time; the descriptor scaffolding sets up the data model future PRs use to drive corner sequencing declaratively.

## Testing

- `tests/test_bundle_order_invariant.py` covers the invariant against every gallery example and topology fixture (zero violations except the pre-existing `fold_stacked_branch` flip).
- `tests/test_inter_section_descriptor.py` covers the parity reducer and the `WRAP_TABLE` ↔ propagator alignment.
- Full `pytest`: **2374 passed**, 7 xfailed.
- Gallery render diff vs `main`: **0 changes**.

## Known scope-out

`WRAP_TABLE` deliberately omits same-row L-shapes and the TB `(BOTTOM, TOP, 1, 0)` straight drop because their geometric parity disagrees with the propagator's row-delta `is_wrap` flag. Tracked in **#393** for reconciliation before the descriptor table is wired into `_route_inter_section`.

## Stack

Base of the #385 split: **A** → B → C → D → E. Other PRs in the chain target this branch.
