### PR TITLE
refactor(routing): principled inter-section gap formula + symmetric multi-bundle

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -173,7 +173,41 @@ External routes (wrap channels, around routes, inter-row bypasses) choose
 their channel position relative to nearby section bboxes.  Without this
 floor the channel may sit one curve_radius + offset_step (~13 px) past
 the edge, which reads as flush against the section in renders.  This
-floor gives a small but visible breathing space."""
+floor gives a small but visible breathing space.
+
+Kept as an alias of :data:`EDGE_TO_BUNDLE_CLEARANCE` (the principled
+"constant A" of the inter-section gap geometry) so legacy call sites
+continue to compile while the new geometry rolls out."""
+
+EDGE_TO_BUNDLE_CLEARANCE: float = 16.0
+"""Constant A: minimum distance between a section bbox edge and the
+nearest line of an adjacent route bundle.
+
+Used as the single source of truth for two related clearances:
+
+- The leftmost (resp. rightmost) line of a bundle running vertically
+  in an inter-section gap sits at least ``A`` from the right (resp.
+  left) edge of the neighbouring section.  Section-placement enforces
+  this via ``_enforce_min_column_gaps`` (gap width >= ``A + Σ widths
+  + (count-1)*B + A``) so renders honour the symmetric geometry without
+  the channel ever being pushed against a section edge.
+- Bypass / around-section routes maintain at least ``A`` from any
+  intervening section's nearest edge.
+
+Equal to :data:`SECTION_ROUTE_CLEARANCE` (the legacy name) so existing
+clearance code paths continue to honour the same physical distance."""
+
+BUNDLE_TO_BUNDLE_CLEARANCE: float = 12.0
+"""Constant B: minimum distance between two adjacent bundles sharing
+the same inter-section gap.
+
+When *N* concentric bundles travel down the same gap (typically a
+``trunk_v_up_pull_away`` bypass paired with an around-section V_up
+channel), the required gap width is
+``A + Σ bundle_widths + (count-1)*B + A`` where bundle width is
+``(n_i - 1) * OFFSET_STEP`` for ``n_i`` lines.  ``B`` gives bundles a
+breathing space that reads visually as a separate stream rather than
+a single fatter bundle."""
 
 BYPASS_NEST_STEP: float = 8.0
 """Per-line vertical offset for stacking multiple bypass routes."""

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -7,11 +7,14 @@ from dataclasses import dataclass
 from enum import Enum
 
 from nf_metro.layout.constants import (
+    BUNDLE_TO_BUNDLE_CLEARANCE,
     BYPASS_CLEARANCE,
     COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
     DEFAULT_LINE_PRIORITY,
+    EDGE_TO_BUNDLE_CLEARANCE,
     HEADER_CLEARANCE,
+    OFFSET_STEP,
     SECTION_HEADER_PROTRUSION,
 )
 from nf_metro.parser.model import Edge, MetroGraph, Section, Station
@@ -48,9 +51,23 @@ def vertical_direction(dy: float) -> Direction:
 # patterns scattered across routing and layout modules.
 
 
-def _sections_in_col(graph: MetroGraph, col: int) -> list[Section]:
-    """Sections in a specific grid column with non-zero width."""
-    return [s for s in graph.sections.values() if s.grid_col == col and s.bbox_w > 0]
+def _sections_in_col(
+    graph: MetroGraph, col: int, row: int | None = None
+) -> list[Section]:
+    """Sections in a specific grid column with non-zero width.
+
+    When *row* is given, restrict to sections occupying that grid row
+    (honouring ``grid_row_span``).  An inter-section diversion travelling
+    in one row must measure the gap against that row's sections only,
+    otherwise a section stacked in another row of the same column (e.g. a
+    wide output section below) corrupts the gap edges.
+    """
+    secs = [s for s in graph.sections.values() if s.grid_col == col and s.bbox_w > 0]
+    if row is not None:
+        secs = [
+            s for s in secs if s.grid_row <= row <= s.grid_row + s.grid_row_span - 1
+        ]
+    return secs
 
 
 def _sections_in_row(graph: MetroGraph, row: int) -> list[Section]:
@@ -58,17 +75,21 @@ def _sections_in_row(graph: MetroGraph, row: int) -> list[Section]:
     return [s for s in graph.sections.values() if s.grid_row == row and s.bbox_h > 0]
 
 
-def col_right_edge(graph: MetroGraph, col: int, default: float = 0.0) -> float:
-    """Rightmost X extent of sections in *col*."""
-    secs = _sections_in_col(graph, col)
+def col_right_edge(
+    graph: MetroGraph, col: int, default: float = 0.0, row: int | None = None
+) -> float:
+    """Rightmost X extent of sections in *col* (optionally a single *row*)."""
+    secs = _sections_in_col(graph, col, row)
     if not secs:
         return default
     return max((s.bbox_x + s.bbox_w for s in secs), default=default)
 
 
-def col_left_edge(graph: MetroGraph, col: int, default: float = 0.0) -> float:
-    """Leftmost X extent of sections in *col*."""
-    secs = _sections_in_col(graph, col)
+def col_left_edge(
+    graph: MetroGraph, col: int, default: float = 0.0, row: int | None = None
+) -> float:
+    """Leftmost X extent of sections in *col* (optionally a single *row*)."""
+    secs = _sections_in_col(graph, col, row)
     return min((s.bbox_x for s in secs), default=default) if secs else default
 
 
@@ -86,12 +107,85 @@ def row_top_edge(graph: MetroGraph, row: int, default: float = 0.0) -> float:
     return min((s.bbox_y for s in secs), default=default) if secs else default
 
 
-def column_gap_midpoint(graph: MetroGraph, col_a: int, col_b: int) -> float:
-    """X midpoint of the gap between two columns."""
-    lo, hi = min(col_a, col_b), max(col_a, col_b)
-    right = col_right_edge(graph, lo)
-    left = col_left_edge(graph, hi, default=right)
+def column_gap_midpoint(
+    graph: MetroGraph, col_a: int, col_b: int, row: int | None = None
+) -> float:
+    """X midpoint of the gap between two columns (optionally within *row*)."""
+    right, left = column_gap_edges(graph, col_a, col_b, row)
     return (right + left) / 2
+
+
+def column_gap_edges(
+    graph: MetroGraph, col_a: int, col_b: int, row: int | None = None
+) -> tuple[float, float]:
+    """Return ``(left_edge, right_edge)`` of the gap between two columns.
+
+    *left_edge* is the right boundary of the lower-column sections;
+    *right_edge* is the left boundary of the higher-column sections.
+
+    When *row* is given, only sections occupying that grid row bound the
+    gap, so a diversion travelling in one row isn't pushed off-centre by a
+    section stacked in another row of the same column.
+    """
+    lo, hi = min(col_a, col_b), max(col_a, col_b)
+    right = col_right_edge(graph, lo, row=row)
+    left = col_left_edge(graph, hi, default=right, row=row)
+    return right, left
+
+
+def symmetric_bundle_midpoint(
+    gap_left: float,
+    gap_right: float,
+    bundle_widths: list[float],
+    bundle_index: int,
+    edge_clearance: float = EDGE_TO_BUNDLE_CLEARANCE,
+    inter_bundle: float = BUNDLE_TO_BUNDLE_CLEARANCE,
+) -> float:
+    """X midline of one bundle when several share an inter-section gap.
+
+    Implements the symmetric placement described in the inter-section
+    gap design contract::
+
+        - ``W = gap_right - gap_left``
+        - ``WT = sum(bundle_widths) + (N - 1) * B``
+        - The leftmost line of the leftmost bundle sits at
+          ``gap_left + (W - WT) / 2``.
+        - Bundles are separated by exactly ``B``; only the
+          edge-to-bundle distance grows when ``W`` exceeds the minimum.
+
+    Returns the midline x for bundle ``bundle_index`` (0-indexed from
+    the leftmost).  ``bundle_widths[k]`` is the visual span of bundle
+    ``k`` (typically ``(n_k - 1) * OFFSET_STEP``).
+
+    When ``W`` is smaller than the required minimum the function still
+    returns the symmetric midline as if the gap were exactly that
+    minimum; the caller is responsible for widening the gap (handled
+    by ``_enforce_min_column_gaps`` during section placement).
+    """
+    n = len(bundle_widths)
+    if n == 0:
+        return (gap_left + gap_right) / 2
+    if bundle_index < 0 or bundle_index >= n:
+        raise IndexError(f"bundle_index {bundle_index} out of range [0,{n})")
+
+    W = gap_right - gap_left
+    WT = sum(bundle_widths) + (n - 1) * inter_bundle
+    # If the gap is wider than the minimum (2A + WT), the extra space
+    # is distributed equally to both edges; the symmetric leftmost-line
+    # offset from gap_left is (W - WT) / 2.
+    leftmost_offset = max(edge_clearance, (W - WT) / 2)
+    # Position of the leftmost line of the leftmost bundle.
+    cursor = gap_left + leftmost_offset
+    for k in range(bundle_index):
+        cursor += bundle_widths[k] + inter_bundle
+    # cursor is now the leftmost line of bundle bundle_index;
+    # the midline is cursor + width/2.
+    return cursor + bundle_widths[bundle_index] / 2
+
+
+def bundle_width(n_lines: int, offset_step: float = OFFSET_STEP) -> float:
+    """Visual span of a bundle of *n_lines* parallel lines."""
+    return max(0, n_lines - 1) * offset_step
 
 
 @dataclass
@@ -104,6 +198,12 @@ class RoutedPath:
     is_inter_section: bool = False
     curve_radii: list[float] | None = None
     offsets_applied: bool = False
+    normalize_exempt: bool = False
+    """Skip this route in the gap-channel normalization post-pass.
+
+    Set by wrap / around-section / TOP-entry handlers whose vertical
+    channels follow a special concentric loop (all corners share one
+    radius) that the standard L-shape re-stacking would break."""
 
 
 def compute_bundle_info(
@@ -259,7 +359,18 @@ def inter_column_channel_x(
     if src_sec and tgt_sec and src_sec.grid_col != tgt_sec.grid_col:
         return column_gap_midpoint(graph, src_sec.grid_col, tgt_sec.grid_col)
 
-    # Fallback: place near source
+    # Extend the same gap-centred placement to junction endpoints (whose
+    # section is found by tracing the junction graph) so a junction-sourced
+    # L-shape centres in the inter-column gap instead of hugging one edge.
+    # Restrict to ADJACENT resolved columns: in staggered layouts a
+    # junction can resolve several columns from its target, and centring in
+    # that far span would drag the channel through empty canvas.
+    res_src = src_sec or resolve_section(graph, src)
+    res_tgt = tgt_sec or resolve_section(graph, tgt)
+    if res_src and res_tgt and abs(res_src.grid_col - res_tgt.grid_col) == 1:
+        return column_gap_midpoint(graph, res_src.grid_col, res_tgt.grid_col)
+
+    # Fallback: place near source (no resolvable adjacent column info)
     if dx > 0:
         return sx + max_r + offset_step
     else:

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -8,6 +8,7 @@ per-line bundle offsets.
 
 from __future__ import annotations
 
+import functools
 import math
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
@@ -34,15 +35,17 @@ from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.routing.common import (
     Direction,
     RoutedPath,
+    bundle_width,
     bypass_bottom_y,
     col_left_edge,
     col_right_edge,
-    column_gap_midpoint,
+    column_gap_edges,
     compute_bundle_info,
     horizontal_direction,
     inter_column_channel_x,
     inter_row_channel_y,
     resolve_section,
+    symmetric_bundle_midpoint,
     vertical_direction,
 )
 from nf_metro.layout.routing.corners import (
@@ -173,6 +176,7 @@ def route_edges(
 
     _center_bubble_stations(routes, graph)
     _spread_diagonal_bundles(routes, ctx)
+    _normalize_gap_channels(routes, ctx)
 
     return routes
 
@@ -977,17 +981,18 @@ def _route_bypass(
         base_radius=ctx.curve_radius,
     )
 
-    # Gap channel centers and per-line positions.
-    base_bypass_offset = ctx.curve_radius + ctx.offset_step
+    # Initial gap-channel centres and per-line positions.  These centre each
+    # leg in its (row-aware) gap via _gap_channel_base; the post-routing
+    # _normalize_gap_channels pass then re-stacks all inter-section channels
+    # into their final centred / B-separated bundle positions.
     half_g1 = (g1_n - 1) * ctx.offset_step / 2
     half_g2 = (g2_n - 1) * ctx.offset_step / 2
 
     if horizontal is Direction.R:
         if fan is not None:
-            # Corner 1 uses unified fan indices for a shared first corner
-            # with L-shape and wrap siblings.  Use the going_right
-            # fan_mid_x formula so curve_start = gap1_x - r1 = junction.x,
-            # eliminating the upstream-past-curve "nubbin".
+            # The fan shares its first corner across siblings; centre the
+            # channel on the gap slot, but never left of the near-source
+            # position or the curve would start behind the junction (nubbin).
             ui, un = fan
             fan_delta, r1, _ = l_shape_radii(
                 ui,
@@ -996,11 +1001,13 @@ def _route_bypass(
                 offset_step=ctx.offset_step,
                 base_radius=ctx.curve_radius,
             )
-            fan_mid_x = sx + ctx.curve_radius + (un - 1) * ctx.offset_step / 2
+            near = sx + ctx.curve_radius + (un - 1) * ctx.offset_step / 2
+            slot = _gap_channel_base(graph, src_col, src_row, un, ctx.offset_step)
+            fan_mid_x = max(near, slot)
             gap1_x = fan_mid_x + fan_delta
         else:
-            gap1_base = (
-                column_gap_midpoint(graph, src_col, src_col + 1) - base_bypass_offset
+            gap1_base = _gap_channel_base(
+                graph, src_col, src_row, g1_n, ctx.offset_step
             )
             gap1_limit = sx + ctx.curve_radius
             if gap1_base - (g1_n - 1) * ctx.offset_step < gap1_limit:
@@ -1009,8 +1016,8 @@ def _route_bypass(
                 gap1_mid = gap1_base - half_g1
             gap1_x = gap1_mid + delta1
 
-        gap2_base = (
-            column_gap_midpoint(graph, tgt_col - 1, tgt_col) + base_bypass_offset
+        gap2_base = _gap_channel_base(
+            graph, tgt_col - 1, tgt_row, g2_n, ctx.offset_step
         )
         gap2_limit = effective_tx - ctx.curve_radius
         if gap2_base + (g2_n - 1) * ctx.offset_step > gap2_limit:
@@ -1018,38 +1025,56 @@ def _route_bypass(
         else:
             gap2_mid = gap2_base + half_g2
         if trunk_v_up_pull_away:
-            # Place this bundle CLOSER to the previous column (away from
-            # the target's edge) so it doesn't overlap with a sibling
-            # around-section bundle that hugs the target's left edge.
-            # The around-section bundle sits at target_left -
-            # (curve_radius + offset_step + extra_clearance + delta) -
-            # i.e. its xmin = target_left - SECTION_ROUTE_CLEARANCE -
-            # 2*max_around_delta.  Anchor this bundle's xmin at
-            # neighbour_right + SECTION_ROUTE_CLEARANCE so it keeps a
-            # visible gap from the neighbour, AND ensure its xmax stays
-            # clear of the around-section bundle.  When the inter-column
-            # gap is too narrow to fit both bundles with clearance, fall
-            # back to the standard placement (overlap is the lesser
-            # evil compared to a route entering the neighbour bbox).
-            neighbour_right = col_right_edge(graph, tgt_col - 1)
-            pulled_mid_candidate = neighbour_right + SECTION_ROUTE_CLEARANCE + half_g2
-            # Around-section xmin (must stay clear of pulled bundle xmax)
-            around_section_xmin = (
-                effective_tx
-                - SECTION_ROUTE_CLEARANCE
-                - 2 * ((g2_n - 1) * ctx.offset_step / 2)
+            # Two bundles share the gap between (tgt_col - 1) and tgt_col:
+            # this bypass (gap2) bundle on the LEFT, paired with an
+            # around-section bundle on the RIGHT (placed by
+            # _route_around_section_below), positioned symmetrically via
+            # symmetric_bundle_midpoint.  When the gap is too narrow to
+            # fit both bundles with clearance, fall back to the standard
+            # (single-bundle) placement; overlap is the lesser evil
+            # compared to a route entering the neighbouring section's bbox.
+            gap_left, gap_right = column_gap_edges(
+                graph, tgt_col - 1, tgt_col, row=tgt_row
             )
-            pulled_xmax = pulled_mid_candidate + half_g2
-            min_inter_bundle_gap = ctx.offset_step  # 1 step between bundles
+            this_width = bundle_width(g2_n, ctx.offset_step)
+            # The around-route bundle's line count equals the merge
+            # trunk's effective line count, which today matches g2_n
+            # (one around-route line per fan_in line).  Use g2_n as a
+            # conservative width estimate.
+            around_width = this_width
+            pulled_mid_candidate = symmetric_bundle_midpoint(
+                gap_left,
+                gap_right,
+                [this_width, around_width],
+                bundle_index=0,
+            )
+            # Sanity: only honour the symmetric placement when both
+            # bundles can fit with at least A clearance from each edge
+            # and B inter-bundle separation.  Otherwise the gap was
+            # never widened (e.g. layout disabled or pull-away
+            # triggered without _enforce_min_column_gaps participating),
+            # so fall back to the standard placement.
+            this_xmin = pulled_mid_candidate - this_width / 2
+            around_mid = symmetric_bundle_midpoint(
+                gap_left,
+                gap_right,
+                [this_width, around_width],
+                bundle_index=1,
+            )
+            around_xmax = around_mid + around_width / 2
             if (
-                pulled_mid_candidate - half_g2 - neighbour_right
-                >= SECTION_ROUTE_CLEARANCE
-                and around_section_xmin - pulled_xmax >= min_inter_bundle_gap
+                this_xmin - gap_left >= SECTION_ROUTE_CLEARANCE
+                and gap_right - around_xmax >= SECTION_ROUTE_CLEARANCE
             ):
                 gap2_mid = pulled_mid_candidate
         gap2_x = gap2_mid + delta2
     else:
         if fan is not None:
+            # Mirror of the going-right fan: centre on the gap slot but never
+            # right of the near-source position (curve must not start behind
+            # the junction).  Wrap-style routes whose source-side curve is on
+            # the RIGHT regardless of dx (left-entry wrap, around-section-
+            # below) are dispatched through their own handlers, not here.
             ui, un = fan
             fan_delta, r1, _ = l_shape_radii(
                 ui,
@@ -1058,18 +1083,13 @@ def _route_bypass(
                 offset_step=ctx.offset_step,
                 base_radius=ctx.curve_radius,
             )
-            # For a leftward bypass the source-side curve sits on the
-            # LEFT of the source section (mirror of the going_right
-            # case), so fan_mid_x must be placed on the negative side
-            # of sx.  Wrap-style routes whose source-side curve is on
-            # the RIGHT regardless of dx (left-entry wrap,
-            # around-section-below) are dispatched through their own
-            # handlers and do NOT reach this branch.
-            fan_mid_x = sx - ctx.curve_radius - (un - 1) * ctx.offset_step / 2
+            near = sx - ctx.curve_radius - (un - 1) * ctx.offset_step / 2
+            slot = _gap_channel_base(graph, src_col - 1, src_row, un, ctx.offset_step)
+            fan_mid_x = min(near, slot)
             gap1_x = fan_mid_x + fan_delta
         else:
-            gap1_base = (
-                column_gap_midpoint(graph, src_col - 1, src_col) + base_bypass_offset
+            gap1_base = _gap_channel_base(
+                graph, src_col - 1, src_row, g1_n, ctx.offset_step
             )
             gap1_limit = sx - ctx.curve_radius
             if gap1_base + (g1_n - 1) * ctx.offset_step > gap1_limit:
@@ -1078,9 +1098,7 @@ def _route_bypass(
                 gap1_mid = gap1_base + half_g1
             gap1_x = gap1_mid + delta1
 
-        gap2_base = (
-            column_gap_midpoint(graph, tgt_col, tgt_col + 1) - base_bypass_offset
-        )
+        gap2_base = _gap_channel_base(graph, tgt_col, tgt_row, g2_n, ctx.offset_step)
         gap2_limit = effective_tx + ctx.curve_radius
         if gap2_base - (g2_n - 1) * ctx.offset_step < gap2_limit:
             gap2_mid = gap2_limit + half_g2
@@ -1297,6 +1315,7 @@ def _route_top_entry_l_shape(
             line_id=edge.line_id,
             points=[(sx, sy), (lx, sy), (lx, ty), (tx, ty)],
             is_inter_section=True,
+            normalize_exempt=True,
             curve_radii=[r_lead, r_second],
         )
     return RoutedPath(
@@ -1304,6 +1323,7 @@ def _route_top_entry_l_shape(
         line_id=edge.line_id,
         points=[(sx, sy), (lx, sy), (lx, hy), (tx, hy), (tx, ty)],
         is_inter_section=True,
+        normalize_exempt=True,
         curve_radii=[r_lead, r_first, r_second],
     )
 
@@ -1509,6 +1529,7 @@ def _route_left_entry_wrap(
             (tx, ty + tgt_off),
         ],
         is_inter_section=True,
+        normalize_exempt=True,
         # Handedness-aware radii: C1 and C2 are right turns (the bundle's
         # outer line is OUTSIDE the turn) so use the larger outside-of-turn
         # radius r_wrap.  C3 and C4 are left turns (outer line is INSIDE
@@ -1519,6 +1540,37 @@ def _route_left_entry_wrap(
         curve_radii=[r_wrap, r_wrap, r_inside, r_inside],
         offsets_applied=True,
     )
+
+
+def _has_bypass_sibling_to_same_entry(
+    edge: Edge,
+    entry_port: Station,
+    ctx: _RoutingCtx,
+) -> bool:
+    """Detect whether a sibling merge trunk's bypass shares the V_up gap.
+
+    Mirrors :func:`_has_around_section_sibling` (which lives on the
+    trunk side and answers "is there an around-route sharing my gap?").
+    Used by :func:`_route_around_section_below` to decide whether the
+    V_up channel shares its gap with a bypass bundle (in which case
+    the around-route is bundle index 1 in the symmetric layout) or
+    has the gap to itself (bundle index 0 of 1).
+    """
+    if entry_port is None:
+        return False
+    ep_id = entry_port.id
+    # Walk back from the entry port through the merge-junction graph
+    # to find the merge junction this entry_port serves.
+    for mj_id, mapped_ep in ctx.merge.entry_port_for.items():
+        if mapped_ep != ep_id:
+            continue
+        # mj_id is a merge junction whose entry_port is ours.  Check
+        # whether the trunk source feeding it routes via bypass.
+        trunk_src = ctx.merge.trunk_source.get(mj_id)
+        if trunk_src is None or trunk_src == edge.source:
+            continue
+        return True
+    return False
 
 
 def _route_around_section_below(
@@ -1637,18 +1689,36 @@ def _route_around_section_below(
         section_left = ep_section.bbox_x
     else:
         section_left = ex
-    # Channel sits at section_left - (curve_radius + offset_step) - delta.
-    # The line CLOSEST to section_left is the one with delta=-max_delta
-    # (innermost in the bundle); its gap to section_left is base_gap -
-    # max_delta.  Bump uniformly so even that closest line stays at
-    # least SECTION_ROUTE_CLEARANCE from the edge.  The shift is uniform
-    # across lines so the per-line delta stagger (and the around-route's
-    # V_up sign convention) is preserved.
     n_for_outer = fan[1] if fan is not None else n
     max_delta = (n_for_outer - 1) * ctx.offset_step / 2
     base_gap = ctx.curve_radius + ctx.offset_step
+    # Bump so the bundle's innermost line keeps SECTION_ROUTE_CLEARANCE from
+    # the target section edge even when base_gap - max_delta falls short.
     extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
-    vx = section_left - base_gap - extra_clearance - delta
+
+    # V_up X: position the bundle within the inter-column gap just
+    # left of the target section, using the principled symmetric
+    # placement.  When a sibling merge-trunk bypass shares this gap,
+    # we're bundle 1 (rightmost); else we're the sole bundle.  The
+    # symmetric helper handles both cases and the post-corner -delta
+    # stagger preserves the around-route's V_up sign convention.
+    paired_with_bypass = _has_bypass_sibling_to_same_entry(edge, entry_port, ctx)
+    if ep_col is not None and ep_col > 0:
+        gap_left, gap_right = column_gap_edges(ctx.graph, ep_col - 1, ep_col)
+        bw = bundle_width(n_for_outer, ctx.offset_step)
+        widths = [bw, bw] if paired_with_bypass else [bw]
+        bundle_idx = 1 if paired_with_bypass else 0
+        vx_mid = symmetric_bundle_midpoint(gap_left, gap_right, widths, bundle_idx)
+        # Sanity floor: keep the V_up clear of the target section's left
+        # edge (re-applying the legacy clamp) when the gap is too narrow
+        # for full symmetric placement.
+        max_vx_mid = section_left - base_gap - extra_clearance
+        vx_mid = min(vx_mid, max_vx_mid)
+        vx = vx_mid - delta
+    else:
+        # Fallback for degenerate cases without column info: legacy
+        # anchored-to-edge placement.
+        vx = section_left - base_gap - extra_clearance - delta
 
     # First-corner X: lead-in right of source, mirroring _route_left_entry_wrap.
     if fan_mid_x is not None:
@@ -1686,6 +1756,7 @@ def _route_around_section_below(
             (ex, ey + tgt_off),
         ],
         is_inter_section=True,
+        normalize_exempt=True,
         # All four corners are CW; the outer bundle line stays on the
         # OUTSIDE of every turn (large y at H_bottom, small x at V_up
         # given the V_up sign flip above), so every corner uses the
@@ -1784,6 +1855,7 @@ def _route_right_entry_wrap(
         line_id=edge.line_id,
         points=[(sx, sy), (lx, sy), (lx, hy), (vx, hy), (vx, ty), (tx, ty)],
         is_inter_section=True,
+        normalize_exempt=True,
         curve_radii=[r_lead, r_first, r_first, r_second],
     )
 
@@ -2981,6 +3053,366 @@ def _resolve_section_row(graph: MetroGraph, station: Station) -> int | None:
     if sec and sec.grid_row >= 0:
         return sec.grid_row
     return None
+
+
+@dataclass
+class _VChannel:
+    """One vertical channel segment of a routed inter-section path.
+
+    Records the route, the segment's start index in ``route.points`` (so
+    ``points[idx]`` and ``points[idx+1]`` are the channel endpoints), its
+    current x, vertical span and direction, plus the indices of any
+    flanking corners in ``route.curve_radii`` and whether each corner is
+    on the OUTSIDE of its turn for this line (recomputed after re-stack).
+    """
+
+    route: RoutedPath
+    idx: int
+    x: float
+    y_lo: float
+    y_hi: float
+    down: bool
+
+
+def _collect_vchannels(routes: list[RoutedPath]) -> list[_VChannel]:
+    """Find every vertical channel segment in inter-section routes."""
+    out: list[_VChannel] = []
+    for rp in routes:
+        if not rp.is_inter_section or rp.normalize_exempt:
+            continue
+        pts = rp.points
+        for k in range(len(pts) - 1):
+            x0, y0 = pts[k]
+            x1, y1 = pts[k + 1]
+            if abs(x1 - x0) < COORD_TOLERANCE and abs(y1 - y0) > COORD_TOLERANCE:
+                out.append(
+                    _VChannel(
+                        route=rp,
+                        idx=k,
+                        x=x0,
+                        y_lo=min(y0, y1),
+                        y_hi=max(y0, y1),
+                        down=y1 > y0,
+                    )
+                )
+    return out
+
+
+def _build_gap_intervals(
+    graph: MetroGraph,
+) -> dict[int | None, list[tuple[int, float, float]]]:
+    """Per-row list of ``(lo_col, gap_left, gap_right)`` for adjacent columns.
+
+    The row key is the grid row; a single combined ``None`` entry is also
+    produced (row-agnostic union) as a fallback for channels whose row
+    can't be matched precisely.
+    """
+    cols = sorted({s.grid_col for s in graph.sections.values() if s.bbox_w > 0})
+    rows = sorted({s.grid_row for s in graph.sections.values() if s.bbox_w > 0})
+    intervals: dict[int | None, list[tuple[int, float, float]]] = {}
+    for row in list(rows) + [None]:
+        per_row: list[tuple[int, float, float]] = []
+        for lo, hi in zip(cols, cols[1:]):
+            if hi != lo + 1:
+                continue
+            left, right = column_gap_edges(graph, lo, hi, row=row)
+            if right > left:
+                per_row.append((lo, left, right))
+        intervals[row] = per_row
+    return intervals
+
+
+def _normalize_gap_channels(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
+    """Re-bundle inter-section vertical channels sharing a gap + direction.
+
+    Post-routing pass that enforces the uniform inter-section gap geometry
+    regardless of which handler placed each leg:
+
+    * All same-direction channels sharing one inter-column gap collapse
+      into ONE concentric bundle, ``OFFSET_STEP`` apart, centred.
+    * A downward bundle and an upward bundle sharing a gap are held
+      ``BUNDLE_TO_BUNDLE_CLEARANCE`` (B) apart, centred as a group.
+    * A lone bundle centres in its gap with at least
+      ``EDGE_TO_BUNDLE_CLEARANCE`` (A) from each bounding section edge.
+
+    Only channels whose current x already lands inside a real inter-column
+    gap are touched, so wrap / around-section legs that deliberately sit
+    outside the immediate gap are left alone.  Corner radii flanking each
+    re-stacked channel are recomputed so the bundle stays concentric.
+    """
+    graph = ctx.graph
+    step = ctx.offset_step
+    channels = _collect_vchannels(routes)
+    if not channels:
+        return
+    gap_intervals = _build_gap_intervals(graph)
+
+    # Per-row vertical band (top/bottom Y) so a channel can be matched to
+    # the row whose gap it actually travels in, not merely the first row
+    # whose x-interval brackets it.  Two channels in the same column gap
+    # but different grid rows (e.g. a row-0 fan and a row-1 bypass) must
+    # NOT be merged into one bundle: each centres on its own row's gap.
+    row_bands: dict[int, tuple[float, float]] = {}
+    for s in graph.sections.values():
+        if s.bbox_h <= 0:
+            continue
+        for r in range(s.grid_row, s.grid_row + max(1, s.grid_row_span)):
+            top, bot = row_bands.get(r, (s.bbox_y, s.bbox_y + s.bbox_h))
+            row_bands[r] = (min(top, s.bbox_y), max(bot, s.bbox_y + s.bbox_h))
+
+    def _find_gap(ch: _VChannel) -> tuple[int, int | None, float, float] | None:
+        """Match a channel to ``(lo_col, row, gap_left, gap_right)``.
+
+        Prefer the row whose x-interval brackets the channel AND whose
+        vertical band the channel overlaps; fall back to any bracketing
+        row, then to the row-agnostic union.
+        """
+        x = ch.x
+        overlap_match: tuple[int, int | None, float, float] | None = None
+        bracket_match: tuple[int, int | None, float, float] | None = None
+        for row in gap_intervals:
+            if row is None:
+                continue
+            for lo, left, right in gap_intervals[row]:
+                if not (left - COORD_TOLERANCE <= x <= right + COORD_TOLERANCE):
+                    continue
+                if bracket_match is None:
+                    bracket_match = (lo, row, left, right)
+                band = row_bands.get(row)
+                if band is not None and ch.y_lo < band[1] and band[0] < ch.y_hi:
+                    if overlap_match is None:
+                        overlap_match = (lo, row, left, right)
+        if overlap_match is not None:
+            return overlap_match
+        if bracket_match is not None:
+            return bracket_match
+        for lo, left, right in gap_intervals.get(None, []):
+            if left - COORD_TOLERANCE <= x <= right + COORD_TOLERANCE:
+                return (lo, None, left, right)
+        return None
+
+    # Bucket channels per (gap lo_col, row, direction).  A channel is only
+    # a candidate when its x lands strictly inside the gap interior (so a
+    # near-vertical drop hugging a section edge is left untouched).
+    buckets: dict[tuple[int, int | None, bool], list[_VChannel]] = defaultdict(list)
+    gap_bounds: dict[tuple[int, int | None], tuple[float, float]] = {}
+    for ch in channels:
+        gap = _find_gap(ch)
+        if gap is None:
+            continue
+        lo, row, left, right = gap
+        if not (left + COORD_TOLERANCE < ch.x < right - COORD_TOLERANCE):
+            # x sits on / outside a section edge: not a clean gap channel.
+            if not (left <= ch.x <= right):
+                continue
+        gap_bounds[(lo, row)] = (left, right)
+        buckets[(lo, row, ch.down)].append(ch)
+
+    # Within a (gap, direction) bucket, split into corridors by vertical
+    # overlap: only channels whose y-spans overlap share a true corridor
+    # (independent vertical runs at different heights must NOT be merged).
+    def _corridors(chans: list[_VChannel]) -> list[list[_VChannel]]:
+        chans = sorted(chans, key=lambda c: (c.y_lo, c.y_hi))
+        groups: list[list[_VChannel]] = []
+        for ch in chans:
+            placed = False
+            for g in groups:
+                if any(
+                    ch.y_lo < o.y_hi - COORD_TOLERANCE
+                    and o.y_lo < ch.y_hi - COORD_TOLERANCE
+                    for o in g
+                ):
+                    g.append(ch)
+                    placed = True
+                    break
+            if not placed:
+                groups.append([ch])
+        return groups
+
+    # Assemble bundles per (gap, row): one per corridor, both directions,
+    # laid out together so a down/up pair sharing a gap is B-separated.
+    by_gap: dict[tuple[int, int | None], list[tuple[bool, list[_VChannel]]]]
+    by_gap = defaultdict(list)
+    for (lo, row, down), chans in buckets.items():
+        for corridor in _corridors(chans):
+            by_gap[(lo, row)].append((down, corridor))
+
+    # Intrusion guard (row-agnostic): a re-stacked channel must never land
+    # inside any section's bbox.
+    def _intrudes(x: float, y_lo: float, y_hi: float) -> bool:
+        for s in graph.sections.values():
+            if s.bbox_w <= 0:
+                continue
+            sx_l = s.bbox_x
+            sx_r = s.bbox_x + s.bbox_w
+            if sx_l - COORD_TOLERANCE < x < sx_r + COORD_TOLERANCE:
+                sy_t = s.bbox_y
+                sy_b = s.bbox_y + s.bbox_h
+                if y_lo < sy_b and sy_t < y_hi:
+                    return True
+        return False
+
+    for (lo, _row), bundles in by_gap.items():
+        # Stable left-to-right order: by current bundle centre.
+        bundles.sort(key=lambda b: sum(c.x for c in b[1]) / len(b[1]))
+        # Distinct-line count per bundle drives the bundle width and the
+        # per-line slotting: multiple segments sharing one line_id (a fan
+        # whose line feeds several targets) overlay at a single x rather
+        # than each claiming an OFFSET_STEP slot.
+        line_orders = [_distinct_line_order(c) for _, c in bundles]
+        # Skip a lone bundle carrying a single distinct line: nothing to
+        # re-bundle and centring risks disturbing wrap geometry.
+        if len(bundles) == 1 and len(line_orders[0]) <= 1:
+            continue
+        gap_left, gap_right = gap_bounds[(lo, _row)]
+        widths = [max(0, len(o) - 1) * step for o in line_orders]
+        # A lone bundle centres on the true gap midpoint (symmetric
+        # clearance both sides) rather than flooring one edge at A, which
+        # would push the bundle off-centre when the gap is sized tighter
+        # than 2A + width.  Multi-bundle gaps keep the symmetric A/B
+        # layout from symmetric_bundle_midpoint.
+        lone = len(bundles) == 1
+        for bi, (down, chans) in enumerate(bundles):
+            order = line_orders[bi]
+            if lone:
+                mid = (gap_left + gap_right) / 2
+            else:
+                mid = symmetric_bundle_midpoint(gap_left, gap_right, widths, bi)
+            n = len(order)
+            # line_id -> (slot index, x); every segment of that line overlays
+            # at its single slot rather than claiming an OFFSET_STEP each.
+            line_slot = {
+                lid: (i, mid + (i - (n - 1) / 2) * step) for i, lid in enumerate(order)
+            }
+            targets = [(ch, line_slot[ch.route.line_id]) for ch in chans]
+            # Intrusion guard: if any target x would land inside a section
+            # bbox (e.g. the gap bounds came from another row), leave this
+            # bundle untouched rather than route through a section.
+            if any(_intrudes(nx, ch.y_lo, ch.y_hi) for ch, (_li, nx) in targets):
+                continue
+            for ch, (li, nx) in targets:
+                _restack_channel(ch, nx, li, n, step, ctx.curve_radius)
+
+
+def _distinct_line_order(chans: list[_VChannel]) -> list[str]:
+    """Left-to-right order of the distinct lines in one gap-bundle corridor.
+
+    Channels sharing a ``line_id`` collapse to a single slot, so the order
+    is over distinct lines.  The ordering minimises crossings between each
+    line's vertical leg and the others' horizontal lead-outs.
+
+    A line's vertical leg spans the gap from the shared trunk level (near
+    the junction) down to its deepest turn-off; each channel segment turns
+    off horizontally at its deep endpoint (``y_hi``).  For a DOWN bundle
+    that lead-out extends RIGHTWARD toward the target; for an UP bundle the
+    lead-in extends LEFTWARD from the source.  When line A sits LEFT of B:
+
+    * DOWN: B's (right-placed, deeper) vertical crosses each A lead-out that
+      turns off shallower than B's deepest point.
+    * UP: A's (left-placed, deeper) vertical crosses each B lead-in (which
+      extends left under A) that attaches shallower than A's deepest point.
+
+    The pairwise comparator picks, for each pair, the side incurring fewer
+    crossings; ties keep the incoming x order.  This places a deep bypass
+    before a shallow neighbour (variant_calling: qc before main) yet still
+    puts a shallow long-reach line before a deeper multi-target fan when
+    that strictly reduces crossings (genomeassembly: hic before assemblies),
+    and mirrors the rule for UP bundles (subworkflows: the deeper
+    preprocess_reporting sits to the RIGHT).
+    """
+    down = chans[0].down if chans else True
+
+    # Per line: the deep turn-off depths of each segment (always y_hi), the
+    # deepest reach, and a representative x for stable tie-breaking.
+    turns: dict[str, list[float]] = defaultdict(list)
+    deepest: dict[str, float] = {}
+    rep_x: dict[str, float] = {}
+    for ch in chans:
+        lid = ch.route.line_id
+        turns[lid].append(ch.y_hi)
+        deepest[lid] = max(deepest.get(lid, ch.y_hi), ch.y_hi)
+        rep_x[lid] = min(rep_x.get(lid, ch.x), ch.x)
+
+    def crossings_if_left(a: str, b: str) -> int:
+        # Number of crossings when a is placed LEFT of b.
+        if down:
+            # b's deeper vertical crosses a's shallower right-going lead-outs.
+            return sum(1 for t in turns[a] if t < deepest[b] - COORD_TOLERANCE)
+        # UP: a's deeper vertical crosses b's shallower left-going lead-ins.
+        return sum(1 for t in turns[b] if t < deepest[a] - COORD_TOLERANCE)
+
+    def cmp(a: str, b: str) -> int:
+        ca = crossings_if_left(a, b)  # a left of b
+        cb = crossings_if_left(b, a)  # b left of a
+        if ca != cb:
+            return -1 if ca < cb else 1
+        if rep_x[a] != rep_x[b]:
+            return -1 if rep_x[a] < rep_x[b] else 1
+        return -1 if a < b else (1 if a > b else 0)
+
+    return sorted(turns, key=functools.cmp_to_key(cmp))
+
+
+def _restack_channel(
+    ch: _VChannel,
+    new_x: float,
+    i: int,
+    n: int,
+    step: float,
+    base_radius: float,
+) -> None:
+    """Move one vertical channel to *new_x* and recompute its corner radii.
+
+    Shifts the channel's two endpoints (which share x) to *new_x*; the
+    flanking horizontal segments stretch.  The re-stacked channel behaves
+    exactly like line *i* of an *n*-line standard L-shape, so its two
+    flanking corner radii come straight from :func:`l_shape_radii`, which
+    encodes the concentric (outermost-line-largest-on-the-outside)
+    geometry for both the down- and up-going cases.
+
+    ``l_shape_radii`` assigns ``i = 0`` to the rightmost (DOWN) / leftmost
+    (UP) line; the bundle here is ordered left-to-right with ``i`` growing
+    rightward, so the index is mapped accordingly.
+    """
+    rp = ch.route
+    pts = rp.points
+    k = ch.idx
+    pts[k] = (new_x, pts[k][1])
+    pts[k + 1] = (new_x, pts[k + 1][1])
+
+    if rp.curve_radii is None:
+        return
+    vertical = Direction.D if ch.down else Direction.U
+    # Map left-to-right index to l_shape_radii's convention.
+    li = (n - 1 - i) if ch.down else i
+    _, r_first, r_second = l_shape_radii(
+        li, n, vertical=vertical, offset_step=step, base_radius=base_radius
+    )
+    # Lead corner radius lives at curve_radii[k-1]; trail at curve_radii[k].
+    if 0 <= k - 1 < len(rp.curve_radii):
+        rp.curve_radii[k - 1] = r_first
+    if k < len(rp.curve_radii) and k + 2 < len(pts):
+        rp.curve_radii[k] = r_second
+
+
+def _gap_channel_base(
+    graph: MetroGraph,
+    lo: int,
+    row: int | None,
+    n: int,
+    offset_step: float,
+) -> float:
+    """Centred midline x for a bundle of *n* lines in gap ``(lo, lo+1)``.
+
+    This is only the initial placement during routing; the post-routing
+    :func:`_normalize_gap_channels` pass re-stacks every inter-section
+    channel into its final centred / B-separated position, so the value
+    here just needs to land the channel in the right gap.
+    """
+    gap_left, gap_right = column_gap_edges(graph, lo, lo + 1, row=row)
+    return symmetric_bundle_midpoint(
+        gap_left, gap_right, [max(0, n - 1) * offset_step], 0
+    )
 
 
 def _has_intervening_sections(

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -14,7 +14,8 @@ import warnings
 from collections import defaultdict, deque
 
 from nf_metro.layout.constants import (
-    CURVE_RADIUS,
+    BUNDLE_TO_BUNDLE_CLEARANCE,
+    EDGE_TO_BUNDLE_CLEARANCE,
     MERGE_GAP_MIN,
     MIN_INTER_SECTION_GAP,
     MIN_INTER_SECTION_ROW_GAP,
@@ -327,48 +328,6 @@ def _rows_overlap(a: Section, b: Section) -> bool:
     return a_start <= b_end and b_start <= a_end
 
 
-def _count_lines_between_columns(
-    graph: MetroGraph,
-    col_assign: dict[str, int],
-    col_a: int,
-    col_b: int,
-) -> int:
-    """Count distinct lines routing between two adjacent columns.
-
-    Examines inter-section edges (those crossing section boundaries via
-    ports and junctions) to find how many lines will need to route through
-    the gap between *col_a* and *col_b*.
-    """
-    junction_ids = graph.junction_ids
-    lines: set[str] = set()
-
-    for edge in graph.edges:
-        src = graph.stations.get(edge.source)
-        tgt = graph.stations.get(edge.target)
-        if not src or not tgt:
-            continue
-
-        # Only inter-section edges (port-to-port or via junctions)
-        is_inter = (src.is_port or edge.source in junction_ids) and (
-            tgt.is_port or edge.target in junction_ids
-        )
-        if not is_inter:
-            continue
-
-        # Resolve source/target section columns
-        src_col = _station_column(graph, src, col_assign, junction_ids)
-        tgt_col = _station_column(graph, tgt, col_assign, junction_ids)
-        if src_col is None or tgt_col is None:
-            continue
-
-        # Check if this edge crosses between col_a and col_b
-        lo, hi = min(src_col, tgt_col), max(src_col, tgt_col)
-        if lo <= col_a and hi >= col_b:
-            lines.add(edge.line_id)
-
-    return len(lines)
-
-
 def _station_column(
     graph: MetroGraph,
     station,
@@ -387,21 +346,103 @@ def _station_column(
     return None
 
 
-def _min_gap_for_bundle(
-    n_lines: int,
-    curve_radius: float = CURVE_RADIUS,
+def _bundles_in_gap(
+    graph: MetroGraph,
+    col_assign: dict[str, int],
+    col_a: int,
+    col_b: int,
+) -> list[int]:
+    """Return ``[n_lines, ...]`` for every distinct bundle traversing the gap.
+
+    Each inter-section edge contributes one or two vertical channels:
+    - A bypass edge (``|tgt_col - src_col| > 1``) contributes a gap1
+      channel in the gap immediately right of its source column, and a
+      gap2 channel in the gap immediately left of its target column.
+    - An L-shape edge between adjacent columns contributes a single
+      channel in the inter-column gap.
+
+    All source-side (gap1) channels in a gap occupy the same x position
+    (just right of the source column) and coalesce into one concentric
+    bundle, regardless of how far each edge ultimately travels; likewise
+    all target-side (gap2) channels coalesce just left of the target
+    column.  A line is therefore counted once per side+direction even
+    when it fans from one source to several target columns (e.g.
+    differentialabundance fans the same lines to an adjacent section and
+    a bypass target -- one down-bundle, not one per target).  Keying by
+    ``(src_col, tgt_col)`` would split that single physical bundle in two
+    and over-widen the gap.
+
+    The returned list contains one entry per distinct bundle; its value
+    is the number of distinct lines in that bundle.
+    """
+    junction_ids = graph.junction_ids
+    bundles: dict[tuple, set[str]] = defaultdict(set)
+
+    lo, hi = min(col_a, col_b), max(col_a, col_b)
+
+    for edge in graph.edges:
+        src = graph.stations.get(edge.source)
+        tgt = graph.stations.get(edge.target)
+        if not src or not tgt:
+            continue
+        is_inter = (src.is_port or edge.source in junction_ids) and (
+            tgt.is_port or edge.target in junction_ids
+        )
+        if not is_inter:
+            continue
+        src_col = _station_column(graph, src, col_assign, junction_ids)
+        tgt_col = _station_column(graph, tgt, col_assign, junction_ids)
+        if src_col is None or tgt_col is None:
+            continue
+        if src_col == tgt_col:
+            continue
+
+        edge_lo = min(src_col, tgt_col)
+        edge_hi = max(src_col, tgt_col)
+        h_dir = 1 if tgt_col > src_col else -1
+        # A gap hosts at most two concentric bundles: the source-side
+        # (gap1, "D") channel just right of its lower column and the
+        # target-side (gap2, "U") channel just left of its upper column.
+        # Key by side + horizontal direction only so every edge whose
+        # channel lands on that side coalesces into one bundle.
+        if edge_hi - edge_lo == 1:
+            if lo == edge_lo and hi == edge_hi:
+                bundles[("D", h_dir)].add(edge.line_id)
+        else:
+            if lo == edge_lo and hi == edge_lo + 1:
+                bundles[("D", h_dir)].add(edge.line_id)
+            if lo == edge_hi - 1 and hi == edge_hi:
+                bundles[("U", h_dir)].add(edge.line_id)
+
+    return [len(lines) for lines in bundles.values() if lines]
+
+
+def _min_gap_for_bundles(
+    bundle_line_counts: list[int],
+    edge_clearance: float = EDGE_TO_BUNDLE_CLEARANCE,
+    inter_bundle: float = BUNDLE_TO_BUNDLE_CLEARANCE,
     offset_step: float = OFFSET_STEP,
 ) -> float:
-    """Compute the minimum inter-section gap needed for *n_lines* in a bundle.
+    """Required gap width for a list of bundles in one inter-section gap.
 
-    The outermost line in an L-shape bundle has a curve radius of
-    ``curve_radius + (n-1) * offset_step``.  The gap must accommodate
-    the outermost arc from both sides of the channel midpoint.
+    Implements the principled formula::
+
+        gap >= A + Σ bundle_widths + (count - 1) * B + A
+
+    where each ``bundle_width = (n_i - 1) * OFFSET_STEP`` is the visual
+    span of the ``n_i`` parallel lines in bundle *i*.  ``A`` is the
+    section-edge-to-bundle clearance (:data:`EDGE_TO_BUNDLE_CLEARANCE`)
+    and ``B`` is the inter-bundle clearance
+    (:data:`BUNDLE_TO_BUNDLE_CLEARANCE`).
+
+    For an empty list, returns 0 (no gap requirement from routing; the
+    caller's static :data:`MIN_INTER_SECTION_GAP` floor still applies).
     """
-    if n_lines <= 0:
-        return MIN_INTER_SECTION_GAP
-    max_radius = curve_radius + max(n_lines - 1, 0) * offset_step
-    return max(2 * max_radius, MIN_INTER_SECTION_GAP)
+    if not bundle_line_counts:
+        return 0.0
+    widths = sum(max(0, n - 1) * offset_step for n in bundle_line_counts)
+    count = len(bundle_line_counts)
+    return 2 * edge_clearance + widths + (count - 1) * inter_bundle
 
 
 def _has_merge_routing_in_gap(
@@ -476,9 +517,15 @@ def _enforce_min_column_gaps(
         if not left_secs or not right_secs:
             continue
 
-        # Compute bundle-aware minimum for this column pair
-        n_lines = _count_lines_between_columns(graph, col_assign, col, col + 1)
-        bundle_min = _min_gap_for_bundle(n_lines)
+        # Principled gap width: A + Σ bundle_widths + (count-1)*B + A.
+        # For a single bundle of one line this collapses to 2*A; with
+        # the default A=16 px that's 32 px, smaller than the static
+        # MIN_INTER_SECTION_GAP=40 px so single-line gaps are NOT widened
+        # past the standard layout column gap.  Multi-line or multi-bundle
+        # corridors deterministically claim only the horizontal space
+        # their visual width actually occupies.
+        bundles = _bundles_in_gap(graph, col_assign, col, col + 1)
+        bundle_min = _min_gap_for_bundles(bundles)
         effective_min = max(min_gap, bundle_min)
 
         # Widen further for gaps with merge junction routing
@@ -502,10 +549,13 @@ def _enforce_min_column_gaps(
 
         # Warn if we're overriding the user's requested gap
         if requested_gap is not None and effective_min > requested_gap:
+            n_bundles = len(bundles)
+            total_lines = sum(bundles)
             warnings.warn(
                 f"Section gap between columns {col} and {col + 1} "
                 f"widened from {requested_gap:.0f}px to {effective_min:.0f}px "
-                f"to accommodate {n_lines} routing line(s)",
+                f"to accommodate {n_bundles} bundle(s) / "
+                f"{total_lines} routing line(s)",
                 stacklevel=2,
             )
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1996,3 +1996,438 @@ class TestPassCBisection:
             assert engine._bisection_should_run(guard_name, prev_phase) is False
         # Final-block phase is not in _PASS_C_BISECTION_ORDER; guard always runs.
         assert engine._bisection_should_run(guard_name, "after final") is True
+
+
+def test_bundles_in_gap_dedupes_fanout_to_multiple_columns():
+    """A line fanning from one source to several target columns occupies a
+    single coalesced channel in the source-side gap, so it must be counted
+    as ONE bundle, not one per target column.
+
+    Regression: differentialabundance fans rnaseq/affy/geo/maxquant from a
+    single junction to functional (col 2), plots (col 2) and reporting
+    (col 3).  Keying down-channels by (src_col, tgt_col) counted the
+    col1->col2 and col1->col3 channels as two bundles of the same four
+    lines, over-widening the col1|col2 gap and pushing the (single) bundle
+    off-centre.
+    """
+    from nf_metro.layout.section_placement import _bundles_in_gap
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "examples"
+        / "differentialabundance.mmd"
+    )
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    col_assign = {sid: s.grid_col for sid, s in graph.sections.items()}
+
+    bundles = _bundles_in_gap(graph, col_assign, 1, 2)
+    assert bundles == [4], (
+        f"expected one coalesced 4-line down-bundle in the col1|col2 gap, "
+        f"got {bundles} (the four data lines fanning to cols 2 and 3 were "
+        f"double-counted)"
+    )
+
+
+def test_bundles_in_gap_dedupes_synthetic_fanout():
+    """Minimal synthetic: one source fanning the same line to an adjacent
+    and a bypass column must count as a single source-side bundle."""
+    from nf_metro.layout.section_placement import _bundles_in_gap
+
+    mmd = (
+        "%%metro line: a | A | #ff0000\n"
+        "%%metro line: b | B | #00ff00\n"
+        "%%metro grid: s0 | 0,0\n"
+        "%%metro grid: s1 | 1,0\n"
+        "%%metro grid: s2 | 2,0\n"
+        "graph LR\n"
+        "    subgraph s0 [S0]\n"
+        "        n0[N0]\n"
+        "    end\n"
+        "    subgraph s1 [S1]\n"
+        "        n1[N1]\n"
+        "    end\n"
+        "    subgraph s2 [S2]\n"
+        "        n2[N2]\n"
+        "    end\n"
+        "    n0 -->|a,b| n1\n"
+        "    n0 -->|a,b| n2\n"
+    )
+    graph = parse_metro_mermaid(mmd)
+    compute_layout(graph)
+    col_assign = {sid: s.grid_col for sid, s in graph.sections.items()}
+    # s0 -> s1 (adjacent) and s0 -> s2 (bypass) share lines a,b and coalesce
+    # in the s0|s1 gap: one 2-line bundle, not two.
+    bundles = _bundles_in_gap(graph, col_assign, 0, 1)
+    assert bundles == [2], f"expected one coalesced 2-line bundle, got {bundles}"
+
+
+@pytest.mark.parametrize(
+    "fixture", ["differentialabundance.mmd", "differentialabundance_default.mmd"]
+)
+def test_single_bundle_inter_section_gap_is_centered(fixture):
+    """A lone vertical bundle in an inter-section gap sits centred: the
+    clearance from the left section edge equals the clearance to the right
+    section edge (the gap is x + bundle_width + y with x == y).
+
+    Fails when the gap is over-sized for a phantom second bundle, which
+    pushes the real bundle hard against the source side.
+    """
+    from nf_metro.layout.routing import route_edges
+    from nf_metro.layout.routing.common import column_gap_edges
+
+    path = Path(__file__).resolve().parent.parent / "examples" / fixture
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    routes = route_edges(graph)
+
+    # functional is col 2; inspect the gap immediately to its left.
+    gap_left, gap_right = column_gap_edges(graph, 1, 2)
+    seg_xs = set()
+    for rp in routes:
+        for (x0, y0), (x1, y1) in zip(rp.points, rp.points[1:]):
+            if abs(x1 - x0) < 0.5 and abs(y1 - y0) > 5:
+                xm = (x0 + x1) / 2
+                if gap_left - 2 <= xm <= gap_right + 2:
+                    seg_xs.add(round(xm, 1))
+    assert seg_xs, "expected a vertical bundle in the col1|col2 gap"
+    lo, hi = min(seg_xs), max(seg_xs)
+    left_clear = lo - gap_left
+    right_clear = gap_right - hi
+    assert abs(left_clear - right_clear) <= 3.0, (
+        f"{fixture}: bundle off-centre in col1|col2 gap — "
+        f"left clearance {left_clear:.1f}px vs right {right_clear:.1f}px "
+        f"(gap W={gap_right - gap_left:.1f})"
+    )
+
+
+def _gap_vertical_channels(graph, routes, col_a, col_b):
+    """Return ``[(x, down, line_id)]`` for vertical channel segments in a gap.
+
+    Picks every vertical channel of an inter-section route whose x falls
+    inside the ``(col_a, col_b)`` inter-column gap, tagged with its
+    direction (``down`` True for a southbound segment) and line id.
+    """
+    from nf_metro.layout.constants import COORD_TOLERANCE
+    from nf_metro.layout.routing.common import column_gap_edges
+
+    gap_left, gap_right = column_gap_edges(graph, col_a, col_b)
+    out: list[tuple[float, bool, str]] = []
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        for (x0, y0), (x1, y1) in zip(rp.points, rp.points[1:]):
+            if abs(x1 - x0) < COORD_TOLERANCE and abs(y1 - y0) > COORD_TOLERANCE:
+                if gap_left - 2 <= x0 <= gap_right + 2:
+                    out.append((round(x0, 2), y1 > y0, rp.line_id))
+    return out
+
+
+@pytest.mark.parametrize(
+    "fixture, col_a, col_b, n_distinct",
+    [
+        # variant_calling: junction_6 fans `main` (adjacent col1) and `qc`
+        # (bypass to col3) -- both DOWNWARD in the col0|col1 gap.  Two
+        # distinct lines, bundled exactly OFFSET_STEP apart.
+        ("examples/variant_calling.mmd", 0, 1, 2),
+        # differentialabundance: four data lines fan downward in the gap
+        # left of `functional`, each feeding BOTH plots and reporting.  The
+        # two segments of a given line OVERLAY at one x, so the bundle is
+        # FOUR distinct lines (not eight separate channels), consecutive
+        # distinct lines OFFSET_STEP apart.
+        ("examples/differentialabundance.mmd", 1, 2, 4),
+    ],
+)
+def test_same_direction_lines_in_gap_bundle_at_offset_step(
+    fixture, col_a, col_b, n_distinct
+):
+    """Same-direction inter-section channels sharing a gap form one
+    concentric bundle keyed on DISTINCT line ids: distinct lines are
+    OFFSET_STEP apart, and every segment carrying the same line id overlays
+    at that line's single x (so a line feeding several targets does not
+    claim multiple slots)."""
+    from nf_metro.layout.constants import OFFSET_STEP
+    from nf_metro.layout.routing import route_edges
+
+    path = Path(__file__).resolve().parent.parent / fixture
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    routes = route_edges(graph)
+
+    down = [
+        (x, lid)
+        for x, is_down, lid in _gap_vertical_channels(graph, routes, col_a, col_b)
+        if is_down
+    ]
+    # Every segment of a given line must share that line's single x.
+    per_line: dict[str, set[float]] = {}
+    for x, lid in down:
+        per_line.setdefault(lid, set()).add(x)
+    for lid, xs in per_line.items():
+        assert len(xs) == 1, (
+            f"{fixture}: line {lid} occupies multiple xs {sorted(xs)} in "
+            f"col{col_a}|col{col_b} gap; same-line segments must overlay"
+        )
+
+    distinct_xs = sorted(next(iter(xs)) for xs in per_line.values())
+    assert len(distinct_xs) == n_distinct, (
+        f"{fixture}: expected {n_distinct} distinct downward lines in "
+        f"col{col_a}|col{col_b} gap, got {len(distinct_xs)} at {distinct_xs}"
+    )
+    gaps = [b - a for a, b in zip(distinct_xs, distinct_xs[1:])]
+    assert all(abs(g - OFFSET_STEP) < 0.5 for g in gaps), (
+        f"{fixture}: distinct downward lines not bundled at OFFSET_STEP "
+        f"({OFFSET_STEP}px); spacings {gaps} at xs {distinct_xs}"
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture, gap",
+    [("section_diamond", (0, 1)), ("mixed_port_sides", (0, 1))],
+)
+def test_junction_sourced_bundle_centers_in_gap(fixture, gap):
+    """A vertical channel sourced from a junction (not a section station)
+    centres in its inter-column gap, same as a section-sourced one.
+
+    Before: ``inter_column_channel_x`` only centred when both endpoints had
+    a section; junction sources fell back to near-source placement and hugged
+    one edge (~4px off in section_diamond / mixed_port_sides).  Now junction
+    columns are resolved (when adjacent to the target) and the channel centres.
+    """
+    from nf_metro.layout.routing import route_edges
+    from nf_metro.layout.routing.common import column_gap_edges
+
+    p = None
+    for d in ("topologies", ""):
+        cand = (
+            Path(__file__).resolve().parent.parent / "examples" / d / f"{fixture}.mmd"
+        )
+        if cand.is_file():
+            p = cand
+            break
+    assert p is not None, f"fixture {fixture} not found"
+
+    graph = parse_metro_mermaid(p.read_text())
+    compute_layout(graph)
+    routes = route_edges(graph)
+    gl, gr = column_gap_edges(graph, *gap)
+    xs = set()
+    for rp in routes:
+        for (x0, y0), (x1, y1) in zip(rp.points, rp.points[1:]):
+            if abs(x1 - x0) < 0.5 and abs(y1 - y0) > 5:
+                xm = (x0 + x1) / 2
+                if gl - 2 <= xm <= gr + 2:
+                    xs.add(round(xm, 1))
+    assert xs, f"{fixture}: expected a vertical bundle in gap {gap}"
+    lo, hi = min(xs), max(xs)
+    left_clear, right_clear = lo - gl, gr - hi
+    assert abs(left_clear - right_clear) <= 3.0, (
+        f"{fixture}: junction-sourced bundle off-centre in gap {gap} — "
+        f"left {left_clear:.1f}px vs right {right_clear:.1f}px"
+    )
+
+
+def _all_segments(routes):
+    """Return ``[(line_id, p0, p1)]`` for every segment of every route."""
+    out = []
+    for rp in routes:
+        for p0, p1 in zip(rp.points, rp.points[1:]):
+            out.append((rp.line_id, p0, p1))
+    return out
+
+
+def _count_inter_line_crossings(routes):
+    """Count proper (interior) crossings between segments of distinct lines."""
+
+    def ccw(a, b, c):
+        return (c[1] - a[1]) * (b[0] - a[0]) - (b[1] - a[1]) * (c[0] - a[0])
+
+    def crosses(p1, p2, p3, p4):
+        d1, d2 = ccw(p3, p4, p1), ccw(p3, p4, p2)
+        d3, d4 = ccw(p1, p2, p3), ccw(p1, p2, p4)
+        return ((d1 > 1e-6 and d2 < -1e-6) or (d1 < -1e-6 and d2 > 1e-6)) and (
+            (d3 > 1e-6 and d4 < -1e-6) or (d3 < -1e-6 and d4 > 1e-6)
+        )
+
+    segs = _all_segments(routes)
+    n = 0
+    for i in range(len(segs)):
+        for j in range(i + 1, len(segs)):
+            if segs[i][0] == segs[j][0]:
+                continue
+            if crosses(segs[i][1], segs[i][2], segs[j][1], segs[j][2]):
+                n += 1
+    return n
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "examples/differentialabundance.mmd",
+        "examples/variant_calling.mmd",
+        "examples/variant_calling_tuned.mmd",
+        "examples/variantprioritization.mmd",
+        "examples/genomeassembly.mmd",
+    ],
+)
+def test_normalization_adds_no_inter_line_crossings(fixture):
+    """The gap-channel normalization post-pass must never INTRODUCE a
+    crossing between two different lines that the un-normalized routing did
+    not already have.  (It may remove crossings; it must not add any.)"""
+    import nf_metro.layout.routing.core as core
+    from nf_metro.layout.routing import route_edges
+
+    path = Path(__file__).resolve().parent.parent / fixture
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+
+    orig = core._normalize_gap_channels
+    core._normalize_gap_channels = lambda *a, **k: None
+    try:
+        pre = _count_inter_line_crossings(route_edges(graph))
+    finally:
+        core._normalize_gap_channels = orig
+    post = _count_inter_line_crossings(route_edges(graph))
+
+    assert post <= pre, (
+        f"{fixture}: normalization introduced crossings "
+        f"(pre-normalize {pre}, post-normalize {post})"
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "examples/differentialabundance.mmd",
+        "examples/genomeassembly.mmd",
+    ],
+)
+def test_same_line_segments_in_gap_bundle_share_x(fixture):
+    """Within an inter-column gap, every vertical channel carrying the same
+    line id sits at one x (overlaid), so a fan whose line feeds several
+    targets does not occupy several parallel slots in the bundle."""
+    from nf_metro.layout.constants import COORD_TOLERANCE
+    from nf_metro.layout.routing import route_edges
+    from nf_metro.layout.routing.common import column_gap_edges
+
+    path = Path(__file__).resolve().parent.parent / fixture
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    routes = route_edges(graph)
+
+    cols = sorted({s.grid_col for s in graph.sections.values() if s.bbox_w > 0})
+    channels_seen = 0
+    for lo, hi in zip(cols, cols[1:]):
+        if hi != lo + 1:
+            continue
+        gl, gr = column_gap_edges(graph, lo, hi)
+        # (line_id, down) -> set of xs of its channel segments in this gap
+        per: dict[tuple[str, bool], set[float]] = {}
+        for rp in routes:
+            if not rp.is_inter_section:
+                continue
+            for (x0, y0), (x1, y1) in zip(rp.points, rp.points[1:]):
+                if abs(x1 - x0) >= COORD_TOLERANCE or abs(y1 - y0) <= COORD_TOLERANCE:
+                    continue
+                if gl - 2 <= x0 <= gr + 2:
+                    per.setdefault((rp.line_id, y1 > y0), set()).add(round(x0, 2))
+        for (lid, _down), xs in per.items():
+            channels_seen += 1
+            # Same-line segments must overlay (allow sub-pixel rounding noise).
+            spread = max(xs) - min(xs)
+            assert spread < COORD_TOLERANCE, (
+                f"{fixture}: line {lid} occupies {sorted(xs)} in gap "
+                f"{lo}|{hi}; same-line segments must overlay"
+            )
+    assert channels_seen, f"{fixture}: expected at least one gap channel (sanity check)"
+
+
+def test_around_section_diversion_up_leg_centers_in_row_gap():
+    """A U-shaped diversion routing below a section centres its up-leg in the
+    *row-aware* inter-section gap, not against the column-wide extent.
+
+    Regression: variantbenchmarking diverts the truth/test lines below
+    Preprocessing from Inputs to Variant Normalization.  output_processing
+    sits in the same column (row 1) and extends far right, so the column-wide
+    gap centre was ~873 and the up-leg hugged Normalization (~738).  With
+    row-aware gap edges + symmetric placement the up-leg centres on the
+    row-0 Preprocessing|Normalization gap (~714).
+    """
+    from nf_metro.layout.routing import route_edges
+    from nf_metro.layout.routing.common import column_gap_midpoint
+
+    path = (
+        Path(__file__).resolve().parent.parent / "examples" / "variantbenchmarking.mmd"
+    )
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    routes = route_edges(graph)
+
+    up_leg_x = None
+    for rp in routes:
+        edge = getattr(rp, "edge", None)
+        if (
+            not edge
+            or edge.source != "__junction_13"
+            or "normalization" not in edge.target
+        ):
+            continue
+        # the up-leg is the rightmost vertical segment of the diversion
+        for (x0, y0), (x1, y1) in zip(rp.points, rp.points[1:]):
+            if abs(x1 - x0) < 0.5 and abs(y1 - y0) > 5:
+                xm = (x0 + x1) / 2
+                if up_leg_x is None or xm > up_leg_x:
+                    up_leg_x = xm
+    assert up_leg_x is not None, "expected a diversion to normalization"
+
+    row0_center = column_gap_midpoint(graph, 1, 2, row=0)
+    assert abs(up_leg_x - row0_center) <= 4.0, (
+        f"diversion up-leg x={up_leg_x:.1f} not centred on row-0 gap "
+        f"center {row0_center:.1f} (off {abs(up_leg_x - row0_center):.1f})"
+    )
+
+
+def test_multi_path_gap_separates_by_b_and_centers():
+    """When a downward and an upward path share one inter-section gap, they
+    sit BUNDLE_TO_BUNDLE_CLEARANCE (B) apart, centred as a group
+    (A + w1 + B + w2 + A).
+
+    03b_fan_in_merge's StepA|StepB gap carries a down-path (junction_7) and
+    an up-path (junction_6); they previously overlapped (~5px) and now
+    separate by B and straddle the gap centre.
+    """
+    from nf_metro.layout.constants import BUNDLE_TO_BUNDLE_CLEARANCE
+    from nf_metro.layout.routing import route_edges
+    from nf_metro.layout.routing.common import column_gap_edges
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "examples"
+        / "guide"
+        / "03b_fan_in_merge.mmd"
+    )
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    routes = route_edges(graph)
+    gl, gr = column_gap_edges(graph, 1, 2, row=0)
+    center = (gl + gr) / 2
+
+    down_x = up_x = None
+    for rp in routes:
+        for (x0, y0), (x1, y1) in zip(rp.points, rp.points[1:]):
+            if abs(x1 - x0) < 0.5 and abs(y1 - y0) > 5:
+                xm = (x0 + x1) / 2
+                if gl - 3 <= xm <= gr + 3:
+                    if y1 > y0:
+                        down_x = xm
+                    else:
+                        up_x = xm
+    assert down_x is not None and up_x is not None, "expected a down and an up path"
+    sep = abs(up_x - down_x)
+    assert sep >= BUNDLE_TO_BUNDLE_CLEARANCE - 1, (
+        f"paths only {sep:.1f}px apart; expected >= B={BUNDLE_TO_BUNDLE_CLEARANCE}"
+    )
+    pair_mid = (down_x + up_x) / 2
+    assert abs(pair_mid - center) <= 3.0, (
+        f"path pair midpoint {pair_mid:.1f} not centred on gap {center:.1f}"
+    )


### PR DESCRIPTION
## Summary

Makes inter-section gap routing principled and uniform: one consistent geometry sizes every gap and places every vertical channel, replacing the curve-radius-based sizing and the per-handler channel placement that bundled lines inconsistently.

- **Gap-width formula** (`constants.py`, `section_placement.py`): each inter-section gap is sized `A + Σ bundle_widths + (N-1)·B + A`, where `A` = `EDGE_TO_BUNDLE_CLEARANCE` (section edge → nearest bundle line) and `B` = `BUNDLE_TO_BUNDLE_CLEARANCE` (between adjacent bundles sharing a gap). `_bundles_in_gap` counts the distinct concentric bundles traversing each gap, so a gap claims only the horizontal space its bundles actually occupy.
- **Geometry helpers** (`common.py`): `symmetric_bundle_midpoint` lays out N bundles in a gap (exactly `B` apart, ≥`A` from each section edge); `column_gap_edges` / `column_gap_midpoint` and the `col_*_edge` helpers are row-aware, so a diversion travelling in one row isn't skewed by a wide section stacked in another row of the same column.
- **Uniform channel placement** (`core.py`): a post-routing pass re-stacks every inter-section vertical channel into its final position the same way regardless of which handler routed it — lines running the same direction in a gap bundle `OFFSET_STEP` apart (segments of a single line overlaid at one x), a downward bundle and an upward bundle sharing a gap separate by `B`, a lone bundle centres, and the per-line order is chosen to minimise crossings. Routes whose channels follow their own concentric loop (wrap / around-section / top-entry) are exempt.

## Why

Inter-section channels were placed independently by each routing handler (bypass, L-shape, inline, merge), so lines sharing a gap bundled inconsistently — same-direction runs could overlap or spread apart, and two paths could cross needlessly — while gaps were sized from the outermost L-shape curve radius rather than the traffic they carry. A single post-routing normalization makes placement uniform, and the gap-width formula makes sizing reflect actual bundle widths.

## Testing

- Full suite green: 2584 passed, 8 known xfails unchanged, plus new invariants for gap sizing, single-bundle centring, same-direction bundling/overlay, down/up B-separation, and no-added-crossings.
- Gallery render-diff vs `main`: 31 of 57 renders change — inter-section bundles are centred / B-separated consistently, same-colour lines overlaid, and crossings minimised, with no overlaps, breeze-past, kinks, or bbox overflow. `genomeassembly_staggered` and `section_diamond` are unchanged.
