### PR TITLE
refactor(routing): adopt Direction enum across all core.py handlers

### DIFF
--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -25,6 +25,21 @@ class Direction(Enum):
     U = "U"  # north, -y
     D = "D"  # south, +y
 
+    @property
+    def sign(self) -> float:
+        """``+1.0`` for R / D (positive axis), ``-1.0`` for L / U."""
+        return 1.0 if self in (Direction.R, Direction.D) else -1.0
+
+
+def horizontal_direction(dx: float) -> Direction:
+    """``Direction.R`` if ``dx > 0`` else ``Direction.L`` (ties resolve to L)."""
+    return Direction.R if dx > 0 else Direction.L
+
+
+def vertical_direction(dy: float) -> Direction:
+    """``Direction.D`` if ``dy > 0`` else ``Direction.U`` (ties resolve to U)."""
+    return Direction.D if dy > 0 else Direction.U
+
 
 # ---------------------------------------------------------------------------
 # Grid-position helpers

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -487,6 +487,8 @@ def _route_inter_section(
     tx, ty = tgt.x, tgt.y
     dx = tx - sx
     dy = ty - sy
+    horizontal = Direction.R if dx > 0 else Direction.L
+    vertical = Direction.D if dy > 0 else Direction.U
 
     i, n = ctx.bundle_info.get((edge.source, edge.target, edge.line_id), (0, 1))
 
@@ -575,12 +577,12 @@ def _route_inter_section(
         delta, r_first, r_second = l_shape_radii(
             i,
             n,
-            going_down=(dy > 0),
+            going_down=vertical is Direction.D,
             offset_step=ctx.offset_step,
             base_radius=ctx.curve_radius,
         )
         # Push channel away from target into the inter-column gap.
-        if dx < 0:
+        if horizontal is Direction.L:
             vx = sx + ctx.curve_radius + ctx.offset_step + delta
         else:
             vx = sx - ctx.curve_radius - ctx.offset_step + delta
@@ -596,7 +598,12 @@ def _route_inter_section(
     # channel around the right side of the target section so the route
     # goes over the top and in from the right, rather than cutting
     # horizontally through the section interior.
-    if tgt_port and tgt_port.is_entry and tgt_port.side == PortSide.RIGHT and dx > 0:
+    if (
+        tgt_port
+        and tgt_port.is_entry
+        and tgt_port.side == PortSide.RIGHT
+        and horizontal is Direction.R
+    ):
         return _route_right_entry_wrap(edge, src, tgt, i, n, ctx)
 
     # Non-bypass edges to merge junctions: route to entry port.
@@ -674,24 +681,25 @@ def _route_merge_branch(
     """
     sx, sy = src.x, src.y
     dx = ctx.graph.stations[edge.target].x - sx
-    trunk_dir = 1.0 if dx > 0 else -1.0
+    trunk: Direction = Direction.R if dx > 0 else Direction.L
+    trunk_sign = 1.0 if trunk is Direction.R else -1.0
     src_off = _get_offset(ctx, edge.source, edge.line_id)
 
     # Trunk bypass Y level (branches drop to meet it)
     by = ctx.merge.trunk_by.get(edge.target, sy)
 
     # Position descent at MERGE_ROUTE_MARGIN from section edge
-    if dx > 0:
+    if trunk is Direction.R:
         lead_x = col_right_edge(ctx.graph, src_col) + MERGE_ROUTE_MARGIN
     else:
         lead_x = col_left_edge(ctx.graph, src_col) - MERGE_ROUTE_MARGIN
     # Clamp to at least curve_radius from the junction
-    min_lead = sx + trunk_dir * ctx.curve_radius
-    if trunk_dir > 0:
+    min_lead = sx + trunk_sign * ctx.curve_radius
+    if trunk is Direction.R:
         lead_x = max(lead_x, min_lead)
     else:
         lead_x = min(lead_x, min_lead)
-    tail_x = lead_x + trunk_dir * ctx.curve_radius * 2
+    tail_x = lead_x + trunk_sign * ctx.curve_radius * 2
 
     return RoutedPath(
         edge=edge,
@@ -762,7 +770,8 @@ def _route_bypass(
     if effective_tx is None:
         effective_tx = tx
     dx = tx - sx
-    going_right = dx > 0
+    horizontal = Direction.R if dx > 0 else Direction.L
+    going_right = horizontal is Direction.R
     graph = ctx.graph
 
     ekey = (edge.source, edge.target, edge.line_id)
@@ -1027,11 +1036,13 @@ def _route_top_entry_l_shape(
     tx, ty = tgt.x, tgt.y
     dx = tx - sx
     dy = ty - sy
+    vertical = Direction.D if dy > 0 else Direction.U
+    going_down = vertical is Direction.D
 
     delta, r_first, r_second = l_shape_radii(
         i,
         n,
-        going_down=(dy > 0),
+        going_down=going_down,
         offset_step=ctx.offset_step,
         base_radius=ctx.curve_radius,
     )
@@ -1047,16 +1058,17 @@ def _route_top_entry_l_shape(
     # line continues with the bundle flow before curving down.
     r_lead = ctx.curve_radius
     if abs(dx) > r_lead:
-        lead_sign = 1.0 if dx > 0 else -1.0
+        lead: Direction = Direction.R if dx > 0 else Direction.L
     else:
-        lead_sign = 1.0  # default rightward
+        lead = Direction.R  # default
         if src.id in ctx.graph.junctions:
             for je in ctx.graph.edges:
                 if je.target == src.id:
                     js = ctx.graph.stations.get(je.source)
                     if js and js.is_port:
-                        lead_sign = 1.0 if js.x < src.x else -1.0
+                        lead = Direction.R if js.x < src.x else Direction.L
                         break
+    lead_sign = 1.0 if lead is Direction.R else -1.0
     lx = sx + lead_sign * r_lead
     # When the lead-in point is close to the target X, skip the
     # intermediate horizontal channel and drop straight down from the
@@ -1100,11 +1112,12 @@ def _route_right_entry_wrap(
     sx, sy = src.x, src.y
     tx, ty = tgt.x, tgt.y
     dy = ty - sy
+    vertical = Direction.D if dy > 0 else Direction.U
 
     delta, r_first, r_second = l_shape_radii(
         i,
         n,
-        going_down=(dy > 0),
+        going_down=vertical is Direction.D,
         offset_step=ctx.offset_step,
         base_radius=ctx.curve_radius,
     )

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -30,6 +30,7 @@ from nf_metro.layout.constants import (
 )
 from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.routing.common import (
+    Direction,
     RoutedPath,
     bypass_bottom_y,
     col_left_edge,
@@ -920,7 +921,10 @@ def _route_l_shape(
     tx, ty = tgt.x, tgt.y
     dx = tx - sx
     dy = ty - sy
-    going_down = dy > 0
+    horizontal = Direction.R if dx > 0 else Direction.L
+    vertical = Direction.D if dy > 0 else Direction.U
+    going_down = vertical is Direction.D
+    h_sign = 1.0 if horizontal is Direction.R else -1.0
 
     # When the junction has both L-shape and bypass siblings, use
     # unified fan-out positions so all lines share one concentric
@@ -938,10 +942,7 @@ def _route_l_shape(
             base_radius=ctx.curve_radius,
         )
         # mid_x places all lines so they diverge at sx
-        if dx > 0:
-            mid_x = sx + ctx.curve_radius + (un - 1) * ctx.offset_step / 2
-        else:
-            mid_x = sx - ctx.curve_radius - (un - 1) * ctx.offset_step / 2
+        mid_x = sx + h_sign * (ctx.curve_radius + (un - 1) * ctx.offset_step / 2)
         # Second corner: from sub-bundle (only L-shape siblings turn here)
         _, _, r_second = l_shape_radii(
             i,

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -37,9 +37,11 @@ from nf_metro.layout.routing.common import (
     col_right_edge,
     column_gap_midpoint,
     compute_bundle_info,
+    horizontal_direction,
     inter_column_channel_x,
     inter_row_channel_y,
     resolve_section,
+    vertical_direction,
 )
 from nf_metro.layout.routing.corners import (
     bypass_radii,
@@ -487,8 +489,8 @@ def _route_inter_section(
     tx, ty = tgt.x, tgt.y
     dx = tx - sx
     dy = ty - sy
-    horizontal = Direction.R if dx > 0 else Direction.L
-    vertical = Direction.D if dy > 0 else Direction.U
+    horizontal = horizontal_direction(dx)
+    vertical = vertical_direction(dy)
 
     i, n = ctx.bundle_info.get((edge.source, edge.target, edge.line_id), (0, 1))
 
@@ -681,25 +683,24 @@ def _route_merge_branch(
     """
     sx, sy = src.x, src.y
     dx = ctx.graph.stations[edge.target].x - sx
-    trunk: Direction = Direction.R if dx > 0 else Direction.L
-    trunk_sign = 1.0 if trunk is Direction.R else -1.0
+    horizontal = horizontal_direction(dx)
     src_off = _get_offset(ctx, edge.source, edge.line_id)
 
     # Trunk bypass Y level (branches drop to meet it)
     by = ctx.merge.trunk_by.get(edge.target, sy)
 
     # Position descent at MERGE_ROUTE_MARGIN from section edge
-    if trunk is Direction.R:
+    if horizontal is Direction.R:
         lead_x = col_right_edge(ctx.graph, src_col) + MERGE_ROUTE_MARGIN
     else:
         lead_x = col_left_edge(ctx.graph, src_col) - MERGE_ROUTE_MARGIN
     # Clamp to at least curve_radius from the junction
-    min_lead = sx + trunk_sign * ctx.curve_radius
-    if trunk is Direction.R:
+    min_lead = sx + horizontal.sign * ctx.curve_radius
+    if horizontal is Direction.R:
         lead_x = max(lead_x, min_lead)
     else:
         lead_x = min(lead_x, min_lead)
-    tail_x = lead_x + trunk_sign * ctx.curve_radius * 2
+    tail_x = lead_x + horizontal.sign * ctx.curve_radius * 2
 
     return RoutedPath(
         edge=edge,
@@ -770,7 +771,7 @@ def _route_bypass(
     if effective_tx is None:
         effective_tx = tx
     dx = tx - sx
-    horizontal = Direction.R if dx > 0 else Direction.L
+    horizontal = horizontal_direction(dx)
     going_right = horizontal is Direction.R
     graph = ctx.graph
 
@@ -930,10 +931,9 @@ def _route_l_shape(
     tx, ty = tgt.x, tgt.y
     dx = tx - sx
     dy = ty - sy
-    horizontal = Direction.R if dx > 0 else Direction.L
-    vertical = Direction.D if dy > 0 else Direction.U
+    horizontal = horizontal_direction(dx)
+    vertical = vertical_direction(dy)
     going_down = vertical is Direction.D
-    h_sign = 1.0 if horizontal is Direction.R else -1.0
 
     # When the junction has both L-shape and bypass siblings, use
     # unified fan-out positions so all lines share one concentric
@@ -951,7 +951,9 @@ def _route_l_shape(
             base_radius=ctx.curve_radius,
         )
         # mid_x places all lines so they diverge at sx
-        mid_x = sx + h_sign * (ctx.curve_radius + (un - 1) * ctx.offset_step / 2)
+        mid_x = sx + horizontal.sign * (
+            ctx.curve_radius + (un - 1) * ctx.offset_step / 2
+        )
         # Second corner: from sub-bundle (only L-shape siblings turn here)
         _, _, r_second = l_shape_radii(
             i,
@@ -1036,7 +1038,7 @@ def _route_top_entry_l_shape(
     tx, ty = tgt.x, tgt.y
     dx = tx - sx
     dy = ty - sy
-    vertical = Direction.D if dy > 0 else Direction.U
+    vertical = vertical_direction(dy)
     going_down = vertical is Direction.D
 
     delta, r_first, r_second = l_shape_radii(
@@ -1058,9 +1060,9 @@ def _route_top_entry_l_shape(
     # line continues with the bundle flow before curving down.
     r_lead = ctx.curve_radius
     if abs(dx) > r_lead:
-        lead: Direction = Direction.R if dx > 0 else Direction.L
+        lead = horizontal_direction(dx)
     else:
-        lead = Direction.R  # default
+        lead = Direction.R
         if src.id in ctx.graph.junctions:
             for je in ctx.graph.edges:
                 if je.target == src.id:
@@ -1068,8 +1070,7 @@ def _route_top_entry_l_shape(
                     if js and js.is_port:
                         lead = Direction.R if js.x < src.x else Direction.L
                         break
-    lead_sign = 1.0 if lead is Direction.R else -1.0
-    lx = sx + lead_sign * r_lead
+    lx = sx + lead.sign * r_lead
     # When the lead-in point is close to the target X, skip the
     # intermediate horizontal channel and drop straight down from the
     # lead-in, curving into the target at the end.  This avoids a
@@ -1112,7 +1113,7 @@ def _route_right_entry_wrap(
     sx, sy = src.x, src.y
     tx, ty = tgt.x, tgt.y
     dy = ty - sy
-    vertical = Direction.D if dy > 0 else Direction.U
+    vertical = vertical_direction(dy)
 
     delta, r_first, r_second = l_shape_radii(
         i,

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -25,7 +25,12 @@ from dataclasses import dataclass
 from enum import Enum
 
 from nf_metro.layout.constants import COORD_TOLERANCE_FINE
-from nf_metro.layout.routing.common import Direction, RoutedPath
+from nf_metro.layout.routing.common import (
+    Direction,
+    RoutedPath,
+    horizontal_direction,
+    vertical_direction,
+)
 
 # Segments shorter than this are sub-pixel artefacts of per-line
 # offsets and carry no meaningful direction of travel.
@@ -110,8 +115,8 @@ def _segment_cardinal(
     if abs(dx) < _MIN_SEGMENT_LENGTH and abs(dy) < _MIN_SEGMENT_LENGTH:
         return None
     if abs(dx) >= abs(dy):
-        return Direction.R if dx > 0 else Direction.L
-    return Direction.D if dy > 0 else Direction.U
+        return horizontal_direction(dx)
+    return vertical_direction(dy)
 
 
 def check_bundle_order_preserved(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -264,3 +264,55 @@ def test_merge_branch_lands_on_trunk_y():
         f"{fp.name}: route endpoints hanging in mid-air (not on a "
         f"station marker or sibling route segment):\n  " + "\n  ".join(offences[:5])
     )
+
+
+def test_l_shape_route_quadrant_symmetry():
+    """An L-shape route and its 180-degree mirror must produce mirrored
+    geometry: same 4-point shape, same curve radii, with all (x,y) offsets
+    from the source negated. This pins down direction handling inside
+    ``_route_l_shape`` so future direction-enum refactors cannot silently
+    swap a sign on one branch only.
+    """
+
+    def _route_one(src_col: int, src_row: int, tgt_col: int, tgt_row: int):
+        # Two single-station sections with forced exit/entry sides on the
+        # axis between them, so the inter-section edge takes the standard
+        # 4-point L-shape (horizontal -> vertical -> horizontal).
+        if tgt_col > src_col:
+            exit_side, entry_side = "right", "left"
+        else:
+            exit_side, entry_side = "left", "right"
+        graph = parse_metro_mermaid(
+            "%%metro line: main | Main | #ff0000\n"
+            f"%%metro grid: s1 | {src_col},{src_row}\n"
+            f"%%metro grid: s2 | {tgt_col},{tgt_row}\n"
+            "graph LR\n"
+            "    subgraph s1 [S1]\n"
+            f"        %%metro exit: {exit_side} | main\n"
+            "        a[A]\n"
+            "    end\n"
+            "    subgraph s2 [S2]\n"
+            f"        %%metro entry: {entry_side} | main\n"
+            "        b[B]\n"
+            "    end\n"
+            "    a -->|main| b\n"
+        )
+        compute_layout(graph)
+        routes = route_edges(graph)
+        inter = [r for r in routes if r.is_inter_section and len(r.points) == 4]
+        assert len(inter) == 1, f"expected 1 L-shape inter-section route, got {inter}"
+        return inter[0]
+
+    # Mirror pair: target down-right vs target up-left, same Manhattan distance.
+    rd = _route_one(0, 0, 1, 1)  # dx>0, dy>0  -> R/D
+    lu = _route_one(1, 1, 0, 0)  # dx<0, dy<0  -> L/U
+
+    # Mirror in source-relative coordinates.
+    rd_rel = [(p[0] - rd.points[0][0], p[1] - rd.points[0][1]) for p in rd.points]
+    lu_rel = [(p[0] - lu.points[0][0], p[1] - lu.points[0][1]) for p in lu.points]
+    for a, b in zip(rd_rel, lu_rel):
+        assert abs(a[0] + b[0]) < 1e-6, f"x mirror broken: {a} vs {b}"
+        assert abs(a[1] + b[1]) < 1e-6, f"y mirror broken: {a} vs {b}"
+
+    # Curve radii are direction-agnostic and must match exactly.
+    assert rd.curve_radii == lu.curve_radii


### PR DESCRIPTION
Closes #395.

## Summary

Migrates `core.py`'s routing handlers to use the `Direction` enum at their internals, replacing the inline `dy > 0` / `dx > 0` / `going_down` / `trunk_dir` patterns with typed enum members.  Each handler converts signed deltas into `Direction.R/L/U/D` at one explicit boundary via `horizontal_direction(dx)` / `vertical_direction(dy)` helpers; downstream code branches on enum identity (`vertical is Direction.D`) and derives scalar signs via `Direction.sign`.

## API additions

In `src/nf_metro/layout/routing/common.py`:

* `Direction.sign` property — `+1.0` for R / D, `-1.0` for L / U.
* `horizontal_direction(dx: float) -> Direction` — convenience for the seven bootstrap sites.
* `vertical_direction(dy: float) -> Direction` — same.

## Handlers migrated

| Handler | What changed |
|---|---|
| `_route_l_shape` | `horizontal` / `vertical` typed; consolidates `dx > 0` / `dx < 0` branches in the fan-out `mid_x` calculation; all `l_shape_radii(going_down=...)` calls use the derived bool. |
| `_route_top_entry_l_shape` | `vertical` typed; `lead: Direction` replaces `lead_sign = 1.0 if dx > 0 else -1.0`; upstream-port fallback writes `Direction.R` / `Direction.L`. |
| `_route_right_entry_wrap` | `vertical` typed at top; `l_shape_radii(going_down=...)` consumes derived bool. |
| `_route_bypass` | `horizontal` bootstraps the existing `going_right` adapter. |
| `_route_merge_branch` | `horizontal` replaces the ad-hoc `trunk_dir` scalar; `lead_x` branching uses `horizontal is Direction.R`; `Direction.sign` provides the arithmetic factor. |
| `_route_inter_section` (dispatcher) | `horizontal` / `vertical` typed; the same-column-junction branch and the RIGHT-entry-wrap dispatch use the typed values. |
| `_route_diagonal` | No change (uses `abs(dx)` + shared `_compute_diagonal_placement`; no inline sign branch). |

`invariants._segment_cardinal` was also refactored to use the new helpers.

## Test

`test_l_shape_route_quadrant_symmetry`: pins the 180-degree mirror invariant for `_route_l_shape` — source-to-target in mirrored quadrants must produce mirrored offsets and identical curve radii.  Catches future sign-flip slips before they reach the gallery render-diff.

## Verification

* `pytest`: **2375 passed**.
* `ruff check` + `ruff format --check`: clean.
* Gallery render diff vs `main`: **0 changes**.

## Out of scope, tracked

* **#397** — corner-radius helpers in `corners.py` (`l_shape_radii`, `bypass_radii`, `corner_radius`) still take `going_down: bool`. Each handler currently keeps a `going_down = vertical is Direction.D` adapter alias to feed those.  Migrating those helpers to take `Direction` directly closes the remaining adapter pattern; filed as a follow-up.
* **#394** — wiring `WRAP_TABLE` into the dispatcher (blocked on #393).
* **#393** — descriptor / propagator parity drift.
