### PR TITLE
chore: retire propagator references; drop unused Section.flip_lines

### DIFF
--- a/src/nf_metro/layout/routing/inter_section.py
+++ b/src/nf_metro/layout/routing/inter_section.py
@@ -1,23 +1,21 @@
 """Declarative inter-section routing descriptors.
 
-:data:`WRAP_TABLE` maps ``(exit_side, entry_side, drow_sign,
-dcol_sign)`` to a :class:`WrapDescriptor` recording the corner
-sequence and its handedness-change parity.  ``exit_side`` is ``None``
-when the source is a junction without a port side; ``drow_sign`` /
-``dcol_sign`` are ``sign()`` values in ``{-1, 0, +1}``.
+:data:`WRAP_TABLE` catalogues the corner sequence each handler in
+``core.py`` produces, keyed by ``(exit_side, entry_side, drow_sign,
+dcol_sign)``.  ``exit_side`` is ``None`` when the source is a
+junction without a port side; ``drow_sign`` / ``dcol_sign`` are
+``sign()`` values in ``{-1, 0, +1}``.
 
-Parity contract: a route whose corner sequence has an odd number of
-CW <-> CCW transitions reverses the bundle's outer/inner ordering
-between source and target.  A future section-DAG propagator must
-agree with the descriptor's parity, else routes visibly cross at
-the entry-port quarter-circles.  The alignment test in
-``tests/test_inter_section_descriptor.py`` keeps the table
-internally consistent against the same row-delta contribution the
-propagator will compute.
+The table is a documentation reference: nothing in routing consumes
+it at runtime.  Bundle ordering across complex paths is preserved
+by the per-corner offset propagation inside the wrap-route
+handlers (handedness-aware radii at each turn); the runtime
+:func:`~nf_metro.layout.routing.invariants.check_bundle_order_preserved`
+guard catches any regression.
 
 Same-row L-shapes and the TB ``(BOTTOM, TOP, 1, 0)`` straight drop
-are deliberately absent: their geometric parity disagrees with the
-propagator's row-delta ``is_wrap`` flag.
+are absent because they're degenerate cases the wrap handlers
+don't fire on; the dispatcher's if-cascade handles them directly.
 """
 
 from __future__ import annotations
@@ -141,10 +139,9 @@ class TurnSequence:
         """``True`` iff the sequence has an odd number of handedness changes.
 
         A "change" is a pair of consecutive corners whose handedness
-        differs (CW->CCW or CCW->CW).  When parity is True, the
-        bundle's outer/inner ordering reverses between the route's
-        first and last corner - the condition a future section-DAG
-        propagator will reflect via ``Section.flip_lines``.
+        differs (CW->CCW or CCW->CW).  Recorded for descriptor-level
+        documentation; runtime wrap handlers preserve bundle ordering
+        via per-corner offset propagation regardless of this value.
 
         Examples
         --------

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -151,10 +151,6 @@ class Section:
     offset_y: float = 0.0
     # Implicit sections are auto-created for loose stations; no visible box
     is_implicit: bool = False
-    # Manual override that reverses the section's line-track order
-    # relative to graph.lines' definition order, to match a cross-row
-    # wrap entry whose zigzag inverts bundle ordering.
-    flip_lines: bool = False
 
 
 @dataclass

--- a/tests/test_inter_section_descriptor.py
+++ b/tests/test_inter_section_descriptor.py
@@ -1,10 +1,7 @@
-"""Tests for the inter-section routing descriptor scaffolding.
+"""Tests for the inter-section routing descriptor catalogue.
 
-These tests pin down the parity contract of :class:`TurnSequence`
-and check that every entry in :data:`WRAP_TABLE` agrees with the
-row-delta parity contribution a future section-DAG propagator will
-assign.  Catches descriptor/propagator drift before the table is
-wired into the dispatcher.
+Pin down :class:`TurnSequence`'s parity-counting contract and
+sanity-check the structure of every :data:`WRAP_TABLE` entry.
 """
 
 from __future__ import annotations
@@ -107,37 +104,8 @@ def test_wrap_descriptor_parity_delegates_to_turn_sequence():
 
 
 # ---------------------------------------------------------------------------
-# WRAP_TABLE alignment check
+# WRAP_TABLE structural checks
 # ---------------------------------------------------------------------------
-#
-# The future section-DAG propagator will set each section's flip parity as
-# ``flip[tgt] = flip[src] XOR (drow_sign != 0)``, with roots at
-# ``flip = False``.  For a fresh section reached from a root predecessor,
-# the parity contribution is therefore exactly ``drow_sign != 0``.  Every
-# descriptor's :attr:`TurnSequence.parity` must equal that contribution
-# or routes visibly cross at the entry-port quarter-circles.
-
-
-def test_wrap_table_parity_matches_propagator_contribution():
-    """Every WRAP_TABLE entry's parity matches the row-delta contribution.
-
-    For an edge with ``drow_sign = D``, the future propagator
-    contributes ``D != 0`` to the target section's flip flag.  Each
-    descriptor's ``TurnSequence.parity`` must equal that contribution.
-    """
-    mismatches: list[str] = []
-    for key, descriptor in WRAP_TABLE.items():
-        _exit_side, _entry_side, drow_sign, _dcol_sign = key
-        propagator_contribution = drow_sign != 0
-        if descriptor.parity != propagator_contribution:
-            mismatches.append(
-                f"{key} ({descriptor.kind}): descriptor.parity = "
-                f"{descriptor.parity}, propagator_contribution = "
-                f"{propagator_contribution}"
-            )
-    assert not mismatches, "WRAP_TABLE / propagator drift:\n  " + "\n  ".join(
-        mismatches
-    )
 
 
 def test_wrap_table_keys_are_well_formed():


### PR DESCRIPTION
Closes #393 (parity drift) and #394 (wire WRAP_TABLE into dispatcher).

## Background

The descriptor scaffolding landed in PR #387 documented a hypothetical future section-DAG propagator (`_propagate_wrap_flip_parity`) that would set `Section.flip_lines` and feed `WRAP_TABLE`.  Neither exists in the codebase:

- `_propagate_wrap_flip_parity` was implemented and then rolled back in #387 before merging.
- `Section.flip_lines` had its single reader (`offsets._flip_offsets_in_wrap_sections`) removed in the same rollback.

The bundle-ordering problem the propagator was meant to solve is handled instead by **per-corner offset propagation** inside the wrap-route handlers (handedness-aware radii at each turn — landing in PR #388).  The runtime `check_bundle_order_preserved` invariant catches any regression.  A third layer of defense (the propagator) would be redundant.

## Changes

- `inter_section.py` module docstring + `TurnSequence.parity` docstring: drop "future propagator" / `_propagate_wrap_flip_parity` / `Section.flip_lines` references; describe `WRAP_TABLE` as a documentation catalogue.
- `test_inter_section_descriptor.py`: drop `test_wrap_table_parity_matches_propagator_contribution` (it tested a contract no consumer enforces).
- `parser/model.py`: delete the unused `Section.flip_lines` field.

## Verification

- `pytest`: **2374 passed** (one less than main: the dropped propagator-alignment test).
- `ruff check` + `ruff format --check`: clean.
- Gallery render diff vs `main`: **0 changes**.