### PR TITLE
fix: make example mmds parse in stock Mermaid

### DIFF
--- a/examples/variantbenchmarking.mmd
+++ b/examples/variantbenchmarking.mmd
@@ -56,15 +56,15 @@ graph LR
         samplesheet -->|test| _inputs_hub
     end
 
-    subgraph preprocess [Preprocessing (Optional)]
+    subgraph preprocess ["Preprocessing (Optional)"]
         %%metro entry: left | truth, test
         %%metro exit: right | truth, test
         subsample[Subsample]
-        liftover[Liftover\n(Picard, UCSC)]
+        liftover["Liftover\n(Picard, UCSC)"]
         subsample -->|test| liftover
     end
 
-    subgraph normalization [Variant Normalization (Optional)]
+    subgraph normalization ["Variant Normalization (Optional)"]
         %%metro entry: left | truth, test
         %%metro exit: right | truth, test
         sv_processing[SV\nProcessing]
@@ -72,7 +72,7 @@ graph LR
         sv_processing -->|test| var_norm
     end
 
-    subgraph filtering [Variant Filtering (Optional)]
+    subgraph filtering ["Variant Filtering (Optional)"]
         %%metro entry: left | test
         %%metro exit: right | test
         filter_contigs[Filter\nContigs]

--- a/examples/variantbenchmarking_auto.mmd
+++ b/examples/variantbenchmarking_auto.mmd
@@ -47,19 +47,19 @@ graph LR
         samplesheet -->|test| _inputs_hub
     end
 
-    subgraph preprocess [Preprocessing (Optional)]
+    subgraph preprocess ["Preprocessing (Optional)"]
         subsample[Subsample]
-        liftover[Liftover\n(Picard, UCSC)]
+        liftover["Liftover\n(Picard, UCSC)"]
         subsample -->|test| liftover
     end
 
-    subgraph normalization [Variant Normalization (Optional)]
+    subgraph normalization ["Variant Normalization (Optional)"]
         sv_processing[SV\nProcessing]
         var_norm[Variant\nNormalization]
         sv_processing -->|test| var_norm
     end
 
-    subgraph filtering [Variant Filtering (Optional)]
+    subgraph filtering ["Variant Filtering (Optional)"]
         filter_contigs[Filter\nContigs]
         bcftools_filter[bcftools\nfilter]
         survivor_filter[SURVIVOR\nfilter]

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -121,7 +121,7 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
         if subgraph_m:
             section_id = subgraph_m.group(1)
             display_name = subgraph_m.group(2) or section_id
-            section = Section(id=section_id, name=display_name.strip())
+            section = Section(id=section_id, name=_unquote(display_name.strip()))
             graph.add_section(section)
             current_section_id = section_id
             continue
@@ -180,6 +180,19 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
 
 # Subgraph pattern: subgraph id [Display Name]
 _SUBGRAPH_PATTERN = re.compile(r"^subgraph\s+(\w+)\s*(?:\[(.+?)\])?\s*$")
+
+
+def _unquote(text: str) -> str:
+    """Strip one pair of surrounding double quotes from a title or label.
+
+    Mermaid requires special characters such as parentheses to be wrapped in
+    double quotes (e.g. ``["Liftover (Picard)"]``) so the diagram parses on
+    GitHub. The quotes are escaping syntax, not part of the displayed text, so
+    they are removed here, leaving the inner text untouched.
+    """
+    if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+        return text[1:-1]
+    return text
 
 
 def _parse_directive(
@@ -364,6 +377,7 @@ def _parse_node(
         if m:
             node_id = m.group(1)
             label = m.group(2).strip() if m.lastindex >= 2 else node_id
+            label = _unquote(label)
             # Convert literal \n sequences to real newlines (multi-line labels)
             if "\\n" in label:
                 label = "\n".join(part.strip() for part in label.split("\\n"))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -124,6 +124,32 @@ def test_parse_multiline_label_multiple_breaks():
     assert graph.stations["node"].label == "A\nB\nC"
 
 
+def test_parse_quoted_label_strips_quotes():
+    """Double-quoted labels (Mermaid escaping for parens) lose the quotes."""
+    text = 'graph LR\n    liftover["Liftover (Picard, UCSC)"]\n'
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["liftover"].label == "Liftover (Picard, UCSC)"
+
+
+def test_parse_quoted_label_with_newline():
+    r"""A quoted label keeps \\n handling after the quotes are stripped."""
+    text = r"graph LR" + "\n" + r'    liftover["Liftover \n (Picard, UCSC)"]' + "\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["liftover"].label == "Liftover\n(Picard, UCSC)"
+
+
+def test_parse_quoted_subgraph_title_strips_quotes():
+    """Double-quoted subgraph titles render without the surrounding quotes."""
+    text = (
+        "graph LR\n"
+        '    subgraph prep ["Preprocessing (Optional)"]\n'
+        "        a[A]\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.sections["prep"].name == "Preprocessing (Optional)"
+
+
 def test_parse_edges():
     text = "graph LR\n    a[Input]\n    b[Output]\n    a -->|main| b\n"
     graph = parse_metro_mermaid(text)


### PR DESCRIPTION
GitHub's built-in Mermaid renderer aborts with a parse error on the variantbenchmarking example mmds because several subgraph titles and a node label contain parentheses:

```
Parse error on line 27:
...cess [Preprocessing (Optional)]
Expecting 'SQE', ... got 'PS'
```

Mermaid only allows special characters like parens inside a title/label when the text is wrapped in double quotes. This PR:

- Quotes the affected titles/labels in `examples/variantbenchmarking.mmd` and `examples/variantbenchmarking_auto.mmd` (`["Preprocessing (Optional)"]`, `["Liftover\n(Picard, UCSC)"]`, etc.).
- Strips a single surrounding pair of double quotes in the parser (`_unquote`), applied to subgraph titles and node labels, so nf-metro's own render is byte-for-byte unchanged.

Verified against the live Mermaid parser: the quoted form parses, and `\n` inside the quotes still renders as a line break. nf-metro's render is unchanged (same section names, same multi-line label). Added parser tests for quote stripping on labels (with and without `\n`) and subgraph titles.

These metro maps still won't render as metro maps on GitHub (the `%%metro` layout is ours, not stock Mermaid), but the source now parses cleanly instead of erroring out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)