### PR TITLE
fix(routing): join fan-out upstream tails to downstream curve start

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -579,9 +579,7 @@ def _guard_fanout_tail_join(
     travel direction (no visible apex notch).
 
     See :func:`nf_metro.layout.routing.invariants.check_fanout_tail_join`
-    for the semantic definition.  A purely perpendicular offset (an inner
-    concentric-corner member's approach Y) is tolerated; only an
-    along-travel "bite" is a violation.
+    for the semantic definition.
     """
     from nf_metro.layout.routing.invariants import check_fanout_tail_join
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -566,6 +566,43 @@ def _guard_bundle_order_preserved(
     raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
 
 
+def _guard_fanout_tail_join(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict | None = None,
+    routes: list | None = None,
+) -> None:
+    """Final-phase: at every single-source fan-out junction, each
+    upstream ``port -> junction`` route must hand off to its same-line
+    downstream ``junction -> target`` route with no gap along the line's
+    travel direction (no visible apex notch).
+
+    See :func:`nf_metro.layout.routing.invariants.check_fanout_tail_join`
+    for the semantic definition.  A purely perpendicular offset (an inner
+    concentric-corner member's approach Y) is tolerated; only an
+    along-travel "bite" is a violation.
+    """
+    from nf_metro.layout.routing.invariants import check_fanout_tail_join
+
+    if routes is None:
+        from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+        if offsets is None:
+            offsets = compute_station_offsets(graph)
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+            return
+
+    gaps = check_fanout_tail_join(routes, graph)
+    if not gaps:
+        return
+    first = gaps[0]
+    extra = f" (+{len(gaps) - 1} more)" if len(gaps) > 1 else ""
+    raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
+
+
 def _guard_off_track_inputs_above_consumer(graph: MetroGraph, phase: str) -> None:
     """After Stage 4.5 and final: off-track input stations must sit at
     least ``GUARD_TOLERANCE`` above (smaller Y than) their on-track
@@ -1475,6 +1512,7 @@ def _compute_section_layout(
                 graph, phase, offsets=offsets, routes=routes
             )
             _guard_bundle_order_preserved(graph, phase, offsets=offsets, routes=routes)
+            _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -177,6 +177,7 @@ def route_edges(
     _center_bubble_stations(routes, graph)
     _spread_diagonal_bundles(routes, ctx)
     _normalize_gap_channels(routes, ctx)
+    _join_fanout_upstream_tails(routes, ctx)
 
     return routes
 
@@ -3292,6 +3293,66 @@ def _normalize_gap_channels(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
                 continue
             for ch, (li, nx) in targets:
                 _restack_channel(ch, nx, li, n, step, ctx.curve_radius)
+
+
+def _join_fanout_upstream_tails(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
+    """Snap each fan-out junction's upstream tail onto its downstream start.
+
+    At a *fan-out* junction (single upstream source, one or more
+    inter-section targets), the incoming ``port -> junction`` route and
+    the outgoing ``junction -> target`` route are two separate
+    :class:`RoutedPath`\\ s.  Their handoff points at the junction don't
+    coincide: the downstream route carries the per-line bundle offset
+    (and, for L-shape fans, a curve lead-in that starts a ``curve_radius``
+    past the junction), while the upstream route ends at the bare junction
+    coordinate.  The mismatch renders as a seam / notch where the two
+    segments meet end-to-end instead of one continuous flowing line.
+
+    This pass extends the upstream route's final, horizontal segment so
+    it ends at the X of the paired (same ``line_id``) downstream route's
+    first waypoint -- closing the horizontal "bite" at the apex that
+    otherwise shows as a notch (the downstream L-shape lead-in starts a
+    ``curve_radius`` PAST the junction, leaving a gap along the line's
+    travel direction between the upstream tail end and the downstream
+    curve start).
+
+    The upstream tail's Y is kept unchanged: when the downstream start
+    carries a per-line bundle ``offset`` (the inner concentric-corner
+    member), the residual PERPENDICULAR offset between the extended
+    upstream end and the downstream start is sub-line-width and hidden
+    under the stroke.  Lifting the upstream Y to match would either tilt
+    the approach or step it, reintroducing a visible kink at the apex, so
+    only the X is extended.  Only the upstream tail is moved; the
+    downstream geometry is left untouched.
+
+    Gated to genuine single-upstream-source fan-out junctions.  Merge
+    junctions (>1 distinct upstream source) are excluded so their trunk
+    routing, which intentionally lands branches on a shared bypass Y, is
+    never perturbed.
+    """
+    from nf_metro.layout.routing.invariants import fanout_junctions
+
+    fanouts = fanout_junctions(ctx.graph)
+    if not fanouts:
+        return
+
+    downstream_start: dict[tuple[str, str], tuple[float, float]] = {}
+    for r in routes:
+        if r.edge.source in fanouts and r.points:
+            downstream_start.setdefault((r.edge.source, r.line_id), r.points[0])
+
+    for r in routes:
+        if r.edge.target not in fanouts or len(r.points) < 2:
+            continue
+        target = downstream_start.get((r.edge.target, r.line_id))
+        if target is None:
+            continue
+        p_prev, p_last = r.points[-2], r.points[-1]
+        # Only a genuinely-horizontal final segment is extended; extend
+        # its X to the downstream start X, keeping the upstream Y so the
+        # approach into the bend stays horizontal.
+        if abs(p_prev[1] - p_last[1]) <= COORD_TOLERANCE_FINE:
+            r.points[-1] = (target[0], p_last[1])
 
 
 def _distinct_line_order(chans: list[_VChannel]) -> list[str]:

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -3330,29 +3330,26 @@ def _join_fanout_upstream_tails(routes: list[RoutedPath], ctx: _RoutingCtx) -> N
     routing, which intentionally lands branches on a shared bypass Y, is
     never perturbed.
     """
-    from nf_metro.layout.routing.invariants import fanout_junctions
+    from nf_metro.layout.routing.invariants import (
+        _fanout_route_maps,
+        fanout_junctions,
+    )
 
     fanouts = fanout_junctions(ctx.graph)
     if not fanouts:
         return
 
-    downstream_start: dict[tuple[str, str], tuple[float, float]] = {}
-    for r in routes:
-        if r.edge.source in fanouts and r.points:
-            downstream_start.setdefault((r.edge.source, r.line_id), r.points[0])
-
-    for r in routes:
-        if r.edge.target not in fanouts or len(r.points) < 2:
+    upstream, downstream = _fanout_route_maps(routes, fanouts)
+    for (jid, line_id), up in upstream.items():
+        down = downstream.get((jid, line_id))
+        if down is None or len(up.points) < 2:
             continue
-        target = downstream_start.get((r.edge.target, r.line_id))
-        if target is None:
-            continue
-        p_prev, p_last = r.points[-2], r.points[-1]
+        p_prev, p_last = up.points[-2], up.points[-1]
         # Only a genuinely-horizontal final segment is extended; extend
         # its X to the downstream start X, keeping the upstream Y so the
         # approach into the bend stays horizontal.
         if abs(p_prev[1] - p_last[1]) <= COORD_TOLERANCE_FINE:
-            r.points[-1] = (target[0], p_last[1])
+            up.points[-1] = (down.points[0][0], p_last[1])
 
 
 def _distinct_line_order(chans: list[_VChannel]) -> list[str]:

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -272,6 +272,30 @@ def fanout_junctions(graph) -> dict[str, str]:  # noqa: ANN001 - MetroGraph (avo
     return result
 
 
+def _fanout_route_maps(
+    routes: list[RoutedPath],
+    fanouts: dict[str, str],
+) -> tuple[dict[tuple[str, str], RoutedPath], dict[tuple[str, str], RoutedPath]]:
+    """Index fan-out-incident routes by ``(junction_id, line_id)``.
+
+    Returns ``(upstream, downstream)``: ``upstream`` holds each
+    ``port -> junction`` route, ``downstream`` the first
+    ``junction -> target`` route for that line.  Both the apex-gap check
+    and the routing pass that closes it consume these maps, so the keying
+    is defined once.
+    """
+    upstream: dict[tuple[str, str], RoutedPath] = {}
+    downstream: dict[tuple[str, str], RoutedPath] = {}
+    for r in routes:
+        if not r.points:
+            continue
+        if r.edge.target in fanouts:
+            upstream[(r.edge.target, r.line_id)] = r
+        if r.edge.source in fanouts:
+            downstream.setdefault((r.edge.source, r.line_id), r)
+    return upstream, downstream
+
+
 def check_fanout_tail_join(
     routes: list[RoutedPath],
     graph,  # noqa: ANN001 - MetroGraph (avoid import cycle)
@@ -293,15 +317,7 @@ def check_fanout_tail_join(
     if not fanouts:
         return []
 
-    upstream: dict[tuple[str, str], RoutedPath] = {}
-    downstream: dict[tuple[str, str], RoutedPath] = {}
-    for r in routes:
-        if not r.points:
-            continue
-        if r.edge.target in fanouts:
-            upstream[(r.edge.target, r.line_id)] = r
-        if r.edge.source in fanouts:
-            downstream.setdefault((r.edge.source, r.line_id), r)
+    upstream, downstream = _fanout_route_maps(routes, fanouts)
 
     gaps: list[FanoutTailGap] = []
     for (jid, line_id), up in upstream.items():

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -207,8 +207,138 @@ def _check_pair(
     return None
 
 
+# ---------------------------------------------------------------------------
+# Fan-out junction tail join
+# ---------------------------------------------------------------------------
+
+# A gap ALONG the upstream travel direction reads as a visible "bite"
+# at the corner apex (the line stops short of its own bend); anything
+# larger than this is the seam / notch the fix closes.  A PERPENDICULAR
+# gap up to a stroke width is hidden under the line and tolerated.
+_TAIL_JOIN_TANGENT_TOLERANCE = 1.0
+
+
+@dataclass(frozen=True)
+class FanoutTailGap:
+    """One upstream/downstream handoff mismatch at a fan-out junction.
+
+    ``junction_id`` is the fan-out junction; ``line_id`` the metro line
+    whose ``port -> junction`` route ends at ``upstream_end`` while its
+    paired ``junction -> target`` route begins at ``downstream_start``.
+    ``tangent_gap`` is the component of the offset ALONG the upstream
+    travel direction -- the visible along-line "bite" at the apex.
+    """
+
+    junction_id: str
+    line_id: str
+    upstream_source: str
+    downstream_target: str
+    upstream_end: tuple[float, float]
+    downstream_start: tuple[float, float]
+    tangent_gap: float
+
+    def message(self) -> str:
+        ux, uy = self.upstream_end
+        dx, dy = self.downstream_start
+        return (
+            f"fan-out junction {self.junction_id!r} line {self.line_id!r}: "
+            f"upstream {self.upstream_source!r}->{self.junction_id!r} ends at "
+            f"({ux:.1f},{uy:.1f}) but downstream {self.junction_id!r}->"
+            f"{self.downstream_target!r} starts at ({dx:.1f},{dy:.1f}); "
+            f"along-travel gap {self.tangent_gap:.1f}px > "
+            f"{_TAIL_JOIN_TANGENT_TOLERANCE:.1f}px (visible apex notch)"
+        )
+
+
+def fanout_junctions(graph) -> dict[str, str]:  # noqa: ANN001 - MetroGraph (avoid cycle)
+    """Map each *fan-out* junction id to its single upstream source id.
+
+    A fan-out junction is a junction station fed by edges from exactly
+    ONE distinct upstream source (a single exit port or upstream
+    junction) and fanning out to one or more inter-section targets.
+    Merge junctions (>1 distinct upstream source) are excluded: their
+    trunk routing intentionally lands branches on a shared bypass Y and
+    must not be snapped together at the junction.
+    """
+    junction_ids = graph.junction_ids
+    result: dict[str, str] = {}
+    for jid in junction_ids:
+        sources = {e.source for e in graph.edges_to(jid)}
+        if len(sources) != 1:
+            continue
+        if not any(True for _ in graph.edges_from(jid)):
+            continue
+        result[jid] = next(iter(sources))
+    return result
+
+
+def check_fanout_tail_join(
+    routes: list[RoutedPath],
+    graph,  # noqa: ANN001 - MetroGraph (avoid import cycle)
+) -> list[FanoutTailGap]:
+    """Return gaps where a fan-out junction's upstream tail does not meet
+    its paired downstream route.
+
+    For every fan-out junction (see :func:`fanout_junctions`), the
+    component of the offset between an incoming ``port -> junction``
+    route's end and the SAME-line outgoing ``junction -> target`` route's
+    start, measured ALONG the upstream travel direction, must be within
+    ``_TAIL_JOIN_TANGENT_TOLERANCE``.  A larger along-travel gap is the
+    visible apex notch (the line stops short of its own bend) that this
+    invariant guards against.  A purely perpendicular offset (the inner
+    bundle member's concentric approach Y) is hidden under the stroke and
+    not flagged.
+    """
+    fanouts = fanout_junctions(graph)
+    if not fanouts:
+        return []
+
+    upstream: dict[tuple[str, str], RoutedPath] = {}
+    downstream: dict[tuple[str, str], RoutedPath] = {}
+    for r in routes:
+        if not r.points:
+            continue
+        if r.edge.target in fanouts:
+            upstream[(r.edge.target, r.line_id)] = r
+        if r.edge.source in fanouts:
+            downstream.setdefault((r.edge.source, r.line_id), r)
+
+    gaps: list[FanoutTailGap] = []
+    for (jid, line_id), up in upstream.items():
+        down = downstream.get((jid, line_id))
+        if down is None or len(up.points) < 2:
+            continue
+        ux, uy = up.points[-1]
+        dx, dy = down.points[0]
+        # Travel direction of the upstream tail (its last segment).
+        p_prev = up.points[-2]
+        tx, ty = ux - p_prev[0], uy - p_prev[1]
+        seg_len = (tx * tx + ty * ty) ** 0.5
+        if seg_len < _MIN_SEGMENT_LENGTH:
+            continue
+        # Project the (downstream_start - upstream_end) offset onto the
+        # unit travel direction: the along-line component.
+        tangent_gap = abs(((dx - ux) * tx + (dy - uy) * ty) / seg_len)
+        if tangent_gap > _TAIL_JOIN_TANGENT_TOLERANCE:
+            gaps.append(
+                FanoutTailGap(
+                    junction_id=jid,
+                    line_id=line_id,
+                    upstream_source=up.edge.source,
+                    downstream_target=down.edge.target,
+                    upstream_end=(ux, uy),
+                    downstream_start=(dx, dy),
+                    tangent_gap=tangent_gap,
+                )
+            )
+    return gaps
+
+
 __all__ = [
     "BundleOrderViolation",
+    "FanoutTailGap",
     "Side",
     "check_bundle_order_preserved",
+    "check_fanout_tail_join",
+    "fanout_junctions",
 ]

--- a/tests/test_fanout_tail_join_invariant.py
+++ b/tests/test_fanout_tail_join_invariant.py
@@ -1,0 +1,92 @@
+"""Tests for the fan-out junction tail-join invariant.
+
+At a fan-out junction (single upstream source, one or more outgoing
+inter-section targets), the upstream ``port -> junction`` route must
+end exactly where the paired same-line ``junction -> target`` route
+begins, so the corner renders as one continuous line rather than two
+segments meeting end-to-end with a notch / seam.
+
+Covers:
+
+* Happy-path: every gallery fixture and example routes with zero
+  fan-out tail gaps.
+* Targeted: ``variant_calling_tuned`` ``__junction_6`` (the reported
+  defect) joins continuously for both ``main`` and ``qc``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.invariants import (
+    check_fanout_tail_join,
+    fanout_junctions,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOPOLOGIES = REPO_ROOT / "tests" / "fixtures" / "topologies"
+EXAMPLES = REPO_ROOT / "examples"
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = []
+    paths.extend(sorted(TOPOLOGIES.glob("*.mmd")))
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    return paths
+
+
+def _route(path: Path):
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    routes = route_edges(graph, station_offsets=compute_station_offsets(graph))
+    return graph, routes
+
+
+@pytest.mark.parametrize(
+    "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
+)
+def test_no_fanout_tail_gaps_in_gallery(path: Path) -> None:
+    """Every shipped topology and example routes without a fan-out
+    junction tail gap (continuous upstream/downstream handoff)."""
+    graph, routes = _route(path)
+    gaps = check_fanout_tail_join(routes, graph)
+    assert not gaps, "\n".join(g.message() for g in gaps)
+
+
+def test_variant_calling_tuned_junction6_joins() -> None:
+    """The reported defect: __junction_6 in variant_calling_tuned, where
+    main (green) and qc (blue) fan out together, must hand off
+    continuously between the upstream and downstream routes."""
+    path = EXAMPLES / "variant_calling_tuned.mmd"
+    graph, routes = _route(path)
+
+    # Sanity: __junction_6 is a genuine single-source fan-out junction.
+    fanouts = fanout_junctions(graph)
+    assert "__junction_6" in fanouts
+
+    gaps = check_fanout_tail_join(routes, graph)
+    j6_gaps = [g for g in gaps if g.junction_id == "__junction_6"]
+    assert not j6_gaps, "\n".join(g.message() for g in j6_gaps)
+
+
+def test_merge_junctions_excluded_from_fanout() -> None:
+    """Merge junctions (>1 upstream source) must NOT be treated as
+    fan-out junctions, so their trunk routing is never snapped."""
+    # sarek-style fixtures carry merge junctions; assert any junction
+    # with multiple distinct upstream sources is excluded.
+    for path in _gather_fixtures():
+        graph = parse_metro_mermaid(path.read_text())
+        compute_layout(graph)
+        fanouts = fanout_junctions(graph)
+        for jid in graph.junction_ids:
+            sources = {e.source for e in graph.edges_to(jid)}
+            if len(sources) > 1:
+                assert jid not in fanouts, (
+                    f"{path.name}: merge junction {jid} "
+                    f"({len(sources)} sources) wrongly classified as fan-out"
+                )


### PR DESCRIPTION
## Summary
- Close the corner seam/notch at fan-out junctions: extend each upstream `port→junction` route's horizontal tail to meet its downstream `junction→target` route's start X, so the line flows continuously through the turn instead of two segments butt-joining with a gap.
- Gated to single-upstream-source fan-out junctions; merge junctions (>1 upstream source) are untouched.

## Why
At a fan-out junction the upstream and downstream routes are separate paths whose handoff X didn't coincide (e.g. `variant_calling_tuned` `__junction_6`: upstream ended at x=272, downstream started at x=275). That 3px tangential gap rendered as a dark notch at the outer line's corner apex and a visible "two lines meeting end-to-end" seam. The corner radii were already correctly concentric (shared arc center), so this is purely a path-handoff fix.

## Testing
- New invariant `tests/test_fanout_tail_join_invariant.py` (gallery happy-path + targeted `__junction_6` case + merge-junction-exclusion assertion); fails on the bug, passes with the fix.
- Runtime validator `check_fanout_tail_join` / `fanout_junctions` in `routing/invariants.py`, plus `_guard_fanout_tail_join` wired into `compute_layout(validate=True)`.
- Full suite: 2601 passed, 3 skipped, 8 xfailed. `ruff format --check` and `ruff check` clean.
- Gallery diff vs `main`: 4/57 renders changed (`nf_variant_calling`, `nf_variant_calling_tuned`, `nf_variant_calling_tuned_icons`, `nf_with_subworkflows`) — all corner-notch improvements; the other 53 byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
