### PR TITLE
fix(layout): restore symmetric section top padding (#406)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -173,6 +173,11 @@ def _guard_section_bboxes_positive(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _bbox_cols_overlap(a: Section, b: Section) -> bool:
+    """True when two sections' bboxes overlap in X (share horizontal extent)."""
+    return a.bbox_x < b.bbox_x + b.bbox_w and b.bbox_x < a.bbox_x + a.bbox_w
+
+
 def _guard_row_gaps(graph: MetroGraph, phase: str, *, section_y_gap: float) -> None:
     """Final phase: column-overlapping adjacent-row section pairs must
     keep at least ``section_y_gap`` between the upper section's bbox
@@ -196,9 +201,7 @@ def _guard_row_gaps(graph: MetroGraph, phase: str, *, section_y_gap: float) -> N
             continue
         next_row = us.grid_row + us.grid_row_span
         for lsid, ls in sections_by_row_start.get(next_row, []):
-            if not (
-                us.bbox_x < ls.bbox_x + ls.bbox_w and ls.bbox_x < us.bbox_x + us.bbox_w
-            ):
+            if not _bbox_cols_overlap(us, ls):
                 continue
             gap = ls.bbox_y - (us.bbox_y + us.bbox_h)
             deficit = section_y_gap - gap
@@ -1485,15 +1488,6 @@ def _compute_section_layout(
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.14")
 
-    # Stage 6.15: Restore canvas-wide grid alignment after all settling.
-    # Stage 6.4 snaps to a per-row grid; later helpers (notably
-    # ``_shift_graph_into_canvas`` shifting by ``section_y_padding -
-    # min_top``, which is not a multiple of ``y_spacing`` when padding
-    # is not a grid multiple) can introduce a uniform half-grid drift.
-    # When every real station shares a single non-zero residue, shift
-    # the whole canvas by the smallest signed amount that returns them
-    # to integer multiples of ``y_spacing``.  No-op when residues are
-    # mixed (e.g. sarek-style multi-row layouts).
     # Stage 6.15a: Restore top padding symmetric with the bottom.  Fan
     # re-distribution (Stages 4.9 / 4.10 / 6.7 / 6.11) can lift a branch
     # above the content-top line the bbox was sized for, crowding the
@@ -1507,6 +1501,15 @@ def _compute_section_layout(
     _grow_bboxes_to_content_top(graph, section_y_padding, section_y_gap)
     _shift_graph_into_canvas(graph, section_y_padding)
 
+    # Stage 6.15: Restore canvas-wide grid alignment after all settling.
+    # Stage 6.4 snaps to a per-row grid; later helpers (notably
+    # ``_shift_graph_into_canvas`` shifting by ``section_y_padding -
+    # min_top``, which is not a multiple of ``y_spacing`` when padding
+    # is not a grid multiple) can introduce a uniform half-grid drift.
+    # When every real station shares a single non-zero residue, shift
+    # the whole canvas by the smallest signed amount that returns them
+    # to integer multiples of ``y_spacing``.  No-op when residues are
+    # mixed (e.g. sarek-style multi-row layouts).
     _snap_canvas_y_to_grid(graph, y_spacing, section_y_padding)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.15")
@@ -4698,16 +4701,15 @@ def _section_content_top_target(
 
     Mirror of the bottom anchor in :func:`_shrink_bboxes_to_content_bottom`:
     the top sits ``section_y_padding`` above the highest content marker
-    (bypass helpers use curve-only clearance; ports must stay inside with
-    no extra pad).  Bounded so it never rises within ``section_y_gap +
-    SECTION_HEADER_PROTRUSION`` of a column-overlapping section in the
-    row above.  The plain ``section_y_gap`` (matching
-    :func:`_guard_row_gaps`) keeps the bboxes apart, but inter-section
-    routes dip into that gap and must clear this section's header badge,
-    which protrudes ``SECTION_HEADER_PROTRUSION`` above its bbox top;
-    reserving that protrusion keeps the grow from crowding the badge up
-    against a route passing over the section's columns.  Returns
-    ``None`` when the section has no real content to anchor to.
+    (bypass helpers use curve-only clearance; ports must stay inside).
+
+    The bound against the row above reserves ``section_y_gap +
+    SECTION_HEADER_PROTRUSION``, not just the bbox gap: the section's
+    header badge protrudes ``SECTION_HEADER_PROTRUSION`` above its bbox
+    top, and inter-section routes dip into the gap, so reserving the
+    protrusion keeps the grow from crowding the badge into a route.
+
+    Returns ``None`` when the section has no real content to anchor to.
     """
     content_min_ys = [
         graph.stations[sid].y
@@ -4743,10 +4745,7 @@ def _section_content_top_target(
             continue
         if other.grid_row + max(1, other.grid_row_span) != section.grid_row:
             continue
-        if not (
-            other.bbox_x < section.bbox_x + section.bbox_w
-            and section.bbox_x < other.bbox_x + other.bbox_w
-        ):
+        if not _bbox_cols_overlap(other, section):
             continue
         above_bots.append(other.bbox_y + other.bbox_h)
     if above_bots:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -44,6 +44,7 @@ from nf_metro.layout.constants import (
     ROW_GAP,
     SECTION_GAP,
     SECTION_X_GAP,
+    SECTION_HEADER_PROTRUSION,
     SECTION_X_PADDING,
     SECTION_Y_GAP,
     SECTION_Y_PADDING,
@@ -212,6 +213,39 @@ def _guard_row_gaps(graph: MetroGraph, phase: str, *, section_y_gap: float) -> N
         f"apart, expected >= {section_y_gap:.1f}px "
         f"(deficit {deficit:.1f}px)"
     )
+
+
+def _guard_section_top_padding(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    section_y_padding: float,
+    section_y_gap: float,
+) -> None:
+    """Final phase: each section's bbox top must clear its highest marker.
+
+    The mirror of the bottom-padding contract.  After
+    :func:`_grow_bboxes_to_content_top` runs, every section's bbox top
+    should sit at its content-anchored target (a full ``section_y_padding``
+    above the highest marker, unless gap-bounded by the row above).  A
+    bbox top below that target means a later pass crowded the topmost
+    marker against the box edge (issue #406).
+    """
+    tol = 1.0
+    for section in graph.sections.values():
+        if section.bbox_h <= 0:
+            continue
+        target = _section_content_top_target(
+            graph, section, section_y_padding, section_y_gap
+        )
+        if target is None:
+            continue
+        if section.bbox_y > target + tol:
+            raise PhaseInvariantError(
+                f"{phase}: section {section.id!r} bbox top {section.bbox_y:.1f} "
+                f"sits below its content-anchored target {target:.1f} "
+                f"(highest marker crowds the bbox top edge)"
+            )
 
 
 def _station_marker_bbox(
@@ -1460,6 +1494,19 @@ def _compute_section_layout(
     # the whole canvas by the smallest signed amount that returns them
     # to integer multiples of ``y_spacing``.  No-op when residues are
     # mixed (e.g. sarek-style multi-row layouts).
+    # Stage 6.15a: Restore top padding symmetric with the bottom.  Fan
+    # re-distribution (Stages 4.9 / 4.10 / 6.7 / 6.11) can lift a branch
+    # above the content-top line the bbox was sized for, crowding the
+    # topmost marker against the bbox top while the bottom keeps its full
+    # band.  Grow each bbox top to a full ``section_y_padding`` above the
+    # highest marker (bounded by the row above) so content fanning above
+    # the trunk sits centred in its box.  The upward growth can push the
+    # topmost section above the canvas top margin, so re-fit; the
+    # re-fit's non-grid shift is then cleaned up by the Stage 6.15
+    # canvas snap below.
+    _grow_bboxes_to_content_top(graph, section_y_padding, section_y_gap)
+    _shift_graph_into_canvas(graph, section_y_padding)
+
     _snap_canvas_y_to_grid(graph, y_spacing, section_y_padding)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.15")
@@ -1470,6 +1517,9 @@ def _compute_section_layout(
         _guard_row_trunk_cy_consistent(graph, phase, offsets=offsets)
         _guard_off_track_inputs_above_consumer(graph, phase)
         _guard_row_gaps(graph, phase, section_y_gap=section_y_gap)
+        _guard_section_top_padding(
+            graph, phase, section_y_padding=section_y_padding, section_y_gap=section_y_gap
+        )
         if routes is not None:
             _guard_inter_section_routes_in_row_band(
                 graph, phase, offsets=offsets, routes=routes
@@ -4636,6 +4686,103 @@ def _shrink_bboxes_to_content_bottom(
         new_h = desired_bot - section.bbox_y
         if new_h < section.bbox_h - 0.5:
             section.bbox_h = max(0.0, new_h)
+
+
+def _section_content_top_target(
+    graph: MetroGraph,
+    section: Section,
+    section_y_padding: float,
+    section_y_gap: float,
+) -> float | None:
+    """Return the bbox top that gives ``section`` a full top padding band.
+
+    Mirror of the bottom anchor in :func:`_shrink_bboxes_to_content_bottom`:
+    the top sits ``section_y_padding`` above the highest content marker
+    (bypass helpers use curve-only clearance; ports must stay inside with
+    no extra pad).  Bounded so it never rises within ``section_y_gap +
+    SECTION_HEADER_PROTRUSION`` of a column-overlapping section in the
+    row above.  The plain ``section_y_gap`` (matching
+    :func:`_guard_row_gaps`) keeps the bboxes apart, but inter-section
+    routes dip into that gap and must clear this section's header badge,
+    which protrudes ``SECTION_HEADER_PROTRUSION`` above its bbox top;
+    reserving that protrusion keeps the grow from crowding the badge up
+    against a route passing over the section's columns.  Returns
+    ``None`` when the section has no real content to anchor to.
+    """
+    content_min_ys = [
+        graph.stations[sid].y
+        for sid in section.station_ids
+        if (
+            sid in graph.stations
+            and not graph.stations[sid].is_port
+            and not sid.startswith("__bypass_")
+        )
+    ]
+    if not content_min_ys:
+        return None
+    bypass_min_ys = [
+        graph.stations[sid].y
+        for sid in section.station_ids
+        if sid in graph.stations and sid.startswith("__bypass_")
+    ]
+    port_min_ys = [
+        graph.stations[sid].y
+        for sid in section.station_ids
+        if sid in graph.stations and graph.stations[sid].is_port
+    ]
+    v_curve_clearance = CURVE_RADIUS + MIN_STATION_FLAT_LENGTH / 2
+    target = min(content_min_ys) - section_y_padding
+    if bypass_min_ys:
+        target = min(target, min(bypass_min_ys) - v_curve_clearance)
+    if port_min_ys:
+        target = min(target, min(port_min_ys))
+
+    above_bots: list[float] = []
+    for other in graph.sections.values():
+        if other.id == section.id or other.bbox_w <= 0 or other.bbox_h <= 0:
+            continue
+        if other.grid_row + max(1, other.grid_row_span) != section.grid_row:
+            continue
+        if not (
+            other.bbox_x < section.bbox_x + section.bbox_w
+            and section.bbox_x < other.bbox_x + other.bbox_w
+        ):
+            continue
+        above_bots.append(other.bbox_y + other.bbox_h)
+    if above_bots:
+        target = max(
+            target, max(above_bots) + section_y_gap + SECTION_HEADER_PROTRUSION
+        )
+    return target
+
+
+def _grow_bboxes_to_content_top(
+    graph: MetroGraph,
+    section_y_padding: float,
+    section_y_gap: float,
+) -> None:
+    """Grow section bbox tops so the highest marker keeps a full padding band.
+
+    Symmetric counterpart to :func:`_shrink_bboxes_to_content_bottom`.
+    Fan-redistribution passes (Stages 4.9 / 4.10 / 6.7 / 6.11) can lift a
+    branch station above the content-top line the bbox was sized for,
+    leaving the topmost marker crowded against the bbox top while the
+    bottom keeps its full ``section_y_padding`` band -- so a fan
+    symmetric about the trunk reads as pushed up within its box
+    (issue #406).
+
+    Grow-only: the top is never lowered, so intentional top-flush row
+    alignment from :func:`_top_align_row_bboxes_only` is preserved.  TOP
+    ports follow the new edge via :func:`_grow_section_bbox_upward`.
+    """
+    for section in graph.sections.values():
+        if section.bbox_h <= 0:
+            continue
+        target = _section_content_top_target(
+            graph, section, section_y_padding, section_y_gap
+        )
+        if target is not None and target < section.bbox_y - 0.5:
+            _grow_section_bbox_upward(graph, section, target)
 
 
 def _tighten_lower_rows_after_shrink(graph: MetroGraph, section_y_gap: float) -> None:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -43,8 +43,8 @@ from nf_metro.layout.constants import (
     OFFSET_STEP,
     ROW_GAP,
     SECTION_GAP,
-    SECTION_X_GAP,
     SECTION_HEADER_PROTRUSION,
+    SECTION_X_GAP,
     SECTION_X_PADDING,
     SECTION_Y_GAP,
     SECTION_Y_PADDING,
@@ -1521,7 +1521,10 @@ def _compute_section_layout(
         _guard_off_track_inputs_above_consumer(graph, phase)
         _guard_row_gaps(graph, phase, section_y_gap=section_y_gap)
         _guard_section_top_padding(
-            graph, phase, section_y_padding=section_y_padding, section_y_gap=section_y_gap
+            graph,
+            phase,
+            section_y_padding=section_y_padding,
+            section_y_gap=section_y_gap,
         )
         if routes is not None:
             _guard_inter_section_routes_in_row_band(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2112,6 +2112,79 @@ def test_section_bbox_has_bottom_padding(fixture):
     )
 
 
+# Section bbox top doesn't carry the configured section_y_padding above
+# the highest station marker (the mirror of bottom padding).  Affects
+# sections whose content fans above the trunk: a fan-redistribution pass
+# lifts a station above the content-top line the bbox was sized for,
+# crowding the topmost marker against the bbox top while the bottom keeps
+# its full band.  Sections gap-bounded against the row above (where full
+# top padding would crowd the section-header badge against an inter-row
+# route) belong here as xfails.
+_XFAIL_BBOX_TOP_PAD: dict[str, str] = {
+    "differentialabundance_default.mmd": (
+        "plots is gap-bounded: growing its top to a full padding band would "
+        "bring its section-header badge within the inter-row route clearance "
+        "(test_routed_paths_clear_next_row_headers), so the top-padding "
+        "restore deliberately stops short. Revisit if the row gap or routing "
+        "changes."
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    _params_with_xfails(ALL_FIXTURES, _XFAIL_BBOX_TOP_PAD),
+)
+def test_section_bbox_has_top_padding(fixture):
+    """Each section's bbox top must sit at least ``section_y_padding``
+    above the centre Y of its highest internal station.
+
+    Symmetric counterpart to ``test_section_bbox_has_bottom_padding``.
+    The codebase convention measures padding from the station's centre
+    Y, so the invariant is ``bbox_top <= min(station.y) -
+    section_y_padding``.
+
+    Fan-redistribution passes (Stages 4.9 / 4.10 / 6.7 / 6.11) lift a
+    branch station above the trunk after the section bbox was sized for
+    the pre-fan content extent.  Without a top-padding restore the
+    topmost marker sits ~10px from the bbox top while the bottom keeps
+    its full 50px, leaving the box visibly uncentred about the trunk
+    (issue #406).
+    """
+    from nf_metro.layout.constants import SECTION_Y_PADDING
+
+    graph = _layout(fixture)
+    tol = 1.0
+
+    offenders: list[str] = []
+    for sec in graph.sections.values():
+        if sec.bbox_h <= 0:
+            continue
+        port_ids = set(sec.entry_ports) | set(sec.exit_ports)
+        internal_ys = [
+            graph.stations[sid].y
+            for sid in sec.station_ids
+            if sid in graph.stations
+            and sid not in port_ids
+            and not graph.stations[sid].is_hidden
+        ]
+        if not internal_ys:
+            continue
+        highest_marker_cy = min(internal_ys)
+        gap = highest_marker_cy - sec.bbox_y
+        if gap + tol < SECTION_Y_PADDING:
+            offenders.append(
+                f"section {sec.id!r}: bbox top={sec.bbox_y:.1f}, "
+                f"highest marker cy={highest_marker_cy:.1f}, "
+                f"gap={gap:.1f} < section_y_padding={SECTION_Y_PADDING}"
+            )
+
+    assert not offenders, (
+        f"{fixture}: section bbox tops must sit at least "
+        f"section_y_padding above the highest station centre: " + "; ".join(offenders)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Inter-row gap accommodates grown bboxes from Stage 6.14 shifts
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Section bbox top padding was asymmetric: the top was anchored to `trunk_y - SECTION_Y_PADDING` while the bottom grew with content (`lowest_marker + SECTION_Y_PADDING`). A fan symmetric about the trunk therefore read as pushed up, with the topmost marker ~10px from the bbox top while the bottom kept its full 50px band (issue #406).

This adds a top-padding restore mirroring the existing bottom contract:

- **New Stage 6.15a** `_grow_bboxes_to_content_top` grows each section's bbox top to a full `SECTION_Y_PADDING` above its highest marker, so content fanning above the trunk sits centred in its box. Grow-only, so intentional top-flush row alignment is preserved; TOP ports follow the new edge.
- Bounded against the row above by `section_y_gap + SECTION_HEADER_PROTRUSION` so a grown lower-row box never crowds its section-header badge into an inter-section route passing over it.
- Shared `_section_content_top_target` helper feeds both the grow pass and a new final-boundary runtime guard `_guard_section_top_padding`.
- New invariant test `test_section_bbox_has_top_padding`, parametrised over all fixtures (mirror of `test_section_bbox_has_bottom_padding`). `differentialabundance_default` is xfailed: its `plots` section is legitimately gap-bounded (full top padding would push its header badge into the inter-row route clearance).
- Extracted a shared `_bbox_cols_overlap` predicate (was inlined in `_guard_row_gaps` and the new helper).

Affected gallery examples (fan-above-trunk sections) become vertically centred on their trunk: `trunk_through_fan`, `terminal_symmetric_fan`, `rnaseq_sections`, `genomeassembly_organellar`, `differentialabundance`. No clipping or overlap; the tallest top-row box rises to sit at the standard canvas margin and shorter row-mates shift down.

Fixes #406

## Test plan
- [x] pytest passes (2641 passed, 9 xfailed) including the new invariant test
- [x] `ruff check` + `ruff format --check` clean on `src/` and `tests/`
- [x] Runtime validator `_guard_section_top_padding` added and wired into the `validate=True` block
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/409/)
- [ ] Render-preview verdict: deltas expected (layout change) — to be classified I/N

🤖 Generated with [Claude Code](https://claude.com/claude-code)
