### PR TITLE
fix(layout): re-anchor junctions after late loop-station shift (#386)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -636,6 +636,43 @@ def _guard_off_track_inputs_above_consumer(graph: MetroGraph, phase: str) -> Non
             )
 
 
+def _guard_fanout_junction_shares_exit_port_y(graph: MetroGraph, phase: str) -> None:
+    """A fan-out junction fed by an LR/RL exit port must share that port's Y.
+
+    ``_position_junctions`` anchors such a junction at the exit port's Y so the
+    bundle runs straight from exit to junction.  When a late settling pass
+    moves the exit port without re-running junction positioning, the junction
+    is stranded above/below the port and the fanned routes dip to the stale
+    junction Y and back (#386).  BOTTOM/TOP exit ports are intentionally offset
+    from their junction, so only LEFT/RIGHT exits are checked.
+    """
+    for jid in graph.junction_ids:
+        junction = graph.stations.get(jid)
+        if junction is None:
+            continue
+        port_preds = {
+            e.source
+            for e in graph.edges_to(jid)
+            if (src := graph.stations.get(e.source)) and src.is_port
+        }
+        entry_succs = {
+            e.target
+            for e in graph.edges_from(jid)
+            if (tgt := graph.stations.get(e.target)) and tgt.is_port
+        }
+        if len(port_preds) != 1 or len(entry_succs) <= 1:
+            continue
+        exit_port = graph.stations[next(iter(port_preds))]
+        port_obj = graph.ports.get(exit_port.id)
+        if port_obj is None or port_obj.side not in (PortSide.LEFT, PortSide.RIGHT):
+            continue
+        if abs(junction.y - exit_port.y) > GUARD_TOLERANCE:
+            raise PhaseInvariantError(
+                f"{phase}: fan-out junction {jid!r} y={junction.y:.1f} "
+                f"stranded from exit port {exit_port.id!r} y={exit_port.y:.1f}"
+            )
+
+
 def is_loop_side_branch_station(graph: MetroGraph, sid: str) -> bool:
     """Mirror ``_recenter_loop_side_stations``'s precondition: a station
     with exactly one in-edge and one out-edge, whose predecessor and
@@ -1483,6 +1520,11 @@ def _compute_section_layout(
     _shift_and_propagate_loop_stations(
         graph, y_spacing, section_y_padding, section_y_gap
     )
+    # The shift can move an exit port off the Y it held when junctions were
+    # last positioned (Stage 6.13).  Re-anchor junctions to the settled port
+    # Ys so a fan-out bundle runs straight from exit to junction instead of
+    # dipping to a stale junction Y and back (#386).
+    _position_junctions(graph)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.14")
 
@@ -1504,6 +1546,7 @@ def _compute_section_layout(
         offsets, routes = _run_pass_c_guards(graph, phase)
         _guard_row_trunk_cy_consistent(graph, phase, offsets=offsets)
         _guard_off_track_inputs_above_consumer(graph, phase)
+        _guard_fanout_junction_shares_exit_port_y(graph, phase)
         _guard_row_gaps(graph, phase, section_y_gap=section_y_gap)
         if routes is not None:
             _guard_inter_section_routes_in_row_band(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -524,6 +524,71 @@ def _guard_inter_section_routes_in_row_band(
                 )
 
 
+def _guard_inter_section_route_no_backtrack(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+) -> None:
+    """After routing: a forward-flowing inter-section route between two LR
+    columns must be X-monotonic.
+
+    A route that exits a port toward its target column (rightward exit, target
+    to the right) must not contain a horizontal segment that reverses; such a
+    backtrack renders as a turn-back toward the section just behind the exit
+    (#386).  Routes that exit AWAY from their target legitimately wrap and are
+    skipped, as are ``normalize_exempt`` wrap legs, TB folds, and same-column
+    routes.
+    """
+    from nf_metro.layout.routing.common import resolve_section
+
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        routes = route_edges(graph)
+
+    def _exit_side(rp) -> PortSide | None:
+        port = graph.ports.get(rp.edge.source)
+        if port is not None:
+            return port.side
+        for e in graph.edges_to(rp.edge.source):
+            port = graph.ports.get(e.source)
+            if port is not None:
+                return port.side
+        return None
+
+    for rp in routes:
+        if not rp.is_inter_section or rp.normalize_exempt:
+            continue
+        src_sec = resolve_section(graph, graph.stations[rp.edge.source])
+        tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
+        if src_sec is None or tgt_sec is None:
+            continue
+        if src_sec.direction != "LR" or tgt_sec.direction != "LR":
+            continue
+        if src_sec.grid_col == tgt_sec.grid_col:
+            continue
+        rightward = tgt_sec.grid_col > src_sec.grid_col
+        side = _exit_side(rp)
+        if rightward and side != PortSide.RIGHT:
+            continue
+        if not rightward and side != PortSide.LEFT:
+            continue
+        xs = [p[0] for p in rp.points]
+        for x1, x2 in zip(xs, xs[1:]):
+            backtracks = (
+                (x2 < x1 - GUARD_TOLERANCE)
+                if rightward
+                else (x2 > x1 + GUARD_TOLERANCE)
+            )
+            if backtracks:
+                raise PhaseInvariantError(
+                    f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} "
+                    f"line {rp.line_id!r} backtracks x={x1:.1f}->{x2:.1f} "
+                    f"against its {'rightward' if rightward else 'leftward'} flow"
+                )
+
+
 def _guard_bundle_order_preserved(
     graph: MetroGraph,
     phase: str,
@@ -1554,6 +1619,7 @@ def _compute_section_layout(
             )
             _guard_bundle_order_preserved(graph, phase, offsets=offsets, routes=routes)
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)
+            _guard_inter_section_route_no_backtrack(graph, phase, routes=routes)
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -3167,6 +3167,13 @@ def _normalize_gap_channels(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
         Prefer the row whose x-interval brackets the channel AND whose
         vertical band the channel overlaps; fall back to any bracketing
         row, then to the row-agnostic union.
+
+        A channel that vertically crosses several rows must clear sections
+        in ALL of them, so its gap is narrowed to the intersection of every
+        crossed row's gap in the same column.  Otherwise a fan climbing out
+        of a row whose section edge sits further out than a sibling row's
+        would centre in the wider sibling gap and step back behind its source
+        section edge (#386).
         """
         x = ch.x
         overlap_match: tuple[int, int | None, float, float] | None = None
@@ -3183,10 +3190,17 @@ def _normalize_gap_channels(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
                 if band is not None and ch.y_lo < band[1] and band[0] < ch.y_hi:
                     if overlap_match is None:
                         overlap_match = (lo, row, left, right)
-        if overlap_match is not None:
-            return overlap_match
-        if bracket_match is not None:
-            return bracket_match
+        match = overlap_match or bracket_match
+        if match is not None:
+            lo, row, left, right = match
+            for r, band in row_bands.items():
+                if not (ch.y_lo < band[1] and band[0] < ch.y_hi):
+                    continue
+                for rlo, rleft, rright in gap_intervals.get(r, []):
+                    if rlo == lo:
+                        left = max(left, rleft)
+                        right = min(right, rright)
+            return (lo, row, left, right)
         for lo, left, right in gap_intervals.get(None, []):
             if left - COORD_TOLERANCE <= x <= right + COORD_TOLERANCE:
                 return (lo, None, left, right)
@@ -3206,6 +3220,13 @@ def _normalize_gap_channels(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
             # x sits on / outside a section edge: not a clean gap channel.
             if not (left <= ch.x <= right):
                 continue
+        # Bundles sharing a (gap, row) are laid out together in one x-range,
+        # so the shared bound must clear every member's crossed rows: narrow
+        # to the intersection rather than letting the last channel win.
+        prev = gap_bounds.get((lo, row))
+        if prev is not None:
+            left = max(left, prev[0])
+            right = min(right, prev[1])
         gap_bounds[(lo, row)] = (left, right)
         buckets[(lo, row, ch.down)].append(ch)
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -749,6 +749,67 @@ def test_no_kink_at_section_boundary(fixture):
 
 
 # ---------------------------------------------------------------------------
+# Fan-out junctions share Y with their feeding LR/RL exit port
+# ---------------------------------------------------------------------------
+
+
+def _fanout_junction_exit_ports(graph: MetroGraph):
+    """Yield ``(junction, exit_port)`` for every fan-out junction fed by a
+    single LEFT/RIGHT exit port.
+
+    A fan-out junction has exactly one port predecessor (the exit port the
+    bundle leaves through) and more than one entry-port successor.  For
+    LEFT/RIGHT (LR/RL) exit ports, ``_position_junctions`` anchors the
+    junction at the exit port's Y so the bundle runs straight from exit to
+    junction; BOTTOM/TOP exit ports are intentionally offset and excluded.
+    """
+    junction_ids = set(graph.junctions)
+    for jid in junction_ids:
+        junction = graph.stations.get(jid)
+        if junction is None:
+            continue
+        # One edge per line, so dedupe to distinct port endpoints.
+        port_preds = {
+            edge.source
+            for edge in graph.edges_to(jid)
+            if (src := graph.stations.get(edge.source)) and src.is_port
+        }
+        succ_entry_ports = {
+            edge.target
+            for edge in graph.edges_from(jid)
+            if (tgt := graph.stations.get(edge.target)) and tgt.is_port
+        }
+        if len(port_preds) != 1 or len(succ_entry_ports) <= 1:
+            continue
+        exit_port = graph.stations.get(next(iter(port_preds)))
+        port_obj = graph.ports.get(exit_port.id)
+        if port_obj is None or port_obj.side not in (PortSide.LEFT, PortSide.RIGHT):
+            continue
+        yield junction, exit_port
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_fanout_junction_shares_exit_port_y(fixture):
+    """A fan-out junction fed by an LR/RL exit port must sit at the exit
+    port's Y.
+
+    ``_position_junctions`` places such a junction at ``exit_port.y`` so the
+    bundle runs straight from the exit into the junction.  Late settling
+    stages (e.g. Stage 6.14 ``_shift_and_propagate_loop_stations``) can move
+    the exit port after junctions were last positioned; if junctions are not
+    re-anchored the junction is stranded above/below the port, forcing the
+    fanned routes to dip to the stale junction Y and back (#386:
+    complex_multipath section 3 -> sections 4/5 S-curve).
+    """
+    graph = _layout(fixture)
+    for junction, exit_port in _fanout_junction_exit_ports(graph):
+        assert abs(junction.y - exit_port.y) < _Y_TOL, (
+            f"{fixture}: fan-out junction {junction.id} y={junction.y} "
+            f"stranded from exit port {exit_port.id} y={exit_port.y}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Side-branch single-line edges stay off the trunk inside the section
 # ---------------------------------------------------------------------------
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -21,6 +21,7 @@ import pytest
 from nf_metro.layout.constants import SECTION_HEADER_PROTRUSION, SECTION_Y_GAP
 from nf_metro.layout.engine import compute_layout, is_loop_side_branch_station
 from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.common import resolve_section
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph, PortSide
 
@@ -806,6 +807,83 @@ def test_fanout_junction_shares_exit_port_y(fixture):
             f"{fixture}: fan-out junction {junction.id} y={junction.y} "
             f"stranded from exit port {exit_port.id} y={exit_port.y}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Inter-section routes don't backtrack in X against their net flow direction
+# ---------------------------------------------------------------------------
+
+
+def _route_exit_port_side(graph: MetroGraph, rp) -> PortSide | None:
+    """Return the side of the exit port a route leaves through.
+
+    The route source is either the exit port itself or a junction fed by
+    one; trace back one step through a junction to reach the port.
+    """
+    port = graph.ports.get(rp.edge.source)
+    if port is not None:
+        return port.side
+    # Source is a junction (also is_port=True but not a boundary port);
+    # trace back one step to the feeding exit port.
+    for e in graph.edges_to(rp.edge.source):
+        port = graph.ports.get(e.source)
+        if port is not None:
+            return port.side
+    return None
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_inter_section_route_no_x_backtrack(fixture):
+    """A forward-flowing inter-section route between two LR columns must be
+    X-monotonic: no horizontal segment may reverse against its net
+    source->target direction.
+
+    A right-to-left segment on a left-to-right route renders as a visible
+    turn-back toward the section just left (#386: the standard/legacy climb
+    out of Full Pre-process stepped from the fan-out junction back toward
+    section 3 before going up, because the gap channel was centred in a
+    wider sibling-row gap that sat left of the junction).
+
+    Scoped to "forward" routes only: both endpoints resolve to LR sections
+    in distinct columns AND the exit port faces the target column.  A route
+    that exits a port facing AWAY from its target (e.g. a right-side port
+    feeding a section to the left) must wrap, so its outward stub legitimately
+    reverses; those, fold/serpentine (TB), same-column, and ``normalize_exempt``
+    wrap legs are skipped.
+    """
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+    for rp in routes:
+        if not rp.is_inter_section or rp.normalize_exempt:
+            continue
+        src_sec = resolve_section(graph, graph.stations[rp.edge.source])
+        tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
+        if src_sec is None or tgt_sec is None:
+            continue
+        if src_sec.direction != "LR" or tgt_sec.direction != "LR":
+            continue
+        if src_sec.grid_col == tgt_sec.grid_col:
+            continue
+        rightward = tgt_sec.grid_col > src_sec.grid_col
+        exit_side = _route_exit_port_side(graph, rp)
+        # Only "forward" routes (exit port faces the target) must be
+        # monotonic; an exit facing away legitimately wraps.
+        if rightward and exit_side != PortSide.RIGHT:
+            continue
+        if not rightward and exit_side != PortSide.LEFT:
+            continue
+        xs = [p[0] for p in rp.points]
+        for x1, x2 in zip(xs, xs[1:]):
+            if rightward:
+                assert x2 >= x1 - _Y_TOL, (
+                    f"{fixture}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
+                    f"backtracks left x={x1:.1f}->{x2:.1f} on a rightward route"
+                )
+            else:
+                assert x2 <= x1 + _Y_TOL, (
+                    f"{fixture}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
+                    f"backtracks right x={x1:.1f}->{x2:.1f} on a leftward route"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -763,8 +763,7 @@ def _fanout_junction_exit_ports(graph: MetroGraph):
     junction at the exit port's Y so the bundle runs straight from exit to
     junction; BOTTOM/TOP exit ports are intentionally offset and excluded.
     """
-    junction_ids = set(graph.junctions)
-    for jid in junction_ids:
+    for jid in graph.junctions:
         junction = graph.stations.get(jid)
         if junction is None:
             continue


### PR DESCRIPTION
## Summary
Two coupled routing fixes for the `complex_multipath` section-3→section-4/5 route, plus invariant tests and runtime guards.

**1. Re-anchor junctions after late settling.** Stage 6.14 (`_shift_and_propagate_loop_stations`) can move an exit port off the Y it held when junctions were last positioned at Stage 6.13. Junctions were only re-anchored inside `_snap_canvas_y_to_grid`, which early-returns when the canvas is already on grid, leaving a fan-out junction stranded above its exit port and the fanned routes dipping to the stale Y and back. Re-run `_position_junctions` after Stage 6.14.

**2. Center multi-row gap channels in the intersected gap.** A vertical inter-section channel that crosses several grid rows was centred in the gap of the first overlapping row only. When a sibling row's section was narrower (column edge further out), the channel centred in that wider gap and stepped back behind its own source section edge - a right-to-left notch on a left-to-right route. `_normalize_gap_channels._find_gap` now narrows a channel's gap to the intersection of every crossed row's column gap, and `gap_bounds` shared by bundles in one `(gap, row)` intersects across members instead of last-write-wins.

Net effect on `complex_multipath`: the `standard`/`legacy` bundle leaves Full Pre-process and climbs straight up a clean vertical channel at the gap midpoint between sections 3 and 5 (no dip, no turn-back); `detailed` runs dead straight into Deep Analysis.

New coverage:
- `test_fanout_junction_shares_exit_port_y` + `_guard_fanout_junction_shares_exit_port_y`
- `test_inter_section_route_no_x_backtrack` + `_guard_inter_section_route_no_backtrack`

Both tests are parametrised over the multi-section fixture corpus.

Fixes #386

## Test plan
- [x] `pytest` passes (2709 passed; both new tests fail on main, pass with the fix)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean (the CI lint scope)
- [x] Runtime validators added
- [x] Whole-gallery render-diff reviewed: only `complex_multipath` changed (no collateral despite touching a shared routing pass)
- [x] Render-preview verdict: 1 changed render, `complex_multipath` (target) - classified **Improvement** (dip + backtrack removed, clean centred climb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
