### PR TITLE
fix(layout): stop serpentine packer placing folds at negative columns

### DIFF
--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -317,9 +317,7 @@ def _assign_grid_positions(
     if folded:
         min_col = min(col for col, _ in folded.values())
         if min_col < 0:
-            folded = {
-                sid: (col - min_col, row) for sid, (col, row) in folded.items()
-            }
+            folded = {sid: (col - min_col, row) for sid, (col, row) in folded.items()}
 
     # Write results to grid_overrides and section fields
     for sid, (col, row) in folded.items():

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -251,7 +251,15 @@ def _assign_grid_positions(
         sids = col_groups[topo_col]
         w = topo_col_width[topo_col]
         stack_size = len(sids)
-        need_fold = cumulative_width > 0 and cumulative_width + w > max_station_columns
+        is_last_col = topo_idx == len(sorted_cols) - 1
+        # Don't fold the final topo column: there are no further columns to
+        # wrap into the next row, so a fold here only creates a spurious TB
+        # bridge (and a negative grid column) instead of bending the chain.
+        need_fold = (
+            not is_last_col
+            and cumulative_width > 0
+            and cumulative_width + w > max_station_columns
+        )
 
         if need_fold:
             fold_col = current_grid_col
@@ -301,6 +309,17 @@ def _assign_grid_positions(
             max_stack_in_band = max(max_stack_in_band, stack_size)
             current_grid_col += col_step
             cumulative_width += w
+
+    # Boustrophedon normalization: a return row built by stepping left from
+    # the fold bridge can run off the left edge into negative columns. Shift
+    # the whole grid right so the leftmost column is 0, keeping every
+    # section's relative position (and thus the serpentine read order).
+    if folded:
+        min_col = min(col for col, _ in folded.values())
+        if min_col < 0:
+            folded = {
+                sid: (col - min_col, row) for sid, (col, row) in folded.items()
+            }
 
     # Write results to grid_overrides and section fields
     for sid, (col, row) in folded.items():

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -173,6 +173,31 @@ def _guard_section_bboxes_positive(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _guard_no_negative_grid_columns(graph: MetroGraph, phase: str) -> None:
+    """After Stage 1.1+: no section may sit at a negative grid column.
+
+    The auto-layout serpentine packer steps a return row leftward from
+    its fold bridge; without normalization that walk can run off the left
+    edge into negative columns (issue #256), which renders the section's
+    badge left of everything and snakes the inter-section trunk down the
+    left margin. ``infer_section_layout`` normalizes the grid so the
+    leftmost column is 0; this guard fails loudly if that ever regresses.
+    """
+    # Read from grid_overrides (populated with an explicit column for every
+    # placed section) rather than Section.grid_col, whose -1 sentinel for
+    # "auto" is indistinguishable from a genuine column -1.
+    offenders = {
+        sid: override[0]
+        for sid, override in graph.grid_overrides.items()
+        if override[0] < 0
+    }
+    if offenders:
+        raise PhaseInvariantError(
+            f"{phase}: sections at negative grid columns "
+            f"(serpentine packer ran off the left edge): {offenders}"
+        )
+
+
 def _bbox_cols_overlap(a: Section, b: Section) -> bool:
     """True when two sections' bboxes overlap in X (share horizontal extent)."""
     return a.bbox_x < b.bbox_x + b.bbox_w and b.bbox_x < a.bbox_x + a.bbox_w
@@ -1128,6 +1153,7 @@ def _compute_section_layout(
 
     if validate:
         _guard_section_bboxes_positive(graph, "after Stage 1.1")
+        _guard_no_negative_grid_columns(graph, "after Stage 1.1")
 
     # Stage 1.2: Align Y grids across same-row, same-direction sections
     _align_row_y_grids(graph, section_subgraphs, y_spacing, section_y_padding)

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -482,13 +482,17 @@ _FOLD_FIXTURES = [
 _FOLD_THRESHOLDS = [3, 4, 9]
 
 
-def _folded_grid(fixture: str, max_station_columns: int):
-    """Parse a fold fixture and return {section_id: (col, row)} after
-    full auto-layout inference (greedy packer + post-passes)."""
+def _fold_layout(fixture: str, max_station_columns: int):
+    """Parse a fold fixture and run full auto-layout inference (greedy
+    packer + post-passes), returning the laid-out graph."""
     path = TOPOLOGIES_DIR / f"{fixture}.mmd"
-    graph = parse_metro_mermaid(
+    return parse_metro_mermaid(
         path.read_text(), max_station_columns=max_station_columns
     )
+
+
+def _grid_of(graph):
+    """{section_id: (grid_col, grid_row)} for every section."""
     return {sid: (sec.grid_col, sec.grid_row) for sid, sec in graph.sections.items()}
 
 
@@ -502,7 +506,7 @@ def test_folded_grid_has_no_negative_columns(fixture, threshold):
     the badge to the left of everything and snakes the trunk down the
     left edge.
     """
-    grid = _folded_grid(fixture, threshold)
+    grid = _grid_of(_fold_layout(fixture, threshold))
     offenders = {sid: (c, r) for sid, (c, r) in grid.items() if c < 0}
     assert not offenders, (
         f"{fixture} (threshold={threshold}): sections at negative grid "
@@ -523,14 +527,13 @@ def test_folded_grid_preserves_topo_order_in_serpentine_read(fixture, threshold)
     sibling-scatter defect from #256 (a converging successor slotted
     between two stacked sibling predecessors).
     """
-    path = TOPOLOGIES_DIR / f"{fixture}.mmd"
-    graph = parse_metro_mermaid(path.read_text(), max_station_columns=threshold)
+    graph = _fold_layout(fixture, threshold)
     # Use the section DAG captured during inference (built before
     # _resolve_sections rewrites inter-section edges into port chains);
     # rebuilding from the resolved graph would lose those edges.
     predecessors = graph.section_dag.predecessors
     sections = graph.sections
-    grid = {sid: (sec.grid_col, sec.grid_row) for sid, sec in sections.items()}
+    grid = _grid_of(graph)
 
     # A row band can be several rows tall: stacked sections share a band and
     # thus a flow direction. Flow alternates per band, not per row. Derive

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from nf_metro.layout.auto_layout import (
     _assign_grid_positions,
     _build_section_dag,
@@ -460,3 +462,115 @@ def test_below_fold_sections_share_rows_with_return():
         f"Return section sec5 at row {sec5_row} should share row with "
         f"below-fold sec4 at row {sec4_row}"
     )
+
+
+# --- Folded-grid topological-order invariants (issue #256) ---
+
+TOPOLOGIES_DIR = EXAMPLES / "topologies"
+
+# Fold-exercising fixtures: each wraps into >=2 rows at small fold
+# thresholds, stressing the serpentine packer's row/column assignment.
+_FOLD_FIXTURES = [
+    "fold_double",
+    "fold_fan_across",
+    "fold_stacked_branch",
+    "u_turn_fold",
+    "deep_linear",
+]
+
+# Fold thresholds that force serpentine wrapping on these fixtures.
+_FOLD_THRESHOLDS = [3, 4, 9]
+
+
+def _folded_grid(fixture: str, max_station_columns: int):
+    """Parse a fold fixture and return {section_id: (col, row)} after
+    full auto-layout inference (greedy packer + post-passes)."""
+    path = TOPOLOGIES_DIR / f"{fixture}.mmd"
+    graph = parse_metro_mermaid(
+        path.read_text(), max_station_columns=max_station_columns
+    )
+    return {sid: (sec.grid_col, sec.grid_row) for sid, sec in graph.sections.items()}
+
+
+@pytest.mark.parametrize("fixture", _FOLD_FIXTURES)
+@pytest.mark.parametrize("threshold", _FOLD_THRESHOLDS)
+def test_folded_grid_has_no_negative_columns(fixture, threshold):
+    """No auto-placed section may land at a negative grid column.
+
+    A negative column means a section was pushed left of the entire
+    layout (the spurious-trailing-fold defect in #256), which renders
+    the badge to the left of everything and snakes the trunk down the
+    left edge.
+    """
+    grid = _folded_grid(fixture, threshold)
+    offenders = {sid: (c, r) for sid, (c, r) in grid.items() if c < 0}
+    assert not offenders, (
+        f"{fixture} (threshold={threshold}): sections at negative grid "
+        f"columns: {offenders}"
+    )
+
+
+@pytest.mark.parametrize("fixture", _FOLD_FIXTURES)
+@pytest.mark.parametrize("threshold", _FOLD_THRESHOLDS)
+def test_folded_grid_preserves_topo_order_in_serpentine_read(fixture, threshold):
+    """A folded grid must read in topological order along the serpentine.
+
+    Reading row 0 left-to-right, row 1 right-to-left, row 2
+    left-to-right, ... must visit each section no earlier than its
+    topological predecessor. A section read before its predecessor means
+    the inter-section trunk has to double back across the wrap - either
+    the spurious-trailing-fold / negative-column defect or the
+    sibling-scatter defect from #256 (a converging successor slotted
+    between two stacked sibling predecessors).
+    """
+    path = TOPOLOGIES_DIR / f"{fixture}.mmd"
+    graph = parse_metro_mermaid(path.read_text(), max_station_columns=threshold)
+    # Use the section DAG captured during inference (built before
+    # _resolve_sections rewrites inter-section edges into port chains);
+    # rebuilding from the resolved graph would lose those edges.
+    predecessors = graph.section_dag.predecessors
+    sections = graph.sections
+    grid = {sid: (sec.grid_col, sec.grid_row) for sid, sec in sections.items()}
+
+    # A row band can be several rows tall: stacked sections share a band and
+    # thus a flow direction. Flow alternates per band, not per row. Derive
+    # each row's flow from the horizontal section directions on it (LR ->
+    # +col, RL -> -col), falling back to serpentine parity for all-vertical
+    # rows. Consecutive rows sharing a flow direction form one band.
+    rows = sorted({r for _, r in grid.values()})
+    row_flow: dict[int, int] = {}
+    for sec in sections.values():
+        if sec.direction in ("LR", "RL"):
+            row_flow.setdefault(sec.grid_row, 1 if sec.direction == "LR" else -1)
+    for row in rows:
+        row_flow.setdefault(row, 1 if row % 2 == 0 else -1)
+
+    band_of: dict[int, int] = {}
+    band_idx = 0
+    for i, row in enumerate(rows):
+        if i > 0 and row_flow[row] != row_flow[rows[i - 1]]:
+            band_idx += 1
+        band_of[row] = band_idx
+
+    # Serpentine read-order rank: bands ascend; within a band, sections are
+    # read along the band's flow direction (stacked sections at the same
+    # column-position read consecutively, by row).
+    def read_rank(item):
+        _sid, (col, row) = item
+        return (band_of[row], row_flow[row] * col, row)
+
+    order = [sid for sid, _ in sorted(grid.items(), key=read_rank)]
+    rank = {sid: i for i, sid in enumerate(order)}
+
+    for sid, preds in predecessors.items():
+        if sid not in rank:
+            continue
+        for pred in preds:
+            if pred not in rank:
+                continue
+            assert rank[pred] <= rank[sid], (
+                f"{fixture} (threshold={threshold}): predecessor {pred!r} "
+                f"at grid {grid[pred]} (read-rank {rank[pred]}) comes AFTER "
+                f"its successor {sid!r} at grid {grid[sid]} (read-rank "
+                f"{rank[sid]}) in serpentine read order"
+            )


### PR DESCRIPTION
## Summary

The auto-layout serpentine packer (`_assign_grid_positions` in `auto_layout.py`) could place a section at a negative grid column, and could fold the final section of a chain into a spurious vertical (TB) bridge with no following row. The negative column rendered the section's badge to the left of the entire layout and snaked the inter-section trunk down the left margin; the spurious trailing fold bent an otherwise-horizontal sink section into an unmotivated vertical stack.

Two defects fixed:

- **Spurious trailing fold.** The packer folded the final topological column even though no further columns remained to wrap into the next row. The fold became a TB bridge (and, when it sat at column 0, a negative grid column). The final column is now placed as a normal section on the current band.
- **Negative return-row columns.** A return row that steps leftward from its fold bridge can still run past the origin. After packing, the grid is normalized so the leftmost column is 0, preserving every section's relative position and the serpentine read order.

A runtime guard `_guard_no_negative_grid_columns` is wired into `compute_layout(validate=True)` (after Stage 1.1) and raises `PhaseInvariantError` if any placed section regresses to a negative column.

Parametrised invariant tests over `fold_double`, `fold_fan_across`, `fold_stacked_branch`, `u_turn_fold`, and `deep_linear` (thresholds 3/4/9) assert no negative columns and that the folded grid reads in topological order along the serpentine (band-aware, so stacked siblings sharing a multi-row band are read together).

Fixes #256

## Visual review

Four gallery renders change, all from the same root cause and all improvements or neutral:

- `deep_linear`: final section "Report" now a horizontal LR terminus instead of a vertical TB fold.
- `rnaseq_lite`: final section "QC & Reporting" now horizontal instead of a vertical TB fold.
- `variant_calling`: final section "Reporting" now horizontal instead of a vertical TB fold.
- `fold_double`: "Integration" no longer at a negative grid column (grid shifted right by one); appearance unchanged.

## Test plan
- [x] pytest passes (2688 passed, including new invariant tests)
- [x] ruff check + ruff format clean on `src/` and `tests/`
- [x] Runtime validator added (`_guard_no_negative_grid_columns`)
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/412/): 4 changed renders, all improvement/neutral
