### PR TITLE
fix(routing): reverse bundle order for bottom-exit fold into RIGHT entry (#411)

### DIFF
--- a/src/nf_metro/layout/routing/reversal.py
+++ b/src/nf_metro/layout/routing/reversal.py
@@ -10,6 +10,25 @@ from __future__ import annotations
 from nf_metro.parser.model import MetroGraph, PortSide
 
 
+def _fed_by_bottom_exit_fold(
+    graph: MetroGraph, port_id: str, junction_ids: set[str]
+) -> bool:
+    """Whether ``port_id`` is fed through a fold junction by a BOTTOM exit.
+
+    The fold junction drops the incoming bundle vertically (BOTTOM exit
+    -> junction) and turns it into the entry port; the down->turn
+    concentric corner is what reverses the bundle ordering.
+    """
+    for edge in graph.edges_to(port_id):
+        if edge.source not in junction_ids:
+            continue
+        for upstream in graph.edges_to(edge.source):
+            src_port = graph.ports.get(upstream.source)
+            if src_port and not src_port.is_entry and src_port.side == PortSide.BOTTOM:
+                return True
+    return False
+
+
 def detect_reversed_sections(graph: MetroGraph) -> set[str]:
     """Find sections where incoming bundle ordering is reversed.
 
@@ -24,6 +43,12 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
        concentric corner routing reverses the bundle ordering (outermost
        vertical line becomes outermost horizontal line), so the downstream
        section must use reversed Y ordering to match.
+
+    3. RIGHT entry fed through a fold junction by a BOTTOM exit: the
+       exit drops the bundle vertically (X offsets) and the fold
+       junction turns it left into the RIGHT entry.  That down->left
+       concentric corner reverses the bundle ordering, so the
+       downstream section must use reversed Y ordering to match.
 
     Reversal propagates: if a reversed section exits to another section
     on the same row, that downstream section is also reversed so bundle
@@ -51,6 +76,19 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
                     and src.section_id in tb_sections
                 ):
                     reversed_secs.add(sec_id)
+
+    # Phase 1c: detect sections whose RIGHT entry is fed through a fold
+    # junction by a BOTTOM exit (down->left concentric corner).
+    for sec_id, section in graph.sections.items():
+        if sec_id in reversed_secs:
+            continue
+        for port_id in section.entry_ports:
+            port = graph.ports.get(port_id)
+            if not port or port.side != PortSide.RIGHT:
+                continue
+            if _fed_by_bottom_exit_fold(graph, port_id, junction_ids):
+                reversed_secs.add(sec_id)
+                break
 
     # Build section adjacency from inter-section edges (used by
     # propagation phases below).  Also pre-compute the section-pair set

--- a/tests/test_bundle_order_invariant.py
+++ b/tests/test_bundle_order_invariant.py
@@ -44,6 +44,7 @@ def _gather_fixtures() -> list[Path]:
     paths: list[Path] = []
     paths.extend(sorted(TOPOLOGIES.glob("*.mmd")))
     paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    paths.extend(sorted((EXAMPLES / "topologies").glob("*.mmd")))
     return paths
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1634,22 +1634,6 @@ EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 TOPOLOGIES_DIR = EXAMPLES_DIR / "topologies"
 
 
-# Fixtures with KNOWN bundle-order violations the criterion correctly
-# surfaces.  ``fold_stacked_branch`` retains a real, pre-existing rna /
-# atac flip at the D->L corner entering ``bio_interp`` (an RL section
-# reached from the integration TB section's BOTTOM exit; the L-shape's
-# concentric arcs swap outer / inner ordering across the CCW turn).
-# Fixing this requires a stagger-flip equivalent to the wrap handler's
-# ``eff_i = (n - 1 - i)`` for L-shape routes whose inner/outer arc role
-# inverts across the corner.  We xfail rather than blunt the criterion to
-# hide it.
-_KNOWN_BUNDLE_ORDER_VIOLATION_FIXTURES = frozenset(
-    {
-        "fold_stacked_branch",
-    }
-)
-
-
 class TestPhaseGuards:
     """Verify that phase-boundary invariants hold across all fixtures."""
 
@@ -1663,12 +1647,6 @@ class TestPhaseGuards:
         ids=lambda p: p.stem,
     )
     def test_topology_fixtures(self, fixture):
-        if fixture.stem in _KNOWN_BUNDLE_ORDER_VIOLATION_FIXTURES:
-            pytest.xfail(
-                f"{fixture.stem}: known bundle-order violation; "
-                "the criterion correctly catches the rna/atac flip at "
-                "the bio_interp entry corner."
-            )
         self._layout_validated(fixture.read_text())
 
     def test_rnaseq_sections(self):


### PR DESCRIPTION
## Summary

- A section whose RIGHT entry port is fed through a fold junction by a BOTTOM exit drops the bundle vertically (X offsets), then turns left into the entry. That down→left concentric corner reverses bundle ordering, but `detect_reversed_sections` only handled TB-section exits, so the downstream section's entry Y offsets did not match the incoming run and the two lines crossed at the fold apex (`rna`/`atac` at `bio_interp` in `fold_stacked_branch.mmd`). The crossing was latent: it only surfaced under `compute_layout(validate=True)` via `_guard_bundle_order_preserved`.
- Add Phase 1c to `detect_reversed_sections` (plus the `_fed_by_bottom_exit_fold` helper) to flag these sections reversed, mirroring the existing TB BOTTOM/LR-exit cases. The fix is gated on the RIGHT-entry-fed-by-bottom-exit-junction precondition, so it only fires for this fold topology.
- Widen the bundle-order invariant sweep in `tests/test_bundle_order_invariant.py` to also cover `examples/topologies/` (the corpus the fixture lives in but the sweep was missing), and drop the now-fixed `fold_stacked_branch` xfail in `tests/test_layout.py`.

Fixes #411

## Test plan
- [x] `pytest` passes (2793 passed); `test_bundle_order_invariant.py` now sweeps `examples/topologies/` and `fold_stacked_branch` passes
- [x] `test_layout.py::TestPhaseGuards::test_topology_fixtures[fold_stacked_branch]` validates cleanly under `validate=True` (xfail removed)
- [x] `ruff check` + `ruff format --check` clean on `src/ tests/` (CI scope)
- [x] Runtime validator `_guard_bundle_order_preserved` already wired into the `validate=True` block; it now passes for this fixture
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/413/)

Generated with Claude Code
