### PR TITLE
fix(layout): wrap wide labels and spread columns to prevent collisions

### DIFF
--- a/examples/topologies/README.md
+++ b/examples/topologies/README.md
@@ -40,6 +40,7 @@ Each fixture is tagged with the layout class(es) it primarily exercises. Use thi
 | `fold_double.mmd` | double-fold serpentine (LR -> RL -> LR) |
 | `fold_stacked_branch.mmd` | stacked branches feeding through fold |
 | `u_turn_fold.mmd` | fold with side line joining mid-trunk and leaving pre-end |
+| `wide_label_fan.mmd` | wide station labels / auto label-wrap + column-spread (issue #405) |
 
 ---
 

--- a/examples/topologies/wide_label_fan.mmd
+++ b/examples/topologies/wide_label_fan.mmd
@@ -1,0 +1,19 @@
+%%metro title: Wide Label Fan
+%%metro style: dark
+%%metro center_ports: true
+%%metro line: a | A | #e63946
+%%metro line: b | B | #0570b0
+
+graph LR
+    subgraph proc [Reporting]
+        %%metro entry: left | a, b
+        hub[Aggregate]
+        align[Alignment Summary]
+        quant[Quantification Report]
+        aqc[Alignment QC HTML]
+        qqc[Quantification QC HTML]
+        hub -->|a| align
+        hub -->|b| quant
+        align -->|a| aqc
+        quant -->|b| qqc
+    end

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -115,6 +115,13 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "symmetric fan-and-reconverge, exit on the merge row (regression "
         "lock for detached reconvergence exits).",
     ),
+    (
+        "wide_label_fan",
+        TOPOLOGIES_DIR,
+        "A two-column fan whose station labels are wider than the column "
+        "pitch; the engine wraps the labels and widens spacing so they "
+        "don't collide (issue #405).",
+    ),
     # --- Branching and multipath ---
     (
         "asymmetric_tree",

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -48,8 +48,9 @@ def cli() -> None:
 @click.option(
     "--x-spacing",
     type=float,
-    default=60.0,
-    help="Horizontal spacing between layers (default: 60)",
+    default=None,
+    help="Horizontal spacing between layers (default: auto - widened from "
+    "60 only when wide labels would otherwise collide)",
 )
 @click.option(
     "--y-spacing",
@@ -131,7 +132,7 @@ def render(
     theme: str,
     width: int | None,
     height: int | None,
-    x_spacing: float,
+    x_spacing: float | None,
     y_spacing: float | None,
     max_layers_per_row: int | None,
     animate: bool,

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -302,6 +302,23 @@ LABEL_NUDGE_MAX: float = 20.0
 LABEL_BBOX_MARGIN: float = 4.0
 """Margin for clamping labels within section bounding box."""
 
+LABEL_OVERLAP_TOL: float = 2.0
+"""Minimum per-axis intrusion (px) before a label box counts as overlapping
+another label or a station marker.
+
+A box pair is treated as overlapping only when it intrudes by more than this
+on *both* axes, so a label whose edge merely grazes a neighbouring marker
+(e.g. the 1px vertical touch between tightly stacked parallel lines) is not
+flagged.  Used by the overlap detector that drives the wrapping pass, the
+runtime guard, and the layout validator."""
+
+LABEL_WRAP_MIN_LINE_CHARS: int = 4
+"""Floor on the per-line character budget when wrapping a colliding label.
+
+Wrapping narrows a label to clear a collision; this stops it shrinking past
+a legible width.  A single word longer than the budget is hard-broken with a
+hyphen (the last-resort split), but never below this many characters."""
+
 # ---------------------------------------------------------------------------
 # Ordering
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -877,9 +877,115 @@ def compute_min_y_spacing(
     return required
 
 
+# Cap on spread-loop passes.  Each pass strictly widens the binding axis,
+# so a handful suffices to clear any realistic crowding before giving up.
+_MAX_SPREAD_ITERS = 6
+
+# Extra clearance (px) added on top of the measured intrusion when widening
+# spacing, so the re-laid-out labels land with a small gap, not flush.
+_SPREAD_SLACK = 4.0
+
+
+def _residual_label_overlaps(graph: MetroGraph, *, allow_hyphenation: bool):
+    """Place labels at the current layout and report leftover overlaps.
+
+    Runs the same offset/route/label pipeline the renderer uses (so the
+    wrapping pass has already fired) and returns the overlaps that wrapping
+    could not resolve.  Returns an empty list if routing/placement raises,
+    so a transient routing failure never blocks layout.
+
+    The spread loop calls this with ``allow_hyphenation=False`` so residual
+    overlaps surface (to be cleared by widening spacing rather than by
+    hard-breaking words); the final guard calls it with True to validate the
+    settled, fully wrapped state the renderer will draw.
+    """
+    from nf_metro.layout.labels import find_label_overlaps, place_labels
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    # Routing and placement mutate the graph (route_edges nudges station X
+    # for bundle separation; place_labels expands section bboxes to fit
+    # labels).  This probe must not leak those mutations, or a clean graph
+    # would drift from its positioned state.  Snapshot station coordinates
+    # and section bboxes, and restore them after measuring.
+    pos_snapshot = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bbox_snapshot = {
+        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
+        for sid, s in graph.sections.items()
+    }
+    try:
+        offsets = compute_station_offsets(graph)
+        routes = route_edges(graph, station_offsets=offsets)
+        placements = place_labels(
+            graph,
+            station_offsets=offsets,
+            routes=routes,
+            allow_hyphenation=allow_hyphenation,
+        )
+        return find_label_overlaps(graph, placements, offsets)
+    except Exception:
+        return []
+    finally:
+        for sid, (x, y) in pos_snapshot.items():
+            st = graph.stations.get(sid)
+            if st is not None:
+                st.x, st.y = x, y
+        for sid, (bx, by, bw, bh) in bbox_snapshot.items():
+            s = graph.sections.get(sid)
+            if s is not None:
+                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+
+
+def _spread_bump(graph, residual, x_spacing, y_spacing, auto_x, auto_y):
+    """Compute widened (x, y) spacing to clear the residual label overlaps.
+
+    Each overlap is attributed to the axis along which its two stations are
+    separated (columns -> x, rows -> y).  The required extra pitch is the
+    intrusion depth shared across the columns/rows between them, plus slack.
+    Only auto-resolved axes are widened; a pinned axis is left untouched.
+    """
+    extra_x = 0.0
+    extra_y = 0.0
+    for ov in residual:
+        a = graph.stations.get(ov.a)
+        b = graph.stations.get(ov.b)
+        if a is None or b is None:
+            continue
+        dx = abs(a.x - b.x)
+        dy = abs(a.y - b.y)
+        if dx >= dy:
+            cols = max(round(dx / x_spacing), 1)
+            extra_x = max(extra_x, (ov.ox + _SPREAD_SLACK) / cols)
+        else:
+            rows = max(round(dy / y_spacing), 1)
+            extra_y = max(extra_y, (ov.oy + _SPREAD_SLACK) / rows)
+    new_x = x_spacing + extra_x if auto_x else x_spacing
+    new_y = y_spacing + extra_y if auto_y else y_spacing
+    return new_x, new_y
+
+
+def _guard_no_label_overlap(graph: MetroGraph, phase: str) -> None:
+    """Raise if any station label overlaps another label or a marker.
+
+    Runs after the spread loop has settled, so it asserts the final, fully
+    wrapped-and-spread state.  Label/label overlap is never tolerated;
+    label/marker grazes within ``LABEL_OVERLAP_TOL`` are allowed (see
+    :func:`nf_metro.layout.labels.find_label_overlaps`).
+    """
+    residual = _residual_label_overlaps(graph, allow_hyphenation=True)
+    if not residual:
+        return
+    ov = residual[0]
+    kind = "label" if ov.kind == "label" else "marker"
+    raise PhaseInvariantError(
+        f"{phase}: station label {ov.a!r} overlaps "
+        f"{kind} {ov.b!r} by ({ov.ox:.1f}, {ov.oy:.1f})px after wrapping and "
+        f"spreading; {len(residual)} overlap(s) total"
+    )
+
+
 def compute_layout(
     graph: MetroGraph,
-    x_spacing: float = X_SPACING,
+    x_spacing: float | None = None,
     y_spacing: float | None = None,
     x_offset: float = X_OFFSET,
     y_offset: float = Y_OFFSET,
@@ -907,7 +1013,9 @@ def compute_layout(
     key phases.  Violations raise ``PhaseInvariantError`` instead of
     silently producing broken layouts.
     """
-    if y_spacing is None:
+    auto_x = x_spacing is None
+    auto_y = y_spacing is None
+    if auto_y:
         y_spacing = compute_min_y_spacing(graph)
     else:
         min_required = compute_min_y_spacing(graph)
@@ -920,15 +1028,69 @@ def compute_layout(
                 UserWarning,
                 stacklevel=2,
             )
+    if auto_x:
+        x_spacing = X_SPACING
+
     # Optionally reorder lines by section span before layout.
     # Must happen here (on the full graph) before section subgraphs are
-    # built, since subgraphs share graph.lines via reference.
+    # built, since subgraphs share graph.lines via reference.  Done once;
+    # the reorder is order-stable across the spread loop below.
     if graph.line_order == "span" and graph.lines:
         from nf_metro.layout.ordering import _reorder_by_span
 
         new_order = _reorder_by_span(graph, list(graph.lines.keys()))
         graph.lines = {lid: graph.lines[lid] for lid in new_order}
 
+    # Spread loop: lay out, then if labels still collide at this pitch
+    # (after wrapping has done what it can), widen the auto-resolved
+    # spacing and lay out again.  A clean layout clears on the first pass
+    # so nothing is widened; only crowded wide-label graphs iterate.  When
+    # the caller pins both spacings explicitly there is nothing to widen,
+    # so a single pass runs.
+    max_iters = _MAX_SPREAD_ITERS if (auto_x or auto_y) else 1
+    for attempt in range(max_iters):
+        _layout_once(
+            graph,
+            x_spacing=x_spacing,
+            y_spacing=y_spacing,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+            section_x_gap=section_x_gap,
+            section_y_gap=section_y_gap,
+            validate=validate,
+        )
+        if attempt == max_iters - 1:
+            break
+        residual = _residual_label_overlaps(graph, allow_hyphenation=False)
+        if not residual:
+            break
+        new_x, new_y = _spread_bump(
+            graph, residual, x_spacing, y_spacing, auto_x, auto_y
+        )
+        if new_x <= x_spacing + 1e-6 and new_y <= y_spacing + 1e-6:
+            break  # can't widen the binding axis (e.g. pinned) -- give up
+        x_spacing, y_spacing = new_x, new_y
+
+    if validate:
+        _guard_no_label_overlap(graph, "final")
+
+
+def _layout_once(
+    graph: MetroGraph,
+    *,
+    x_spacing: float,
+    y_spacing: float,
+    x_offset: float,
+    y_offset: float,
+    section_x_padding: float,
+    section_y_padding: float,
+    section_x_gap: float,
+    section_y_gap: float,
+    validate: bool,
+) -> None:
+    """Run one full positioning pass at the given spacing (idempotent)."""
     if not graph.sections:
         _compute_flat_layout(
             graph,

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from nf_metro.layout.constants import (
     CHAR_WIDTH,
@@ -30,7 +30,6 @@ from nf_metro.layout.constants import (
     LABEL_OVERLAP_TOL,
     LABEL_WRAP_MIN_LINE_CHARS,
     PORT_LABEL_MAX_DX,
-    STATION_RADIUS_APPROX,
     TB_LABEL_H_SPACING,
     TB_LINE_Y_OFFSET,
     TB_PILL_EDGE_OFFSET,
@@ -120,31 +119,6 @@ def _boxes_overlap(
     )
 
 
-def _marker_bbox(
-    graph: MetroGraph,
-    station,
-    station_offsets: dict[tuple[str, str], float] | None,
-) -> tuple[float, float, float, float]:
-    """Bounding box of a station's rendered pill marker.
-
-    The pill is ``STATION_RADIUS_APPROX`` wide either side of the station
-    centre and spans the line offsets vertically (a multi-line bundle's pill
-    is taller), matching ``render.svg`` pill geometry.
-    """
-    r = STATION_RADIUS_APPROX
-    offs = (
-        [
-            station_offsets.get((station.id, lid), 0.0)
-            for lid in graph.station_lines(station.id)
-        ]
-        if station_offsets
-        else []
-    )
-    lo = min(offs) if offs else 0.0
-    hi = max(offs) if offs else 0.0
-    return (station.x - r, station.y + lo - r, station.x + r, station.y + hi + r)
-
-
 class LabelOverlap(NamedTuple):
     """A detected overlap involving a station label.
 
@@ -155,7 +129,7 @@ class LabelOverlap(NamedTuple):
     ``ox``/``oy`` are the per-axis intrusion depths in px.
     """
 
-    kind: str
+    kind: Literal["label", "marker"]
     a: str
     b: str
     ox: float
@@ -210,10 +184,14 @@ def find_label_overlaps(
                     LabelOverlap("label", pa.station_id, pb.station_id, ox, oy)
                 )
 
+    # Reuse the engine's pill geometry (returns None for ports, hidden
+    # stations, and junctions, none of which render a marker to collide with).
+    from nf_metro.layout.engine import _station_marker_bbox
+
     markers = {
-        s.id: _marker_bbox(graph, s, station_offsets)
-        for s in graph.stations.values()
-        if not s.is_port and not s.is_hidden
+        sid: bbox
+        for sid in graph.stations
+        if (bbox := _station_marker_bbox(graph, sid, station_offsets)) is not None
     }
     for p, lb in boxes:
         for sid, mb in markers.items():
@@ -907,7 +885,7 @@ def _wrap_overlapping_labels(
     originals = {sid: graph.stations[sid].label for sid in by_id}
     budgets = {sid: len(by_id[sid].text) for sid in wrappable}
 
-    def floor(sid: str) -> int:
+    def min_budget(sid: str) -> int:
         if allow_hyphenation:
             return LABEL_WRAP_MIN_LINE_CHARS
         longest_word = max((len(w) for w in originals[sid].split()), default=1)
@@ -919,7 +897,7 @@ def _wrap_overlapping_labels(
         if offender is None:
             break
         new_budget = budgets[offender] - 1
-        if new_budget < floor(offender):
+        if new_budget < min_budget(offender):
             wrappable.discard(offender)
             continue
         budgets[offender] = new_budget

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -6,10 +6,16 @@ above/below alternation and collision avoidance.
 
 from __future__ import annotations
 
-__all__ = ["LabelPlacement", "label_text_width", "place_labels"]
+__all__ = [
+    "LabelOverlap",
+    "LabelPlacement",
+    "find_label_overlaps",
+    "label_text_width",
+    "place_labels",
+]
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from nf_metro.layout.constants import (
     CHAR_WIDTH,
@@ -21,7 +27,10 @@ from nf_metro.layout.constants import (
     LABEL_MARGIN,
     LABEL_NUDGE_MAX,
     LABEL_OFFSET,
+    LABEL_OVERLAP_TOL,
+    LABEL_WRAP_MIN_LINE_CHARS,
     PORT_LABEL_MAX_DX,
+    STATION_RADIUS_APPROX,
     TB_LABEL_H_SPACING,
     TB_LINE_Y_OFFSET,
     TB_PILL_EDGE_OFFSET,
@@ -109,6 +118,143 @@ def _boxes_overlap(
         or a[3] + margin < b[1]
         or b[3] + margin < a[1]
     )
+
+
+def _marker_bbox(
+    graph: MetroGraph,
+    station,
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> tuple[float, float, float, float]:
+    """Bounding box of a station's rendered pill marker.
+
+    The pill is ``STATION_RADIUS_APPROX`` wide either side of the station
+    centre and spans the line offsets vertically (a multi-line bundle's pill
+    is taller), matching ``render.svg`` pill geometry.
+    """
+    r = STATION_RADIUS_APPROX
+    offs = (
+        [
+            station_offsets.get((station.id, lid), 0.0)
+            for lid in graph.station_lines(station.id)
+        ]
+        if station_offsets
+        else []
+    )
+    lo = min(offs) if offs else 0.0
+    hi = max(offs) if offs else 0.0
+    return (station.x - r, station.y + lo - r, station.x + r, station.y + hi + r)
+
+
+class LabelOverlap(NamedTuple):
+    """A detected overlap involving a station label.
+
+    ``kind`` is ``"label"`` (label box over another label box) or
+    ``"marker"`` (label box over a non-owner station marker).  ``a`` is the
+    owning station of the label; ``b`` is the other label's station (for
+    ``"label"``) or the intruded marker's station (for ``"marker"``).
+    ``ox``/``oy`` are the per-axis intrusion depths in px.
+    """
+
+    kind: str
+    a: str
+    b: str
+    ox: float
+    oy: float
+
+
+def _intrusion(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> tuple[float, float]:
+    """Return per-axis overlap depth (negative when separated on that axis)."""
+    ox = min(a[2], b[2]) - max(a[0], b[0])
+    oy = min(a[3], b[3]) - max(a[1], b[1])
+    return ox, oy
+
+
+def find_label_overlaps(
+    graph: MetroGraph,
+    placements: list[LabelPlacement],
+    station_offsets: dict[tuple[str, str], float] | None = None,
+    marker_tol: float = LABEL_OVERLAP_TOL,
+) -> list[LabelOverlap]:
+    """Find label/label and label/marker overlaps in a set of placements.
+
+    Two *label* boxes count as overlapping when they intrude on both axes
+    (beyond a sub-pixel epsilon): text-on-text is never acceptable.  A label
+    over a *marker* is reported only when it intrudes by more than
+    ``marker_tol`` on both axes, so a label whose edge merely grazes a pill
+    (the 1px touch between tightly stacked parallel lines) is tolerated.
+
+    Shared by the wrapping pass, the runtime guard, and the layout validator
+    so all three agree on what "overlap" means.
+    """
+    eps = 0.5
+    labels = [
+        p
+        for p in placements
+        if p.station_id
+        and not p.station_id.startswith("__")
+        and p.obstacle_bbox is None
+    ]
+    boxes = [(p, _label_bbox(p)) for p in labels]
+    overlaps: list[LabelOverlap] = []
+
+    for i in range(len(boxes)):
+        pa, ba = boxes[i]
+        for j in range(i + 1, len(boxes)):
+            pb, bb = boxes[j]
+            ox, oy = _intrusion(ba, bb)
+            if ox > eps and oy > eps:
+                overlaps.append(
+                    LabelOverlap("label", pa.station_id, pb.station_id, ox, oy)
+                )
+
+    markers = {
+        s.id: _marker_bbox(graph, s, station_offsets)
+        for s in graph.stations.values()
+        if not s.is_port and not s.is_hidden
+    }
+    for p, lb in boxes:
+        for sid, mb in markers.items():
+            if sid == p.station_id:
+                continue
+            ox, oy = _intrusion(lb, mb)
+            if ox > marker_tol and oy > marker_tol:
+                overlaps.append(LabelOverlap("marker", p.station_id, sid, ox, oy))
+
+    return overlaps
+
+
+def _wrap_text_to_chars(text: str, max_chars: int) -> str:
+    """Word-wrap ``text`` so no line exceeds ``max_chars`` characters.
+
+    Words longer than the budget are hard-broken with a trailing hyphen as a
+    last resort (so a single long token like "Quantification" can still be
+    narrowed).  ``max_chars`` is floored at ``LABEL_WRAP_MIN_LINE_CHARS``.
+    """
+    budget = max(max_chars, LABEL_WRAP_MIN_LINE_CHARS)
+    lines: list[str] = []
+    cur = ""
+    for word in text.split():
+        w = word
+        # Hard-break tokens that can't fit the budget on their own.
+        while len(w) > budget:
+            if cur:
+                lines.append(cur)
+                cur = ""
+            lines.append(w[: budget - 1] + "-")
+            w = w[budget - 1 :]
+        if not cur:
+            cur = w
+        elif len(cur) + 1 + len(w) <= budget:
+            cur += " " + w
+        else:
+            lines.append(cur)
+            cur = w
+    if cur:
+        lines.append(cur)
+    return "\n".join(lines)
 
 
 def _nudge_to_clear(
@@ -414,6 +560,7 @@ def place_labels(
     station_offsets: dict[tuple[str, str], float] | None = None,
     icon_obstacles: list[tuple[float, float, float, float]] | None = None,
     routes: list["RoutedPath"] | None = None,
+    allow_hyphenation: bool = True,
 ) -> list[LabelPlacement]:
     """Place horizontal labels alternating above/below stations.
 
@@ -708,7 +855,125 @@ def place_labels(
     if routes:
         _avoid_diagonal_routes(placements, graph, routes, station_offsets)
 
+    _wrap_overlapping_labels(
+        placements, graph, station_offsets, allow_hyphenation=allow_hyphenation
+    )
+
     return [p for p in placements if p.obstacle_bbox is None]
+
+
+# Upper bound on wrapping rounds.  Each round narrows one offending label by
+# at least one line-width step, so this comfortably exceeds the steps any
+# realistic label needs to shrink from full width to the legibility floor.
+_WRAP_MAX_ROUNDS = 200
+
+
+def _wrap_overlapping_labels(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+    station_offsets: dict[tuple[str, str], float] | None,
+    allow_hyphenation: bool = True,
+) -> None:
+    """Narrow colliding labels by wrapping them onto multiple lines.
+
+    Conditional: only labels that actually overlap a neighbour (per
+    :func:`find_label_overlaps`) are wrapped, so a clean layout is left
+    byte-identical.  Each round picks the widest wrappable offender and
+    shrinks its line budget by one character, re-wrapping the *original*
+    label (never the already-wrapped text, which would compound hyphens).
+    The label grows away from its station so the extra height never intrudes
+    on the pill.  Author-specified multi-line labels are left untouched --
+    the author already chose the breaks.
+
+    When ``allow_hyphenation`` is False the budget stops at the longest word
+    (word-boundary wrapping only), leaving any residual overlap for the
+    engine's spread loop to clear by widening spacing.  When True (the final
+    render, where spacing is settled) a word may be hard-broken with a hyphen
+    down to ``LABEL_WRAP_MIN_LINE_CHARS`` as a last resort.
+    """
+    by_id = {
+        p.station_id: p
+        for p in placements
+        if p.station_id
+        and not p.station_id.startswith("__")
+        and p.obstacle_bbox is None
+        and graph.stations.get(p.station_id) is not None
+    }
+    # Only re-flow single-line labels; respect any author-chosen breaks.
+    wrappable = {sid for sid, p in by_id.items() if "\n" not in p.text}
+    if not wrappable:
+        return
+
+    originals = {sid: graph.stations[sid].label for sid in by_id}
+    budgets = {sid: len(by_id[sid].text) for sid in wrappable}
+
+    def floor(sid: str) -> int:
+        if allow_hyphenation:
+            return LABEL_WRAP_MIN_LINE_CHARS
+        longest_word = max((len(w) for w in originals[sid].split()), default=1)
+        return max(LABEL_WRAP_MIN_LINE_CHARS, longest_word)
+
+    for _ in range(_WRAP_MAX_ROUNDS):
+        overlaps = find_label_overlaps(graph, placements, station_offsets)
+        offender = _choose_wrap_offender(overlaps, by_id, wrappable)
+        if offender is None:
+            break
+        new_budget = budgets[offender] - 1
+        if new_budget < floor(offender):
+            wrappable.discard(offender)
+            continue
+        budgets[offender] = new_budget
+        by_id[offender].text = _wrap_text_to_chars(originals[offender], new_budget)
+
+    _expand_sections_for_wrapped_labels(placements, graph)
+
+
+def _choose_wrap_offender(
+    overlaps: list[LabelOverlap],
+    by_id: dict[str, LabelPlacement],
+    wrappable: set[str],
+) -> str | None:
+    """Pick the widest still-wrappable label involved in any overlap.
+
+    For ``"marker"`` overlaps only the label owner can be narrowed; for
+    ``"label"`` overlaps either side is a candidate.  Narrowing the wider
+    label first does the most to clear the collision with the least wrapping.
+    """
+    best: str | None = None
+    best_w = -1.0
+    for ov in overlaps:
+        candidates = (ov.a,) if ov.kind == "marker" else (ov.a, ov.b)
+        for sid in candidates:
+            if sid not in wrappable:
+                continue
+            w = label_text_width(by_id[sid].text)
+            if w > best_w:
+                best_w = w
+                best = sid
+    return best
+
+
+def _expand_sections_for_wrapped_labels(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+) -> None:
+    """Grow each section's bbox to contain its (now taller) wrapped labels."""
+    margin = LABEL_BBOX_MARGIN
+    for p in placements:
+        if not p.station_id or p.station_id.startswith("__") or p.obstacle_bbox:
+            continue
+        station = graph.stations.get(p.station_id)
+        if station is None or not station.section_id:
+            continue
+        sec = graph.sections.get(station.section_id)
+        if sec is None or sec.bbox_w <= 0:
+            continue
+        x_min, y_min, x_max, y_max = _label_bbox(p)
+        if y_min - margin < sec.bbox_y:
+            sec.bbox_h += sec.bbox_y - (y_min - margin)
+            sec.bbox_y = y_min - margin
+        if y_max + margin > sec.bbox_y + sec.bbox_h:
+            sec.bbox_h = (y_max + margin) - sec.bbox_y
 
 
 def _avoid_diagonal_routes(

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -54,6 +54,7 @@ def validate_layout(graph: MetroGraph) -> list[Violation]:
     precomputed = _compute_routes(graph)
     violations.extend(check_edge_waypoints(graph, _precomputed=precomputed))
     if precomputed is not None:
+        violations.extend(check_label_overlap(graph, _precomputed=precomputed))
         violations.extend(check_edge_section_crossing(graph, _precomputed=precomputed))
         violations.extend(
             check_bypass_section_clearance(graph, _precomputed=precomputed)
@@ -293,6 +294,55 @@ def check_minimum_section_spacing(
                     )
                 )
 
+    return violations
+
+
+def check_label_overlap(
+    graph: MetroGraph,
+    _precomputed: tuple[dict[tuple[str, str], float], list[RoutedPath]] | None = None,
+) -> list[Violation]:
+    """Check that no station label overlaps another label or a marker.
+
+    Mirrors the runtime guard: label/label overlap is never allowed;
+    label/marker grazes within ``LABEL_OVERLAP_TOL`` are tolerated.  Uses the
+    same detector the engine and wrapping pass use, so this reports exactly
+    what the final render would draw.
+    """
+    from nf_metro.layout.labels import find_label_overlaps, place_labels
+
+    violations: list[Violation] = []
+    if _precomputed is not None:
+        offsets, routes = _precomputed
+    else:
+        precomputed = _compute_routes(graph)
+        if precomputed is None:
+            return violations
+        offsets, routes = precomputed
+
+    try:
+        placements = place_labels(graph, station_offsets=offsets, routes=routes)
+    except Exception as e:
+        return [
+            Violation(
+                check="label_overlap",
+                severity=Severity.ERROR,
+                message=f"Label placement failed: {e}",
+            )
+        ]
+
+    for ov in find_label_overlaps(graph, placements, offsets):
+        target = "label" if ov.kind == "label" else "marker"
+        violations.append(
+            Violation(
+                check="label_overlap",
+                severity=Severity.ERROR,
+                message=(
+                    f"Label {ov.a!r} overlaps {target} {ov.b!r} by "
+                    f"({ov.ox:.1f}, {ov.oy:.1f})px"
+                ),
+                context={"a": ov.a, "b": ov.b, "kind": ov.kind},
+            )
+        )
     return violations
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -945,6 +945,34 @@ def test_section_bbox_contains_all_content(fixture, params):
 
 
 # ---------------------------------------------------------------------------
+# Station labels must not overlap each other or non-owner markers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_no_label_overlap(fixture):
+    """No station label may overlap another label or a non-owner marker.
+
+    The auto-spacing engine wraps wide labels and widens column/row pitch so
+    dense sections don't ship colliding labels (issue #405).  This asserts
+    the final rendered placements are collision-free across the whole corpus
+    -- label/label overlap is never allowed; a label grazing a marker within
+    ``LABEL_OVERLAP_TOL`` is tolerated (see ``find_label_overlaps``).
+    """
+    from nf_metro.layout.labels import find_label_overlaps, place_labels
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    placements = place_labels(graph, station_offsets=offsets, routes=routes)
+    overlaps = find_label_overlaps(graph, placements, offsets)
+    assert not overlaps, "; ".join(
+        f"{ov.a!r} overlaps {ov.kind} {ov.b!r} by ({ov.ox:.1f}, {ov.oy:.1f})px"
+        for ov in overlaps
+    )
+
+
+# ---------------------------------------------------------------------------
 # Adjacent-row sections that overlap horizontally must keep the configured
 # section_y_gap between upper bbox bottom and lower bbox top
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Dense sections with wide station labels could ship labels overrunning a neighbouring label or marker: placement used a fixed per-station offset and spaced stations by the grid pitch, reserving no room for the label's rendered width (#405).

This adds two cooperating, **conditional** mechanisms that leave a clean layout untouched:

- **Conditional wrapping** - a label that actually overlaps a neighbour is word-wrapped onto multiple lines (growing away from its pill), narrowing it just enough to clear. A single over-long word is hard-broken with a hyphen only as a last resort when spacing is pinned.
- **Auto-spread loop** - when wrapping can't clear an overlap at the current pitch, `compute_layout` widens the auto-resolved x/y spacing and lays out again. "No residual overlap -> no widening", so every existing render stays byte-identical. `--x-spacing` now defaults to auto (matching `--y-spacing`); pass an explicit value to pin it.

A single shared detector (`find_label_overlaps`) drives the wrapping pass, a runtime guard (`_guard_no_label_overlap`, under `compute_layout(validate=True)`), and a layout-validator check (`check_label_overlap`). Label/label overlap is never tolerated; a label grazing a marker within `LABEL_OVERLAP_TOL` (the ~1px touch between tightly stacked parallel lines) is allowed. Marker geometry is reused from the engine's pill helper, so junctions (no rendered marker) are excluded.

Adds the `wide_label_fan` topology fixture and a corpus-parametrised `test_no_label_overlap` invariant.

Fixes #405

## Test plan
- [ ] pytest passes (2684 passed locally, incl. new `test_no_label_overlap` across the corpus and the new fixture; `test_no_label_overlap[topologies/wide_label_fan.mmd]` fails without the fix)
- [ ] ruff check + ruff format clean on src/ + tests/
- [ ] Runtime validator (`check_label_overlap`) + phase guard (`_guard_no_label_overlap`) added
- [ ] Visual review of the render preview
- [ ] Render-preview verdict captured (expect: no changes to existing gallery; new `wide_label_fan` appears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
