### PR TITLE
fix(routing): slot perpendicular re-joining line by approach side at merge ports

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -693,6 +693,37 @@ def _guard_bundle_order_preserved(
     raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
 
 
+def _guard_merge_port_approach_side(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict | None = None,
+) -> None:
+    """Final-phase: at every multi-feeder reconvergence merge port, a
+    line that re-joins the bundle perpendicular (rising from a section
+    below, descending from one above) must take the bundle slot nearest
+    its approach side, so its riser does not cross over the lines that
+    arrive horizontally.
+
+    See
+    :func:`nf_metro.layout.routing.invariants.check_merge_port_approach_side`
+    for the semantic definition.
+    """
+    from nf_metro.layout.routing.invariants import check_merge_port_approach_side
+
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
+
+        offsets = compute_station_offsets(graph)
+
+    violations = check_merge_port_approach_side(graph, offsets)
+    if not violations:
+        return
+    first = violations[0]
+    extra = f" (+{len(violations) - 1} more)" if len(violations) > 1 else ""
+    raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
+
+
 def _guard_fanout_tail_join(
     graph: MetroGraph,
     phase: str,
@@ -1688,6 +1719,7 @@ def _compute_section_layout(
         _guard_row_trunk_cy_consistent(graph, phase, offsets=offsets)
         _guard_off_track_inputs_above_consumer(graph, phase)
         _guard_fanout_junction_shares_exit_port_y(graph, phase)
+        _guard_merge_port_approach_side(graph, phase, offsets=offsets)
         _guard_row_gaps(graph, phase, section_y_gap=section_y_gap)
         _guard_section_top_padding(
             graph,

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -384,11 +384,10 @@ class MergePortApproachViolation:
     bound: float
 
     def message(self) -> str:
-        rel = "below" if self.approach == "below" else "above"
         slot = "bottom" if self.approach == "below" else "top"
         return (
             f"merge port {self.port_id!r} line {self.line_id!r}: arrives "
-            f"from {rel} but sits at offset {self.offset:.1f}, on the wrong "
+            f"from {self.approach} but sits at offset {self.offset:.1f}, on the wrong "
             f"side of horizontal co-travellers (bound {self.bound:.1f}); "
             f"a perpendicular re-joining line must take the {slot} slot to "
             f"avoid crossing the bundle"

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -31,6 +31,7 @@ from nf_metro.layout.routing.common import (
     horizontal_direction,
     vertical_direction,
 )
+from nf_metro.parser.model import PortSide
 
 # Segments shorter than this are sub-pixel artefacts of per-line
 # offsets and carry no meaningful direction of travel.
@@ -350,11 +351,179 @@ def check_fanout_tail_join(
     return gaps
 
 
+# ---------------------------------------------------------------------------
+# Merge-port approach-side slot allocation
+# ---------------------------------------------------------------------------
+
+# Feeders sharing a port's row land within a few px of its base Y once
+# per-line offsets are applied; a perpendicular feeder arrives from a
+# different section row, a whole section-height away.  10px cleanly
+# separates the two without tripping on multi-line bundle spread.
+_MERGE_APPROACH_Y_TOL = 10.0
+
+
+@dataclass(frozen=True)
+class MergePortApproachViolation:
+    """A line slotted on the wrong side of a multi-feeder merge port.
+
+    At an LR/RL entry port fed by more than one exit port, a line that
+    arrives perpendicular to the bundle (rising from a section below or
+    descending from one above, with no horizontal co-travel in the
+    port's row) must take the bundle slot nearest its approach side: the
+    bottom slot when rising from below, the top slot when descending
+    from above.  Otherwise its perpendicular riser crosses over the
+    lines that arrive horizontally.  ``offset`` is the offending line's
+    Y offset at the port; ``bound`` is the horizontal-co-traveller
+    offset it violates.
+    """
+
+    port_id: str
+    line_id: str
+    approach: str  # "below" or "above"
+    offset: float
+    bound: float
+
+    def message(self) -> str:
+        rel = "below" if self.approach == "below" else "above"
+        slot = "bottom" if self.approach == "below" else "top"
+        return (
+            f"merge port {self.port_id!r} line {self.line_id!r}: arrives "
+            f"from {rel} but sits at offset {self.offset:.1f}, on the wrong "
+            f"side of horizontal co-travellers (bound {self.bound:.1f}); "
+            f"a perpendicular re-joining line must take the {slot} slot to "
+            f"avoid crossing the bundle"
+        )
+
+
+def _immediate_feeder(graph, port_id: str, line_id: str):  # noqa: ANN001, ANN202
+    """Return ``(source_station, is_junction)`` feeding ``line_id`` in.
+
+    Uses the IMMEDIATE edge source - it does not walk back through a
+    junction.  Whether the source is a fan/merge junction matters: only
+    a line fed by a direct exit port at a different row is a clean
+    inter-section edge the router L-shapes into the port with a riser at
+    the boundary (a true perpendicular join).  A junction-fed line may
+    drop to the port's row far upstream and co-travel horizontally, so
+    its junction's Y does not describe how it approaches the port.
+    """
+    for edge in graph.edges_to(port_id):
+        if edge.line_id != line_id:
+            continue
+        src = graph.stations.get(edge.source)
+        if src is None:
+            return None, False
+        return src, edge.source in graph.junctions
+    return None, False
+
+
+def classify_merge_port_feeders(
+    graph,  # noqa: ANN001 - MetroGraph (avoid import cycle)
+    port_id: str,
+) -> tuple[list[str], list[str], list[str]] | None:
+    """Classify a merge port's feeder lines by approach side.
+
+    Returns ``(horizontal, below, above)`` line-id lists for an LR/RL
+    entry port fed by at least two distinct feeders, with at least one
+    horizontal co-traveller and at least one perpendicular feeder.  A
+    line is horizontal when its immediate feeder sits in the port's own
+    row; it is ``below`` / ``above`` only when fed by a direct exit port
+    (not a junction) a row below / above the port - the clean
+    inter-section edge that arrives perpendicular at the boundary.  A
+    line dropped into the row by an upstream fan/merge junction
+    co-travels horizontally and is not a perpendicular joiner, so it is
+    left unclassified.  Returns ``None`` when the port is not such a
+    reconvergence merge - i.e. when there is no approach-side decision
+    to make.
+    """
+    port_obj = graph.ports.get(port_id)
+    if port_obj is None or not port_obj.is_entry:
+        return None
+    if port_obj.side not in (PortSide.LEFT, PortSide.RIGHT):
+        return None
+    port_st = graph.stations.get(port_id)
+    if port_st is None:
+        return None
+
+    distinct_sources: set[int] = set()
+    horizontal: list[str] = []
+    below: list[str] = []
+    above: list[str] = []
+    for lid in graph.station_lines(port_id):
+        src, is_junction = _immediate_feeder(graph, port_id, lid)
+        if src is None:
+            continue
+        distinct_sources.add(id(src))
+        dy = src.y - port_st.y
+        if abs(dy) <= _MERGE_APPROACH_Y_TOL:
+            horizontal.append(lid)
+        elif is_junction:
+            continue
+        elif dy > 0:
+            below.append(lid)
+        else:
+            above.append(lid)
+    if len(distinct_sources) < 2:
+        return None
+    if not horizontal or not (below or above):
+        return None
+    return horizontal, below, above
+
+
+def check_merge_port_approach_side(
+    graph,  # noqa: ANN001 - MetroGraph (avoid import cycle)
+    offsets: dict[tuple[str, str], float],
+) -> list[MergePortApproachViolation]:
+    """Return merge ports where a perpendicular feeder is mis-slotted.
+
+    For every reconvergence merge port (see
+    :func:`classify_merge_port_feeders`), a line rising from below must
+    sit at or below every horizontal co-traveller, and a line descending
+    from above must sit at or above every horizontal co-traveller.
+    """
+    violations: list[MergePortApproachViolation] = []
+    for port_id in graph.ports:
+        classified = classify_merge_port_feeders(graph, port_id)
+        if classified is None:
+            continue
+        horizontal, below, above = classified
+        horiz_offs = [offsets.get((port_id, lid), 0.0) for lid in horizontal]
+        max_horiz = max(horiz_offs)
+        min_horiz = min(horiz_offs)
+        for lid in below:
+            off = offsets.get((port_id, lid), 0.0)
+            if off < max_horiz - COORD_TOLERANCE_FINE:
+                violations.append(
+                    MergePortApproachViolation(
+                        port_id=port_id,
+                        line_id=lid,
+                        approach="below",
+                        offset=off,
+                        bound=max_horiz,
+                    )
+                )
+        for lid in above:
+            off = offsets.get((port_id, lid), 0.0)
+            if off > min_horiz + COORD_TOLERANCE_FINE:
+                violations.append(
+                    MergePortApproachViolation(
+                        port_id=port_id,
+                        line_id=lid,
+                        approach="above",
+                        offset=off,
+                        bound=min_horiz,
+                    )
+                )
+    return violations
+
+
 __all__ = [
     "BundleOrderViolation",
     "FanoutTailGap",
+    "MergePortApproachViolation",
     "Side",
     "check_bundle_order_preserved",
     "check_fanout_tail_join",
+    "check_merge_port_approach_side",
+    "classify_merge_port_feeders",
     "fanout_junctions",
 ]

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -6,6 +6,7 @@ from collections import deque
 from dataclasses import dataclass, field
 
 from nf_metro.layout.constants import OFFSET_STEP
+from nf_metro.layout.routing.invariants import classify_merge_port_feeders
 from nf_metro.layout.routing.reversal import detect_reversed_sections
 from nf_metro.parser.model import MetroGraph, PortSide
 
@@ -1020,6 +1021,92 @@ def _align_junction_to_entry_port(ctx: _OffsetCtx) -> None:
                         ctx.offsets[(feeding_exit, lid)] = off
 
 
+def _allocate_merge_ports_by_approach(ctx: _OffsetCtx) -> None:
+    """Re-slot perpendicular re-joining lines at multi-feeder merge ports.
+
+    At an LR/RL entry port fed by more than one exit port, a line that
+    arrives perpendicular to the bundle (rising from a section below, or
+    descending from one above) with no horizontal co-travel in the
+    port's row has no upstream ordering to preserve.  Forced into its
+    priority slot - especially under a section-reversal flip - it can
+    land on the far side of the bundle, so its riser crosses over the
+    horizontally-arriving lines.
+
+    For each such port, leave the horizontal co-travellers on their
+    incoming offsets (so their feeder edges stay flat) and move only a
+    mis-slotted perpendicular line: a ``below`` line is pushed just past
+    the bottom of the horizontal band (one step below its largest
+    offset), an ``above`` line just past the top.  Multiple perpendicular
+    lines on the same side keep their incoming relative order.  Ports
+    already in approach order are unchanged.  The new per-line offsets
+    propagate to every downstream station in the port's section so the
+    bundle stays consistent through the section.
+    """
+    if ctx.compact:
+        return
+
+    graph = ctx.graph
+    for port_id in graph.ports:
+        classified = classify_merge_port_feeders(graph, port_id)
+        if classified is None:
+            continue
+        horizontal, below, above = classified
+
+        def _cur(lid: str) -> float:
+            return ctx.offsets.get((port_id, lid), 0.0)
+
+        max_horiz = max(_cur(lid) for lid in horizontal)
+        min_horiz = min(_cur(lid) for lid in horizontal)
+
+        new_offs: dict[str, float] = {}
+        for rank, lid in enumerate(sorted(below, key=_cur), start=1):
+            new_offs[lid] = max_horiz + rank * ctx.offset_step
+        for rank, lid in enumerate(sorted(above, key=_cur, reverse=True), start=1):
+            new_offs[lid] = min_horiz - rank * ctx.offset_step
+
+        if all(
+            abs(new_offs[lid] - _cur(lid)) <= _OFFSET_EQ_TOLERANCE for lid in new_offs
+        ):
+            continue
+
+        sec_id = graph.ports[port_id].section_id
+        _apply_offsets_through_section(ctx, port_id, sec_id, new_offs)
+
+
+def _apply_offsets_through_section(
+    ctx: _OffsetCtx,
+    port_id: str,
+    sec_id: str | None,
+    new_offs: dict[str, float],
+) -> None:
+    """Set ``new_offs`` at ``port_id`` and propagate downstream in-section.
+
+    Walks ``edges_from`` from the port through non-port stations of the
+    same section, copying each line's new offset so the whole bundle
+    moves together.  Stops at section boundaries and ports.
+    """
+    graph = ctx.graph
+    for lid, off in new_offs.items():
+        ctx.offsets[(port_id, lid)] = off
+
+    visited = {port_id}
+    queue = deque([port_id])
+    while queue:
+        cur = queue.popleft()
+        for edge in graph.edges_from(cur):
+            tgt_id = edge.target
+            if tgt_id in visited:
+                continue
+            tgt = graph.stations.get(tgt_id)
+            if tgt is None or tgt.is_port or tgt.section_id != sec_id:
+                continue
+            visited.add(tgt_id)
+            for lid in graph.station_lines(tgt_id):
+                if lid in new_offs:
+                    ctx.offsets[(tgt_id, lid)] = new_offs[lid]
+            queue.append(tgt_id)
+
+
 def _reconcile_horizontal_offsets(ctx: _OffsetCtx, max_iterations: int = 10) -> None:
     """Snap offsets for same-section edges where endpoints share base Y.
 
@@ -1125,6 +1212,9 @@ def compute_station_offsets(
     6. **Junction inheritance** - copies exit port offsets to junctions.
     7. **Entry port offsets** - TOP entry override for TB BOTTOM exits,
        LR/RL exit-to-entry propagation, compact entry separation.
+    7b. **Merge-port approach-side allocation** - at multi-feeder LR/RL
+       entry ports, re-slots a perpendicular re-joining line to the
+       bundle slot nearest its approach side (non-compact only).
     8. **Horizontal reconciliation** - snaps mismatched offsets on
        same-Y edges to eliminate almost-horizontal slopes.
 
@@ -1140,5 +1230,6 @@ def compute_station_offsets(
     _propagate_to_junctions(ctx)
     _compute_entry_port_offsets(ctx)
     _align_junction_to_entry_port(ctx)
+    _allocate_merge_ports_by_approach(ctx)
     _reconcile_horizontal_offsets(ctx)
     return ctx.offsets

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -1051,21 +1051,22 @@ def _allocate_merge_ports_by_approach(ctx: _OffsetCtx) -> None:
         if classified is None:
             continue
         horizontal, below, above = classified
+        cur = {
+            lid: ctx.offsets.get((port_id, lid), 0.0)
+            for lid in graph.station_lines(port_id)
+        }
 
-        def _cur(lid: str) -> float:
-            return ctx.offsets.get((port_id, lid), 0.0)
-
-        max_horiz = max(_cur(lid) for lid in horizontal)
-        min_horiz = min(_cur(lid) for lid in horizontal)
+        max_horiz = max(cur[lid] for lid in horizontal)
+        min_horiz = min(cur[lid] for lid in horizontal)
 
         new_offs: dict[str, float] = {}
-        for rank, lid in enumerate(sorted(below, key=_cur), start=1):
+        for rank, lid in enumerate(sorted(below, key=cur.get), start=1):
             new_offs[lid] = max_horiz + rank * ctx.offset_step
-        for rank, lid in enumerate(sorted(above, key=_cur, reverse=True), start=1):
+        for rank, lid in enumerate(sorted(above, key=cur.get, reverse=True), start=1):
             new_offs[lid] = min_horiz - rank * ctx.offset_step
 
         if all(
-            abs(new_offs[lid] - _cur(lid)) <= _OFFSET_EQ_TOLERANCE for lid in new_offs
+            abs(new_offs[lid] - cur[lid]) <= _OFFSET_EQ_TOLERANCE for lid in new_offs
         ):
             continue
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -3813,3 +3813,54 @@ def test_thick_bundle_row_pitch(fixture):
         f"{fixture}: no thick (>= 4-line) bundle column with >= 2 stacked "
         f"stations matched the precondition"
     )
+
+
+# ---------------------------------------------------------------------------
+# Merge-port approach-side slot allocation
+# ---------------------------------------------------------------------------
+
+
+def _fixtures_with_merge_port() -> list[str]:
+    """Fixtures with at least one reconvergence merge port.
+
+    A merge port here is an LR/RL entry port fed by >= 2 exit ports with
+    both a horizontal co-traveller and a perpendicular feeder - the case
+    the approach-side allocation governs.  Computed once at import time.
+    """
+    from nf_metro.layout.routing.invariants import classify_merge_port_feeders
+
+    out: list[str] = []
+    for name in ALL_FIXTURES:
+        try:
+            g = _layout(name)
+        except Exception:
+            continue
+        if any(classify_merge_port_feeders(g, pid) is not None for pid in g.ports):
+            out.append(name)
+    return out
+
+
+_FIXTURES_WITH_MERGE_PORT = _fixtures_with_merge_port()
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_WITH_MERGE_PORT)
+def test_merge_port_rejoining_line_takes_approach_slot(fixture):
+    """A line that re-joins a bundle perpendicular at a multi-feeder
+    entry port must take the bundle slot nearest its approach side.
+
+    A line rising from a section below must sit at or below every
+    horizontally-arriving co-traveller (bottom slot); a line descending
+    from a section above must sit at or above them (top slot).  When it
+    is forced into a priority slot on the far side instead, its
+    perpendicular riser crosses over the horizontal lines - the visible
+    crossover this invariant guards against (issue #415).
+    """
+    from nf_metro.layout.routing.invariants import check_merge_port_approach_side
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    violations = check_merge_port_approach_side(graph, offsets)
+    assert violations == [], (
+        f"{fixture}: {len(violations)} merge-port approach-side "
+        f"violation(s); first: {violations[0].message() if violations else ''}"
+    )


### PR DESCRIPTION
## Summary

At a multi-feeder LR/RL entry port, a line that re-joins the bundle perpendicular (rising from a section below, or descending from one above) with no horizontal co-travel in the port's row was forced into its line-priority slot. Under a section-reversal flip it could land on the far side of the bundle, so its vertical riser crossed over the lines arriving horizontally.

This surfaced at `examples/topologies/fold_stacked_branch.mmd`'s `Aggregate` merge after the #411 reversal flipped `protein` from the bottom slot to the top: `protein` rises from `tech_qc` below and had to climb over `atac`/`rna` to reach the top slot.

- New offset phase `_allocate_merge_ports_by_approach` moves only the mis-slotted perpendicular line to the bundle slot nearest its approach side (below → just past the bottom of the horizontal band, above → just past the top), leaving horizontal co-travellers on their incoming offsets so their feeder edges stay flat. The new offsets propagate through the section.
- Classification (`classify_merge_port_feeders`) and the violation check (`check_merge_port_approach_side`) live in `routing/invariants.py`. A line is treated as a perpendicular joiner only when fed by a direct exit port a row above/below; a line dropped into the row by an upstream fan/merge junction co-travels horizontally and is left alone (this is why `genomeassembly_staggered`'s horizontally co-travelling `hic_reads` is correctly not flagged).
- Runtime guard `_guard_merge_port_approach_side` wired into `compute_layout(validate=True)`.
- Parametrised invariant test in `test_layout_invariants.py`, exercised against every gallery/topology fixture with a qualifying merge port.

Resolves the merge crossover together with the #411 entry-corner fix: `fold_stacked_branch` now renders with zero crossings at both the `Aggregate` merge and the `bio_interp` entry corner.

Fixes #415

## Test plan
- [x] pytest passes (2935 passed), including the new invariant test
- [x] new invariant test fails on base, passes with the fix
- [x] ruff check + ruff format clean on `src/ tests/` (CI scope)
- [x] runtime validator added (`_guard_merge_port_approach_side`)
- [ ] visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/417/)
- [ ] render-preview verdict captured and gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)