### PR TITLE
fix(render): orient terminus file icons to TB section flow

### DIFF
--- a/examples/tb_file_termini.mmd
+++ b/examples/tb_file_termini.mmd
@@ -1,0 +1,33 @@
+%%metro title: TB section file outputs
+%%metro style: dark
+%%metro line: rna | RNA-seq | #1f9e89
+%%metro line: dna | Variant | #2c7fb8
+%%metro file: report_html | HTML | Report
+%%metro file: bundle_zip | ZIP | Bundle
+%%metro file: multiqc_html | HTML | MultiQC
+
+graph LR
+    subgraph analysis [Analysis]
+        align[Align]
+        call[Call]
+        align -->|rna,dna| call
+    end
+
+    subgraph reporting [Reporting]
+        %%metro direction: TB
+        %%metro entry: left | rna, dna
+        report[Build report]
+        bundle[Zip bundle]
+        multiqc[MultiQC]
+        report_html[ ]
+        bundle_zip[ ]
+        multiqc_html[ ]
+
+        report -->|rna,dna| report_html
+        report -->|rna,dna| bundle
+        bundle -->|rna,dna| bundle_zip
+        report -->|rna,dna| multiqc
+        multiqc -->|rna,dna| multiqc_html
+    end
+
+    call -->|rna,dna| report

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -65,6 +65,11 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "Same nf-core/differentialabundance map at default (uncentered) layout — useful for spotting regressions that only show with default port placement.",
     ),
     (
+        "tb_file_termini",
+        EXAMPLES_DIR,
+        "A `%%metro direction: TB` reporting section whose file outputs are line termini. Regression fixture for #254 (terminus file icons now orient to a vertical flow, with the connector entering from the top).",
+    ),
+    (
         "genomeassembly_staggered",
         EXAMPLES_DIR,
         "sanger-tol/genomeassembly with explicit `%%metro grid:` directives stacking each section in its own grid row. Regression fixture for #250 (cross-column junction routes were going backward in X).",

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -394,6 +394,22 @@ Accounts for station_radius (~5px) + icon gap (6px) + icon width (28px) = 39px
 extent, plus ~19px visual margin so icons don't crowd the section border.
 """
 
+TERMINUS_ICON_CLEARANCE_V: float = (
+    STATION_RADIUS_APPROX
+    + 6.0  # icon gap (render-side ICON_STATION_GAP)
+    + 2 * ICON_HALF_HEIGHT
+    + ICON_CAPTION_GAP
+    + ICON_CAPTION_FONT_HEIGHT
+    + 14.0  # visual margin so captions don't crowd the section border
+)
+"""Minimum clearance from a terminus station center to the section bbox
+edge along the *vertical* (flow) axis, used by TB/BT sections.
+
+TB/BT termini stack their file icon (and under-icon caption) below or
+above the station instead of beside it, so the reservation uses icon
+height + caption height rather than icon width.
+"""
+
 PORT_LABEL_MAX_DX: float = 120.0
 """Max horizontal distance for port-route label override.
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -5913,6 +5913,16 @@ def _terminus_icon_clearance_vertical(
     return TERMINUS_ICON_CLEARANCE_V + (n_icons - 1) * step
 
 
+def _terminus_icons_extend_forward(is_source: bool, section_dir: str) -> bool:
+    """Whether a terminus's icons extend in the section's forward flow.
+
+    Sinks extend forwards (down for TB, right for LR), sources backwards;
+    RL/BT mirror that.  Single source of truth for the rule that
+    ``render.svg._terminus_icon_centers`` applies on the render side.
+    """
+    return is_source if section_dir in ("RL", "BT") else not is_source
+
+
 def _terminus_y_overhang(
     station: Station, section_dir: str, graph: MetroGraph
 ) -> tuple[float, float]:
@@ -5925,11 +5935,12 @@ def _terminus_y_overhang(
     if not station.is_terminus or section_dir not in ("TB", "BT"):
         return 0.0, 0.0
     is_source = not graph.edges_to(station.id)
-    extends_forward = is_source if section_dir == "BT" else not is_source
     extent = _terminus_icon_clearance_vertical(
         len(station.terminus_labels), station.terminus_names
     )
-    return (0.0, extent) if extends_forward else (extent, 0.0)
+    if _terminus_icons_extend_forward(is_source, section_dir):  # below
+        return 0.0, extent
+    return extent, 0.0
 
 
 def _adjust_terminus_icon_clearance(
@@ -5953,9 +5964,7 @@ def _adjust_terminus_icon_clearance(
 
         n_icons = len(station.terminus_labels)
         is_source = not graph.edges_to(station.id)
-        # Sinks extend in the forward flow direction, sources in reverse;
-        # RL/BT mirror.  Matches render.svg._terminus_icon_centers.
-        extends_forward = is_source if section_dir in ("RL", "BT") else not is_source
+        extends_forward = _terminus_icons_extend_forward(is_source, section_dir)
 
         if is_tb:
             needed = _terminus_icon_clearance_vertical(n_icons, station.terminus_names)

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -26,6 +26,7 @@ from nf_metro.layout.constants import (
     ICON_CAPTION_FONT_HEIGHT,
     ICON_CAPTION_GAP,
     ICON_HALF_HEIGHT,
+    ICON_INTER_GAP,
     ICON_STACK_LABEL_CLEARANCE,
     JUNCTION_MARGIN,
     LABEL_BBOX_MARGIN,
@@ -52,6 +53,7 @@ from nf_metro.layout.constants import (
     STATION_RADIUS_APPROX,
     TB_LINE_Y_OFFSET,
     TERMINUS_ICON_CLEARANCE,
+    TERMINUS_ICON_CLEARANCE_V,
     TERMINUS_WIDTH,
     X_OFFSET,
     X_SPACING,
@@ -274,6 +276,38 @@ def _guard_section_top_padding(
                 f"sits below its content-anchored target {target:.1f} "
                 f"(highest marker crowds the bbox top edge)"
             )
+
+
+def _guard_terminus_icons_within_bbox(graph: MetroGraph, phase: str) -> None:
+    """Final phase: TB/BT terminus file icons must fit inside the section bbox.
+
+    Vertical-flow termini stack their file icon (and caption) below or
+    above the station marker; the section bbox must reserve that extent so
+    the icon doesn't spill past the box edge (issue #254).
+    """
+    tol = 1.0
+    for section in graph.sections.values():
+        if section.bbox_h <= 0 or section.direction not in ("TB", "BT"):
+            continue
+        top = section.bbox_y
+        bottom = section.bbox_y + section.bbox_h
+        for sid in section.station_ids:
+            st = graph.stations.get(sid)
+            if st is None or not st.is_terminus:
+                continue
+            above, below = _terminus_y_overhang(st, section.direction, graph)
+            if st.y + below > bottom + tol:
+                raise PhaseInvariantError(
+                    f"{phase}: terminus {sid!r} icons extend to "
+                    f"{st.y + below:.1f}, past section {section.id!r} bbox "
+                    f"bottom {bottom:.1f}"
+                )
+            if st.y - above < top - tol:
+                raise PhaseInvariantError(
+                    f"{phase}: terminus {sid!r} icons extend to "
+                    f"{st.y - above:.1f}, above section {section.id!r} bbox "
+                    f"top {top:.1f}"
+                )
 
 
 def _station_marker_bbox(
@@ -1875,6 +1909,20 @@ def _compute_section_layout(
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.15")
 
+    # Stage 6.16: Re-align LEFT/RIGHT entry ports with their feeders.  A
+    # TB section's perpendicular entry port is pinned a fixed offset above
+    # its first internal station, so the late vertical settling (Stages
+    # 6.13-6.15) that shifts the section's content also drags the entry
+    # port off the upstream feeder Y it was snapped to in Stage 3.2,
+    # re-introducing an inter-section S-kink.  Re-running the alignment
+    # (TB/BT sections only, to leave settled LR/RL geometry untouched)
+    # re-snaps the port to its now-settled feeder.  Junctions are
+    # re-anchored afterwards for the same reason as Stages 6.13/6.14.
+    _align_entry_ports(graph, tb_only=True)
+    _position_junctions(graph)
+    if validate:
+        _run_pass_c_guards(graph, "after Stage 6.16")
+
     if validate:
         phase = "after final"
         offsets, routes = _run_pass_c_guards(graph, phase)
@@ -1889,6 +1937,7 @@ def _compute_section_layout(
             section_y_padding=section_y_padding,
             section_y_gap=section_y_gap,
         )
+        _guard_terminus_icons_within_bbox(graph, phase)
         if routes is not None:
             _guard_inter_section_routes_in_row_band(
                 graph, phase, offsets=offsets, routes=routes
@@ -5020,8 +5069,17 @@ def _shrink_bboxes_to_content_bottom(
     for section in graph.sections.values():
         if section.bbox_h <= 0:
             continue
-        content_max_ys = [
+        section_dir = section.direction or "LR"
+        # Each non-port station reserves at least ``section_y_padding`` below
+        # its marker; a TB/BT terminus whose icons hang below reserves their
+        # full vertical extent instead.  (Overhang is 0 for LR/RL, so this
+        # stays byte-identical there.)
+        content_bots = [
             graph.stations[sid].y
+            + max(
+                section_y_padding,
+                _terminus_y_overhang(graph.stations[sid], section_dir, graph)[1],
+            )
             for sid in section.station_ids
             if (
                 sid in graph.stations
@@ -5039,9 +5097,9 @@ def _shrink_bboxes_to_content_bottom(
             for sid in section.station_ids
             if sid in graph.stations and graph.stations[sid].is_port
         ]
-        if not content_max_ys:
+        if not content_bots:
             continue
-        content_bot = max(content_max_ys) + section_y_padding
+        content_bot = max(content_bots)
         if bypass_max_ys:
             content_bot = max(content_bot, max(bypass_max_ys) + v_curve_clearance)
         if port_max_ys:
@@ -5836,6 +5894,44 @@ def _terminus_icon_clearance(
     return TERMINUS_ICON_CLEARANCE + extra
 
 
+def _terminus_icon_clearance_vertical(
+    n_icons: int,
+    names: list[str] | None = None,
+) -> float:
+    """Vertical clearance for *n_icons* file icons stacked along the flow axis.
+
+    TB/BT counterpart of ``_terminus_icon_clearance``: icons stack along Y,
+    so each additional icon adds the icon height plus (when captions are
+    present) a caption row, matching the renderer's TB step.
+    """
+    if n_icons <= 1:
+        return TERMINUS_ICON_CLEARANCE_V
+    caption_room = (
+        ICON_CAPTION_GAP + ICON_CAPTION_FONT_HEIGHT if names and any(names) else 0.0
+    )
+    step = 2 * ICON_HALF_HEIGHT + ICON_INTER_GAP + caption_room
+    return TERMINUS_ICON_CLEARANCE_V + (n_icons - 1) * step
+
+
+def _terminus_y_overhang(
+    station: Station, section_dir: str, graph: MetroGraph
+) -> tuple[float, float]:
+    """(above, below) px a TB/BT terminus's icons extend past its marker.
+
+    Returns ``(0.0, 0.0)`` for non-terminus stations and for LR/RL
+    sections (whose icons extend horizontally), so content-extent callers
+    stay byte-identical there.
+    """
+    if not station.is_terminus or section_dir not in ("TB", "BT"):
+        return 0.0, 0.0
+    is_source = not graph.edges_to(station.id)
+    extends_forward = is_source if section_dir == "BT" else not is_source
+    extent = _terminus_icon_clearance_vertical(
+        len(station.terminus_labels), station.terminus_names
+    )
+    return (0.0, extent) if extends_forward else (extent, 0.0)
+
+
 def _adjust_terminus_icon_clearance(
     sub: MetroGraph,
     section: Section,
@@ -5843,42 +5939,48 @@ def _adjust_terminus_icon_clearance(
 ) -> None:
     """Expand bbox when terminus file icons would be too close to the edge.
 
-    Terminus stations display file icon(s) on their "outside" (flow-entry for
-    sources, flow-exit for sinks).  The icon(s) extend horizontally from the
-    station center.  If SECTION_X_PADDING doesn't provide enough room, we
-    grow the bbox on the affected side.
+    Terminus icons march along the section's flow axis (horizontally for
+    LR/RL, vertically for TB/BT), on the station's "outside": forwards for
+    sinks, backwards for sources, with RL/BT mirrored.  When the section
+    padding doesn't leave enough room, grow the bbox on the affected side.
     """
+    section_dir = section.direction or "LR"
+    is_tb = section_dir in ("TB", "BT")
+
     for station in sub.stations.values():
         if not station.is_terminus:
             continue
 
         n_icons = len(station.terminus_labels)
-        needed = _terminus_icon_clearance(n_icons, station.terminus_names)
-
-        # Determine source vs sink from the full graph's edges
         is_source = not graph.edges_to(station.id)
+        # Sinks extend in the forward flow direction, sources in reverse;
+        # RL/BT mirror.  Matches render.svg._terminus_icon_centers.
+        extends_forward = is_source if section_dir in ("RL", "BT") else not is_source
 
-        section_dir = section.direction or "LR"
-
-        # Icon is always placed horizontally (left or right of station),
-        # even for TB/BT sections.
-        if section_dir in ("LR", "TB"):
-            icon_on_left = is_source
-        else:  # RL, BT
-            icon_on_left = not is_source
-
-        if icon_on_left:
-            clearance = station.x - section.bbox_x
-            if clearance < needed:
-                expand = needed - clearance
-                section.bbox_x -= expand
-                section.bbox_w += expand
+        if is_tb:
+            needed = _terminus_icon_clearance_vertical(n_icons, station.terminus_names)
+            if extends_forward:  # icons below the station
+                clearance = section.bbox_y + section.bbox_h - station.y
+                if clearance < needed:
+                    section.bbox_h += needed - clearance
+            else:  # icons above the station
+                clearance = station.y - section.bbox_y
+                if clearance < needed:
+                    expand = needed - clearance
+                    section.bbox_y -= expand
+                    section.bbox_h += expand
         else:
-            bbox_right = section.bbox_x + section.bbox_w
-            clearance = bbox_right - station.x
-            if clearance < needed:
-                expand = needed - clearance
-                section.bbox_w += expand
+            needed = _terminus_icon_clearance(n_icons, station.terminus_names)
+            if not extends_forward:  # icons left of the station
+                clearance = station.x - section.bbox_x
+                if clearance < needed:
+                    expand = needed - clearance
+                    section.bbox_x -= expand
+                    section.bbox_w += expand
+            else:  # icons right of the station
+                clearance = section.bbox_x + section.bbox_w - station.x
+                if clearance < needed:
+                    section.bbox_w += needed - clearance
 
 
 def _shift_lr_perp_entry_stations(
@@ -6189,11 +6291,16 @@ def _set_port_x(graph: MetroGraph, port_id: str, x: float) -> None:
         port.x = x
 
 
-def _align_entry_ports(graph: MetroGraph) -> None:
+def _align_entry_ports(graph: MetroGraph, tb_only: bool = False) -> None:
     """Align entry ports with their incoming connection's coordinates.
 
     LEFT/RIGHT ports: align Y for straight horizontal runs.
     TOP/BOTTOM ports: align X for vertical drops or Y for cross-column.
+
+    With ``tb_only`` set, only ports on TB/BT sections are re-aligned --
+    used by the late re-alignment pass (Stage 6.16), which targets the
+    perpendicular-entry drift that vertical settling introduces in
+    TB sections without disturbing settled LR/RL geometry.
     """
     junction_ids = graph.junction_ids
 
@@ -6203,6 +6310,9 @@ def _align_entry_ports(graph: MetroGraph) -> None:
 
         entry_section = graph.sections.get(port.section_id)
         if not entry_section:
+            continue
+
+        if tb_only and entry_section.direction not in ("TB", "BT"):
             continue
 
         if port.side in (PortSide.LEFT, PortSide.RIGHT):

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -952,10 +952,11 @@ def _render_terminus_icons(
     caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
     name_widths = [len(n) * caption_font_size * 0.55 if n else 0.0 for n in names]
     # LR/RL march icons along X, so widen the step when adjacent captions
-    # would overlap.  TB/BT stack icons along Y, where height (not caption
-    # width) sets the spacing.
+    # would overlap.  TB/BT stack icons along Y, where icon height (plus a
+    # caption row, when present) sets the spacing.
     if is_tb:
-        icon_step = theme.terminus_height + ICON_INTER_GAP
+        caption_room = caption_font_size + ICON_NAME_GAP if any(names) else 0.0
+        icon_step = theme.terminus_height + ICON_INTER_GAP + caption_room
     else:
         icon_step = caption_aware_icon_step(names, name_widths, theme.terminus_width)
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -790,12 +790,21 @@ def _render_stations(
         # (same size as pill, no rounding)
         is_blank_terminus = station.is_terminus and not station.label.strip()
         if is_blank_terminus:
-            w = r * 2
-            h = span + r * 2
-            cy = station.y + (min_off + max_off) / 2
+            # Match the section flow axis: a horizontal nub for TB/BT (lines
+            # arrive vertically), a vertical nub otherwise.
+            if is_tb_vert:
+                w = span + r * 2
+                h = r * 2
+                cx = station.x + (min_off + max_off) / 2
+                cy = station.y
+            else:
+                w = r * 2
+                h = span + r * 2
+                cx = station.x
+                cy = station.y + (min_off + max_off) / 2
             d.append(
                 draw.Rectangle(
-                    station.x - w / 2,
+                    cx - w / 2,
                     cy - h / 2,
                     w,
                     h,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -881,6 +881,38 @@ def caption_aware_icon_step(
     return required
 
 
+def _terminus_icon_centers(
+    station: Station,
+    section_dir: str,
+    is_source: bool,
+    n: int,
+    first_offset: float,
+    step: float,
+    bundle_center: float,
+) -> list[tuple[float, float]]:
+    """Centre coordinates for a terminus station's file icons.
+
+    Icons march away from the station along the section's *flow* axis
+    (X for LR/RL, Y for TB/BT) and stay centred on the station's bundle
+    on the *cross* axis.  Sinks extend in the forward flow direction,
+    sources in the reverse; RL/BT mirror that so icons always point to
+    the outside of the diagram.
+    """
+    is_tb = section_dir in ("TB", "BT")
+    # Sinks sit at the end of the flow and extend forwards; sources sit at
+    # the start and extend backwards.  RL/BT reverse the forward direction.
+    extends_forward = is_source if section_dir in ("RL", "BT") else not is_source
+    sign = 1.0 if extends_forward else -1.0
+    centers: list[tuple[float, float]] = []
+    for i in range(n):
+        flow = sign * (first_offset + i * step)
+        if is_tb:
+            centers.append((station.x + bundle_center, station.y + flow))
+        else:
+            centers.append((station.x + flow, station.y + bundle_center))
+    return centers
+
+
 def _render_terminus_icons(
     d: draw.Drawing,
     station: Station,
@@ -892,44 +924,50 @@ def _render_terminus_icons(
 ) -> None:
     """Render file icon(s) adjacent to a terminus station.
 
-    Multiple icons are arranged in a horizontal row, extending away from
-    the station (i.e. the first icon is closest to the station pill).
+    Multiple icons march away from the station along the section's flow
+    axis (a horizontal row for LR/RL, a vertical stack for TB/BT), with
+    the first icon closest to the station pill.
     """
     section: Section | None = (
         graph.sections.get(station.section_id) if station.section_id else None
     )
     # Detect if station is a source (no incoming edges) or sink.
     is_source = not graph.edges_to(station.id)
-    # Place icons on the "outside" of the flow
+    section_dir = section.direction if section else "LR"
+    is_tb = section_dir in ("TB", "BT")
+    # Gap between the station pill and the first icon, plus the icon's own
+    # half-extent along the flow axis (width for LR/RL, height for TB/BT).
     icon_gap = r + ICON_STATION_GAP
     icon_half_w = theme.terminus_width / 2
-    section_dir = section.direction if section else "LR"
+    icon_half_h = theme.terminus_height / 2
+    icon_half_flow = icon_half_h if is_tb else icon_half_w
 
-    # Determine direction: icons extend leftward for sources (LR/TB)
-    # or rightward for sinks, inverted for RL.
-    if section_dir == "RL":
-        icons_go_right = is_source
-    else:
-        icons_go_right = not is_source
-
-    icon_cy = station.y + (min_off + max_off) / 2
+    bundle_center = (min_off + max_off) / 2
 
     icon_types = station.terminus_icon_types or [ICON_TYPE_FILE] * len(
         station.terminus_labels
     )
     names = station.terminus_names or [""] * len(station.terminus_labels)
 
-    # Compute per-icon X step.  When adjacent captions would overlap
-    # at the default step, widen it so both fit on the same row.
     caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
     name_widths = [len(n) * caption_font_size * 0.55 if n else 0.0 for n in names]
-    icon_step = caption_aware_icon_step(names, name_widths, theme.terminus_width)
-
-    # Base X for the first (nearest) icon center
-    if icons_go_right:
-        base_cx = station.x + icon_gap + icon_half_w
+    # LR/RL march icons along X, so widen the step when adjacent captions
+    # would overlap.  TB/BT stack icons along Y, where height (not caption
+    # width) sets the spacing.
+    if is_tb:
+        icon_step = theme.terminus_height + ICON_INTER_GAP
     else:
-        base_cx = station.x - icon_gap - icon_half_w
+        icon_step = caption_aware_icon_step(names, name_widths, theme.terminus_width)
+
+    centers = _terminus_icon_centers(
+        station,
+        section_dir,
+        is_source,
+        len(station.terminus_labels),
+        icon_gap + icon_half_flow,
+        icon_step,
+        bundle_center,
+    )
 
     # Captions sitting at the same Y overlap when their estimated
     # widths exceed icon_step; in that case, every other caption is
@@ -947,13 +985,15 @@ def _render_terminus_icons(
         icon_type = icon_types[i] if i < len(icon_types) else ICON_TYPE_FILE
         name = names[i] if i < len(names) else ""
 
-        if icons_go_right:
-            icon_cx = base_cx + i * icon_step
-        else:
-            icon_cx = base_cx - i * icon_step
+        icon_cx, icon_cy = centers[i]
 
-        # Clamp to stay within section bbox
-        if section and section.bbox_w > 0:
+        # Clamp to stay within the section bbox, on whichever axis the
+        # icons march along.
+        if section and is_tb and section.bbox_h > 0:
+            top = section.bbox_y + icon_half_h + ICON_BBOX_MARGIN
+            bottom = section.bbox_y + section.bbox_h - icon_half_h - ICON_BBOX_MARGIN
+            icon_cy = max(top, min(icon_cy, bottom))
+        elif section and not is_tb and section.bbox_w > 0:
             icon_right = (
                 section.bbox_x + section.bbox_w - icon_half_w - ICON_BBOX_MARGIN
             )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,7 +4,8 @@ import xml.etree.ElementTree as ET
 
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
-from nf_metro.render.svg import render_svg
+from nf_metro.parser.model import Station
+from nf_metro.render.svg import _terminus_icon_centers, render_svg
 from nf_metro.themes import LIGHT_THEME, NFCORE_THEME
 
 
@@ -463,3 +464,103 @@ def test_render_icon_type_guide_fixtures():
         svg = render_svg(graph, NFCORE_THEME)
         root = ET.fromstring(svg)
         assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+# --- Terminus icon orientation (issue #254) ---
+
+
+def _station(x=100.0, y=50.0):
+    return Station(id="t", label="", x=x, y=y)
+
+
+def test_terminus_icons_lr_march_along_x():
+    """LR termini lay icons out horizontally, centred on the bundle Y."""
+    st = _station()
+    # Sink (no outgoing) extends to the right (forward flow).
+    centers = _terminus_icon_centers(
+        st, "LR", is_source=False, n=2, first_offset=10.0, step=4.0, bundle_center=3.0
+    )
+    assert centers == [(110.0, 53.0), (114.0, 53.0)]
+    # Source (no incoming) extends to the left (reverse flow).
+    src = _terminus_icon_centers(
+        st, "LR", is_source=True, n=1, first_offset=10.0, step=4.0, bundle_center=0.0
+    )
+    assert src == [(90.0, 50.0)]
+
+
+def test_terminus_icons_rl_mirror_lr():
+    """RL flows right-to-left, so the forward/reverse sides are mirrored."""
+    st = _station()
+    sink = _terminus_icon_centers(
+        st, "RL", is_source=False, n=1, first_offset=10.0, step=4.0, bundle_center=0.0
+    )
+    assert sink == [(90.0, 50.0)]
+
+
+def test_terminus_icons_tb_march_along_y():
+    """TB termini stack icons vertically, centred on the bundle X.
+
+    Regression test for #254: in a TB section the line arrives from
+    above/below, so icons must be displaced along Y (the flow axis), not
+    along X as for LR.
+    """
+    st = _station()
+    # Sink at the bottom of a TB flow: icons extend downward.
+    sink = _terminus_icon_centers(
+        st, "TB", is_source=False, n=2, first_offset=10.0, step=4.0, bundle_center=3.0
+    )
+    assert sink == [(103.0, 60.0), (103.0, 64.0)]
+    # Every icon stays on the station's X (cross axis); only Y advances.
+    assert all(cx == 103.0 for cx, _ in sink)
+    assert all(cy != st.y for _, cy in sink)
+    # Source at the top of a TB flow: icons extend upward.
+    src = _terminus_icon_centers(
+        st, "TB", is_source=True, n=1, first_offset=10.0, step=4.0, bundle_center=0.0
+    )
+    assert src == [(100.0, 40.0)]
+
+
+def test_terminus_icons_bt_mirror_tb():
+    """BT flows bottom-to-top, mirroring TB's forward/reverse sides."""
+    st = _station()
+    sink = _terminus_icon_centers(
+        st, "BT", is_source=False, n=1, first_offset=10.0, step=4.0, bundle_center=0.0
+    )
+    assert sink == [(100.0, 40.0)]
+
+
+def test_render_tb_section_file_icon_below_station():
+    """A file terminus in a TB section renders its icon below the station."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: report_out | HTML | Report\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        %%metro direction: TB\n"
+        "        run[Run]\n"
+        "        report_out[ ]\n"
+        "        run -->|main| report_out\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    station = graph.stations["report_out"]
+    section = graph.sections["sec"]
+    assert section.direction == "TB"
+    centers = _terminus_icon_centers(
+        station,
+        "TB",
+        is_source=False,
+        n=1,
+        first_offset=10.0,
+        step=4.0,
+        bundle_center=0.0,
+    )
+    (icon_cx, icon_cy) = centers[0]
+    # Icon sits on the station's X column and below it (downward TB flow).
+    assert abs(icon_cx - station.x) < 1e-6
+    assert icon_cy > station.y
+    # And the render still succeeds and carries the icon label.
+    svg = render_svg(graph, NFCORE_THEME)
+    assert "HTML" in svg
+    root = ET.fromstring(svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -564,3 +564,31 @@ def test_render_tb_section_file_icon_below_station():
     assert "HTML" in svg
     root = ET.fromstring(svg)
     assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_render_tb_terminus_pill_is_horizontal():
+    """A blank terminus nub in a TB section is a horizontal (wide) pill."""
+    import re
+
+    graph = parse_metro_mermaid(
+        "%%metro line: a | A | #ff0000\n"
+        "%%metro line: b | B | #00ff00\n"
+        "%%metro file: out | HTML\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        %%metro direction: TB\n"
+        "        run[Run]\n"
+        "        out[ ]\n"
+        "        run -->|a,b| out\n"
+        "    end\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    # The terminus nub <rect> carries data-station-id="out"; in a TB section
+    # it must be wider than tall (lines arrive vertically into it).
+    m = re.search(r'<rect\b[^>]*data-station-id="out"[^>]*/?>', svg)
+    assert m, "terminus nub rect not found"
+    rect = m.group(0)
+    width = float(re.search(r'width="([0-9.]+)"', rect).group(1))
+    height = float(re.search(r'height="([0-9.]+)"', rect).group(1))
+    assert width > height, f"TB terminus pill not horizontal: {width=} {height=}"

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -424,6 +424,43 @@ class TestTbFileTerminiRegression:
         ]
         assert len(termini) == 3
 
+    def test_termini_icons_reserved_below_in_bbox(self, tb_graph):
+        """The TB section bbox bottom must clear its sink terminus icons."""
+        reporting = tb_graph.sections["reporting"]
+        bottom = reporting.bbox_y + reporting.bbox_h
+        sink_termini = [
+            tb_graph.stations[sid]
+            for sid in reporting.station_ids
+            if tb_graph.stations[sid].is_terminus
+        ]
+        assert sink_termini
+        # Each sink terminus sits above the bbox bottom with room for its
+        # downward icon (a bare marker would only need ~5px).
+        for st in sink_termini:
+            assert bottom - st.y > 2 * 16.0, (
+                f"{st.id}: only {bottom - st.y:.1f}px below station for icon"
+            )
+
+    def test_entry_port_aligned_with_feeder_no_kink(self, tb_graph):
+        """The TB entry port shares its feeder's Y (Stage 6.16 re-align)."""
+        entry_ports = tb_graph.sections["reporting"].entry_ports
+        assert entry_ports
+        for pid in entry_ports:
+            feeder_ys = [
+                tb_graph.stations[e.source].y
+                for e in tb_graph.edges_to(pid)
+                if e.source in tb_graph.stations
+            ]
+            assert feeder_ys
+            port_y = tb_graph.stations[pid].y
+            assert min(abs(port_y - fy) for fy in feeder_ys) < 1.0
+
+    def test_validate_guards_pass(self):
+        """compute_layout(validate=True) exercises the terminus-icon guard."""
+        text = TB_FILE_TERMINI_FILE.read_text()
+        graph = parse_metro_mermaid(text)
+        compute_layout(graph, validate=True)
+
 
 # --- Topology-specific assertions ---
 

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -40,6 +40,7 @@ TOPOLOGY_IDS = [f.stem for f in TOPOLOGY_FILES]
 RNASEQ_FILE = EXAMPLES_DIR / "rnaseq_sections.mmd"
 EPITOPEPREDICTION_FILE = EXAMPLES_DIR / "epitopeprediction.mmd"
 HLATYPING_FILE = EXAMPLES_DIR / "hlatyping.mmd"
+TB_FILE_TERMINI_FILE = EXAMPLES_DIR / "tb_file_termini.mmd"
 
 
 def _load_and_layout(path: Path, max_station_columns: int = 15):
@@ -388,6 +389,40 @@ class TestHlatypingRegression:
         for sid, section in hlatyping_graph.sections.items():
             assert section.bbox_w > 0, f"Section '{sid}' has zero width"
             assert section.bbox_h > 0, f"Section '{sid}' has zero height"
+
+
+class TestTbFileTerminiRegression:
+    """Ensure the TB-section file-termini example lays out cleanly (#254)."""
+
+    @pytest.fixture
+    def tb_graph(self):
+        return _load_and_layout(TB_FILE_TERMINI_FILE)
+
+    def test_no_section_overlap(self, tb_graph):
+        violations = check_section_overlap(tb_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_station_containment(self, tb_graph):
+        violations = check_station_containment(tb_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_coordinate_sanity(self, tb_graph):
+        violations = check_coordinate_sanity(tb_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_reporting_section_is_tb_with_termini(self, tb_graph):
+        """The reporting section must stay TB and own the file termini."""
+        reporting = tb_graph.sections["reporting"]
+        assert reporting.direction == "TB"
+        termini = [
+            tb_graph.stations[sid]
+            for sid in reporting.station_ids
+            if tb_graph.stations[sid].is_terminus
+        ]
+        assert len(termini) == 3
 
 
 # --- Topology-specific assertions ---


### PR DESCRIPTION
## Summary

Terminus file icons in `%%metro direction: TB`/`BT` sections were laid out as if the line arrived horizontally - the connector stub pointed sideways while the metro line enters from above/below. This orients terminus icons (and their layout reservations) to the section's flow axis.

**Render**
- New pure helper `_terminus_icon_centers` computes icon centres along the section flow axis (X for LR/RL, Y for TB/BT), centred on the station's bundle on the cross axis. Sinks extend forward, sources backward; RL/BT mirror so icons always point outward.
- `_render_terminus_icons` picks the icon step, bbox-clamp axis, and caption room by direction.

**Layout**
- TB/BT sections now reserve vertical bbox room for the stacked icon + caption (new `TERMINUS_ICON_CLEARANCE_V`); `_adjust_terminus_icon_clearance` and the content-bottom/top extent passes are axis-aware. Previously the bbox reserved only horizontal room, so TB icons spilled onto the section border.
- A TB section's perpendicular entry port is pinned above its first station, so late vertical settling dragged it off the upstream feeder Y, producing an inter-section kink. Stage 6.16 re-runs entry-port alignment for TB/BT sections after settling.
- New `_guard_terminus_icons_within_bbox` fails loudly if a TB/BT terminus icon would spill past the section bbox.

**Fixtures / tests**
- New gallery example `examples/tb_file_termini.mmd` (registered in `scripts/build_gallery.py`) exercises a TB reporting section whose file outputs are line termini, so the corrected icons show in the render preview.
- Unit coverage of `_terminus_icon_centers` (LR/RL/TB/BT × sink/source), a render-level check, and a layout regression class asserting icon orientation, bbox containment, entry-port alignment, and `validate=True` guards.

All existing gallery/topology renders are **byte-identical**; only the new `tb_file_termini` example is affected.

Fixes #254

## Test plan
- [x] `pytest` passes (2978 passed; pre-existing xfails unchanged), incl. new invariant + regression tests
- [x] `ruff check` + `ruff format --check` clean on `src/ tests/`
- [x] Runtime validator added (`_guard_terminus_icons_within_bbox`)
- [x] All 43 existing gallery/topology renders byte-identical vs `main`
- [ ] Visual review of the render preview (new `tb_file_termini` example: vertical icons, bottom clearance, no inter-section kink)
