### PR TITLE
fix(layout): serpentine routing for stacked same-direction sections

### DIFF
--- a/examples/topologies/stacked_lr_serpentine.mmd
+++ b/examples/topologies/stacked_lr_serpentine.mmd
@@ -1,0 +1,36 @@
+%%metro title: Stacked LR Serpentine
+%%metro style: dark
+%%metro line: main | Main | #e63946
+%%metro grid: ingest | 0,0,3,1
+%%metro grid: align | 1,0,1,1
+%%metro grid: dedup | 1,1,1,1
+%%metro grid: call | 1,2,1,1
+
+graph LR
+    subgraph ingest [Ingest]
+        i1[Read]
+        i2[QC]
+        i1 -->|main| i2
+    end
+
+    subgraph align [Alignment]
+        a1[Map]
+        a2[Sort]
+        a1 -->|main| a2
+    end
+
+    subgraph dedup [Dedup]
+        d1[Mark Dup]
+        d2[Recalibrate]
+        d1 -->|main| d2
+    end
+
+    subgraph call [Variant Calling]
+        c1[Call]
+        c2[Filter]
+        c1 -->|main| c2
+    end
+
+    i2 -->|main| a1
+    a2 -->|main| d1
+    d2 -->|main| c1

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -171,6 +171,12 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         TOPOLOGIES_DIR,
         "Stacked analysis sections feeding through a fold into branching targets.",
     ),
+    (
+        "stacked_lr_serpentine",
+        TOPOLOGIES_DIR,
+        "Same-direction sections stacked in one grid column, chained via short "
+        "vertical drops on alternating sides (serpentine), no wrap-around.",
+    ),
     # --- Offset and bypass ---
     (
         "mismatched_tracks",

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -9,7 +9,7 @@ Preserves any values explicitly set by %%metro directives.
 
 from __future__ import annotations
 
-__all__ = ["infer_section_layout"]
+__all__ = ["infer_section_layout", "detect_serpentine_runs"]
 
 from collections import defaultdict, deque
 
@@ -39,6 +39,14 @@ def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> No
     if not successors and not predecessors:
         return
 
+    # Capture which sections carry author-supplied port hints before
+    # inference fills the rest in: the serpentine pass must only override
+    # inferred port sides, never explicit %%metro entry:/exit: directives.
+    explicit_entry_sections = {
+        sid for sid, s in graph.sections.items() if s.entry_hints
+    }
+    explicit_exit_sections = {sid for sid, s in graph.sections.items() if s.exit_hints}
+
     fold_sections, below_fold_sections, convergence_sections = _assign_grid_positions(
         graph,
         successors,
@@ -58,6 +66,15 @@ def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> No
         edge_lines,
         fold_sections,
         convergence_sections,
+    )
+    _serpentine_stacked_sections(
+        graph,
+        successors,
+        predecessors,
+        edge_lines,
+        fold_sections,
+        explicit_entry_sections,
+        explicit_exit_sections,
     )
 
 
@@ -980,3 +997,166 @@ def _relative_side(
         return PortSide.TOP
 
     return PortSide.RIGHT  # same position, default right
+
+
+def _effective_grid_pos(graph: MetroGraph, sec_id: str) -> tuple[int, int, int, int]:
+    """Return (col, row, row_span, col_span) for a section during inference.
+
+    Explicit grid overrides are applied to ``section.grid_col`` only later in
+    section_placement, so during auto-layout they read -1.  Prefer the value
+    recorded in ``graph.grid_overrides`` when present.
+    """
+    if sec_id in graph.grid_overrides:
+        return graph.grid_overrides[sec_id]
+    section = graph.sections[sec_id]
+    return (
+        section.grid_col,
+        section.grid_row,
+        section.grid_row_span,
+        section.grid_col_span,
+    )
+
+
+def detect_serpentine_runs(
+    graph: MetroGraph,
+    successors: dict[str, set[str]],
+    predecessors: dict[str, set[str]],
+) -> list[list[str]]:
+    """Find runs of vertically-stacked single-cell sections forming a chain.
+
+    A serpentine run is a maximal sequence of sections that
+
+    * occupy a single grid cell (row_span == col_span == 1),
+    * share a grid column,
+    * sit on consecutive grid rows, and
+    * form a simple chain: the section on row N feeds exactly one section
+      in the same column (the one on row N+1), and that lower section is
+      fed from the column only by the upper one.
+
+    Returns runs as lists of section ids ordered top-to-bottom.  Runs of
+    length < 2 are omitted.  Used to serpentine the effective flow
+    direction of stacked same-direction sections (issue #421).
+    """
+    # Group single-cell sections by grid column, keyed by row.
+    col_rows: dict[int, dict[int, str]] = defaultdict(dict)
+    for sec_id in graph.sections:
+        col, row, row_span, col_span = _effective_grid_pos(graph, sec_id)
+        if col < 0 or row < 0 or row_span != 1 or col_span != 1:
+            continue
+        # Two sections sharing a (col, row) cell is malformed; skip the column.
+        if row in col_rows[col]:
+            col_rows[col][row] = ""  # poison marker
+        else:
+            col_rows[col][row] = sec_id
+
+    runs: list[list[str]] = []
+    for col, rows in col_rows.items():
+        if any(v == "" for v in rows.values()):
+            continue
+        ordered_rows = sorted(rows)
+        in_column = set(rows.values())
+        i = 0
+        while i < len(ordered_rows):
+            run = [rows[ordered_rows[i]]]
+            j = i
+            while j + 1 < len(ordered_rows):
+                upper_row = ordered_rows[j]
+                lower_row = ordered_rows[j + 1]
+                if lower_row != upper_row + 1:
+                    break
+                upper = rows[upper_row]
+                lower = rows[lower_row]
+                # upper must feed lower, and lower must be the only in-column
+                # successor of upper (a clean chain, not a fan-out).
+                upper_col_succ = successors.get(upper, set()) & in_column
+                lower_col_pred = predecessors.get(lower, set()) & in_column
+                if (
+                    lower in successors.get(upper, set())
+                    and upper_col_succ == {lower}
+                    and lower_col_pred == {upper}
+                ):
+                    run.append(lower)
+                    j += 1
+                else:
+                    break
+            if len(run) >= 2:
+                runs.append(run)
+            i = j + 1
+    return runs
+
+
+def _serpentine_stacked_sections(
+    graph: MetroGraph,
+    successors: dict[str, set[str]],
+    predecessors: dict[str, set[str]],
+    edge_lines: dict[tuple[str, str], set[str]],
+    fold_sections: set[str],
+    explicit_entry_sections: set[str],
+    explicit_exit_sections: set[str],
+) -> None:
+    """Serpentine the flow of vertically-stacked same-direction sections.
+
+    When same-direction sections are stacked in one grid column and chained
+    (issue #421), connecting them naively forces a wrap-around: the upper
+    section exits one side and the lower section enters the same side while
+    still flowing the same way internally, kinking the internal route.
+
+    The transit-map answer is to alternate the effective flow row by row
+    (LR, RL, LR, ...) so consecutive sections meet on a shared side joined by
+    a short vertical drop.  We flip the direction of every other section in
+    the run and re-point its inferred entry/exit hints accordingly.
+
+    Author-set ``%%metro direction:`` / ``entry:`` / ``exit:`` directives
+    always win; only inferred values are changed.
+    """
+    runs = detect_serpentine_runs(graph, successors, predecessors)
+    for run in runs:
+        head = graph.sections[run[0]]
+        # Only serpentine horizontal-flow stacks; TB/fold stacks already drop
+        # vertically and need no reversal.
+        if head.direction not in ("LR", "RL"):
+            continue
+        if any(sid in fold_sections for sid in run):
+            continue
+        # Author-set port sides or directions pin the layout; serpentine only
+        # fills the fully-inferred case (issue #421).  If any section in the
+        # run carries an explicit entry/exit/direction directive, leave the
+        # whole run alone so the author's intent is honoured end-to-end.
+        if any(
+            sid in explicit_entry_sections
+            or sid in explicit_exit_sections
+            or sid in graph._explicit_directions
+            for sid in run
+        ):
+            continue
+
+        base = head.direction
+        flipped = "RL" if base == "LR" else "LR"
+        for idx, sec_id in enumerate(run):
+            want = base if idx % 2 == 0 else flipped
+            section = graph.sections[sec_id]
+            if want != section.direction and sec_id not in graph._explicit_directions:
+                section.direction = want
+
+        # Re-derive entry/exit sides for the (now alternating) run so each
+        # internal hop is a clean vertical drop between consecutive sections.
+        for idx, sec_id in enumerate(run):
+            section = graph.sections[sec_id]
+            entry_side = PortSide.RIGHT if section.direction == "RL" else PortSide.LEFT
+            exit_side = (
+                PortSide.LEFT if entry_side == PortSide.RIGHT else PortSide.RIGHT
+            )
+
+            if sec_id not in explicit_entry_sections and predecessors.get(sec_id):
+                in_lines: set[str] = set()
+                for src in predecessors[sec_id]:
+                    in_lines.update(edge_lines.get((src, sec_id), set()))
+                if in_lines:
+                    section.entry_hints = [(entry_side, sorted(in_lines))]
+
+            if sec_id not in explicit_exit_sections and successors.get(sec_id):
+                out_lines: set[str] = set()
+                for tgt in successors[sec_id]:
+                    out_lines.update(edge_lines.get((sec_id, tgt), set()))
+                if out_lines:
+                    section.exit_hints = [(exit_side, sorted(out_lines))]

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -1037,21 +1037,21 @@ def detect_serpentine_runs(
     length < 2 are omitted.  Used to serpentine the effective flow
     direction of stacked same-direction sections (issue #421).
     """
-    # Group single-cell sections by grid column, keyed by row.
+    # Group single-cell sections by grid column, keyed by row.  A column with
+    # two sections claiming one (col, row) cell is malformed and is skipped.
     col_rows: dict[int, dict[int, str]] = defaultdict(dict)
+    collided_cols: set[int] = set()
     for sec_id in graph.sections:
         col, row, row_span, col_span = _effective_grid_pos(graph, sec_id)
         if col < 0 or row < 0 or row_span != 1 or col_span != 1:
             continue
-        # Two sections sharing a (col, row) cell is malformed; skip the column.
         if row in col_rows[col]:
-            col_rows[col][row] = ""  # poison marker
-        else:
-            col_rows[col][row] = sec_id
+            collided_cols.add(col)
+        col_rows[col][row] = sec_id
 
     runs: list[list[str]] = []
     for col, rows in col_rows.items():
-        if any(v == "" for v in rows.values()):
+        if col in collided_cols:
             continue
         ordered_rows = sorted(rows)
         in_column = set(rows.values())

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -652,6 +652,62 @@ def _guard_inter_section_route_no_backtrack(
                 )
 
 
+def _guard_serpentine_no_backtrack(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+) -> None:
+    """After routing: stacked same-direction sections must not backtrack.
+
+    Same-direction sections stacked in one grid column and chained (#421)
+    serpentine their effective flow row by row so consecutive sections meet
+    on a shared side joined by a short vertical drop.  A section that fails
+    to alternate enters on the wrong side and folds its internal route back
+    across the section width.  For every section in a detected serpentine
+    run, the wrong-way horizontal travel of its internal segments must stay
+    below half the section width.
+    """
+    from nf_metro.layout.auto_layout import detect_serpentine_runs
+
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        routes = route_edges(graph)
+
+    dag = graph.section_dag
+    if dag is None:
+        return
+    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
+    serpentine_sections = {sid for run in runs for sid in run}
+    if not serpentine_sections:
+        return
+
+    wrong_way: dict[str, float] = {sid: 0.0 for sid in serpentine_sections}
+    for rp in routes:
+        src_sec = graph.section_for_station(rp.edge.source)
+        if src_sec != graph.section_for_station(rp.edge.target):
+            continue
+        if src_sec not in serpentine_sections:
+            continue
+        forward = 1.0 if graph.sections[src_sec].direction != "RL" else -1.0
+        xs = [p[0] for p in rp.points]
+        for x1, x2 in zip(xs, xs[1:]):
+            dx = x2 - x1
+            if dx * forward < 0:
+                wrong_way[src_sec] += abs(dx)
+
+    for sid, against in wrong_way.items():
+        section = graph.sections[sid]
+        limit = 0.5 * max(section.bbox_w, 1.0)
+        if against > limit + GUARD_TOLERANCE:
+            raise PhaseInvariantError(
+                f"{phase}: stacked section {sid!r} (dir={section.direction}) "
+                f"backtracks {against:.1f}px against its flow (>{limit:.1f}px); "
+                f"the serpentine chain is kinking instead of dropping vertically"
+            )
+
+
 def _guard_inter_row_run_clearance(
     graph: MetroGraph,
     phase: str,
@@ -1958,6 +2014,7 @@ def _compute_section_layout(
             _guard_bundle_order_preserved(graph, phase, offsets=offsets, routes=routes)
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)
             _guard_inter_section_route_no_backtrack(graph, phase, routes=routes)
+            _guard_serpentine_no_backtrack(graph, phase, routes=routes)
             _guard_inter_row_run_clearance(graph, phase, routes=routes)
 
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -644,6 +644,27 @@ def _route_inter_section(
             return _route_around_section_below(edge, src, tgt, tgt, i, n, ctx)
         return _route_left_entry_wrap(edge, src, tgt, i, n, ctx)
 
+    # Serpentine LEFT exit -> LEFT entry stacked in the same column (#421):
+    # an RL section's left exit dropping to the LR section directly below
+    # whose left entry sits a few px inward.  The standard L-shape places
+    # its vertical channel at sx + radius, which lands inside the source
+    # bbox.  Drop the channel on the LEFT of the column instead so the
+    # connector stays outside both section boxes.
+    if (
+        src_port is not None
+        and not src_port.is_entry
+        and src_port.side == PortSide.LEFT
+        and tgt_port is not None
+        and tgt_port.is_entry
+        and tgt_port.side == PortSide.LEFT
+        and src_col is not None
+        and tgt_col is not None
+        and src_col == tgt_col
+        and src_row is not None
+        and _resolve_section_row(graph, tgt) != src_row
+    ):
+        return _route_left_exit_left_entry_drop(edge, src, tgt, i, n, ctx)
+
     # Non-bypass edges to merge junctions: route to entry port.
     # When dy is tiny, use a straight line to avoid cramped curves.
     ep_id = ctx.merge.entry_port_for.get(edge.target)
@@ -1326,6 +1347,46 @@ def _route_top_entry_l_shape(
         is_inter_section=True,
         normalize_exempt=True,
         curve_radii=[r_lead, r_first, r_second],
+    )
+
+
+def _route_left_exit_left_entry_drop(
+    edge: Edge, src: Station, tgt: Station, i: int, n: int, ctx: _RoutingCtx
+) -> RoutedPath:
+    """Drop a LEFT exit into a LEFT entry stacked directly below (#421).
+
+    Both ports sit on the left edge of one grid column.  Run a short lead
+    out to the left of the column, drop vertically in that channel, then
+    come back in to the target's left entry port::
+
+        (sx,sy) -> (vx,sy) -> (vx,ty) -> (tx,ty)
+
+    The channel ``vx`` is placed just left of the column's leftmost edge so
+    the connector never re-enters either section's bbox.
+    """
+    sx, sy = src.x, src.y
+    tx, ty = tgt.x, tgt.y
+    dy = ty - sy
+    vertical = vertical_direction(dy)
+
+    delta, r_first, r_second = l_shape_radii(
+        i,
+        n,
+        vertical=vertical,
+        offset_step=ctx.offset_step,
+        base_radius=ctx.curve_radius,
+    )
+
+    src_col = _resolve_section_col(ctx.graph, src)
+    left_edge = col_left_edge(ctx.graph, src_col, default=min(sx, tx))
+    vx = min(left_edge, sx, tx) - ctx.curve_radius - ctx.offset_step + delta
+
+    return RoutedPath(
+        edge=edge,
+        line_id=edge.line_id,
+        points=[(sx, sy), (vx, sy), (vx, ty), (tx, ty)],
+        is_inter_section=True,
+        curve_radii=[r_first, r_second],
     )
 
 

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -75,6 +75,9 @@ def validate_layout(graph: MetroGraph) -> list[Violation]:
         violations.extend(
             check_route_segment_crossings(graph, _precomputed=precomputed)
         )
+        violations.extend(
+            check_serpentine_no_backtrack(graph, _precomputed=precomputed)
+        )
     return violations
 
 
@@ -1537,6 +1540,87 @@ def check_exit_port_feeder_alignment(
                         "delta": delta,
                         "port_coord": port_coord,
                         "station_coord": st_coord,
+                    },
+                )
+            )
+
+    return violations
+
+
+def check_serpentine_no_backtrack(
+    graph: MetroGraph,
+    backtrack_frac: float = 0.5,
+    _precomputed: tuple[dict[tuple[str, str], float], list[RoutedPath]] | None = None,
+) -> list[Violation]:
+    """Stacked same-direction sections must not backtrack horizontally.
+
+    When same-direction sections are stacked in one grid column and chained
+    (issue #421), the engine serpentines their effective flow so consecutive
+    sections meet on a shared side joined by a short vertical drop.  A section
+    that fails to serpentine instead enters on the wrong side and folds its
+    internal route back across (nearly) the full section width.
+
+    For every section in a detected serpentine run, this sums the horizontal
+    travel of its internal routed segments that runs *against* the section's
+    flow direction.  If that wrong-way travel exceeds ``backtrack_frac`` of the
+    section width, the section is kinking the chain.
+    """
+    from nf_metro.layout.auto_layout import detect_serpentine_runs
+
+    violations: list[Violation] = []
+
+    if _precomputed is not None:
+        offsets, routes = _precomputed
+    else:
+        try:
+            offsets = compute_station_offsets(graph)
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:
+            return violations
+
+    dag = graph.section_dag
+    if dag is None:
+        return violations
+    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
+    serpentine_sections = {sid for run in runs for sid in run}
+    if not serpentine_sections:
+        return violations
+
+    # Internal route segments grouped by home section.
+    wrong_way: dict[str, float] = {sid: 0.0 for sid in serpentine_sections}
+    for route in routes:
+        src_sec = graph.section_for_station(route.edge.source)
+        tgt_sec = graph.section_for_station(route.edge.target)
+        if src_sec != tgt_sec or src_sec not in serpentine_sections:
+            continue
+        section = graph.sections[src_sec]
+        forward = 1.0 if section.direction != "RL" else -1.0
+        pts = apply_route_offsets(route, offsets)
+        for k in range(len(pts) - 1):
+            dx = pts[k + 1][0] - pts[k][0]
+            if dx * forward < 0:
+                wrong_way[src_sec] += abs(dx)
+
+    for sid, against in wrong_way.items():
+        section = graph.sections[sid]
+        limit = backtrack_frac * max(section.bbox_w, 1.0)
+        if against > limit:
+            violations.append(
+                Violation(
+                    check="serpentine_no_backtrack",
+                    severity=Severity.ERROR,
+                    message=(
+                        f"Stacked section '{sid}' (dir={section.direction}) "
+                        f"backtracks {against:.0f}px against its flow "
+                        f"(>{limit:.0f}px = {backtrack_frac:.0%} of width "
+                        f"{section.bbox_w:.0f}); the serpentine chain is "
+                        f"kinking instead of dropping vertically"
+                    ),
+                    context={
+                        "section": sid,
+                        "direction": section.direction,
+                        "against": against,
+                        "limit": limit,
                     },
                 )
             )

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -146,6 +146,46 @@ class TestTopologyValidation:
             )
 
 
+# --- Serpentine stacked-section invariant (issue #421) ---
+
+# Fixtures known to contain a serpentine run of stacked, chained,
+# same-direction single-cell sections in one grid column. The new
+# stacked_lr_serpentine fixture is the targeted case; variantbenchmarking_auto
+# is an existing gallery pipeline whose Variant Filtering -> Benchmarking
+# sections stack in one column, so the invariant must generalise to it.
+SERPENTINE_FILES = [
+    TOPOLOGIES_DIR / "stacked_lr_serpentine.mmd",
+    EXAMPLES_DIR / "variantbenchmarking_auto.mmd",
+]
+SERPENTINE_IDS = [f.stem for f in SERPENTINE_FILES]
+
+
+@pytest.mark.parametrize("path", SERPENTINE_FILES, ids=SERPENTINE_IDS)
+def test_stacked_sections_serpentine_no_backtrack(path):
+    """Stacked same-direction sections must connect via vertical drops.
+
+    Each section in a detected serpentine run must flow internally without
+    folding its route back across the section width: a section that fails to
+    alternate direction would enter on the wrong side and wrap around. This
+    test fails on the pre-#421 engine, which inferred LR for every stacked
+    section regardless of position.
+    """
+    from layout_validator import check_serpentine_no_backtrack
+
+    from nf_metro.layout.auto_layout import detect_serpentine_runs
+
+    graph = _load_and_layout(path)
+
+    dag = graph.section_dag
+    assert dag is not None
+    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
+    assert runs, f"{path.stem}: expected at least one serpentine run to exist"
+
+    violations = check_serpentine_no_backtrack(graph)
+    errors = [v for v in violations if v.severity == Severity.ERROR]
+    assert not errors, "\n".join(v.message for v in errors)
+
+
 # --- Layout-quality warning reporter ---
 #
 # The intra-section-chain and exit-port-feeder validators emit WARNING-level


### PR DESCRIPTION
## Summary

Same-direction sections stacked in one grid column and chained (exit of row N feeds entry of row N+1) previously connected via a wrap-around dog-leg. The root cause: auto-layout inference runs before explicit `%%metro grid:` overrides are applied to `section.grid_col`, so every explicitly-stacked section read `grid_col=-1` during inference and defaulted to `LR` with a `RIGHT` entry. A `RIGHT` entry into an internally-`LR` section forces the route to fold back across the section width.

This PR detects such runs and serpentines them: the effective flow alternates row by row (LR, RL, LR, ...) so consecutive sections meet on a shared side joined by a short vertical drop, mirroring the within-section fold/reversal idea at the meta-grid level.

- `detect_serpentine_runs` (auto_layout): finds maximal runs of single-cell sections sharing a column on consecutive rows that form a simple chain (no fan-out).
- `_serpentine_stacked_sections` (auto_layout): flips every other section's direction and re-points its inferred entry/exit sides. Gated to the fully-inferred case only - any author-set `direction:`/`entry:`/`exit:` directive on any section in the run leaves the whole run untouched.
- `_route_left_exit_left_entry_drop` (routing/core): drops a LEFT exit into the LEFT entry directly below through a channel placed left of the column, so the connector never re-enters either section bbox (the standard L-shape would place its channel inside the source box).
- `_guard_serpentine_no_backtrack` (engine): runtime invariant - each serpentine section's wrong-way horizontal travel must stay below half its width; raises `PhaseInvariantError` otherwise.
- `check_serpentine_no_backtrack` (layout_validator) + parametrised invariant test over the new fixture and `variantbenchmarking_auto`.
- New gallery fixture `examples/topologies/stacked_lr_serpentine.mmd`, wired into `scripts/build_gallery.py`.

Fixes #421

## Test plan
- [x] pytest passes (3089 passed; new invariant test fails on the pre-fix engine)
- [x] ruff check + ruff format clean on `src/ tests/` (CI scope)
- [x] Runtime validator added (`_guard_serpentine_no_backtrack`)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/427/)
- [x] Render-preview verdict: local gallery diff shows only the new fixture changed; all existing gallery examples byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)
