### PR TITLE
fix(routing): clear inter-section descent channels off section edges (#423)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -14,6 +14,7 @@ from collections import Counter, defaultdict
 from nf_metro.layout.constants import (
     BYPASS_CLEARANCE,
     CANVAS_GRID_SHIFT_THRESHOLD,
+    COORD_TOLERANCE,
     CURVE_RADIUS,
     DESCENDER_CLEARANCE,
     DIAGONAL_RUN,
@@ -786,6 +787,8 @@ def _guard_inter_section_descent_edge_clearance(
     in :func:`_route_l_shape` pushes such channels outward; this guard
     fails loudly if a future change lets one creep back against an edge.
     """
+    from nf_metro.layout.routing.common import endpoint_port_xs
+
     if routes is None:
         from nf_metro.layout.routing import route_edges
 
@@ -795,17 +798,13 @@ def _guard_inter_section_descent_edge_clearance(
     for rp in routes:
         if not rp.is_inter_section:
             continue
-        port_xs = [
-            st.x
-            for sid in (rp.edge.source, rp.edge.target)
-            if (st := graph.stations.get(sid)) is not None and st.is_port
-        ]
+        port_xs = endpoint_port_xs(graph, rp.edge)
         pts = rp.points
         for (x0, y0), (x1, y1) in zip(pts, pts[1:]):
             if abs(x1 - x0) > tol:
                 continue  # vertical segments only
             vx = (x0 + x1) / 2
-            if any(abs(vx - px) <= 1.0 for px in port_xs):
+            if any(abs(vx - px) <= COORD_TOLERANCE for px in port_xs):
                 continue  # legitimate port-to-port drop
             ylo, yhi = sorted((y0, y1))
             for sec in graph.sections.values():

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -769,6 +769,67 @@ def _guard_inter_row_run_clearance(
                 )
 
 
+def _guard_inter_section_descent_edge_clearance(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+) -> None:
+    """After routing: a vertical descent channel of an inter-section route
+    must not *incidentally* graze a section bbox edge.
+
+    A descent legitimately sits on a section edge when its X coincides
+    with a port at one of the route's endpoints (a port-to-port drop).
+    When the channel instead lands within ``EDGE_TO_BUNDLE_CLEARANCE`` of
+    a section edge, on the interior side, with no endpoint port at that
+    X, the lines visibly cross the border (#423).  The channel-x selection
+    in :func:`_route_l_shape` pushes such channels outward; this guard
+    fails loudly if a future change lets one creep back against an edge.
+    """
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        routes = route_edges(graph)
+
+    tol = GUARD_TOLERANCE
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        port_xs = [
+            st.x
+            for sid in (rp.edge.source, rp.edge.target)
+            if (st := graph.stations.get(sid)) is not None and st.is_port
+        ]
+        pts = rp.points
+        for (x0, y0), (x1, y1) in zip(pts, pts[1:]):
+            if abs(x1 - x0) > tol:
+                continue  # vertical segments only
+            vx = (x0 + x1) / 2
+            if any(abs(vx - px) <= 1.0 for px in port_xs):
+                continue  # legitimate port-to-port drop
+            ylo, yhi = sorted((y0, y1))
+            for sec in graph.sections.values():
+                if sec.bbox_w <= 0:
+                    continue
+                if yhi < sec.bbox_y or ylo > sec.bbox_y + sec.bbox_h:
+                    continue
+                left = sec.bbox_x
+                right = left + sec.bbox_w
+                from_left = vx - left
+                from_right = right - vx
+                grazes = (-tol <= from_left < EDGE_TO_BUNDLE_CLEARANCE - tol) or (
+                    -tol <= from_right < EDGE_TO_BUNDLE_CLEARANCE - tol
+                )
+                if grazes:
+                    edge_x = left if from_left < from_right else right
+                    raise PhaseInvariantError(
+                        f"{phase}: descent of {rp.edge.source!r}->"
+                        f"{rp.edge.target!r} line {rp.line_id!r} at x={vx:.1f} "
+                        f"grazes section {sec.id!r} edge x={edge_x:.1f} "
+                        f"(< {EDGE_TO_BUNDLE_CLEARANCE})"
+                    )
+
+
 def _guard_bundle_order_preserved(
     graph: MetroGraph,
     phase: str,
@@ -2016,6 +2077,7 @@ def _compute_section_layout(
             _guard_inter_section_route_no_backtrack(graph, phase, routes=routes)
             _guard_serpentine_no_backtrack(graph, phase, routes=routes)
             _guard_inter_row_run_clearance(graph, phase, routes=routes)
+            _guard_inter_section_descent_edge_clearance(graph, phase, routes=routes)
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -378,6 +378,16 @@ def inter_column_channel_x(
         return sx - max_r - offset_step
 
 
+def endpoint_port_xs(graph: MetroGraph, edge: Edge) -> list[float]:
+    """X of any port stations at *edge*'s endpoints (for edge-graze checks)."""
+    xs: list[float] = []
+    for sid in (edge.source, edge.target):
+        st = graph.stations.get(sid)
+        if st is not None and st.is_port:
+            xs.append(st.x)
+    return xs
+
+
 def clear_channel_of_section_edge(
     graph: MetroGraph,
     mid_x: float,
@@ -386,7 +396,7 @@ def clear_channel_of_section_edge(
     y_hi: float,
     endpoint_port_xs: list[float],
     edge_clearance: float = EDGE_TO_BUNDLE_CLEARANCE,
-    port_tol: float = 1.0,
+    port_tol: float = COORD_TOLERANCE,
 ) -> float:
     """Nudge a vertical channel out of an *incidental* section-edge graze.
 

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -378,6 +378,67 @@ def inter_column_channel_x(
         return sx - max_r - offset_step
 
 
+def clear_channel_of_section_edge(
+    graph: MetroGraph,
+    mid_x: float,
+    half_width: float,
+    y_lo: float,
+    y_hi: float,
+    endpoint_port_xs: list[float],
+    edge_clearance: float = EDGE_TO_BUNDLE_CLEARANCE,
+    port_tol: float = 1.0,
+) -> float:
+    """Nudge a vertical channel out of an *incidental* section-edge graze.
+
+    A descent channel of an inter-section route legitimately sits on a
+    section edge when that edge carries a port at one of the route's
+    endpoints (a port-to-port drop).  When the channel instead lands
+    within *edge_clearance* of a section's bbox edge on the interior
+    side, with no endpoint port at that x, the graze is incidental and
+    the lines visibly cross the section border (#423).
+
+    *mid_x* is the channel's midline; the bundle's nearest line to a
+    section edge sits at most *half_width* from *mid_x*.  *y_lo*/*y_hi*
+    bound the vertical run so only sections it actually passes are
+    considered.  Returns *mid_x* shifted just enough that the nearest
+    line clears every incidentally-grazed edge by *edge_clearance*,
+    pushing OUTWARD (away from the section interior).  Channels that
+    coincide with an endpoint port (within *port_tol*) are left
+    untouched.
+    """
+    adjusted = mid_x
+    for sec in graph.sections.values():
+        if sec.bbox_w <= 0:
+            continue
+        if y_hi < sec.bbox_y or y_lo > sec.bbox_y + sec.bbox_h:
+            continue  # channel does not span this section's Y range
+        left = sec.bbox_x
+        right = left + sec.bbox_w
+        if any(abs(adjusted - px) <= port_tol for px in endpoint_port_xs):
+            continue  # legitimate port-to-port drop on this edge
+        # Bundle span (outermost lines either side of the midline).
+        bundle_lo = adjusted - half_width
+        bundle_hi = adjusted + half_width
+        # A graze means the bundle's nearest line toward an edge does not
+        # clear that edge by ``edge_clearance``.  Distance of the nearest
+        # line to the right edge (positive = outside, to the right) and to
+        # the left edge (positive = outside, to the left).
+        clear_of_right = bundle_lo - right
+        clear_of_left = left - bundle_hi
+        # Only act when the bundle is near or inside this section's span;
+        # a bundle comfortably outside both edges is fine.
+        if clear_of_right >= edge_clearance or clear_of_left >= edge_clearance:
+            continue
+        # Push OUTWARD via the nearer edge: if the midline is closer to the
+        # right edge, push right until the leftmost line clears it; else
+        # push left until the rightmost line clears the left edge.
+        if right - adjusted <= adjusted - left:
+            adjusted += edge_clearance - clear_of_right
+        else:
+            adjusted -= edge_clearance - clear_of_left
+    return adjusted
+
+
 def line_source_y_at_port(
     port_id: str,
     graph: MetroGraph,

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -42,6 +42,7 @@ from nf_metro.layout.routing.common import (
     col_right_edge,
     column_gap_edges,
     compute_bundle_info,
+    endpoint_port_xs,
     horizontal_direction,
     inter_column_channel_x,
     inter_row_channel_y,
@@ -1151,16 +1152,6 @@ def _route_bypass(
     )
 
 
-def _endpoint_port_xs(graph: MetroGraph, edge: Edge) -> list[float]:
-    """X of any port stations at *edge*'s endpoints (for edge-graze checks)."""
-    xs: list[float] = []
-    for sid in (edge.source, edge.target):
-        st = graph.stations.get(sid)
-        if st is not None and st.is_port:
-            xs.append(st.x)
-    return xs
-
-
 def _route_l_shape(
     edge: Edge, src: Station, tgt: Station, i: int, n: int, ctx: _RoutingCtx
 ) -> RoutedPath:
@@ -1208,7 +1199,7 @@ def _route_l_shape(
             half_width,
             min(sy, ty),
             max(sy, ty),
-            _endpoint_port_xs(ctx.graph, edge),
+            endpoint_port_xs(ctx.graph, edge),
         )
         # Second corner: from sub-bundle (only L-shape siblings turn here)
         _, _, r_second = l_shape_radii(
@@ -1240,7 +1231,7 @@ def _route_l_shape(
             half_width,
             min(sy, ty),
             max(sy, ty),
-            _endpoint_port_xs(ctx.graph, edge),
+            endpoint_port_xs(ctx.graph, edge),
         )
 
     vx = mid_x + delta

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -37,6 +37,7 @@ from nf_metro.layout.routing.common import (
     RoutedPath,
     bundle_width,
     bypass_bottom_y,
+    clear_channel_of_section_edge,
     col_left_edge,
     col_right_edge,
     column_gap_edges,
@@ -1150,6 +1151,16 @@ def _route_bypass(
     )
 
 
+def _endpoint_port_xs(graph: MetroGraph, edge: Edge) -> list[float]:
+    """X of any port stations at *edge*'s endpoints (for edge-graze checks)."""
+    xs: list[float] = []
+    for sid in (edge.source, edge.target):
+        st = graph.stations.get(sid)
+        if st is not None and st.is_port:
+            xs.append(st.x)
+    return xs
+
+
 def _route_l_shape(
     edge: Edge, src: Station, tgt: Station, i: int, n: int, ctx: _RoutingCtx
 ) -> RoutedPath:
@@ -1186,6 +1197,19 @@ def _route_l_shape(
         mid_x = sx + horizontal.sign * (
             ctx.curve_radius + (un - 1) * ctx.offset_step / 2
         )
+        # The fan pivots the channel through ``sx +/- curve_radius``,
+        # which hugs the source section's edge.  When that edge is also a
+        # section bbox border the descent grazes it incidentally (#423):
+        # push the channel outward so the nearest line clears the edge.
+        half_width = (un - 1) * ctx.offset_step / 2
+        mid_x = clear_channel_of_section_edge(
+            ctx.graph,
+            mid_x,
+            half_width,
+            min(sy, ty),
+            max(sy, ty),
+            _endpoint_port_xs(ctx.graph, edge),
+        )
         # Second corner: from sub-bundle (only L-shape siblings turn here)
         _, _, r_second = l_shape_radii(
             i,
@@ -1205,6 +1229,18 @@ def _route_l_shape(
         max_r = ctx.curve_radius + (n - 1) * ctx.offset_step
         mid_x = inter_column_channel_x(
             ctx.graph, src, tgt, sx, tx, dx, max_r, ctx.offset_step
+        )
+        # The near-source fallback hugs the source section's edge; push
+        # the channel outward when that edge is a section bbox border the
+        # route doesn't enter (#423).
+        half_width = (n - 1) * ctx.offset_step / 2
+        mid_x = clear_channel_of_section_edge(
+            ctx.graph,
+            mid_x,
+            half_width,
+            min(sy, ty),
+            max(sy, ty),
+            _endpoint_port_xs(ctx.graph, edge),
         )
 
     vx = mid_x + delta

--- a/tests/fixtures/regressions/sarek_serpentine_stacked.mmd
+++ b/tests/fixtures/regressions/sarek_serpentine_stacked.mmd
@@ -1,0 +1,174 @@
+%%metro title: nf-core/sarek
+%%metro logo: nf-core-sarek_logo_dark.png
+%%metro style: dark
+%%metro legend: br
+%%metro line_order: definition
+%%metro center_ports: true
+%%metro compact_offsets: true
+%%metro file: fastq_in | FASTQ
+%%metro file: bam_in | BAM
+%%metro file: cram_in | CRAM
+%%metro file: vcf_out | VCF
+%%metro file: report_out | HTML
+%%metro line: germline | Germline | #0570b0
+%%metro line: tumor_only | Tumor only | #d62728
+%%metro line: somatic | Tumor-normal pair | #756bb1
+%%metro grid: preprocessing | 0,0,1,2
+%%metro grid: variant_calling | 0,1,3,1
+%%metro grid: post_vc | 1,1,1,1
+%%metro grid: annotation | 1,2,1,1
+%%metro grid: reporting | 1,3,1,1
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        %%metro exit: right | germline, tumor_only, somatic
+        fastq_in[ ]
+        bam_in[ ]
+        fastqc[FastQC]
+        fastp[FastP]
+        umi[UMI consensus]
+        bwa[BWA-MEM]
+        bwa2[BWA-MEM2]
+        dragmap[DragMap]
+        sentieon_bwa[Sentieon BWA]
+        merge_index[samtools merge/index]
+        markdup[MarkDuplicates]
+        sentieon_dedup[Sentieon Dedup]
+        bqsr[BaseRecalibrator]
+        applybqsr[ApplyBQSR]
+        mosdepth[mosdepth]
+        ngscheckmate[NGSCheckmate]
+
+        fastq_in -->|germline,tumor_only,somatic| fastqc
+        fastq_in -->|germline,tumor_only,somatic| fastp
+        bam_in -->|germline,tumor_only,somatic| fastp
+        fastp -->|germline,tumor_only,somatic| umi
+        umi -->|germline,tumor_only,somatic| bwa
+        umi -->|germline,tumor_only,somatic| bwa2
+        umi -->|germline,tumor_only,somatic| dragmap
+        umi -->|germline,tumor_only,somatic| sentieon_bwa
+        bwa -->|germline,tumor_only,somatic| merge_index
+        bwa2 -->|germline,tumor_only,somatic| merge_index
+        dragmap -->|germline,tumor_only,somatic| merge_index
+        sentieon_bwa -->|germline,tumor_only,somatic| merge_index
+        merge_index -->|germline,tumor_only,somatic| markdup
+        merge_index -->|germline,tumor_only,somatic| sentieon_dedup
+        markdup -->|germline,tumor_only,somatic| bqsr
+        sentieon_dedup -->|germline,tumor_only,somatic| bqsr
+        bqsr -->|germline,tumor_only,somatic| applybqsr
+        applybqsr -->|germline,tumor_only,somatic| mosdepth
+        applybqsr -->|germline,tumor_only,somatic| ngscheckmate
+    end
+
+    subgraph variant_calling [Variant calling]
+        %%metro entry: left | germline, tumor_only, somatic
+        %%metro exit: right | germline, tumor_only, somatic
+        cram_in[ ]
+        haplotypecaller[HaplotypeCaller]
+        deepvariant[DeepVariant]
+        sentieon_dnascope[Sentieon DNAscope]
+        sentieon_haplotyper[Sentieon Haplotyper]
+        freebayes[FreeBayes]
+        strelka[Strelka]
+        mpileup[bcftools mpileup]
+        mutect2[Mutect2]
+        lofreq[LoFreq]
+        muse[MuSE]
+        sentieon_tnscope[Sentieon TNscope]
+        manta[Manta]
+        tiddit[TIDDIT]
+        ascat[ASCAT]
+        cnvkit[CNVkit]
+        controlfreec[Control-FREEC]
+        indexcov[indexcov]
+        msisensor2[MSIsensor2]
+        msisensorpro[MSIsensor-pro]
+        vcfs[ ]
+
+        cram_in -->|germline| haplotypecaller
+        cram_in -->|germline| deepvariant
+        cram_in -->|germline| sentieon_dnascope
+        cram_in -->|germline| sentieon_haplotyper
+        cram_in -->|germline,tumor_only,somatic| freebayes
+        cram_in -->|germline,somatic| strelka
+        cram_in -->|germline,tumor_only,somatic| mpileup
+        cram_in -->|tumor_only,somatic| mutect2
+        cram_in -->|tumor_only| lofreq
+        cram_in -->|somatic| muse
+        cram_in -->|tumor_only,somatic| sentieon_tnscope
+        cram_in -->|germline,tumor_only,somatic| manta
+        cram_in -->|germline,tumor_only,somatic| tiddit
+        cram_in -->|somatic| ascat
+        cram_in -->|germline,tumor_only,somatic| cnvkit
+        cram_in -->|tumor_only,somatic| controlfreec
+        cram_in -->|germline,somatic| indexcov
+        cram_in -->|tumor_only| msisensor2
+        cram_in -->|somatic| msisensorpro
+
+        haplotypecaller -->|germline| vcfs
+        deepvariant -->|germline| vcfs
+        sentieon_dnascope -->|germline| vcfs
+        sentieon_haplotyper -->|germline| vcfs
+        freebayes -->|germline,tumor_only,somatic| vcfs
+        strelka -->|germline,somatic| vcfs
+        mpileup -->|germline,tumor_only,somatic| vcfs
+        mutect2 -->|tumor_only,somatic| vcfs
+        lofreq -->|tumor_only| vcfs
+        muse -->|somatic| vcfs
+        sentieon_tnscope -->|tumor_only,somatic| vcfs
+        manta -->|germline,tumor_only,somatic| vcfs
+        tiddit -->|germline,tumor_only,somatic| vcfs
+        ascat -->|somatic| vcfs
+        cnvkit -->|germline,tumor_only,somatic| vcfs
+        controlfreec -->|tumor_only,somatic| vcfs
+        indexcov -->|germline,somatic| vcfs
+        msisensor2 -->|tumor_only| vcfs
+        msisensorpro -->|somatic| vcfs
+    end
+
+    subgraph post_vc [Post-processing]
+        filter_vcfs[Filter VCFs]
+        normalize[Normalize]
+        concatenate[Concatenate]
+        consensus[Consensus]
+        varlociraptor[Varlociraptor]
+        bcftools_stats[bcftools stats]
+        vcftools[VCFtools]
+
+        filter_vcfs -->|germline,tumor_only,somatic| normalize
+        normalize -->|germline,tumor_only,somatic| concatenate
+        concatenate -->|germline,tumor_only,somatic| consensus
+        consensus -->|germline,tumor_only,somatic| varlociraptor
+        varlociraptor -->|germline,tumor_only,somatic| bcftools_stats
+        bcftools_stats -->|germline,tumor_only,somatic| vcftools
+    end
+
+    subgraph annotation [Annotation]
+        snpeff[snpEff]
+        vep[VEP]
+        bcftools_ann[bcftools annotate]
+        snpsift[SnpSift]
+
+        snpeff -->|germline,tumor_only,somatic| vep
+        vep -->|germline,tumor_only,somatic| bcftools_ann
+        bcftools_ann -->|germline,tumor_only,somatic| snpsift
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+        vcf_out[ ]
+        report_out[ ]
+
+        multiqc -->|germline,tumor_only,somatic| report_out
+        snpsift_to_vcf[ ]
+        snpsift_to_vcf -->|germline,tumor_only,somatic| vcf_out
+    end
+
+    %% Inter-section edges
+    applybqsr -->|germline,tumor_only,somatic| cram_in
+    vcfs -->|germline,tumor_only,somatic| filter_vcfs
+    vcftools -->|germline,tumor_only,somatic| snpeff
+    snpsift -->|germline,tumor_only,somatic| snpsift_to_vcf
+    fastqc -->|germline,tumor_only,somatic| multiqc
+    mosdepth -->|germline,tumor_only,somatic| multiqc
+    bcftools_stats -->|germline,tumor_only,somatic| multiqc

--- a/tests/test_edge_clearance_invariant.py
+++ b/tests/test_edge_clearance_invariant.py
@@ -1,0 +1,146 @@
+"""Inter-section descent channels must clear section bbox edges.
+
+A vertical descent channel of an inter-section route may legitimately
+sit on a section edge when it is a port-to-port connection: the descent
+x coincides with an exit or entry port that genuinely lives on that edge
+(serpentine right-exit dropping to a right-entry below, around-section
+exit drops, etc.).
+
+It is a bug when the graze is *incidental*: the descent x falls within
+``EDGE_TO_BUNDLE_CLEARANCE`` of a section bbox edge (and on the interior
+side of it) yet is NOT a port at either endpoint of the route.  The line
+then visibly grazes / crosses the section border (sarek #423: the
+MultiQC fan-in ``__junction_8 -> __merge_*`` descent ran at x=1219..1225
+against preprocessing's right edge x=1225).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.constants import EDGE_TO_BUNDLE_CLEARANCE
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+TOPOLOGIES = FIXTURES / "topologies"
+EXAMPLES = REPO_ROOT / "examples"
+
+# Tolerance for "x coincides with a port that lives on this edge".
+_PORT_TOL = 1.0
+# Tolerance for "this vertical segment is actually vertical".
+_V_TOL = 1.0
+
+
+SAREK_FIXTURE = FIXTURES / "regressions" / "sarek_serpentine_stacked.mmd"
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = [SAREK_FIXTURE]
+    paths.extend(sorted(TOPOLOGIES.glob("*.mmd")))
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    return paths
+
+
+def _route(path: Path):
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    return graph, routes
+
+
+def _endpoint_port_xs(graph, route) -> list[float]:
+    """X coordinates of any port stations at the route's two endpoints."""
+    xs: list[float] = []
+    for sid in (route.edge.source, route.edge.target):
+        st = graph.stations.get(sid)
+        if st is not None and getattr(st, "is_port", False):
+            xs.append(st.x)
+    return xs
+
+
+def _incidental_grazes(graph, routes) -> list[str]:
+    """Return human-readable descriptions of incidental edge grazes."""
+    violations: list[str] = []
+    for route in routes:
+        if not route.is_inter_section:
+            continue
+        pts = route.points
+        port_xs = _endpoint_port_xs(graph, route)
+        for (ax, ay), (bx, by) in zip(pts, pts[1:]):
+            if abs(bx - ax) > _V_TOL:
+                continue  # not a vertical segment
+            vx = (ax + bx) / 2
+            ylo, yhi = (ay, by) if ay <= by else (by, ay)
+            for sec in graph.sections.values():
+                if sec.bbox_w <= 0:
+                    continue
+                left = sec.bbox_x
+                right = sec.bbox_x + sec.bbox_w
+                top = sec.bbox_y
+                bot = sec.bbox_y + sec.bbox_h
+                # Vertical segment must overlap the section's Y span.
+                if yhi < top or ylo > bot:
+                    continue
+                # Distance inside each edge (positive = interior side).
+                from_left = vx - left
+                from_right = right - vx
+                grazes_left = -_V_TOL <= from_left < EDGE_TO_BUNDLE_CLEARANCE
+                grazes_right = -_V_TOL <= from_right < EDGE_TO_BUNDLE_CLEARANCE
+                if not (grazes_left or grazes_right):
+                    continue
+                # Legitimate when vx coincides with an endpoint port.
+                if any(abs(vx - px) <= _PORT_TOL for px in port_xs):
+                    continue
+                edge_x = left if grazes_left else right
+                violations.append(
+                    f"{route.edge.source} -> {route.edge.target} "
+                    f"[{route.line_id}] descent x={vx:.1f} grazes "
+                    f"section {sec.id!r} edge x={edge_x:.1f} "
+                    f"(gap {abs(vx - edge_x):.1f} < {EDGE_TO_BUNDLE_CLEARANCE})"
+                )
+    return violations
+
+
+@pytest.mark.parametrize("path", _gather_fixtures(), ids=lambda p: p.stem)
+def test_no_incidental_edge_graze(path: Path) -> None:
+    graph, routes = _route(path)
+    violations = _incidental_grazes(graph, routes)
+    assert not violations, "Incidental section-edge grazes:\n" + "\n".join(violations)
+
+
+def test_sarek_junction8_merge_descent_clears_preprocessing_right_edge() -> None:
+    """Targeted check for sarek #423.
+
+    The ``__junction_8 -> __merge_*`` MultiQC fan-in descent must sit at
+    least ``EDGE_TO_BUNDLE_CLEARANCE`` outside preprocessing's right edge.
+    """
+    graph, routes = _route(SAREK_FIXTURE)
+    prep = graph.sections["preprocessing"]
+    right_edge = prep.bbox_x + prep.bbox_w
+
+    descents: list[float] = []
+    for route in routes:
+        if route.edge.source != "__junction_8":
+            continue
+        if not route.edge.target.startswith("__merge_"):
+            continue
+        pts = route.points
+        for (ax, _ay), (bx, _by) in zip(pts, pts[1:]):
+            if abs(bx - ax) <= _V_TOL:
+                descents.append((ax + bx) / 2)
+
+    assert descents, "expected junction_8 -> merge descent segments"
+    nearest = min(descents, key=lambda x: abs(x - right_edge))
+    # Outward (the section interior is to the LEFT) means descent x must
+    # be >= right_edge + clearance.
+    assert nearest >= right_edge + EDGE_TO_BUNDLE_CLEARANCE, (
+        f"descent x={nearest:.1f} not clear of preprocessing right edge "
+        f"{right_edge:.1f} by {EDGE_TO_BUNDLE_CLEARANCE} "
+        f"(need >= {right_edge + EDGE_TO_BUNDLE_CLEARANCE:.1f})"
+    )


### PR DESCRIPTION
## Summary

Inter-section L-shaped routes pick their vertical descent channel by pivoting through `sx +/- curve_radius` (the fan-out branch) or the near-source fallback in `_route_l_shape`. When the source station sits at a section's edge, that channel hugs the section's bbox border. If the border is also a section edge the route does not enter, the descent grazes / crosses it incidentally.

Concretely, on a serpentine-stacked sarek layout the MultiQC fan-in `__junction_8 -> __merge_2/3/4` ran its descent at x=1219/1222/1225 against preprocessing's right edge x=1225 (0 / 3 / 6 px inside). The `__junction_9` fan-in did the same against post_vc's right edge.

This PR:

- Adds `clear_channel_of_section_edge` (`routing/common.py`): when a chosen channel midline puts the bundle's nearest line within `EDGE_TO_BUNDLE_CLEARANCE` of a section bbox edge on the interior side, and the channel x is not a port at either route endpoint, it pushes the bundle outward (away from the section interior) so the nearest line clears the edge by the full clearance. Legitimate port-to-port drops (channel x equals an endpoint port) are left untouched.
- Applies the clearance at both channel-x selection sites in `_route_l_shape` (fan-out and near-source fallback).
- Promotes `endpoint_port_xs` to `routing/common.py` for shared use.
- Adds `_guard_inter_section_descent_edge_clearance`, a post-route guard wired into `compute_layout(validate=True)`, that fails loudly if a future change lets a descent creep back against an edge.
- Adds `tests/test_edge_clearance_invariant.py`: a gallery-parametrised "no incidental edge graze" invariant plus a targeted sarek check, with a regression fixture under `tests/fixtures/regressions/`.

After the fix the sarek descent sits at x=1241/1244/1247, with the nearest line exactly `EDGE_TO_BUNDLE_CLEARANCE` (16px) outside the edge.

Scope note: this addresses clearance only. The right-then-left dog-leg shape of these around-section descents is tracked separately (#425).

Fixes #423

## Test plan
- [x] pytest passes (new invariant test fails before / passes after; full suite green)
- [x] ruff check + ruff format clean on src/ tests/
- [x] Runtime validator added (`_guard_inter_section_descent_edge_clearance`)
- [x] Gallery vet: one render changed (`around_section_below`), classified Improvement (line A's descent moved off the Source section's right edge; now clears by 19px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)