### PR TITLE
fix(routing): step nested-column merge descent instead of full-width dog-leg (#425)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -653,6 +653,106 @@ def _guard_inter_section_route_no_backtrack(
                 )
 
 
+def _canvas_width(graph: MetroGraph) -> float:
+    """Horizontal extent of all positioned sections (rightmost - leftmost)."""
+    rights = [s.bbox_x + s.bbox_w for s in graph.sections.values() if s.bbox_w > 0]
+    lefts = [s.bbox_x for s in graph.sections.values() if s.bbox_w > 0]
+    if not rights or not lefts:
+        return 0.0
+    return max(rights) - min(lefts)
+
+
+def inter_section_route_backtrack_legs(graph: MetroGraph, routes: list):
+    """Yield ``(rp, x1, x2)`` for each horizontal leg that reverses against
+    its route's exit-direction flow.
+
+    "Flow" mirrors :func:`_guard_inter_section_route_no_backtrack`: a
+    forward route between two distinct LR columns whose exit port faces the
+    target column flows toward that column (rightward when the target column
+    is higher).  A leg that moves the opposite way is a backtrack.  Routes
+    that exit away from their target legitimately wrap and are skipped, as
+    are TB folds and same-column routes.  Unlike the strict guard, exempt
+    (``normalize_exempt``) wrap routes are *included* so a multi-corner
+    around-section dog-leg is still measured.
+    """
+    from nf_metro.layout.routing.common import resolve_section
+
+    def _exit_side(rp):
+        port = graph.ports.get(rp.edge.source)
+        if port is not None:
+            return port.side
+        for e in graph.edges_to(rp.edge.source):
+            port = graph.ports.get(e.source)
+            if port is not None:
+                return port.side
+        return None
+
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        src_sec = resolve_section(graph, graph.stations[rp.edge.source])
+        tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
+        if src_sec is None or tgt_sec is None:
+            continue
+        if src_sec.direction != "LR" or tgt_sec.direction != "LR":
+            continue
+        if src_sec.grid_col == tgt_sec.grid_col:
+            continue
+        rightward = tgt_sec.grid_col > src_sec.grid_col
+        side = _exit_side(rp)
+        if rightward and side != PortSide.RIGHT:
+            continue
+        if not rightward and side != PortSide.LEFT:
+            continue
+        xs = [p[0] for p in rp.points]
+        for x1, x2 in zip(xs, xs[1:]):
+            backtracks = (x2 < x1) if rightward else (x2 > x1)
+            if backtracks:
+                yield rp, x1, x2
+
+
+def _guard_inter_section_route_no_full_width_backtrack(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+    fraction: float = 0.4,
+) -> None:
+    """After routing: a forward inter-section route may reverse in X (when a
+    narrow target column nests inside an oversized sibling) but no single
+    backtrack leg may exceed *fraction* of the canvas width.
+
+    The strict :func:`_guard_inter_section_route_no_backtrack` forbids *any*
+    reversal on a forward LR route, assuming grid-column order matches X
+    order.  When a column is geometrically nested inside an oversized
+    sibling (e.g. sarek's narrow ``reporting`` column under the wide
+    ``preprocessing`` row-span), reaching it requires a legitimate X
+    reversal, so such routes are made ``normalize_exempt`` and the strict
+    guard skips them.  This guard still bounds those reversals: a
+    right-then-left dog-leg sweeping the whole diagram (#425) is forbidden
+    even when exempt.
+    """
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        routes = route_edges(graph)
+
+    canvas_width = _canvas_width(graph)
+    if canvas_width <= 0:
+        return
+    limit = fraction * canvas_width
+
+    for rp, x1, x2 in inter_section_route_backtrack_legs(graph, routes):
+        span = abs(x2 - x1)
+        if span > limit + GUARD_TOLERANCE:
+            raise PhaseInvariantError(
+                f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} "
+                f"line {rp.line_id!r} backtracks {span:.1f}px in one leg "
+                f"(x={x1:.1f}->{x2:.1f}), exceeding {fraction:.0%} of canvas "
+                f"width {canvas_width:.1f} - a full-width dog-leg"
+            )
+
+
 def _guard_serpentine_no_backtrack(
     graph: MetroGraph,
     phase: str,
@@ -2074,6 +2174,9 @@ def _compute_section_layout(
             _guard_bundle_order_preserved(graph, phase, offsets=offsets, routes=routes)
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)
             _guard_inter_section_route_no_backtrack(graph, phase, routes=routes)
+            _guard_inter_section_route_no_full_width_backtrack(
+                graph, phase, routes=routes
+            )
             _guard_serpentine_no_backtrack(graph, phase, routes=routes)
             _guard_inter_row_run_clearance(graph, phase, routes=routes)
             _guard_inter_section_descent_edge_clearance(graph, phase, routes=routes)

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -20,6 +20,7 @@ from nf_metro.layout.constants import (
     CROSS_ROW_THRESHOLD,
     CURVE_RADIUS,
     DIAGONAL_RUN,
+    EDGE_TO_BUNDLE_CLEARANCE,
     FOLD_MARGIN,
     ICON_TERMINUS_FORK_LEAD,
     JUNCTION_MARGIN,
@@ -692,6 +693,14 @@ def _route_inter_section(
                 exclude = {src.section_id} if src.section_id else set()
                 if _h_segment_crosses_other_section(graph, sx, ep.x, ep.y, exclude):
                     return _route_around_section_below(edge, src, tgt, ep, i, n, ctx)
+            # RIGHT entry nested inside an oversized source section: a
+            # single-channel L-shape would descend far right and sweep
+            # back across the whole diagram (#425).  Step down past the
+            # source then into a channel near the target instead.
+            if edge.source in ctx.junction_ids and _should_step_descent(
+                graph, src, ep, ep_port
+            ):
+                return _route_stepped_descent(edge, src, ep, i, n, ctx)
             return _route_l_shape(edge, src, ep, i, n, ctx)
 
     # Standard L-shape
@@ -1150,6 +1159,155 @@ def _route_bypass(
         curve_radii=[r1, r2, r3, r4],
         offsets_applied=True,
     )
+
+
+def _nested_target_clear_channel_x(
+    graph: MetroGraph,
+    ep: Station,
+    y_lo: float,
+    y_hi: float,
+    clearance: float,
+) -> float | None:
+    """X of a clear vertical channel just right of the target column's stack.
+
+    For a route whose entry port *ep* sits in a narrow column nested inside
+    an oversized source section, the only single-channel descent that
+    clears the source is far to the right (producing the #425 dog-leg).
+    A stepped descent instead drops to just below the source, steps left
+    into the channel returned here - the rightmost edge of any section in
+    the target's column that the descent's vertical run (*y_lo*..*y_hi*)
+    would otherwise cross, plus *clearance* - then drops to the entry Y.
+
+    Returns ``None`` when the target column has no resolvable sections.
+    """
+    ep_sec = graph.sections.get(ep.section_id) if ep.section_id else None
+    if ep_sec is None:
+        return None
+    tgt_col = ep_sec.grid_col
+    rights = [
+        s.bbox_x + s.bbox_w
+        for s in graph.sections.values()
+        if s.bbox_w > 0
+        and s.grid_col == tgt_col
+        and not (y_hi < s.bbox_y or y_lo > s.bbox_y + s.bbox_h)
+    ]
+    if not rights:
+        return None
+    return max(rights) + clearance
+
+
+def _route_stepped_descent(
+    edge: Edge,
+    src: Station,
+    ep: Station,
+    i: int,
+    n: int,
+    ctx: _RoutingCtx,
+) -> RoutedPath:
+    """Stepped descent to an entry port nested inside an oversized source.
+
+    Replaces the far-right dog-leg (#425) for a junction-sourced merge
+    route whose single-channel L-shape would be shoved to the far edge of
+    an oversized source section.  Routes a 6-corner step::
+
+        (sx, sy) -> (corner_x, sy)      ; H lead-in right out of the source
+        (corner_x, sy) -> (corner_x, step_y) ; V down past the source bottom
+        (corner_x, step_y) -> (chan_x, step_y) ; H left into the target channel
+        (chan_x, step_y) -> (chan_x, ey) ; V down to the entry Y
+        (chan_x, ey) -> (ex, ey)        ; H into the entry port
+
+    ``corner_x`` clears the source section's right edge; ``step_y`` sits
+    just below the source bottom; ``chan_x`` is the clear channel right of
+    the target column's stack.  Both leftward legs stay well under half the
+    canvas width, eliminating the full-width sweep.
+    """
+    graph = ctx.graph
+    sx, sy = src.x, src.y
+    ex, ey = ep.x, ep.y
+    src_off = _get_offset(ctx, edge.source, edge.line_id)
+    tgt_off = _get_offset(ctx, edge.target, edge.line_id)
+    r = ctx.curve_radius
+
+    src_sec = graph.sections.get(src.section_id) if src.section_id else None
+    # Trace through the junction to the feeding exit port's section.
+    if src_sec is None:
+        src_sec = resolve_section(graph, src)
+    src_right = (src_sec.bbox_x + src_sec.bbox_w) if src_sec else sx
+    src_bottom = (src_sec.bbox_y + src_sec.bbox_h) if src_sec else sy
+
+    # Spread parallel lines: outer lines sit further out / lower.
+    spread = (n - 1 - i) * ctx.offset_step
+    corner_x = src_right + SECTION_ROUTE_CLEARANCE + spread
+    corner_x = max(corner_x, sx + r)
+    step_y = src_bottom + EDGE_TO_BUNDLE_CLEARANCE + spread
+
+    chan_x = _nested_target_clear_channel_x(
+        graph, ep, step_y, ey + tgt_off, SECTION_ROUTE_CLEARANCE
+    )
+    if chan_x is None:
+        chan_x = ex + SECTION_ROUTE_CLEARANCE
+    chan_x += spread
+
+    return RoutedPath(
+        edge=edge,
+        line_id=edge.line_id,
+        points=[
+            (sx, sy + src_off),
+            (corner_x, sy + src_off),
+            (corner_x, step_y),
+            (chan_x, step_y),
+            (chan_x, ey + tgt_off),
+            (ex, ey + tgt_off),
+        ],
+        is_inter_section=True,
+        normalize_exempt=True,
+        curve_radii=[r, r, r, r],
+        offsets_applied=True,
+    )
+
+
+def _should_step_descent(
+    graph: MetroGraph,
+    src: Station,
+    ep: Station,
+    ep_port,
+) -> bool:
+    """Detect the nested-column degenerate geometry that needs a stepped
+    descent (#425).
+
+    Fires only when a junction-sourced merge route to a RIGHT entry port
+    would otherwise drop in a single far-right channel because the target
+    column is geometrically nested inside an oversized source section: the
+    source section's right edge sits well to the right of the entry port,
+    so a single-channel L-shape must descend far right and sweep all the
+    way back left.  The stepped descent replaces that with two short legs.
+    """
+    if ep_port is None or ep_port.side != PortSide.RIGHT:
+        return False
+    src_sec = graph.sections.get(src.section_id) if src.section_id else None
+    if src_sec is None:
+        src_sec = resolve_section(graph, src)
+    ep_sec = graph.sections.get(ep.section_id) if ep.section_id else None
+    if src_sec is None or ep_sec is None or src_sec.bbox_w <= 0:
+        return False
+    # Target column must be to the RIGHT in grid terms (forward route)...
+    if ep_sec.grid_col <= src_sec.grid_col:
+        return False
+    src_right = src_sec.bbox_x + src_sec.bbox_w
+    # ...yet the entry port sits well LEFT of the source's right edge, so a
+    # single-channel descent would be shoved far right of the target (the
+    # nested-column degeneracy).  Require a clear target-side channel to
+    # step into; if none resolves, fall back to the standard L-shape.
+    if src_right <= ep.x + SECTION_ROUTE_CLEARANCE:
+        return False
+    chan_x = _nested_target_clear_channel_x(
+        graph, ep, src_sec.bbox_y + src_sec.bbox_h, ep.y, SECTION_ROUTE_CLEARANCE
+    )
+    if chan_x is None:
+        return False
+    # The channel must genuinely improve on the far-right descent: it has
+    # to land left of the source's right edge (otherwise we gain nothing).
+    return chan_x < src_right - SECTION_ROUTE_CLEARANCE
 
 
 def _route_l_shape(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -157,6 +157,14 @@ def _fixtures_with(predicate) -> list[str]:
 _FIXTURES_WITH_OFF_TRACK = _fixtures_with(lambda t: "off_track:" in t)
 _FIXTURES_MULTI_SECTION = _fixtures_with(lambda t: t.count("subgraph") >= 2)
 
+# Fixtures for the full-width dog-leg invariant (#425): every multi-section
+# gallery fixture plus the sarek serpentine-stacked regression, whose narrow
+# ``reporting`` column nests under the wide ``preprocessing`` row-span and so
+# exposes the nested-column degenerate routing geometry.
+_FIXTURES_DOGLEG = sorted(
+    {*_FIXTURES_MULTI_SECTION, "regressions/sarek_serpentine_stacked.mmd"}
+)
+
 
 def _fixtures_with_bypass() -> list[str]:
     """Return fixtures whose layout produces at least one ``__bypass_``
@@ -888,6 +896,39 @@ def test_inter_section_route_no_x_backtrack(fixture):
                     f"{fixture}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
                     f"backtracks right x={x1:.1f}->{x2:.1f} on a leftward route"
                 )
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_DOGLEG)
+def test_inter_section_route_no_full_width_dogleg(fixture):
+    """A forward inter-section route may reverse in X to reach a target
+    column nested inside an oversized sibling, but no single backtrack leg
+    may sweep more than 40% of the canvas width (#425).
+
+    The strict X-monotonic guard above forbids *any* reversal on a forward
+    LR route and skips wrapping (``normalize_exempt``) routes.  When a
+    narrow target column nests inside an oversized sibling (sarek's
+    ``reporting`` under the wide ``preprocessing`` row-span), reaching it
+    requires a legitimate reversal, so such routes are exempt.  This still
+    bounds those reversals: a right-then-left dog-leg sweeping the whole
+    diagram is forbidden even when exempt.
+    """
+    from nf_metro.layout.engine import (
+        _canvas_width,
+        inter_section_route_backtrack_legs,
+    )
+
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+    canvas_width = _canvas_width(graph)
+    assert canvas_width > 0
+    limit = 0.4 * canvas_width
+    for rp, x1, x2 in inter_section_route_backtrack_legs(graph, routes):
+        span = abs(x2 - x1)
+        assert span <= limit + _Y_TOL, (
+            f"{fixture}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
+            f"backtracks {span:.1f}px in one leg (x={x1:.1f}->{x2:.1f}), "
+            f"exceeding 40% of canvas width {canvas_width:.1f}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A junction-sourced merge route to a RIGHT entry port whose target column is geometrically nested inside an oversized source section (sarek's narrow `reporting` column under the wide `preprocessing` row-span) was routed as a single far-right L-shape: the descent dropped at the source section's far edge, then swept the full diagram width back left to reach the target. The MultiQC fan-in `fastqc/mosdepth/bcftools_stats -> multiqc` read as a large right-down-left C-shape.

This detects that nested-column geometry and routes a stepped descent instead:

- `_should_step_descent` - fires only when a junction-sourced merge route to a RIGHT entry port has its target column to the right in grid terms yet geometrically nested left of the oversized source section's right edge, with a clear target-side channel to step into.
- `_route_stepped_descent` - exits right past the source edge, drops just below the source bottom, steps left into the clear channel right of the target column's stack, then drops to the entry Y and into the port. Turns smooth into curves.

The largest backtrack leg on the sarek `__junction_8 -> __merge_*` route shrinks from ~591px to ~318px (well under half the canvas width). `__junction_8` X is unchanged (1235); the route shape changes, not the junction placement.

A new runtime guard `_guard_inter_section_route_no_full_width_backtrack` (and the shared `inter_section_route_backtrack_legs` helper) bounds any forward route's single backtrack leg to 40% of canvas width. The strict `_guard_inter_section_route_no_backtrack` skips this exempt wrap route; the span guard catches a full-width dog-leg even when exempt. A parametrised invariant test (`test_inter_section_route_no_full_width_dogleg`) runs over every multi-section gallery fixture plus the sarek regression fixture.

The #423 edge-clearance descent check still passes (the first descent leg clears `preprocessing`'s right edge), and gallery renders are byte-identical: the precondition fires only on the nested-column degeneracy.

Fixes #425

## Test plan
- [x] pytest passes (3163 passed, 8 xfailed) including new invariant test (fails before fix, passes after)
- [x] ruff check + ruff format clean on `src/ tests/`
- [x] Runtime validator added (`_guard_inter_section_route_no_full_width_backtrack`)
- [x] Gallery diff: no render changes (byte-identical SVGs base vs PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)