### PR TITLE
fix(layout): reserve inter-row wrap gap for rowspan targets (#422)

### DIFF
--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -389,13 +389,11 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
         # ``inter_row_channel_y``) that must clear the next-row header.
         if port.side not in (PortSide.LEFT, PortSide.RIGHT, PortSide.TOP):
             continue
+        # Only the target's top edge (its grid_row) bounds the gap, so a
+        # multi-row-span target still reserves it; its span is irrelevant.
+        # The source must be single-row: its bottom edge is the gap's upper
+        # bound, and a multi-row source routes via reversal handling.
         tgt_sec = graph.sections.get(port.section_id)
-        # Only the target's TOP edge (its ``grid_row``) bounds the gap the
-        # run lands in, so a multi-row-span target (rowspan grid placement,
-        # #422) still reserves the gap -- only its existence matters here,
-        # not its span.  The source must be a single-row flow section: its
-        # bottom edge is the gap's upper bound, and a multi-row source would
-        # route via reversal handling instead.
         if tgt_sec is None:
             continue
         src = graph.stations.get(edge.source)

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -367,8 +367,10 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
     ``(upper_row, lower_row)`` pair, the required bbox-to-bbox gap so the
     placement pass can widen too-tight rows.
 
-    Fold/serpentine sections (multi-row span) route via reversal handling,
-    not this channel, and are excluded.
+    A multi-row-span *source* routes via reversal handling, not this
+    channel, and is excluded; a multi-row-span *target* (rowspan grid
+    placement) is fine -- only its top edge bounds the gap, so the
+    adjacent ``(src_row, tgt_row)`` reservation still applies (#422).
     """
 
     def _is_flow_section(sec) -> bool:
@@ -388,7 +390,13 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
         if port.side not in (PortSide.LEFT, PortSide.RIGHT, PortSide.TOP):
             continue
         tgt_sec = graph.sections.get(port.section_id)
-        if not _is_flow_section(tgt_sec):
+        # Only the target's TOP edge (its ``grid_row``) bounds the gap the
+        # run lands in, so a multi-row-span target (rowspan grid placement,
+        # #422) still reserves the gap -- only its existence matters here,
+        # not its span.  The source must be a single-row flow section: its
+        # bottom edge is the gap's upper bound, and a multi-row source would
+        # route via reversal handling instead.
+        if tgt_sec is None:
             continue
         src = graph.stations.get(edge.source)
         if src is None:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -161,9 +161,18 @@ _FIXTURES_MULTI_SECTION = _fixtures_with(lambda t: t.count("subgraph") >= 2)
 # gallery fixture plus the sarek serpentine-stacked regression, whose narrow
 # ``reporting`` column nests under the wide ``preprocessing`` row-span and so
 # exposes the nested-column degenerate routing geometry.
-_FIXTURES_DOGLEG = sorted(
+# Multi-section gallery fixtures plus the sarek serpentine-stacked
+# regression.  The regression's narrow ``reporting`` column nests under the
+# wide ``preprocessing`` row-span (exposing the nested-column dog-leg
+# geometry, #425) and its ``variant_calling`` row-span (rows 1-3) separates
+# an inter-row wrap's source/target rows by a multi-row placement (#422); the
+# multi-section gallery fixtures cover the adjacent-row, non-rowspan wrap
+# (via ``topologies/stacked_lr_serpentine.mmd``).
+_FIXTURES_MULTI_SECTION_PLUS_SAREK_STACK = sorted(
     {*_FIXTURES_MULTI_SECTION, "regressions/sarek_serpentine_stacked.mmd"}
 )
+_FIXTURES_DOGLEG = _FIXTURES_MULTI_SECTION_PLUS_SAREK_STACK
+_FIXTURES_INTER_ROW_CLEARANCE = _FIXTURES_MULTI_SECTION_PLUS_SAREK_STACK
 
 
 def _fixtures_with_bypass() -> list[str]:
@@ -946,7 +955,7 @@ def _section_bbox(sec) -> tuple[float, float, float, float]:
     return sec.bbox_x, sec.bbox_x + sec.bbox_w, sec.bbox_y, sec.bbox_y + sec.bbox_h
 
 
-@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+@pytest.mark.parametrize("fixture", _FIXTURES_INTER_ROW_CLEARANCE)
 def test_inter_row_run_clears_source_section(fixture):
     """A horizontal leg of an inter-*row* route must not graze its source
     section's bbox edge.

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -157,10 +157,6 @@ def _fixtures_with(predicate) -> list[str]:
 _FIXTURES_WITH_OFF_TRACK = _fixtures_with(lambda t: "off_track:" in t)
 _FIXTURES_MULTI_SECTION = _fixtures_with(lambda t: t.count("subgraph") >= 2)
 
-# Fixtures for the full-width dog-leg invariant (#425): every multi-section
-# gallery fixture plus the sarek serpentine-stacked regression, whose narrow
-# ``reporting`` column nests under the wide ``preprocessing`` row-span and so
-# exposes the nested-column degenerate routing geometry.
 # Multi-section gallery fixtures plus the sarek serpentine-stacked
 # regression.  The regression's narrow ``reporting`` column nests under the
 # wide ``preprocessing`` row-span (exposing the nested-column dog-leg


### PR DESCRIPTION
## Summary
The inter-row wrap-channel clearance (#414/#418) centres a horizontal run in the gap between the source section's bottom and the target section's top, reserving that gap via `_wrap_bundle_row_minimums` (honoured in `_enforce_min_row_gaps`). The reservation was skipped whenever the target section used a multi-row `rowspan` grid placement: `_wrap_bundle_row_minimums` required `grid_row_span == 1` on the target, so e.g. sarek's `variant_calling` (rows 1-3) never registered a minimum for the row 0-1 gap. The wrap run then fell flush under the source section (8px below `preprocessing`, versus the 16px `EDGE_TO_BUNDLE_CLEARANCE` required), tripping the `_guard_inter_row_run_clearance` runtime guard.

Only the target's top edge (its `grid_row`) bounds the gap the run lands in, so a multi-row-span target is fine; only the *source* must be a single-row flow section. This PR drops the span check on the target while keeping it on the source.

- `_wrap_bundle_row_minimums`: reserve the adjacent-row gap for any target section (regardless of rowspan), gated on the source still being a single-row flow section.
- Extend the `test_inter_row_run_clears_source_section` invariant test to the sarek serpentine-stacked rowspan regression fixture. The adjacent-row, non-rowspan arm is already covered by the multi-section gallery fixtures (e.g. `topologies/stacked_lr_serpentine.mmd`).

After the fix the `__junction_8 -> variant_calling__entry_left_4` wrap run clears `preprocessing`'s bottom by 19px and all layout guards pass under `validate=True`.

Stacked on top of #425. Fixes #422.

## Test plan
- [x] pytest passes (3164 passed, 3 skipped, 8 known xfails), including the new rowspan arm of the inter-row clearance invariant
- [x] ruff check + ruff format clean on `src/` and `tests/`
- [x] `_guard_inter_row_run_clearance` passes on the sarek rowspan fixture under `validate=True`
- [x] Gallery byte-identical (0 of 60 gallery renders changed); mid-chain PR so no CI render preview

Generated with Claude Code