### PR TITLE
fix(routing): descend inter-column corridor for downward MultiQC fan-in feeders (#432)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -663,15 +663,23 @@ def _canvas_width(graph: MetroGraph) -> float:
 
 
 def inter_section_route_backtrack_legs(graph: MetroGraph, routes: list):
-    """Yield ``(rp, x1, x2)`` for each horizontal leg that reverses against
-    its route's exit-direction flow.
+    """Yield ``(rp, x1, x2)`` for each horizontal leg that moves *away* from
+    the route's own endpoint X - a genuine out-and-back dog-leg.
 
-    "Flow" mirrors :func:`_guard_inter_section_route_no_backtrack`: a
-    forward route between two distinct LR columns whose exit port faces the
-    target column flows toward that column (rightward when the target column
-    is higher).  A leg that moves the opposite way is a backtrack.  Routes
-    that exit away from their target legitimately wrap and are skipped, as
-    are TB folds and same-column routes.  Unlike the strict guard, exempt
+    A backtrack is reverse-direction travel: the line heads away from where
+    it is going, then has to come back.  This is measured against the
+    route's actual endpoint X (its last waypoint), not the grid-column
+    order.  Grid columns can disagree with X order when a narrow target
+    column nests inside a wide row-span sibling (sarek's ``reporting`` under
+    the full-width ``preprocessing`` row): there the target column is
+    "higher" yet sits to the *left*, so a single long leftward traverse is a
+    monotonic approach toward the target - not a dog-leg - and is not
+    yielded.  A true #425 dog-leg (right past the target, then back left)
+    still moves away from the endpoint on its outward leg and is yielded.
+
+    Routes that exit a port facing away from their endpoint legitimately
+    wrap and are skipped, as are TB folds and same-column routes.  Unlike
+    the strict :func:`_guard_inter_section_route_no_backtrack`, exempt
     (``normalize_exempt``) wrap routes are *included* so a multi-corner
     around-section dog-leg is still measured.
     """
@@ -698,15 +706,23 @@ def inter_section_route_backtrack_legs(graph: MetroGraph, routes: list):
             continue
         if src_sec.grid_col == tgt_sec.grid_col:
             continue
-        rightward = tgt_sec.grid_col > src_sec.grid_col
-        side = _exit_side(rp)
-        if rightward and side != PortSide.RIGHT:
-            continue
-        if not rightward and side != PortSide.LEFT:
-            continue
         xs = [p[0] for p in rp.points]
+        if len(xs) < 2:
+            continue
+        # Direction toward the route's own endpoint: a leg moving the other
+        # way (away from where the route ends) is the dog-leg's outward leg.
+        toward_endpoint_is_right = xs[-1] > xs[0]
+        side = _exit_side(rp)
+        # An exit port facing away from the endpoint legitimately wraps; its
+        # outward stub is not a dog-leg.  (Grid-column-based skip preserved
+        # for the wrap case: the exit faces the target column it serves.)
+        rightward_cols = tgt_sec.grid_col > src_sec.grid_col
+        if rightward_cols and side != PortSide.RIGHT:
+            continue
+        if not rightward_cols and side != PortSide.LEFT:
+            continue
         for x1, x2 in zip(xs, xs[1:]):
-            backtracks = (x2 < x1) if rightward else (x2 > x1)
+            backtracks = (x2 < x1) if toward_endpoint_is_right else (x2 > x1)
             if backtracks:
                 yield rp, x1, x2
 

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -94,17 +94,30 @@ def col_left_edge(
     return min((s.bbox_x for s in secs), default=default) if secs else default
 
 
-def row_bottom_edge(graph: MetroGraph, row: int, default: float = 0.0) -> float:
-    """Bottommost Y extent of sections in *row*."""
+def row_bottom_edge(
+    graph: MetroGraph, row: int, default: float = 0.0, col: int | None = None
+) -> float:
+    """Bottommost Y extent of sections in *row* (optionally a single *col*).
+
+    When *col* is given, restrict to sections in that grid column so an
+    inter-row diversion travelling within one column isn't pushed down by a
+    tall row-span section stacked in a different column of the same row.
+    """
     secs = _sections_in_row(graph, row)
+    if col is not None:
+        secs = [s for s in secs if s.grid_col == col]
     if not secs:
         return default
     return max((s.bbox_y + s.bbox_h for s in secs), default=default)
 
 
-def row_top_edge(graph: MetroGraph, row: int, default: float = 0.0) -> float:
-    """Topmost Y extent of sections in *row*."""
+def row_top_edge(
+    graph: MetroGraph, row: int, default: float = 0.0, col: int | None = None
+) -> float:
+    """Topmost Y extent of sections in *row* (optionally a single *col*)."""
     secs = _sections_in_row(graph, row)
+    if col is not None:
+        secs = [s for s in secs if s.grid_col == col]
     return min((s.bbox_y for s in secs), default=default) if secs else default
 
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -23,6 +23,7 @@ from nf_metro.layout.constants import (
     EDGE_TO_BUNDLE_CLEARANCE,
     FOLD_MARGIN,
     ICON_TERMINUS_FORK_LEAD,
+    INTER_ROW_HEADER_CLEARANCE,
     JUNCTION_MARGIN,
     MERGE_ROUTE_MARGIN,
     MIN_STATION_FLAT_LENGTH,
@@ -36,6 +37,7 @@ from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.routing.common import (
     Direction,
     RoutedPath,
+    _center_inter_row_channel,
     bundle_width,
     bypass_bottom_y,
     clear_channel_of_section_edge,
@@ -1944,15 +1946,26 @@ def _route_inter_row_gap_corridor(
     ep_row = _resolve_section_row(ctx.graph, entry_port)
 
     # Inter-row gap Y just below the source row (column-restricted so a
-    # tall row-span in another column doesn't push the channel down).
+    # tall row-span in another column doesn't push the channel down).  Use
+    # the header-aware band so the leftward traverse clears the next row's
+    # section-header badge, not just the bbox edge.
     gap_top = row_bottom_edge(ctx.graph, src_row, col=src_col)
     gap_bottom = row_top_edge(ctx.graph, src_row + 1, col=src_col, default=gap_top)
     if gap_bottom > gap_top:
-        gy_base = (gap_top + gap_bottom) / 2
+        gy_base = _center_inter_row_channel(gap_top, gap_bottom)
     else:
         gy_base = gap_top + EDGE_TO_BUNDLE_CLEARANCE
     # Outer line sits at LARGER y in this leftward run (CW D->L corner).
     gy = gy_base + delta
+    # Keep every staggered line inside the clearance band: at least
+    # EDGE_TO_BUNDLE_CLEARANCE below the source-row bottom and clear of the
+    # next row's header badge.  In a tight gap the band is narrower than the
+    # bundle, so the per-line stagger collapses rather than grazing an edge.
+    if gap_bottom > gap_top:
+        gy = min(
+            max(gy, gap_top + EDGE_TO_BUNDLE_CLEARANCE),
+            gap_bottom - INTER_ROW_HEADER_CLEARANCE,
+        )
 
     # Inter-column descent channel left of the target column.
     vx = _corridor_descent_x(ctx, ep_col, ep_row, delta)

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -48,6 +48,8 @@ from nf_metro.layout.routing.common import (
     inter_column_channel_x,
     inter_row_channel_y,
     resolve_section,
+    row_bottom_edge,
+    row_top_edge,
     symmetric_bundle_midpoint,
     vertical_direction,
 )
@@ -644,6 +646,8 @@ def _route_inter_section(
         wrap_hy = inter_row_channel_y(graph, src, tgt, sy, ty, dy, ctx.curve_radius)
         exclude = {src.section_id} if src.section_id else set()
         if _h_segment_crosses_other_section(graph, sx, tx, wrap_hy, exclude):
+            if _corridor_is_viable(ctx, src, tgt):
+                return _route_inter_row_gap_corridor(edge, src, tgt, tgt, i, n, ctx)
             return _route_around_section_below(edge, src, tgt, tgt, i, n, ctx)
         return _route_left_entry_wrap(edge, src, tgt, i, n, ctx)
 
@@ -692,6 +696,14 @@ def _route_inter_section(
             if ep_port and ep_port.side == PortSide.LEFT:
                 exclude = {src.section_id} if src.section_id else set()
                 if _h_segment_crosses_other_section(graph, sx, ep.x, ep.y, exclude):
+                    # When a clear inter-row / inter-column corridor exists
+                    # (downward cross-row feeder, e.g. sarek's MultiQC
+                    # fan-in), descend it instead of looping below the
+                    # canvas (#432).
+                    if _corridor_is_viable(ctx, src, ep):
+                        return _route_inter_row_gap_corridor(
+                            edge, src, tgt, ep, i, n, ctx
+                        )
                     return _route_around_section_below(edge, src, tgt, ep, i, n, ctx)
             # RIGHT entry nested inside an oversized source section: a
             # single-channel L-shape would descend far right and sweep
@@ -1818,6 +1830,160 @@ def _has_bypass_sibling_to_same_entry(
             continue
         return True
     return False
+
+
+def _corridor_descent_x(
+    ctx: _RoutingCtx, ep_col: int, ep_row: int, delta: float
+) -> float | None:
+    """X of the inter-column channel just LEFT of the target column.
+
+    The corridor descends the clear gap between ``ep_col - 1`` and
+    ``ep_col`` measured at the *target* row (so a wide row-span section in
+    a different row - e.g. sarek's full-width ``preprocessing`` in row 0 -
+    does not collapse the gap).  Returns ``None`` when there is no column
+    to the left (degenerate; caller falls back to the around-below loop).
+    """
+    if ep_col <= 0:
+        return None
+    gap_left, gap_right = column_gap_edges(ctx.graph, ep_col - 1, ep_col, row=ep_row)
+    if gap_right <= gap_left:
+        return None
+    return (gap_left + gap_right) / 2 - delta
+
+
+def _corridor_is_viable(ctx: _RoutingCtx, src: Station, entry_port: Station) -> bool:
+    """Whether the inter-row-gap + inter-column-channel corridor exists.
+
+    Used to route a downward cross-row merge feeder (sarek's MultiQC
+    fan-in) through the clear corridor instead of the canvas-bottom loop
+    (:func:`_route_around_section_below`).  Requires:
+
+    * a LEFT entry port (the corridor descends just left of the target);
+    * the target section sits in a row strictly *below* the source's row
+      (a downward cross-row feeder; same-row fan-ins U-route in the gap
+      below the row and must keep the legacy handler);
+    * an inter-row gap below the source row exists in the source's column;
+    * a clear inter-column channel exists left of the target column.
+    """
+    if entry_port is None:
+        return False
+    ep_port = ctx.graph.ports.get(entry_port.id)
+    if ep_port is None or ep_port.side != PortSide.LEFT:
+        return False
+    src_row = _resolve_section_row(ctx.graph, src)
+    ep_row = _resolve_section_row(ctx.graph, entry_port)
+    src_col = _resolve_section_col(ctx.graph, src)
+    ep_col = _resolve_section_col(ctx.graph, entry_port)
+    if None in (src_row, ep_row, src_col, ep_col):
+        return False
+    if ep_row <= src_row:
+        return False
+    if _corridor_descent_x(ctx, ep_col, ep_row, 0.0) is None:
+        return False
+    # An inter-row gap must open below the source row within its column.
+    gap_top = row_bottom_edge(ctx.graph, src_row, col=src_col)
+    gap_bottom = row_top_edge(ctx.graph, src_row + 1, col=src_col)
+    return gap_bottom - gap_top > EDGE_TO_BUNDLE_CLEARANCE
+
+
+def _route_inter_row_gap_corridor(
+    edge: Edge,
+    src: Station,
+    tgt: Station,
+    entry_port: Station,
+    i: int,
+    n: int,
+    ctx: _RoutingCtx,
+) -> RoutedPath:
+    """Route a downward cross-row LEFT-entry merge feeder via the clear
+    inter-row / inter-column corridor instead of the canvas-bottom loop.
+
+    The sarek MultiQC fan-in feeds the left-entry ``reporting`` section
+    (row 3) from QC sources exiting on the right in rows 0 and 1.  Rather
+    than dropping to the canvas bottom (below the tall ``variant_calling``
+    row-span) and climbing back up (:func:`_route_around_section_below`),
+    descend through the corridor that genuinely exists::
+
+        (lx, sy)        -> H lead-in right of source
+        (corner_x, sy)  ; turn down
+        (corner_x, gy)  -> V down to the inter-row gap below the source row
+        (vx, gy)        -> H left in that gap to the inter-column channel
+        (vx, ey)        -> V down the channel to the entry Y
+        (ex, ey)        -> H right into the LEFT entry port
+
+    All feeders converge in the same inter-column channel (``vx``) just
+    left of the target column, so they travel down together as one bundle
+    meeting the carriage-return spine, rather than two separate loops.
+
+    Corners: R->D (CW), D->L (CW), L->D (CCW), D->R (CW).  The bundle is
+    staggered by ``delta`` (the L-shape offset) on each leg so parallel
+    lines keep concentric corners and a constant gap.
+    """
+    sx, sy = src.x, src.y
+    ex, ey = entry_port.x, entry_port.y
+
+    delta, _r1, _r2 = l_shape_radii(
+        i,
+        n,
+        vertical=Direction.D,
+        offset_step=ctx.offset_step,
+        base_radius=ctx.curve_radius,
+    )
+    off_for_radius = (n - 1 - i) * ctx.offset_step
+    max_off_for_radius = (n - 1) * ctx.offset_step
+    r_outer = corner_radius(
+        off_for_radius,
+        max_off_for_radius,
+        outside=True,
+        base_radius=ctx.curve_radius,
+    )
+
+    src_row = _resolve_section_row(ctx.graph, src)
+    src_col = _resolve_section_col(ctx.graph, src)
+    ep_col = _resolve_section_col(ctx.graph, entry_port)
+    ep_row = _resolve_section_row(ctx.graph, entry_port)
+
+    # Inter-row gap Y just below the source row (column-restricted so a
+    # tall row-span in another column doesn't push the channel down).
+    gap_top = row_bottom_edge(ctx.graph, src_row, col=src_col)
+    gap_bottom = row_top_edge(ctx.graph, src_row + 1, col=src_col, default=gap_top)
+    if gap_bottom > gap_top:
+        gy_base = (gap_top + gap_bottom) / 2
+    else:
+        gy_base = gap_top + EDGE_TO_BUNDLE_CLEARANCE
+    # Outer line sits at LARGER y in this leftward run (CW D->L corner).
+    gy = gy_base + delta
+
+    # Inter-column descent channel left of the target column.
+    vx = _corridor_descent_x(ctx, ep_col, ep_row, delta)
+
+    # H lead-in right of the source, clear of the source section's edge.
+    src_section = ctx.graph.sections.get(src.section_id) if src.section_id else None
+    corner_x = sx + ctx.curve_radius + (n - 1) * ctx.offset_step / 2 + delta
+    if src_section and src_section.bbox_w > 0:
+        section_right = src_section.bbox_x + src_section.bbox_w
+        current_gap = sx + ctx.curve_radius - section_right
+        corner_x += max(0.0, SECTION_ROUTE_CLEARANCE - current_gap)
+
+    src_off = _get_offset(ctx, edge.source, edge.line_id)
+    tgt_off = _get_offset(ctx, edge.target, edge.line_id)
+
+    return RoutedPath(
+        edge=edge,
+        line_id=edge.line_id,
+        points=[
+            (sx, sy + src_off),
+            (corner_x, sy + src_off),
+            (corner_x, gy),
+            (vx, gy),
+            (vx, ey + tgt_off),
+            (ex, ey + tgt_off),
+        ],
+        is_inter_section=True,
+        normalize_exempt=True,
+        curve_radii=[r_outer, r_outer, r_outer, r_outer],
+        offsets_applied=True,
+    )
 
 
 def _route_around_section_below(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2780,17 +2780,10 @@ def _icon_x_extent(graph: MetroGraph, station, section) -> tuple[float, float]:
     return cx - icon_half_w, cx + icon_half_w
 
 
-# sarek's ``reporting`` file icons (``report_out``/``vcf_out``) sit on the
-# row the MultiQC fan-in merge bundle sweeps across.  The merge trunk's
-# full-width horizontal into the left entry crosses an icon; clearing it
-# needs the deferred MultiQC merge-bundle around-routing (#432).  Pre-existing
-# on the integration branch.
-_XFAIL_ICON_OVERLAP: dict[str, str] = {
-    "sarek.mmd": (
-        "#432: MultiQC fan-in merge bundle sweeps the reporting row and "
-        "crosses a file icon; merge-bundle around-routing deferred"
-    ),
-}
+# sarek's MultiQC fan-in now descends the inter-column corridor into the
+# left-entry ``reporting`` section instead of sweeping the reporting row's
+# full width, so the merge bundle no longer crosses the file icons (#432).
+_XFAIL_ICON_OVERLAP: dict[str, str] = {}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -903,20 +903,98 @@ def test_inter_section_route_no_x_backtrack(fixture):
                 )
 
 
-# sarek's MultiQC fan-in feeds a left-entry ``reporting`` section in row 3
-# from sources spread across row 0 (preprocessing, far right) and row 1
-# (post_vc).  Reaching the left entry from the far-right source is an
-# intrinsic full-width sweep; routing that long-range multi-row merge bundle
-# around the diagram is deferred (#432, MultiQC fan-in).  The carriage-return
-# spine and the per-port boundary invariant both hold; only this single
-# dog-leg leg is still oversized.
-_XFAIL_DOGLEG: dict[str, str] = {
-    f: (
-        "#432: long-range MultiQC fan-in feeder sweeps full width into the "
-        "left-entry reporting section; merge-bundle around-routing deferred"
+# ---------------------------------------------------------------------------
+# Merge feeders descend the inter-column corridor, not the canvas bottom
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    sorted({*_FIXTURES_MULTI_SECTION, "sarek.mmd"}),
+)
+def test_merge_feeder_does_not_loop_below_target(fixture):
+    """A merge-junction feeder reaching a target row *below* its source must
+    not dip far below the target section's bottom edge to reach it (#432).
+
+    The sarek MultiQC fan-in feeds the left-entry ``reporting`` section
+    (row 3) from QC sources that exit on the right in rows 0 and 1.  The
+    naive around-below route drops the feeder to the very bottom of the
+    canvas (below the tall ``variant_calling`` row-span), runs leftward
+    there, then climbs back up into the entry - two big loops sweeping the
+    canvas bottom.  A clear inter-column corridor exists between the source
+    and target columns: drop into the inter-row gap below the source row,
+    traverse left in that gap to the inter-column channel, then descend
+    that channel straight to the entry.  This invariant pins the corridor:
+    a downward cross-row feeder must stay within a bounded margin of the
+    target section's bottom rather than looping below everything beneath
+    it.
+
+    Scoped to *downward cross-row* feeders.  A same-row fan-in merge
+    legitimately U-routes through the inter-row gap *below* the row and
+    climbs back into a same-row target (e.g. ``03b_fan_in_merge``,
+    ``genomeassembly``); that gap-dip is the intended geometry, not a
+    canvas-bottom loop.
+    """
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    for rp in routes:
+        if not (
+            rp.edge.source.startswith("__junction")
+            and rp.edge.target.startswith("__merge")
+        ):
+            continue
+        src_sec = resolve_section(graph, graph.stations[rp.edge.source])
+        tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
+        if src_sec is None or tgt_sec is None:
+            continue
+        # Only downward cross-row feeders take the corridor; same-row
+        # fan-ins legitimately U-route through the gap below the row.
+        if tgt_sec.grid_row <= src_sec.grid_row:
+            continue
+        tgt_bottom = tgt_sec.bbox_y + tgt_sec.bbox_h
+        max_y = max(p[1] for p in rp.points)
+        # The route may sweep a little below the entry port (its descent
+        # curve) but must not loop below the target section's whole box.
+        assert max_y <= tgt_bottom + SECTION_Y_GAP + _Y_TOL, (
+            f"{fixture}: merge feeder {rp.edge.source}->{rp.edge.target} "
+            f"({rp.line_id}) dips to y={max_y:.1f}, far below the target "
+            f"section bottom {tgt_bottom:.1f} - it loops below the canvas "
+            f"instead of descending the inter-column corridor"
+        )
+
+
+@pytest.mark.parametrize("fixture", sorted({*_FIXTURES_MULTI_SECTION_PLUS_SAREK_STACK}))
+def test_inter_section_route_no_full_width_dogleg_clean(fixture):
+    """No merge feeder takes a full-width out-and-back dog-leg (#432).
+
+    The corridor route's long leftward traverse in the inter-row gap is a
+    monotonic approach toward the target, not a backtrack, so the refined
+    full-width guard passes on sarek now.
+    """
+    from nf_metro.layout.engine import (
+        _canvas_width,
+        inter_section_route_backtrack_legs,
     )
-    for f in ("regressions/sarek_serpentine_stacked.mmd", "sarek.mmd")
-}
+
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+    canvas_width = _canvas_width(graph)
+    assert canvas_width > 0
+    limit = 0.4 * canvas_width
+    for rp, x1, x2 in inter_section_route_backtrack_legs(graph, routes):
+        span = abs(x2 - x1)
+        assert span <= limit + _Y_TOL, (
+            f"{fixture}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
+            f"backtracks {span:.1f}px in one leg (x={x1:.1f}->{x2:.1f}), "
+            f"exceeding 40% of canvas width {canvas_width:.1f}"
+        )
+
+
+# sarek's MultiQC fan-in now descends the shared inter-column corridor into
+# the left-entry ``reporting`` section, so the feeders are X-monotonic toward
+# the target and no longer trip the full-width dog-leg guard.
+_XFAIL_DOGLEG: dict[str, str] = {}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Continues #432 (part B). The sarek MultiQC fan-in feeds the left-entry `reporting` section (row 3) from QC sources that exit on the right in rows 0 and 1 (FastQC/mosdepth via `__junction_8`, bcftools_stats via `__junction_9`). The around-below handler dropped each feeder to the canvas bottom (below the tall `variant_calling` row-span), ran leftward there, then climbed back up into the left entry port - two big loops sweeping the canvas bottom.

This routes a downward cross-row LEFT-entry merge feeder through the clear corridor instead:

1. Drop into the inter-row gap below the source row (column-restricted, header-aware band).
2. Traverse left in that gap to the inter-column channel just left of the target column.
3. Descend that channel straight into the LEFT entry port.

All feeders converge in the shared inter-column channel, travelling down as one bundle with the carriage-return spine, rather than two separate canvas-bottom loops.

The full-width-backtrack measurement (`inter_section_route_backtrack_legs`) is refined to flag genuine away-from-endpoint travel rather than total leg length: a backtrack is measured against the route's own endpoint X, not grid-column order. The corridor's long monotonic leftward traverse (a narrow column nested under a wide row-span sits to the left despite a "higher" grid column) now passes, while a true out-and-back dog-leg (#425) still fails.

### Routing (sarek)
- `__junction_8 -> __merge_*`: drops to y~338 (inter-row gap below row 0), left to x~460 (inter-column channel), descends to y~758 entry. (was y=1246, canvas bottom)
- `__junction_9 -> __merge_*`: drops to y~504 (inter-row gap below row 1, col 1), left to x~458, descends to entry. (was y=876)

### New invariants
- `test_merge_feeder_does_not_loop_below_target` (parametrised over multi-section fixtures + sarek): a downward cross-row merge feeder must stay within a bounded margin of the target section's bottom. Same-row fan-ins (which legitimately U-route below the row) are scoped out.
- `test_inter_section_route_no_full_width_dogleg_clean`: no merge feeder takes a full-width out-and-back dog-leg.
- `compute_layout(validate=True)` now passes on sarek (refined `_guard_inter_section_route_no_full_width_backtrack`).

### Gating / regressions
- The corridor only fires for downward cross-row LEFT-entry merge feeders with a clear gap below the source row and a clear inter-column channel left of the target. Same-row fan-ins and the left-entry-wrap path keep `_route_around_section_below`.
- All 60 gallery renders are byte-identical to the base branch - the only behavioral change is sarek (not in the gallery). The single fixture still exercising `_route_around_section_below` (`around_section_below.mmd`) is unchanged.
- Cleared three now-passing sarek xfails (`_XFAIL_DOGLEG`, `_XFAIL_ICON_OVERLAP`).

## Test plan
- [x] pytest passes (3373 passed, 8 xfailed)
- [x] ruff check + format clean on src/ tests/
- [x] Runtime validator refined (`compute_layout(validate=True)` passes on sarek)
- [x] Gallery byte-identical to base (no regressions); sarek eyeballed - corridor descends cleanly, no canvas-bottom loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)