### PR TITLE
fix(routing): corridor curve quality - concentric corners, dedupe shared descent (#435)

### DIFF
--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -294,9 +294,14 @@ def compute_bundle_info(
             if src_sec and tgt_sec and src_sec.grid_col != tgt_sec.grid_col:
                 col_key = (src_sec.grid_col, tgt_sec.grid_col)
             elif tgt_sec:
-                # Source is a junction: include target column so edges
-                # to different columns get separate bundles.
-                col_key = (round(sx), tgt_sec.grid_col)
+                # Source is a junction: include target column AND row so
+                # edges to different sections get separate bundles.  A
+                # junction can fan to two targets in the same column but
+                # different rows (e.g. sarek junction_9 -> annotation row 2
+                # via a wrap and -> reporting row 3 via the MultiQC
+                # corridor); those are distinct corridors and must not be
+                # conflated into one over-wide interleaved bundle.
+                col_key = (round(sx), tgt_sec.grid_col, tgt_sec.grid_row)
             else:
                 col_key = round(sx)
             key = ("L", col_key, v_dir, h_dir)

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -1850,7 +1850,11 @@ def _corridor_descent_x(
     gap_left, gap_right = column_gap_edges(ctx.graph, ep_col - 1, ep_col, row=ep_row)
     if gap_right <= gap_left:
         return None
-    return (gap_left + gap_right) / 2 - delta
+    # +delta (not -delta): the L->D corner into this channel is concentric
+    # only when vx + r is constant across the bundle.  r_inner shrinks for
+    # the +delta (rightmost) line, so that line must sit at the LARGER vx;
+    # the opposite sign delaminates the descent corner.
+    return (gap_left + gap_right) / 2 + delta
 
 
 def _corridor_is_viable(ctx: _RoutingCtx, src: Station, entry_port: Station) -> bool:
@@ -1917,7 +1921,7 @@ def _route_inter_row_gap_corridor(
     left of the target column, so they travel down together as one bundle
     meeting the carriage-return spine, rather than two separate loops.
 
-    Corners: R->D (CW), D->L (CW), L->D (CCW), D->R (CW).  The bundle is
+    Corners: R->D (CW), D->L (CW), L->D (CCW), D->R (CCW).  The bundle is
     staggered by ``delta`` (the L-shape offset) on each leg so parallel
     lines keep concentric corners and a constant gap.
     """
@@ -1937,6 +1941,12 @@ def _route_inter_row_gap_corridor(
         off_for_radius,
         max_off_for_radius,
         outside=True,
+        base_radius=ctx.curve_radius,
+    )
+    r_inner = corner_radius(
+        off_for_radius,
+        max_off_for_radius,
+        outside=False,
         base_radius=ctx.curve_radius,
     )
 
@@ -1994,7 +2004,13 @@ def _route_inter_row_gap_corridor(
         ],
         is_inter_section=True,
         normalize_exempt=True,
-        curve_radii=[r_outer, r_outer, r_outer, r_outer],
+        # Corridor turns R->D->L->D->R (handedness CW, CW, CCW, CCW).  The
+        # bundle's outer line is OUTSIDE corners 1-2 (larger radius r_outer)
+        # but INSIDE corners 3-4 (smaller radius r_inner), so each corner's
+        # arcs share a center and the bundle holds even spacing through the
+        # descent.  Using r_outer at all four corners delaminates the L->D and
+        # D->R turns.  Mirrors :func:`_route_left_entry_wrap`.
+        curve_radii=[r_outer, r_outer, r_inner, r_inner],
         offsets_applied=True,
     )
 

--- a/tests/test_svg_paths.py
+++ b/tests/test_svg_paths.py
@@ -530,3 +530,126 @@ class TestLineZOrderConsistent:
     def test_topology_fixtures(self, fixture):
         _, _, _, svg = _layout_and_route_file(fixture)
         self._check(svg)
+
+
+# ---------------------------------------------------------------------------
+# 8. Concentric arc centers must coincide across a bundle at every corner
+# ---------------------------------------------------------------------------
+
+
+def _arc_center(prev, curr, nxt, r):
+    """Center of the rounded-corner arc at vertex *curr* with radius *r*.
+
+    For an axis-aligned 90-degree turn the center lies *r* along each of the
+    two incident segment directions from the vertex (i.e. along the inward
+    normals).  ``center = curr + r*(unit(prev-curr) + unit(nxt-curr))``.
+    """
+    import math
+
+    def unit(a, b):
+        dx, dy = b[0] - a[0], b[1] - a[1]
+        d = math.hypot(dx, dy)
+        return (0.0, 0.0) if d == 0 else (dx / d, dy / d)
+
+    u1 = unit(curr, prev)
+    u2 = unit(curr, nxt)
+    return (curr[0] + r * (u1[0] + u2[0]), curr[1] + r * (u1[1] + u2[1]))
+
+
+def _corridor_descent_x(pts) -> float | None:
+    """X of a routed path's inter-column descent channel, or None.
+
+    The MultiQC-corridor feeders (#432) traverse the inter-row gap LEFTWARD
+    (a long >150px horizontal run) and immediately turn DOWN into a tall
+    (>150px) inter-column channel.  This long-leftward-then-long-down
+    signature distinguishes corridor descents from short L-shape / bypass
+    turns and from fan-out lead-ins, so the concentricity check stays scoped
+    to the corridor curves.  Returns the descent channel x.
+    """
+    for j in range(len(pts) - 2):
+        ax, ay = pts[j]
+        bx, by = pts[j + 1]
+        cx, cy = pts[j + 2]
+        leftward = abs(ay - by) < 1 and (ax - bx) > 150
+        down = abs(bx - cx) < 1 and (cy - by) > 150
+        if leftward and down:
+            return bx
+    return None
+
+
+class TestConcentricArcCenters:
+    """Corridor bundle lines must share an arc center at every shared corner.
+
+    Distinct radii (TestConcentricBundles) are necessary but not sufficient
+    for visually concentric corners: if two lines turn the same corner with
+    radii r and r+step but *different* arc centers, they splay apart through
+    the turn ("delamination").  True concentricity requires every line in the
+    bundle to pivot about the SAME center at each corner, with radii spaced by
+    the bundle step.  This pins the MultiQC-corridor curves (#432/#435), whose
+    feeders co-route from one junction source, against delamination.
+    """
+
+    # An L-shape staggers lines by offset_step in the channel; concentric
+    # centers must agree to within a fraction of that step.
+    CENTER_EPS = 1.5
+
+    def _check(self, routes, offsets):
+        from collections import defaultdict
+
+        # A corridor bundle is the per-line fan from one junction source that
+        # shares one descent channel (the feeder lines that travel together).
+        # Group by (source, channel) so unrelated routes from the same source
+        # are not conflated.
+        bundles: dict[tuple[str, int], list[RoutedPath]] = defaultdict(list)
+        for r in routes:
+            if not r.is_inter_section or not r.curve_radii:
+                continue
+            pts = apply_route_offsets(r, offsets)
+            vx = _corridor_descent_x(pts)
+            if vx is None:
+                continue
+            bundles[(r.edge.source, round(vx / 10))].append(r)
+
+        for src, bundle in bundles.items():
+            if len(bundle) < 2:
+                continue
+            applied = [(r, apply_route_offsets(r, offsets)) for r in bundle]
+            # Compare corner-by-corner only when the bundle shares structure.
+            if any(len(pts) - 2 != len(r.curve_radii) for r, pts in applied):
+                continue
+            n_corners = min(len(r.curve_radii) for r, _ in applied)
+            for corner_idx in range(n_corners):
+                centers = [
+                    _arc_center(
+                        pts[corner_idx],
+                        pts[corner_idx + 1],
+                        pts[corner_idx + 2],
+                        r.curve_radii[corner_idx],
+                    )
+                    for r, pts in applied
+                ]
+                cx = [c[0] for c in centers]
+                cy = [c[1] for c in centers]
+                spread = max(max(cx) - min(cx), max(cy) - min(cy))
+                assert spread <= self.CENTER_EPS, (
+                    f"Corridor bundle from {src!r} corner {corner_idx}: arc "
+                    f"centers splay by {spread:.2f}px (>{self.CENTER_EPS}); "
+                    f"lines delaminate through the turn. "
+                    f"centers={[(round(x, 1), round(y, 1)) for x, y in centers]}"
+                )
+
+    def test_sarek_corridor(self):
+        fixture = EXAMPLES_DIR / "sarek.mmd"
+        if not fixture.exists():
+            pytest.skip(f"fixture not available: {fixture}")
+        _, routes, offsets, _ = _layout_and_route_file(fixture)
+        self._check(routes, offsets)
+
+    @pytest.mark.parametrize(
+        "fixture",
+        sorted(TOPOLOGIES_DIR.glob("*.mmd")),
+        ids=lambda p: p.stem,
+    )
+    def test_topology_fixtures(self, fixture):
+        _, routes, offsets, _ = _layout_and_route_file(fixture)
+        self._check(routes, offsets)

--- a/tests/test_svg_paths.py
+++ b/tests/test_svg_paths.py
@@ -8,6 +8,7 @@ RoutedPath waypoints + curve_radii into well-formed SVG paths with:
 - Concentric bundle lines maintaining distinct radii through curves
 """
 
+import math
 import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -544,7 +545,6 @@ def _arc_center(prev, curr, nxt, r):
     two incident segment directions from the vertex (i.e. along the inward
     normals).  ``center = curr + r*(unit(prev-curr) + unit(nxt-curr))``.
     """
-    import math
 
     def unit(a, b):
         dx, dy = b[0] - a[0], b[1] - a[1]
@@ -556,7 +556,7 @@ def _arc_center(prev, curr, nxt, r):
     return (curr[0] + r * (u1[0] + u2[0]), curr[1] + r * (u1[1] + u2[1]))
 
 
-def _corridor_descent_x(pts) -> float | None:
+def _corridor_descent_channel_x(pts) -> float | None:
     """X of a routed path's inter-column descent channel, or None.
 
     The MultiQC-corridor feeders (#432) traverse the inter-row gap LEFTWARD
@@ -605,7 +605,7 @@ class TestConcentricArcCenters:
             if not r.is_inter_section or not r.curve_radii:
                 continue
             pts = apply_route_offsets(r, offsets)
-            vx = _corridor_descent_x(pts)
+            vx = _corridor_descent_channel_x(pts)
             if vx is None:
                 continue
             bundles[(r.edge.source, round(vx / 10))].append(r)


### PR DESCRIPTION
## Summary

Fixes the three curve-quality defects in the MultiQC-corridor routing (#432/PR #434), all rooted in the corridor descent's corner radii and bundle grouping. Scoped to corridor curves; the gallery is byte-identical.

- **Bundle-order flip / non-concentric turn-down (defect 1).** The corridor turns `R->D->L->D->R` (handedness CW, CW, CCW, CCW). Corners 3-4 put the bundle's outer line on the INSIDE of the turn, so they need the smaller inside-of-turn radius, not `r_outer`. Using `r_outer` at all four corners splayed the L->D and D->R arcs (non-shared centers). Now `[r_outer, r_outer, r_inner, r_inner]`, mirroring `_route_left_entry_wrap`.
- **Delamination (defect 2).** The inter-column descent x staggered by `-delta`, which delaminated the L->D corner (`vx + r_inner` was not constant across the bundle). Staggering by `+delta` puts the smaller-radius line at the larger `vx` so every line's arc shares a center and the bundle holds even spacing.
- **Smeared two-bundle overlap in the shared left channel (defect 3).** `compute_bundle_info` conflated two distinct corridors from one junction (sarek `junction_9 -> annotation` row 2 via a wrap and `-> reporting` row 3 via the corridor) into one over-wide interleaved 6-line bundle. Keying the junction `col_key` on target row as well as column splits them into separate 3-line bundles; the spine and feeder then **coincide exactly** as one clean bundle (same 3 colours overlay), the cleaner of the two acceptable outcomes since both carry the same lines to the same merge stations.

Adds `TestConcentricArcCenters`: checks arc-center concentricity (not just distinct radii) scoped to corridor descents, parametrised over sarek + topology fixtures. Fails on the pre-fix corridor, passes after.

Fixes #435

## Test plan
- [x] pytest passes (3404 passed, 8 pre-existing xfail) including new `TestConcentricArcCenters`
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] sarek passes `compute_layout(validate=True)`
- [x] Gallery byte-identical vs base (60 renders + manifest unchanged); sarek corridor corners now concentric, left channel a single clean bundle
- [ ] Visual review of render preview

Generated with Claude Code