### PR TITLE
fix(routing): coincide junction fan spine and corridor bundles (#437)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -653,6 +653,18 @@ def _guard_inter_section_route_no_backtrack(
                 )
 
 
+def first_vertical_leg_x(points) -> float | None:
+    """X of the first (near-)vertical leg of *points*.
+
+    The source-side vertical channel ("V1") of an inter-section route;
+    ``None`` when no vertical leg exists.
+    """
+    for (x0, y0), (x1, y1) in zip(points, points[1:]):
+        if abs(x1 - x0) < 1.0 and abs(y1 - y0) > 1.0:
+            return x1
+    return None
+
+
 def _guard_fan_bundles_coincide_or_separate(
     graph: MetroGraph,
     phase: str,
@@ -682,17 +694,11 @@ def _guard_fan_bundles_coincide_or_separate(
     if not fan_sources:
         return
 
-    def _first_vertical_leg_x(points) -> float | None:
-        for (x0, y0), (x1, y1) in zip(points, points[1:]):
-            if abs(x1 - x0) < 1.0 and abs(y1 - y0) > 1.0:
-                return x1
-        return None
-
     by_src_line: dict[tuple[str, str], list[float]] = {}
     for rp in routes:
         if not rp.is_inter_section or rp.edge.source not in fan_sources:
             continue
-        vx = _first_vertical_leg_x(rp.points)
+        vx = first_vertical_leg_x(rp.points)
         if vx is None:
             continue
         by_src_line.setdefault((rp.edge.source, rp.line_id), []).append(vx)

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -653,6 +653,69 @@ def _guard_inter_section_route_no_backtrack(
                 )
 
 
+def _guard_fan_bundles_coincide_or_separate(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+) -> None:
+    """After routing: two routes carrying the SAME line out of a unified-fan
+    junction must coincide on their source-side vertical channel or separate
+    clearly - never smear a few px apart (#437).
+
+    A unified-fan junction (one the router assigns shared
+    ``junction_fan_info`` positions) fans the same line to multiple targets
+    that are MEANT to pivot through one channel.  When two such routes' first
+    vertical legs sit between ``OFFSET_STEP`` (the legitimate per-bundle
+    stagger) and ``SECTION_Y_GAP`` (a clean column split) apart, they render
+    as a smeared partial overlap rather than one bundle or two separated
+    bundles.
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.routing.core import _build_routing_context
+
+    offsets = compute_station_offsets(graph)
+    if routes is None:
+        routes = route_edges(graph, station_offsets=offsets)
+    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
+    fan_sources = {key[0] for key in ctx.junction_fan_info}
+    if not fan_sources:
+        return
+
+    def _first_vertical_leg_x(points) -> float | None:
+        for (x0, y0), (x1, y1) in zip(points, points[1:]):
+            if abs(x1 - x0) < 1.0 and abs(y1 - y0) > 1.0:
+                return x1
+        return None
+
+    by_src_line: dict[tuple[str, str], list[float]] = {}
+    for rp in routes:
+        if not rp.is_inter_section or rp.edge.source not in fan_sources:
+            continue
+        vx = _first_vertical_leg_x(rp.points)
+        if vx is None:
+            continue
+        by_src_line.setdefault((rp.edge.source, rp.line_id), []).append(vx)
+
+    # Coincide within the per-bundle stagger plus a 1px rounding epsilon;
+    # GUARD_TOLERANCE (5px) would swallow the 6px smear this guards against.
+    coincide_tol = OFFSET_STEP + 1.0
+    for (src, line), xs in by_src_line.items():
+        if len(xs) < 2:
+            continue
+        ordered = sorted(xs)
+        for lo, hi in zip(ordered, ordered[1:]):
+            gap = hi - lo
+            if coincide_tol < gap < SECTION_Y_GAP:
+                raise PhaseInvariantError(
+                    f"{phase}: junction {src!r} line {line!r} fans two routes "
+                    f"whose first vertical channels are {gap:.1f}px apart "
+                    f"(x={lo:.1f} vs {hi:.1f}) - neither coincident "
+                    f"(<= {coincide_tol:.1f}) nor clearly separated "
+                    f"(>= {SECTION_Y_GAP:.1f}); a smeared partial overlap"
+                )
+
+
 def _canvas_width(graph: MetroGraph) -> float:
     """Horizontal extent of all positioned sections (rightmost - leftmost)."""
     rights = [s.bbox_x + s.bbox_w for s in graph.sections.values() if s.bbox_w > 0]
@@ -2317,6 +2380,7 @@ def _compute_section_layout(
             _guard_serpentine_no_backtrack(graph, phase, routes=routes)
             _guard_inter_row_run_clearance(graph, phase, routes=routes)
             _guard_inter_section_descent_edge_clearance(graph, phase, routes=routes)
+            _guard_fan_bundles_coincide_or_separate(graph, phase, routes=routes)
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -1686,6 +1686,16 @@ def _route_left_entry_wrap(
     base_gap = ctx.curve_radius + ctx.offset_step
     extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
     vx = tx - base_gap - extra_clearance + delta
+    # When this wrap shares a junction fan with a corridor feeder descending
+    # the same target column (e.g. sarek's __junction_9 spine + QC feed),
+    # anchor the descent channel to the column's LEFT edge so the spine and
+    # the corridor overlay as one bundle instead of smearing (#437).
+    if fan is not None and _fan_has_corridor_sibling(edge.source, ctx):
+        tgt_col = _resolve_section_col(ctx.graph, tgt)
+        if tgt_col is not None:
+            shared_vx = _fan_left_entry_descent_x(ctx, tgt_col, n_for_outer, delta)
+            if shared_vx is not None:
+                vx = shared_vx
 
     # Apply src/tgt station offsets explicitly so the renderer's later
     # _apply_line_offsets pass doesn't double-apply.  Without this, the
@@ -1857,6 +1867,52 @@ def _corridor_descent_x(
     return (gap_left + gap_right) / 2 + delta
 
 
+def _fan_left_entry_descent_x(
+    ctx: _RoutingCtx, tgt_col: int, n_outer: int, delta: float
+) -> float | None:
+    """Shared descent-channel X for a junction fan's LEFT-entry targets.
+
+    When one junction fans the same lines to two LEFT-entry sections
+    stacked in the same column - one reached by :func:`_route_left_entry_wrap`
+    (the spine), the other by :func:`_route_inter_row_gap_corridor` (the QC
+    feed) - both bundles must descend the SAME vertical channel so they
+    overlay as one clean bundle rather than smearing a few px apart (#437).
+
+    Anchor the channel to the column's LEFT edge (the leftmost section left
+    edge across all rows of *tgt_col*) so both handlers, whose individual
+    targets sit at slightly different x, agree on one channel.  The
+    per-line ``delta`` stagger is preserved.  Returns ``None`` when the
+    column has no measurable left edge.
+    """
+    col_left = col_left_edge(ctx.graph, tgt_col, default=0.0)
+    if col_left <= 0.0:
+        return None
+    base_gap = ctx.curve_radius + ctx.offset_step
+    max_delta = (n_outer - 1) * ctx.offset_step / 2
+    extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
+    return col_left - base_gap - extra_clearance + delta
+
+
+def _fan_has_corridor_sibling(junction_id: str, ctx: _RoutingCtx) -> bool:
+    """True if *junction_id* fans an edge routed via the inter-row-gap corridor.
+
+    Used so a sibling :func:`_route_left_entry_wrap` spine aligns its descent
+    channel with the corridor feeder's (#437).  A corridor feeder is a
+    downward cross-row edge into a LEFT-entry section (merge junction or
+    direct port) for which :func:`_corridor_is_viable` holds.
+    """
+    graph = ctx.graph
+    for edge in graph.edges_from(junction_id):
+        tgt = graph.stations.get(edge.target)
+        if tgt is None:
+            continue
+        ep_id = ctx.merge.entry_port_for.get(edge.target)
+        ep = graph.stations.get(ep_id) if ep_id else tgt
+        if ep is not None and _corridor_is_viable(ctx, graph.stations[junction_id], ep):
+            return True
+    return False
+
+
 def _corridor_is_viable(ctx: _RoutingCtx, src: Station, entry_port: Station) -> bool:
     """Whether the inter-row-gap + inter-column-channel corridor exists.
 
@@ -1928,15 +1984,25 @@ def _route_inter_row_gap_corridor(
     sx, sy = src.x, src.y
     ex, ey = entry_port.x, entry_port.y
 
+    # When this corridor feeder shares a junction fan with a sibling wrap
+    # (e.g. sarek's __junction_9 spine into Annotation), consume the unified
+    # fan position so the source-side first corner and the inter-row gap
+    # stagger MATCH the wrap exactly.  Without this the corridor picks its
+    # own per-bundle (i, n) and the two same-line bundles smear a few px
+    # apart instead of overlaying (#437).
+    ekey = (edge.source, edge.target, edge.line_id)
+    fan = ctx.junction_fan_info.get(ekey)
+    pos_i, pos_n = fan if fan is not None else (i, n)
+
     delta, _r1, _r2 = l_shape_radii(
-        i,
-        n,
+        pos_i,
+        pos_n,
         vertical=Direction.D,
         offset_step=ctx.offset_step,
         base_radius=ctx.curve_radius,
     )
-    off_for_radius = (n - 1 - i) * ctx.offset_step
-    max_off_for_radius = (n - 1) * ctx.offset_step
+    off_for_radius = (pos_n - 1 - pos_i) * ctx.offset_step
+    max_off_for_radius = (pos_n - 1) * ctx.offset_step
     r_outer = corner_radius(
         off_for_radius,
         max_off_for_radius,
@@ -1961,7 +2027,15 @@ def _route_inter_row_gap_corridor(
     # section-header badge, not just the bbox edge.
     gap_top = row_bottom_edge(ctx.graph, src_row, col=src_col)
     gap_bottom = row_top_edge(ctx.graph, src_row + 1, col=src_col, default=gap_top)
-    if gap_bottom > gap_top:
+    if fan is not None:
+        # Share the sibling wrap's inter-row band: it centres the leftward
+        # traverse in the gap below the SOURCE row using the global (non
+        # column-restricted) row edges, so the two bundles' H legs coincide
+        # rather than smearing 3px apart (#437).
+        wrap_top = row_bottom_edge(ctx.graph, src_row, default=gap_top)
+        wrap_bottom = row_top_edge(ctx.graph, src_row + 1, default=wrap_top)
+        gy_base = _center_inter_row_channel(wrap_top, wrap_bottom)
+    elif gap_bottom > gap_top:
         gy_base = _center_inter_row_channel(gap_top, gap_bottom)
     else:
         gy_base = gap_top + EDGE_TO_BUNDLE_CLEARANCE
@@ -1971,22 +2045,36 @@ def _route_inter_row_gap_corridor(
     # EDGE_TO_BUNDLE_CLEARANCE below the source-row bottom and clear of the
     # next row's header badge.  In a tight gap the band is narrower than the
     # bundle, so the per-line stagger collapses rather than grazing an edge.
-    if gap_bottom > gap_top:
+    # Skipped for fan feeders, which share the wrap sibling's (unclamped)
+    # band so the two bundles' H legs coincide (#437).
+    if fan is None and gap_bottom > gap_top:
         gy = min(
             max(gy, gap_top + EDGE_TO_BUNDLE_CLEARANCE),
             gap_bottom - INTER_ROW_HEADER_CLEARANCE,
         )
 
-    # Inter-column descent channel left of the target column.
-    vx = _corridor_descent_x(ctx, ep_col, ep_row, delta)
+    # Inter-column descent channel left of the target column.  For a fan
+    # feeder, anchor it to the target COLUMN's left edge (shared with the
+    # sibling wrap) so the two bundles descend the same channel; otherwise
+    # use the inter-column gap midpoint.
+    vx = None
+    if fan is not None and ep_col is not None:
+        vx = _fan_left_entry_descent_x(ctx, ep_col, pos_n, delta)
+    if vx is None:
+        vx = _corridor_descent_x(ctx, ep_col, ep_row, delta)
 
     # H lead-in right of the source, clear of the source section's edge.
+    # When the source is a sectionless junction, fall back to its own X as
+    # the reference edge (mirrors :func:`_route_left_entry_wrap`) so a fan
+    # feeder gets the SAME source-side clearance as its sibling wrap (#437).
     src_section = ctx.graph.sections.get(src.section_id) if src.section_id else None
-    corner_x = sx + ctx.curve_radius + (n - 1) * ctx.offset_step / 2 + delta
+    corner_x = sx + ctx.curve_radius + (pos_n - 1) * ctx.offset_step / 2 + delta
     if src_section and src_section.bbox_w > 0:
         section_right = src_section.bbox_x + src_section.bbox_w
-        current_gap = sx + ctx.curve_radius - section_right
-        corner_x += max(0.0, SECTION_ROUTE_CLEARANCE - current_gap)
+    else:
+        section_right = sx
+    current_gap = sx + ctx.curve_radius - section_right
+    corner_x += max(0.0, SECTION_ROUTE_CLEARANCE - current_gap)
 
     src_off = _get_offset(ctx, edge.source, edge.line_id)
     tgt_off = _get_offset(ctx, edge.target, edge.line_id)

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -964,18 +964,6 @@ def test_merge_feeder_does_not_loop_below_target(fixture):
         )
 
 
-def _first_vertical_leg_x(points) -> float | None:
-    """X of the first leg of *points* that runs (near-)vertically.
-
-    The source-side vertical channel ("V1") of an inter-section route.
-    Returns ``None`` when no vertical leg exists.
-    """
-    for (x0, y0), (x1, y1) in zip(points, points[1:]):
-        if abs(x1 - x0) < 1.0 and abs(y1 - y0) > 1.0:
-            return x1
-    return None
-
-
 @pytest.mark.parametrize(
     "fixture",
     sorted({*_FIXTURES_MULTI_SECTION, "sarek.mmd"}),
@@ -1003,6 +991,7 @@ def test_junction_same_line_fans_coincide_or_separate(fixture):
     columns are a separate concern.
     """
     from nf_metro.layout.constants import CURVE_RADIUS, DIAGONAL_RUN, OFFSET_STEP
+    from nf_metro.layout.engine import first_vertical_leg_x
     from nf_metro.layout.routing.core import _build_routing_context
 
     graph = _layout(fixture)
@@ -1016,7 +1005,7 @@ def test_junction_same_line_fans_coincide_or_separate(fixture):
     for rp in routes:
         if not rp.is_inter_section or rp.edge.source not in fan_sources:
             continue
-        vx = _first_vertical_leg_x(rp.points)
+        vx = first_vertical_leg_x(rp.points)
         if vx is None:
             continue
         by_src_line[(rp.edge.source, rp.line_id)].append((rp, vx))

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -964,6 +964,80 @@ def test_merge_feeder_does_not_loop_below_target(fixture):
         )
 
 
+def _first_vertical_leg_x(points) -> float | None:
+    """X of the first leg of *points* that runs (near-)vertically.
+
+    The source-side vertical channel ("V1") of an inter-section route.
+    Returns ``None`` when no vertical leg exists.
+    """
+    for (x0, y0), (x1, y1) in zip(points, points[1:]):
+        if abs(x1 - x0) < 1.0 and abs(y1 - y0) > 1.0:
+            return x1
+    return None
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    sorted({*_FIXTURES_MULTI_SECTION, "sarek.mmd"}),
+)
+def test_junction_same_line_fans_coincide_or_separate(fixture):
+    """Two routes carrying the SAME line out of a UNIFIED-FAN junction must
+    either coincide on their source-side vertical channel or separate
+    clearly - never smear by a few px (#437).
+
+    sarek's ``__junction_9`` (Post-processing's right exit) fans the same
+    three lines to two destinations: the spine into Annotation (a LEFT-entry
+    wrap) and the QC feed down the inter-column corridor to MultiQC.  The
+    engine assigns both a shared :func:`_compute_junction_fan_info` position
+    so they're MEANT to pivot through one channel; when their first vertical
+    channels sit 6-18px apart they read as a single smeared band rather than
+    one clean overlay.  This invariant forbids that intermediate spacing:
+    for each unified-fan junction and each line fanning to >=2 inter-section
+    targets, the first vertical legs must coincide (<= ``OFFSET_STEP`` apart,
+    i.e. within the per-bundle stagger) or be cleanly separated (>= a
+    section gap apart, the intended split when targets land in different
+    columns).
+
+    Scoped to junctions the engine treats as a unified fan (present in
+    ``junction_fan_info``); pure L-shape/bypass fans to genuinely distinct
+    columns are a separate concern.
+    """
+    from nf_metro.layout.constants import CURVE_RADIUS, DIAGONAL_RUN, OFFSET_STEP
+    from nf_metro.layout.routing.core import _build_routing_context
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
+    fan_sources = {key[0] for key in ctx.junction_fan_info}
+
+    # Group inter-section routes by (junction source, line).
+    by_src_line: dict[tuple[str, str], list] = defaultdict(list)
+    for rp in routes:
+        if not rp.is_inter_section or rp.edge.source not in fan_sources:
+            continue
+        vx = _first_vertical_leg_x(rp.points)
+        if vx is None:
+            continue
+        by_src_line[(rp.edge.source, rp.line_id)].append((rp, vx))
+
+    coincide_tol = OFFSET_STEP + _Y_TOL
+    separate_min = SECTION_Y_GAP
+    for (src, line), entries in by_src_line.items():
+        if len(entries) < 2:
+            continue
+        xs = sorted(vx for _rp, vx in entries)
+        for lo, hi in zip(xs, xs[1:]):
+            gap = hi - lo
+            assert gap <= coincide_tol or gap >= separate_min, (
+                f"{fixture}: junction {src} line {line} fans two routes "
+                f"whose first vertical channels are {gap:.1f}px apart "
+                f"(x={lo:.1f} vs {hi:.1f}) - neither coincident "
+                f"(<= {coincide_tol:.1f}) nor clearly separated "
+                f"(>= {separate_min:.1f}); a smeared partial overlap"
+            )
+
+
 @pytest.mark.parametrize("fixture", sorted({*_FIXTURES_MULTI_SECTION_PLUS_SAREK_STACK}))
 def test_inter_section_route_no_full_width_dogleg_clean(fixture):
     """No merge feeder takes a full-width out-and-back dog-leg (#432).


### PR DESCRIPTION
## Summary
A junction that fans the same lines to two LEFT-entry targets stacked in one column - the spine into the adjacent-row section (via `_route_left_entry_wrap`) and the QC feed down the inter-column corridor (via `_route_inter_row_gap_corridor`) - routed the two same-colour bundles 6-18px apart, producing a smeared partial overlap out of the section and a tangle at the turn-down above the next section. On `examples/sarek.mmd` this affected both `__junction_9` (Post-processing exit -> Annotation spine + MultiQC feed) and `__junction_8`.

The two handlers each computed their own source-side first corner, inter-row gap band, and descent channel, so they diverged even though `_compute_junction_fan_info` already assigns both the same per-line position.

This makes the corridor feeder consume the shared `junction_fan_info` so its first corner, gap band, and per-line stagger match the sibling wrap exactly, and anchors both handlers' descent channel to the target column's left edge via a shared `_fan_left_entry_descent_x` helper. The two bundles now overlay as one clean 3-line bundle while parallel and split only where the spine enters the section and the QC continues down the corridor.

Adds:
- an invariant test (`test_junction_same_line_fans_coincide_or_separate`, parametrised over the multi-section gallery) asserting unified-fan same-line routes coincide on their first vertical channel or separate by a full section gap, never an intermediate smear;
- a runtime guard (`_guard_fan_bundles_coincide_or_separate`) wired into `compute_layout(validate=True)` that fails loudly on the same condition.

Gallery renders are byte-identical except `examples/sarek.mmd` and the sarek-derived regression fixture `sarek_serpentine_stacked.mmd`, both of which show the intended coincide improvement.

Fixes #437

## Test plan
- [x] pytest passes (3461 passed, including new invariant test)
- [x] ruff check + ruff format clean on src/ and tests/
- [x] Runtime validator added
- [x] sarek `validate=True` passes; new guard fires on base, passes on fix
- [x] Local gallery diff: only sarek + sarek_serpentine_stacked changed (both improvements)

Generated with Claude Code