### PR TITLE
feat: stacked-section serpentine routing + inter-column corridor fan-in

### DIFF
--- a/examples/genomic_pipeline.mmd
+++ b/examples/genomic_pipeline.mmd
@@ -1,0 +1,173 @@
+%%metro title: Variant Calling Pipeline
+%%metro style: dark
+%%metro legend: br
+%%metro line_order: definition
+%%metro center_ports: true
+%%metro compact_offsets: true
+%%metro file: fastq_in | FASTQ
+%%metro file: bam_in | BAM
+%%metro file: cram_in | CRAM
+%%metro file: vcf_out | VCF
+%%metro file: report_out | HTML
+%%metro line: germline | Germline | #0570b0
+%%metro line: tumor_only | Tumor only | #d62728
+%%metro line: somatic | Tumor-normal pair | #756bb1
+%%metro grid: preprocessing | 0,0,1,2
+%%metro grid: variant_calling | 0,1,3,1
+%%metro grid: post_vc | 1,1,1,1
+%%metro grid: annotation | 1,2,1,1
+%%metro grid: reporting | 1,3,1,1
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        %%metro exit: right | germline, tumor_only, somatic
+        fastq_in[ ]
+        bam_in[ ]
+        fastqc[FastQC]
+        fastp[FastP]
+        umi[UMI consensus]
+        bwa[BWA-MEM]
+        bwa2[BWA-MEM2]
+        dragmap[DragMap]
+        sentieon_bwa[Sentieon BWA]
+        merge_index[samtools merge/index]
+        markdup[MarkDuplicates]
+        sentieon_dedup[Sentieon Dedup]
+        bqsr[BaseRecalibrator]
+        applybqsr[ApplyBQSR]
+        mosdepth[mosdepth]
+        ngscheckmate[NGSCheckmate]
+
+        fastq_in -->|germline,tumor_only,somatic| fastqc
+        fastq_in -->|germline,tumor_only,somatic| fastp
+        bam_in -->|germline,tumor_only,somatic| fastp
+        fastp -->|germline,tumor_only,somatic| umi
+        umi -->|germline,tumor_only,somatic| bwa
+        umi -->|germline,tumor_only,somatic| bwa2
+        umi -->|germline,tumor_only,somatic| dragmap
+        umi -->|germline,tumor_only,somatic| sentieon_bwa
+        bwa -->|germline,tumor_only,somatic| merge_index
+        bwa2 -->|germline,tumor_only,somatic| merge_index
+        dragmap -->|germline,tumor_only,somatic| merge_index
+        sentieon_bwa -->|germline,tumor_only,somatic| merge_index
+        merge_index -->|germline,tumor_only,somatic| markdup
+        merge_index -->|germline,tumor_only,somatic| sentieon_dedup
+        markdup -->|germline,tumor_only,somatic| bqsr
+        sentieon_dedup -->|germline,tumor_only,somatic| bqsr
+        bqsr -->|germline,tumor_only,somatic| applybqsr
+        applybqsr -->|germline,tumor_only,somatic| mosdepth
+        applybqsr -->|germline,tumor_only,somatic| ngscheckmate
+    end
+
+    subgraph variant_calling [Variant calling]
+        %%metro entry: left | germline, tumor_only, somatic
+        %%metro exit: right | germline, tumor_only, somatic
+        cram_in[ ]
+        haplotypecaller[HaplotypeCaller]
+        deepvariant[DeepVariant]
+        sentieon_dnascope[Sentieon DNAscope]
+        sentieon_haplotyper[Sentieon Haplotyper]
+        freebayes[FreeBayes]
+        strelka[Strelka]
+        mpileup[bcftools mpileup]
+        mutect2[Mutect2]
+        lofreq[LoFreq]
+        muse[MuSE]
+        sentieon_tnscope[Sentieon TNscope]
+        manta[Manta]
+        tiddit[TIDDIT]
+        ascat[ASCAT]
+        cnvkit[CNVkit]
+        controlfreec[Control-FREEC]
+        indexcov[indexcov]
+        msisensor2[MSIsensor2]
+        msisensorpro[MSIsensor-pro]
+        vcfs[ ]
+
+        cram_in -->|germline| haplotypecaller
+        cram_in -->|germline| deepvariant
+        cram_in -->|germline| sentieon_dnascope
+        cram_in -->|germline| sentieon_haplotyper
+        cram_in -->|germline,tumor_only,somatic| freebayes
+        cram_in -->|germline,somatic| strelka
+        cram_in -->|germline,tumor_only,somatic| mpileup
+        cram_in -->|tumor_only,somatic| mutect2
+        cram_in -->|tumor_only| lofreq
+        cram_in -->|somatic| muse
+        cram_in -->|tumor_only,somatic| sentieon_tnscope
+        cram_in -->|germline,tumor_only,somatic| manta
+        cram_in -->|germline,tumor_only,somatic| tiddit
+        cram_in -->|somatic| ascat
+        cram_in -->|germline,tumor_only,somatic| cnvkit
+        cram_in -->|tumor_only,somatic| controlfreec
+        cram_in -->|germline,somatic| indexcov
+        cram_in -->|tumor_only| msisensor2
+        cram_in -->|somatic| msisensorpro
+
+        haplotypecaller -->|germline| vcfs
+        deepvariant -->|germline| vcfs
+        sentieon_dnascope -->|germline| vcfs
+        sentieon_haplotyper -->|germline| vcfs
+        freebayes -->|germline,tumor_only,somatic| vcfs
+        strelka -->|germline,somatic| vcfs
+        mpileup -->|germline,tumor_only,somatic| vcfs
+        mutect2 -->|tumor_only,somatic| vcfs
+        lofreq -->|tumor_only| vcfs
+        muse -->|somatic| vcfs
+        sentieon_tnscope -->|tumor_only,somatic| vcfs
+        manta -->|germline,tumor_only,somatic| vcfs
+        tiddit -->|germline,tumor_only,somatic| vcfs
+        ascat -->|somatic| vcfs
+        cnvkit -->|germline,tumor_only,somatic| vcfs
+        controlfreec -->|tumor_only,somatic| vcfs
+        indexcov -->|germline,somatic| vcfs
+        msisensor2 -->|tumor_only| vcfs
+        msisensorpro -->|somatic| vcfs
+    end
+
+    subgraph post_vc [Post-processing]
+        filter_vcfs[Filter VCFs]
+        normalize[Normalize]
+        concatenate[Concatenate]
+        consensus[Consensus]
+        varlociraptor[Varlociraptor]
+        bcftools_stats[bcftools stats]
+        vcftools[VCFtools]
+
+        filter_vcfs -->|germline,tumor_only,somatic| normalize
+        normalize -->|germline,tumor_only,somatic| concatenate
+        concatenate -->|germline,tumor_only,somatic| consensus
+        consensus -->|germline,tumor_only,somatic| varlociraptor
+        varlociraptor -->|germline,tumor_only,somatic| bcftools_stats
+        bcftools_stats -->|germline,tumor_only,somatic| vcftools
+    end
+
+    subgraph annotation [Annotation]
+        snpeff[snpEff]
+        vep[VEP]
+        bcftools_ann[bcftools annotate]
+        snpsift[SnpSift]
+
+        snpeff -->|germline,tumor_only,somatic| vep
+        vep -->|germline,tumor_only,somatic| bcftools_ann
+        bcftools_ann -->|germline,tumor_only,somatic| snpsift
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+        vcf_out[ ]
+        report_out[ ]
+
+        multiqc -->|germline,tumor_only,somatic| report_out
+        snpsift_to_vcf[ ]
+        snpsift_to_vcf -->|germline,tumor_only,somatic| vcf_out
+    end
+
+    %% Inter-section edges
+    applybqsr -->|germline,tumor_only,somatic| cram_in
+    vcfs -->|germline,tumor_only,somatic| filter_vcfs
+    vcftools -->|germline,tumor_only,somatic| snpeff
+    snpsift -->|germline,tumor_only,somatic| snpsift_to_vcf
+    fastqc -->|germline,tumor_only,somatic| multiqc
+    mosdepth -->|germline,tumor_only,somatic| multiqc
+    bcftools_stats -->|germline,tumor_only,somatic| multiqc

--- a/examples/topologies/stacked_lr_serpentine.mmd
+++ b/examples/topologies/stacked_lr_serpentine.mmd
@@ -1,0 +1,36 @@
+%%metro title: Stacked LR Serpentine
+%%metro style: dark
+%%metro line: main | Main | #e63946
+%%metro grid: ingest | 0,0,3,1
+%%metro grid: align | 1,0,1,1
+%%metro grid: dedup | 1,1,1,1
+%%metro grid: call | 1,2,1,1
+
+graph LR
+    subgraph ingest [Ingest]
+        i1[Read]
+        i2[QC]
+        i1 -->|main| i2
+    end
+
+    subgraph align [Alignment]
+        a1[Map]
+        a2[Sort]
+        a1 -->|main| a2
+    end
+
+    subgraph dedup [Dedup]
+        d1[Mark Dup]
+        d2[Recalibrate]
+        d1 -->|main| d2
+    end
+
+    subgraph call [Variant Calling]
+        c1[Call]
+        c2[Filter]
+        c1 -->|main| c2
+    end
+
+    i2 -->|main| a1
+    a2 -->|main| d1
+    d2 -->|main| c1

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -55,6 +55,13 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "showing how explicit directives can fine-tune placement.",
     ),
     (
+        "genomic_pipeline",
+        EXAMPLES_DIR,
+        "Multi-section genomic variant-calling pipeline: same-direction sections "
+        "stacked in one column (serpentine carriage-return) plus a multi-row QC "
+        "collector fan-in descending a shared inter-column corridor.",
+    ),
+    (
         "differentialabundance",
         EXAMPLES_DIR,
         "nf-core/differentialabundance with four input lines, off-track gene-set inputs, and a bypass-heavy reporting row. Uses `%%metro center_ports: true`.",
@@ -176,6 +183,12 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         TOPOLOGIES_DIR,
         "Stacked analysis sections feeding through a fold into branching targets.",
     ),
+    (
+        "stacked_lr_serpentine",
+        TOPOLOGIES_DIR,
+        "Same-direction sections stacked in one grid column, chained via short "
+        "vertical drops on alternating sides (serpentine), no wrap-around.",
+    ),
     # --- Offset and bypass ---
     (
         "mismatched_tracks",
@@ -198,7 +211,7 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         TOPOLOGIES_DIR,
         "Cross-row route to a LEFT-entry target where the natural inter-row "
         "channel would cut through an intervening section's bbox. Exercises "
-        "`_route_around_section_below` (sarek-style geometry).",
+        "`_route_around_section_below` (collector-fan-in geometry).",
     ),
     (
         "inter_row_wrap_clearance",

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -799,26 +799,28 @@ def _flow_aligned_sides(direction: str) -> tuple[PortSide, PortSide]:
     return PortSide.LEFT, PortSide.RIGHT
 
 
-def _has_fold_predecessor_above(
+def _feeds_from_vertical_drop_above(
     graph: MetroGraph,
     sec_id: str,
-    my_col: int,
     my_row: int,
     predecessors: dict[str, set[str]],
     fold_sections: set[str],
 ) -> bool:
-    """True when a fold predecessor sits in this section's column on a row
-    above it.
+    """True when a vertically-exiting predecessor (a TB or fold section) sits above.
 
-    A fold section exits BOTTOM and drops straight down; the section it
-    feeds should accept that drop on its TOP edge rather than wrap to a
-    flow-aligned side.
+    A TB/fold section exits BOTTOM and drops straight down, so the section it
+    feeds should accept that drop on its TOP edge; forcing a flow-aligned side
+    there bends the vertical drop into a diagonal.  Horizontal-flow (LR/RL)
+    predecessors instead exit sideways and wrap to a flow-aligned entry
+    (a carriage-return chain or an around-section wrap), so they don't block it.
     """
     for src in predecessors.get(sec_id, set()):
-        if src not in fold_sections:
+        src_sec = graph.sections.get(src)
+        if not src_sec:
             continue
-        src_col, src_row, src_row_span, _src_col_span = _effective_grid_pos(graph, src)
-        if src_col == my_col and (src_row + src_row_span - 1) < my_row:
+        _src_col, src_row, src_row_span, _src_col_span = _effective_grid_pos(graph, src)
+        is_vertical = src_sec.direction == "TB" or src in fold_sections
+        if is_vertical and (src_row + src_row_span - 1) < my_row:
             return True
     return False
 
@@ -860,8 +862,8 @@ def _infer_port_sides(
         # a clean straight drop; forcing a flow-aligned side there would add
         # an unnecessary wrap (#432 narrows flow-alignment to the horizontal
         # carriage-return case it is meant for).
-        flow_aligned_entry = horizontal and not _has_fold_predecessor_above(
-            graph, sec_id, my_col, my_row, predecessors, fold_sections
+        flow_aligned_entry = horizontal and not _feeds_from_vertical_drop_above(
+            graph, sec_id, my_row, predecessors, fold_sections
         )
 
         # Infer exit hints (only if section has no explicit exit_hints)

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -9,7 +9,7 @@ Preserves any values explicitly set by %%metro directives.
 
 from __future__ import annotations
 
-__all__ = ["infer_section_layout"]
+__all__ = ["infer_section_layout", "detect_serpentine_runs"]
 
 from collections import defaultdict, deque
 
@@ -785,6 +785,44 @@ def _infer_directions(
         section.direction = "LR"
 
 
+def _flow_aligned_sides(direction: str) -> tuple[PortSide, PortSide]:
+    """Return ``(entry_side, exit_side)`` aligned with a section's flow.
+
+    A left-to-right section enters on the LEFT and exits on the RIGHT; a
+    right-to-left section is mirrored.  Horizontal-flow sections always
+    present flow-aligned ports regardless of where their neighbours sit
+    on the grid; the inter-section router carriage-returns the connection
+    (right -> down -> left -> down -> right) for a same-column stack.
+    """
+    if direction == "RL":
+        return PortSide.RIGHT, PortSide.LEFT
+    return PortSide.LEFT, PortSide.RIGHT
+
+
+def _has_fold_predecessor_above(
+    graph: MetroGraph,
+    sec_id: str,
+    my_col: int,
+    my_row: int,
+    predecessors: dict[str, set[str]],
+    fold_sections: set[str],
+) -> bool:
+    """True when a fold predecessor sits in this section's column on a row
+    above it.
+
+    A fold section exits BOTTOM and drops straight down; the section it
+    feeds should accept that drop on its TOP edge rather than wrap to a
+    flow-aligned side.
+    """
+    for src in predecessors.get(sec_id, set()):
+        if src not in fold_sections:
+            continue
+        src_col, src_row, src_row_span, _src_col_span = _effective_grid_pos(graph, src)
+        if src_col == my_col and (src_row + src_row_span - 1) < my_row:
+            return True
+    return False
+
+
 def _infer_port_sides(
     graph: MetroGraph,
     successors: dict[str, set[str]],
@@ -793,17 +831,38 @@ def _infer_port_sides(
     fold_sections: set[str],
     convergence_sections: set[str] | None = None,
 ) -> None:
-    """Infer entry/exit port sides from relative section grid positions.
+    """Infer entry/exit port sides from section flow and grid positions.
+
+    Horizontal-flow (LR/RL) sections present flow-aligned ports: entry on
+    the leading edge, exit on the trailing edge, regardless of neighbour
+    position.  A same-column stack of LR sections therefore connects via a
+    carriage-return wrap rather than a TOP/BOTTOM hop.
 
     Fold sections (TB bridges) get entry LEFT, exit BOTTOM.
-    Other sections use _relative_side to determine sides from grid positions.
-    Convergence return-row sections get TOP entry for above-row predecessors.
+    Remaining TB sections use _relative_side to derive sides from grid
+    positions; convergence return-row sections get TOP entry for above-row
+    predecessors.
     """
     if convergence_sections is None:
         convergence_sections = set()
     for sec_id, section in graph.sections.items():
-        my_col = section.grid_col
-        my_row = section.grid_row
+        my_col, my_row, _row_span, my_col_span = _effective_grid_pos(graph, sec_id)
+        horizontal = section.direction in ("LR", "RL") and sec_id not in fold_sections
+        entry_aligned, exit_aligned = _flow_aligned_sides(section.direction)
+
+        # A horizontal section exits flow-aligned (LR -> RIGHT, RL -> LEFT)
+        # regardless of neighbour position; the router carriage-returns.
+        flow_aligned_exit = horizontal
+
+        # Entry is flow-aligned only when no predecessor drops in vertically
+        # from a fold above in the same column.  A fold predecessor exits
+        # BOTTOM, so a TOP entry (handled by the relative-side branch) gives
+        # a clean straight drop; forcing a flow-aligned side there would add
+        # an unnecessary wrap (#432 narrows flow-alignment to the horizontal
+        # carriage-return case it is meant for).
+        flow_aligned_entry = horizontal and not _has_fold_predecessor_above(
+            graph, sec_id, my_col, my_row, predecessors, fold_sections
+        )
 
         # Infer exit hints (only if section has no explicit exit_hints)
         if not section.exit_hints and sec_id in successors:
@@ -815,48 +874,57 @@ def _infer_port_sides(
             if all_exit_lines:
                 if sec_id in fold_sections:
                     exit_side = _compute_fold_exit_side(
-                        graph, section, sec_id, successors, edge_lines
+                        graph, sec_id, successors, edge_lines
                     )
                     section.exit_hints.append((exit_side, sorted(all_exit_lines)))
+                elif flow_aligned_exit:
+                    section.exit_hints.append((exit_aligned, sorted(all_exit_lines)))
                 else:
-                    _compute_exit_hints_by_side(
-                        graph, section, sec_id, successors, edge_lines
-                    )
+                    _compute_exit_hints_by_side(graph, sec_id, successors, edge_lines)
 
         # Infer entry hints (only if section has no explicit entry_hints)
         if not section.entry_hints and sec_id in predecessors:
-            side_lines: dict[PortSide, set[str]] = defaultdict(set)
-
+            all_entry_lines: set[str] = set()
             for src in predecessors[sec_id]:
-                src_sec = graph.sections.get(src)
-                if not src_sec or src not in graph.grid_overrides:
-                    continue
+                all_entry_lines.update(edge_lines.get((src, sec_id), set()))
 
-                lines = edge_lines.get((src, sec_id), set())
-                # Convergence return-row sections: predecessors on a row
-                # above should use TOP entry for clean vertical connections.
-                src_bottom_row = src_sec.grid_row + src_sec.grid_row_span - 1
-                if sec_id in convergence_sections and src_bottom_row < my_row:
-                    side = PortSide.TOP
-                else:
-                    side = _relative_side(
-                        my_col,
-                        my_row,
-                        src_sec.grid_col,
-                        src_sec.grid_row,
-                        section.grid_col_span,
-                        src_sec.grid_col_span,
+            if flow_aligned_entry:
+                if all_entry_lines:
+                    section.entry_hints.append((entry_aligned, sorted(all_entry_lines)))
+            else:
+                side_lines: dict[PortSide, set[str]] = defaultdict(set)
+                for src in predecessors[sec_id]:
+                    src_sec = graph.sections.get(src)
+                    if not src_sec or src not in graph.grid_overrides:
+                        continue
+                    src_col, src_row, src_row_span, src_col_span = _effective_grid_pos(
+                        graph, src
                     )
-                side_lines[side].update(lines)
+                    lines = edge_lines.get((src, sec_id), set())
+                    # Convergence return-row sections: predecessors on a row
+                    # above should use TOP entry for clean vertical
+                    # connections.
+                    src_bottom_row = src_row + src_row_span - 1
+                    if sec_id in convergence_sections and src_bottom_row < my_row:
+                        side = PortSide.TOP
+                    else:
+                        side = _relative_side(
+                            my_col,
+                            my_row,
+                            src_col,
+                            src_row,
+                            my_col_span,
+                            src_col_span,
+                        )
+                    side_lines[side].update(lines)
 
-            for side, lines in sorted(side_lines.items(), key=lambda x: x[0].value):
-                if lines:
-                    section.entry_hints.append((side, sorted(lines)))
+                for side, lines in sorted(side_lines.items(), key=lambda x: x[0].value):
+                    if lines:
+                        section.entry_hints.append((side, sorted(lines)))
 
 
 def _compute_fold_exit_side(
     graph: MetroGraph,
-    section,
     sec_id: str,
     successors: dict[str, set[str]],
     edge_lines: dict[tuple[str, str], set[str]],
@@ -867,22 +935,22 @@ def _compute_fold_exit_side(
     exit is LEFT. For multi-row spans where all successors are below,
     uses BOTTOM so lines continue their vertical flow.
     """
-    my_col = section.grid_col
-    my_row = section.grid_row
+    my_col, my_row, my_row_span, my_col_span = _effective_grid_pos(graph, sec_id)
 
     side_votes: dict[PortSide, int] = defaultdict(int)
     for tgt in successors.get(sec_id, set()):
         tgt_sec = graph.sections.get(tgt)
         if not tgt_sec:
             continue
+        tgt_col, tgt_row, _tgt_row_span, tgt_col_span = _effective_grid_pos(graph, tgt)
         lines = edge_lines.get((sec_id, tgt), set())
         side = _relative_side(
             my_col,
             my_row,
-            tgt_sec.grid_col,
-            tgt_sec.grid_row,
-            section.grid_col_span,
-            tgt_sec.grid_col_span,
+            tgt_col,
+            tgt_row,
+            my_col_span,
+            tgt_col_span,
         )
         side_votes[side] += len(lines)
 
@@ -893,10 +961,10 @@ def _compute_fold_exit_side(
 
     # Override for multi-row spans: if all successors are below the fold
     # span, use BOTTOM exit so lines continue their vertical flow.
-    if section.grid_row_span > 1:
-        fold_bottom_row = section.grid_row + section.grid_row_span - 1
+    if my_row_span > 1:
+        fold_bottom_row = my_row + my_row_span - 1
         all_below = all(
-            graph.sections[tgt].grid_row > fold_bottom_row
+            _effective_grid_pos(graph, tgt)[1] > fold_bottom_row
             for tgt in successors.get(sec_id, set())
             if tgt in graph.sections
         )
@@ -908,7 +976,6 @@ def _compute_fold_exit_side(
 
 def _compute_exit_hints_by_side(
     graph: MetroGraph,
-    section,
     sec_id: str,
     successors: dict[str, set[str]],
     edge_lines: dict[tuple[str, str], set[str]],
@@ -918,25 +985,26 @@ def _compute_exit_hints_by_side(
     Creates one exit hint per side, collecting all lines that exit
     toward that side.
     """
-    my_col = section.grid_col
-    my_row = section.grid_row
+    my_col, my_row, _my_row_span, my_col_span = _effective_grid_pos(graph, sec_id)
 
     side_exit_lines: dict[PortSide, set[str]] = defaultdict(set)
     for tgt in successors.get(sec_id, set()):
         tgt_sec = graph.sections.get(tgt)
         if not tgt_sec or tgt not in graph.grid_overrides:
             continue
+        tgt_col, tgt_row, _tgt_row_span, tgt_col_span = _effective_grid_pos(graph, tgt)
         lines = edge_lines.get((sec_id, tgt), set())
         side = _relative_side(
             my_col,
             my_row,
-            tgt_sec.grid_col,
-            tgt_sec.grid_row,
-            section.grid_col_span,
-            tgt_sec.grid_col_span,
+            tgt_col,
+            tgt_row,
+            my_col_span,
+            tgt_col_span,
         )
         side_exit_lines[side].update(lines)
 
+    section = graph.sections[sec_id]
     if side_exit_lines:
         for side, lines in sorted(side_exit_lines.items(), key=lambda x: x[0].value):
             if lines:
@@ -980,3 +1048,89 @@ def _relative_side(
         return PortSide.TOP
 
     return PortSide.RIGHT  # same position, default right
+
+
+def _effective_grid_pos(graph: MetroGraph, sec_id: str) -> tuple[int, int, int, int]:
+    """Return (col, row, row_span, col_span) for a section during inference.
+
+    Explicit grid overrides are applied to ``section.grid_col`` only later in
+    section_placement, so during auto-layout they read -1.  Prefer the value
+    recorded in ``graph.grid_overrides`` when present.
+    """
+    if sec_id in graph.grid_overrides:
+        return graph.grid_overrides[sec_id]
+    section = graph.sections[sec_id]
+    return (
+        section.grid_col,
+        section.grid_row,
+        section.grid_row_span,
+        section.grid_col_span,
+    )
+
+
+def detect_serpentine_runs(
+    graph: MetroGraph,
+    successors: dict[str, set[str]],
+    predecessors: dict[str, set[str]],
+) -> list[list[str]]:
+    """Find runs of vertically-stacked single-cell sections forming a chain.
+
+    A serpentine run is a maximal sequence of sections that
+
+    * occupy a single grid cell (row_span == col_span == 1),
+    * share a grid column,
+    * sit on consecutive grid rows, and
+    * form a simple chain: the section on row N feeds exactly one section
+      in the same column (the one on row N+1), and that lower section is
+      fed from the column only by the upper one.
+
+    Returns runs as lists of section ids ordered top-to-bottom.  Runs of
+    length < 2 are omitted.  Used to serpentine the effective flow
+    direction of stacked same-direction sections (issue #421).
+    """
+    # Group single-cell sections by grid column, keyed by row.  A column with
+    # two sections claiming one (col, row) cell is malformed and is skipped.
+    col_rows: dict[int, dict[int, str]] = defaultdict(dict)
+    collided_cols: set[int] = set()
+    for sec_id in graph.sections:
+        col, row, row_span, col_span = _effective_grid_pos(graph, sec_id)
+        if col < 0 or row < 0 or row_span != 1 or col_span != 1:
+            continue
+        if row in col_rows[col]:
+            collided_cols.add(col)
+        col_rows[col][row] = sec_id
+
+    runs: list[list[str]] = []
+    for col, rows in col_rows.items():
+        if col in collided_cols:
+            continue
+        ordered_rows = sorted(rows)
+        in_column = set(rows.values())
+        i = 0
+        while i < len(ordered_rows):
+            run = [rows[ordered_rows[i]]]
+            j = i
+            while j + 1 < len(ordered_rows):
+                upper_row = ordered_rows[j]
+                lower_row = ordered_rows[j + 1]
+                if lower_row != upper_row + 1:
+                    break
+                upper = rows[upper_row]
+                lower = rows[lower_row]
+                # upper must feed lower, and lower must be the only in-column
+                # successor of upper (a clean chain, not a fan-out).
+                upper_col_succ = successors.get(upper, set()) & in_column
+                lower_col_pred = predecessors.get(lower, set()) & in_column
+                if (
+                    lower in successors.get(upper, set())
+                    and upper_col_succ == {lower}
+                    and lower_col_pred == {upper}
+                ):
+                    run.append(lower)
+                    j += 1
+                else:
+                    break
+            if len(run) >= 2:
+                runs.append(run)
+            i = j + 1
+    return runs

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -856,12 +856,9 @@ def _infer_port_sides(
         # regardless of neighbour position; the router carriage-returns.
         flow_aligned_exit = horizontal
 
-        # Entry is flow-aligned only when no predecessor drops in vertically
-        # from a fold above in the same column.  A fold predecessor exits
-        # BOTTOM, so a TOP entry (handled by the relative-side branch) gives
-        # a clean straight drop; forcing a flow-aligned side there would add
-        # an unnecessary wrap (#432 narrows flow-alignment to the horizontal
-        # carriage-return case it is meant for).
+        # Entry is flow-aligned unless a vertically-exiting (TB/fold)
+        # predecessor sits above: that drops straight down, so the
+        # relative-side branch's TOP entry reads cleaner than a wrap.
         flow_aligned_entry = horizontal and not _feeds_from_vertical_drop_above(
             graph, sec_id, my_row, predecessors, fold_sections
         )
@@ -1088,7 +1085,7 @@ def detect_serpentine_runs(
 
     Returns runs as lists of section ids ordered top-to-bottom.  Runs of
     length < 2 are omitted.  Used to serpentine the effective flow
-    direction of stacked same-direction sections (issue #421).
+    direction of stacked same-direction sections.
     """
     # Group single-cell sections by grid column, keyed by row.  A column with
     # two sections claiming one (col, row) cell is malformed and is skipped.

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -459,7 +459,6 @@ Above this threshold, the canvas is treated as uniformly off-grid by a
 late helper (typically ``_shift_graph_into_canvas`` shifting by a non-
 grid amount): a single shift restores every station to integer
 multiples of ``y_spacing``.  Below the threshold, sections sit at
-multiple distinct residues by construction (e.g. sarek, where wrap
-endpoints land at three different residues 10px apart by design), so
+multiple distinct residues by construction, so
 no single shift can align them all and the per-section snap from Stage
 6.4 is honoured as the best-effort alignment."""

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -14,6 +14,7 @@ from collections import Counter, defaultdict
 from nf_metro.layout.constants import (
     BYPASS_CLEARANCE,
     CANVAS_GRID_SHIFT_THRESHOLD,
+    COORD_TOLERANCE,
     CURVE_RADIUS,
     DESCENDER_CLEARANCE,
     DIAGONAL_RUN,
@@ -686,6 +687,365 @@ def _guard_inter_section_route_no_backtrack(
                 )
 
 
+def first_vertical_leg_x(points) -> float | None:
+    """X of the first (near-)vertical leg of *points*.
+
+    The source-side vertical channel ("V1") of an inter-section route;
+    ``None`` when no vertical leg exists.
+    """
+    for (x0, y0), (x1, y1) in zip(points, points[1:]):
+        if abs(x1 - x0) < 1.0 and abs(y1 - y0) > 1.0:
+            return x1
+    return None
+
+
+def _guard_fan_bundles_coincide_or_separate(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+) -> None:
+    """After routing: two routes carrying the SAME line out of a unified-fan
+    junction must coincide on their source-side vertical channel or separate
+    clearly - never smear a few px apart (#437).
+
+    A unified-fan junction (one the router assigns shared
+    ``junction_fan_info`` positions) fans the same line to multiple targets
+    that are MEANT to pivot through one channel.  When two such routes' first
+    vertical legs sit between ``OFFSET_STEP`` (the legitimate per-bundle
+    stagger) and ``SECTION_Y_GAP`` (a clean column split) apart, they render
+    as a smeared partial overlap rather than one bundle or two separated
+    bundles.
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.routing.core import _build_routing_context
+
+    offsets = compute_station_offsets(graph)
+    if routes is None:
+        routes = route_edges(graph, station_offsets=offsets)
+    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
+    fan_sources = {key[0] for key in ctx.junction_fan_info}
+    if not fan_sources:
+        return
+
+    by_src_line: dict[tuple[str, str], list[float]] = {}
+    for rp in routes:
+        if not rp.is_inter_section or rp.edge.source not in fan_sources:
+            continue
+        vx = first_vertical_leg_x(rp.points)
+        if vx is None:
+            continue
+        by_src_line.setdefault((rp.edge.source, rp.line_id), []).append(vx)
+
+    # Coincide within the per-bundle stagger plus a 1px rounding epsilon;
+    # GUARD_TOLERANCE (5px) would swallow the 6px smear this guards against.
+    coincide_tol = OFFSET_STEP + 1.0
+    for (src, line), xs in by_src_line.items():
+        if len(xs) < 2:
+            continue
+        ordered = sorted(xs)
+        for lo, hi in zip(ordered, ordered[1:]):
+            gap = hi - lo
+            if coincide_tol < gap < SECTION_Y_GAP:
+                raise PhaseInvariantError(
+                    f"{phase}: junction {src!r} line {line!r} fans two routes "
+                    f"whose first vertical channels are {gap:.1f}px apart "
+                    f"(x={lo:.1f} vs {hi:.1f}) - neither coincident "
+                    f"(<= {coincide_tol:.1f}) nor clearly separated "
+                    f"(>= {SECTION_Y_GAP:.1f}); a smeared partial overlap"
+                )
+
+
+def _canvas_width(graph: MetroGraph) -> float:
+    """Horizontal extent of all positioned sections (rightmost - leftmost)."""
+    rights = [s.bbox_x + s.bbox_w for s in graph.sections.values() if s.bbox_w > 0]
+    lefts = [s.bbox_x for s in graph.sections.values() if s.bbox_w > 0]
+    if not rights or not lefts:
+        return 0.0
+    return max(rights) - min(lefts)
+
+
+def inter_section_route_backtrack_legs(graph: MetroGraph, routes: list):
+    """Yield ``(rp, x1, x2)`` for each horizontal leg that moves *away* from
+    the route's own endpoint X - a genuine out-and-back dog-leg.
+
+    A backtrack is reverse-direction travel: the line heads away from where
+    it is going, then has to come back.  This is measured against the
+    route's actual endpoint X (its last waypoint), not the grid-column
+    order.  Grid columns can disagree with X order when a narrow target
+    column nests inside a wide row-span sibling: there the target column is
+    "higher" yet sits to the *left*, so a single long leftward traverse is a
+    monotonic approach toward the target - not a dog-leg - and is not
+    yielded.  A true #425 dog-leg (right past the target, then back left)
+    still moves away from the endpoint on its outward leg and is yielded.
+
+    Routes that exit a port facing away from their endpoint legitimately
+    wrap and are skipped, as are TB folds and same-column routes.  Unlike
+    the strict :func:`_guard_inter_section_route_no_backtrack`, exempt
+    (``normalize_exempt``) wrap routes are *included* so a multi-corner
+    around-section dog-leg is still measured.
+    """
+    from nf_metro.layout.routing.common import resolve_section
+
+    def _exit_side(rp):
+        port = graph.ports.get(rp.edge.source)
+        if port is not None:
+            return port.side
+        for e in graph.edges_to(rp.edge.source):
+            port = graph.ports.get(e.source)
+            if port is not None:
+                return port.side
+        return None
+
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        src_sec = resolve_section(graph, graph.stations[rp.edge.source])
+        tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
+        if src_sec is None or tgt_sec is None:
+            continue
+        if src_sec.direction != "LR" or tgt_sec.direction != "LR":
+            continue
+        if src_sec.grid_col == tgt_sec.grid_col:
+            continue
+        xs = [p[0] for p in rp.points]
+        if len(xs) < 2:
+            continue
+        # Direction toward the route's own endpoint: a leg moving the other
+        # way (away from where the route ends) is the dog-leg's outward leg.
+        toward_endpoint_is_right = xs[-1] > xs[0]
+        side = _exit_side(rp)
+        # An exit port facing away from the endpoint legitimately wraps; its
+        # outward stub is not a dog-leg.  (Grid-column-based skip preserved
+        # for the wrap case: the exit faces the target column it serves.)
+        rightward_cols = tgt_sec.grid_col > src_sec.grid_col
+        if rightward_cols and side != PortSide.RIGHT:
+            continue
+        if not rightward_cols and side != PortSide.LEFT:
+            continue
+        for x1, x2 in zip(xs, xs[1:]):
+            backtracks = (x2 < x1) if toward_endpoint_is_right else (x2 > x1)
+            if backtracks:
+                yield rp, x1, x2
+
+
+def _guard_inter_section_route_no_full_width_backtrack(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+    fraction: float = 0.4,
+) -> None:
+    """After routing: a forward inter-section route may reverse in X (when a
+    narrow target column nests inside an oversized sibling) but no single
+    backtrack leg may exceed *fraction* of the canvas width.
+
+    The strict :func:`_guard_inter_section_route_no_backtrack` forbids *any*
+    reversal on a forward LR route, assuming grid-column order matches X
+    order.  When a column is geometrically nested inside an oversized
+    sibling, reaching it requires a legitimate X
+    reversal, so such routes are made ``normalize_exempt`` and the strict
+    guard skips them.  This guard still bounds those reversals: a
+    right-then-left dog-leg sweeping the whole diagram (#425) is forbidden
+    even when exempt.
+    """
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        routes = route_edges(graph)
+
+    canvas_width = _canvas_width(graph)
+    if canvas_width <= 0:
+        return
+    limit = fraction * canvas_width
+
+    for rp, x1, x2 in inter_section_route_backtrack_legs(graph, routes):
+        span = abs(x2 - x1)
+        if span > limit + GUARD_TOLERANCE:
+            raise PhaseInvariantError(
+                f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} "
+                f"line {rp.line_id!r} backtracks {span:.1f}px in one leg "
+                f"(x={x1:.1f}->{x2:.1f}), exceeding {fraction:.0%} of canvas "
+                f"width {canvas_width:.1f} - a full-width dog-leg"
+            )
+
+
+def _route_crosses_section_boundary(
+    graph: MetroGraph,
+    routes: list,
+    *,
+    port_tol: float = 24.0,
+    inset: float = 4.0,
+    axis_tol: float = 1.0,
+) -> tuple | None:
+    """Return the first ``(route, section_id, x, y)`` where an axis-aligned
+    routed segment crosses a section bbox edge away from any declared port,
+    else None.
+
+    A segment p1->p2 "crosses" a section edge when it passes strictly
+    through one of the four bbox sides within the perpendicular extent of
+    that side.  Crossings within *port_tol* of one of the section's ports
+    are permitted (that is how a line legitimately enters/leaves).  Any
+    other crossing means a horizontal or vertical run is cutting through a
+    section box where no port invites it -- the symptom this guard forbids
+    (e.g. an entry inferred on the wrong side so the connector slices the
+    box, #432).
+
+    Two classes are intentionally out of scope:
+
+    * **Diagonal transition segments** (45-degree corner curves) clip box
+      corners while legitimately approaching a side port; only axis-aligned
+      runs (within *axis_tol*) are inspected.
+    * **Fan-in/-out bundle routes** through ``__junction_*`` / ``__merge_*``
+      / ``__bypass_*`` virtual nodes route around or through neighbouring
+      sections by a separate mechanism with its own guards; long-range
+      multi-row merge bundles are a known, tracked
+      limitation and are excluded here.
+    """
+    ports_by_sec: dict[str, list] = {}
+    for port in graph.ports.values():
+        ports_by_sec.setdefault(port.section_id, []).append(port)
+
+    def near_port(sec_id: str, x: float, y: float) -> bool:
+        return any(
+            abs(p.x - x) <= port_tol and abs(p.y - y) <= port_tol
+            for p in ports_by_sec.get(sec_id, [])
+        )
+
+    def edge_crossings(p1, p2, x0, y0, x1, y1):
+        ax, ay = p1
+        bx, by = p2
+        hits = []
+        for ex in (x0, x1):
+            if (ax - ex) * (bx - ex) < 0:
+                t = (ex - ax) / (bx - ax)
+                yy = ay + t * (by - ay)
+                if y0 - inset <= yy <= y1 + inset:
+                    hits.append((ex, yy))
+        for ey in (y0, y1):
+            if (ay - ey) * (by - ey) < 0:
+                t = (ey - ay) / (by - ay)
+                xx = ax + t * (bx - ax)
+                if x0 - inset <= xx <= x1 + inset:
+                    hits.append((xx, ey))
+        return hits
+
+    def is_bundle_node(node_id: str) -> bool:
+        return node_id.startswith(("__junction", "__merge", "__bypass"))
+
+    boxes = [
+        (
+            sid,
+            sec.bbox_x,
+            sec.bbox_y,
+            sec.bbox_x + sec.bbox_w,
+            sec.bbox_y + sec.bbox_h,
+        )
+        for sid, sec in graph.sections.items()
+        if sec.bbox_w > 0 and sec.bbox_h > 0
+    ]
+    for rp in routes:
+        if is_bundle_node(rp.edge.source) or is_bundle_node(rp.edge.target):
+            continue
+        pts = rp.points
+        for i in range(len(pts) - 1):
+            p1, p2 = pts[i], pts[i + 1]
+            # Only axis-aligned runs cut a box; diagonal corner curves clip
+            # edges while approaching side ports legitimately.
+            if abs(p1[0] - p2[0]) > axis_tol and abs(p1[1] - p2[1]) > axis_tol:
+                continue
+            for sid, x0, y0, x1, y1 in boxes:
+                for bx, by in edge_crossings(p1, p2, x0, y0, x1, y1):
+                    if not near_port(sid, bx, by):
+                        return (rp, sid, bx, by)
+    return None
+
+
+def _guard_routes_enter_sections_at_ports(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+) -> None:
+    """After routing: no routed segment may cross a section bbox boundary
+    except within tolerance of a declared port on that section.
+
+    A line that cuts through a section box anywhere other than a port is
+    visually entering/leaving the section where nothing invites it (e.g. a
+    fan-in merge bundle ploughing into a section through its right edge, or
+    an entry inferred on the wrong side so the connector slices the box).
+    """
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        routes = route_edges(graph)
+
+    hit = _route_crosses_section_boundary(graph, routes)
+    if hit is not None:
+        rp, sid, bx, by = hit
+        raise PhaseInvariantError(
+            f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} "
+            f"line {rp.line_id!r} crosses section {sid!r} boundary at "
+            f"({bx:.1f}, {by:.1f}) away from any declared port"
+        )
+
+
+def _guard_serpentine_no_backtrack(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+) -> None:
+    """After routing: stacked same-direction sections must not backtrack.
+
+    Same-direction sections stacked in one grid column and chained (#421)
+    serpentine their effective flow row by row so consecutive sections meet
+    on a shared side joined by a short vertical drop.  A section that fails
+    to alternate enters on the wrong side and folds its internal route back
+    across the section width.  For every section in a detected serpentine
+    run, the wrong-way horizontal travel of its internal segments must stay
+    below half the section width.
+    """
+    from nf_metro.layout.auto_layout import detect_serpentine_runs
+
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        routes = route_edges(graph)
+
+    dag = graph.section_dag
+    if dag is None:
+        return
+    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
+    serpentine_sections = {sid for run in runs for sid in run}
+    if not serpentine_sections:
+        return
+
+    wrong_way: dict[str, float] = {sid: 0.0 for sid in serpentine_sections}
+    for rp in routes:
+        src_sec = graph.section_for_station(rp.edge.source)
+        if src_sec != graph.section_for_station(rp.edge.target):
+            continue
+        if src_sec not in serpentine_sections:
+            continue
+        forward = 1.0 if graph.sections[src_sec].direction != "RL" else -1.0
+        xs = [p[0] for p in rp.points]
+        for x1, x2 in zip(xs, xs[1:]):
+            dx = x2 - x1
+            if dx * forward < 0:
+                wrong_way[src_sec] += abs(dx)
+
+    for sid, against in wrong_way.items():
+        section = graph.sections[sid]
+        limit = 0.5 * max(section.bbox_w, 1.0)
+        if against > limit + GUARD_TOLERANCE:
+            raise PhaseInvariantError(
+                f"{phase}: stacked section {sid!r} (dir={section.direction}) "
+                f"backtracks {against:.1f}px against its flow (>{limit:.1f}px); "
+                f"the serpentine chain is kinking instead of dropping vertically"
+            )
+
+
 def _guard_inter_row_run_clearance(
     graph: MetroGraph,
     phase: str,
@@ -745,6 +1105,65 @@ def _guard_inter_row_run_clearance(
                     f"{top - y:.1f}px above source section {src_sec.id!r} "
                     f"top={top:.1f} (< {EDGE_TO_BUNDLE_CLEARANCE})"
                 )
+
+
+def _guard_inter_section_descent_edge_clearance(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list | None = None,
+) -> None:
+    """After routing: a vertical descent channel of an inter-section route
+    must not *incidentally* graze a section bbox edge.
+
+    A descent legitimately sits on a section edge when its X coincides
+    with a port at one of the route's endpoints (a port-to-port drop).
+    When the channel instead lands within ``EDGE_TO_BUNDLE_CLEARANCE`` of
+    a section edge, on the interior side, with no endpoint port at that
+    X, the lines visibly cross the border (#423).  The channel-x selection
+    in :func:`_route_l_shape` pushes such channels outward; this guard
+    fails loudly if a future change lets one creep back against an edge.
+    """
+    from nf_metro.layout.routing.common import endpoint_port_xs
+
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        routes = route_edges(graph)
+
+    tol = GUARD_TOLERANCE
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        port_xs = endpoint_port_xs(graph, rp.edge)
+        pts = rp.points
+        for (x0, y0), (x1, y1) in zip(pts, pts[1:]):
+            if abs(x1 - x0) > tol:
+                continue  # vertical segments only
+            vx = (x0 + x1) / 2
+            if any(abs(vx - px) <= COORD_TOLERANCE for px in port_xs):
+                continue  # legitimate port-to-port drop
+            ylo, yhi = sorted((y0, y1))
+            for sec in graph.sections.values():
+                if sec.bbox_w <= 0:
+                    continue
+                if yhi < sec.bbox_y or ylo > sec.bbox_y + sec.bbox_h:
+                    continue
+                left = sec.bbox_x
+                right = left + sec.bbox_w
+                from_left = vx - left
+                from_right = right - vx
+                grazes = (-tol <= from_left < EDGE_TO_BUNDLE_CLEARANCE - tol) or (
+                    -tol <= from_right < EDGE_TO_BUNDLE_CLEARANCE - tol
+                )
+                if grazes:
+                    edge_x = left if from_left < from_right else right
+                    raise PhaseInvariantError(
+                        f"{phase}: descent of {rp.edge.source!r}->"
+                        f"{rp.edge.target!r} line {rp.line_id!r} at x={vx:.1f} "
+                        f"grazes section {sec.id!r} edge x={edge_x:.1f} "
+                        f"(< {EDGE_TO_BUNDLE_CLEARANCE})"
+                    )
 
 
 def _guard_bundle_order_preserved(
@@ -1966,7 +2385,7 @@ def _compute_section_layout(
     # When every real station shares a single non-zero residue, shift
     # the whole canvas by the smallest signed amount that returns them
     # to integer multiples of ``y_spacing``.  No-op when residues are
-    # mixed (e.g. sarek-style multi-row layouts).
+    # mixed.
     _snap_canvas_y_to_grid(graph, y_spacing, section_y_padding)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.15")
@@ -2007,7 +2426,14 @@ def _compute_section_layout(
             _guard_bundle_order_preserved(graph, phase, offsets=offsets, routes=routes)
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)
             _guard_inter_section_route_no_backtrack(graph, phase, routes=routes)
+            _guard_inter_section_route_no_full_width_backtrack(
+                graph, phase, routes=routes
+            )
+            _guard_routes_enter_sections_at_ports(graph, phase, routes=routes)
+            _guard_serpentine_no_backtrack(graph, phase, routes=routes)
             _guard_inter_row_run_clearance(graph, phase, routes=routes)
+            _guard_inter_section_descent_edge_clearance(graph, phase, routes=routes)
+            _guard_fan_bundles_coincide_or_separate(graph, phase, routes=routes)
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:
@@ -4341,8 +4767,7 @@ def _snap_canvas_y_to_grid(
 
     Apply ``delta`` to every station, port, junction (via bbox + offset
     chain) and section bbox.  If the dominant residue does NOT meet
-    threshold (e.g. sarek where sections sit at multiple residues by
-    construction), no shift is applied: the per-section snap from Stage
+    threshold, no shift is applied: the per-section snap from Stage
     6.4 is honoured as the best-effort alignment.
     """
     if y_spacing <= 0 or not graph.sections:
@@ -6263,7 +6688,17 @@ def _position_merge_junction(
     merging at the junction; passing 1 falls back to the baseline margin.
     """
     max_pred_x = max(p.x for p in predecessors)
-    junction.x = max_pred_x + _required_junction_margin(n)
+    margin = _required_junction_margin(n)
+    # Normal forward fan-in: merge just past the right-most predecessor on its
+    # way into a target to the right.  But when the target sits well to the LEFT
+    # of the predecessors (a collector like MultiQC fed from across the map),
+    # merging at max_pred_x forces the whole merged bundle to backtrack the full
+    # width into the entry.  Merge local to the target instead, so only the
+    # individual feeders make the long approach and the merge->entry hop is short.
+    if entry_port.x < max_pred_x - margin:
+        junction.x = entry_port.x - margin
+    else:
+        junction.x = max_pred_x + margin
     junction.y = entry_port.y
 
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -703,11 +703,12 @@ def _guard_fan_bundles_coincide_or_separate(
     graph: MetroGraph,
     phase: str,
     *,
+    offsets: dict | None = None,
     routes: list | None = None,
 ) -> None:
     """After routing: two routes carrying the SAME line out of a unified-fan
     junction must coincide on their source-side vertical channel or separate
-    clearly - never smear a few px apart (#437).
+    clearly - never smear a few px apart.
 
     A unified-fan junction (one the router assigns shared
     ``junction_fan_info`` positions) fans the same line to multiple targets
@@ -720,7 +721,8 @@ def _guard_fan_bundles_coincide_or_separate(
     from nf_metro.layout.routing import compute_station_offsets, route_edges
     from nf_metro.layout.routing.core import _build_routing_context
 
-    offsets = compute_station_offsets(graph)
+    if offsets is None:
+        offsets = compute_station_offsets(graph)
     if routes is None:
         routes = route_edges(graph, station_offsets=offsets)
     ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
@@ -776,7 +778,7 @@ def inter_section_route_backtrack_legs(graph: MetroGraph, routes: list):
     column nests inside a wide row-span sibling: there the target column is
     "higher" yet sits to the *left*, so a single long leftward traverse is a
     monotonic approach toward the target - not a dog-leg - and is not
-    yielded.  A true #425 dog-leg (right past the target, then back left)
+    yielded.  A true dog-leg (right past the target, then back left)
     still moves away from the endpoint on its outward leg and is yielded.
 
     Routes that exit a port facing away from their endpoint legitimately
@@ -846,7 +848,7 @@ def _guard_inter_section_route_no_full_width_backtrack(
     sibling, reaching it requires a legitimate X
     reversal, so such routes are made ``normalize_exempt`` and the strict
     guard skips them.  This guard still bounds those reversals: a
-    right-then-left dog-leg sweeping the whole diagram (#425) is forbidden
+    right-then-left dog-leg sweeping the whole diagram is forbidden
     even when exempt.
     """
     if routes is None:
@@ -889,7 +891,7 @@ def _route_crosses_section_boundary(
     other crossing means a horizontal or vertical run is cutting through a
     section box where no port invites it -- the symptom this guard forbids
     (e.g. an entry inferred on the wrong side so the connector slices the
-    box, #432).
+    box,).
 
     Two classes are intentionally out of scope:
 
@@ -998,7 +1000,7 @@ def _guard_serpentine_no_backtrack(
 ) -> None:
     """After routing: stacked same-direction sections must not backtrack.
 
-    Same-direction sections stacked in one grid column and chained (#421)
+    Same-direction sections stacked in one grid column and chained
     serpentine their effective flow row by row so consecutive sections meet
     on a shared side joined by a short vertical drop.  A section that fails
     to alternate enters on the wrong side and folds its internal route back
@@ -1120,7 +1122,7 @@ def _guard_inter_section_descent_edge_clearance(
     with a port at one of the route's endpoints (a port-to-port drop).
     When the channel instead lands within ``EDGE_TO_BUNDLE_CLEARANCE`` of
     a section edge, on the interior side, with no endpoint port at that
-    X, the lines visibly cross the border (#423).  The channel-x selection
+    X, the lines visibly cross the border.  The channel-x selection
     in :func:`_route_l_shape` pushes such channels outward; this guard
     fails loudly if a future change lets one creep back against an edge.
     """
@@ -2433,7 +2435,9 @@ def _compute_section_layout(
             _guard_serpentine_no_backtrack(graph, phase, routes=routes)
             _guard_inter_row_run_clearance(graph, phase, routes=routes)
             _guard_inter_section_descent_edge_clearance(graph, phase, routes=routes)
-            _guard_fan_bundles_coincide_or_separate(graph, phase, routes=routes)
+            _guard_fan_bundles_coincide_or_separate(
+                graph, phase, offsets=offsets, routes=routes
+            )
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -94,17 +94,30 @@ def col_left_edge(
     return min((s.bbox_x for s in secs), default=default) if secs else default
 
 
-def row_bottom_edge(graph: MetroGraph, row: int, default: float = 0.0) -> float:
-    """Bottommost Y extent of sections in *row*."""
+def row_bottom_edge(
+    graph: MetroGraph, row: int, default: float = 0.0, col: int | None = None
+) -> float:
+    """Bottommost Y extent of sections in *row* (optionally a single *col*).
+
+    When *col* is given, restrict to sections in that grid column so an
+    inter-row diversion travelling within one column isn't pushed down by a
+    tall row-span section stacked in a different column of the same row.
+    """
     secs = _sections_in_row(graph, row)
+    if col is not None:
+        secs = [s for s in secs if s.grid_col == col]
     if not secs:
         return default
     return max((s.bbox_y + s.bbox_h for s in secs), default=default)
 
 
-def row_top_edge(graph: MetroGraph, row: int, default: float = 0.0) -> float:
-    """Topmost Y extent of sections in *row*."""
+def row_top_edge(
+    graph: MetroGraph, row: int, default: float = 0.0, col: int | None = None
+) -> float:
+    """Topmost Y extent of sections in *row* (optionally a single *col*)."""
     secs = _sections_in_row(graph, row)
+    if col is not None:
+        secs = [s for s in secs if s.grid_col == col]
     return min((s.bbox_y for s in secs), default=default) if secs else default
 
 
@@ -281,9 +294,12 @@ def compute_bundle_info(
             if src_sec and tgt_sec and src_sec.grid_col != tgt_sec.grid_col:
                 col_key = (src_sec.grid_col, tgt_sec.grid_col)
             elif tgt_sec:
-                # Source is a junction: include target column so edges
-                # to different columns get separate bundles.
-                col_key = (round(sx), tgt_sec.grid_col)
+                # Source is a junction: include target column AND row so
+                # edges to different sections get separate bundles.  A
+                # junction can fan to two targets in the same column but
+                # different rows; those are distinct corridors and must not be
+                # conflated into one over-wide interleaved bundle.
+                col_key = (round(sx), tgt_sec.grid_col, tgt_sec.grid_row)
             else:
                 col_key = round(sx)
             key = ("L", col_key, v_dir, h_dir)
@@ -376,6 +392,77 @@ def inter_column_channel_x(
         return sx + max_r + offset_step
     else:
         return sx - max_r - offset_step
+
+
+def endpoint_port_xs(graph: MetroGraph, edge: Edge) -> list[float]:
+    """X of any port stations at *edge*'s endpoints (for edge-graze checks)."""
+    xs: list[float] = []
+    for sid in (edge.source, edge.target):
+        st = graph.stations.get(sid)
+        if st is not None and st.is_port:
+            xs.append(st.x)
+    return xs
+
+
+def clear_channel_of_section_edge(
+    graph: MetroGraph,
+    mid_x: float,
+    half_width: float,
+    y_lo: float,
+    y_hi: float,
+    endpoint_port_xs: list[float],
+    edge_clearance: float = EDGE_TO_BUNDLE_CLEARANCE,
+    port_tol: float = COORD_TOLERANCE,
+) -> float:
+    """Nudge a vertical channel out of an *incidental* section-edge graze.
+
+    A descent channel of an inter-section route legitimately sits on a
+    section edge when that edge carries a port at one of the route's
+    endpoints (a port-to-port drop).  When the channel instead lands
+    within *edge_clearance* of a section's bbox edge on the interior
+    side, with no endpoint port at that x, the graze is incidental and
+    the lines visibly cross the section border (#423).
+
+    *mid_x* is the channel's midline; the bundle's nearest line to a
+    section edge sits at most *half_width* from *mid_x*.  *y_lo*/*y_hi*
+    bound the vertical run so only sections it actually passes are
+    considered.  Returns *mid_x* shifted just enough that the nearest
+    line clears every incidentally-grazed edge by *edge_clearance*,
+    pushing OUTWARD (away from the section interior).  Channels that
+    coincide with an endpoint port (within *port_tol*) are left
+    untouched.
+    """
+    adjusted = mid_x
+    for sec in graph.sections.values():
+        if sec.bbox_w <= 0:
+            continue
+        if y_hi < sec.bbox_y or y_lo > sec.bbox_y + sec.bbox_h:
+            continue  # channel does not span this section's Y range
+        left = sec.bbox_x
+        right = left + sec.bbox_w
+        if any(abs(adjusted - px) <= port_tol for px in endpoint_port_xs):
+            continue  # legitimate port-to-port drop on this edge
+        # Bundle span (outermost lines either side of the midline).
+        bundle_lo = adjusted - half_width
+        bundle_hi = adjusted + half_width
+        # A graze means the bundle's nearest line toward an edge does not
+        # clear that edge by ``edge_clearance``.  Distance of the nearest
+        # line to the right edge (positive = outside, to the right) and to
+        # the left edge (positive = outside, to the left).
+        clear_of_right = bundle_lo - right
+        clear_of_left = left - bundle_hi
+        # Only act when the bundle is near or inside this section's span;
+        # a bundle comfortably outside both edges is fine.
+        if clear_of_right >= edge_clearance or clear_of_left >= edge_clearance:
+            continue
+        # Push OUTWARD via the nearer edge: if the midline is closer to the
+        # right edge, push right until the leftmost line clears it; else
+        # push left until the rightmost line clears the left edge.
+        if right - adjusted <= adjusted - left:
+            adjusted += edge_clearance - clear_of_right
+        else:
+            adjusted -= edge_clearance - clear_of_left
+    return adjusted
 
 
 def line_source_y_at_port(

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -410,7 +410,7 @@ def clear_channel_of_section_edge(
     half_width: float,
     y_lo: float,
     y_hi: float,
-    endpoint_port_xs: list[float],
+    port_xs: list[float],
     edge_clearance: float = EDGE_TO_BUNDLE_CLEARANCE,
     port_tol: float = COORD_TOLERANCE,
 ) -> float:
@@ -421,7 +421,7 @@ def clear_channel_of_section_edge(
     endpoints (a port-to-port drop).  When the channel instead lands
     within *edge_clearance* of a section's bbox edge on the interior
     side, with no endpoint port at that x, the graze is incidental and
-    the lines visibly cross the section border (#423).
+    the lines visibly cross the section border.
 
     *mid_x* is the channel's midline; the bundle's nearest line to a
     section edge sits at most *half_width* from *mid_x*.  *y_lo*/*y_hi*
@@ -440,7 +440,7 @@ def clear_channel_of_section_edge(
             continue  # channel does not span this section's Y range
         left = sec.bbox_x
         right = left + sec.bbox_w
-        if any(abs(adjusted - px) <= port_tol for px in endpoint_port_xs):
+        if any(abs(adjusted - px) <= port_tol for px in port_xs):
             continue  # legitimate port-to-port drop on this edge
         # Bundle span (outermost lines either side of the midline).
         bundle_lo = adjusted - half_width

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -653,7 +653,7 @@ def _route_inter_section(
             return _route_around_section_below(edge, src, tgt, tgt, i, n, ctx)
         return _route_left_entry_wrap(edge, src, tgt, i, n, ctx)
 
-    # Serpentine LEFT exit -> LEFT entry stacked in the same column (#421):
+    # Serpentine LEFT exit -> LEFT entry stacked in the same column:
     # an RL section's left exit dropping to the LR section directly below
     # whose left entry sits a few px inward.  The standard L-shape places
     # its vertical channel at sx + radius, which lands inside the source
@@ -696,10 +696,9 @@ def _route_inter_section(
             if ep_port and ep_port.side == PortSide.LEFT:
                 exclude = {src.section_id} if src.section_id else set()
                 if _h_segment_crosses_other_section(graph, sx, ep.x, ep.y, exclude):
-                    # When a clear inter-row / inter-column corridor exists
-                    # (downward cross-row feeder
-                    # fan-in), descend it instead of looping below the
-                    # canvas (#432).
+                    # When a clear inter-row / inter-column corridor exists for
+                    # this downward cross-row feeder, descend it instead of
+                    # looping below the canvas.
                     if _corridor_is_viable(ctx, src, ep):
                         return _route_inter_row_gap_corridor(
                             edge, src, tgt, ep, i, n, ctx
@@ -707,7 +706,7 @@ def _route_inter_section(
                     return _route_around_section_below(edge, src, tgt, ep, i, n, ctx)
             # RIGHT entry nested inside an oversized source section: a
             # single-channel L-shape would descend far right and sweep
-            # back across the whole diagram (#425).  Step down past the
+            # back across the whole diagram.  Step down past the
             # source then into a channel near the target instead.
             if edge.source in ctx.junction_ids and _should_step_descent(
                 graph, src, ep, ep_port
@@ -1182,7 +1181,7 @@ def _nested_target_clear_channel_x(
 
     For a route whose entry port *ep* sits in a narrow column nested inside
     an oversized source section, the only single-channel descent that
-    clears the source is far to the right (producing the #425 dog-leg).
+    clears the source is far to the right (producing the dog-leg).
     A stepped descent instead drops to just below the source, steps left
     into the channel returned here - the rightmost edge of any section in
     the target's column that the descent's vertical run (*y_lo*..*y_hi*)
@@ -1216,7 +1215,7 @@ def _route_stepped_descent(
 ) -> RoutedPath:
     """Stepped descent to an entry port nested inside an oversized source.
 
-    Replaces the far-right dog-leg (#425) for a junction-sourced merge
+    Replaces the far-right dog-leg for a junction-sourced merge
     route whose single-channel L-shape would be shoved to the far edge of
     an oversized source section.  Routes a 6-corner step::
 
@@ -1283,7 +1282,7 @@ def _should_step_descent(
     ep_port,
 ) -> bool:
     """Detect the nested-column degenerate geometry that needs a stepped
-    descent (#425).
+    descent.
 
     Fires only when a junction-sourced merge route to a RIGHT entry port
     would otherwise drop in a single far-right channel because the target
@@ -1358,7 +1357,7 @@ def _route_l_shape(
         )
         # The fan pivots the channel through ``sx +/- curve_radius``,
         # which hugs the source section's edge.  When that edge is also a
-        # section bbox border the descent grazes it incidentally (#423):
+        # section bbox border the descent grazes it incidentally:
         # push the channel outward so the nearest line clears the edge.
         half_width = (un - 1) * ctx.offset_step / 2
         mid_x = clear_channel_of_section_edge(
@@ -1391,7 +1390,7 @@ def _route_l_shape(
         )
         # The near-source fallback hugs the source section's edge; push
         # the channel outward when that edge is a section bbox border the
-        # route doesn't enter (#423).
+        # route doesn't enter.
         half_width = (n - 1) * ctx.offset_step / 2
         mid_x = clear_channel_of_section_edge(
             ctx.graph,
@@ -1548,7 +1547,7 @@ def _route_top_entry_l_shape(
 def _route_left_exit_left_entry_drop(
     edge: Edge, src: Station, tgt: Station, i: int, n: int, ctx: _RoutingCtx
 ) -> RoutedPath:
-    """Drop a LEFT exit into a LEFT entry stacked directly below (#421).
+    """Drop a LEFT exit into a LEFT entry stacked directly below.
 
     Both ports sit on the left edge of one grid column.  Run a short lead
     out to the left of the column, drop vertically in that channel, then
@@ -1683,9 +1682,8 @@ def _route_left_entry_wrap(
     extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
     vx = tx - base_gap - extra_clearance + delta
     # When this wrap shares a junction fan with a corridor feeder descending
-    # the same target column,
-    # anchor the descent channel to the column's LEFT edge so the spine and
-    # the corridor overlay as one bundle instead of smearing (#437).
+    # the same target column, anchor the descent channel to the column's LEFT
+    # edge so the spine and the corridor overlay as one bundle instead of smearing.
     if fan is not None and _fan_has_corridor_sibling(edge.source, ctx):
         tgt_col = _resolve_section_col(ctx.graph, tgt)
         if tgt_col is not None:
@@ -1846,10 +1844,9 @@ def _corridor_descent_x(
     """X of the inter-column channel just LEFT of the target column.
 
     The corridor descends the clear gap between ``ep_col - 1`` and
-    ``ep_col`` measured at the *target* row (so a wide row-span section in
-    a different row -
-    does not collapse the gap).  Returns ``None`` when there is no column
-    to the left (degenerate; caller falls back to the around-below loop).
+    ``ep_col`` measured at the *target* row, so a wide row-span section in a
+    different row does not collapse the gap.  Returns ``None`` when there is no
+    column to the left (degenerate; caller falls back to the around-below loop).
     """
     if ep_col <= 0:
         return None
@@ -1872,7 +1869,7 @@ def _fan_left_entry_descent_x(
     stacked in the same column - one reached by :func:`_route_left_entry_wrap`
     (the spine), the other by :func:`_route_inter_row_gap_corridor` (the QC
     feed) - both bundles must descend the SAME vertical channel so they
-    overlay as one clean bundle rather than smearing a few px apart (#437).
+    overlay as one clean bundle rather than smearing a few px apart.
 
     Anchor the channel to the column's LEFT edge (the leftmost section left
     edge across all rows of *tgt_col*) so both handlers, whose individual
@@ -1893,7 +1890,7 @@ def _fan_has_corridor_sibling(junction_id: str, ctx: _RoutingCtx) -> bool:
     """True if *junction_id* fans an edge routed via the inter-row-gap corridor.
 
     Used so a sibling :func:`_route_left_entry_wrap` spine aligns its descent
-    channel with the corridor feeder's (#437).  A corridor feeder is a
+    channel with the corridor feeder's.  A corridor feeder is a
     downward cross-row edge into a LEFT-entry section (merge junction or
     direct port) for which :func:`_corridor_is_viable` holds.
     """
@@ -1980,35 +1977,23 @@ def _route_inter_row_gap_corridor(
     sx, sy = src.x, src.y
     ex, ey = entry_port.x, entry_port.y
 
-    # When this corridor feeder shares a junction fan with a sibling wrap
-    # , consume the unified
-    # fan position so the source-side first corner and the inter-row gap
-    # stagger MATCH the wrap exactly.  Without this the corridor picks its
-    # own per-bundle (i, n) and the two same-line bundles smear a few px
-    # apart instead of overlaying (#437).
+    # When this corridor feeder shares a junction fan with a sibling wrap,
+    # consume the unified fan position so the source-side first corner and the
+    # inter-row gap stagger match the wrap exactly.  Without this the corridor
+    # picks its own per-bundle (i, n) and the two same-line bundles smear a few
+    # px apart instead of overlaying.
     ekey = (edge.source, edge.target, edge.line_id)
     fan = ctx.junction_fan_info.get(ekey)
     pos_i, pos_n = fan if fan is not None else (i, n)
 
-    delta, _r1, _r2 = l_shape_radii(
+    # l_shape_radii(Direction.D) already returns the outer (corners 1-2) and
+    # inner (corners 3-4) radii for this bundle; reuse them rather than
+    # recomputing via corner_radius.
+    delta, r_outer, r_inner = l_shape_radii(
         pos_i,
         pos_n,
         vertical=Direction.D,
         offset_step=ctx.offset_step,
-        base_radius=ctx.curve_radius,
-    )
-    off_for_radius = (pos_n - 1 - pos_i) * ctx.offset_step
-    max_off_for_radius = (pos_n - 1) * ctx.offset_step
-    r_outer = corner_radius(
-        off_for_radius,
-        max_off_for_radius,
-        outside=True,
-        base_radius=ctx.curve_radius,
-    )
-    r_inner = corner_radius(
-        off_for_radius,
-        max_off_for_radius,
-        outside=False,
         base_radius=ctx.curve_radius,
     )
 
@@ -2027,7 +2012,7 @@ def _route_inter_row_gap_corridor(
         # Share the sibling wrap's inter-row band: it centres the leftward
         # traverse in the gap below the SOURCE row using the global (non
         # column-restricted) row edges, so the two bundles' H legs coincide
-        # rather than smearing 3px apart (#437).
+        # rather than smearing 3px apart.
         wrap_top = row_bottom_edge(ctx.graph, src_row, default=gap_top)
         wrap_bottom = row_top_edge(ctx.graph, src_row + 1, default=wrap_top)
         gy_base = _center_inter_row_channel(wrap_top, wrap_bottom)
@@ -2042,7 +2027,7 @@ def _route_inter_row_gap_corridor(
     # next row's header badge.  In a tight gap the band is narrower than the
     # bundle, so the per-line stagger collapses rather than grazing an edge.
     # Skipped for fan feeders, which share the wrap sibling's (unclamped)
-    # band so the two bundles' H legs coincide (#437).
+    # band so the two bundles' H legs coincide.
     if fan is None and gap_bottom > gap_top:
         gy = min(
             max(gy, gap_top + EDGE_TO_BUNDLE_CLEARANCE),
@@ -2062,7 +2047,7 @@ def _route_inter_row_gap_corridor(
     # H lead-in right of the source, clear of the source section's edge.
     # When the source is a sectionless junction, fall back to its own X as
     # the reference edge (mirrors :func:`_route_left_entry_wrap`) so a fan
-    # feeder gets the SAME source-side clearance as its sibling wrap (#437).
+    # feeder gets the SAME source-side clearance as its sibling wrap.
     src_section = ctx.graph.sections.get(src.section_id) if src.section_id else None
     corner_x = sx + ctx.curve_radius + (pos_n - 1) * ctx.offset_step / 2 + delta
     if src_section and src_section.bbox_w > 0:

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -20,8 +20,10 @@ from nf_metro.layout.constants import (
     CROSS_ROW_THRESHOLD,
     CURVE_RADIUS,
     DIAGONAL_RUN,
+    EDGE_TO_BUNDLE_CLEARANCE,
     FOLD_MARGIN,
     ICON_TERMINUS_FORK_LEAD,
+    INTER_ROW_HEADER_CLEARANCE,
     JUNCTION_MARGIN,
     MERGE_ROUTE_MARGIN,
     MIN_STATION_FLAT_LENGTH,
@@ -35,16 +37,21 @@ from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.routing.common import (
     Direction,
     RoutedPath,
+    _center_inter_row_channel,
     bundle_width,
     bypass_bottom_y,
+    clear_channel_of_section_edge,
     col_left_edge,
     col_right_edge,
     column_gap_edges,
     compute_bundle_info,
+    endpoint_port_xs,
     horizontal_direction,
     inter_column_channel_x,
     inter_row_channel_y,
     resolve_section,
+    row_bottom_edge,
+    row_top_edge,
     symmetric_bundle_midpoint,
     vertical_direction,
 )
@@ -641,8 +648,31 @@ def _route_inter_section(
         wrap_hy = inter_row_channel_y(graph, src, tgt, sy, ty, dy, ctx.curve_radius)
         exclude = {src.section_id} if src.section_id else set()
         if _h_segment_crosses_other_section(graph, sx, tx, wrap_hy, exclude):
+            if _corridor_is_viable(ctx, src, tgt):
+                return _route_inter_row_gap_corridor(edge, src, tgt, tgt, i, n, ctx)
             return _route_around_section_below(edge, src, tgt, tgt, i, n, ctx)
         return _route_left_entry_wrap(edge, src, tgt, i, n, ctx)
+
+    # Serpentine LEFT exit -> LEFT entry stacked in the same column (#421):
+    # an RL section's left exit dropping to the LR section directly below
+    # whose left entry sits a few px inward.  The standard L-shape places
+    # its vertical channel at sx + radius, which lands inside the source
+    # bbox.  Drop the channel on the LEFT of the column instead so the
+    # connector stays outside both section boxes.
+    if (
+        src_port is not None
+        and not src_port.is_entry
+        and src_port.side == PortSide.LEFT
+        and tgt_port is not None
+        and tgt_port.is_entry
+        and tgt_port.side == PortSide.LEFT
+        and src_col is not None
+        and tgt_col is not None
+        and src_col == tgt_col
+        and src_row is not None
+        and _resolve_section_row(graph, tgt) != src_row
+    ):
+        return _route_left_exit_left_entry_drop(edge, src, tgt, i, n, ctx)
 
     # Non-bypass edges to merge junctions: route to entry port.
     # When dy is tiny, use a straight line to avoid cramped curves.
@@ -659,16 +689,30 @@ def _route_inter_section(
                 )
             # If the standard L-shape's horizontal segment at the entry
             # port's Y would cross a section bbox the route doesn't
-            # enter (e.g. sarek __junction_8 -> __merge_X reaches
-            # reporting's LEFT entry by cutting through reporting at
-            # y=ep.y), route AROUND BELOW the target section instead.
+            # enter, route AROUND BELOW the target section instead.
             # The source section is excluded - its right-edge lead-in
             # is safe even when its bbox spans the route's Y range.
             ep_port = graph.ports.get(ep_id)
             if ep_port and ep_port.side == PortSide.LEFT:
                 exclude = {src.section_id} if src.section_id else set()
                 if _h_segment_crosses_other_section(graph, sx, ep.x, ep.y, exclude):
+                    # When a clear inter-row / inter-column corridor exists
+                    # (downward cross-row feeder
+                    # fan-in), descend it instead of looping below the
+                    # canvas (#432).
+                    if _corridor_is_viable(ctx, src, ep):
+                        return _route_inter_row_gap_corridor(
+                            edge, src, tgt, ep, i, n, ctx
+                        )
                     return _route_around_section_below(edge, src, tgt, ep, i, n, ctx)
+            # RIGHT entry nested inside an oversized source section: a
+            # single-channel L-shape would descend far right and sweep
+            # back across the whole diagram (#425).  Step down past the
+            # source then into a channel near the target instead.
+            if edge.source in ctx.junction_ids and _should_step_descent(
+                graph, src, ep, ep_port
+            ):
+                return _route_stepped_descent(edge, src, ep, i, n, ctx)
             return _route_l_shape(edge, src, ep, i, n, ctx)
 
     # Standard L-shape
@@ -838,16 +882,14 @@ def _route_merge_trunk(
     "hanging" curve disconnected from the entry port.
 
     When the trunk and entry are in the same grid row but separated by
-    intervening row-mates (e.g. sarek's post_vc -> reporting trunk
-    bypassing annotation), the standard above-row bypass channel sits
+    intervening row-mates, the standard above-row bypass channel sits
     in the inter-row gap that also holds the target row's section
     titles.  Force ``cross_row`` so the channel runs BELOW all sections
     in the column range, mirroring :func:`_route_around_section_below`
     and avoiding overlap with the title text.
 
     When a sibling edge to the same merge junction will route via
-    :func:`_route_around_section_below` (e.g. sarek's preprocessing wrap
-    that also lands at reporting's LEFT entry), both routes would place
+    :func:`_route_around_section_below`, both routes would place
     their V_up channels in the inter-column gap just left of the target
     section, producing overlapping bundles in the same x range.  Detect
     that and pull the trunk's V_up channel further from the target edge
@@ -1129,6 +1171,155 @@ def _route_bypass(
     )
 
 
+def _nested_target_clear_channel_x(
+    graph: MetroGraph,
+    ep: Station,
+    y_lo: float,
+    y_hi: float,
+    clearance: float,
+) -> float | None:
+    """X of a clear vertical channel just right of the target column's stack.
+
+    For a route whose entry port *ep* sits in a narrow column nested inside
+    an oversized source section, the only single-channel descent that
+    clears the source is far to the right (producing the #425 dog-leg).
+    A stepped descent instead drops to just below the source, steps left
+    into the channel returned here - the rightmost edge of any section in
+    the target's column that the descent's vertical run (*y_lo*..*y_hi*)
+    would otherwise cross, plus *clearance* - then drops to the entry Y.
+
+    Returns ``None`` when the target column has no resolvable sections.
+    """
+    ep_sec = graph.sections.get(ep.section_id) if ep.section_id else None
+    if ep_sec is None:
+        return None
+    tgt_col = ep_sec.grid_col
+    rights = [
+        s.bbox_x + s.bbox_w
+        for s in graph.sections.values()
+        if s.bbox_w > 0
+        and s.grid_col == tgt_col
+        and not (y_hi < s.bbox_y or y_lo > s.bbox_y + s.bbox_h)
+    ]
+    if not rights:
+        return None
+    return max(rights) + clearance
+
+
+def _route_stepped_descent(
+    edge: Edge,
+    src: Station,
+    ep: Station,
+    i: int,
+    n: int,
+    ctx: _RoutingCtx,
+) -> RoutedPath:
+    """Stepped descent to an entry port nested inside an oversized source.
+
+    Replaces the far-right dog-leg (#425) for a junction-sourced merge
+    route whose single-channel L-shape would be shoved to the far edge of
+    an oversized source section.  Routes a 6-corner step::
+
+        (sx, sy) -> (corner_x, sy)      ; H lead-in right out of the source
+        (corner_x, sy) -> (corner_x, step_y) ; V down past the source bottom
+        (corner_x, step_y) -> (chan_x, step_y) ; H left into the target channel
+        (chan_x, step_y) -> (chan_x, ey) ; V down to the entry Y
+        (chan_x, ey) -> (ex, ey)        ; H into the entry port
+
+    ``corner_x`` clears the source section's right edge; ``step_y`` sits
+    just below the source bottom; ``chan_x`` is the clear channel right of
+    the target column's stack.  Both leftward legs stay well under half the
+    canvas width, eliminating the full-width sweep.
+    """
+    graph = ctx.graph
+    sx, sy = src.x, src.y
+    ex, ey = ep.x, ep.y
+    src_off = _get_offset(ctx, edge.source, edge.line_id)
+    tgt_off = _get_offset(ctx, edge.target, edge.line_id)
+    r = ctx.curve_radius
+
+    src_sec = graph.sections.get(src.section_id) if src.section_id else None
+    # Trace through the junction to the feeding exit port's section.
+    if src_sec is None:
+        src_sec = resolve_section(graph, src)
+    src_right = (src_sec.bbox_x + src_sec.bbox_w) if src_sec else sx
+    src_bottom = (src_sec.bbox_y + src_sec.bbox_h) if src_sec else sy
+
+    # Spread parallel lines: outer lines sit further out / lower.
+    spread = (n - 1 - i) * ctx.offset_step
+    corner_x = src_right + SECTION_ROUTE_CLEARANCE + spread
+    corner_x = max(corner_x, sx + r)
+    step_y = src_bottom + EDGE_TO_BUNDLE_CLEARANCE + spread
+
+    chan_x = _nested_target_clear_channel_x(
+        graph, ep, step_y, ey + tgt_off, SECTION_ROUTE_CLEARANCE
+    )
+    if chan_x is None:
+        chan_x = ex + SECTION_ROUTE_CLEARANCE
+    chan_x += spread
+
+    return RoutedPath(
+        edge=edge,
+        line_id=edge.line_id,
+        points=[
+            (sx, sy + src_off),
+            (corner_x, sy + src_off),
+            (corner_x, step_y),
+            (chan_x, step_y),
+            (chan_x, ey + tgt_off),
+            (ex, ey + tgt_off),
+        ],
+        is_inter_section=True,
+        normalize_exempt=True,
+        curve_radii=[r, r, r, r],
+        offsets_applied=True,
+    )
+
+
+def _should_step_descent(
+    graph: MetroGraph,
+    src: Station,
+    ep: Station,
+    ep_port,
+) -> bool:
+    """Detect the nested-column degenerate geometry that needs a stepped
+    descent (#425).
+
+    Fires only when a junction-sourced merge route to a RIGHT entry port
+    would otherwise drop in a single far-right channel because the target
+    column is geometrically nested inside an oversized source section: the
+    source section's right edge sits well to the right of the entry port,
+    so a single-channel L-shape must descend far right and sweep all the
+    way back left.  The stepped descent replaces that with two short legs.
+    """
+    if ep_port is None or ep_port.side != PortSide.RIGHT:
+        return False
+    src_sec = graph.sections.get(src.section_id) if src.section_id else None
+    if src_sec is None:
+        src_sec = resolve_section(graph, src)
+    ep_sec = graph.sections.get(ep.section_id) if ep.section_id else None
+    if src_sec is None or ep_sec is None or src_sec.bbox_w <= 0:
+        return False
+    # Target column must be to the RIGHT in grid terms (forward route)...
+    if ep_sec.grid_col <= src_sec.grid_col:
+        return False
+    src_right = src_sec.bbox_x + src_sec.bbox_w
+    # ...yet the entry port sits well LEFT of the source's right edge, so a
+    # single-channel descent would be shoved far right of the target (the
+    # nested-column degeneracy).  Require a clear target-side channel to
+    # step into; if none resolves, fall back to the standard L-shape.
+    if src_right <= ep.x + SECTION_ROUTE_CLEARANCE:
+        return False
+    chan_x = _nested_target_clear_channel_x(
+        graph, ep, src_sec.bbox_y + src_sec.bbox_h, ep.y, SECTION_ROUTE_CLEARANCE
+    )
+    if chan_x is None:
+        return False
+    # The channel must genuinely improve on the far-right descent: it has
+    # to land left of the source's right edge (otherwise we gain nothing).
+    return chan_x < src_right - SECTION_ROUTE_CLEARANCE
+
+
 def _route_l_shape(
     edge: Edge, src: Station, tgt: Station, i: int, n: int, ctx: _RoutingCtx
 ) -> RoutedPath:
@@ -1165,6 +1356,19 @@ def _route_l_shape(
         mid_x = sx + horizontal.sign * (
             ctx.curve_radius + (un - 1) * ctx.offset_step / 2
         )
+        # The fan pivots the channel through ``sx +/- curve_radius``,
+        # which hugs the source section's edge.  When that edge is also a
+        # section bbox border the descent grazes it incidentally (#423):
+        # push the channel outward so the nearest line clears the edge.
+        half_width = (un - 1) * ctx.offset_step / 2
+        mid_x = clear_channel_of_section_edge(
+            ctx.graph,
+            mid_x,
+            half_width,
+            min(sy, ty),
+            max(sy, ty),
+            endpoint_port_xs(ctx.graph, edge),
+        )
         # Second corner: from sub-bundle (only L-shape siblings turn here)
         _, _, r_second = l_shape_radii(
             i,
@@ -1184,6 +1388,18 @@ def _route_l_shape(
         max_r = ctx.curve_radius + (n - 1) * ctx.offset_step
         mid_x = inter_column_channel_x(
             ctx.graph, src, tgt, sx, tx, dx, max_r, ctx.offset_step
+        )
+        # The near-source fallback hugs the source section's edge; push
+        # the channel outward when that edge is a section bbox border the
+        # route doesn't enter (#423).
+        half_width = (n - 1) * ctx.offset_step / 2
+        mid_x = clear_channel_of_section_edge(
+            ctx.graph,
+            mid_x,
+            half_width,
+            min(sy, ty),
+            max(sy, ty),
+            endpoint_port_xs(ctx.graph, edge),
         )
 
     vx = mid_x + delta
@@ -1329,6 +1545,46 @@ def _route_top_entry_l_shape(
     )
 
 
+def _route_left_exit_left_entry_drop(
+    edge: Edge, src: Station, tgt: Station, i: int, n: int, ctx: _RoutingCtx
+) -> RoutedPath:
+    """Drop a LEFT exit into a LEFT entry stacked directly below (#421).
+
+    Both ports sit on the left edge of one grid column.  Run a short lead
+    out to the left of the column, drop vertically in that channel, then
+    come back in to the target's left entry port::
+
+        (sx,sy) -> (vx,sy) -> (vx,ty) -> (tx,ty)
+
+    The channel ``vx`` is placed just left of the column's leftmost edge so
+    the connector never re-enters either section's bbox.
+    """
+    sx, sy = src.x, src.y
+    tx, ty = tgt.x, tgt.y
+    dy = ty - sy
+    vertical = vertical_direction(dy)
+
+    delta, r_first, r_second = l_shape_radii(
+        i,
+        n,
+        vertical=vertical,
+        offset_step=ctx.offset_step,
+        base_radius=ctx.curve_radius,
+    )
+
+    src_col = _resolve_section_col(ctx.graph, src)
+    left_edge = col_left_edge(ctx.graph, src_col, default=min(sx, tx))
+    vx = min(left_edge, sx, tx) - ctx.curve_radius - ctx.offset_step + delta
+
+    return RoutedPath(
+        edge=edge,
+        line_id=edge.line_id,
+        points=[(sx, sy), (vx, sy), (vx, ty), (tx, ty)],
+        is_inter_section=True,
+        curve_radii=[r_first, r_second],
+    )
+
+
 def _route_left_entry_wrap(
     edge: Edge, src: Station, tgt: Station, i: int, n: int, ctx: _RoutingCtx
 ) -> RoutedPath:
@@ -1426,6 +1682,16 @@ def _route_left_entry_wrap(
     base_gap = ctx.curve_radius + ctx.offset_step
     extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
     vx = tx - base_gap - extra_clearance + delta
+    # When this wrap shares a junction fan with a corridor feeder descending
+    # the same target column,
+    # anchor the descent channel to the column's LEFT edge so the spine and
+    # the corridor overlay as one bundle instead of smearing (#437).
+    if fan is not None and _fan_has_corridor_sibling(edge.source, ctx):
+        tgt_col = _resolve_section_col(ctx.graph, tgt)
+        if tgt_col is not None:
+            shared_vx = _fan_left_entry_descent_x(ctx, tgt_col, n_for_outer, delta)
+            if shared_vx is not None:
+                vx = shared_vx
 
     # Apply src/tgt station offsets explicitly so the renderer's later
     # _apply_line_offsets pass doesn't double-apply.  Without this, the
@@ -1482,7 +1748,7 @@ def _route_left_entry_wrap(
         # fan of size n).  Without this lead-in, corner_x == sx puts
         # V1 right at the section boundary and collapses all lines
         # onto a single column, producing the "compressed bundle at
-        # the section edge" visual reported on sarek section 2.
+        # the section edge" visual reported on a tall stacked section.
         non_fan_mid_x = sx + ctx.curve_radius + (n - 1) * ctx.offset_step / 2
         corner_x = non_fan_mid_x + delta
     # Ensure the V1 channel (the per-line vertical run on the SOURCE's
@@ -1574,6 +1840,265 @@ def _has_bypass_sibling_to_same_entry(
     return False
 
 
+def _corridor_descent_x(
+    ctx: _RoutingCtx, ep_col: int, ep_row: int, delta: float
+) -> float | None:
+    """X of the inter-column channel just LEFT of the target column.
+
+    The corridor descends the clear gap between ``ep_col - 1`` and
+    ``ep_col`` measured at the *target* row (so a wide row-span section in
+    a different row -
+    does not collapse the gap).  Returns ``None`` when there is no column
+    to the left (degenerate; caller falls back to the around-below loop).
+    """
+    if ep_col <= 0:
+        return None
+    gap_left, gap_right = column_gap_edges(ctx.graph, ep_col - 1, ep_col, row=ep_row)
+    if gap_right <= gap_left:
+        return None
+    # +delta (not -delta): the L->D corner into this channel is concentric
+    # only when vx + r is constant across the bundle.  r_inner shrinks for
+    # the +delta (rightmost) line, so that line must sit at the LARGER vx;
+    # the opposite sign delaminates the descent corner.
+    return (gap_left + gap_right) / 2 + delta
+
+
+def _fan_left_entry_descent_x(
+    ctx: _RoutingCtx, tgt_col: int, n_outer: int, delta: float
+) -> float | None:
+    """Shared descent-channel X for a junction fan's LEFT-entry targets.
+
+    When one junction fans the same lines to two LEFT-entry sections
+    stacked in the same column - one reached by :func:`_route_left_entry_wrap`
+    (the spine), the other by :func:`_route_inter_row_gap_corridor` (the QC
+    feed) - both bundles must descend the SAME vertical channel so they
+    overlay as one clean bundle rather than smearing a few px apart (#437).
+
+    Anchor the channel to the column's LEFT edge (the leftmost section left
+    edge across all rows of *tgt_col*) so both handlers, whose individual
+    targets sit at slightly different x, agree on one channel.  The
+    per-line ``delta`` stagger is preserved.  Returns ``None`` when the
+    column has no measurable left edge.
+    """
+    col_left = col_left_edge(ctx.graph, tgt_col, default=0.0)
+    if col_left <= 0.0:
+        return None
+    base_gap = ctx.curve_radius + ctx.offset_step
+    max_delta = (n_outer - 1) * ctx.offset_step / 2
+    extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
+    return col_left - base_gap - extra_clearance + delta
+
+
+def _fan_has_corridor_sibling(junction_id: str, ctx: _RoutingCtx) -> bool:
+    """True if *junction_id* fans an edge routed via the inter-row-gap corridor.
+
+    Used so a sibling :func:`_route_left_entry_wrap` spine aligns its descent
+    channel with the corridor feeder's (#437).  A corridor feeder is a
+    downward cross-row edge into a LEFT-entry section (merge junction or
+    direct port) for which :func:`_corridor_is_viable` holds.
+    """
+    graph = ctx.graph
+    for edge in graph.edges_from(junction_id):
+        tgt = graph.stations.get(edge.target)
+        if tgt is None:
+            continue
+        ep_id = ctx.merge.entry_port_for.get(edge.target)
+        ep = graph.stations.get(ep_id) if ep_id else tgt
+        if ep is not None and _corridor_is_viable(ctx, graph.stations[junction_id], ep):
+            return True
+    return False
+
+
+def _corridor_is_viable(ctx: _RoutingCtx, src: Station, entry_port: Station) -> bool:
+    """Whether the inter-row-gap + inter-column-channel corridor exists.
+
+    Used to route a downward cross-row merge feeder through the clear
+    corridor instead of the canvas-bottom loop
+    (:func:`_route_around_section_below`).  Requires:
+
+    * a LEFT entry port (the corridor descends just left of the target);
+    * the target section sits in a row strictly *below* the source's row
+      (a downward cross-row feeder; same-row fan-ins U-route in the gap
+      below the row and must keep the legacy handler);
+    * an inter-row gap below the source row exists in the source's column;
+    * a clear inter-column channel exists left of the target column.
+    """
+    if entry_port is None:
+        return False
+    ep_port = ctx.graph.ports.get(entry_port.id)
+    if ep_port is None or ep_port.side != PortSide.LEFT:
+        return False
+    src_row = _resolve_section_row(ctx.graph, src)
+    ep_row = _resolve_section_row(ctx.graph, entry_port)
+    src_col = _resolve_section_col(ctx.graph, src)
+    ep_col = _resolve_section_col(ctx.graph, entry_port)
+    if None in (src_row, ep_row, src_col, ep_col):
+        return False
+    if ep_row <= src_row:
+        return False
+    if _corridor_descent_x(ctx, ep_col, ep_row, 0.0) is None:
+        return False
+    # An inter-row gap must open below the source row within its column.
+    gap_top = row_bottom_edge(ctx.graph, src_row, col=src_col)
+    gap_bottom = row_top_edge(ctx.graph, src_row + 1, col=src_col)
+    return gap_bottom - gap_top > EDGE_TO_BUNDLE_CLEARANCE
+
+
+def _route_inter_row_gap_corridor(
+    edge: Edge,
+    src: Station,
+    tgt: Station,
+    entry_port: Station,
+    i: int,
+    n: int,
+    ctx: _RoutingCtx,
+) -> RoutedPath:
+    """Route a downward cross-row LEFT-entry merge feeder via the clear
+    inter-row / inter-column corridor instead of the canvas-bottom loop.
+
+    A multi-row collector fan-in feeds the left-entry ``reporting`` section
+    (row 3) from QC sources exiting on the right in rows 0 and 1.  Rather
+    than dropping to the canvas bottom (below the tall ``variant_calling``
+    row-span) and climbing back up (:func:`_route_around_section_below`),
+    descend through the corridor that genuinely exists::
+
+        (lx, sy)        -> H lead-in right of source
+        (corner_x, sy)  ; turn down
+        (corner_x, gy)  -> V down to the inter-row gap below the source row
+        (vx, gy)        -> H left in that gap to the inter-column channel
+        (vx, ey)        -> V down the channel to the entry Y
+        (ex, ey)        -> H right into the LEFT entry port
+
+    All feeders converge in the same inter-column channel (``vx``) just
+    left of the target column, so they travel down together as one bundle
+    meeting the carriage-return spine, rather than two separate loops.
+
+    Corners: R->D (CW), D->L (CW), L->D (CCW), D->R (CCW).  The bundle is
+    staggered by ``delta`` (the L-shape offset) on each leg so parallel
+    lines keep concentric corners and a constant gap.
+    """
+    sx, sy = src.x, src.y
+    ex, ey = entry_port.x, entry_port.y
+
+    # When this corridor feeder shares a junction fan with a sibling wrap
+    # , consume the unified
+    # fan position so the source-side first corner and the inter-row gap
+    # stagger MATCH the wrap exactly.  Without this the corridor picks its
+    # own per-bundle (i, n) and the two same-line bundles smear a few px
+    # apart instead of overlaying (#437).
+    ekey = (edge.source, edge.target, edge.line_id)
+    fan = ctx.junction_fan_info.get(ekey)
+    pos_i, pos_n = fan if fan is not None else (i, n)
+
+    delta, _r1, _r2 = l_shape_radii(
+        pos_i,
+        pos_n,
+        vertical=Direction.D,
+        offset_step=ctx.offset_step,
+        base_radius=ctx.curve_radius,
+    )
+    off_for_radius = (pos_n - 1 - pos_i) * ctx.offset_step
+    max_off_for_radius = (pos_n - 1) * ctx.offset_step
+    r_outer = corner_radius(
+        off_for_radius,
+        max_off_for_radius,
+        outside=True,
+        base_radius=ctx.curve_radius,
+    )
+    r_inner = corner_radius(
+        off_for_radius,
+        max_off_for_radius,
+        outside=False,
+        base_radius=ctx.curve_radius,
+    )
+
+    src_row = _resolve_section_row(ctx.graph, src)
+    src_col = _resolve_section_col(ctx.graph, src)
+    ep_col = _resolve_section_col(ctx.graph, entry_port)
+    ep_row = _resolve_section_row(ctx.graph, entry_port)
+
+    # Inter-row gap Y just below the source row (column-restricted so a
+    # tall row-span in another column doesn't push the channel down).  Use
+    # the header-aware band so the leftward traverse clears the next row's
+    # section-header badge, not just the bbox edge.
+    gap_top = row_bottom_edge(ctx.graph, src_row, col=src_col)
+    gap_bottom = row_top_edge(ctx.graph, src_row + 1, col=src_col, default=gap_top)
+    if fan is not None:
+        # Share the sibling wrap's inter-row band: it centres the leftward
+        # traverse in the gap below the SOURCE row using the global (non
+        # column-restricted) row edges, so the two bundles' H legs coincide
+        # rather than smearing 3px apart (#437).
+        wrap_top = row_bottom_edge(ctx.graph, src_row, default=gap_top)
+        wrap_bottom = row_top_edge(ctx.graph, src_row + 1, default=wrap_top)
+        gy_base = _center_inter_row_channel(wrap_top, wrap_bottom)
+    elif gap_bottom > gap_top:
+        gy_base = _center_inter_row_channel(gap_top, gap_bottom)
+    else:
+        gy_base = gap_top + EDGE_TO_BUNDLE_CLEARANCE
+    # Outer line sits at LARGER y in this leftward run (CW D->L corner).
+    gy = gy_base + delta
+    # Keep every staggered line inside the clearance band: at least
+    # EDGE_TO_BUNDLE_CLEARANCE below the source-row bottom and clear of the
+    # next row's header badge.  In a tight gap the band is narrower than the
+    # bundle, so the per-line stagger collapses rather than grazing an edge.
+    # Skipped for fan feeders, which share the wrap sibling's (unclamped)
+    # band so the two bundles' H legs coincide (#437).
+    if fan is None and gap_bottom > gap_top:
+        gy = min(
+            max(gy, gap_top + EDGE_TO_BUNDLE_CLEARANCE),
+            gap_bottom - INTER_ROW_HEADER_CLEARANCE,
+        )
+
+    # Inter-column descent channel left of the target column.  For a fan
+    # feeder, anchor it to the target COLUMN's left edge (shared with the
+    # sibling wrap) so the two bundles descend the same channel; otherwise
+    # use the inter-column gap midpoint.
+    vx = None
+    if fan is not None and ep_col is not None:
+        vx = _fan_left_entry_descent_x(ctx, ep_col, pos_n, delta)
+    if vx is None:
+        vx = _corridor_descent_x(ctx, ep_col, ep_row, delta)
+
+    # H lead-in right of the source, clear of the source section's edge.
+    # When the source is a sectionless junction, fall back to its own X as
+    # the reference edge (mirrors :func:`_route_left_entry_wrap`) so a fan
+    # feeder gets the SAME source-side clearance as its sibling wrap (#437).
+    src_section = ctx.graph.sections.get(src.section_id) if src.section_id else None
+    corner_x = sx + ctx.curve_radius + (pos_n - 1) * ctx.offset_step / 2 + delta
+    if src_section and src_section.bbox_w > 0:
+        section_right = src_section.bbox_x + src_section.bbox_w
+    else:
+        section_right = sx
+    current_gap = sx + ctx.curve_radius - section_right
+    corner_x += max(0.0, SECTION_ROUTE_CLEARANCE - current_gap)
+
+    src_off = _get_offset(ctx, edge.source, edge.line_id)
+    tgt_off = _get_offset(ctx, edge.target, edge.line_id)
+
+    return RoutedPath(
+        edge=edge,
+        line_id=edge.line_id,
+        points=[
+            (sx, sy + src_off),
+            (corner_x, sy + src_off),
+            (corner_x, gy),
+            (vx, gy),
+            (vx, ey + tgt_off),
+            (ex, ey + tgt_off),
+        ],
+        is_inter_section=True,
+        normalize_exempt=True,
+        # Corridor turns R->D->L->D->R (handedness CW, CW, CCW, CCW).  The
+        # bundle's outer line is OUTSIDE corners 1-2 (larger radius r_outer)
+        # but INSIDE corners 3-4 (smaller radius r_inner), so each corner's
+        # arcs share a center and the bundle holds even spacing through the
+        # descent.  Using r_outer at all four corners delaminates the L->D and
+        # D->R turns.  Mirrors :func:`_route_left_entry_wrap`.
+        curve_radii=[r_outer, r_outer, r_inner, r_inner],
+        offsets_applied=True,
+    )
+
+
 def _route_around_section_below(
     edge: Edge,
     src: Station,
@@ -1586,12 +2111,11 @@ def _route_around_section_below(
     """Route to a LEFT entry port by going AROUND BELOW the target section.
 
     Used when a standard L-shape or :func:`_route_left_entry_wrap` would
-    have its horizontal segment cross an intervening section's bbox
-    (e.g. sarek section 1 -> section 5 LEFT entry, where the natural
-    inter-row gap lands inside variant_calling).  Routes via 4 corners
-    in a clockwise R-D-L-U-R loop that descends past the target row's
-    bottom, runs leftward under everything, rises in the inter-section
-    gap to the entry Y, and enters the LEFT port from below::
+    have its horizontal segment cross an intervening section's bbox.
+    Routes via 4 corners in a clockwise R-D-L-U-R loop that descends
+    past the target row's bottom, runs leftward under everything, rises
+    in the inter-section gap to the entry Y, and enters the LEFT port
+    from below::
 
         (lx, sy) -> (cx, sy)          ; H lead-in right
         (cx, sy) -> (cx, by)          ; V down past target row's bottom

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -370,7 +370,7 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
     A multi-row-span *source* routes via reversal handling, not this
     channel, and is excluded; a multi-row-span *target* (rowspan grid
     placement) is fine -- only its top edge bounds the gap, so the
-    adjacent ``(src_row, tgt_row)`` reservation still applies (#422).
+    adjacent ``(src_row, tgt_row)`` reservation still applies.
     """
 
     def _is_flow_section(sec) -> bool:

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -367,8 +367,10 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
     ``(upper_row, lower_row)`` pair, the required bbox-to-bbox gap so the
     placement pass can widen too-tight rows.
 
-    Fold/serpentine sections (multi-row span) route via reversal handling,
-    not this channel, and are excluded.
+    A multi-row-span *source* routes via reversal handling, not this
+    channel, and is excluded; a multi-row-span *target* (rowspan grid
+    placement) is fine -- only its top edge bounds the gap, so the
+    adjacent ``(src_row, tgt_row)`` reservation still applies (#422).
     """
 
     def _is_flow_section(sec) -> bool:
@@ -387,8 +389,12 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
         # ``inter_row_channel_y``) that must clear the next-row header.
         if port.side not in (PortSide.LEFT, PortSide.RIGHT, PortSide.TOP):
             continue
+        # Only the target's top edge (its grid_row) bounds the gap, so a
+        # multi-row-span target still reserves it; its span is irrelevant.
+        # The source must be single-row: its bottom edge is the gap's upper
+        # bound, and a multi-row source routes via reversal handling.
         tgt_sec = graph.sections.get(port.section_id)
-        if not _is_flow_section(tgt_sec):
+        if tgt_sec is None:
             continue
         src = graph.stations.get(edge.source)
         if src is None:

--- a/tests/fixtures/regressions/stacked_collector_fanin.mmd
+++ b/tests/fixtures/regressions/stacked_collector_fanin.mmd
@@ -1,0 +1,173 @@
+%%metro title: Stacked Collector Fan-in
+%%metro style: dark
+%%metro legend: br
+%%metro line_order: definition
+%%metro center_ports: true
+%%metro compact_offsets: true
+%%metro file: fastq_in | FASTQ
+%%metro file: bam_in | BAM
+%%metro file: cram_in | CRAM
+%%metro file: vcf_out | VCF
+%%metro file: report_out | HTML
+%%metro line: germline | Germline | #0570b0
+%%metro line: tumor_only | Tumor only | #d62728
+%%metro line: somatic | Tumor-normal pair | #756bb1
+%%metro grid: preprocessing | 0,0,1,2
+%%metro grid: variant_calling | 0,1,3,1
+%%metro grid: post_vc | 1,1,1,1
+%%metro grid: annotation | 1,2,1,1
+%%metro grid: reporting | 1,3,1,1
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        %%metro exit: right | germline, tumor_only, somatic
+        fastq_in[ ]
+        bam_in[ ]
+        fastqc[FastQC]
+        fastp[FastP]
+        umi[UMI consensus]
+        bwa[BWA-MEM]
+        bwa2[BWA-MEM2]
+        dragmap[DragMap]
+        sentieon_bwa[Sentieon BWA]
+        merge_index[samtools merge/index]
+        markdup[MarkDuplicates]
+        sentieon_dedup[Sentieon Dedup]
+        bqsr[BaseRecalibrator]
+        applybqsr[ApplyBQSR]
+        mosdepth[mosdepth]
+        ngscheckmate[NGSCheckmate]
+
+        fastq_in -->|germline,tumor_only,somatic| fastqc
+        fastq_in -->|germline,tumor_only,somatic| fastp
+        bam_in -->|germline,tumor_only,somatic| fastp
+        fastp -->|germline,tumor_only,somatic| umi
+        umi -->|germline,tumor_only,somatic| bwa
+        umi -->|germline,tumor_only,somatic| bwa2
+        umi -->|germline,tumor_only,somatic| dragmap
+        umi -->|germline,tumor_only,somatic| sentieon_bwa
+        bwa -->|germline,tumor_only,somatic| merge_index
+        bwa2 -->|germline,tumor_only,somatic| merge_index
+        dragmap -->|germline,tumor_only,somatic| merge_index
+        sentieon_bwa -->|germline,tumor_only,somatic| merge_index
+        merge_index -->|germline,tumor_only,somatic| markdup
+        merge_index -->|germline,tumor_only,somatic| sentieon_dedup
+        markdup -->|germline,tumor_only,somatic| bqsr
+        sentieon_dedup -->|germline,tumor_only,somatic| bqsr
+        bqsr -->|germline,tumor_only,somatic| applybqsr
+        applybqsr -->|germline,tumor_only,somatic| mosdepth
+        applybqsr -->|germline,tumor_only,somatic| ngscheckmate
+    end
+
+    subgraph variant_calling [Variant calling]
+        %%metro entry: left | germline, tumor_only, somatic
+        %%metro exit: right | germline, tumor_only, somatic
+        cram_in[ ]
+        haplotypecaller[HaplotypeCaller]
+        deepvariant[DeepVariant]
+        sentieon_dnascope[Sentieon DNAscope]
+        sentieon_haplotyper[Sentieon Haplotyper]
+        freebayes[FreeBayes]
+        strelka[Strelka]
+        mpileup[bcftools mpileup]
+        mutect2[Mutect2]
+        lofreq[LoFreq]
+        muse[MuSE]
+        sentieon_tnscope[Sentieon TNscope]
+        manta[Manta]
+        tiddit[TIDDIT]
+        ascat[ASCAT]
+        cnvkit[CNVkit]
+        controlfreec[Control-FREEC]
+        indexcov[indexcov]
+        msisensor2[MSIsensor2]
+        msisensorpro[MSIsensor-pro]
+        vcfs[ ]
+
+        cram_in -->|germline| haplotypecaller
+        cram_in -->|germline| deepvariant
+        cram_in -->|germline| sentieon_dnascope
+        cram_in -->|germline| sentieon_haplotyper
+        cram_in -->|germline,tumor_only,somatic| freebayes
+        cram_in -->|germline,somatic| strelka
+        cram_in -->|germline,tumor_only,somatic| mpileup
+        cram_in -->|tumor_only,somatic| mutect2
+        cram_in -->|tumor_only| lofreq
+        cram_in -->|somatic| muse
+        cram_in -->|tumor_only,somatic| sentieon_tnscope
+        cram_in -->|germline,tumor_only,somatic| manta
+        cram_in -->|germline,tumor_only,somatic| tiddit
+        cram_in -->|somatic| ascat
+        cram_in -->|germline,tumor_only,somatic| cnvkit
+        cram_in -->|tumor_only,somatic| controlfreec
+        cram_in -->|germline,somatic| indexcov
+        cram_in -->|tumor_only| msisensor2
+        cram_in -->|somatic| msisensorpro
+
+        haplotypecaller -->|germline| vcfs
+        deepvariant -->|germline| vcfs
+        sentieon_dnascope -->|germline| vcfs
+        sentieon_haplotyper -->|germline| vcfs
+        freebayes -->|germline,tumor_only,somatic| vcfs
+        strelka -->|germline,somatic| vcfs
+        mpileup -->|germline,tumor_only,somatic| vcfs
+        mutect2 -->|tumor_only,somatic| vcfs
+        lofreq -->|tumor_only| vcfs
+        muse -->|somatic| vcfs
+        sentieon_tnscope -->|tumor_only,somatic| vcfs
+        manta -->|germline,tumor_only,somatic| vcfs
+        tiddit -->|germline,tumor_only,somatic| vcfs
+        ascat -->|somatic| vcfs
+        cnvkit -->|germline,tumor_only,somatic| vcfs
+        controlfreec -->|tumor_only,somatic| vcfs
+        indexcov -->|germline,somatic| vcfs
+        msisensor2 -->|tumor_only| vcfs
+        msisensorpro -->|somatic| vcfs
+    end
+
+    subgraph post_vc [Post-processing]
+        filter_vcfs[Filter VCFs]
+        normalize[Normalize]
+        concatenate[Concatenate]
+        consensus[Consensus]
+        varlociraptor[Varlociraptor]
+        bcftools_stats[bcftools stats]
+        vcftools[VCFtools]
+
+        filter_vcfs -->|germline,tumor_only,somatic| normalize
+        normalize -->|germline,tumor_only,somatic| concatenate
+        concatenate -->|germline,tumor_only,somatic| consensus
+        consensus -->|germline,tumor_only,somatic| varlociraptor
+        varlociraptor -->|germline,tumor_only,somatic| bcftools_stats
+        bcftools_stats -->|germline,tumor_only,somatic| vcftools
+    end
+
+    subgraph annotation [Annotation]
+        snpeff[snpEff]
+        vep[VEP]
+        bcftools_ann[bcftools annotate]
+        snpsift[SnpSift]
+
+        snpeff -->|germline,tumor_only,somatic| vep
+        vep -->|germline,tumor_only,somatic| bcftools_ann
+        bcftools_ann -->|germline,tumor_only,somatic| snpsift
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+        vcf_out[ ]
+        report_out[ ]
+
+        multiqc -->|germline,tumor_only,somatic| report_out
+        snpsift_to_vcf[ ]
+        snpsift_to_vcf -->|germline,tumor_only,somatic| vcf_out
+    end
+
+    %% Inter-section edges
+    applybqsr -->|germline,tumor_only,somatic| cram_in
+    vcfs -->|germline,tumor_only,somatic| filter_vcfs
+    vcftools -->|germline,tumor_only,somatic| snpeff
+    snpsift -->|germline,tumor_only,somatic| snpsift_to_vcf
+    fastqc -->|germline,tumor_only,somatic| multiqc
+    mosdepth -->|germline,tumor_only,somatic| multiqc
+    bcftools_stats -->|germline,tumor_only,somatic| multiqc

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -75,6 +75,9 @@ def validate_layout(graph: MetroGraph) -> list[Violation]:
         violations.extend(
             check_route_segment_crossings(graph, _precomputed=precomputed)
         )
+        violations.extend(
+            check_serpentine_no_backtrack(graph, _precomputed=precomputed)
+        )
     return violations
 
 
@@ -1549,6 +1552,87 @@ def check_exit_port_feeder_alignment(
                         "delta": delta,
                         "port_coord": port_coord,
                         "station_coord": st_coord,
+                    },
+                )
+            )
+
+    return violations
+
+
+def check_serpentine_no_backtrack(
+    graph: MetroGraph,
+    backtrack_frac: float = 0.5,
+    _precomputed: tuple[dict[tuple[str, str], float], list[RoutedPath]] | None = None,
+) -> list[Violation]:
+    """Stacked same-direction sections must not backtrack horizontally.
+
+    When same-direction sections are stacked in one grid column and chained
+    (issue #421), the engine serpentines their effective flow so consecutive
+    sections meet on a shared side joined by a short vertical drop.  A section
+    that fails to serpentine instead enters on the wrong side and folds its
+    internal route back across (nearly) the full section width.
+
+    For every section in a detected serpentine run, this sums the horizontal
+    travel of its internal routed segments that runs *against* the section's
+    flow direction.  If that wrong-way travel exceeds ``backtrack_frac`` of the
+    section width, the section is kinking the chain.
+    """
+    from nf_metro.layout.auto_layout import detect_serpentine_runs
+
+    violations: list[Violation] = []
+
+    if _precomputed is not None:
+        offsets, routes = _precomputed
+    else:
+        try:
+            offsets = compute_station_offsets(graph)
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:
+            return violations
+
+    dag = graph.section_dag
+    if dag is None:
+        return violations
+    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
+    serpentine_sections = {sid for run in runs for sid in run}
+    if not serpentine_sections:
+        return violations
+
+    # Internal route segments grouped by home section.
+    wrong_way: dict[str, float] = {sid: 0.0 for sid in serpentine_sections}
+    for route in routes:
+        src_sec = graph.section_for_station(route.edge.source)
+        tgt_sec = graph.section_for_station(route.edge.target)
+        if src_sec != tgt_sec or src_sec not in serpentine_sections:
+            continue
+        section = graph.sections[src_sec]
+        forward = 1.0 if section.direction != "RL" else -1.0
+        pts = apply_route_offsets(route, offsets)
+        for k in range(len(pts) - 1):
+            dx = pts[k + 1][0] - pts[k][0]
+            if dx * forward < 0:
+                wrong_way[src_sec] += abs(dx)
+
+    for sid, against in wrong_way.items():
+        section = graph.sections[sid]
+        limit = backtrack_frac * max(section.bbox_w, 1.0)
+        if against > limit:
+            violations.append(
+                Violation(
+                    check="serpentine_no_backtrack",
+                    severity=Severity.ERROR,
+                    message=(
+                        f"Stacked section '{sid}' (dir={section.direction}) "
+                        f"backtracks {against:.0f}px against its flow "
+                        f"(>{limit:.0f}px = {backtrack_frac:.0%} of width "
+                        f"{section.bbox_w:.0f}); the serpentine chain is "
+                        f"kinking instead of dropping vertically"
+                    ),
+                    context={
+                        "section": sid,
+                        "direction": section.direction,
+                        "against": against,
+                        "limit": limit,
                     },
                 )
             )

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -293,8 +293,14 @@ def test_port_side_explicit_preserved():
     assert graph.sections["sec2"].entry_hints[0][0] == PortSide.TOP
 
 
-def test_port_side_below_section():
-    """Entry from a section above gets TOP entry side."""
+def test_stacked_lr_sections_flow_aligned_ports():
+    """Stacked LR sections connect via a carriage-return wrap (#432).
+
+    A left-to-right section stacked directly below another in the same
+    grid column must present flow-aligned ports - exit RIGHT, entry LEFT -
+    not a TOP/BOTTOM vertical hop.  The inter-section router carriage-
+    returns (right -> down -> left -> down -> right) to join them.
+    """
     graph = _make_graph_with_sections(
         ["top_sec", "bottom_sec"],
         [("top_sec_s1", "top_sec", "bottom_sec_s1", "bottom_sec", "main")],
@@ -302,18 +308,41 @@ def test_port_side_below_section():
     successors, predecessors, edge_lines = _build_section_dag(graph)
     _assign_grid_positions(graph, successors, predecessors, max_station_columns=100)
 
-    # Force bottom_sec to be below top_sec
+    # Force bottom_sec to be below top_sec in the same column.
     graph.sections["top_sec"].grid_col = 0
     graph.sections["top_sec"].grid_row = 0
     graph.sections["bottom_sec"].grid_col = 0
     graph.sections["bottom_sec"].grid_row = 1
+    assert graph.sections["top_sec"].direction == "LR"
+    assert graph.sections["bottom_sec"].direction == "LR"
 
     _infer_port_sides(graph, successors, predecessors, edge_lines, set())
 
-    # Exit should be BOTTOM
-    assert graph.sections["top_sec"].exit_hints[0][0] == PortSide.BOTTOM
-    # Entry should be TOP
-    assert graph.sections["bottom_sec"].entry_hints[0][0] == PortSide.TOP
+    # Exit on the trailing (RIGHT) edge, entry on the leading (LEFT) edge.
+    assert graph.sections["top_sec"].exit_hints[0][0] == PortSide.RIGHT
+    assert graph.sections["bottom_sec"].entry_hints[0][0] == PortSide.LEFT
+
+
+def test_rl_sections_flow_aligned_ports():
+    """RL sections mirror the flow-aligned rule: entry RIGHT, exit LEFT."""
+    graph = _make_graph_with_sections(
+        ["top_sec", "bottom_sec"],
+        [("top_sec_s1", "top_sec", "bottom_sec_s1", "bottom_sec", "main")],
+    )
+    successors, predecessors, edge_lines = _build_section_dag(graph)
+    _assign_grid_positions(graph, successors, predecessors, max_station_columns=100)
+
+    graph.sections["top_sec"].grid_col = 0
+    graph.sections["top_sec"].grid_row = 0
+    graph.sections["top_sec"].direction = "RL"
+    graph.sections["bottom_sec"].grid_col = 0
+    graph.sections["bottom_sec"].grid_row = 1
+    graph.sections["bottom_sec"].direction = "RL"
+
+    _infer_port_sides(graph, successors, predecessors, edge_lines, set())
+
+    assert graph.sections["top_sec"].exit_hints[0][0] == PortSide.LEFT
+    assert graph.sections["bottom_sec"].entry_hints[0][0] == PortSide.RIGHT
 
 
 # --- Edge cases ---
@@ -349,6 +378,32 @@ def test_single_section_no_op():
 
 
 # --- Integration tests ---
+
+
+def test_stacked_sections_infer_left_entry():
+    """the stacked col-1 sections auto-infer LEFT entry ports (#432).
+
+    ``post_vc``/``annotation``/``reporting`` carry no explicit entry/exit
+    directives; with only their grid positions declared they must still
+    infer flow-aligned LEFT entries so they connect via a carriage-return
+    wrap, not enter through the right edge.
+    """
+    from nf_metro.layout.engine import compute_layout
+
+    text = (EXAMPLES / "genomic_pipeline.mmd").read_text()
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph)
+
+    for sec_id in ("post_vc", "annotation", "reporting"):
+        entries = [
+            p for p in graph.ports.values() if p.section_id == sec_id and p.is_entry
+        ]
+        assert entries, f"{sec_id} should have an entry port"
+        for port in entries:
+            assert port.side == PortSide.LEFT, (
+                f"{sec_id} entry port {port.id} inferred on {port.side.name}, "
+                "expected LEFT (flow-aligned carriage-return)"
+            )
 
 
 def test_rnaseq_auto_renders():

--- a/tests/test_edge_clearance_invariant.py
+++ b/tests/test_edge_clearance_invariant.py
@@ -1,0 +1,144 @@
+"""Inter-section descent channels must clear section bbox edges.
+
+A vertical descent channel of an inter-section route may legitimately
+sit on a section edge when it is a port-to-port connection: the descent
+x coincides with an exit or entry port that genuinely lives on that edge
+(serpentine right-exit dropping to a right-entry below, around-section
+exit drops, etc.).
+
+It is a bug when the graze is *incidental*: the descent x falls within
+``EDGE_TO_BUNDLE_CLEARANCE`` of a section bbox edge (and on the interior
+side of it) yet is NOT a port at either endpoint of the route.  The line
+then visibly grazes / crosses the section border.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.constants import EDGE_TO_BUNDLE_CLEARANCE
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+TOPOLOGIES = FIXTURES / "topologies"
+EXAMPLES = REPO_ROOT / "examples"
+
+# Tolerance for "x coincides with a port that lives on this edge".
+_PORT_TOL = 1.0
+# Tolerance for "this vertical segment is actually vertical".
+_V_TOL = 1.0
+
+
+STACKED_FIXTURE = FIXTURES / "regressions" / "stacked_collector_fanin.mmd"
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = [STACKED_FIXTURE]
+    paths.extend(sorted(TOPOLOGIES.glob("*.mmd")))
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    return paths
+
+
+def _route(path: Path):
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    return graph, routes
+
+
+def _endpoint_port_xs(graph, route) -> list[float]:
+    """X coordinates of any port stations at the route's two endpoints."""
+    xs: list[float] = []
+    for sid in (route.edge.source, route.edge.target):
+        st = graph.stations.get(sid)
+        if st is not None and getattr(st, "is_port", False):
+            xs.append(st.x)
+    return xs
+
+
+def _incidental_grazes(graph, routes) -> list[str]:
+    """Return human-readable descriptions of incidental edge grazes."""
+    violations: list[str] = []
+    for route in routes:
+        if not route.is_inter_section:
+            continue
+        pts = route.points
+        port_xs = _endpoint_port_xs(graph, route)
+        for (ax, ay), (bx, by) in zip(pts, pts[1:]):
+            if abs(bx - ax) > _V_TOL:
+                continue  # not a vertical segment
+            vx = (ax + bx) / 2
+            ylo, yhi = (ay, by) if ay <= by else (by, ay)
+            for sec in graph.sections.values():
+                if sec.bbox_w <= 0:
+                    continue
+                left = sec.bbox_x
+                right = sec.bbox_x + sec.bbox_w
+                top = sec.bbox_y
+                bot = sec.bbox_y + sec.bbox_h
+                # Vertical segment must overlap the section's Y span.
+                if yhi < top or ylo > bot:
+                    continue
+                # Distance inside each edge (positive = interior side).
+                from_left = vx - left
+                from_right = right - vx
+                grazes_left = -_V_TOL <= from_left < EDGE_TO_BUNDLE_CLEARANCE
+                grazes_right = -_V_TOL <= from_right < EDGE_TO_BUNDLE_CLEARANCE
+                if not (grazes_left or grazes_right):
+                    continue
+                # Legitimate when vx coincides with an endpoint port.
+                if any(abs(vx - px) <= _PORT_TOL for px in port_xs):
+                    continue
+                edge_x = left if grazes_left else right
+                violations.append(
+                    f"{route.edge.source} -> {route.edge.target} "
+                    f"[{route.line_id}] descent x={vx:.1f} grazes "
+                    f"section {sec.id!r} edge x={edge_x:.1f} "
+                    f"(gap {abs(vx - edge_x):.1f} < {EDGE_TO_BUNDLE_CLEARANCE})"
+                )
+    return violations
+
+
+@pytest.mark.parametrize("path", _gather_fixtures(), ids=lambda p: p.stem)
+def test_no_incidental_edge_graze(path: Path) -> None:
+    graph, routes = _route(path)
+    violations = _incidental_grazes(graph, routes)
+    assert not violations, "Incidental section-edge grazes:\n" + "\n".join(violations)
+
+
+def test_collector_merge_descent_clears_source_right_edge() -> None:
+    """Targeted check for #423.
+
+    The ``__junction_8 -> __merge_*`` MultiQC fan-in descent must sit at
+    least ``EDGE_TO_BUNDLE_CLEARANCE`` outside preprocessing's right edge.
+    """
+    graph, routes = _route(STACKED_FIXTURE)
+    prep = graph.sections["preprocessing"]
+    right_edge = prep.bbox_x + prep.bbox_w
+
+    descents: list[float] = []
+    for route in routes:
+        if route.edge.source != "__junction_8":
+            continue
+        if not route.edge.target.startswith("__merge_"):
+            continue
+        pts = route.points
+        for (ax, _ay), (bx, _by) in zip(pts, pts[1:]):
+            if abs(bx - ax) <= _V_TOL:
+                descents.append((ax + bx) / 2)
+
+    assert descents, "expected junction_8 -> merge descent segments"
+    nearest = min(descents, key=lambda x: abs(x - right_edge))
+    # Outward (the section interior is to the LEFT) means descent x must
+    # be >= right_edge + clearance.
+    assert nearest >= right_edge + EDGE_TO_BUNDLE_CLEARANCE, (
+        f"descent x={nearest:.1f} not clear of preprocessing right edge "
+        f"{right_edge:.1f} by {EDGE_TO_BUNDLE_CLEARANCE} "
+        f"(need >= {right_edge + EDGE_TO_BUNDLE_CLEARANCE:.1f})"
+    )

--- a/tests/test_fanout_tail_join_invariant.py
+++ b/tests/test_fanout_tail_join_invariant.py
@@ -77,7 +77,7 @@ def test_variant_calling_tuned_junction6_joins() -> None:
 def test_merge_junctions_excluded_from_fanout() -> None:
     """Merge junctions (>1 upstream source) must NOT be treated as
     fan-out junctions, so their trunk routing is never snapped."""
-    # sarek-style fixtures carry merge junctions; assert any junction
+    # collector-fan-in-style fixtures carry merge junctions; assert any junction
     # with multiple distinct upstream sources is excluded.
     for path in _gather_fixtures():
         graph = parse_metro_mermaid(path.read_text())

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -157,6 +157,19 @@ def _fixtures_with(predicate) -> list[str]:
 _FIXTURES_WITH_OFF_TRACK = _fixtures_with(lambda t: "off_track:" in t)
 _FIXTURES_MULTI_SECTION = _fixtures_with(lambda t: t.count("subgraph") >= 2)
 
+# Multi-section gallery fixtures plus the serpentine-stacked
+# regression.  The regression's narrow ``reporting`` column nests under the
+# wide ``preprocessing`` row-span (exposing the nested-column dog-leg
+# geometry, #425) and its ``variant_calling`` row-span (rows 1-3) separates
+# an inter-row wrap's source/target rows by a multi-row placement (#422); the
+# multi-section gallery fixtures cover the adjacent-row, non-rowspan wrap
+# (via ``topologies/stacked_lr_serpentine.mmd``).
+_FIXTURES_MULTI_SECTION_PLUS_STACK = sorted(
+    {*_FIXTURES_MULTI_SECTION, "regressions/stacked_collector_fanin.mmd"}
+)
+_FIXTURES_DOGLEG = _FIXTURES_MULTI_SECTION_PLUS_STACK
+_FIXTURES_INTER_ROW_CLEARANCE = _FIXTURES_MULTI_SECTION_PLUS_STACK
+
 
 def _fixtures_with_bypass() -> list[str]:
     """Return fixtures whose layout produces at least one ``__bypass_``
@@ -891,6 +904,227 @@ def test_inter_section_route_no_x_backtrack(fixture):
 
 
 # ---------------------------------------------------------------------------
+# Merge feeders descend the inter-column corridor, not the canvas bottom
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    sorted({*_FIXTURES_MULTI_SECTION, "genomic_pipeline.mmd"}),
+)
+def test_merge_feeder_does_not_loop_below_target(fixture):
+    """A merge-junction feeder reaching a target row *below* its source must
+    not dip far below the target section's bottom edge to reach it (#432).
+
+    A multi-row collector fan-in feeds the left-entry ``reporting`` section
+    (row 3) from QC sources that exit on the right in rows 0 and 1.  The
+    naive around-below route drops the feeder to the very bottom of the
+    canvas (below the tall ``variant_calling`` row-span), runs leftward
+    there, then climbs back up into the entry - two big loops sweeping the
+    canvas bottom.  A clear inter-column corridor exists between the source
+    and target columns: drop into the inter-row gap below the source row,
+    traverse left in that gap to the inter-column channel, then descend
+    that channel straight to the entry.  This invariant pins the corridor:
+    a downward cross-row feeder must stay within a bounded margin of the
+    target section's bottom rather than looping below everything beneath
+    it.
+
+    Scoped to *downward cross-row* feeders.  A same-row fan-in merge
+    legitimately U-routes through the inter-row gap *below* the row and
+    climbs back into a same-row target (e.g. ``03b_fan_in_merge``,
+    ``genomeassembly``); that gap-dip is the intended geometry, not a
+    canvas-bottom loop.
+    """
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    for rp in routes:
+        if not (
+            rp.edge.source.startswith("__junction")
+            and rp.edge.target.startswith("__merge")
+        ):
+            continue
+        src_sec = resolve_section(graph, graph.stations[rp.edge.source])
+        tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
+        if src_sec is None or tgt_sec is None:
+            continue
+        # Only downward cross-row feeders take the corridor; same-row
+        # fan-ins legitimately U-route through the gap below the row.
+        if tgt_sec.grid_row <= src_sec.grid_row:
+            continue
+        tgt_bottom = tgt_sec.bbox_y + tgt_sec.bbox_h
+        max_y = max(p[1] for p in rp.points)
+        # The route may sweep a little below the entry port (its descent
+        # curve) but must not loop below the target section's whole box.
+        assert max_y <= tgt_bottom + SECTION_Y_GAP + _Y_TOL, (
+            f"{fixture}: merge feeder {rp.edge.source}->{rp.edge.target} "
+            f"({rp.line_id}) dips to y={max_y:.1f}, far below the target "
+            f"section bottom {tgt_bottom:.1f} - it loops below the canvas "
+            f"instead of descending the inter-column corridor"
+        )
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    sorted({*_FIXTURES_MULTI_SECTION, "genomic_pipeline.mmd"}),
+)
+def test_junction_same_line_fans_coincide_or_separate(fixture):
+    """Two routes carrying the SAME line out of a UNIFIED-FAN junction must
+    either coincide on their source-side vertical channel or separate
+    clearly - never smear by a few px (#437).
+
+    the ``__junction_9`` (Post-processing's right exit) fans the same
+    three lines to two destinations: the spine into Annotation (a LEFT-entry
+    wrap) and the QC feed down the inter-column corridor to MultiQC.  The
+    engine assigns both a shared :func:`_compute_junction_fan_info` position
+    so they're MEANT to pivot through one channel; when their first vertical
+    channels sit 6-18px apart they read as a single smeared band rather than
+    one clean overlay.  This invariant forbids that intermediate spacing:
+    for each unified-fan junction and each line fanning to >=2 inter-section
+    targets, the first vertical legs must coincide (<= ``OFFSET_STEP`` apart,
+    i.e. within the per-bundle stagger) or be cleanly separated (>= a
+    section gap apart, the intended split when targets land in different
+    columns).
+
+    Scoped to junctions the engine treats as a unified fan (present in
+    ``junction_fan_info``); pure L-shape/bypass fans to genuinely distinct
+    columns are a separate concern.
+    """
+    from nf_metro.layout.constants import CURVE_RADIUS, DIAGONAL_RUN, OFFSET_STEP
+    from nf_metro.layout.engine import first_vertical_leg_x
+    from nf_metro.layout.routing.core import _build_routing_context
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
+    fan_sources = {key[0] for key in ctx.junction_fan_info}
+
+    # Group inter-section routes by (junction source, line).
+    by_src_line: dict[tuple[str, str], list] = defaultdict(list)
+    for rp in routes:
+        if not rp.is_inter_section or rp.edge.source not in fan_sources:
+            continue
+        vx = first_vertical_leg_x(rp.points)
+        if vx is None:
+            continue
+        by_src_line[(rp.edge.source, rp.line_id)].append((rp, vx))
+
+    coincide_tol = OFFSET_STEP + _Y_TOL
+    separate_min = SECTION_Y_GAP
+    for (src, line), entries in by_src_line.items():
+        if len(entries) < 2:
+            continue
+        xs = sorted(vx for _rp, vx in entries)
+        for lo, hi in zip(xs, xs[1:]):
+            gap = hi - lo
+            assert gap <= coincide_tol or gap >= separate_min, (
+                f"{fixture}: junction {src} line {line} fans two routes "
+                f"whose first vertical channels are {gap:.1f}px apart "
+                f"(x={lo:.1f} vs {hi:.1f}) - neither coincident "
+                f"(<= {coincide_tol:.1f}) nor clearly separated "
+                f"(>= {separate_min:.1f}); a smeared partial overlap"
+            )
+
+
+@pytest.mark.parametrize("fixture", sorted({*_FIXTURES_MULTI_SECTION_PLUS_STACK}))
+def test_inter_section_route_no_full_width_dogleg_clean(fixture):
+    """No merge feeder takes a full-width out-and-back dog-leg (#432).
+
+    The corridor route's long leftward traverse in the inter-row gap is a
+    monotonic approach toward the target, not a backtrack, so the refined
+    full-width guard passes on now.
+    """
+    from nf_metro.layout.engine import (
+        _canvas_width,
+        inter_section_route_backtrack_legs,
+    )
+
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+    canvas_width = _canvas_width(graph)
+    assert canvas_width > 0
+    limit = 0.4 * canvas_width
+    for rp, x1, x2 in inter_section_route_backtrack_legs(graph, routes):
+        span = abs(x2 - x1)
+        assert span <= limit + _Y_TOL, (
+            f"{fixture}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
+            f"backtracks {span:.1f}px in one leg (x={x1:.1f}->{x2:.1f}), "
+            f"exceeding 40% of canvas width {canvas_width:.1f}"
+        )
+
+
+# a multi-row collector fan-in now descends the shared inter-column corridor into
+# the left-entry ``reporting`` section, so the feeders are X-monotonic toward
+# the target and no longer trip the full-width dog-leg guard.
+_XFAIL_DOGLEG: dict[str, str] = {}
+
+
+@pytest.mark.parametrize(
+    "fixture", _params_with_xfails(_FIXTURES_DOGLEG, _XFAIL_DOGLEG)
+)
+def test_inter_section_route_no_full_width_dogleg(fixture):
+    """A forward inter-section route may reverse in X to reach a target
+    column nested inside an oversized sibling, but no single backtrack leg
+    may sweep more than 40% of the canvas width (#425).
+
+    The strict X-monotonic guard above forbids *any* reversal on a forward
+    LR route and skips wrapping (``normalize_exempt``) routes.  When a
+    narrow target column nests inside an oversized sibling, reaching it
+    requires a legitimate reversal, so such routes are exempt.  This still
+    bounds those reversals: a right-then-left dog-leg sweeping the whole
+    diagram is forbidden even when exempt.
+    """
+    from nf_metro.layout.engine import (
+        _canvas_width,
+        inter_section_route_backtrack_legs,
+    )
+
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+    canvas_width = _canvas_width(graph)
+    assert canvas_width > 0
+    limit = 0.4 * canvas_width
+    for rp, x1, x2 in inter_section_route_backtrack_legs(graph, routes):
+        span = abs(x2 - x1)
+        assert span <= limit + _Y_TOL, (
+            f"{fixture}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
+            f"backtracks {span:.1f}px in one leg (x={x1:.1f}->{x2:.1f}), "
+            f"exceeding 40% of canvas width {canvas_width:.1f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Routes enter/leave sections only at declared ports
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION_PLUS_STACK)
+def test_routes_enter_sections_only_at_ports(fixture):
+    """No routed segment may cross a section bbox boundary except within
+    tolerance of a declared port (#432).
+
+    A line that slices through a section box anywhere other than a port is
+    visually entering/leaving where nothing invites it - the symptom of a
+    port inferred on the wrong side (so the connector cuts the box) or a
+    fan-in bundle ploughing into a section through an undeclared edge.
+    """
+    from nf_metro.layout.engine import _route_crosses_section_boundary
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    hit = _route_crosses_section_boundary(graph, routes)
+    assert hit is None, (
+        f"{fixture}: route {hit[0].edge.source}->{hit[0].edge.target} "
+        f"({hit[0].line_id}) crosses section {hit[1]!r} boundary at "
+        f"({hit[2]:.1f}, {hit[3]:.1f}) away from any declared port"
+        if hit is not None
+        else ""
+    )
+
+
+# ---------------------------------------------------------------------------
 # Inter-row horizontal channels keep clearance from the source section
 # ---------------------------------------------------------------------------
 
@@ -905,7 +1139,7 @@ def _section_bbox(sec) -> tuple[float, float, float, float]:
     return sec.bbox_x, sec.bbox_x + sec.bbox_w, sec.bbox_y, sec.bbox_y + sec.bbox_h
 
 
-@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+@pytest.mark.parametrize("fixture", _FIXTURES_INTER_ROW_CLEARANCE)
 def test_inter_row_run_clears_source_section(fixture):
     """A horizontal leg of an inter-*row* route must not graze its source
     section's bbox edge.
@@ -2608,7 +2842,15 @@ def _icon_x_extent(graph: MetroGraph, station, section) -> tuple[float, float]:
     return cx - icon_half_w, cx + icon_half_w
 
 
-@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+# a multi-row collector fan-in now descends the inter-column corridor into the
+# left-entry ``reporting`` section instead of sweeping the reporting row's
+# full width, so the merge bundle no longer crosses the file icons (#432).
+_XFAIL_ICON_OVERLAP: dict[str, str] = {}
+
+
+@pytest.mark.parametrize(
+    "fixture", _params_with_xfails(ALL_FIXTURES, _XFAIL_ICON_OVERLAP)
+)
 def test_no_icon_overlaps_line_path(fixture):
     """A station's rendered file icon must not be crossed by routed line
     segments belonging to lines the station neither produces nor consumes.

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -323,7 +323,7 @@ def test_around_section_below_dispatched_for_cross_row_left_entry():
     reached from the opposite-row source when the natural inter-row
     channel would cut through an intervening section's bbox.
 
-    Mirrors the sarek section 1 -> section 5 LEFT-entry geometry: 3-row
+    Mirrors a row-0 source to lower-row LEFT-entry geometry: 3-row
     layout with target in the bottom row, source in the top row to the
     right of target, and an intervening section in the middle row whose
     bbox falls in the inter-row channel's Y range.

--- a/tests/test_svg_paths.py
+++ b/tests/test_svg_paths.py
@@ -8,6 +8,7 @@ RoutedPath waypoints + curve_radii into well-formed SVG paths with:
 - Concentric bundle lines maintaining distinct radii through curves
 """
 
+import math
 import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -530,3 +531,125 @@ class TestLineZOrderConsistent:
     def test_topology_fixtures(self, fixture):
         _, _, _, svg = _layout_and_route_file(fixture)
         self._check(svg)
+
+
+# ---------------------------------------------------------------------------
+# 8. Concentric arc centers must coincide across a bundle at every corner
+# ---------------------------------------------------------------------------
+
+
+def _arc_center(prev, curr, nxt, r):
+    """Center of the rounded-corner arc at vertex *curr* with radius *r*.
+
+    For an axis-aligned 90-degree turn the center lies *r* along each of the
+    two incident segment directions from the vertex (i.e. along the inward
+    normals).  ``center = curr + r*(unit(prev-curr) + unit(nxt-curr))``.
+    """
+
+    def unit(a, b):
+        dx, dy = b[0] - a[0], b[1] - a[1]
+        d = math.hypot(dx, dy)
+        return (0.0, 0.0) if d == 0 else (dx / d, dy / d)
+
+    u1 = unit(curr, prev)
+    u2 = unit(curr, nxt)
+    return (curr[0] + r * (u1[0] + u2[0]), curr[1] + r * (u1[1] + u2[1]))
+
+
+def _corridor_descent_channel_x(pts) -> float | None:
+    """X of a routed path's inter-column descent channel, or None.
+
+    The MultiQC-corridor feeders (#432) traverse the inter-row gap LEFTWARD
+    (a long >150px horizontal run) and immediately turn DOWN into a tall
+    (>150px) inter-column channel.  This long-leftward-then-long-down
+    signature distinguishes corridor descents from short L-shape / bypass
+    turns and from fan-out lead-ins, so the concentricity check stays scoped
+    to the corridor curves.  Returns the descent channel x.
+    """
+    for j in range(len(pts) - 2):
+        ax, ay = pts[j]
+        bx, by = pts[j + 1]
+        cx, cy = pts[j + 2]
+        leftward = abs(ay - by) < 1 and (ax - bx) > 150
+        down = abs(bx - cx) < 1 and (cy - by) > 150
+        if leftward and down:
+            return bx
+    return None
+
+
+class TestConcentricArcCenters:
+    """Corridor bundle lines must share an arc center at every shared corner.
+
+    Distinct radii (TestConcentricBundles) are necessary but not sufficient
+    for visually concentric corners: if two lines turn the same corner with
+    radii r and r+step but *different* arc centers, they splay apart through
+    the turn ("delamination").  True concentricity requires every line in the
+    bundle to pivot about the SAME center at each corner, with radii spaced by
+    the bundle step.  This pins the MultiQC-corridor curves (#432/#435), whose
+    feeders co-route from one junction source, against delamination.
+    """
+
+    # An L-shape staggers lines by offset_step in the channel; concentric
+    # centers must agree to within a fraction of that step.
+    CENTER_EPS = 1.5
+
+    def _check(self, routes, offsets):
+        from collections import defaultdict
+
+        # A corridor bundle is the per-line fan from one junction source that
+        # shares one descent channel (the feeder lines that travel together).
+        # Group by (source, channel) so unrelated routes from the same source
+        # are not conflated.
+        bundles: dict[tuple[str, int], list[RoutedPath]] = defaultdict(list)
+        for r in routes:
+            if not r.is_inter_section or not r.curve_radii:
+                continue
+            pts = apply_route_offsets(r, offsets)
+            vx = _corridor_descent_channel_x(pts)
+            if vx is None:
+                continue
+            bundles[(r.edge.source, round(vx / 10))].append(r)
+
+        for src, bundle in bundles.items():
+            if len(bundle) < 2:
+                continue
+            applied = [(r, apply_route_offsets(r, offsets)) for r in bundle]
+            # Compare corner-by-corner only when the bundle shares structure.
+            if any(len(pts) - 2 != len(r.curve_radii) for r, pts in applied):
+                continue
+            n_corners = min(len(r.curve_radii) for r, _ in applied)
+            for corner_idx in range(n_corners):
+                centers = [
+                    _arc_center(
+                        pts[corner_idx],
+                        pts[corner_idx + 1],
+                        pts[corner_idx + 2],
+                        r.curve_radii[corner_idx],
+                    )
+                    for r, pts in applied
+                ]
+                cx = [c[0] for c in centers]
+                cy = [c[1] for c in centers]
+                spread = max(max(cx) - min(cx), max(cy) - min(cy))
+                assert spread <= self.CENTER_EPS, (
+                    f"Corridor bundle from {src!r} corner {corner_idx}: arc "
+                    f"centers splay by {spread:.2f}px (>{self.CENTER_EPS}); "
+                    f"lines delaminate through the turn. "
+                    f"centers={[(round(x, 1), round(y, 1)) for x, y in centers]}"
+                )
+
+    def test_stacked_collector_corridor(self):
+        fixture = EXAMPLES_DIR / "genomic_pipeline.mmd"
+        if not fixture.exists():
+            pytest.skip(f"fixture not available: {fixture}")
+        _, routes, offsets, _ = _layout_and_route_file(fixture)
+        self._check(routes, offsets)
+
+    @pytest.mark.parametrize(
+        "fixture",
+        sorted(TOPOLOGIES_DIR.glob("*.mmd")),
+        ids=lambda p: p.stem,
+    )
+    def test_topology_fixtures(self, fixture):
+        _, routes, offsets, _ = _layout_and_route_file(fixture)
+        self._check(routes, offsets)

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -147,6 +147,46 @@ class TestTopologyValidation:
             )
 
 
+# --- Serpentine stacked-section invariant (issue #421) ---
+
+# Fixtures known to contain a serpentine run of stacked, chained,
+# same-direction single-cell sections in one grid column. The new
+# stacked_lr_serpentine fixture is the targeted case; variantbenchmarking_auto
+# is an existing gallery pipeline whose Variant Filtering -> Benchmarking
+# sections stack in one column, so the invariant must generalise to it.
+SERPENTINE_FILES = [
+    TOPOLOGIES_DIR / "stacked_lr_serpentine.mmd",
+    EXAMPLES_DIR / "variantbenchmarking_auto.mmd",
+]
+SERPENTINE_IDS = [f.stem for f in SERPENTINE_FILES]
+
+
+@pytest.mark.parametrize("path", SERPENTINE_FILES, ids=SERPENTINE_IDS)
+def test_stacked_sections_serpentine_no_backtrack(path):
+    """Stacked same-direction sections must connect via vertical drops.
+
+    Each section in a detected serpentine run must flow internally without
+    folding its route back across the section width: a section that fails to
+    alternate direction would enter on the wrong side and wrap around. This
+    test fails on the pre-#421 engine, which inferred LR for every stacked
+    section regardless of position.
+    """
+    from layout_validator import check_serpentine_no_backtrack
+
+    from nf_metro.layout.auto_layout import detect_serpentine_runs
+
+    graph = _load_and_layout(path)
+
+    dag = graph.section_dag
+    assert dag is not None
+    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
+    assert runs, f"{path.stem}: expected at least one serpentine run to exist"
+
+    violations = check_serpentine_no_backtrack(graph)
+    errors = [v for v in violations if v.severity == Severity.ERROR]
+    assert not errors, "\n".join(v.message for v in errors)
+
+
 # --- Layout-quality warning reporter ---
 #
 # The intra-section-chain and exit-port-feeder validators emit WARNING-level


### PR DESCRIPTION
## Summary
Adds layout/routing capabilities for **vertically-stacked same-direction sections** and **collector fan-ins**, plus a multi-section example that exercises them. Consolidates a long line of incremental work into one reviewable change.

### Layout
- **Flow-aligned port inference**: a left-to-right section stacked below another in the same grid column auto-infers a left entry / right exit, so it connects to the section below via a carriage-return wrap - no explicit `%%metro entry:/exit:` directives. Reads explicit grid overrides via `_effective_grid_pos`. Sections fed by a vertical-drop (TB/fold) predecessor directly above keep their clean TOP entry.

### Routing
- **Inter-column corridor**: downward cross-row merge feeders descend a shared corridor (inter-row gap then inter-column channel) into a left entry, instead of looping around the canvas bottom.
- **Collector merge-junction placement** near its target when the target is left of the sources; a junction's same-line spine and feeder bundles **coincide** into one clean bundle.
- Inter-section edge clearance, stepped descent (no full-width dog-leg), rowspan inter-row wrap-gap reservation.
- **New `validate=True` guards**: routes enter a section only at a declared port; no full-width backtrack; fan bundles coincide-or-separate; inter-row run clearance.

### Example / tests
- A multi-section example (`examples/genomic_pipeline.mmd`) demonstrating the stacked-serpentine + collector-corridor layout, wired into the gallery.
- A stacked collector-fan-in regression fixture and parametrised invariants (corridor, edge clearance, port-entry, concentric-curve centres).

## Gallery impact
Existing renders are byte-identical to `main` **except**:
- `topologies/around_section_below` - intended edge-clearance improvement (descent no longer grazes the section edge).
- `examples/variantbenchmarking_auto` - one RL section's entry flow-aligns to a clean right-side drop (matches its predecessor's right exit); renders cleanly, no new kinks.

(New: `genomic_pipeline`, `topologies/stacked_lr_serpentine`.)

## Test plan
- [ ] `pytest` (3548 passed locally incl. new invariants)
- [ ] `ruff check` + `ruff format --check` clean
- [ ] CI render-preview reviewed: the two deltas above are improvement/neutral

## Notes
- Follow-ups tracked separately: code-cleanup pass (#442), bottom-right logo placement (#440), bridge/hop glyph for non-merging crossings (#439). Full development history preserved on `backup/stacked-pipeline-render`.

Generated with Claude Code