### PR TITLE
fix(layout): collapse reserved absent-line slots at partial fan branches

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -137,6 +137,9 @@ COORD_TOLERANCE: float = 1.0
 COORD_TOLERANCE_FINE: float = 0.01
 """Fine tolerance for detecting nearly identical Y coordinates."""
 
+SAME_Y_TOLERANCE: float = 0.1
+"""Tolerance for treating two stations as sharing a base Y row."""
+
 CROSS_ROW_THRESHOLD: float = 80.0
 """Y gap threshold for detecting cross-row (fold) edges."""
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1241,6 +1241,36 @@ def _guard_merge_port_approach_side(
     raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
 
 
+def _guard_partial_branch_offset_gaps(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict | None = None,
+) -> None:
+    """Final-phase: under ``compact_offsets``, an independent fan branch
+    that carries only a subset of a bundle's lines must place them on
+    consecutive offset slots, not reserve an empty interior slot for the
+    lines it omits (which parks its marker off-centre with a gap).
+
+    See
+    :func:`nf_metro.layout.routing.invariants.check_partial_branch_offset_gaps`
+    for the semantic definition.
+    """
+    from nf_metro.layout.routing.invariants import check_partial_branch_offset_gaps
+
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
+
+        offsets = compute_station_offsets(graph)
+
+    violations = check_partial_branch_offset_gaps(graph, offsets)
+    if not violations:
+        return
+    first = violations[0]
+    extra = f" (+{len(violations) - 1} more)" if len(violations) > 1 else ""
+    raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
+
+
 def _guard_fanout_tail_join(
     graph: MetroGraph,
     phase: str,
@@ -2413,6 +2443,7 @@ def _compute_section_layout(
         _guard_off_track_inputs_above_consumer(graph, phase)
         _guard_fanout_junction_shares_exit_port_y(graph, phase)
         _guard_merge_port_approach_side(graph, phase, offsets=offsets)
+        _guard_partial_branch_offset_gaps(graph, phase, offsets=offsets)
         _guard_row_gaps(graph, phase, section_y_gap=section_y_gap)
         _guard_section_top_padding(
             graph,

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -21,17 +21,18 @@ gallery example and topology fixture.
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 
-from nf_metro.layout.constants import COORD_TOLERANCE_FINE
+from nf_metro.layout.constants import COORD_TOLERANCE_FINE, OFFSET_STEP
 from nf_metro.layout.routing.common import (
     Direction,
     RoutedPath,
     horizontal_direction,
     vertical_direction,
 )
-from nf_metro.parser.model import PortSide
+from nf_metro.parser.model import MetroGraph, PortSide
 
 # Segments shorter than this are sub-pixel artefacts of per-line
 # offsets and carry no meaningful direction of travel.
@@ -515,14 +516,139 @@ def check_merge_port_approach_side(
     return violations
 
 
+# ---------------------------------------------------------------------------
+# Partial-line fan-branch offset gaps
+# ---------------------------------------------------------------------------
+
+# Two stations share a base Y row when their centres are within this many
+# px; matches the offset module's same-Y tolerance.
+_SAME_Y_TOL = 0.1
+
+
+def _distinct_levels(values: Iterable[float]) -> list[float]:
+    """Return ascending offset levels, merging values within tolerance.
+
+    Coincident lines (offsets within ``COORD_TOLERANCE_FINE``) collapse
+    to a single level so they are treated as one occupied slot.
+    """
+    levels: list[float] = []
+    for v in sorted(values):
+        if not levels or v - levels[-1] > COORD_TOLERANCE_FINE:
+            levels.append(v)
+    return levels
+
+
+def is_independent_fan_branch(graph: MetroGraph, station_id: str) -> bool:
+    """Return whether a station is an independent fan branch.
+
+    Such a station carries two or more lines that all arrive from a
+    fan-out and leave to a fan-in at other rows: it has no edge to a
+    same-section neighbour on its own base Y, so no straight horizontal
+    through-track runs through its marker.  Re-compacting its present
+    lines onto consecutive offset slots therefore cannot bend a shared
+    track - the only connections are the fan-out / fan-in curves, which
+    bend regardless.
+
+    A station with a same-Y same-section neighbour (a port, a hidden
+    pass-through, or another station) is excluded: its lines genuinely
+    run straight across that neighbour and must keep their bundle slots.
+    """
+    st = graph.stations.get(station_id)
+    if st is None or st.is_port or st.is_hidden or st.section_id is None:
+        return False
+    if station_id in graph.junctions:
+        return False
+    if len(graph.station_lines(station_id)) < 2:
+        return False
+    for edge in graph.edges:
+        if edge.source == station_id:
+            other_id = edge.target
+        elif edge.target == station_id:
+            other_id = edge.source
+        else:
+            continue
+        other = graph.stations.get(other_id)
+        if other is None or other.section_id != st.section_id:
+            continue
+        if abs(other.y - st.y) <= _SAME_Y_TOL:
+            return False
+    return True
+
+
+@dataclass(frozen=True)
+class PartialBranchGapViolation:
+    """An independent fan branch whose present lines reserve an absent
+    line's offset slot, leaving a gap in its marker.
+
+    ``offsets`` is the sorted ``(line_id, offset)`` tuple of the lines
+    the station actually carries; the gap is the missing slot between
+    two of them.
+    """
+
+    station_id: str
+    offsets: tuple[tuple[str, float], ...]
+
+    def message(self) -> str:
+        slots = ", ".join(f"{lid}={off:.1f}" for lid, off in self.offsets)
+        return (
+            f"station {self.station_id!r} is an independent fan branch but "
+            f"its lines reserve an absent-line slot ({slots}); present lines "
+            f"must occupy consecutive offset slots with no gap"
+        )
+
+
+def check_partial_branch_offset_gaps(
+    graph: MetroGraph,
+    offsets: dict[tuple[str, str], float],
+    *,
+    offset_step: float = OFFSET_STEP,
+) -> list[PartialBranchGapViolation]:
+    """Return independent fan branches whose marker reserves an absent slot.
+
+    Only meaningful under ``compact_offsets``: that mode promises to
+    tighten bundle spacing, so a partial-line branch should sit on
+    consecutive slots rather than reserve a gap for lines it does not
+    carry.  In non-compact mode lines keep globally reserved slots by
+    design, so the check is a no-op there.
+    """
+    if not graph.compact_offsets:
+        return []
+    violations: list[PartialBranchGapViolation] = []
+    for sid in graph.stations:
+        if not is_independent_fan_branch(graph, sid):
+            continue
+        sorted_offs = sorted(
+            (offsets.get((sid, lid), 0.0), lid) for lid in graph.station_lines(sid)
+        )
+        levels = _distinct_levels(off for off, _ in sorted_offs)
+        # A reserved absent-line slot is an interior gap between two
+        # distinct occupied levels wider than one step.  Lines that share
+        # a level (coincident) collapse to one level and never trip this.
+        has_gap = any(
+            levels[i + 1] - levels[i] > offset_step + COORD_TOLERANCE_FINE
+            for i in range(len(levels) - 1)
+        )
+        if has_gap:
+            violations.append(
+                PartialBranchGapViolation(
+                    station_id=sid,
+                    offsets=tuple((lid, off) for off, lid in sorted_offs),
+                )
+            )
+    return violations
+
+
 __all__ = [
     "BundleOrderViolation",
     "FanoutTailGap",
     "MergePortApproachViolation",
+    "PartialBranchGapViolation",
     "Side",
     "check_bundle_order_preserved",
     "check_fanout_tail_join",
     "check_merge_port_approach_side",
+    "check_partial_branch_offset_gaps",
     "classify_merge_port_feeders",
     "fanout_junctions",
+    "is_independent_fan_branch",
 ]

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -25,7 +25,11 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 
-from nf_metro.layout.constants import COORD_TOLERANCE_FINE, OFFSET_STEP
+from nf_metro.layout.constants import (
+    COORD_TOLERANCE_FINE,
+    OFFSET_STEP,
+    SAME_Y_TOLERANCE,
+)
 from nf_metro.layout.routing.common import (
     Direction,
     RoutedPath,
@@ -520,12 +524,8 @@ def check_merge_port_approach_side(
 # Partial-line fan-branch offset gaps
 # ---------------------------------------------------------------------------
 
-# Two stations share a base Y row when their centres are within this many
-# px; matches the offset module's same-Y tolerance.
-_SAME_Y_TOL = 0.1
 
-
-def _distinct_levels(values: Iterable[float]) -> list[float]:
+def distinct_offset_levels(values: Iterable[float]) -> list[float]:
     """Return ascending offset levels, merging values within tolerance.
 
     Coincident lines (offsets within ``COORD_TOLERANCE_FINE``) collapse
@@ -560,17 +560,13 @@ def is_independent_fan_branch(graph: MetroGraph, station_id: str) -> bool:
         return False
     if len(graph.station_lines(station_id)) < 2:
         return False
-    for edge in graph.edges:
-        if edge.source == station_id:
-            other_id = edge.target
-        elif edge.target == station_id:
-            other_id = edge.source
-        else:
-            continue
+    neighbours = [e.target for e in graph.edges_from(station_id)]
+    neighbours += [e.source for e in graph.edges_to(station_id)]
+    for other_id in neighbours:
         other = graph.stations.get(other_id)
         if other is None or other.section_id != st.section_id:
             continue
-        if abs(other.y - st.y) <= _SAME_Y_TOL:
+        if abs(other.y - st.y) <= SAME_Y_TOLERANCE:
             return False
     return True
 
@@ -620,7 +616,7 @@ def check_partial_branch_offset_gaps(
         sorted_offs = sorted(
             (offsets.get((sid, lid), 0.0), lid) for lid in graph.station_lines(sid)
         )
-        levels = _distinct_levels(off for off, _ in sorted_offs)
+        levels = distinct_offset_levels(off for off, _ in sorted_offs)
         # A reserved absent-line slot is an interior gap between two
         # distinct occupied levels wider than one step.  Lines that share
         # a level (coincident) collapse to one level and never trip this.
@@ -649,6 +645,7 @@ __all__ = [
     "check_merge_port_approach_side",
     "check_partial_branch_offset_gaps",
     "classify_merge_port_feeders",
+    "distinct_offset_levels",
     "fanout_junctions",
     "is_independent_fan_branch",
 ]

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -5,13 +5,21 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import dataclass, field
 
-from nf_metro.layout.constants import OFFSET_STEP
-from nf_metro.layout.routing.invariants import classify_merge_port_feeders
+from nf_metro.layout.constants import (
+    COORD_TOLERANCE_FINE,
+    OFFSET_STEP,
+    SAME_Y_TOLERANCE,
+)
+from nf_metro.layout.routing.invariants import (
+    check_partial_branch_offset_gaps,
+    classify_merge_port_feeders,
+    distinct_offset_levels,
+)
 from nf_metro.layout.routing.reversal import detect_reversed_sections
 from nf_metro.parser.model import MetroGraph, PortSide
 
 # Tolerances used across offset phases
-_SAME_Y_TOLERANCE: float = 0.1
+_SAME_Y_TOLERANCE: float = SAME_Y_TOLERANCE
 _OFFSET_EQ_TOLERANCE: float = 0.001
 
 
@@ -1165,27 +1173,18 @@ def _recenter_partial_fan_branches(ctx: _OffsetCtx) -> None:
     if not ctx.compact:
         return
 
-    from nf_metro.layout.routing.invariants import check_partial_branch_offset_gaps
-
-    graph = ctx.graph
     for violation in check_partial_branch_offset_gaps(
-        graph, ctx.offsets, offset_step=ctx.offset_step
+        ctx.graph, ctx.offsets, offset_step=ctx.offset_step
     ):
-        sid = violation.station_id
-        lines = graph.station_lines(sid)
-        levels: list[float] = []
-        for off in sorted(ctx.offsets.get((sid, lid), 0.0) for lid in lines):
-            if not levels or off - levels[-1] > _OFFSET_EQ_TOLERANCE:
-                levels.append(off)
+        levels = distinct_offset_levels(off for _, off in violation.offsets)
         base = levels[0]
-        for lid in lines:
-            cur = ctx.offsets.get((sid, lid), 0.0)
+        for lid, cur in violation.offsets:
             idx = next(
                 i
                 for i, lvl in enumerate(levels)
-                if abs(lvl - cur) <= _OFFSET_EQ_TOLERANCE
+                if abs(lvl - cur) <= COORD_TOLERANCE_FINE
             )
-            ctx.offsets[(sid, lid)] = base + idx * ctx.offset_step
+            ctx.offsets[(violation.station_id, lid)] = base + idx * ctx.offset_step
 
 
 def _reconcile_horizontal_offsets(ctx: _OffsetCtx, max_iterations: int = 10) -> None:

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -1146,6 +1146,48 @@ def _apply_offsets_through_section(
             queue.append(tgt_id)
 
 
+def _recenter_partial_fan_branches(ctx: _OffsetCtx) -> None:
+    """Collapse reserved absent-line slots at independent fan branches.
+
+    :func:`_apply_compact_section_consistency` gives every multi-line
+    station the section-wide slot map so straight through-lines keep
+    aligned slots.  An independent fan branch (its lines enter from a
+    fan-out and leave to a fan-in, with no straight horizontal
+    through-track to a same-Y neighbour) thereby reserves an empty slot
+    for any bundle line it does not carry, parking its marker off-centre
+    with a visible gap.
+
+    Remap such a station's distinct offset levels onto consecutive slots
+    anchored at its top line.  This removes interior gaps while
+    preserving line order and any coincident lines, and cannot bend a
+    shared track since the branch has none (compact mode only).
+    """
+    if not ctx.compact:
+        return
+
+    from nf_metro.layout.routing.invariants import check_partial_branch_offset_gaps
+
+    graph = ctx.graph
+    for violation in check_partial_branch_offset_gaps(
+        graph, ctx.offsets, offset_step=ctx.offset_step
+    ):
+        sid = violation.station_id
+        lines = graph.station_lines(sid)
+        levels: list[float] = []
+        for off in sorted(ctx.offsets.get((sid, lid), 0.0) for lid in lines):
+            if not levels or off - levels[-1] > _OFFSET_EQ_TOLERANCE:
+                levels.append(off)
+        base = levels[0]
+        for lid in lines:
+            cur = ctx.offsets.get((sid, lid), 0.0)
+            idx = next(
+                i
+                for i, lvl in enumerate(levels)
+                if abs(lvl - cur) <= _OFFSET_EQ_TOLERANCE
+            )
+            ctx.offsets[(sid, lid)] = base + idx * ctx.offset_step
+
+
 def _reconcile_horizontal_offsets(ctx: _OffsetCtx, max_iterations: int = 10) -> None:
     """Snap offsets for same-section edges where endpoints share base Y.
 
@@ -1256,6 +1298,9 @@ def compute_station_offsets(
        bundle slot nearest its approach side (non-compact only).
     8. **Horizontal reconciliation** - snaps mismatched offsets on
        same-Y edges to eliminate almost-horizontal slopes.
+    9. **Partial fan-branch re-centring** - collapses reserved
+       absent-line slots at independent fan branches so a partial-line
+       station's marker has no interior gap (compact only).
 
     Returns dict mapping (station_id, line_id) -> y_offset.
     """
@@ -1271,4 +1316,5 @@ def compute_station_offsets(
     _align_junction_to_entry_port(ctx)
     _allocate_merge_ports_by_approach(ctx)
     _reconcile_horizontal_offsets(ctx)
+    _recenter_partial_fan_branches(ctx)
     return ctx.offsets

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -156,6 +156,7 @@ def _fixtures_with(predicate) -> list[str]:
 
 _FIXTURES_WITH_OFF_TRACK = _fixtures_with(lambda t: "off_track:" in t)
 _FIXTURES_MULTI_SECTION = _fixtures_with(lambda t: t.count("subgraph") >= 2)
+_FIXTURES_COMPACT = _fixtures_with(lambda t: "compact_offsets: true" in t)
 
 # Multi-section gallery fixtures plus the serpentine-stacked
 # regression.  The regression's narrow ``reporting`` column nests under the
@@ -4197,5 +4198,34 @@ def test_merge_port_rejoining_line_takes_approach_slot(fixture):
     violations = check_merge_port_approach_side(graph, offsets)
     assert violations == [], (
         f"{fixture}: {len(violations)} merge-port approach-side "
+        f"violation(s); first: {violations[0].message() if violations else ''}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Partial-line fan branches must not reserve absent-line offset slots
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_COMPACT)
+def test_partial_fan_branch_has_no_offset_gap(fixture):
+    """Under ``compact_offsets``, an independent fan branch that carries
+    only a subset of a bundle's lines must place those lines on
+    consecutive offset slots, not reserve an empty slot for the lines it
+    omits.
+
+    Catches the genomic_pipeline Variant-calling regression where
+    ``strelka``/``indexcov`` (germline + somatic, no tumor_only) parked
+    their two lines in the top and bottom of three reserved slots,
+    leaving a visible gap where the absent ``tumor_only`` track would be
+    (issue #443).
+    """
+    from nf_metro.layout.routing.invariants import check_partial_branch_offset_gaps
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    violations = check_partial_branch_offset_gaps(graph, offsets)
+    assert violations == [], (
+        f"{fixture}: {len(violations)} partial-branch offset-gap "
         f"violation(s); first: {violations[0].message() if violations else ''}"
     )


### PR DESCRIPTION
## Summary

Under `compact_offsets`, a station that carries only a subset of a bundle's lines reserved the absent lines' offset slots, parking its marker off-centre with a visible gap where the missing line's track would be. In `examples/genomic_pipeline.mmd` the Variant-calling fan showed this on `strelka`/`indexcov` (germline + somatic, no `tumor_only`): their two lines sat in the top and bottom of three reserved slots with an empty middle.

This adds a final offset phase, `_recenter_partial_fan_branches`, that remaps an independent fan branch's distinct offset levels onto consecutive slots anchored at its top line. It is gated on `is_independent_fan_branch` (a station with no same-Y same-section neighbour, i.e. no straight horizontal through-track), so a station whose lines genuinely run straight across a neighbour is never re-centred and no line is bent. Coincident lines are preserved.

The shared `check_partial_branch_offset_gaps` / `is_independent_fan_branch` helpers in `routing/invariants.py` back both a new parametrized invariant test and the `_guard_partial_branch_offset_gaps` runtime validator.

Fixes #443

## Behaviour

- `strelka`/`indexcov` markers are centred on their two lines with no reserved-slot gap; full-bundle callers (freebayes, mpileup, ...) are unchanged.
- The same bug class in `topologies/funcprofiler_upstream.mmd` (per-tool db + own-line + multiqc markers) is also collapsed.
- Non-`compact_offsets` graphs are unaffected (the check is a no-op there).

## Test plan
- [x] pytest passes including the new parametrized invariant `test_partial_fan_branch_has_no_offset_gap` (verified failing on `main`, passing with the fix)
- [x] `ruff check` + `ruff format --check` clean on `src/ tests/`
- [x] Runtime validator `_guard_partial_branch_offset_gaps` wired into `compute_layout(validate=True)`
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/444/)
- [x] Render-preview verdict: one intended delta on `genomic_pipeline.mmd` (strelka/indexcov gap collapsed); no other gallery renders changed

Generated with Claude Code
