### PR TITLE
refactor(routing): dedup helpers, guard efficiency, backtrack unification (#442 follow-up)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -622,6 +622,15 @@ def _guard_inter_section_routes_in_row_band(
                 )
 
 
+def _ensure_routes(graph: MetroGraph, routes: list | None) -> list:
+    """Return *routes*, routing all edges first if the caller didn't supply them."""
+    if routes is not None:
+        return routes
+    from nf_metro.layout.routing import route_edges
+
+    return route_edges(graph)
+
+
 def _route_exit_side(graph: MetroGraph, rp) -> PortSide | None:
     """Side of the port a route exits through (directly or via its feeder)."""
     port = graph.ports.get(rp.edge.source)
@@ -710,10 +719,7 @@ def _guard_inter_section_route_no_backtrack(
     """
     from nf_metro.layout.routing.common import resolve_section
 
-    if routes is None:
-        from nf_metro.layout.routing import route_edges
-
-        routes = route_edges(graph)
+    routes = _ensure_routes(graph, routes)
 
     for rp, x1, x2 in _inter_section_backtrack_legs(
         graph, routes, reference="grid", tolerance=GUARD_TOLERANCE
@@ -735,7 +741,7 @@ def first_vertical_leg_x(points) -> float | None:
     ``None`` when no vertical leg exists.
     """
     for (x0, y0), (x1, y1) in zip(points, points[1:]):
-        if abs(x1 - x0) < 1.0 and abs(y1 - y0) > 1.0:
+        if abs(x1 - x0) < COORD_TOLERANCE and abs(y1 - y0) > COORD_TOLERANCE:
             return x1
     return None
 
@@ -852,10 +858,7 @@ def _guard_inter_section_route_no_full_width_backtrack(
     right-then-left dog-leg sweeping the whole diagram is forbidden
     even when exempt.
     """
-    if routes is None:
-        from nf_metro.layout.routing import route_edges
-
-        routes = route_edges(graph)
+    routes = _ensure_routes(graph, routes)
 
     canvas_width = _canvas_width(graph)
     if canvas_width <= 0:
@@ -978,10 +981,7 @@ def _guard_routes_enter_sections_at_ports(
     fan-in merge bundle ploughing into a section through its right edge, or
     an entry inferred on the wrong side so the connector slices the box).
     """
-    if routes is None:
-        from nf_metro.layout.routing import route_edges
-
-        routes = route_edges(graph)
+    routes = _ensure_routes(graph, routes)
 
     hit = _route_crosses_section_boundary(graph, routes)
     if hit is not None:
@@ -1011,10 +1011,7 @@ def _guard_serpentine_no_backtrack(
     """
     from nf_metro.layout.auto_layout import detect_serpentine_runs
 
-    if routes is None:
-        from nf_metro.layout.routing import route_edges
-
-        routes = route_edges(graph)
+    routes = _ensure_routes(graph, routes)
 
     dag = graph.section_dag
     if dag is None:
@@ -1067,10 +1064,7 @@ def _guard_inter_row_run_clearance(
     """
     from nf_metro.layout.routing.common import resolve_section
 
-    if routes is None:
-        from nf_metro.layout.routing import route_edges
-
-        routes = route_edges(graph)
+    routes = _ensure_routes(graph, routes)
 
     tol = GUARD_TOLERANCE
     for rp in routes:
@@ -1129,10 +1123,7 @@ def _guard_inter_section_descent_edge_clearance(
     """
     from nf_metro.layout.routing.common import endpoint_port_xs
 
-    if routes is None:
-        from nf_metro.layout.routing import route_edges
-
-        routes = route_edges(graph)
+    routes = _ensure_routes(graph, routes)
 
     tol = GUARD_TOLERANCE
     for rp in routes:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -760,14 +760,13 @@ def _guard_fan_bundles_coincide_or_separate(
     bundles.
     """
     from nf_metro.layout.routing import compute_station_offsets, route_edges
-    from nf_metro.layout.routing.core import _build_routing_context
+    from nf_metro.layout.routing.core import compute_junction_fan_info
 
     if offsets is None:
         offsets = compute_station_offsets(graph)
     if routes is None:
         routes = route_edges(graph, station_offsets=offsets)
-    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
-    fan_sources = {key[0] for key in ctx.junction_fan_info}
+    fan_sources = {key[0] for key in compute_junction_fan_info(graph)}
     if not fan_sources:
         return
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -622,6 +622,76 @@ def _guard_inter_section_routes_in_row_band(
                 )
 
 
+def _route_exit_side(graph: MetroGraph, rp) -> PortSide | None:
+    """Side of the port a route exits through (directly or via its feeder)."""
+    port = graph.ports.get(rp.edge.source)
+    if port is not None:
+        return port.side
+    for e in graph.edges_to(rp.edge.source):
+        port = graph.ports.get(e.source)
+        if port is not None:
+            return port.side
+    return None
+
+
+def _inter_section_backtrack_legs(
+    graph: MetroGraph,
+    routes: list,
+    *,
+    reference: str = "grid",
+    tolerance: float = 0.0,
+    include_exempt: bool = False,
+):
+    """Yield ``(rp, x1, x2)`` for each horizontal leg of a forward LR
+    inter-section route that reverses against its flow.
+
+    *reference* selects how "forward" is defined:
+
+    * ``"grid"`` - flow points toward the target grid column (strict;
+      used by the monotonic guard, which assumes grid order matches X).
+    * ``"endpoint"`` - flow points toward the route's own endpoint X
+      (tolerant of a nested-column approach where the target column sits
+      left of its source; used by the full-width dog-leg guard).
+
+    *tolerance* widens the reversal threshold; *include_exempt* keeps
+    ``normalize_exempt`` wrap routes (needed to measure around-section
+    dog-legs).  Routes exiting a port that faces away from their target
+    column legitimately wrap and are skipped, as are TB folds and
+    same-column routes.
+    """
+    from nf_metro.layout.routing.common import resolve_section
+
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        if rp.normalize_exempt and not include_exempt:
+            continue
+        src_sec = resolve_section(graph, graph.stations[rp.edge.source])
+        tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
+        if src_sec is None or tgt_sec is None:
+            continue
+        if src_sec.direction != "LR" or tgt_sec.direction != "LR":
+            continue
+        if src_sec.grid_col == tgt_sec.grid_col:
+            continue
+        xs = [p[0] for p in rp.points]
+        if len(xs) < 2:
+            continue
+        rightward_cols = tgt_sec.grid_col > src_sec.grid_col
+        side = _route_exit_side(graph, rp)
+        if rightward_cols and side != PortSide.RIGHT:
+            continue
+        if not rightward_cols and side != PortSide.LEFT:
+            continue
+        forward_is_right = rightward_cols if reference == "grid" else xs[-1] > xs[0]
+        for x1, x2 in zip(xs, xs[1:]):
+            backtracks = (
+                (x2 < x1 - tolerance) if forward_is_right else (x2 > x1 + tolerance)
+            )
+            if backtracks:
+                yield rp, x1, x2
+
+
 def _guard_inter_section_route_no_backtrack(
     graph: MetroGraph,
     phase: str,
@@ -645,46 +715,17 @@ def _guard_inter_section_route_no_backtrack(
 
         routes = route_edges(graph)
 
-    def _exit_side(rp) -> PortSide | None:
-        port = graph.ports.get(rp.edge.source)
-        if port is not None:
-            return port.side
-        for e in graph.edges_to(rp.edge.source):
-            port = graph.ports.get(e.source)
-            if port is not None:
-                return port.side
-        return None
-
-    for rp in routes:
-        if not rp.is_inter_section or rp.normalize_exempt:
-            continue
+    for rp, x1, x2 in _inter_section_backtrack_legs(
+        graph, routes, reference="grid", tolerance=GUARD_TOLERANCE
+    ):
         src_sec = resolve_section(graph, graph.stations[rp.edge.source])
         tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
-        if src_sec is None or tgt_sec is None:
-            continue
-        if src_sec.direction != "LR" or tgt_sec.direction != "LR":
-            continue
-        if src_sec.grid_col == tgt_sec.grid_col:
-            continue
         rightward = tgt_sec.grid_col > src_sec.grid_col
-        side = _exit_side(rp)
-        if rightward and side != PortSide.RIGHT:
-            continue
-        if not rightward and side != PortSide.LEFT:
-            continue
-        xs = [p[0] for p in rp.points]
-        for x1, x2 in zip(xs, xs[1:]):
-            backtracks = (
-                (x2 < x1 - GUARD_TOLERANCE)
-                if rightward
-                else (x2 > x1 + GUARD_TOLERANCE)
-            )
-            if backtracks:
-                raise PhaseInvariantError(
-                    f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} "
-                    f"line {rp.line_id!r} backtracks x={x1:.1f}->{x2:.1f} "
-                    f"against its {'rightward' if rightward else 'leftward'} flow"
-                )
+        raise PhaseInvariantError(
+            f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} "
+            f"line {rp.line_id!r} backtracks x={x1:.1f}->{x2:.1f} "
+            f"against its {'rightward' if rightward else 'leftward'} flow"
+        )
 
 
 def first_vertical_leg_x(points) -> float | None:
@@ -787,48 +828,9 @@ def inter_section_route_backtrack_legs(graph: MetroGraph, routes: list):
     (``normalize_exempt``) wrap routes are *included* so a multi-corner
     around-section dog-leg is still measured.
     """
-    from nf_metro.layout.routing.common import resolve_section
-
-    def _exit_side(rp):
-        port = graph.ports.get(rp.edge.source)
-        if port is not None:
-            return port.side
-        for e in graph.edges_to(rp.edge.source):
-            port = graph.ports.get(e.source)
-            if port is not None:
-                return port.side
-        return None
-
-    for rp in routes:
-        if not rp.is_inter_section:
-            continue
-        src_sec = resolve_section(graph, graph.stations[rp.edge.source])
-        tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
-        if src_sec is None or tgt_sec is None:
-            continue
-        if src_sec.direction != "LR" or tgt_sec.direction != "LR":
-            continue
-        if src_sec.grid_col == tgt_sec.grid_col:
-            continue
-        xs = [p[0] for p in rp.points]
-        if len(xs) < 2:
-            continue
-        # Direction toward the route's own endpoint: a leg moving the other
-        # way (away from where the route ends) is the dog-leg's outward leg.
-        toward_endpoint_is_right = xs[-1] > xs[0]
-        side = _exit_side(rp)
-        # An exit port facing away from the endpoint legitimately wraps; its
-        # outward stub is not a dog-leg.  (Grid-column-based skip preserved
-        # for the wrap case: the exit faces the target column it serves.)
-        rightward_cols = tgt_sec.grid_col > src_sec.grid_col
-        if rightward_cols and side != PortSide.RIGHT:
-            continue
-        if not rightward_cols and side != PortSide.LEFT:
-            continue
-        for x1, x2 in zip(xs, xs[1:]):
-            backtracks = (x2 < x1) if toward_endpoint_is_right else (x2 > x1)
-            if backtracks:
-                yield rp, x1, x2
+    yield from _inter_section_backtrack_legs(
+        graph, routes, reference="endpoint", tolerance=0.0, include_exempt=True
+    )
 
 
 def _guard_inter_section_route_no_full_width_backtrack(

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -53,7 +53,10 @@ def vertical_direction(dy: float) -> Direction:
 
 
 def _sections_in_col(
-    graph: MetroGraph, col: int, row: int | None = None
+    graph: MetroGraph,
+    col: int,
+    row: int | None = None,
+    y_band: tuple[float, float] | None = None,
 ) -> list[Section]:
     """Sections in a specific grid column with non-zero width.
 
@@ -62,12 +65,19 @@ def _sections_in_col(
     in one row must measure the gap against that row's sections only,
     otherwise a section stacked in another row of the same column (e.g. a
     wide output section below) corrupts the gap edges.
+
+    When *y_band* ``(lo, hi)`` is given, restrict to sections whose bbox
+    overlaps that vertical span - used when a descent's vertical run must
+    clear only the sections it would actually cross, not the whole column.
     """
     secs = [s for s in graph.sections.values() if s.grid_col == col and s.bbox_w > 0]
     if row is not None:
         secs = [
             s for s in secs if s.grid_row <= row <= s.grid_row + s.grid_row_span - 1
         ]
+    if y_band is not None:
+        lo, hi = y_band
+        secs = [s for s in secs if not (hi < s.bbox_y or lo > s.bbox_y + s.bbox_h)]
     return secs
 
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -538,9 +538,9 @@ def _route_inter_section(
         and src.section_id in ctx.tb_sections
     )
 
-    # Resolve section columns and row for bypass detection
+    # Resolve section columns and rows for bypass detection
     src_col, src_row = _resolve_section_colrow(graph, src)
-    tgt_col = _resolve_section_col(graph, tgt)
+    tgt_col, tgt_row = _resolve_section_colrow(graph, tgt)
     needs_bypass = (
         src_col is not None
         and tgt_col is not None
@@ -606,9 +606,9 @@ def _route_inter_section(
         edge.source in ctx.junction_ids
         and abs(dx) <= JUNCTION_MARGIN + COORD_TOLERANCE
         and abs(dy) > abs(dx) * 3
-        and (src_col_for_special := _resolve_section_col(graph, src)) is not None
-        and (tgt_col_for_special := _resolve_section_col(graph, tgt)) is not None
-        and src_col_for_special == tgt_col_for_special
+        and src_col is not None
+        and tgt_col is not None
+        and src_col == tgt_col
     ):
         delta, r_first, r_second = l_shape_radii(
             i,
@@ -655,8 +655,8 @@ def _route_inter_section(
         and tgt_port.side == PortSide.LEFT
         and dx < 0
         and src_row is not None
-        and _resolve_section_row(graph, tgt) is not None
-        and src_row != _resolve_section_row(graph, tgt)
+        and tgt_row is not None
+        and src_row != tgt_row
     ):
         # When the inter-row channel _route_left_entry_wrap would use
         # lands inside an intervening section (e.g. a multi-row jump
@@ -690,7 +690,7 @@ def _route_inter_section(
         and tgt_col is not None
         and src_col == tgt_col
         and src_row is not None
-        and _resolve_section_row(graph, tgt) != src_row
+        and tgt_row != src_row
     ):
         return _route_left_exit_left_entry_drop(edge, src, tgt, i, n, ctx)
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -1584,6 +1584,56 @@ def _route_left_exit_left_entry_drop(
     )
 
 
+def _left_entry_descent_x(
+    ctx: _RoutingCtx, anchor_x: float, n_outer: int, signed_delta: float = 0.0
+) -> float:
+    """Descent-channel X for a LEFT-entry bundle, left of *anchor_x*.
+
+    Places the bundle ``base_gap`` (curve radius + one offset step) left of
+    *anchor_x*, bumping further when that gap would bring the bundle's
+    innermost line within ``SECTION_ROUTE_CLEARANCE`` of the edge.  Callers
+    pass the per-line stagger as *signed_delta* (``+delta`` when the channel
+    sits on the bundle's right, ``-delta`` when on its left) to keep the
+    concentric-corner handedness local to each handler.
+    """
+    base_gap = ctx.curve_radius + ctx.offset_step
+    max_delta = (n_outer - 1) * ctx.offset_step / 2
+    extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
+    return anchor_x - base_gap - extra_clearance + signed_delta
+
+
+def _radius_inputs(
+    fan: tuple[int, int] | None, i: int, n: int, offset_step: float
+) -> tuple[float, float]:
+    """Concentric-radius inputs ``(off, max_off)`` for a wrap/around corner.
+
+    Uses the unified fan position ``(ui, un)`` when the edge pivots through a
+    shared junction fan, else the edge's own ``(i, n)`` sub-bundle index.
+    """
+    if fan is not None:
+        ui, un = fan
+        return (un - 1 - ui) * offset_step, (un - 1) * offset_step
+    return (n - 1 - i) * offset_step, (n - 1) * offset_step
+
+
+def _v1_corner_x(ctx: _RoutingCtx, src: Station, sx: float, corner_x: float) -> float:
+    """Push *corner_x* right so the source-side V1 channel keeps
+    ``SECTION_ROUTE_CLEARANCE`` from the source section's right edge.
+
+    When the source station sits at its section's right edge (e.g. a
+    right-side exit port), the default lead-in lands the closest line only
+    ~curve_radius past the edge, which reads as flush.  A junction source
+    already offset past the edge yields a zero bump.
+    """
+    src_section = ctx.graph.sections.get(src.section_id) if src.section_id else None
+    if src_section and src_section.bbox_w > 0:
+        section_right = src_section.bbox_x + src_section.bbox_w
+    else:
+        section_right = sx
+    current_gap = sx + ctx.curve_radius - section_right
+    return corner_x + max(0.0, SECTION_ROUTE_CLEARANCE - current_gap)
+
+
 def _route_left_entry_wrap(
     edge: Edge, src: Station, tgt: Station, i: int, n: int, ctx: _RoutingCtx
 ) -> RoutedPath:
@@ -1677,10 +1727,7 @@ def _route_left_entry_wrap(
     # A uniform extra shift preserves the per-line delta stagger so the
     # offset propagation rule is unchanged.
     n_for_outer = fan[1] if fan is not None else n
-    max_delta = (n_for_outer - 1) * ctx.offset_step / 2
-    base_gap = ctx.curve_radius + ctx.offset_step
-    extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
-    vx = tx - base_gap - extra_clearance + delta
+    vx = _left_entry_descent_x(ctx, tx, n_for_outer, delta)
     # When this wrap shares a junction fan with a corridor feeder descending
     # the same target column, anchor the descent channel to the column's LEFT
     # edge so the spine and the corridor overlay as one bundle instead of smearing.
@@ -1719,12 +1766,7 @@ def _route_left_entry_wrap(
     # short, producing the visible "outer line collapses at C4"
     # asymmetry against C1/C2/C3.  Mirrors the [r_lead, r_first,
     # r_first, r_second] pattern in _route_right_entry_wrap.
-    if fan is not None:
-        off_for_radius = (un - 1 - ui) * ctx.offset_step
-        max_off_for_radius = (un - 1) * ctx.offset_step
-    else:
-        off_for_radius = (n - 1 - i) * ctx.offset_step
-        max_off_for_radius = (n - 1) * ctx.offset_step
+    off_for_radius, max_off_for_radius = _radius_inputs(fan, i, n, ctx.offset_step)
     r_wrap = corner_radius(
         off_for_radius,
         max_off_for_radius,
@@ -1759,27 +1801,17 @@ def _route_left_entry_wrap(
     # JUNCTION_MARGIN), this shift is zero.  Uniform across lines, so the
     # per-line delta stagger and the corner_x - r_wrap == sx cancellation
     # below are preserved by also shifting lx.
-    src_section = ctx.graph.sections.get(src.section_id) if src.section_id else None
-    if src_section and src_section.bbox_w > 0:
-        section_right = src_section.bbox_x + src_section.bbox_w
-    else:
-        section_right = sx
-    # Closest line to the source edge sits at corner_x_min = sx + curve_radius
-    # (the line at delta = -max_delta).  Required gap from section_right
-    # is SECTION_ROUTE_CLEARANCE; current gap is sx + curve_radius -
-    # section_right.
-    current_v1_gap = sx + ctx.curve_radius - section_right
-    extra_v1 = max(0.0, SECTION_ROUTE_CLEARANCE - current_v1_gap)
-    corner_x += extra_v1
+    corner_x = _v1_corner_x(ctx, src, sx, corner_x)
     # Lead-in extends r_wrap LEFT of the corner so the first corner
     # gets the SAME concentric radius as the other three corners.  With
     # the virtual-fan corner_x above, every line lands lx == sx
     # exactly (corner_x - r_wrap = sx + curve_radius + (n-1)*step/2 +
     # delta - r_wrap, and r_wrap = curve_radius + (n-1-i)*step, delta
-    # = ((n-1)/2 - i)*step => they cancel to sx for every i).  With
-    # extra_v1 > 0, that cancellation places lx at sx + extra_v1; pin
-    # lx back to sx so the route starts at the source station/port and
-    # the extra clearance manifests as a longer horizontal lead-in
+    # = ((n-1)/2 - i)*step => they cancel to sx for every i).  When the
+    # source clearance bump is non-zero, that cancellation places lx at
+    # sx + bump; pin lx back to sx so the route starts at the source
+    # station/port and the extra clearance manifests as a longer
+    # horizontal lead-in
     # before C1 rather than a gap at the start of the path.
     lx = sx
     return RoutedPath(
@@ -1880,10 +1912,7 @@ def _fan_left_entry_descent_x(
     col_left = col_left_edge(ctx.graph, tgt_col, default=0.0)
     if col_left <= 0.0:
         return None
-    base_gap = ctx.curve_radius + ctx.offset_step
-    max_delta = (n_outer - 1) * ctx.offset_step / 2
-    extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
-    return col_left - base_gap - extra_clearance + delta
+    return _left_entry_descent_x(ctx, col_left, n_outer, delta)
 
 
 def _fan_has_corridor_sibling(junction_id: str, ctx: _RoutingCtx) -> bool:
@@ -2048,14 +2077,8 @@ def _route_inter_row_gap_corridor(
     # When the source is a sectionless junction, fall back to its own X as
     # the reference edge (mirrors :func:`_route_left_entry_wrap`) so a fan
     # feeder gets the SAME source-side clearance as its sibling wrap.
-    src_section = ctx.graph.sections.get(src.section_id) if src.section_id else None
     corner_x = sx + ctx.curve_radius + (pos_n - 1) * ctx.offset_step / 2 + delta
-    if src_section and src_section.bbox_w > 0:
-        section_right = src_section.bbox_x + src_section.bbox_w
-    else:
-        section_right = sx
-    current_gap = sx + ctx.curve_radius - section_right
-    corner_x += max(0.0, SECTION_ROUTE_CLEARANCE - current_gap)
+    corner_x = _v1_corner_x(ctx, src, sx, corner_x)
 
     src_off = _get_offset(ctx, edge.source, edge.line_id)
     tgt_off = _get_offset(ctx, edge.target, edge.line_id)
@@ -2139,8 +2162,6 @@ def _route_around_section_below(
         )
         fan_mid_x = sx + ctx.curve_radius + (un - 1) * ctx.offset_step / 2
         delta = fan_delta
-        off_for_radius = (un - 1 - ui) * ctx.offset_step
-        max_off_for_radius = (un - 1) * ctx.offset_step
     else:
         delta, _r_first, _r_second = l_shape_radii(
             i,
@@ -2150,8 +2171,7 @@ def _route_around_section_below(
             base_radius=ctx.curve_radius,
         )
         fan_mid_x = None
-        off_for_radius = (n - 1 - i) * ctx.offset_step
-        max_off_for_radius = (n - 1) * ctx.offset_step
+    off_for_radius, max_off_for_radius = _radius_inputs(fan, i, n, ctx.offset_step)
 
     # All four corners are CW (clockwise loop: R->D->L->U->R).  The outer
     # line of the bundle stays OUTSIDE every turn and gets the larger
@@ -2200,11 +2220,6 @@ def _route_around_section_below(
     else:
         section_left = ex
     n_for_outer = fan[1] if fan is not None else n
-    max_delta = (n_for_outer - 1) * ctx.offset_step / 2
-    base_gap = ctx.curve_radius + ctx.offset_step
-    # Bump so the bundle's innermost line keeps SECTION_ROUTE_CLEARANCE from
-    # the target section edge even when base_gap - max_delta falls short.
-    extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
 
     # V_up X: position the bundle within the inter-column gap just
     # left of the target section, using the principled symmetric
@@ -2222,13 +2237,13 @@ def _route_around_section_below(
         # Sanity floor: keep the V_up clear of the target section's left
         # edge (re-applying the legacy clamp) when the gap is too narrow
         # for full symmetric placement.
-        max_vx_mid = section_left - base_gap - extra_clearance
+        max_vx_mid = _left_entry_descent_x(ctx, section_left, n_for_outer)
         vx_mid = min(vx_mid, max_vx_mid)
         vx = vx_mid - delta
     else:
         # Fallback for degenerate cases without column info: legacy
         # anchored-to-edge placement.
-        vx = section_left - base_gap - extra_clearance - delta
+        vx = _left_entry_descent_x(ctx, section_left, n_for_outer, -delta)
 
     # First-corner X: lead-in right of source, mirroring _route_left_entry_wrap.
     if fan_mid_x is not None:
@@ -2238,17 +2253,10 @@ def _route_around_section_below(
         corner_x = non_fan_mid_x + delta
     # V1 clearance from the source section's right edge, mirroring
     # _route_left_entry_wrap.  See comments there for the derivation.
-    src_section = ctx.graph.sections.get(src.section_id) if src.section_id else None
-    if src_section and src_section.bbox_w > 0:
-        v1_section_right = src_section.bbox_x + src_section.bbox_w
-    else:
-        v1_section_right = sx
-    current_v1_gap = sx + ctx.curve_radius - v1_section_right
-    extra_v1 = max(0.0, SECTION_ROUTE_CLEARANCE - current_v1_gap)
-    corner_x += extra_v1
-    # Pin lx at sx so the route starts at the source station; extra_v1
-    # manifests as a longer H lead-in before C1.  See the analogous
-    # comment in _route_left_entry_wrap.
+    corner_x = _v1_corner_x(ctx, src, sx, corner_x)
+    # Pin lx at sx so the route starts at the source station; the source
+    # clearance bump manifests as a longer H lead-in before C1.  See the
+    # analogous comment in _route_left_entry_wrap.
     lx = sx
 
     src_off = _get_offset(ctx, edge.source, edge.line_id)

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -38,6 +38,7 @@ from nf_metro.layout.routing.common import (
     Direction,
     RoutedPath,
     _center_inter_row_channel,
+    _sections_in_col,
     bundle_width,
     bypass_bottom_y,
     clear_channel_of_section_edge,
@@ -1192,17 +1193,10 @@ def _nested_target_clear_channel_x(
     ep_sec = graph.sections.get(ep.section_id) if ep.section_id else None
     if ep_sec is None:
         return None
-    tgt_col = ep_sec.grid_col
-    rights = [
-        s.bbox_x + s.bbox_w
-        for s in graph.sections.values()
-        if s.bbox_w > 0
-        and s.grid_col == tgt_col
-        and not (y_hi < s.bbox_y or y_lo > s.bbox_y + s.bbox_h)
-    ]
-    if not rights:
+    secs = _sections_in_col(graph, ep_sec.grid_col, y_band=(y_lo, y_hi))
+    if not secs:
         return None
-    return max(rights) + clearance
+    return max(s.bbox_x + s.bbox_w for s in secs) + clearance
 
 
 def _route_stepped_descent(

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -256,8 +256,7 @@ def _classify_merge_edges(
             pred = graph.stations.get(edge.source)
             if not pred:
                 continue
-            pred_col = _resolve_section_col(graph, pred)
-            pred_row = _resolve_section_row(graph, pred)
+            pred_col, pred_row = _resolve_section_colrow(graph, pred)
             if (
                 pred_col is not None
                 and abs(tgt_col - pred_col) > 1
@@ -420,6 +419,27 @@ def _build_routing_context(
     )
 
 
+def compute_junction_fan_info(graph: MetroGraph) -> dict[_EdgeKey, tuple[int, int]]:
+    """Unified per-edge fan positions for fan-out junctions.
+
+    The offset-independent subset of :func:`_build_routing_context` needed by
+    the fan-coincidence guard, so it need not build the full routing context
+    just to read ``junction_fan_info``.
+    """
+    junction_ids = graph.junction_ids
+    fork_targets: dict[str, set[str]] = defaultdict(set)
+    join_sources: dict[str, set[str]] = defaultdict(set)
+    for e in graph.edges:
+        fork_targets[e.source].add(e.target)
+        join_sources[e.target].add(e.source)
+    merge = _classify_merge_edges(graph, junction_ids, join_sources, fork_targets)
+    line_priority = {lid: i for i, lid in enumerate(graph.lines.keys())}
+    all_exclude = merge.skip_edges | merge.index_exclude
+    return _compute_junction_fan_info(
+        graph, junction_ids, line_priority, skip_edges=all_exclude
+    )
+
+
 def _compute_section_trunk_ys(graph: MetroGraph) -> dict[str, float]:
     """Return a mapping ``section_id -> trunk_y`` for LR/RL sections.
 
@@ -519,9 +539,8 @@ def _route_inter_section(
     )
 
     # Resolve section columns and row for bypass detection
-    src_col = _resolve_section_col(graph, src)
+    src_col, src_row = _resolve_section_colrow(graph, src)
     tgt_col = _resolve_section_col(graph, tgt)
-    src_row = _resolve_section_row(graph, src)
     needs_bypass = (
         src_col is not None
         and tgt_col is not None
@@ -846,8 +865,7 @@ def _has_around_section_sibling(
             continue
         # Skip siblings that would dispatch through the bypass branch.
         # needs_bypass = (|tgt_col - src_col| > 1) AND intervening.
-        other_col = _resolve_section_col(graph, other_src)
-        other_row = _resolve_section_row(graph, other_src)
+        other_col, other_row = _resolve_section_colrow(graph, other_src)
         if (
             other_col is not None
             and ep_col is not None
@@ -1948,10 +1966,8 @@ def _corridor_is_viable(ctx: _RoutingCtx, src: Station, entry_port: Station) -> 
     ep_port = ctx.graph.ports.get(entry_port.id)
     if ep_port is None or ep_port.side != PortSide.LEFT:
         return False
-    src_row = _resolve_section_row(ctx.graph, src)
-    ep_row = _resolve_section_row(ctx.graph, entry_port)
-    src_col = _resolve_section_col(ctx.graph, src)
-    ep_col = _resolve_section_col(ctx.graph, entry_port)
+    src_col, src_row = _resolve_section_colrow(ctx.graph, src)
+    ep_col, ep_row = _resolve_section_colrow(ctx.graph, entry_port)
     if None in (src_row, ep_row, src_col, ep_col):
         return False
     if ep_row <= src_row:
@@ -2020,10 +2036,8 @@ def _route_inter_row_gap_corridor(
         base_radius=ctx.curve_radius,
     )
 
-    src_row = _resolve_section_row(ctx.graph, src)
-    src_col = _resolve_section_col(ctx.graph, src)
-    ep_col = _resolve_section_col(ctx.graph, entry_port)
-    ep_row = _resolve_section_row(ctx.graph, entry_port)
+    src_col, src_row = _resolve_section_colrow(ctx.graph, src)
+    ep_col, ep_row = _resolve_section_colrow(ctx.graph, entry_port)
 
     # Inter-row gap Y just below the source row (column-restricted so a
     # tall row-span in another column doesn't push the channel down).  Use
@@ -2179,7 +2193,7 @@ def _route_around_section_below(
 
     # Bypass Y below all sections in the column range so the route
     # clears every intervening section (cross_row=True).
-    src_col = _resolve_section_col(ctx.graph, src)
+    src_col, src_row = _resolve_section_colrow(ctx.graph, src)
     ep_col = _resolve_section_col(ctx.graph, entry_port)
     # Fallbacks if a column can't be resolved (degenerate cases).
     bc_src_col = src_col if src_col is not None else 0
@@ -2189,7 +2203,7 @@ def _route_around_section_below(
         bc_src_col,
         bc_tgt_col,
         BYPASS_CLEARANCE,
-        src_row=_resolve_section_row(ctx.graph, src),
+        src_row=src_row,
         cross_row=True,
     )
     by = by_base + delta
@@ -2322,10 +2336,8 @@ def _route_right_entry_wrap(
     # Detect cross-row case: use bypass-style Y just below the source
     # row's sections so the line runs horizontally under the adjacent
     # section before dropping to the target row.
-    src_row = _resolve_section_row(ctx.graph, src)
-    tgt_row = _resolve_section_row(ctx.graph, tgt)
-    src_col = _resolve_section_col(ctx.graph, src)
-    tgt_col = _resolve_section_col(ctx.graph, tgt)
+    src_col, src_row = _resolve_section_colrow(ctx.graph, src)
+    tgt_col, tgt_row = _resolve_section_colrow(ctx.graph, tgt)
 
     cross_row = (
         src_row is not None
@@ -3567,6 +3579,22 @@ def _resolve_section_row(graph: MetroGraph, station: Station) -> int | None:
     return None
 
 
+def _resolve_section_colrow(
+    graph: MetroGraph, station: Station
+) -> tuple[int | None, int | None]:
+    """Resolve grid ``(col, row)`` for a port/junction station in one pass.
+
+    ``_resolve_section_col`` and ``_resolve_section_row`` each re-resolve the
+    section (an adjacency walk); callers needing both should resolve once.
+    """
+    sec = resolve_section(graph, station, prefer_upstream=False)
+    if sec is None:
+        return None, None
+    col = sec.grid_col if sec.grid_col >= 0 else None
+    row = sec.grid_row if sec.grid_row >= 0 else None
+    return col, row
+
+
 @dataclass
 class _VChannel:
     """One vertical channel segment of a routed inter-section path.
@@ -4123,9 +4151,8 @@ def _compute_bypass_gap_indices(
         if not is_inter:
             continue
 
-        src_col = _resolve_section_col(graph, src)
+        src_col, src_row = _resolve_section_colrow(graph, src)
         tgt_col = _resolve_section_col(graph, tgt)
-        src_row = _resolve_section_row(graph, src)
         if (
             src_col is None
             or tgt_col is None
@@ -4212,10 +4239,9 @@ def _compute_junction_fan_info(
         jst = graph.stations.get(jid)
         if not jst:
             continue
-        src_col = _resolve_section_col(graph, jst)
+        src_col, src_row = _resolve_section_colrow(graph, jst)
         if src_col is None:
             continue
-        src_row = _resolve_section_row(graph, jst)
 
         # Classify each outgoing edge into one of: L-shape (adjacent col,
         # no intervening sections), bypass (column gap with intervening),
@@ -4240,10 +4266,9 @@ def _compute_junction_fan_info(
             tgt = graph.stations.get(edge.target)
             if not tgt or not (tgt.is_port or edge.target in junction_ids):
                 continue
-            tgt_col = _resolve_section_col(graph, tgt)
+            tgt_col, tgt_row = _resolve_section_colrow(graph, tgt)
             if tgt_col is None:
                 continue
-            tgt_row = _resolve_section_row(graph, tgt)
             tgt_port = graph.ports.get(edge.target)
             is_bypass = abs(tgt_col - src_col) > 1 and _has_intervening_sections(
                 graph, src_col, tgt_col, src_row


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup of the routing landed in #441 (the dedup,
efficiency, and comment items deferred from that change to keep it
behavior-preserving). Gallery output is byte-identical to `main`.

**Dedup**
- Extract three triplicated arithmetic blocks shared by `_route_left_entry_wrap`, `_route_inter_row_gap_corridor`, and `_route_around_section_below`: `_left_entry_descent_x` (channel placement; callers keep the `+delta`/`-delta` handedness), `_radius_inputs` (fan-aware concentric-radius inputs), and `_v1_corner_x` (source-edge clearance bump).
- Generalise `_sections_in_col` with an optional `y_band=(lo, hi)` filter and route `_nested_target_clear_channel_x` through it.
- Unify `inter_section_route_backtrack_legs` and `_guard_inter_section_route_no_backtrack` into one `_inter_section_backtrack_legs` generator (parametrised by grid-vs-endpoint reference, reversal tolerance, and `normalize_exempt` inclusion); hoist the shared `_exit_side` to a module-level `_route_exit_side`.

**Efficiency**
- Add `compute_junction_fan_info(graph)` exposing the offset-independent fan-info subset of `_build_routing_context`; `_guard_fan_bundles_coincide_or_separate` now calls it instead of rebuilding the full routing context on every `validate=True` render.
- Add `_resolve_section_colrow` resolving a station's section once and returning `(col, row)`; route the col+row call-site pairs (including the per-edge dispatcher `_route_inter_section`) through it so the adjacency walk runs once per station instead of twice/four-times.

**Minor**
- `first_vertical_leg_x` uses the named `COORD_TOLERANCE` (`== 1.0`) instead of a bare literal.
- Collapse the six identical "route if not supplied" lazy-init blocks in the layout guards into a shared `_ensure_routes` helper.

## Deferred

The `_infer_directions` -> `_effective_grid_pos` consistency item from the issue is **not** included: routing its grid reads through `_effective_grid_pos` is correct in principle (direction inference is currently disabled for explicit-grid sections, which all fall through to `LR`), but it re-orients 5 gallery renders (`genomic_pipeline`, `stacked_lr_serpentine`, `around_section_below`, `genomeassembly_staggered`, `inter_row_wrap_clearance`) by flipping explicitly-gridded sections from `LR` to `TB`/`RL`. That contradicts #442 byte-identical acceptance and needs its own fixture-reblessing investigation. Tracked in #446.

Fixes #442 (less the deferred `_infer_directions` item).

## Test plan
- [x] `pytest` passes (3558 passed, 6 xfailed) including all layout invariants
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean (CI scope)
- [x] Gallery byte-identical to `main` across all 62 renders
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/445/) - expected verdict: no visual changes

Generated with Claude Code
