### PR TITLE
fix(layout): skip explicit-grid sections in direction inference (#446)

### DIFF
--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -727,12 +727,10 @@ def _infer_directions(
     Fold sections are forced to TB (they bridge between row bands).
     Sections whose predecessors are all to the right get RL.
 
-    Explicitly-gridded sections keep the default LR unless they carry an
-    explicit %%metro direction. Their grid position is the author's manual
-    layout intent, not a flow-direction signal: inferring RL/TB from it
-    reorients serpentine-stacked sections vertically (see #446). Skipping
-    them also avoids the stale grid_col == -1 these sections read during
-    auto-layout, which previously fired spurious RL/TB against auto-placed
+    Explicitly-gridded sections are skipped: their grid position is manual
+    layout intent, not a flow-direction signal (#446). They also still read
+    grid_col == -1 here (the override is applied later in section_placement),
+    so without the skip the -1 fires spurious RL/TB against auto-placed
     neighbours in mixed grids.
     """
     for sec_id, section in graph.sections.items():

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -726,9 +726,20 @@ def _infer_directions(
     Only modifies sections NOT in graph._explicit_directions.
     Fold sections are forced to TB (they bridge between row bands).
     Sections whose predecessors are all to the right get RL.
+
+    Explicitly-gridded sections keep the default LR unless they carry an
+    explicit %%metro direction. Their grid position is the author's manual
+    layout intent, not a flow-direction signal: inferring RL/TB from it
+    reorients serpentine-stacked sections vertically (see #446). Skipping
+    them also avoids the stale grid_col == -1 these sections read during
+    auto-layout, which previously fired spurious RL/TB against auto-placed
+    neighbours in mixed grids.
     """
     for sec_id, section in graph.sections.items():
         if sec_id in graph._explicit_directions:
+            continue
+
+        if sec_id in graph._explicit_grid:
             continue
 
         # Fold sections are always TB (vertical bridge between rows)

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -214,10 +214,8 @@ def _guard_explicit_grid_directions(graph: MetroGraph, phase: str) -> None:
     """
     offenders = {
         sid: graph.sections[sid].direction
-        for sid in graph._explicit_grid
-        if sid in graph.sections
-        and sid not in graph._explicit_directions
-        and graph.sections[sid].direction != "LR"
+        for sid in graph._explicit_grid - graph._explicit_directions
+        if sid in graph.sections and graph.sections[sid].direction != "LR"
     }
     if offenders:
         raise PhaseInvariantError(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -202,6 +202,30 @@ def _guard_no_negative_grid_columns(graph: MetroGraph, phase: str) -> None:
         )
 
 
+def _guard_explicit_grid_directions(graph: MetroGraph, phase: str) -> None:
+    """Explicit-grid sections keep the LR default unless they carry an
+    explicit %%metro direction.
+
+    A section's grid position is the author's manual layout intent, not a
+    flow-direction signal (issue #446). Direction inference therefore skips
+    explicit-grid sections; this guard fails loudly if a future change ever
+    lets inference reorient one (e.g. by reading override-aware positions),
+    which would silently elongate serpentine-stacked maps vertically.
+    """
+    offenders = {
+        sid: graph.sections[sid].direction
+        for sid in graph._explicit_grid
+        if sid in graph.sections
+        and sid not in graph._explicit_directions
+        and graph.sections[sid].direction != "LR"
+    }
+    if offenders:
+        raise PhaseInvariantError(
+            f"{phase}: explicit-grid sections with no %%metro direction were "
+            f"inferred to a non-LR direction: {offenders}"
+        )
+
+
 def _bbox_cols_overlap(a: Section, b: Section) -> bool:
     """True when two sections' bboxes overlap in X (share horizontal extent)."""
     return a.bbox_x < b.bbox_x + b.bbox_w and b.bbox_x < a.bbox_x + a.bbox_w
@@ -1988,6 +2012,7 @@ def _compute_section_layout(
     if validate:
         _guard_section_bboxes_positive(graph, "after Stage 1.1")
         _guard_no_negative_grid_columns(graph, "after Stage 1.1")
+        _guard_explicit_grid_directions(graph, "after Stage 1.1")
 
     # Stage 1.2: Align Y grids across same-row, same-direction sections
     _align_row_y_grids(graph, section_subgraphs, y_spacing, section_y_padding)

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -240,6 +240,59 @@ def test_direction_explicit_preserved():
     assert graph.sections["sec1"].direction == "TB"
 
 
+def test_explicit_grid_section_keeps_lr_against_auto_successor_below():
+    """An explicit-grid section keeps the LR default even when an auto-placed
+    successor lands in a lower grid row.
+
+    Regression lock for #446: during auto-layout an explicit-grid section
+    still reads grid_col == -1, so comparing it against an auto neighbour
+    (row >= 0) used to fire the "all successors below" TB branch and reorient
+    the section vertically.
+    """
+    graph = _make_graph_with_sections(
+        ["manual", "downstream"],
+        [("manual_s1", "manual", "downstream_s1", "downstream", "main")],
+    )
+    # 'manual' is explicitly gridded; 'downstream' is left to auto-layout.
+    graph.grid_overrides["manual"] = (0, 0, 1, 1)
+    graph._explicit_grid.add("manual")
+
+    successors, predecessors, _ = _build_section_dag(graph)
+    _assign_grid_positions(graph, successors, predecessors, max_station_columns=100)
+    _infer_directions(graph, successors, predecessors, set())
+
+    assert graph.sections["manual"].direction == "LR"
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        "genomic_pipeline.mmd",
+        "genomeassembly_staggered.mmd",
+        "topologies/stacked_lr_serpentine.mmd",
+        "topologies/around_section_below.mmd",
+        "topologies/inter_row_wrap_clearance.mmd",
+    ],
+)
+def test_explicit_grid_sections_default_lr(fixture):
+    """Explicit-grid sections with no %%metro direction stay LR after layout.
+
+    These fixtures lay every section out by hand; their grid stacks
+    successors below predecessors (serpentine wraps), which must not be read
+    as vertical internal flow (#446).
+    """
+    text = (EXAMPLES / fixture).read_text()
+    graph = parse_metro_mermaid(text)
+
+    explicit = graph._explicit_grid - graph._explicit_directions
+    assert explicit, f"{fixture} has no explicit-grid sections to check"
+    for sec_id in explicit:
+        assert graph.sections[sec_id].direction == "LR", (
+            f"{fixture}: {sec_id} should default LR, got "
+            f"{graph.sections[sec_id].direction}"
+        )
+
+
 # --- Phase 4: Port side inference ---
 
 


### PR DESCRIPTION
## Summary

`_infer_directions` read a section's flow direction (LR/RL/TB) from its grid position, but explicitly-gridded sections still carry `grid_col == -1` during auto-layout - the `%%metro grid:` override is applied later, in `section_placement`. In all-explicit maps their successor/predecessor position lists came up empty and they fell through to the `LR` default by accident; in *mixed* grids the `-1` compared against an auto-placed neighbour's real row could fire a spurious `TB`/`RL`, reorienting the section vertically.

This makes the `LR` default deliberate: `_infer_directions` now skips `_explicit_grid` sections (mirroring the existing `_explicit_directions` skip). A section's manual grid position is layout intent, not a flow-direction signal. `%%metro direction:` remains the escape hatch for an explicit grid that genuinely wants `TB`/`RL`.

### Why not route the reads through override-aware positions (the alternative #446 floats)

Investigated and rejected on visual evidence. Feeding the real override positions into the inference fires `RL`/`TB` for explicit grids and regresses all 5 affected fixtures - `genomic_pipeline` (1242px → 3633px tall, large empty void), `stacked_lr_serpentine`, `around_section_below`, `genomeassembly_staggered`, `inter_row_wrap_clearance` - turning compact horizontal maps into elongated vertical ones, some with backwards (`Output ← Process`) internal flow. In every case the successor-below is a serpentine wrap, not genuine vertical flow, and no fixture wants the inferred orientation.

### Changes

- `auto_layout.py`: skip `_explicit_grid` sections in `_infer_directions`.
- `engine.py`: `_guard_explicit_grid_directions` runtime validator (fails loudly if a future change ever reorients an explicit-grid section with no explicit direction).
- `tests/test_auto_layout.py`: a mixed-graph regression test (fails on `main` with `TB`) and a parametrised contract lock over the 5 explicit-grid fixtures.

The full 47-fixture gallery renders **byte-identical** to `main`.

Fixes #446

## Test plan
- [x] pytest passes (3564 passed); new unit test fails on `main` (`TB`), passes here (`LR`)
- [x] ruff check + ruff format clean on `src/ tests/` (CI lint scope)
- [x] Runtime validator added (`_guard_explicit_grid_directions`)
- [ ] Visual review of render preview
- [x] Gallery byte-identical to main (verified locally across all 47 fixtures)

Generated with Claude Code