### PR TITLE
fix(layout): reject stations laid outside their section bbox (#424)

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import click
 
 from nf_metro import __version__
-from nf_metro.layout import compute_layout
+from nf_metro.layout import PhaseInvariantError, compute_layout
 from nf_metro.parser import parse_metro_mermaid
 from nf_metro.render import render_svg
 from nf_metro.render.html import render_html
@@ -182,7 +182,10 @@ def render(
         layout_kwargs["section_x_gap"] = section_x_gap
     if section_y_gap is not None:
         layout_kwargs["section_y_gap"] = section_y_gap
-    compute_layout(graph, **layout_kwargs)
+    try:
+        compute_layout(graph, **layout_kwargs)
+    except PhaseInvariantError as e:
+        raise click.ClickException(str(e))
 
     theme_obj = THEMES[theme]
 

--- a/src/nf_metro/layout/__init__.py
+++ b/src/nf_metro/layout/__init__.py
@@ -1,5 +1,9 @@
 """Layout engine for metro map positioning."""
 
-from nf_metro.layout.engine import compute_layout, compute_min_y_spacing
+from nf_metro.layout.engine import (
+    PhaseInvariantError,
+    compute_layout,
+    compute_min_y_spacing,
+)
 
-__all__ = ["compute_layout", "compute_min_y_spacing"]
+__all__ = ["PhaseInvariantError", "compute_layout", "compute_min_y_spacing"]

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -144,6 +144,76 @@ def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
             )
 
 
+# Sides that lie along a section's internal flow axis: an LR/RL section
+# flows horizontally, so its flow-aligned ports are on the left/right; a
+# TB/BT section flows vertically, so its flow-aligned ports are on the
+# top/bottom.  A section with at least one flow-aligned port has an edge
+# to anchor the start (or end) of its run to the bbox boundary.
+_FLOW_ALIGNED_SIDES = {
+    "LR": {PortSide.LEFT, PortSide.RIGHT},
+    "RL": {PortSide.LEFT, PortSide.RIGHT},
+    "TB": {PortSide.TOP, PortSide.BOTTOM},
+    "BT": {PortSide.TOP, PortSide.BOTTOM},
+}
+
+
+def _section_lacks_flow_aligned_port(graph: MetroGraph, section: Section) -> bool:
+    """True when *section* has ports but none on its flow axis.
+
+    An internally-horizontal (LR/RL) section whose only ports are on the
+    top/bottom (or a vertical section with only left/right ports) has no
+    flow-aligned edge to pin its run to the bbox, so the engine lays the
+    run out past the box.  This is the unsupported directive combination
+    behind issue #424; the bbox-containment guard uses it to emit an
+    actionable error.
+    """
+    flow_sides = _FLOW_ALIGNED_SIDES.get(section.direction)
+    if flow_sides is None:
+        return False
+    sides = [p.side for p in graph.ports.values() if p.section_id == section.id]
+    return bool(sides) and not any(s in flow_sides for s in sides)
+
+
+def _guard_stations_within_bbox(graph: MetroGraph, phase: str) -> None:
+    """Always-on postcondition: every station centre must lie within its
+    section's bbox (plus a small tolerance).
+
+    Unlike :func:`_guard_stations_in_sections` (which runs only under
+    ``validate`` mid-layout and checks marker-edge containment on the Y
+    axis), this guard runs on every layout -- including the default render
+    path -- and checks the *settled* bbox on both axes.  It is the
+    backstop for issue #424: forcing perpendicular ports on a horizontal
+    section lays its stations out past the right of its own bbox, and the
+    engine must reject that loudly rather than render it silently.
+    """
+    junction_ids = graph.junction_ids
+    tol = GUARD_TOLERANCE
+    for sid, st in graph.stations.items():
+        sec = graph.sections.get(st.section_id or "")
+        if not sec or st.is_port or sid in junction_ids or sec.bbox_w == 0:
+            continue
+        inside_x = sec.bbox_x - tol <= st.x <= sec.bbox_x + sec.bbox_w + tol
+        inside_y = sec.bbox_y - tol <= st.y <= sec.bbox_y + sec.bbox_h + tol
+        if inside_x and inside_y:
+            continue
+        detail = (
+            f"{phase}: station {sid!r} centre ({st.x:.1f}, {st.y:.1f}) "
+            f"outside section {st.section_id!r} bbox "
+            f"({sec.bbox_x:.1f}, {sec.bbox_y:.1f}, "
+            f"w={sec.bbox_w:.1f}, h={sec.bbox_h:.1f})"
+        )
+        if _section_lacks_flow_aligned_port(graph, sec):
+            detail += (
+                f"; section {st.section_id!r} is internally {sec.direction} "
+                f"but its only ports are perpendicular to that flow, so the "
+                f"run has no flow-aligned port to anchor it to the bbox. "
+                f"Give the section a flow-aligned entry/exit port "
+                f"(left/right for LR/RL, top/bottom for TB/BT) or change "
+                f"its '%%metro direction:'."
+            )
+        raise PhaseInvariantError(detail)
+
+
 def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:
     """After Stage 3.1+: ports must sit on their section's bounding box edge."""
     tolerance = GUARD_TOLERANCE
@@ -1863,6 +1933,12 @@ def compute_layout(
         if new_x <= x_spacing + 1e-6 and new_y <= y_spacing + 1e-6:
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y
+
+    # Always-on backstop (independent of ``validate``): the settled layout
+    # must never leave a station outside its own section bbox.  Runs on the
+    # render path so an unsupported directive combination fails loudly
+    # instead of shipping a silently-broken diagram (issue #424).
+    _guard_stations_within_bbox(graph, "final")
 
     if validate:
         _guard_no_label_overlap(graph, "final")

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -101,6 +101,20 @@ def _guard_coordinates_finite(graph: MetroGraph, phase: str) -> None:
                 )
 
 
+def _bbox_guarded_stations(graph: MetroGraph):
+    """Yield ``(sid, station, section)`` for each rendered station that a
+    bbox-containment guard should check: skips ports, junctions, and
+    stations whose section has no sized bbox.  Shared by the marker-edge
+    and centre-containment guards so they can't drift on what they exempt.
+    """
+    junction_ids = graph.junction_ids
+    for sid, st in graph.stations.items():
+        sec = graph.sections.get(st.section_id or "")
+        if not sec or st.is_port or sid in junction_ids or sec.bbox_w == 0:
+            continue
+        yield sid, st, sec
+
+
 def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
     """After Stage 2.1+: rendered station markers (and terminus icons) must
     be fully within their section bbox.
@@ -113,12 +127,8 @@ def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
     height) spill above the bbox top while still being technically "in" the
     section.
     """
-    junction_ids = graph.junction_ids
     tol = GUARD_TOLERANCE
-    for sid, st in graph.stations.items():
-        sec = graph.sections.get(st.section_id or "")
-        if not sec or st.is_port or sid in junction_ids or sec.bbox_w == 0:
-            continue
+    for sid, st, sec in _bbox_guarded_stations(graph):
         # Off-track inputs and terminus icons render at icon scale; on-track
         # markers render at station-pill scale.  Use the wider reach so the
         # guard catches icon spill-over above the bbox top.
@@ -163,14 +173,13 @@ def _section_lacks_flow_aligned_port(graph: MetroGraph, section: Section) -> boo
     An internally-horizontal (LR/RL) section whose only ports are on the
     top/bottom (or a vertical section with only left/right ports) has no
     flow-aligned edge to pin its run to the bbox, so the engine lays the
-    run out past the box.  This is the unsupported directive combination
-    behind issue #424; the bbox-containment guard uses it to emit an
-    actionable error.
+    run out past the box.  The bbox-containment guard uses this to emit an
+    actionable error for that unsupported directive combination.
     """
     flow_sides = _FLOW_ALIGNED_SIDES.get(section.direction)
     if flow_sides is None:
         return False
-    sides = [p.side for p in graph.ports.values() if p.section_id == section.id]
+    sides = [graph.ports[pid].side for pid in section.port_ids if pid in graph.ports]
     return bool(sides) and not any(s in flow_sides for s in sides)
 
 
@@ -181,17 +190,13 @@ def _guard_stations_within_bbox(graph: MetroGraph, phase: str) -> None:
     Unlike :func:`_guard_stations_in_sections` (which runs only under
     ``validate`` mid-layout and checks marker-edge containment on the Y
     axis), this guard runs on every layout -- including the default render
-    path -- and checks the *settled* bbox on both axes.  It is the
-    backstop for issue #424: forcing perpendicular ports on a horizontal
-    section lays its stations out past the right of its own bbox, and the
-    engine must reject that loudly rather than render it silently.
+    path -- and checks the *settled* bbox on both axes.  Forcing
+    perpendicular ports on a horizontal section lays its stations out past
+    the right of its own bbox, and the engine must reject that loudly
+    rather than render it silently.
     """
-    junction_ids = graph.junction_ids
     tol = GUARD_TOLERANCE
-    for sid, st in graph.stations.items():
-        sec = graph.sections.get(st.section_id or "")
-        if not sec or st.is_port or sid in junction_ids or sec.bbox_w == 0:
-            continue
+    for sid, st, sec in _bbox_guarded_stations(graph):
         inside_x = sec.bbox_x - tol <= st.x <= sec.bbox_x + sec.bbox_w + tol
         inside_y = sec.bbox_y - tol <= st.y <= sec.bbox_y + sec.bbox_h + tol
         if inside_x and inside_y:

--- a/tests/fixtures/regressions/lr_perpendicular_ports_overflow.mmd
+++ b/tests/fixtures/regressions/lr_perpendicular_ports_overflow.mmd
@@ -1,0 +1,31 @@
+%%metro title: LR section with both ports forced perpendicular
+%%metro line: l1 | Line 1 | #e64980 | solid
+%%metro grid: upstream | 0,0
+%%metro grid: annotation | 0,1
+%%metro grid: downstream | 0,2
+
+graph LR
+    subgraph upstream [Upstream]
+        u1[U1]
+        u2[U2]
+        u1 -->|l1| u2
+    end
+    subgraph annotation [Annotation]
+        %%metro direction: LR
+        %%metro entry: top | l1
+        %%metro exit: bottom | l1
+        snpeff[snpEff]
+        vep[VEP]
+        bcftools_ann[bcftools]
+        snpsift[SnpSift]
+        snpeff -->|l1| vep
+        vep -->|l1| bcftools_ann
+        bcftools_ann -->|l1| snpsift
+    end
+    subgraph downstream [Downstream]
+        d1[D1]
+        d2[D2]
+        d1 -->|l1| d2
+    end
+    u2 -->|l1| snpeff
+    snpsift -->|l1| d1

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1406,7 +1406,9 @@ def test_section_bbox_contains_all_content(fixture, params):
                 f"(y={st.y}, half={half}) overflows bbox bottom "
                 f"y={section.bbox_y + section.bbox_h}"
             )
-            assert section.bbox_x - 0.5 <= st.x <= section.bbox_x + section.bbox_w + 0.5, (
+            assert (
+                section.bbox_x - 0.5 <= st.x <= section.bbox_x + section.bbox_w + 0.5
+            ), (
                 f"Section {sec_id}: station {sid} x={st.x} outside bbox "
                 f"x-range [{section.bbox_x}, {section.bbox_x + section.bbox_w}]"
             )

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -23,7 +23,11 @@ from nf_metro.layout.constants import (
     SECTION_HEADER_PROTRUSION,
     SECTION_Y_GAP,
 )
-from nf_metro.layout.engine import compute_layout, is_loop_side_branch_station
+from nf_metro.layout.engine import (
+    PhaseInvariantError,
+    compute_layout,
+    is_loop_side_branch_station,
+)
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.layout.routing.common import resolve_section
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -1338,23 +1342,45 @@ _BBOX_PARAM_SETS = [
     pytest.param({}, id="default"),
 ]
 
+# The full corpus plus a deliberately-unsupported topology (an internally
+# horizontal section whose only ports are perpendicular, leaving no
+# flow-aligned edge to anchor the horizontal run -- issue #424).  On the
+# corpus the invariant holds outright; on the regression fixture the engine
+# must either keep content in-bbox or reject it loudly, never silently
+# overflow.
+_BBOX_CONTAINMENT_FIXTURES = [
+    *ALL_FIXTURES,
+    "regressions/lr_perpendicular_ports_overflow.mmd",
+]
 
-@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+
+@pytest.mark.parametrize("fixture", _BBOX_CONTAINMENT_FIXTURES)
 @pytest.mark.parametrize("params", _BBOX_PARAM_SETS)
 def test_section_bbox_contains_all_content(fixture, params):
     """Every section's bbox must contain its on-track stations and any
-    off-track / terminus icons.  Catches regressions where an icon
-    (off-track input or single-icon terminus) is placed near the bbox
-    top so the icon spills outside the section background.
+    off-track / terminus icons, on both axes.  Catches regressions where
+    an icon (off-track input or single-icon terminus) is placed near the
+    bbox top so the icon spills outside the section background, and where
+    an internally-horizontal section lays its stations out to the right of
+    its own bbox (issue #424).
 
     Margin: on-track station markers reach ~9.5 px above the centre,
     file icons reach ``terminus_height / 2 = 16`` px above the centre
     (both off-track inputs and on-track terminus stations render the
     same icon at ``station.y + bundle_mid``).  We assert
     ``station.y - reach >= bbox_y - 0.5`` (sub-pixel tolerance) and
-    ``station.y + reach <= bbox_y + bbox_h + 0.5``.
+    ``station.y + reach <= bbox_y + bbox_h + 0.5`` vertically, and the
+    station centre within ``[bbox_x - 0.5, bbox_x + bbox_w + 0.5]``
+    horizontally.
+
+    A loud ``PhaseInvariantError`` upholds the invariant: it means the
+    engine refused to ship an out-of-bbox layout rather than rendering it
+    silently.  The dedicated rejection test below pins that path.
     """
-    graph = _layout(fixture, **params)
+    try:
+        graph = _layout(fixture, **params)
+    except PhaseInvariantError:
+        return
     junction_ids = set(graph.junctions)
 
     for sec_id, section in graph.sections.items():
@@ -1380,6 +1406,29 @@ def test_section_bbox_contains_all_content(fixture, params):
                 f"(y={st.y}, half={half}) overflows bbox bottom "
                 f"y={section.bbox_y + section.bbox_h}"
             )
+            assert section.bbox_x - 0.5 <= st.x <= section.bbox_x + section.bbox_w + 0.5, (
+                f"Section {sec_id}: station {sid} x={st.x} outside bbox "
+                f"x-range [{section.bbox_x}, {section.bbox_x + section.bbox_w}]"
+            )
+
+
+def test_lr_section_all_perpendicular_ports_rejected():
+    """An internally-LR/RL section whose only ports are perpendicular
+    (every entry/exit on top/bottom) has no flow-aligned edge to anchor
+    its horizontal run, so its stations are laid out past the right of
+    its own bbox.  The engine must reject this loudly with an actionable
+    message naming the section, rather than rendering it silently (#424).
+    """
+    text = (
+        FIXTURES / "regressions" / "lr_perpendicular_ports_overflow.mmd"
+    ).read_text()
+    graph = parse_metro_mermaid(text)
+    graph.center_ports = True
+    with pytest.raises(PhaseInvariantError) as excinfo:
+        compute_layout(graph)
+    msg = str(excinfo.value).lower()
+    assert "annotation" in msg
+    assert "perpendicular" in msg or "flow-aligned" in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Forcing perpendicular ports (`entry: top` / `exit: bottom`) on an internally-`LR`/`RL` section leaves its horizontal run with no flow-aligned port to anchor it to the bbox, so the engine lays stations out past the right edge of their own section box. The CLI render path (`compute_layout(validate=False)`) shipped this silently.

- Add an always-on postcondition `_guard_stations_within_bbox` wired into `compute_layout` unconditionally (not gated on `validate`). It checks every station centre against its settled section bbox on both axes and raises `PhaseInvariantError` on overflow. When the offending section has only perpendicular ports, the error explains the unsupported directive combination and how to fix it.
- Surface the error as a clean `click.ClickException` on the `render` command instead of a traceback.
- Export `PhaseInvariantError` from `nf_metro.layout`.
- Extend `test_section_bbox_contains_all_content` to assert horizontal containment across the full fixture corpus plus a new regression fixture (`regressions/lr_perpendicular_ports_overflow.mmd`); a loud `PhaseInvariantError` counts as upholding the invariant. Add a focused `test_lr_section_all_perpendicular_ports_rejected` pinning the rejection message.
- Factor the shared station skip-predicate into `_bbox_guarded_stations`, consumed by both the marker-edge and centre-containment guards.

Every shipping gallery fixture has zero bbox overflow, so the guard never fires on existing content.

Fixes #424

## Test plan
- [x] `pytest` passes (3628 passed, 3 skipped, 6 xfailed), including the new invariant + rejection tests
- [x] New tests verified failing on `main`, passing with the fix
- [x] `ruff check` + `ruff format --check` clean on `src/ tests/` (CI scope)
- [x] Runtime validator added (`_guard_stations_within_bbox`, always-on)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/450/)
- [ ] Render-preview verdict (expected: No visual changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
