### PR TITLE
EXPERIMENT (do not merge): fully-uniform maintained invariants (#365)

### DIFF
--- a/docs/dev/maintained_invariants_spike.md
+++ b/docs/dev/maintained_invariants_spike.md
@@ -1,0 +1,145 @@
+# Spike: declarative maintained invariants (#365)
+
+**Verdict: partial land.** The mechanism works byte-identically for the
+*simple, cheap-to-check* restore invariants (junction positioning, canvas
+top-margin) and removes a real class of bug (#386). It does **not** pay for
+the complex restores (off-track stacking, row top-align, fan re-center),
+for a concrete mechanism-level reason documented below. This is outcome
+(a) from the issue, scoped: "promising for a subset, procedural phases
+survive elsewhere."
+
+This is explicitly **not** a constraint solver. The #353 failure mode
+(Cassowary weak attractors couldn't reproduce the engine's hierarchical
+decision order) is not relitigated here: the repairs *are* the existing
+constructive helpers, applied in a *declared* order, not numeric
+attractors relaxed to equilibrium.
+
+## What the pipeline actually looks like
+
+`_compute_section_layout` has two kinds of Pass-C phase:
+
+- **Constructive** phases that make a layout decision (lift off-track, fan
+  content, compact rows, re-center bundles, snap to grid).
+- **Restore** phases that re-establish an invariant a constructive phase
+  just broke. These are the scattered re-runs:
+  - `_position_junctions` - **6 sites** (Stages 5.1, 5.5, 6.4, 6.13, 6.14,
+    6.16)
+  - `_shift_graph_into_canvas` - **4 sites** (5.2, 6.6, 6.8, 6.15a)
+  - `_top_align_row_bboxes_only` - **3 sites** (5.3, 6.9)
+  - `_reanchor_off_track_to_consumer` - **2 sites** (6.6, 6.8)
+
+The "run the restore after the thing that breaks it" ordering lives
+*implicitly* in the call sequence. Adding a port-moving phase silently
+regresses any junction whose restore the author forgot to re-trigger -
+which is exactly #386 ("re-run `_position_junctions` after Stage 6.14 to
+kill the dip").
+
+The restore phases **are** maintained invariants. The spike lifts them
+into data: each declares a *predicate* (does it hold?), a *repair*
+(re-establish it), and a *priority* (lower repairs first). `maintain`
+applies the repairs in priority order to a fixpoint, so one
+`maintain(graph, ...)` call after each constructive phase subsumes the
+scattered manual re-runs.
+
+## What landed
+
+`src/nf_metro/layout/phases/maintained.py`:
+
+- `MaintainedInvariant(name, priority, predicate, repair, description)`.
+- `maintain(graph, invariants, max_passes=8)` - priority-ordered fixpoint;
+  raises loudly on non-convergence (the "two repairs are fighting" =
+  #353-shape backstop).
+- `assert_maintained(graph, invariants, phase)` - runtime guard for
+  `validate=True`.
+- Two invariants: `JUNCTIONS_TRACK_PORTS` (priority 30) and
+  `canvas_top_margin(section_y_padding)` (priority 20).
+
+The orchestrator's 9 manual restore calls (5 `_position_junctions`
+re-runs + 4 `_shift_graph_into_canvas`) are replaced by `maintain(graph,
+maintained)`. **All 76 gallery renders are byte-identical to main.**
+
+## Why these two invariants work and the others don't
+
+The decisive finding: **a guard predicate is not the same as the repair's
+postcondition, and the maintained-invariant predicate must mirror the
+*repair*.**
+
+For an idempotent repair `R`, the faithful predicate is "would `R` be a
+no-op?" - i.e. "is the state already exactly what `R` would produce?". The
+hand-written pipeline re-ran each restore *unconditionally*, so the
+invariant it kept is **exact equality**, not the looser "good enough"
+condition the validate-mode guards check.
+
+- `_position_junctions` writes `junction.xy = _compute_junction_xy(...)`,
+  a pure function of port coordinates that reads no stored junction state.
+  The "would it be a no-op?" predicate is a one-line exact comparison
+  against `_compute_junction_xy`. **Cheap and exact.** (A first cut used a
+  0.5px tolerance and diverged on `genomeassembly_staggered`, because a
+  sub-pixel port nudge moved the target while the manual code re-snapped
+  it exactly. Tightening to FP-epsilon restored byte-identity - direct
+  evidence that the invariant is exact equality.)
+- `_shift_graph_into_canvas` is a uniform whole-graph translate; its
+  no-op predicate is `min_section_bbox_top >= margin`, identical to the
+  helper's own early-return. **Cheap and exact.** Being a translate, it
+  moves junctions and ports together, so it can never break the junction
+  invariant - the two compose trivially.
+
+The complex restores fail the cheapness test:
+
+- `_reanchor_off_track_to_consumer` pins each off-track at *exactly*
+  `consumer.y - n*y_spacing`, where the target accounts for trunk
+  line-track bands, sibling-icon clearance, and iterative overlap
+  stepping (`_place_off_track_above_consumers`). The matching guard,
+  `_guard_off_track_inputs_above_consumer`, only checks the *weak*
+  condition `off.y < consumer.y - tol`. A predicate that mirrors the
+  *repair* would have to re-derive the entire placement computation - the
+  predicate costs as much as the repair and is a fresh bug surface. The
+  guard cannot be reused as the predicate (it would say "holds" while the
+  repair would still move the icon, diverging).
+- `_top_align_row_bboxes_only` and `_recenter_full_bundle_columns` have
+  the same shape: complex postconditions whose faithful no-op predicate is
+  a re-derivation.
+
+So the value of the mechanism is gated on **predicate cheapness**, not on
+the priority-ordered fixpoint (which is sound - the convergence backstop
+and the junctions+canvas composition both hold). Where the repair's
+postcondition is a cheap exact predicate, lifting it removes real
+bookkeeping and a real bug class. Where it isn't, the predicate-authoring
+cost exceeds the benefit of declaring the order, and the implicit
+procedural ordering should stay.
+
+## Trust-but-verify finding (CONTRACT.md drift)
+
+Mining the rules surfaced that `CONTRACT.md` had drifted from the code
+(verified helper-by-helper):
+
+- **Stage 6.15a** (`_grow_bboxes_to_content_top`) and **Stage 6.16**
+  (`_align_entry_ports(tb_only=True)` + junction re-anchor) are real code
+  stages **missing** from the contract table.
+- **Stage 6.11** is documented as unconditional but is double-gated on
+  `_explicit_grid AND center_ports`.
+- **Stages 4.9 / 4.10** are gated *inside* the helper, not at the call
+  site (the contract implies a caller-level `if`).
+- All `engine.py:NNNN` helper line numbers are stale post-#451 (helpers
+  now live in `phases/`).
+
+The per-helper "Invariants preserved" claims otherwise held up. The
+contract drift is itself the structural-debt signal the spike was filed to
+probe: prose ordering documentation goes stale; machine-checkable
+invariants (`assert_maintained`) do not.
+
+## Recommendation
+
+1. **Keep** the `maintained.py` mechanism and the two invariants. They are
+   byte-identical, tested, and `assert_maintained` makes the junction/canvas
+   ordering machine-checkable (closes the #386 regression class).
+2. **Adopt incrementally**: a new restore-class phase whose postcondition
+   is a cheap exact predicate should be added as a `MaintainedInvariant`,
+   not a hand-placed re-run.
+3. **Do not** force the complex restores (off-track, top-align, recenter)
+   through the mechanism. Their faithful predicate is a re-derivation of
+   the repair; the ordering is better left procedural until/unless those
+   helpers are refactored to expose a cheap "is this already placed?"
+   query.
+4. **Fix the contract drift** (separate change): add the 6.15a/6.16 rows,
+   correct the 6.11 and 4.9/4.10 gating notes.

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -53,10 +53,10 @@ Stages split into three regimes:
 | after Stage 3.1 | ports-on-boundaries |
 | after top-align (Stage 3.5) | ports-on-boundaries |
 | after each Pass C sub-stage (bisection) | finite coords, bboxes-positive, ports-on-boundaries, station-x-column-drift, plus three phase-gated guards (see below) |
-| after final | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
+| after final | bisection set (all unconditional) + maintained-invariants (`assert_maintained`), off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
 Bisection checkpoints fire after every Pass C sub-stage (see the
-`# Stage 5.2:` through `# Stage 6.15:` comments in
+`# Stage 5.2:` through `# Stage 6.16:` comments in
 `_compute_section_layout`). Three guards
 hold continuously only from a specific checkpoint onward, and the
 bisection runner skips them earlier; see `_BISECTION_FIRST_VALID` in
@@ -72,8 +72,31 @@ Three further guards are excluded from the bisection set entirely
 (meaningful only at the final boundary); the `_run_pass_c_guards`
 docstring in `engine.py` is the authoritative list.
 
-Guard bodies live at the top of `engine.py` (lines 83-275); the
-bisection runner is `_run_pass_c_guards`.
+Guard bodies live in `phases/guards.py` and are imported into `engine.py`;
+the bisection runner is `_run_pass_c_guards`.
+
+## Maintained invariants (#365)
+
+Several Pass-C properties are kept alive *declaratively* rather than by
+hand-placed restore calls. `phases/maintained.py` declares each as a
+`MaintainedInvariant` (predicate + idempotent repair + priority); the
+orchestrator calls `maintain(graph, maintained)` after each constructive
+Pass-C phase that may perturb one, and the repairs run in priority order to
+a fixpoint. The set:
+
+| Invariant | Priority | Predicate | Repair |
+|---|---|---|---|
+| `canvas_top_margin` | 20 | topmost section bbox top `>= section_y_padding` | `_shift_graph_into_canvas` |
+| `junctions_track_ports` | 30 | `junction.xy == _compute_junction_xy` | `_position_junctions` |
+
+This is why the per-stage "re-run `_position_junctions`" / "shift into
+canvas" notes below describe an *effect* now produced by `maintain`, not a
+literal helper call at that line. A new restore-class property with a
+*cheap, exact* "is it already satisfied?" predicate should be added here
+as an invariant rather than as another hand-placed re-run; see
+[`docs/dev/maintained_invariants_spike.md`](../../../docs/dev/maintained_invariants_spike.md)
+for why complex restores (off-track stacking, top-align) stay procedural.
+`assert_maintained` re-checks the set at the final validate boundary.
 
 ## Stage overview
 
@@ -326,9 +349,10 @@ in pipeline order.
 ### Stage 4.9: redistribute fan-out siblings (engine.py:644-648)
 - **Purpose**: For each fan-out column with a unique trunk junction
   (one station carrying the full bundle plus >=2 side branches),
-  redistribute side stations symmetrically around the trunk Y. Gated
-  on `graph.center_ports`.
-- **Helper**: `_redistribute_fanout_siblings` (engine.py:3163).
+  redistribute side stations symmetrically around the trunk Y. No-op
+  unless `graph.center_ports` (guard inside the helper, not at the call
+  site).
+- **Helper**: `_redistribute_fanout_siblings` (`phases/fan_bundles.py`).
 - **Precondition**: Trunk Ys aligned (Stage 4.8).
 - **Postcondition**: In qualifying columns, fan-out siblings sit
   symmetrically around the trunk station's Y. Linear chains, fan-in
@@ -338,9 +362,9 @@ in pipeline order.
 ### Stage 4.10: redistribute full-bundle columns (engine.py)
 - **Purpose**: When a column has no unique trunk (every station
   carries the full bundle - e.g. Reporting's Shiny + Quarto),
-  symmetrically fan stations around the local LR port Y. Gated on
-  `center_ports`.
-- **Helper**: `_redistribute_full_bundle_columns`.
+  symmetrically fan stations around the local LR port Y. No-op unless
+  `center_ports` (guard inside the helper, not at the call site).
+- **Helper**: `_redistribute_full_bundle_columns` (`phases/fan_bundles.py`).
 - **Precondition**: Stage 4.9 ran.
 - **Postcondition**: Full-bundle columns sit symmetric around the
   LR port Y.
@@ -549,11 +573,14 @@ in pipeline order.
 - **Invariants preserved**: Multi-station columns.
 - **Related tests**: `test_terminus_not_directly_after_diagonal`.
 
-### Stage 6.11: balance section content around trunk (engine.py:765-771)
+### Stage 6.11: balance section content around trunk
 - **Purpose**: Auto-balance pass. For sections whose final layout
   still has an empty band above the trunk while more siblings sit
   below than above, lift bottommost movable siblings into the empty
   top band. U-turn-safe and bbox-bounded.
+- **Gating**: Early-returns unless **both** `graph._explicit_grid` and
+  `graph.center_ports` are set (scoped to explicit-`%%metro grid:` +
+  centre-ports pipelines), so it is a no-op on auto-laid graphs.
 - **Helper**: `_balance_section_content_around_trunk` (engine.py:2030).
 - **Precondition**: All earlier 13-phase reshuffles done.
 - **Postcondition**: Sibling count above trunk >= sibling count below
@@ -621,6 +648,22 @@ in pipeline order.
   `test_no_icon_overlaps_line_path`,
   `test_row_gap_accommodates_bypass`.
 
+### Stage 6.15a: restore symmetric top padding
+- **Purpose**: Fan re-distribution (Stages 4.9 / 4.10 / 6.7 / 6.11) can
+  lift a branch above the content-top line the bbox was sized for,
+  crowding the topmost marker against the bbox top while the bottom keeps
+  its full band. Grow each bbox top to a full `section_y_padding` above the
+  highest marker (bounded by the row above) so fanned-above content sits
+  centred. The upward grow can breach the canvas top margin, restored by
+  the `canvas_top_margin` invariant.
+- **Helper**: `_grow_bboxes_to_content_top` (`phases/bbox.py`), then
+  `maintain` (canvas restore).
+- **Precondition**: All content Ys final (post-6.14).
+- **Postcondition**: Each bbox top sits `section_y_padding` above its
+  highest marker, bounded by the row above.
+- **Invariants preserved**: Station Ys (only bbox tops grow). Resolves #406.
+- **Related tests**: `test_section_bbox_has_top_padding`.
+
 ### Stage 6.15: snap canvas to the y-grid
 - **Purpose**: After all settling, restore canvas-wide grid alignment.
   Stage 6.4 snaps to a per-row grid, but later helpers (notably
@@ -636,6 +679,23 @@ in pipeline order.
   canvas moves by one delta).
 - **Related tests**: `test_auto_y_spacing_fits_content`.
 
+### Stage 6.16: re-align TB entry ports with feeders
+- **Purpose**: A TB/BT section's perpendicular entry port is pinned a fixed
+  offset above its first internal station, so the late vertical settling
+  (Stages 6.13-6.15) that shifts the section's content drags the entry port
+  off the upstream feeder Y it was snapped to in Stage 3.2, re-introducing
+  an inter-section S-kink. Re-run the alignment (TB/BT only, to leave
+  settled LR/RL geometry untouched) to re-snap the port to its now-settled
+  feeder; the `junctions_track_ports` invariant re-anchors junctions after.
+- **Helper**: `_align_entry_ports(graph, tb_only=True)` (`phases/ports.py`),
+  then `maintain` (junction restore).
+- **Precondition**: All vertical settling done (post-6.15).
+- **Postcondition**: TB/BT entry ports share their upstream feeder's Y;
+  junctions re-anchored to the settled ports.
+- **Invariants preserved**: LR/RL entry/exit geometry (skipped by
+  `tb_only`).
+- **Validate guard after**: bisection set ("after Stage 6.16").
+
 ## Unclear / structural-debt signals
 
 No open signals at this time. Add new entries here when phase
@@ -648,7 +708,7 @@ following before merging:
 
 1. **Stage tag**: pick the next sequential number within the
    appropriate stage (e.g. a new Stage 6.x sub-step gets the next
-   integer after Stage 6.15).  Historical note: the organic phase
+   integer after Stage 6.16).  Historical note: the organic phase
    suffix tree (`13d2`, `13k2`, the `Phase 13k` -> `Phase 13k2`
    rename in PR #342) is what the flat Stage.N scheme is designed to
    prevent.

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -53,10 +53,10 @@ Stages split into three regimes:
 | after Stage 3.1 | ports-on-boundaries |
 | after top-align (Stage 3.5) | ports-on-boundaries |
 | after each Pass C sub-stage (bisection) | finite coords, bboxes-positive, ports-on-boundaries, station-x-column-drift, plus three phase-gated guards (see below) |
-| after final | bisection set (all unconditional) + maintained-invariants (`assert_maintained`), off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
+| after final | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
 Bisection checkpoints fire after every Pass C sub-stage (see the
-`# Stage 5.2:` through `# Stage 6.16:` comments in
+`# Stage 5.2:` through `# Stage 6.15:` comments in
 `_compute_section_layout`). Three guards
 hold continuously only from a specific checkpoint onward, and the
 bisection runner skips them earlier; see `_BISECTION_FIRST_VALID` in
@@ -72,31 +72,8 @@ Three further guards are excluded from the bisection set entirely
 (meaningful only at the final boundary); the `_run_pass_c_guards`
 docstring in `engine.py` is the authoritative list.
 
-Guard bodies live in `phases/guards.py` and are imported into `engine.py`;
-the bisection runner is `_run_pass_c_guards`.
-
-## Maintained invariants (#365)
-
-Several Pass-C properties are kept alive *declaratively* rather than by
-hand-placed restore calls. `phases/maintained.py` declares each as a
-`MaintainedInvariant` (predicate + idempotent repair + priority); the
-orchestrator calls `maintain(graph, maintained)` after each constructive
-Pass-C phase that may perturb one, and the repairs run in priority order to
-a fixpoint. The set:
-
-| Invariant | Priority | Predicate | Repair |
-|---|---|---|---|
-| `canvas_top_margin` | 20 | topmost section bbox top `>= section_y_padding` | `_shift_graph_into_canvas` |
-| `junctions_track_ports` | 30 | `junction.xy == _compute_junction_xy` | `_position_junctions` |
-
-This is why the per-stage "re-run `_position_junctions`" / "shift into
-canvas" notes below describe an *effect* now produced by `maintain`, not a
-literal helper call at that line. A new restore-class property with a
-*cheap, exact* "is it already satisfied?" predicate should be added here
-as an invariant rather than as another hand-placed re-run; see
-[`docs/dev/maintained_invariants_spike.md`](../../../docs/dev/maintained_invariants_spike.md)
-for why complex restores (off-track stacking, top-align) stay procedural.
-`assert_maintained` re-checks the set at the final validate boundary.
+Guard bodies live at the top of `engine.py` (lines 83-275); the
+bisection runner is `_run_pass_c_guards`.
 
 ## Stage overview
 
@@ -349,10 +326,9 @@ in pipeline order.
 ### Stage 4.9: redistribute fan-out siblings (engine.py:644-648)
 - **Purpose**: For each fan-out column with a unique trunk junction
   (one station carrying the full bundle plus >=2 side branches),
-  redistribute side stations symmetrically around the trunk Y. No-op
-  unless `graph.center_ports` (guard inside the helper, not at the call
-  site).
-- **Helper**: `_redistribute_fanout_siblings` (`phases/fan_bundles.py`).
+  redistribute side stations symmetrically around the trunk Y. Gated
+  on `graph.center_ports`.
+- **Helper**: `_redistribute_fanout_siblings` (engine.py:3163).
 - **Precondition**: Trunk Ys aligned (Stage 4.8).
 - **Postcondition**: In qualifying columns, fan-out siblings sit
   symmetrically around the trunk station's Y. Linear chains, fan-in
@@ -362,9 +338,9 @@ in pipeline order.
 ### Stage 4.10: redistribute full-bundle columns (engine.py)
 - **Purpose**: When a column has no unique trunk (every station
   carries the full bundle - e.g. Reporting's Shiny + Quarto),
-  symmetrically fan stations around the local LR port Y. No-op unless
-  `center_ports` (guard inside the helper, not at the call site).
-- **Helper**: `_redistribute_full_bundle_columns` (`phases/fan_bundles.py`).
+  symmetrically fan stations around the local LR port Y. Gated on
+  `center_ports`.
+- **Helper**: `_redistribute_full_bundle_columns`.
 - **Precondition**: Stage 4.9 ran.
 - **Postcondition**: Full-bundle columns sit symmetric around the
   LR port Y.
@@ -573,14 +549,11 @@ in pipeline order.
 - **Invariants preserved**: Multi-station columns.
 - **Related tests**: `test_terminus_not_directly_after_diagonal`.
 
-### Stage 6.11: balance section content around trunk
+### Stage 6.11: balance section content around trunk (engine.py:765-771)
 - **Purpose**: Auto-balance pass. For sections whose final layout
   still has an empty band above the trunk while more siblings sit
   below than above, lift bottommost movable siblings into the empty
   top band. U-turn-safe and bbox-bounded.
-- **Gating**: Early-returns unless **both** `graph._explicit_grid` and
-  `graph.center_ports` are set (scoped to explicit-`%%metro grid:` +
-  centre-ports pipelines), so it is a no-op on auto-laid graphs.
 - **Helper**: `_balance_section_content_around_trunk` (engine.py:2030).
 - **Precondition**: All earlier 13-phase reshuffles done.
 - **Postcondition**: Sibling count above trunk >= sibling count below
@@ -648,22 +621,6 @@ in pipeline order.
   `test_no_icon_overlaps_line_path`,
   `test_row_gap_accommodates_bypass`.
 
-### Stage 6.15a: restore symmetric top padding
-- **Purpose**: Fan re-distribution (Stages 4.9 / 4.10 / 6.7 / 6.11) can
-  lift a branch above the content-top line the bbox was sized for,
-  crowding the topmost marker against the bbox top while the bottom keeps
-  its full band. Grow each bbox top to a full `section_y_padding` above the
-  highest marker (bounded by the row above) so fanned-above content sits
-  centred. The upward grow can breach the canvas top margin, restored by
-  the `canvas_top_margin` invariant.
-- **Helper**: `_grow_bboxes_to_content_top` (`phases/bbox.py`), then
-  `maintain` (canvas restore).
-- **Precondition**: All content Ys final (post-6.14).
-- **Postcondition**: Each bbox top sits `section_y_padding` above its
-  highest marker, bounded by the row above.
-- **Invariants preserved**: Station Ys (only bbox tops grow). Resolves #406.
-- **Related tests**: `test_section_bbox_has_top_padding`.
-
 ### Stage 6.15: snap canvas to the y-grid
 - **Purpose**: After all settling, restore canvas-wide grid alignment.
   Stage 6.4 snaps to a per-row grid, but later helpers (notably
@@ -679,23 +636,6 @@ in pipeline order.
   canvas moves by one delta).
 - **Related tests**: `test_auto_y_spacing_fits_content`.
 
-### Stage 6.16: re-align TB entry ports with feeders
-- **Purpose**: A TB/BT section's perpendicular entry port is pinned a fixed
-  offset above its first internal station, so the late vertical settling
-  (Stages 6.13-6.15) that shifts the section's content drags the entry port
-  off the upstream feeder Y it was snapped to in Stage 3.2, re-introducing
-  an inter-section S-kink. Re-run the alignment (TB/BT only, to leave
-  settled LR/RL geometry untouched) to re-snap the port to its now-settled
-  feeder; the `junctions_track_ports` invariant re-anchors junctions after.
-- **Helper**: `_align_entry_ports(graph, tb_only=True)` (`phases/ports.py`),
-  then `maintain` (junction restore).
-- **Precondition**: All vertical settling done (post-6.15).
-- **Postcondition**: TB/BT entry ports share their upstream feeder's Y;
-  junctions re-anchored to the settled ports.
-- **Invariants preserved**: LR/RL entry/exit geometry (skipped by
-  `tb_only`).
-- **Validate guard after**: bisection set ("after Stage 6.16").
-
 ## Unclear / structural-debt signals
 
 No open signals at this time. Add new entries here when phase
@@ -708,7 +648,7 @@ following before merging:
 
 1. **Stage tag**: pick the next sequential number within the
    appropriate stage (e.g. a new Stage 6.x sub-step gets the next
-   integer after Stage 6.16).  Historical note: the organic phase
+   integer after Stage 6.15).  Historical note: the organic phase
    suffix tree (`13d2`, `13k2`, the `Phase 13k` -> `Phase 13k2`
    rename in PR #342) is what the flat Stage.N scheme is designed to
    prevent.

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -53,7 +53,7 @@ Stages split into three regimes:
 | after Stage 3.1 | ports-on-boundaries |
 | after top-align (Stage 3.5) | ports-on-boundaries |
 | after each Pass C sub-stage (bisection) | finite coords, bboxes-positive, ports-on-boundaries, station-x-column-drift, plus three phase-gated guards (see below) |
-| after final | bisection set (all unconditional) + off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
+| after final | bisection set (all unconditional) + maintained-invariants (`assert_maintained`), off-track-above-consumer, row-trunk-cy-consistent, inter-section-routes-in-row-band |
 
 Bisection checkpoints fire after every Pass C sub-stage (see the
 `# Stage 5.2:` through `# Stage 6.15:` comments in
@@ -74,6 +74,29 @@ docstring in `engine.py` is the authoritative list.
 
 Guard bodies live at the top of `engine.py` (lines 83-275); the
 bisection runner is `_run_pass_c_guards`.
+
+## Maintained invariants (#365)
+
+Several Pass-C properties are kept alive *declaratively* rather than by
+hand-placed restore calls. `phases/maintained.py` declares each as a
+`MaintainedInvariant` (predicate + idempotent repair + priority); the
+orchestrator calls `maintain(graph, maintained)` after each constructive
+Pass-C phase that may perturb one, and the repairs run in priority order to
+a fixpoint. The set:
+
+| Invariant | Priority | Predicate | Repair |
+|---|---|---|---|
+| `canvas_top_margin` | 20 | topmost section bbox top `>= section_y_padding` | `_shift_graph_into_canvas` |
+| `junctions_track_ports` | 30 | `junction.xy == _compute_junction_xy` | `_position_junctions` |
+
+This is why the per-stage "re-run `_position_junctions`" / "shift into
+canvas" notes below describe an *effect* now produced by `maintain`, not a
+literal helper call at that line. A new restore-class property with a
+*cheap, exact* "is it already satisfied?" predicate should be added here
+as an invariant rather than as another hand-placed re-run; see
+[`docs/dev/maintained_invariants_spike.md`](../../../docs/dev/maintained_invariants_spike.md)
+for why complex restores (off-track stacking, top-align) stay procedural.
+`assert_maintained` re-checks the set at the final validate boundary.
 
 ## Stage overview
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -148,10 +148,12 @@ from nf_metro.layout.phases.junctions import (  # noqa: F401
 )
 from nf_metro.layout.phases.maintained import (  # noqa: F401
     JUNCTIONS_TRACK_PORTS,
+    ROW_BBOX_TOPS_FLUSH,
     MaintainedInvariant,
     assert_maintained,
     canvas_top_margin,
     maintain,
+    off_track_above_consumer,
 )
 from nf_metro.layout.phases.off_track import (  # noqa: F401
     _align_phantom_pass_throughs,
@@ -236,13 +238,21 @@ otherwise only surface as subtle visual defects.
 """
 
 
-def _pass_c_maintained(section_y_padding: float) -> list[MaintainedInvariant]:
+def _pass_c_maintained(
+    section_y_padding: float, y_spacing: float
+) -> list[MaintainedInvariant]:
     """The Pass-C invariant set, bound to this layout's spacing params.
 
-    ``maintain`` re-applies these repairs after each constructive phase that
-    may perturb a junction or the canvas top margin; see ``maintained.py``.
+    ``maintain`` re-applies these repairs (in priority order) after each
+    constructive phase, replacing the hand-placed restore calls; see
+    ``maintained.py``.
     """
-    return [JUNCTIONS_TRACK_PORTS, canvas_top_margin(section_y_padding)]
+    return [
+        off_track_above_consumer(y_spacing, section_y_padding),
+        canvas_top_margin(section_y_padding),
+        ROW_BBOX_TOPS_FLUSH,
+        JUNCTIONS_TRACK_PORTS,
+    ]
 
 
 def compute_min_y_spacing(
@@ -746,7 +756,7 @@ def _compute_section_layout(
     # with them).  Stage 6 below handles the rest of Pass C.
 
     # Invariant set re-applied by ``maintain`` after each perturbing phase.
-    maintained = _pass_c_maintained(section_y_padding)
+    maintained = _pass_c_maintained(section_y_padding, y_spacing)
 
     # Stage 5.1: Position junction stations in the inter-section gap.
     _position_junctions(graph)
@@ -762,11 +772,11 @@ def _compute_section_layout(
         _run_pass_c_guards(graph, "after Stage 5.2")
 
     # Stage 5.3: Re-align bbox tops within each grid row after off-track
-    # lifting expanded some sections upward.  Unlike Stages 3.5 / 4.7 which
-    # shifts stations with the bbox, this only grows the bbox upward so
-    # the empty input-band space lines up across the row.  Station Ys
-    # in unlifted sections are preserved.
-    _top_align_row_bboxes_only(graph)
+    # lifting expanded some sections upward.  The row_bbox_tops_flush
+    # invariant grows the other row-mate bboxes upward to match so the
+    # empty input-band space lines up across the row; station Ys in
+    # unlifted sections are preserved.
+    maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 5.3")
 
@@ -853,15 +863,11 @@ def _compute_section_layout(
 
     # Stage 6.6: Re-anchor off-track inputs to their consumer's final
     # (snapped) Y.  Stage 5.2's lift placed them relative to pre-snap
-    # consumer Ys; snapping the consumer to the grid can shift it by
-    # up to half a pitch, which would collapse the y_spacing gap above
-    # off-track.  Recomputing here pins each off-track at
-    # consumer.y - n*y_spacing on the final grid and grows the bbox
-    # upward if the new position rises above the padding zone.
-    _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
-    # Same canvas-fit safeguard as after Stage 5.2: a reanchor-driven
-    # bbox grow can push the topmost section above the canvas top; the
-    # canvas_top_margin invariant restores it.
+    # consumer Ys; snapping the consumer to the grid can shift it by up to
+    # half a pitch, which would collapse the y_spacing gap above off-track.
+    # The off_track_above_consumer invariant re-pins each off-track at
+    # consumer.y - n*y_spacing on the final grid (growing the bbox upward
+    # as needed); canvas_top_margin then restores any breached margin.
     maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.6")
@@ -876,29 +882,15 @@ def _compute_section_layout(
     # Y as the anchor so the trunk row stays empty in each fanned
     # column.
     #
-    # Stage 6.8 and Stage 6.9 below restore invariants the recenter
-    # breaks.
+    # The recenter perturbs several invariants (Stages 6.8/6.9 used to
+    # restore them by hand): it strands off-track icons at their old
+    # consumer Y, its bbox grow can breach the canvas margin, and that grow
+    # leaves the grown section's bbox above its row mates'.  The maintained
+    # set re-establishes off_track_above_consumer, canvas_top_margin, and
+    # row_bbox_tops_flush in priority order.
     if graph.center_ports:
         _recenter_full_bundle_columns(graph, y_spacing)
-
-        # Stage 6.8: Re-anchor off-track inputs after the recenter.
-        # The recenter moves consumers to the final trunk-anchored Y,
-        # which can leave the off-track icon stranded at the old
-        # consumer Y (overlapping the consumer station instead of
-        # sitting one row above it).  Uses each consumer's post-
-        # recenter Y as the new anchor and grows the section bbox
-        # upward when the lifted band moves above its current top.
-        _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
-        # Same canvas-fit safeguard as Stage 5.2 / Stage 6.6: a
-        # reanchor-driven bbox grow can push the topmost section
-        # above the canvas top; the canvas_top_margin invariant restores it.
         maintain(graph, maintained)
-
-        # Stage 6.9: Re-run row top-align.  A Stage 6.8 reanchor-
-        # driven bbox grow leaves the section's bbox above its row
-        # mates'; pull row mates' bbox tops up to match so the section
-        # row stays flush along its top edge.
-        _top_align_row_bboxes_only(graph)
         if validate:
             _run_pass_c_guards(graph, "after Stage 6.9")
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -236,14 +236,12 @@ otherwise only surface as subtle visual defects.
 """
 
 
-# Invariants kept alive across Pass-C settling (#365).  Each constructive
-# Pass-C phase that may perturb one is followed by ``maintain(graph, ...)``,
-# which re-applies any violated invariant's repair in priority order.  This
-# replaces the hand-placed restore calls (the repeated ``_position_junctions``
-# and ``_shift_graph_into_canvas`` re-runs) with declared rules, so a new
-# phase needs no "remember to re-run the restore" bookkeeping.
 def _pass_c_maintained(section_y_padding: float) -> list[MaintainedInvariant]:
-    """The Pass-C invariant set, bound to this layout's spacing params."""
+    """The Pass-C invariant set, bound to this layout's spacing params.
+
+    ``maintain`` re-applies these repairs after each constructive phase that
+    may perturb a junction or the canvas top margin; see ``maintained.py``.
+    """
     return [JUNCTIONS_TRACK_PORTS, canvas_top_margin(section_y_padding)]
 
 
@@ -747,9 +745,7 @@ def _compute_section_layout(
     # port pairs (re-running Stage 5.1 for the junctions that move
     # with them).  Stage 6 below handles the rest of Pass C.
 
-    # Invariants maintained across the Pass-C settle (#365), bound to this
-    # layout's spacing.  Each constructive phase below is followed by
-    # ``maintain(graph, maintained)`` instead of hand-placed restore calls.
+    # Invariant set re-applied by ``maintain`` after each perturbing phase.
     maintained = _pass_c_maintained(section_y_padding)
 
     # Stage 5.1: Position junction stations in the inter-section gap.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -137,13 +137,21 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     inter_section_route_backtrack_legs,
 )
 from nf_metro.layout.phases.junctions import (  # noqa: F401
+    _compute_junction_xy,
     _junction_incoming_line_count,
     _junction_outgoing_line_count,
+    _merge_junction_xy,
     _position_junctions,
-    _position_merge_junction,
     _required_junction_margin,
     _resolve_source_section_id,
     _resolve_source_xy,
+)
+from nf_metro.layout.phases.maintained import (  # noqa: F401
+    JUNCTIONS_TRACK_PORTS,
+    MaintainedInvariant,
+    assert_maintained,
+    canvas_top_margin,
+    maintain,
 )
 from nf_metro.layout.phases.off_track import (  # noqa: F401
     _align_phantom_pass_throughs,
@@ -226,6 +234,17 @@ Controlled by the ``validate`` parameter on ``compute_layout``.
 Tests pass ``validate=True`` to catch cross-phase corruption that would
 otherwise only surface as subtle visual defects.
 """
+
+
+# Invariants kept alive across Pass-C settling (#365).  Each constructive
+# Pass-C phase that may perturb one is followed by ``maintain(graph, ...)``,
+# which re-applies any violated invariant's repair in priority order.  This
+# replaces the hand-placed restore calls (the repeated ``_position_junctions``
+# and ``_shift_graph_into_canvas`` re-runs) with declared rules, so a new
+# phase needs no "remember to re-run the restore" bookkeeping.
+def _pass_c_maintained(section_y_padding: float) -> list[MaintainedInvariant]:
+    """The Pass-C invariant set, bound to this layout's spacing params."""
+    return [JUNCTIONS_TRACK_PORTS, canvas_top_margin(section_y_padding)]
 
 
 def compute_min_y_spacing(
@@ -728,16 +747,21 @@ def _compute_section_layout(
     # port pairs (re-running Stage 5.1 for the junctions that move
     # with them).  Stage 6 below handles the rest of Pass C.
 
+    # Invariants maintained across the Pass-C settle (#365), bound to this
+    # layout's spacing.  Each constructive phase below is followed by
+    # ``maintain(graph, maintained)`` instead of hand-placed restore calls.
+    maintained = _pass_c_maintained(section_y_padding)
+
     # Stage 5.1: Position junction stations in the inter-section gap.
     _position_junctions(graph)
 
     # Stage 5.2: Lift off_track stations above their section's top track.
     # Runs last so it operates on finalised station Ys and bboxes.
     _lift_off_track_stations(graph, y_spacing, section_y_padding)
-    # The upward bbox growth above can push the topmost section above
-    # the canvas top margin set by Stage 1.5; shift the whole graph
-    # down to restore the margin.  No-op when no section overflowed.
-    _shift_graph_into_canvas(graph, section_y_padding)
+    # The upward bbox growth above can push the topmost section above the
+    # canvas top margin; the canvas_top_margin invariant shifts the whole
+    # graph down to restore it (no-op when no section overflowed).
+    maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 5.2")
 
@@ -766,7 +790,7 @@ def _compute_section_layout(
     # port Y, and either the snap pass or ``_compact_row_content_to_bbox_top``
     # may have moved the exit port since then.
     _snap_inter_section_port_pairs(graph)
-    _position_junctions(graph)
+    maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 5.5")
 
@@ -819,7 +843,7 @@ def _compute_section_layout(
     # snap re-anchors them to the moved exit ports so the L-shape route
     # doesn't U-turn through a stale junction Y.
     _snap_all_y_to_grid(graph, y_spacing)
-    _position_junctions(graph)
+    maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.4")
 
@@ -840,8 +864,9 @@ def _compute_section_layout(
     # upward if the new position rises above the padding zone.
     _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
     # Same canvas-fit safeguard as after Stage 5.2: a reanchor-driven
-    # bbox grow can push the topmost section above the canvas top.
-    _shift_graph_into_canvas(graph, section_y_padding)
+    # bbox grow can push the topmost section above the canvas top; the
+    # canvas_top_margin invariant restores it.
+    maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.6")
 
@@ -870,8 +895,8 @@ def _compute_section_layout(
         _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
         # Same canvas-fit safeguard as Stage 5.2 / Stage 6.6: a
         # reanchor-driven bbox grow can push the topmost section
-        # above the canvas top.
-        _shift_graph_into_canvas(graph, section_y_padding)
+        # above the canvas top; the canvas_top_margin invariant restores it.
+        maintain(graph, maintained)
 
         # Stage 6.9: Re-run row top-align.  A Stage 6.8 reanchor-
         # driven bbox grow leaves the section's bbox above its row
@@ -922,7 +947,7 @@ def _compute_section_layout(
     # the now-shifted exit/entry port Ys (otherwise the trunk dips to
     # the junction's pre-shift Y and produces an S-kink).
     _shrink_and_tighten_rows(graph, section_y_padding, section_y_gap)
-    _position_junctions(graph)
+    maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.13")
 
@@ -937,10 +962,11 @@ def _compute_section_layout(
         graph, y_spacing, section_y_padding, section_y_gap
     )
     # The shift can move an exit port off the Y it held when junctions were
-    # last positioned (Stage 6.13).  Re-anchor junctions to the settled port
-    # Ys so a fan-out bundle runs straight from exit to junction instead of
-    # dipping to a stale junction Y and back (#386).
-    _position_junctions(graph)
+    # last positioned (Stage 6.13).  The junctions_track_ports invariant
+    # re-anchors them to the settled port Ys so a fan-out bundle runs
+    # straight from exit to junction instead of dipping to a stale junction
+    # Y and back (#386).
+    maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.14")
 
@@ -955,7 +981,7 @@ def _compute_section_layout(
     # re-fit's non-grid shift is then cleaned up by the Stage 6.15
     # canvas snap below.
     _grow_bboxes_to_content_top(graph, section_y_padding, section_y_gap)
-    _shift_graph_into_canvas(graph, section_y_padding)
+    maintain(graph, maintained)
 
     # Stage 6.15: Restore canvas-wide grid alignment after all settling.
     # Stage 6.4 snaps to a per-row grid; later helpers (notably
@@ -980,13 +1006,14 @@ def _compute_section_layout(
     # re-snaps the port to its now-settled feeder.  Junctions are
     # re-anchored afterwards for the same reason as Stages 6.13/6.14.
     _align_entry_ports(graph, tb_only=True)
-    _position_junctions(graph)
+    maintain(graph, maintained)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.16")
 
     if validate:
         phase = "after final"
         offsets, routes = _run_pass_c_guards(graph, phase)
+        assert_maintained(graph, maintained, phase)
         _guard_row_trunk_cy_consistent(graph, phase, offsets=offsets)
         _guard_off_track_inputs_above_consumer(graph, phase)
         _guard_fanout_junction_shares_exit_port_y(graph, phase)

--- a/src/nf_metro/layout/phases/junctions.py
+++ b/src/nf_metro/layout/phases/junctions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 from nf_metro.layout.constants import (
     JUNCTION_MARGIN,
 )
@@ -107,6 +109,25 @@ def _compute_junction_xy(graph: MetroGraph, jid: str) -> tuple[float, float] | N
     return exit_port_x + direction * margin, exit_port_y
 
 
+def _resolvable_junctions(
+    graph: MetroGraph,
+) -> Iterator[tuple[Station, tuple[float, float]]]:
+    """Yield ``(junction, target_xy)`` for each junction with a placement.
+
+    Skips junctions whose station is missing or whose ``_compute_junction_xy``
+    returns ``None`` (no resolvable placement).  Shared by the repair
+    (``_position_junctions``) and the ``junctions_track_ports`` predicate so
+    they iterate identically.
+    """
+    for jid in graph.junctions:
+        junction = graph.stations.get(jid)
+        if not junction:
+            continue
+        target = _compute_junction_xy(graph, jid)
+        if target is not None:
+            yield junction, target
+
+
 def _position_junctions(graph: MetroGraph) -> None:
     """Position junction stations at the midpoint of the inter-section gap.
 
@@ -118,13 +139,8 @@ def _position_junctions(graph: MetroGraph) -> None:
     at ``max(pred.x) + _required_junction_margin(n)``, y = entry_port.y to
     create a visible single-line segment from merge point to entry.
     """
-    for jid in graph.junctions:
-        junction = graph.stations.get(jid)
-        if not junction:
-            continue
-        target = _compute_junction_xy(graph, jid)
-        if target is not None:
-            junction.x, junction.y = target
+    for junction, target in _resolvable_junctions(graph):
+        junction.x, junction.y = target
 
 
 def _merge_junction_xy(

--- a/src/nf_metro/layout/phases/junctions.py
+++ b/src/nf_metro/layout/phases/junctions.py
@@ -37,6 +37,76 @@ def _junction_incoming_line_count(graph: MetroGraph, jid: str) -> int:
     return len({e.line_id for e in graph.edges_to(jid)}) or 1
 
 
+def _compute_junction_xy(graph: MetroGraph, jid: str) -> tuple[float, float] | None:
+    """Return the (x, y) ``_position_junctions`` would assign to *jid*.
+
+    Pure function of the current port/predecessor coordinates - reads no
+    stored junction position.  Returns ``None`` when the junction has no
+    resolvable placement (no positioned exit port and not a recognised
+    merge), in which case ``_position_junctions`` leaves it untouched.
+
+    Backs both the repair (``_position_junctions``) and the
+    ``junctions_track_ports`` maintained invariant's predicate, so the two
+    cannot drift.
+    """
+    junction = graph.stations.get(jid)
+    if not junction:
+        return None
+
+    predecessors: list[Station] = []
+    successor_ports: list[Station] = []
+    exit_port_id: str | None = None
+
+    for edge in graph.edges_to(jid):
+        src = graph.stations.get(edge.source)
+        if src:
+            predecessors.append(src)
+            if src.is_port:
+                exit_port_id = edge.source
+    for edge in graph.edges_from(jid):
+        tgt = graph.stations.get(edge.target)
+        if tgt and tgt.is_port:
+            successor_ports.append(tgt)
+
+    # Merge junction: N>1 predecessors, 1 entry port successor
+    if len(predecessors) > 1 and len(successor_ports) == 1:
+        entry_port = successor_ports[0]
+        entry_port_obj = graph.ports.get(entry_port.id)
+        if entry_port_obj and entry_port_obj.is_entry:
+            return _merge_junction_xy(
+                predecessors,
+                entry_port,
+                n=_junction_incoming_line_count(graph, jid),
+            )
+
+    # Fan-out junction: 1 exit port predecessor, N>1 entry port successors
+    exit_port_x: float | None = None
+    exit_port_y: float | None = None
+    entry_port_xs: list[float] = []
+
+    for pred in predecessors:
+        if pred.is_port:
+            exit_port_x = pred.x
+            exit_port_y = pred.y
+
+    for succ in successor_ports:
+        entry_port_xs.append(succ.x)
+
+    if exit_port_x is None or exit_port_y is None or not entry_port_xs:
+        return None
+
+    margin = _required_junction_margin(_junction_outgoing_line_count(graph, jid))
+    exit_port_obj = graph.ports.get(exit_port_id) if exit_port_id else None
+    if exit_port_obj and exit_port_obj.side == PortSide.BOTTOM:
+        return exit_port_x, exit_port_y + margin
+    if exit_port_obj and exit_port_obj.side in (PortSide.RIGHT, PortSide.LEFT):
+        direction = 1.0 if exit_port_obj.side == PortSide.RIGHT else -1.0
+        return exit_port_x + direction * margin, exit_port_y
+    nearest_entry_x = min(entry_port_xs, key=lambda x: abs(x - exit_port_x))
+    direction = 1.0 if nearest_entry_x > exit_port_x else -1.0
+    return exit_port_x + direction * margin, exit_port_y
+
+
 def _position_junctions(graph: MetroGraph) -> None:
     """Position junction stations at the midpoint of the inter-section gap.
 
@@ -52,78 +122,17 @@ def _position_junctions(graph: MetroGraph) -> None:
         junction = graph.stations.get(jid)
         if not junction:
             continue
-
-        # Collect predecessors and successors
-        predecessors: list[Station] = []
-        successor_ports: list[Station] = []
-        exit_port_id: str | None = None
-
-        for edge in graph.edges_to(jid):
-            src = graph.stations.get(edge.source)
-            if src:
-                predecessors.append(src)
-                if src.is_port:
-                    exit_port_id = edge.source
-        for edge in graph.edges_from(jid):
-            tgt = graph.stations.get(edge.target)
-            if tgt and tgt.is_port:
-                successor_ports.append(tgt)
-
-        # Merge junction: N>1 predecessors, 1 entry port successor
-        if len(predecessors) > 1 and len(successor_ports) == 1:
-            entry_port = successor_ports[0]
-            entry_port_obj = graph.ports.get(entry_port.id)
-            if entry_port_obj and entry_port_obj.is_entry:
-                _position_merge_junction(
-                    junction,
-                    predecessors,
-                    entry_port,
-                    n=_junction_incoming_line_count(graph, jid),
-                )
-                continue
-
-        # Fan-out junction: 1 exit port predecessor, N>1 entry port successors
-        exit_port_x: float | None = None
-        exit_port_y: float | None = None
-        entry_port_xs: list[float] = []
-
-        for pred in predecessors:
-            if pred.is_port:
-                exit_port_x = pred.x
-                exit_port_y = pred.y
-
-        for succ in successor_ports:
-            entry_port_xs.append(succ.x)
-
-        if exit_port_x is not None and exit_port_y is not None and entry_port_xs:
-            margin = _required_junction_margin(
-                _junction_outgoing_line_count(graph, jid)
-            )
-            exit_port_obj = graph.ports.get(exit_port_id) if exit_port_id else None
-            if exit_port_obj and exit_port_obj.side == PortSide.BOTTOM:
-                junction.x = exit_port_x
-                junction.y = exit_port_y + margin
-            elif exit_port_obj and exit_port_obj.side in (
-                PortSide.RIGHT,
-                PortSide.LEFT,
-            ):
-                direction = 1.0 if exit_port_obj.side == PortSide.RIGHT else -1.0
-                junction.x = exit_port_x + direction * margin
-                junction.y = exit_port_y
-            else:
-                nearest_entry_x = min(entry_port_xs, key=lambda x: abs(x - exit_port_x))
-                direction = 1.0 if nearest_entry_x > exit_port_x else -1.0
-                junction.x = exit_port_x + direction * margin
-                junction.y = exit_port_y
+        target = _compute_junction_xy(graph, jid)
+        if target is not None:
+            junction.x, junction.y = target
 
 
-def _position_merge_junction(
-    junction: Station,
+def _merge_junction_xy(
     predecessors: list[Station],
     entry_port: Station,
     n: int = 1,
-) -> None:
-    """Position a merge junction near the entry port it feeds.
+) -> tuple[float, float]:
+    """Return the (x, y) a merge junction near *entry_port* should occupy.
 
     Places at x = max(predecessor.x) + _required_junction_margin(n),
     y = entry_port.y so all converging lines share a visible single-line
@@ -139,10 +148,8 @@ def _position_merge_junction(
     # width into the entry.  Merge local to the target instead, so only the
     # individual feeders make the long approach and the merge->entry hop is short.
     if entry_port.x < max_pred_x - margin:
-        junction.x = entry_port.x - margin
-    else:
-        junction.x = max_pred_x + margin
-    junction.y = entry_port.y
+        return entry_port.x - margin, entry_port.y
+    return max_pred_x + margin, entry_port.y
 
 
 def _resolve_source_section_id(

--- a/src/nf_metro/layout/phases/maintained.py
+++ b/src/nf_metro/layout/phases/maintained.py
@@ -11,17 +11,28 @@ phase silently regresses any junction whose restore the author forgot to
 re-trigger (cf. #386).
 
 This module lifts that implicit "restore-after-break" ordering into data:
-each invariant declares a *predicate* (does it currently hold?), a *repair*
-(re-establish it), and a *priority* (lower repairs first).  ``maintain``
-applies the repairs in priority order until a full pass makes no change
-(fixpoint), so a single ``maintain(graph)`` call after each constructive
-phase subsumes the scattered manual re-runs - and a new phase needs no
-bookkeeping, because the invariant catches its perturbation automatically.
+each invariant declares a *repair* (re-establish it), a *priority* (lower
+repairs first), and a *predicate* (does it currently hold?).  ``maintain``
+runs every repair in priority order, repeating until a full pass changes
+nothing (a fixpoint), so one ``maintain(graph)`` call after each
+constructive phase subsumes the scattered manual re-runs - and a new phase
+needs no bookkeeping, because the repairs re-fire automatically.
+
+The repairs are idempotent (a no-op once their property holds), so running
+them unconditionally and detecting convergence by *change* - rather than by
+re-checking a predicate first - keeps the mechanism uniform: every restore
+is the same kind of object, regardless of whether a cheap exact "is it
+satisfied?" predicate exists for it.  The predicate is used only by
+``assert_maintained`` (the runtime guard); for restores whose exact
+predicate would merely re-derive the repair (off-track stacking) it is a
+loose necessary check, which is all a guard needs.
 
 This is deliberately *not* a constraint solver (cf. #351 / #353): repairs
-are the existing constructive helpers, applied in a declared order, not
-weak numeric attractors relaxed to equilibrium.  The fixpoint loop only
-re-applies a repair whose predicate a higher-priority repair just broke.
+are the existing constructive helpers, applied in a declared priority
+order, not weak numeric attractors relaxed to equilibrium.  The priority
+numbers encode the dependency order that used to live implicitly in the
+call sequence (a lower-priority repair feeds a higher one); see
+``docs/dev/maintained_invariants_spike.md``.
 """
 
 from __future__ import annotations
@@ -29,13 +40,19 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from nf_metro.layout.phases._common import _row_contiguous_column_groups
 from nf_metro.layout.phases.bbox import _min_section_bbox_top
 from nf_metro.layout.phases.canvas import _shift_graph_into_canvas
-from nf_metro.layout.phases.guards import PhaseInvariantError
+from nf_metro.layout.phases.guards import (
+    PhaseInvariantError,
+    _guard_off_track_inputs_above_consumer,
+)
 from nf_metro.layout.phases.junctions import (
     _position_junctions,
     _resolvable_junctions,
 )
+from nf_metro.layout.phases.off_track import _reanchor_off_track_to_consumer
+from nf_metro.layout.phases.row_align import _top_align_row_bboxes_only
 from nf_metro.parser.model import MetroGraph
 
 # Predicate comparison epsilon.  The repair (``_position_junctions``)
@@ -52,12 +69,15 @@ _MAINTAIN_TOL = 1e-9
 class MaintainedInvariant:
     """A property the pipeline keeps alive across constructive phases.
 
-    - ``predicate(graph)`` returns ``True`` when the invariant holds.
-    - ``repair(graph)`` re-establishes it; must be idempotent (a no-op
-      when the predicate already holds) so repeated application converges.
+    - ``repair(graph)`` re-establishes the property; must be idempotent (a
+      no-op once it holds) so ``maintain`` can run it unconditionally and
+      detect convergence by change.
     - ``priority`` orders repairs within a ``maintain`` pass: lower runs
-      first, so an invariant that *feeds* another (e.g. a whole-canvas
-      translate that other repairs read) gets a lower number.
+      first, so a repair that *feeds* another (e.g. a whole-canvas
+      translate that a later repair reads) gets a lower number.
+    - ``predicate(graph)`` returns ``True`` when the property holds.  Used
+      only by ``assert_maintained``; it may be a loose necessary check
+      where an exact one would just re-derive the repair.
     """
 
     name: str
@@ -67,36 +87,50 @@ class MaintainedInvariant:
     description: str
 
 
+def _y_state_snapshot(graph: MetroGraph) -> tuple:
+    """Hashable snapshot of every coordinate a repair can move.
+
+    Covers station x/y (junctions are stations), port y, and section bbox
+    top/height - the union of what the maintained repairs mutate.  Used to
+    detect whether a ``maintain`` pass changed anything.
+    """
+    return (
+        tuple((sid, st.x, st.y) for sid, st in graph.stations.items()),
+        tuple((pid, port.y) for pid, port in graph.ports.items()),
+        tuple((kid, sec.bbox_y, sec.bbox_h) for kid, sec in graph.sections.items()),
+    )
+
+
 def maintain(
     graph: MetroGraph,
     invariants: list[MaintainedInvariant],
     *,
     max_passes: int = 8,
+    snapshot: Callable[[MetroGraph], object] = _y_state_snapshot,
 ) -> None:
-    """Apply each invariant's repair in priority order until a fixpoint.
+    """Run every repair in priority order until a pass changes nothing.
 
-    One pass walks the invariants by ascending ``priority``, repairing any
-    whose predicate is violated.  Because a repair can break a
-    lower-priority invariant that an earlier pass already satisfied, the
-    walk repeats until a full pass triggers no repair.
+    Each pass applies all repairs by ascending ``priority``; because the
+    repairs are idempotent, a pass that mutates no coordinate means the set
+    has converged.  Running unconditionally (rather than gating on a
+    predicate) keeps the mechanism uniform across restores with and without
+    a cheap exact "is it satisfied?" predicate.
 
-    ``max_passes`` is a loud backstop: if the invariants don't converge it
-    means two repairs are fighting (the #353 failure shape), which must
-    surface as an error rather than a silently truncated layout.
+    ``max_passes`` is a loud backstop: if a pass never stops changing state
+    two repairs are fighting (the #353 failure shape), which must surface as
+    an error rather than a silently truncated layout.  ``snapshot`` is
+    injectable so the driver can be unit-tested against non-graph state.
     """
     ordered = sorted(invariants, key=lambda inv: inv.priority)
     for _ in range(max_passes):
-        repaired = False
+        before = snapshot(graph)
         for inv in ordered:
-            if not inv.predicate(graph):
-                inv.repair(graph)
-                repaired = True
-        if not repaired:
+            inv.repair(graph)
+        if snapshot(graph) == before:
             return
-    unstable = [inv.name for inv in ordered if not inv.predicate(graph)]
     raise RuntimeError(
-        f"maintained invariants did not converge in {max_passes} passes; "
-        f"still violated: {unstable}. Two repairs are likely fighting - "
+        f"maintained invariants did not converge in {max_passes} passes: "
+        f"{[inv.name for inv in ordered]}. Two repairs are likely fighting - "
         "check their relative priority."
     )
 
@@ -180,5 +214,78 @@ def canvas_top_margin(section_y_padding: float) -> MaintainedInvariant:
         description=(
             "The topmost non-empty section's bbox top sits at least "
             "section_y_padding below the canvas origin."
+        ),
+    )
+
+
+def _row_bbox_tops_flush_holds(graph: MetroGraph) -> bool:
+    """True when each row's contiguous column group has flush bbox tops.
+
+    Mirrors ``_top_align_row_bboxes_only``'s no-op condition exactly: the
+    repair grows any section whose ``bbox_y`` exceeds its group min (strict,
+    no tolerance), so a group is already flush iff none exceed the min.
+    """
+    for group in _row_contiguous_column_groups(graph):
+        min_top = min(s.bbox_y for s in group)
+        if any(s.bbox_y > min_top for s in group):
+            return False
+    return True
+
+
+# ``_top_align_row_bboxes_only`` only grows bbox tops up to the group min, so
+# it is idempotent (a no-op once tops are flush).
+ROW_BBOX_TOPS_FLUSH = MaintainedInvariant(
+    name="row_bbox_tops_flush",
+    priority=25,
+    predicate=_row_bbox_tops_flush_holds,
+    repair=_top_align_row_bboxes_only,
+    description=(
+        "Within each row's contiguous column group, all section bbox tops "
+        "are flush (share the group's minimum bbox_y)."
+    ),
+)
+
+
+def _off_track_above_consumer_holds(graph: MetroGraph) -> bool:
+    """Loose guard predicate: every off-track input sits above its consumer.
+
+    Reuses the existing ``_guard_off_track_inputs_above_consumer`` check
+    (a necessary, not exact, condition).  The exact "is it already placed?"
+    predicate would re-derive the repair's stacking computation, so this
+    invariant relies on ``maintain``'s change-detection for convergence and
+    keeps this loose check only for ``assert_maintained``.
+    """
+    try:
+        _guard_off_track_inputs_above_consumer(graph, "maintain")
+    except PhaseInvariantError:
+        return False
+    return True
+
+
+def off_track_above_consumer(
+    y_spacing: float, section_y_padding: float
+) -> MaintainedInvariant:
+    """Invariant: off-track inputs sit a pitch above their consumer.
+
+    A factory because the repair needs the layout's spacing.  Lowest
+    priority: its bbox-grow can breach the canvas margin and unflush a row's
+    bbox tops, so ``canvas_top_margin`` (20) and ``row_bbox_tops_flush`` (25)
+    must run after it within the same ``maintain`` pass.  A uniform
+    whole-graph translate and a bbox-top grow never move an off-track
+    station relative to its consumer, so neither feeds back here (the
+    dependency order is a DAG).
+    """
+
+    def repair(graph: MetroGraph) -> None:
+        _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
+
+    return MaintainedInvariant(
+        name="off_track_above_consumer",
+        priority=10,
+        predicate=_off_track_above_consumer_holds,
+        repair=repair,
+        description=(
+            "Each off-track input sits n*y_spacing above its on-track "
+            "consumer, inside the section bbox."
         ),
     )

--- a/src/nf_metro/layout/phases/maintained.py
+++ b/src/nf_metro/layout/phases/maintained.py
@@ -32,7 +32,10 @@ from dataclasses import dataclass
 from nf_metro.layout.phases.bbox import _min_section_bbox_top
 from nf_metro.layout.phases.canvas import _shift_graph_into_canvas
 from nf_metro.layout.phases.guards import PhaseInvariantError
-from nf_metro.layout.phases.junctions import _compute_junction_xy, _position_junctions
+from nf_metro.layout.phases.junctions import (
+    _position_junctions,
+    _resolvable_junctions,
+)
 from nf_metro.parser.model import MetroGraph
 
 # Predicate comparison epsilon.  The repair (``_position_junctions``)
@@ -123,17 +126,10 @@ def assert_maintained(
 def _junctions_track_ports_holds(graph: MetroGraph) -> bool:
     """True when every junction sits where its ports place it.
 
-    Compares each junction's stored ``(x, y)`` against the pure
-    ``_compute_junction_xy`` target.  A mismatch means a port moved since
-    the junction was last positioned.
+    Compares each junction's stored ``(x, y)`` against its computed target.
+    A mismatch means a port moved since the junction was last positioned.
     """
-    for jid in graph.junctions:
-        junction = graph.stations.get(jid)
-        if not junction:
-            continue
-        target = _compute_junction_xy(graph, jid)
-        if target is None:
-            continue
+    for junction, target in _resolvable_junctions(graph):
         if (
             abs(junction.x - target[0]) > _MAINTAIN_TOL
             or abs(junction.y - target[1]) > _MAINTAIN_TOL

--- a/src/nf_metro/layout/phases/maintained.py
+++ b/src/nf_metro/layout/phases/maintained.py
@@ -1,0 +1,188 @@
+"""Declarative maintained invariants for the layout pipeline.
+
+Spike (#365): the layout pipeline keeps a handful of *invariants* alive
+across the long Pass-C settling sequence by manually re-running "restore"
+helpers after every constructive phase that might perturb them.  The most
+visible case is junction positioning: ``_position_junctions`` is re-called
+at six different stages purely because some preceding phase moved an exit
+or entry port.  The order ("run the restore after the thing that breaks
+it") lives implicitly in the call sequence, so adding a new port-moving
+phase silently regresses any junction whose restore the author forgot to
+re-trigger (cf. #386).
+
+This module lifts that implicit "restore-after-break" ordering into data:
+each invariant declares a *predicate* (does it currently hold?), a *repair*
+(re-establish it), and a *priority* (lower repairs first).  ``maintain``
+applies the repairs in priority order until a full pass makes no change
+(fixpoint), so a single ``maintain(graph)`` call after each constructive
+phase subsumes the scattered manual re-runs - and a new phase needs no
+bookkeeping, because the invariant catches its perturbation automatically.
+
+This is deliberately *not* a constraint solver (cf. #351 / #353): repairs
+are the existing constructive helpers, applied in a declared order, not
+weak numeric attractors relaxed to equilibrium.  The fixpoint loop only
+re-applies a repair whose predicate a higher-priority repair just broke.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from nf_metro.layout.phases.bbox import _min_section_bbox_top
+from nf_metro.layout.phases.canvas import _shift_graph_into_canvas
+from nf_metro.layout.phases.guards import PhaseInvariantError
+from nf_metro.layout.phases.junctions import _compute_junction_xy, _position_junctions
+from nf_metro.parser.model import MetroGraph
+
+# Predicate comparison epsilon.  The repair (``_position_junctions``)
+# snaps each junction to the *exact* ``_compute_junction_xy`` target, and
+# the hand-written pipeline re-ran it unconditionally, so the invariant it
+# kept is exact equality - a sub-pixel port nudge that moves the target
+# still changes the rendered junction.  A wider tolerance would let that
+# drift survive and diverge from the legacy layout, so this epsilon only
+# absorbs floating-point noise, not real movement.
+_MAINTAIN_TOL = 1e-9
+
+
+@dataclass(frozen=True)
+class MaintainedInvariant:
+    """A property the pipeline keeps alive across constructive phases.
+
+    - ``predicate(graph)`` returns ``True`` when the invariant holds.
+    - ``repair(graph)`` re-establishes it; must be idempotent (a no-op
+      when the predicate already holds) so repeated application converges.
+    - ``priority`` orders repairs within a ``maintain`` pass: lower runs
+      first, so an invariant that *feeds* another (e.g. a whole-canvas
+      translate that other repairs read) gets a lower number.
+    """
+
+    name: str
+    priority: int
+    predicate: Callable[[MetroGraph], bool]
+    repair: Callable[[MetroGraph], None]
+    description: str
+
+
+def maintain(
+    graph: MetroGraph,
+    invariants: list[MaintainedInvariant],
+    *,
+    max_passes: int = 8,
+) -> None:
+    """Apply each invariant's repair in priority order until a fixpoint.
+
+    One pass walks the invariants by ascending ``priority``, repairing any
+    whose predicate is violated.  Because a repair can break a
+    lower-priority invariant that an earlier pass already satisfied, the
+    walk repeats until a full pass triggers no repair.
+
+    ``max_passes`` is a loud backstop: if the invariants don't converge it
+    means two repairs are fighting (the #353 failure shape), which must
+    surface as an error rather than a silently truncated layout.
+    """
+    ordered = sorted(invariants, key=lambda inv: inv.priority)
+    for _ in range(max_passes):
+        repaired = False
+        for inv in ordered:
+            if not inv.predicate(graph):
+                inv.repair(graph)
+                repaired = True
+        if not repaired:
+            return
+    unstable = [inv.name for inv in ordered if not inv.predicate(graph)]
+    raise RuntimeError(
+        f"maintained invariants did not converge in {max_passes} passes; "
+        f"still violated: {unstable}. Two repairs are likely fighting - "
+        "check their relative priority."
+    )
+
+
+def assert_maintained(
+    graph: MetroGraph,
+    invariants: list[MaintainedInvariant],
+    phase: str,
+) -> None:
+    """Raise ``PhaseInvariantError`` if any maintained invariant is violated.
+
+    The runtime counterpart to ``maintain``: ``maintain`` *re-establishes*
+    the invariants after each constructive phase, this *checks* they still
+    hold at a validation boundary.  Catches a future phase added after the
+    last ``maintain`` call that perturbs an invariant without re-triggering
+    its repair - the exact regression class (#386) this mechanism exists to
+    prevent.
+    """
+    for inv in invariants:
+        if not inv.predicate(graph):
+            raise PhaseInvariantError(
+                f"{phase}: maintained invariant {inv.name!r} violated - "
+                f"{inv.description}"
+            )
+
+
+def _junctions_track_ports_holds(graph: MetroGraph) -> bool:
+    """True when every junction sits where its ports place it.
+
+    Compares each junction's stored ``(x, y)`` against the pure
+    ``_compute_junction_xy`` target.  A mismatch means a port moved since
+    the junction was last positioned.
+    """
+    for jid in graph.junctions:
+        junction = graph.stations.get(jid)
+        if not junction:
+            continue
+        target = _compute_junction_xy(graph, jid)
+        if target is None:
+            continue
+        if (
+            abs(junction.x - target[0]) > _MAINTAIN_TOL
+            or abs(junction.y - target[1]) > _MAINTAIN_TOL
+        ):
+            return False
+    return True
+
+
+# ``_position_junctions`` overwrites every junction from its current port
+# coordinates, reading no stored junction state, so it is the idempotent
+# repair for this invariant: a no-op when ports haven't moved.
+JUNCTIONS_TRACK_PORTS = MaintainedInvariant(
+    name="junctions_track_ports",
+    priority=30,
+    predicate=_junctions_track_ports_holds,
+    repair=_position_junctions,
+    description=(
+        "Every fan-out / merge junction sits at the position derived from "
+        "its exit/entry ports (junction.xy == _compute_junction_xy)."
+    ),
+)
+
+
+def canvas_top_margin(section_y_padding: float) -> MaintainedInvariant:
+    """Invariant: the topmost section keeps its margin from the canvas top.
+
+    A factory because the margin is a layout parameter, not graph state.
+    The repair is a uniform whole-graph translate, so it moves junctions,
+    ports, and bboxes together - it can never break a position-relative
+    invariant (e.g. junctions stay on their ports).  Priority sits below
+    the junction invariant so a translate settles before junctions are
+    rechecked (the recheck is then a no-op).
+    """
+
+    def holds(graph: MetroGraph) -> bool:
+        # Mirror ``_shift_graph_into_canvas``'s own early-return condition
+        # exactly so the predicate is true iff the repair is a no-op.
+        return _min_section_bbox_top(graph, section_y_padding) >= section_y_padding
+
+    def repair(graph: MetroGraph) -> None:
+        _shift_graph_into_canvas(graph, section_y_padding)
+
+    return MaintainedInvariant(
+        name="canvas_top_margin",
+        priority=20,
+        predicate=holds,
+        repair=repair,
+        description=(
+            "The topmost non-empty section's bbox top sits at least "
+            "section_y_padding below the canvas origin."
+        ),
+    )

--- a/tests/test_maintained_invariants.py
+++ b/tests/test_maintained_invariants.py
@@ -1,0 +1,167 @@
+"""Tests for the declarative maintained-invariants mechanism (#365).
+
+Covers the ``maintain`` priority-ordered fixpoint driver, the
+``junctions_track_ports`` invariant's predicate/repair pair, and the
+end-to-end property that every junction satisfies the invariant after a
+full layout - parametrised across the multi-section corpus so the rule
+generalises beyond a single fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+from test_layout_invariants import _FIXTURES_MULTI_SECTION, _layout
+
+from nf_metro.layout.phases.guards import PhaseInvariantError
+from nf_metro.layout.phases.junctions import _compute_junction_xy
+from nf_metro.layout.phases.maintained import (
+    JUNCTIONS_TRACK_PORTS,
+    MaintainedInvariant,
+    _junctions_track_ports_holds,
+    assert_maintained,
+    maintain,
+)
+
+# ---------------------------------------------------------------------------
+# maintain() driver
+# ---------------------------------------------------------------------------
+
+
+def _counter_invariant(name, priority, log, *, breaks=None):
+    """Build a toy invariant whose repair flips a flag and records its name.
+
+    ``breaks`` is a list of state keys this repair sets back to violated,
+    used to exercise the fixpoint re-application across priorities.
+    """
+
+    def predicate(state):
+        return state.get(name, False)
+
+    def repair(state):
+        log.append(name)
+        state[name] = True
+        for k in breaks or ():
+            state[k] = False
+
+    return MaintainedInvariant(
+        name=name,
+        priority=priority,
+        predicate=predicate,
+        repair=repair,
+        description=name,
+    )
+
+
+def test_maintain_applies_repairs_in_priority_order():
+    log: list[str] = []
+    state: dict = {}
+    invs = [
+        _counter_invariant("c", 30, log),
+        _counter_invariant("a", 10, log),
+        _counter_invariant("b", 20, log),
+    ]
+    maintain(state, invs)
+    assert log == ["a", "b", "c"]
+
+
+def test_maintain_skips_satisfied_invariants():
+    log: list[str] = []
+    state = {"a": True, "b": False}
+    invs = [
+        _counter_invariant("a", 10, log),
+        _counter_invariant("b", 20, log),
+    ]
+    maintain(state, invs)
+    assert log == ["b"]  # a already held, only b repaired
+
+
+def test_maintain_reaches_fixpoint_when_repair_breaks_lower_priority():
+    # 'a' (priority 10) breaks 'b' (priority 20) each time it repairs; the
+    # loop must re-run 'b' after 'a', then settle.
+    log: list[str] = []
+    state: dict = {}
+    invs = [
+        _counter_invariant("a", 10, log, breaks=["b"]),
+        _counter_invariant("b", 20, log),
+    ]
+    maintain(state, invs)
+    # pass1: a (sets a, breaks b), b (sets b). pass2: nothing -> settle.
+    assert log == ["a", "b"]
+    assert state == {"a": True, "b": True}
+
+
+def test_maintain_raises_on_non_convergence():
+    # Two repairs that perpetually break each other never settle.
+    log: list[str] = []
+    state: dict = {}
+    invs = [
+        _counter_invariant("a", 10, log, breaks=["b"]),
+        _counter_invariant("b", 20, log, breaks=["a"]),
+    ]
+    with pytest.raises(RuntimeError, match="did not converge"):
+        maintain(state, invs, max_passes=3)
+
+
+# ---------------------------------------------------------------------------
+# junctions_track_ports invariant
+# ---------------------------------------------------------------------------
+
+
+def _first_fanout_or_merge_junction(graph):
+    for jid in graph.junctions:
+        if _compute_junction_xy(graph, jid) is not None:
+            return jid
+    return None
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_junction_invariant_holds_after_layout(fixture):
+    """Every resolvable junction sits at its computed target post-layout."""
+    graph = _layout(fixture)
+    assert _junctions_track_ports_holds(graph)
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_junction_predicate_detects_and_repair_fixes_staleness(fixture):
+    """Perturbing a junction violates the predicate; the repair restores it."""
+    graph = _layout(fixture)
+    jid = _first_fanout_or_merge_junction(graph)
+    if jid is None:
+        pytest.skip("fixture has no resolvable junction")
+
+    graph.stations[jid].y += 137.0  # move it well past the FP epsilon
+    assert not _junctions_track_ports_holds(graph)
+
+    JUNCTIONS_TRACK_PORTS.repair(graph)
+    assert _junctions_track_ports_holds(graph)
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_junction_repair_is_idempotent(fixture):
+    """Re-running the repair when the invariant holds changes nothing."""
+    graph = _layout(fixture)
+
+    def snapshot():
+        return {
+            jid: (graph.stations[jid].x, graph.stations[jid].y)
+            for jid in graph.junctions
+        }
+
+    before = snapshot()
+    JUNCTIONS_TRACK_PORTS.repair(graph)
+    assert snapshot() == before
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_assert_maintained_raises_on_violation(fixture):
+    """The runtime guard raises (with the invariant name) when perturbed."""
+    graph = _layout(fixture)
+    # Holds straight after layout.
+    assert_maintained(graph, [JUNCTIONS_TRACK_PORTS], "test")
+
+    jid = _first_fanout_or_merge_junction(graph)
+    if jid is None:
+        pytest.skip("fixture has no resolvable junction")
+    graph.stations[jid].y += 137.0
+    with pytest.raises(PhaseInvariantError, match="junctions_track_ports"):
+        assert_maintained(graph, [JUNCTIONS_TRACK_PORTS], "test")


### PR DESCRIPTION
**Draft / experiment - do not merge.** Opened only to surface the render-preview visual diffs.

This applies the maintained-invariants mechanism to **all four** Pass-C restores (junctions, canvas, off_track, top_align) with change-detection termination, replacing every hand-placed restore call with `maintain()`. Based on #459 (which is byte-identical to main), so the render preview shows **exactly** what going fully-uniform costs.

Result: **not byte-identical** - 7 fixtures diverge:
- differentialabundance, differentialabundance_default, da_pipeline (off-track)
- off_track_convergence (off-track)
- terminal_symmetric_fan, trunk_through_fan (fans)
- variantbenchmarking

Root causes (fundamental, not scope):
- **off_track** has a precondition (final/snapped consumer Ys) + monotonic bbox-grow → running it at early `maintain` sites bakes in wrong positions.
- **top_align** is not a final-state invariant: Stage 6.13 shrink/tighten deliberately un-flushes lower-row bbox tops at the end.

The shippable maximal byte-identical subset (junctions + canvas) is #459.

Generated with Claude Code