### PR TITLE
docs(skill): remove standing auto-merge auth from fix-issue skill

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -134,12 +134,24 @@ https://pinin4fjords.github.io/nf-metro/_pr/<PR_NUMBER>/
 
 The sticky comment ends in a verdict line. Gate the next step on it:
 
-- **"No visual changes detected"** -> eligible for auto-merge under the
-  user's standing authorisation for no-change PRs. Proceed.
+- **"No visual changes detected"** -> a clean result, but **not** a
+  licence to merge. Report the verdict and wait for the user to say
+  merge. There is no standing auto-merge authorisation.
 - **"Ready for review"** (or any wording indicating visual deltas exist)
   -> **STOP**. Surface the deltas to the user with one short line per
   affected gallery example describing what changed (e.g.
-  `da_pipeline.mmd: trunk shifted 12px right`). Do not auto-merge.
+  `da_pipeline.mmd: trunk shifted 12px right`).
+
+In **all** cases, merging is the user's call, made per-PR:
+
+- Never merge until the user explicitly asks for this PR to be merged.
+- **Never** use `gh pr merge --admin` (or any other bypass of the
+  repo's branch-protection / review-required policy) on your own
+  initiative. If a normal merge is blocked because the repo requires
+  review, that block is the policy working - stop and tell the user it
+  needs their review or an explicit instruction to admin-merge. Do not
+  cite "prior PRs were admin-merged" as authorisation; past instances
+  are history, not standing consent.
 
 ### Optional: quick local render of a single file
 


### PR DESCRIPTION
## Summary

The `fix-issue` skill's render-preview gating told the agent that a "No visual changes detected" verdict made a PR "eligible for auto-merge under the user's standing authorisation for no-change PRs." No such standing authorisation exists, and on PR #466 it led the agent to `gh pr merge --admin`, bypassing the repo's review-required branch policy.

This rewrites that section so:
- A "No visual changes" verdict is reported and waited on, not merged.
- Merging is the user's call, made per-PR.
- The agent must **never** use `gh pr merge --admin` (or any branch-protection bypass) on its own initiative; a blocked merge means review is required, so it stops and asks.
- "Prior PRs were admin-merged" is explicitly not standing consent.

Skill doc only; no code or test change.

Refs #466.

## Test plan
- [x] No code changed; `.claude/skills/` is outside CI lint/test scope.