### PR TITLE
docs(layout): clarify Lifecycle invariant/transient principle + harden test (#462)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -36,6 +36,16 @@ silently violate a downstream pass's expectations.
     has no final-boundary property to declare. The superseding stage is
     named.
 
+  The distinction is about the *property*, not the coordinates. A stage
+  stays **invariant** when a later stage recomputes the exact coordinates
+  but the abstract property it established (no-kink flow, horizontal port
+  connection, filled top band, grid-snapped Y) still holds at the end -
+  that is maintenance. It is **transient** only when a later stage
+  discards the decision itself, replacing the property with a different
+  layout (flush row tops giving way to content-hugging tops; an early fan
+  re-fanned around the final trunk Y). The test in doubt: does the
+  property survive to the end, or is the decision overwritten?
+
   Lifecycle answers "what does this phase guarantee at the end" and is
   pinned by `tests/test_contract_lifecycle.py`. It is **orthogonal** to
   the question #365 explored: "is this invariant safe to *lift* into a
@@ -517,7 +527,10 @@ in pipeline order.
   `test_section1_input_above_trunk`.
 - **Lifecycle:** invariant - the filled top band / content balanced
   around the trunk holds at the final boundary
-  (`test_section_top_band_filled`).
+  (`test_section_top_band_filled`). Stage 6.11 can fill the same band on
+  the same section, but moves a *disjoint* station set (strict-subset,
+  non-trunk siblings; this stage moves only full-bundle trunk
+  candidates), so it does not override this placement.
 
 ### Stage 6.2: fan source inputs upward (engine.py:695-700)
 - **Purpose**: Companion to Stage 6.1 for source-stack sections (single

--- a/tests/test_contract_lifecycle.py
+++ b/tests/test_contract_lifecycle.py
@@ -80,7 +80,7 @@ def test_transient_stages_name_superseding_stage(tag, block):
     kind, rest = found[0]
     if kind != "transient":
         pytest.skip(f"Stage {tag} is invariant")
-    assert "Stage" in rest, (
+    assert re.search(r"Stage \d+\.\d+[a-z]?", rest), (
         f"Stage {tag} is transient but its Lifecycle line names no "
-        f"superseding stage: {rest!r}"
+        f"superseding stage (expected a 'Stage N.N' reference): {rest!r}"
     )


### PR DESCRIPTION
## Summary

Post-merge follow-ups to #466 (which tagged every `CONTRACT.md` stage `invariant`/`transient` per #462). Doc + test only; no engine change, gallery byte-identical.

1. **Explicit principle.** The "How to read this doc" Lifecycle bullet now states the rule that was previously implicit: the tag is about the *property*, not the coordinates. A stage stays **invariant** when a later stage recomputes the exact coordinates but the abstract property it established (no-kink flow, horizontal port connection, filled top band, grid-snapped Y) still holds at the end (maintenance). It is **transient** only when a later stage discards the decision itself. This resolves the apparent fuzziness at seams like Stage 4.1 (invariant, Y refined by 5.5) vs Stage 4.9 (transient, re-fanned by 6.7): both have a later phase that recomputes, but only one keeps the property. Spot-checked 3.2, 3.4, 4.1, 4.2 against the principle - all already consistent, no re-tags.

2. **6.1 vs 6.11 collision check.** Both `_fan_free_content_upward` (6.1) and `_balance_section_content_around_trunk` (6.11) cite `test_section_top_band_filled`. Read both helpers: they can act on the same section, but on **disjoint** station sets - 6.1 moves only full-bundle trunk candidates (`station_lines == bundle`), 6.11 moves only strict-subset non-trunk siblings (`lines < bundle`, skipping trunks), and 6.11's `_column_occupied_ys` avoids occupied slots. So 6.11 cannot override 6.1's placement. 6.1 stays `invariant`; added a one-line note recording why.

3. **Hardened test.** `test_transient_stages_name_superseding_stage` now requires a real `Stage N.N` reference (`re.search(r"Stage \d+\.\d+[a-z]?", rest)`) instead of the bare substring `"Stage"`, so it cannot pass vacuously and survives a reflow of the Lifecycle bullet.

Refs #462 #466.

## Test plan
- [x] `pytest tests/test_contract_lifecycle.py` passes (52 passed, 35 skipped)
- [x] full `pytest` passes (3703 passed, 6 pre-existing xfails)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [ ] Render-preview verdict: expected "No visual changes" (doc + test only)

Generated with Claude Code