### PR TITLE
PR2 of #464 - enable Group A top-shrink (render-changing)

### DIFF
--- a/docs/dev/bbox_top_unification_design.md
+++ b/docs/dev/bbox_top_unification_design.md
@@ -235,14 +235,50 @@ top). Expected render impact: **none** (byte-identical gallery). Verification: f
 gallery hash diff == main; existing top/bottom-padding + lifecycle tests green.
 
 **PR2 - enable shrink for Group A (pure flush bands).**
+
+Step 0 (implementation note, from the #470 review): the shrink target is
+ceiling-free, and `_section_fit_top` does NOT change. `_section_fit_top` folds the
+row-above grow ceiling (`above_bottom + section_y_gap + SECTION_HEADER_PROTRUSION`)
+into its single return, and is shared by the grow pass (6.15a) AND
+`_guard_section_top_padding`. Leave it alone. The row-above ceiling is a GROW bound
+only and cannot bind when shrinking: lowering a too-tall top moves it away from the
+row above, so the ceiling is never the active constraint in the shrink direction.
+Therefore PR2's Group A shrink target is the PURE content-hug (content + port/bypass
+clamps, NO row-above ceiling) - exactly `_off_track_fit_top`'s shape. Implement the
+final top pass as: compute content-hug; if it sits above the current top -> apply the
+ceiling and grow (unchanged, byte-identical); if it sits below the current top AND the
+section is Group A (no port/bypass above content) -> shrink to the ceiling-free
+content-hug. This keeps `_section_fit_top`, its grow path, `_guard_section_top_padding`,
+and PR1's clamp tests (incl. `test_section_fit_top_bounded_by_row_above`) all unchanged;
+only the new Group A shrink branch is render-visible.
+
 Allow the final pass to also lower the top for sections with no port / bypass above
-content. Expected render impact: differentialabundance, differentialabundance_default,
-off_track_convergence lose their empty bands (boxes drop to content-hug; row tops
-become staggered). 5 sections, 3 fixtures. Highest-risk fixture here is
-off_track_convergence (233px change, adjacent to #463's off-track machinery).
-Verification: gallery diff shows only those 3 fixtures; off-track invariant tests
-(`test_off_track_inputs_above_consumer`) and lifecycle tests green; new equality test
-(see PR4) added scoped to Group A.
+content. Implemented as a new ceiling-free `_section_content_hug_top` + a
+`_section_band_is_empty` (Group A) gate + a shrink branch in
+`_grow_bboxes_to_content_top`; `_section_fit_top` untouched.
+
+DONE. Confirmed gallery delta - 6 fixtures, every changed section now hugs
+content at exactly `section_y_padding`:
+
+- differentialabundance: `reporting` -58px.
+- differentialabundance_default: `differential`, `reporting` -116px each.
+- off_track_convergence: `input`, `output` -233px each.
+- genomeassembly_staggered: `scaffolding` -8.2px.
+- nf_flat_pipeline: `pipeline` -12.2px.
+- nf_unquoted_labels: `pipeline` -12.2px.
+
+The last three were under-stated in the original prediction: the section 1.4
+diagnostic scanned only `examples/` + `examples/topologies/`, missing the
+`tests/fixtures/nextflow/` conversions (the two `nf_*`) and rounding off the 8.2px
+`scaffolding` case. All six are genuine empty-band reclamations on the same gate.
+`differentialabundance_default/plots` keeps its band (ceiling-bound, pre-existing
+xfail). The synthetic `test_compute_layout_rowspan_section_compacts_content` was
+updated: it asserted the now-dropped row-top flush; it now asserts each section hugs
+its own content (trunk-Y assertions unchanged).
+
+Verification: gallery diff shows only those 6 fixtures; new equality test
+`test_section_bbox_top_hugs_content` green; `test_off_track_inputs_above_consumer`,
+the off-track suite, `test_contract_lifecycle`, and PR1's clamp tests all green.
 
 **PR3 - enable shrink for Group B (port-bearing bands), conditionally and per-case.**
 Group B is NOT a blanket "shrink all six". Some of those port-bearing bands are
@@ -342,8 +378,13 @@ Two adjustments to the staging plan (folded into section 4 above):
   SVGs). Added unit tests exercising the bypass, port and row-above clamps of
   `_section_fit_top` (those branches never bind at the current grow-only call site,
   the same coverage gap #463 closed for `_off_track_fit_top`).
-- **PR2 onward: pending.** They change renders and need preview review; PR3/Group B
-  needs the per-case judgement above.
+- **PR2 (Group A shrink): done.** New ceiling-free `_section_content_hug_top`
+  + `_section_band_is_empty` gate + a shrink branch in `_grow_bboxes_to_content_top`;
+  `_section_fit_top` and the guard untouched. Render-changing: 6 fixtures lose genuinely
+  empty top bands (deltas recorded under PR2 in section 4). New equality test
+  `test_section_bbox_top_hugs_content`.
+- **PR3 onward: pending.** PR3/Group B needs the per-case judgement above; PR4 retires
+  the dead 5.4 step-1 and folds the grow-only pass in (flush stays).
 
 ## Verification (for the implementation phase, not this design task)
 

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -524,27 +524,114 @@ def _section_fit_top(
     return target
 
 
+def _section_content_hug_top(
+    graph: MetroGraph,
+    section: Section,
+    section_y_padding: float,
+) -> float | None:
+    """Ceiling-free content-hug top for ``section``.
+
+    The shrink twin of :func:`_section_fit_top`: the same content-hug
+    (``section_y_padding`` above the highest content marker, clamped to
+    keep bypass helpers and ports inside) but WITHOUT the row-above grow
+    ceiling.  The ceiling is a grow-direction bound only -- lowering a
+    too-tall top moves it away from the row above, so it never binds when
+    hugging content downward.
+
+    Separate from ``_section_fit_top`` so the grow target it shares with
+    ``_guard_section_top_padding`` is untouched.  Same content set as
+    ``_section_fit_top`` / ``_off_track_fit_top``: non-port stations
+    excluding ``__bypass_`` helpers, phantoms kept.
+
+    Returns ``None`` when the section has no real content to anchor to.
+    """
+    content_min_ys = [
+        graph.stations[sid].y
+        for sid in section.station_ids
+        if (
+            sid in graph.stations
+            and not graph.stations[sid].is_port
+            and not sid.startswith("__bypass_")
+        )
+    ]
+    if not content_min_ys:
+        return None
+    bypass_min_ys = [
+        graph.stations[sid].y
+        for sid in section.station_ids
+        if sid in graph.stations and sid.startswith("__bypass_")
+    ]
+    port_min_ys = [
+        graph.stations[sid].y
+        for sid in section.station_ids
+        if sid in graph.stations and graph.stations[sid].is_port
+    ]
+    v_curve_clearance = CURVE_RADIUS + MIN_STATION_FLAT_LENGTH / 2
+    target = min(content_min_ys) - section_y_padding
+    if bypass_min_ys:
+        target = min(target, min(bypass_min_ys) - v_curve_clearance)
+    if port_min_ys:
+        target = min(target, min(port_min_ys))
+    return target
+
+
+def _section_band_is_empty(graph: MetroGraph, section: Section) -> bool:
+    """True when the band above ``section``'s topmost content is empty.
+
+    Empty means no ``is_port`` station and no ``__bypass_`` helper sits
+    above the highest content marker.  Such a band carries nothing, so
+    the bbox top can be lowered to hug content.  A port or bypass helper
+    above content is intentional runway for that port's approach and must
+    not be shrunk into.
+    """
+    content_min_ys = [
+        graph.stations[sid].y
+        for sid in section.station_ids
+        if (
+            sid in graph.stations
+            and not graph.stations[sid].is_port
+            and not sid.startswith("__bypass_")
+        )
+    ]
+    if not content_min_ys:
+        return False
+    topmost = min(content_min_ys)
+    for sid in section.station_ids:
+        st = graph.stations.get(sid)
+        if st is None:
+            continue
+        if (st.is_port or sid.startswith("__bypass_")) and st.y < topmost - 0.5:
+            return False
+    return True
+
+
 def _grow_bboxes_to_content_top(
     graph: MetroGraph,
     section_y_padding: float,
     section_y_gap: float,
 ) -> None:
-    """Grow section bbox tops so the highest marker keeps a full padding band.
+    """Fit section bbox tops to content: grow to keep a full padding band,
+    and shrink to reclaim a genuinely empty flush band.
 
-    Symmetric counterpart to :func:`_shrink_bboxes_to_content_bottom`.
-    Fan-redistribution passes (Stages 4.9 / 4.10 / 6.7 / 6.11) can lift a
-    branch station above the content-top line the bbox was sized for,
-    leaving the topmost marker crowded against the bbox top while the
-    bottom keeps its full ``section_y_padding`` band -- so a fan
-    symmetric about the trunk reads as pushed up within its box
-    (issue #406).
+    Grow side (issue #406): fan-redistribution passes (Stages 4.9 / 4.10 /
+    6.7 / 6.11) can lift a branch above the content-top line the bbox was
+    sized for, crowding the topmost marker against the bbox top while the
+    bottom keeps its full ``section_y_padding`` band.  Growing the top to
+    :func:`_section_fit_top` (content-hug, bounded by the row-above
+    ceiling) restores the band.
 
-    Grow-only: the gate fires only when the content-hug target sits above
-    the current top, so the top is never lowered and the top-flush row
-    alignment from :func:`_top_align_row_bboxes_only` is preserved.  The
-    move uses the bidirectional :func:`_set_section_bbox_top` (TOP ports
-    follow the new edge); the gate, not the primitive, keeps this pass
-    one-directional.
+    Shrink side: the transient row-top flush
+    (:func:`_top_align_row_bboxes_only`) can leave a short section's top
+    flushed up to a tall fan/off-track row-mate with empty space above its
+    content.  When that band carries nothing
+    (:func:`_section_band_is_empty`), lower the top to the ceiling-free
+    :func:`_section_content_hug_top`.  A band holding a port or bypass
+    helper is left intact.
+
+    The grow branch keeps precedence, so a section whose top the row-above
+    ceiling pushed down is grown rather than shrunk into the badge.  Both
+    moves go through the bidirectional :func:`_set_section_bbox_top` (TOP
+    ports follow the new edge).
     """
     for section in graph.sections.values():
         if section.bbox_h <= 0:
@@ -552,6 +639,14 @@ def _grow_bboxes_to_content_top(
         target = _section_fit_top(graph, section, section_y_padding, section_y_gap)
         if target is not None and target < section.bbox_y - 0.5:
             _set_section_bbox_top(graph, section, target)
+            continue
+        hug = _section_content_hug_top(graph, section, section_y_padding)
+        if (
+            hug is not None
+            and hug > section.bbox_y + 0.5
+            and _section_band_is_empty(graph, section)
+        ):
+            _set_section_bbox_top(graph, section, hug)
 
 
 def _tighten_lower_rows_after_shrink(graph: MetroGraph, section_y_gap: float) -> None:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from layout_validator import Severity, check_station_as_elbow
 
-from nf_metro.layout.constants import CHAR_WIDTH
+from nf_metro.layout.constants import CHAR_WIDTH, SECTION_Y_PADDING
 from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.layers import assign_layers
@@ -163,10 +163,9 @@ def test_compute_layout_rowspan_section_compacts_content():
 
     A row-spanning section without its own off-track content should
     sit on the row's trunk Y so a straight inter-section bundle passes
-    through it without kinking.  When a row-mate has off-track inputs
-    that raise its bbox top, the rowspan section's bbox top follows so
-    the row's overall bbox shapes consistently, even if that leaves
-    the trunk content below the top padding zone.
+    through it without kinking.  Its bbox top hugs its own content
+    rather than following an off-track row-mate's raised top, so the two
+    do not share a bbox top.
     """
     graph = parse_metro_mermaid(
         "%%metro line: main | Main | #ff0000\n"
@@ -203,9 +202,20 @@ def test_compute_layout_rowspan_section_compacts_content():
     assert a_out_y == pytest.approx(b_y), (
         f"a_out y={a_out_y} and b y={b_y} must share trunk Y across sections"
     )
-    # Tall and short share the same bbox top (row-level top alignment).
-    assert tall.bbox_y == pytest.approx(short.bbox_y), (
-        f"tall bbox_y={tall.bbox_y} should match short bbox_y={short.bbox_y}"
+    # Each section hugs its own content, so the rowspan top sits below
+    # the off-track row-mate's raised top instead of matching it.
+    tall_content_top = min(
+        graph.stations[sid].y
+        for sid in tall.station_ids
+        if not graph.stations[sid].is_port and not sid.startswith("__bypass_")
+    )
+    assert tall.bbox_y == pytest.approx(tall_content_top - SECTION_Y_PADDING), (
+        f"tall bbox_y={tall.bbox_y} should hug its content "
+        f"(top {tall_content_top} - padding {SECTION_Y_PADDING})"
+    )
+    assert tall.bbox_y > short.bbox_y + 1, (
+        f"tall bbox_y={tall.bbox_y} should sit below short's off-track-raised "
+        f"top ({short.bbox_y})"
     )
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -33,7 +33,11 @@ from nf_metro.layout.engine import (
     is_loop_side_branch_station,
 )
 from nf_metro.layout.phases._common import _grow_section_bbox_upward
-from nf_metro.layout.phases.bbox import _section_fit_top
+from nf_metro.layout.phases.bbox import (
+    _section_band_is_empty,
+    _section_content_hug_top,
+    _section_fit_top,
+)
 from nf_metro.layout.phases.off_track import (
     _off_track_fit_top,
     _off_track_groups,
@@ -2953,6 +2957,53 @@ def test_section_bbox_has_top_padding(fixture):
     assert not offenders, (
         f"{fixture}: section bbox tops must sit at least "
         f"section_y_padding above the highest station centre: " + "; ".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_section_bbox_top_hugs_content(fixture):
+    """Empty-band sections hug content to an EQUALITY, not just a floor.
+
+    A section with a genuinely empty flush band -- no port and no
+    ``__bypass_`` helper above its topmost content
+    (:func:`_section_band_is_empty`) -- has its bbox top sit exactly
+    ``section_y_padding`` above the highest content marker, leaving no
+    empty band.  This is the equality companion to the ``>=`` floor
+    invariant ``test_section_bbox_has_top_padding``.
+
+    Ceiling-bound sections (where the row-above grow ceiling raises
+    :func:`_section_fit_top` above the ceiling-free
+    :func:`_section_content_hug_top`) legitimately keep a band so the
+    header badge clears the inter-row routing; they are skipped here and
+    covered by the floor test instead.
+    """
+    graph = _layout(fixture)
+    tol = 1.0
+
+    offenders: list[str] = []
+    for sec in graph.sections.values():
+        if sec.bbox_h <= 0 or not _section_band_is_empty(graph, sec):
+            continue
+        fit = _section_fit_top(graph, sec, SECTION_Y_PADDING, SECTION_Y_GAP)
+        hug = _section_content_hug_top(graph, sec, SECTION_Y_PADDING)
+        if fit is None or hug is None or fit > hug + tol:
+            continue
+        content_top = min(
+            graph.stations[sid].y
+            for sid in sec.station_ids
+            if not graph.stations[sid].is_port and not sid.startswith("__bypass_")
+        )
+        gap = content_top - sec.bbox_y
+        if abs(gap - SECTION_Y_PADDING) > tol:
+            offenders.append(
+                f"section {sec.id!r}: gap={gap:.1f} != "
+                f"section_y_padding={SECTION_Y_PADDING} "
+                f"(leftover band {gap - SECTION_Y_PADDING:.1f})"
+            )
+
+    assert not offenders, (
+        f"{fixture}: section tops with an empty band must hug content to "
+        f"section_y_padding with no leftover space: " + "; ".join(offenders)
     )
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2986,6 +2986,8 @@ def test_section_bbox_top_hugs_content(fixture):
             continue
         fit = _section_fit_top(graph, sec, SECTION_Y_PADDING, SECTION_Y_GAP)
         hug = _section_content_hug_top(graph, sec, SECTION_Y_PADDING)
+        # fit > hug means the row-above ceiling raised the top above the
+        # content-hug, so a band is reserved for the header badge.
         if fit is None or hug is None or fit > hug + tol:
             continue
         content_top = min(


### PR DESCRIPTION
## Summary

Second PR of the #464 bbox-top unification (design: `docs/dev/bbox_top_unification_design.md`). Builds on PR1 (#470). **This PR changes renders** - it is not byte-identical by design.

The final section-top pass (`_grow_bboxes_to_content_top`) now also lowers a section's bbox top to hug its content when the band above the topmost content is genuinely empty (no port, no `__bypass_` helper). This reclaims the empty space a short section inherited when the transient row-top flush stretched its box up to a tall fan / off-track row-mate.

- New `_section_content_hug_top`: the ceiling-free content-hug (content + port/bypass clamps, no row-above ceiling), the shrink target.
- New `_section_band_is_empty`: gates the shrink so a band holding a port or bypass helper (intentional approach runway) is left intact.
- Shrink branch added to `_grow_bboxes_to_content_top`; the grow branch keeps precedence, so a ceiling-bound section grows rather than shrinking into its header badge.
- `_section_fit_top` and `_guard_section_top_padding` are untouched (the row-above ceiling is a grow-direction bound and cannot bind when shrinking).

## Expected render delta (6 fixtures, all genuine empty-band removals)

Each changed section now hugs content at exactly `section_y_padding`:

- differentialabundance: `reporting` -58px
- differentialabundance_default: `differential`, `reporting` -116px each
- off_track_convergence: `input`, `output` -233px each
- genomeassembly_staggered: `scaffolding` -8.2px
- nf_flat_pipeline: `pipeline` -12.2px
- nf_unquoted_labels: `pipeline` -12.2px

The last three were under-stated in the original prediction (the design diagnostic scanned `examples/` + `examples/topologies/` only, missing the `tests/fixtures/nextflow/` conversions and rounding off the 8.2px case); all six are the same gate firing. `differentialabundance_default/plots` keeps its band (ceiling-bound, pre-existing xfail).

Row tops become staggered where a short section no longer flushes to a tall row-mate (row-top flush is dropped per the #464 plan, not a final-boundary property).

## Test plan
- [x] pytest passes; new `test_section_bbox_top_hugs_content` (equality companion to the `>=` `test_section_bbox_has_top_padding`); `test_off_track_inputs_above_consumer`, off-track suite, `test_contract_lifecycle`, and PR1's clamp tests all green
- [x] `test_compute_layout_rowspan_section_compacts_content` updated: it asserted the now-dropped row-top flush; it now asserts per-section content-hug (trunk-Y assertions unchanged)
- [x] `ruff check` + `ruff format --check` clean on `src/ tests/`
- [ ] Visual review of the render preview (the 6 deltas above) - the authoritative gate for this render-changing PR

Refs #464, #463, #365.

Generated with Claude Code