### PR TITLE
style: make whole-repo ruff check clean (#471)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,8 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+
+[tool.ruff.lint.per-file-ignores]
+# Generator emits long literal HTML/JS template lines; wrapping them would
+# distort the produced markup rather than improve readability.
+".claude/skills/nf-metro-layout-triage/build_review.py" = ["E501"]

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -64,12 +64,16 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
     (
         "differentialabundance",
         EXAMPLES_DIR,
-        "nf-core/differentialabundance with four input lines, off-track gene-set inputs, and a bypass-heavy reporting row. Uses `%%metro center_ports: true`.",
+        "nf-core/differentialabundance with four input lines, off-track "
+        "gene-set inputs, and a bypass-heavy reporting row. Uses "
+        "`%%metro center_ports: true`.",
     ),
     (
         "differentialabundance_default",
         EXAMPLES_DIR,
-        "Same nf-core/differentialabundance map at default (uncentered) layout — useful for spotting regressions that only show with default port placement.",
+        "Same nf-core/differentialabundance map at default (uncentered) "
+        "layout — useful for spotting regressions that only show with "
+        "default port placement.",
     ),
     (
         "legend_logo_placement",
@@ -84,12 +88,16 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
     (
         "tb_file_termini",
         EXAMPLES_DIR,
-        "A `%%metro direction: TB` reporting section whose file outputs are line termini. Regression fixture for #254 (terminus file icons now orient to a vertical flow, with the connector entering from the top).",
+        "A `%%metro direction: TB` reporting section whose file outputs are "
+        "line termini. Regression fixture for #254 (terminus file icons now "
+        "orient to a vertical flow, with the connector entering from the top).",
     ),
     (
         "genomeassembly_staggered",
         EXAMPLES_DIR,
-        "sanger-tol/genomeassembly with explicit `%%metro grid:` directives stacking each section in its own grid row. Regression fixture for #250 (cross-column junction routes were going backward in X).",
+        "sanger-tol/genomeassembly with explicit `%%metro grid:` directives "
+        "stacking each section in its own grid row. Regression fixture for "
+        "#250 (cross-column junction routes were going backward in X).",
     ),
     # --- Simple topologies ---
     (


### PR DESCRIPTION
## Summary

Makes `ruff check .` from the repo root clean, so the whole-repo lint guard used by the fix-issue / simplify workflows stops surfacing pre-existing failures outside CI's `src/ tests/` scope.

- `scripts/build_gallery.py`: wrap four overlong gallery `description` strings across adjacent string literals, matching the existing wrapped entries in the same list. Implicit concatenation makes the resulting strings byte-identical, so the gallery is unaffected.
- `pyproject.toml`: add a `[tool.ruff.lint.per-file-ignores]` entry ignoring `E501` for `.claude/skills/nf-metro-layout-triage/build_review.py`, whose long lines are literal HTML/JS template text where wrapping would distort the generated output rather than improve readability.

Fixes #471

## Test plan
- [x] `ruff check .` clean on whole repo
- [x] `ruff format --check .` clean on whole repo
- [x] Gallery `description` strings verified byte-identical to `main`
- [ ] Render-preview verdict: expected "No visual changes" (no src/ or fixture changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)