### PR TITLE
PR4 of #464 - finish: content-clamp dedup, rename bidirectional fit, lock equality

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -773,24 +773,29 @@ in pipeline order.
   half-pitch offset at the final boundary; row gaps preserved across any
   bbox grow.
 
-### Stage 6.15a: restore symmetric top padding
-- **Purpose**: Fan re-distribution (Stages 4.9 / 4.10 / 6.7 / 6.11) can
-  lift a branch above the content-top line the bbox was sized for,
-  crowding the topmost marker against the bbox top while the bottom keeps
-  its full band. Grow each bbox top to a full `section_y_padding` above the
-  highest marker (bounded by the row above) so fanned-above content sits
-  centred. The upward grow can breach the canvas top margin, so
+### Stage 6.15a: fit bbox tops to content (grow and shrink)
+- **Purpose**: Size each bbox top to `section_y_padding` above its highest
+  marker, bounded by the row above. Grows when fan re-distribution (Stages
+  4.9 / 4.10 / 6.7 / 6.11) lifted a branch above the line the bbox was sized
+  for, crowding the topmost marker (issue #406). Shrinks when the transient
+  row-top flush left an empty band above content with nothing in it (no port
+  or bypass helper); a band holding a port or bypass helper is left intact.
+  The upward grow can breach the canvas top margin, so
   `_shift_graph_into_canvas` runs immediately after.
-- **Helper**: `_grow_bboxes_to_content_top` (`phases/bbox.py`), then
+- **Helper**: `_fit_bboxes_to_content_top` (`phases/bbox.py`), then
   `_shift_graph_into_canvas`.
 - **Precondition**: All content Ys final (post-6.14).
 - **Postcondition**: Each bbox top sits `section_y_padding` above its
-  highest marker, bounded by the row above.
-- **Invariants preserved**: Station Ys (only bbox tops grow). Resolves #406.
-- **Related tests**: `test_section_bbox_has_top_padding`.
-- **Lifecycle:** invariant - each bbox top sits a full
-  `section_y_padding` above its highest marker at the final boundary
-  (the final top-sizing pass).
+  highest marker, bounded by the row above. For a section with an empty
+  band (no port / bypass above content) this is an equality, not just a
+  floor: the excess band is reclaimed.
+- **Invariants preserved**: Station Ys (only bbox tops move). Resolves #406.
+- **Related tests**: `test_section_bbox_has_top_padding`,
+  `test_section_bbox_top_hugs_content`.
+- **Lifecycle:** invariant - each bbox top hugs its highest marker at the
+  final boundary (a full `section_y_padding`, an equality for empty-band
+  sections), the final top-sizing pass. Row-top flush alignment is not a
+  maintained property; it is transient scaffolding superseded here.
 
 ### Stage 6.15: snap canvas to the y-grid
 - **Purpose**: After all settling, restore canvas-wide grid alignment.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -64,7 +64,7 @@ from nf_metro.layout.phases.balancing import (  # noqa: F401
 )
 from nf_metro.layout.phases.bbox import (  # noqa: F401
     _aggregate_bypass_spans,
-    _grow_bboxes_to_content_top,
+    _fit_bboxes_to_content_top,
     _lift_would_cause_uturn,
     _loop_corner_x,
     _min_section_bbox_top,
@@ -961,7 +961,7 @@ def _compute_section_layout(
     # topmost section above the canvas top margin, so re-fit; the
     # re-fit's non-grid shift is then cleaned up by the Stage 6.15
     # canvas snap below.
-    _grow_bboxes_to_content_top(graph, section_y_padding, section_y_gap)
+    _fit_bboxes_to_content_top(graph, section_y_padding, section_y_gap)
     _shift_graph_into_canvas(graph, section_y_padding)
 
     # Stage 6.15: Restore canvas-wide grid alignment after all settling.

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -17,6 +17,28 @@ def _bbox_cols_overlap(a: Section, b: Section) -> bool:
     return a.bbox_x < b.bbox_x + b.bbox_w and b.bbox_x < a.bbox_x + a.bbox_w
 
 
+def _content_station_ys(graph: MetroGraph, section: Section) -> list[float]:
+    """Y of every content marker in ``section``.
+
+    Content = non-port stations excluding the ``__bypass_`` helpers; hidden
+    phantoms are kept.  The single definition of the content set the
+    top-fit helpers (:func:`...bbox._section_content_hug_top`,
+    :func:`...bbox._section_fit_top`,
+    :func:`...off_track._off_track_fit_top`) anchor on, so the set cannot
+    drift between them -- e.g. a switch to ``is_hidden``, a superset that
+    would drop the phantoms.
+    """
+    return [
+        graph.stations[sid].y
+        for sid in section.station_ids
+        if (
+            sid in graph.stations
+            and not graph.stations[sid].is_port
+            and not sid.startswith("__bypass_")
+        )
+    ]
+
+
 def _station_marker_bbox(
     graph: MetroGraph,
     sid: str,

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -14,7 +14,11 @@ from nf_metro.layout.constants import (
     SECTION_HEADER_PROTRUSION,
 )
 from nf_metro.layout.labels import label_text_width
-from nf_metro.layout.phases._common import _bbox_cols_overlap, _set_section_bbox_top
+from nf_metro.layout.phases._common import (
+    _bbox_cols_overlap,
+    _content_station_ys,
+    _set_section_bbox_top,
+)
 from nf_metro.layout.phases.single_section import _terminus_y_overhang
 from nf_metro.parser.model import MetroGraph, Section, Station
 
@@ -480,33 +484,9 @@ def _section_fit_top(
 
     Returns ``None`` when the section has no real content to anchor to.
     """
-    content_min_ys = [
-        graph.stations[sid].y
-        for sid in section.station_ids
-        if (
-            sid in graph.stations
-            and not graph.stations[sid].is_port
-            and not sid.startswith("__bypass_")
-        )
-    ]
-    if not content_min_ys:
+    target = _section_content_hug_top(graph, section, section_y_padding)
+    if target is None:
         return None
-    bypass_min_ys = [
-        graph.stations[sid].y
-        for sid in section.station_ids
-        if sid in graph.stations and sid.startswith("__bypass_")
-    ]
-    port_min_ys = [
-        graph.stations[sid].y
-        for sid in section.station_ids
-        if sid in graph.stations and graph.stations[sid].is_port
-    ]
-    v_curve_clearance = CURVE_RADIUS + MIN_STATION_FLAT_LENGTH / 2
-    target = min(content_min_ys) - section_y_padding
-    if bypass_min_ys:
-        target = min(target, min(bypass_min_ys) - v_curve_clearance)
-    if port_min_ys:
-        target = min(target, min(port_min_ys))
 
     above_bots: list[float] = []
     for other in graph.sections.values():
@@ -538,22 +518,9 @@ def _section_content_hug_top(
     too-tall top moves it away from the row above, so it never binds when
     hugging content downward.
 
-    Separate from ``_section_fit_top`` so the grow target it shares with
-    ``_guard_section_top_padding`` is untouched.  Same content set as
-    ``_section_fit_top`` / ``_off_track_fit_top``: non-port stations
-    excluding ``__bypass_`` helpers, phantoms kept.
-
     Returns ``None`` when the section has no real content to anchor to.
     """
-    content_min_ys = [
-        graph.stations[sid].y
-        for sid in section.station_ids
-        if (
-            sid in graph.stations
-            and not graph.stations[sid].is_port
-            and not sid.startswith("__bypass_")
-        )
-    ]
+    content_min_ys = _content_station_ys(graph, section)
     if not content_min_ys:
         return None
     bypass_min_ys = [
@@ -584,15 +551,7 @@ def _section_band_is_empty(graph: MetroGraph, section: Section) -> bool:
     above content is intentional runway for that port's approach and must
     not be shrunk into.
     """
-    content_min_ys = [
-        graph.stations[sid].y
-        for sid in section.station_ids
-        if (
-            sid in graph.stations
-            and not graph.stations[sid].is_port
-            and not sid.startswith("__bypass_")
-        )
-    ]
+    content_min_ys = _content_station_ys(graph, section)
     if not content_min_ys:
         return False
     topmost = min(content_min_ys)

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -464,16 +464,8 @@ def _section_fit_top(
 ) -> float | None:
     """Return the content-hug bbox top for ``section``.
 
-    The top sits ``section_y_padding`` above the highest content marker,
-    clamped so bypass helpers (curve-only clearance) and ports stay
-    inside; mirror of the bottom anchor in
-    :func:`_shrink_bboxes_to_content_bottom`.  The off-track variant
-    :func:`nf_metro.layout.phases.off_track._off_track_fit_top` is the
-    same target anchored on just the off-track band.
-
-    Content set: non-port stations excluding ``__bypass_`` helpers, with
-    hidden phantoms kept -- deliberately not ``is_hidden`` (a superset
-    that drops those phantoms and diverges from ``_off_track_fit_top``).
+    :func:`_section_content_hug_top` over the shared content set, then
+    bounded by the row above.
 
     The row-above bound reserves ``section_y_gap +
     SECTION_HEADER_PROTRUSION`` (the header badge protrudes above the

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -564,7 +564,7 @@ def _section_band_is_empty(graph: MetroGraph, section: Section) -> bool:
     return True
 
 
-def _grow_bboxes_to_content_top(
+def _fit_bboxes_to_content_top(
     graph: MetroGraph,
     section_y_padding: float,
     section_y_gap: float,

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -300,7 +300,7 @@ def _guard_section_top_padding(
     """Final phase: each section's bbox top must clear its highest marker.
 
     The mirror of the bottom-padding contract.  After
-    :func:`_grow_bboxes_to_content_top` runs, every section's bbox top
+    :func:`_fit_bboxes_to_content_top` runs, every section's bbox top
     should sit at its content-anchored target (a full ``section_y_padding``
     above the highest marker, unless gap-bounded by the row above).  A
     bbox top below that target means a later pass crowded the topmost

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -13,6 +13,7 @@ from nf_metro.layout.constants import (
 )
 from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.phases._common import (
+    _content_station_ys,
     _grow_section_bbox_upward,
     _set_section_bbox_top,
 )
@@ -585,15 +586,12 @@ def _off_track_fit_top(
     this in both directions so a stale too-tall box is reclaimed.
     """
     target = highest_off_track_y - section_y_padding
-    for sid in section.station_ids:
-        st = graph.stations.get(sid)
-        # Mirror the content set of ``_section_fit_top``
-        # (bbox.py): ports and bypass V helpers are excluded, but hidden
-        # phantoms are kept, so this must not switch to ``st.is_hidden``
-        # (which would also drop phantoms and diverge from that helper).
-        if st is None or st.is_port or sid.startswith("__bypass_"):
-            continue
-        target = min(target, st.y - section_y_padding)
+    for y in _content_station_ys(graph, section):
+        target = min(target, y - section_y_padding)
+    # Non-TOP ports bound the fit so they aren't stranded above the new
+    # top; TOP ports follow the edge and impose no bound.  This port clamp
+    # is deliberately narrower than the bbox helpers' all-port clamp, so
+    # only the content set is shared, not the port handling.
     for pid in section.entry_ports + section.exit_ports:
         port = graph.ports.get(pid)
         port_st = graph.stations.get(pid)


### PR DESCRIPTION
## Summary

Final PR of the #464 bbox-top unification (PR1 #470, PR2 #472 merged). Cleanup + lock-in; **byte-identical** across the full corpus (gallery + topologies + guide + tests/fixtures + nextflow conversions).

- **Content set defined once.** `_section_fit_top`, `_section_content_hug_top` (bbox.py) and `_off_track_fit_top` (off_track.py) held three copies of the content-set comprehension (non-port, non-`__bypass_`, phantoms kept) - the sync footgun. Extract `_content_station_ys` into `_common.py`; all three (plus `_section_band_is_empty`) source it. `_section_fit_top` now builds on `_section_content_hug_top` + the row-above ceiling. off_track keeps its deliberately narrower non-TOP-port clamp (TOP ports follow the edge) and no bypass clamp - only the content set is shared, not the port handling.
- **Rename** `_grow_bboxes_to_content_top` -> `_fit_bboxes_to_content_top`: since PR2 the final top pass grows and shrinks, so the `_grow_` name was a misnomer.
- **CONTRACT.md** Stage 6.15a retagged: bidirectional grow+shrink, equality (not just a floor) for empty-band sections, and row-top flush noted as transient scaffolding, not a maintained property.

### Not done: retiring compaction step-1

The plan flagged `_compact_row_content_to_bbox_top` step-1 (the content pull-up) as possibly dead. **Verified it is not** - disabling it changes 5 renders (variantbenchmarking x3, multiline_labels x2): it compacts those rows by raising content uniformly to preserve trunk alignment, which the per-section top-shrink does not replicate. Removing it would re-open top bands with no benefit, so it is kept. (The "dead" claim was conditional on dropping the row-top flush, which we kept.)

## Test plan
- [x] Full-corpus gallery hash/diff == origin/main (byte-identical)
- [x] pytest passes (incl. `test_section_bbox_top_hugs_content`, off-track + lifecycle suites); `test_contract_lifecycle` green after the retag
- [x] `ruff check` + `ruff format --check` clean (whole repo)
- [x] `compute_layout(validate=True)` clean

Refs #464, #463, #365.

Generated with Claude Code