### PR TITLE
fix(types): close ruff ANN gaps and add mypy to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      - run: pip install ruff mypy
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
+      - run: mypy
 
   test:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "ruff>=0.4",
+    "mypy>=1.8",
 ]
 docs = [
     "mkdocs-material>=9.0",
@@ -60,9 +61,21 @@ addopts = "-rxX"
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W"]
+select = ["E", "F", "I", "W", "ANN"]
 
 [tool.ruff.lint.per-file-ignores]
+# Type-annotation rules are enforced on the library only; tests favour
+# brevity over fully annotated fixtures and helpers.
+"tests/**" = ["ANN"]
+"scripts/**" = ["ANN"]
 # Generator emits long literal HTML/JS template lines; wrapping them would
 # distort the produced markup rather than improve readability.
 ".claude/skills/nf-metro-layout-triage/build_review.py" = ["E501"]
+
+[tool.mypy]
+files = ["src"]
+mypy_path = "src"
+explicit_package_bases = true
+python_version = "3.10"
+ignore_missing_imports = true
+strict_optional = false

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 __all__ = ["infer_section_layout", "detect_serpentine_runs"]
 
 from collections import defaultdict, deque
+from collections.abc import Set as AbstractSet
 
 from nf_metro.parser.model import MetroGraph, PortSide, SectionDAG
 
@@ -605,7 +606,7 @@ def _adjust_explicit_tb_sections(
 def _optimize_colspans(
     graph: MetroGraph,
     fold_sections: set[str],
-    below_fold_sections: set[str] = frozenset(),
+    below_fold_sections: AbstractSet[str] = frozenset(),
     successors: dict[str, set[str]] | None = None,
 ) -> None:
     """Optimize column spans to reduce dead space from oversized sections.
@@ -719,7 +720,7 @@ def _infer_directions(
     successors: dict[str, set[str]],
     predecessors: dict[str, set[str]],
     fold_sections: set[str],
-    below_fold_sections: set[str] = frozenset(),
+    below_fold_sections: AbstractSet[str] = frozenset(),
 ) -> None:
     """Infer section flow direction (LR/RL/TB) from grid positions.
 

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -39,6 +39,7 @@ from nf_metro.parser.model import MetroGraph
 
 if TYPE_CHECKING:
     from nf_metro.layout.routing.common import RoutedPath
+    from nf_metro.parser.model import Section, Station
 
 
 def label_text_width(label: str) -> float:
@@ -379,7 +380,7 @@ def _compute_port_label_preference(
 
 
 def _apply_edge_override(
-    station,
+    station: Station,
     start_above: bool,
     section_y_range: dict[str, tuple[float, float]],
     sections_with_multiline: set[str],
@@ -1034,8 +1035,8 @@ def _avoid_diagonal_routes(
 
 def _clamp_label_vertical(
     candidate: LabelPlacement,
-    sec,
-    station,
+    sec: Section,
+    station: Station,
     label_offset: float,
     min_off: float,
     max_off: float,
@@ -1227,7 +1228,7 @@ def _compute_safe_offsets(
 
 
 def _try_place(
-    station,
+    station: Station,
     label_offset: float,
     above: bool,
     existing: list[LabelPlacement],

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -68,7 +68,7 @@ def _station_marker_bbox(
     return (st.x - radius, cy - half_h, st.x + radius, cy + half_h)
 
 
-def first_vertical_leg_x(points) -> float | None:
+def first_vertical_leg_x(points: list[tuple[float, float]]) -> float | None:
     """X of the first (near-)vertical leg of *points*.
 
     The source-side vertical channel ("V1") of an inter-section route;
@@ -131,7 +131,14 @@ def _route_crosses_section_boundary(
             for p in ports_by_sec.get(sec_id, [])
         )
 
-    def edge_crossings(p1, p2, x0, y0, x1, y1):
+    def edge_crossings(
+        p1: tuple[float, float],
+        p2: tuple[float, float],
+        x0: float,
+        y0: float,
+        x1: float,
+        y1: float,
+    ) -> list[tuple[float, float]]:
         ax, ay = p1
         bx, by = p2
         hits = []
@@ -429,7 +436,9 @@ def _build_section_subgraph(graph: MetroGraph, section: Section) -> MetroGraph:
     return sub
 
 
-def _set_section_bbox_top(graph: MetroGraph, section, new_bbox_top: float) -> None:
+def _set_section_bbox_top(
+    graph: MetroGraph, section: Section, new_bbox_top: float
+) -> None:
     """Move a section's bbox top to *new_bbox_top* and pull TOP ports along.
 
     Works in both directions: a smaller *new_bbox_top* grows the box
@@ -448,7 +457,9 @@ def _set_section_bbox_top(graph: MetroGraph, section, new_bbox_top: float) -> No
             port.y = port_st.y
 
 
-def _grow_section_bbox_upward(graph: MetroGraph, section, new_bbox_top: float) -> None:
+def _grow_section_bbox_upward(
+    graph: MetroGraph, section: Section, new_bbox_top: float
+) -> None:
     """Expand a section's bbox upward to *new_bbox_top* and pull TOP ports.
 
     Grow-only convenience wrapper: callers guard on ``new_bbox_top <

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -99,7 +99,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
                 src_ys.add(round(src.y, 1))
         if len(src_ys) >= 2:
             for edge in graph.edges_from(port_id):
-                entry_candidates: list[str] = []
+                entry_candidates = []
                 tgt_port = graph.ports.get(edge.target)
                 if tgt_port and tgt_port.is_entry:
                     entry_candidates.append(edge.target)
@@ -521,9 +521,9 @@ def _balance_section_content_around_trunk(
             top_band = section_top_y - section.bbox_y
             if top_band <= y_spacing + 0.5:
                 break
-            ys = {s: graph.stations[s].y for s in movable}
-            above = [s for s, y in ys.items() if y < trunk_y - 0.5]
-            below = [s for s, y in ys.items() if y > trunk_y + 0.5]
+            ys_by_sid = {s: graph.stations[s].y for s in movable}
+            above = [s for s, y in ys_by_sid.items() if y < trunk_y - 0.5]
+            below = [s for s, y in ys_by_sid.items() if y > trunk_y + 0.5]
             if len(below) <= len(above):
                 break
             line_sets = {frozenset(graph.station_lines(s)) for s in movable}
@@ -806,7 +806,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
             continue
         port_ids = section.port_ids
         # Determine the section's trunk Y from a horizontal port.
-        trunk_y: float | None = None
+        section_trunk_y: float | None = None
         for pid in section.entry_ports + section.exit_ports:
             ps = graph.stations.get(pid)
             port = graph.ports.get(pid)
@@ -815,9 +815,9 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                 and port is not None
                 and port.side in (PortSide.LEFT, PortSide.RIGHT)
             ):
-                trunk_y = ps.y
+                section_trunk_y = ps.y
                 break
-        if trunk_y is None:
+        if section_trunk_y is None:
             continue
 
         # Visible trunk-Y predecessor/successor X-extent for a station.
@@ -831,7 +831,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                 p = graph.stations.get(e.source)
                 if p is None or p.is_hidden:
                     continue
-                if abs(p.y - trunk_y) > 0.5:
+                if abs(p.y - section_trunk_y) > 0.5:
                     return None
                 if (
                     pred_x is None
@@ -843,7 +843,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                 t = graph.stations.get(e.target)
                 if t is None or t.is_hidden:
                     continue
-                if abs(t.y - trunk_y) > 0.5:
+                if abs(t.y - section_trunk_y) > 0.5:
                     return None
                 if (
                     succ_x is None
@@ -880,7 +880,7 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
             anchor_xs: list[float] = []
             for sid in members:
                 st = graph.stations[sid]
-                if abs(st.y - trunk_y) <= 0.5:
+                if abs(st.y - section_trunk_y) <= 0.5:
                     trunk_members.append(sid)
                     continue
                 # Anchor X must come from a station pass-1 already

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -40,7 +40,7 @@ def _predicted_bypass_bottom_in_row(
     if not sections_in_row:
         return {}
 
-    def _node_section(node_id: str):
+    def _node_section(node_id: str) -> Section | None:
         st = graph.stations.get(node_id) or graph.ports.get(node_id)
         if st is None:
             return None
@@ -49,7 +49,9 @@ def _predicted_bypass_bottom_in_row(
 
     resolve_cache: dict[tuple[str, bool], Section | None] = {}
 
-    def _resolve(node_id: str, upstream: bool, visited: set[str] | None = None):
+    def _resolve(
+        node_id: str, upstream: bool, visited: set[str] | None = None
+    ) -> Section | None:
         key = (node_id, upstream)
         if key in resolve_cache:
             return resolve_cache[key]

--- a/src/nf_metro/layout/phases/canvas.py
+++ b/src/nf_metro/layout/phases/canvas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from nf_metro.layout.phases.bbox import _min_section_bbox_top
-from nf_metro.parser.model import MetroGraph
+from nf_metro.parser.model import MetroGraph, Section
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:
@@ -88,7 +88,7 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
         elif sw not in sweep_is_rl and s.direction == "LR":
             sweep_is_rl[sw] = False
 
-    def _sort_key(s):
+    def _sort_key(s: Section) -> tuple[int, int, int, int]:
         sw = sweep[s.id]
         col = -s.grid_col if sweep_is_rl.get(sw, False) else s.grid_col
         return (comp_idx.get(s.id, 0), sw, col, s.grid_row)

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
     COORD_TOLERANCE,
@@ -29,7 +30,12 @@ from nf_metro.layout.phases._common import (
 from nf_metro.layout.phases.bbox import _section_fit_top
 from nf_metro.layout.phases.single_section import _terminus_y_overhang
 from nf_metro.layout.phases.spacing import _residual_label_overlaps
-from nf_metro.parser.model import MetroGraph, PortSide, Section
+from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from nf_metro.layout.routing.common import RoutedPath
 
 
 class PhaseInvariantError(Exception):
@@ -52,7 +58,9 @@ def _guard_coordinates_finite(graph: MetroGraph, phase: str) -> None:
                 )
 
 
-def _bbox_guarded_stations(graph: MetroGraph):
+def _bbox_guarded_stations(
+    graph: MetroGraph,
+) -> Iterator[tuple[str, Station, Section]]:
     """Yield ``(sid, station, section)`` for each rendered station that a
     bbox-containment guard should check: skips ports, junctions, and
     stations whose section has no sized bbox.  Shared by the marker-edge
@@ -474,7 +482,9 @@ def _guard_row_trunk_cy_consistent(
 
         offsets = compute_station_offsets(graph)
 
-    def _section_trunk_info(sec) -> tuple[float, float, float, set[str]] | None:
+    def _section_trunk_info(
+        sec: Section,
+    ) -> tuple[float, float, float, set[str]] | None:
         bundle = _section_bundle_lines(graph, sec)
         if not bundle:
             return None
@@ -643,7 +653,7 @@ def _ensure_routes(graph: MetroGraph, routes: list | None) -> list:
     return route_edges(graph)
 
 
-def _route_exit_side(graph: MetroGraph, rp) -> PortSide | None:
+def _route_exit_side(graph: MetroGraph, rp: RoutedPath) -> PortSide | None:
     """Side of the port a route exits through (directly or via its feeder)."""
     port = graph.ports.get(rp.edge.source)
     if port is not None:
@@ -662,7 +672,7 @@ def _inter_section_backtrack_legs(
     reference: str = "grid",
     tolerance: float = 0.0,
     include_exempt: bool = False,
-):
+) -> Iterator[tuple[RoutedPath, float, float]]:
     """Yield ``(rp, x1, x2)`` for each horizontal leg of a forward LR
     inter-section route that reverses against its flow.
 
@@ -804,7 +814,9 @@ def _guard_fan_bundles_coincide_or_separate(
                 )
 
 
-def inter_section_route_backtrack_legs(graph: MetroGraph, routes: list):
+def inter_section_route_backtrack_legs(
+    graph: MetroGraph, routes: list
+) -> Iterator[tuple[RoutedPath, float, float]]:
     """Yield ``(rp, x1, x2)`` for each horizontal leg that moves *away* from
     the route's own endpoint X - a genuine out-and-back dog-leg.
 

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -162,10 +162,10 @@ def _compute_fork_join_gaps(
     visible_tracks = {t for sid, t in tracks.items() if not sid.startswith("__bypass_")}
     is_single_track = len(visible_tracks) <= 1
 
-    def _has_bypass(ids):
+    def _has_bypass(ids: set[str]) -> bool:
         return any(nid.startswith("__bypass_") for nid in ids)
 
-    def _bypass_aware_tracks(ids, owner_sid):
+    def _bypass_aware_tracks(ids: set[str], owner_sid: str) -> set[float]:
         """Visible peer tracks plus the owner's own track, V's removed."""
         result: set[float] = set()
         owner_track = tracks.get(owner_sid)

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from nf_metro.parser.model import MetroGraph
+
+if TYPE_CHECKING:
+    from nf_metro.layout.labels import LabelOverlap
 
 # Cap on spread-loop passes.  Each pass strictly widens the binding axis,
 # so a handful suffices to clear any realistic crowding before giving up.
@@ -13,7 +18,9 @@ _MAX_SPREAD_ITERS = 6
 _SPREAD_SLACK = 4.0
 
 
-def _residual_label_overlaps(graph: MetroGraph, *, allow_hyphenation: bool):
+def _residual_label_overlaps(
+    graph: MetroGraph, *, allow_hyphenation: bool
+) -> list[LabelOverlap]:
     """Place labels at the current layout and report leftover overlaps.
 
     Runs the same offset/route/label pipeline the renderer uses (so the
@@ -62,7 +69,14 @@ def _residual_label_overlaps(graph: MetroGraph, *, allow_hyphenation: bool):
                 s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
 
 
-def _spread_bump(graph, residual, x_spacing, y_spacing, auto_x, auto_y):
+def _spread_bump(
+    graph: MetroGraph,
+    residual: list[LabelOverlap],
+    x_spacing: float,
+    y_spacing: float,
+    auto_x: bool,
+    auto_y: bool,
+) -> tuple[float, float]:
     """Compute widened (x, y) spacing to clear the residual label overlaps.
 
     Each overlap is attributed to the axis along which its two stations are

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -280,7 +280,7 @@ def compute_bundle_info(
 
         if abs(dx) < COORD_TOLERANCE:
             # Vertical: group by shared X position
-            key = ("V", round(sx), v_dir)
+            key: tuple = ("V", round(sx), v_dir)
         else:
             # L-shaped: group by the inter-column gap the vertical
             # channel will occupy.  Use (src_col, tgt_col) when
@@ -301,6 +301,7 @@ def compute_bundle_info(
                 if tgt_st and tgt_st.section_id
                 else None
             )
+            col_key: int | tuple[int, ...]
             if src_sec and tgt_sec and src_sec.grid_col != tgt_sec.grid_col:
                 col_key = (src_sec.grid_col, tgt_sec.grid_col)
             elif tgt_sec:

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -366,8 +366,8 @@ def compute_bundle_info(
 
 def inter_column_channel_x(
     graph: MetroGraph,
-    src,
-    tgt,
+    src: Station,
+    tgt: Station,
     sx: float,
     tx: float,
     dx: float,

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -4180,7 +4180,6 @@ def _compute_bypass_gap_indices(
             continue
 
         dx = tgt.x - src.x
-        ekey: EdgeKey = (edge.source, edge.target, edge.line_id)
         bypass_edges.append((ekey, src_col, tgt_col, dx))
 
     gap1_groups: dict[tuple[int, int], list[tuple[EdgeKey, int]]] = defaultdict(list)
@@ -4209,14 +4208,14 @@ def _compute_bypass_gap_indices(
             gap1_idx[ek] = (j, n)
 
     lp = line_priority or {}
-    for group in gap2_groups.values():
+    for gap2_group in gap2_groups.values():
         # Sort by line priority so the lowest-offset line (highest
         # priority) gets the outermost vertical channel.  This
         # prevents crossings when lines converge at an entry port
         # from different source columns.
-        group.sort(key=lambda x: lp.get(x[2], 0))
-        n = len(group)
-        for j, (ek, _sc, _lid) in enumerate(group):
+        gap2_group.sort(key=lambda x: lp.get(x[2], 0))
+        n = len(gap2_group)
+        for j, (ek, _sc, _lid) in enumerate(gap2_group):
             gap2_idx[ek] = (j, n)
 
     result: dict[EdgeKey, tuple[int, int, int, int]] = {}

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -64,7 +64,7 @@ from nf_metro.layout.routing.corners import (
     tb_entry_corner,
     tb_exit_corner,
 )
-from nf_metro.parser.model import Edge, MetroGraph, PortSide, Station
+from nf_metro.parser.model import Edge, MetroGraph, Port, PortSide, Station
 
 # ---------------------------------------------------------------------------
 # Routing context: pre-computed state shared by all handlers
@@ -847,7 +847,7 @@ def _route_merge_branch(
 
 
 def _has_around_section_sibling(
-    edge: Edge, ep: Station, ep_port, ctx: _RoutingCtx
+    edge: Edge, ep: Station, ep_port: Port | None, ctx: _RoutingCtx
 ) -> bool:
     """Detect whether another edge to the same entry port will route via
     :func:`_route_around_section_below`.
@@ -1309,7 +1309,7 @@ def _should_step_descent(
     graph: MetroGraph,
     src: Station,
     ep: Station,
-    ep_port,
+    ep_port: Port | None,
 ) -> bool:
     """Detect the nested-column degenerate geometry that needs a stepped
     descent.

--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -387,7 +387,7 @@ def tb_entry_corner(
     max_tgt_off: float,
     entry_right: bool,
     base_radius: float = CURVE_RADIUS,
-) -> tuple[float, float, float]:
+) -> tuple[float, float]:
     """Compute offsets and radius for a TB section entry L-shape.
 
     Routes: horizontal from LEFT or RIGHT entry port -> corner ->

--- a/src/nf_metro/layout/routing/inter_section.py
+++ b/src/nf_metro/layout/routing/inter_section.py
@@ -20,6 +20,7 @@ don't fire on; the dispatcher's if-cascade handles them directly.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property
@@ -128,10 +129,10 @@ class TurnSequence:
     def __len__(self) -> int:
         return len(self.corners)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Corner]:
         return iter(self.corners)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> Corner:
         return self.corners[idx]
 
     @cached_property

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -762,10 +762,12 @@ def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
     # --- Compact entry port offset separation ---
     if ctx.compact:
         for sec_id, section in graph.sections.items():
-            entry_lines: list[str] = []
+            compact_entry_lines: list[str] = []
             for pid in section.entry_ports:
-                entry_lines.extend(graph.station_lines(pid))
-            unique = sorted(set(entry_lines), key=lambda x: ctx.line_priority.get(x, 0))
+                compact_entry_lines.extend(graph.station_lines(pid))
+            unique = sorted(
+                set(compact_entry_lines), key=lambda x: ctx.line_priority.get(x, 0)
+            )
             if len(unique) < 2:
                 continue
             existing = [

--- a/src/nf_metro/layout/routing/reversal.py
+++ b/src/nf_metro/layout/routing/reversal.py
@@ -7,7 +7,7 @@ assignments in compute_station_offsets().
 
 from __future__ import annotations
 
-from nf_metro.parser.model import MetroGraph, PortSide
+from nf_metro.parser.model import MetroGraph, Port, PortSide
 
 
 def _fed_by_bottom_exit_fold(
@@ -168,7 +168,7 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
     # We iterate because a later TB section may become reversed
     # through row propagation from an earlier TB section's
     # downstream (e.g. calling -> hard_filter -> ... -> integration).
-    def _is_tb_lr_exit_nonreversed(port_obj):
+    def _is_tb_lr_exit_nonreversed(port_obj: Port | None) -> bool:
         """Check if port is an LR exit of a non-reversed TB section."""
         return (
             port_obj is not None

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -29,7 +29,7 @@ from nf_metro.layout.constants import (
     SECTION_X_PADDING,
 )
 from nf_metro.layout.routing.common import resolve_section
-from nf_metro.parser.model import MetroGraph, PortSide, Section
+from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
 
 
 def _assign_grid_layout(
@@ -337,7 +337,7 @@ def _rows_overlap(a: Section, b: Section) -> bool:
 
 def _station_column(
     graph: MetroGraph,
-    station,
+    station: Station,
     col_assign: dict[str, int],
     junction_ids: set[str],
 ) -> int | None:
@@ -373,7 +373,7 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
     adjacent ``(src_row, tgt_row)`` reservation still applies.
     """
 
-    def _is_flow_section(sec) -> bool:
+    def _is_flow_section(sec: Section | None) -> bool:
         return sec is not None and sec.grid_row_span == 1
 
     # (upper_row, lower_row) -> entry_port_id -> set of line ids

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -201,7 +201,9 @@ class MetroGraph:
     # Section IDs that had explicit %%metro direction: directives
     _explicit_directions: set[str] = field(default_factory=set)
     # Pending terminus designations: station_id -> list of (label, icon_type)
-    _pending_terminus: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+    _pending_terminus: dict[str, list[tuple[str, str, str]]] = field(
+        default_factory=dict
+    )
     # Pending off-track marks: station_ids to lift above section top track
     _pending_off_track: list[str] = field(default_factory=list)
     # Lazy caches keyed off the edge list; invalidated on edge mutation.

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -8,6 +8,7 @@ import html
 import textwrap
 import warnings
 from pathlib import Path
+from typing import Any
 
 import drawsvg as draw
 
@@ -368,7 +369,7 @@ def render_svg(
 
     # Compute legend and logo dimensions
     logo_w, logo_h = (0.0, 0.0)
-    show_logo = graph.logo_path and Path(graph.logo_path).is_file()
+    show_logo = bool(graph.logo_path) and Path(graph.logo_path).is_file()
     if show_logo:
         logo_w, logo_h = compute_logo_dimensions(graph.logo_path)
 
@@ -1170,7 +1171,7 @@ def _render_terminus_icons(
                 min(icon_cx, icon_right),
             )
 
-        common = dict(
+        common: dict[str, Any] = dict(
             cx=icon_cx,
             cy=icon_cy,
             width=theme.terminus_width,


### PR DESCRIPTION
## Summary

Tightens type-hint coverage and adds type checking to CI.

- Closes all ruff `ANN` argument/return gaps in `src/` (helper boundaries across layout, routing, render, and parser).
- Enables the ruff `ANN` rule family, with `tests/` and `scripts/` per-file-ignored so the rules are enforced on the library only.
- Adds a lenient `mypy` configuration (`ignore_missing_imports`, `strict_optional` off, `mypy_path = "src"`) and wires `mypy` into the CI lint job.
- Resolves the 29 type-correctness issues mypy surfaced. Two were genuine annotation bugs: `MetroGraph._pending_terminus` was typed as 2-tuples but stores `(label, icon_type, name)` 3-tuples, and `tb_entry_corner` was annotated to return a 3-tuple but returns 2. The rest are annotation precision, local name-reuse renames, and heterogeneous-kwargs typing.

Annotation-only change; no runtime behaviour change; gallery byte-identical.

Strict-optional mypy (which would require ~60 further `None`-narrowing guards on coordinate/port fields) is intentionally deferred; this lands the lenient pass first.

Fixes #455

## Test plan
- [x] `pytest` passes (3781 passed, 6 xfailed)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] `mypy` clean, verified in a clean venv with no package installed (matches the CI lint job)
- [x] Gallery byte-identical (verified after both commits)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/476/)
- [ ] Render-preview verdict: expected "No visual changes"

Generated with Claude Code
