### PR TITLE
feat(layout): guard that content placement never moves a trunk anchor (#465 stage 1)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -104,6 +104,25 @@ docstring in `engine.py` is the authoritative list.
 Guard bodies live in `phases/guards.py` and are imported into `engine.py`;
 the bisection runner is `_run_pass_c_guards`.
 
+## Anchor invariant
+
+The **trunk anchor** of a section is the Y of its LEFT/RIGHT (LR/RL) port
+stations: the level at which the inter-section line bundle runs. Anchors are
+set only by structural phases - port positioning along the section DAG
+(align/snap entry/exit ports, inter-section port-pair snap), the row trunk
+alignment (4.8), grid snapping, the inter-row cascade (6.13/6.14 phase 2) and
+uniform canvas/row translation.
+
+The **content-placement** phases - fan-out / full-bundle redistribution (4.9,
+4.10), band-fill (6.1, 6.2), the 2-branch symfan half-grid (6.3), full-bundle
+recenter (6.7), balance-around-trunk (6.11) and loop-side recenter (6.12) -
+position content *around* the resolved anchors and must never move one. Each
+runs through the `_placed` wrapper in `_compute_section_layout`, which under
+`validate=True` calls `_guard_anchors_frozen_during_placement` to assert the
+LR port Ys are unchanged across the phase. This separation (structural anchors
+vs. dependent placement) is what makes the layout forward-resolvable: content
+is a function of the frozen anchors, not the reverse.
+
 ## Stage overview
 
 The pipeline groups into six stages aligned with the coord-regime

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -711,17 +711,19 @@ def _compute_section_layout(
     # position content around them and must never move one; ``_placed`` runs
     # each so that, under ``validate``, a guard asserts the anchors stayed
     # frozen.  See CONTRACT.md (anchor invariant).
-    def _placed(label: str, fn: Callable[..., None], *args: object) -> None:
+    def _placed(stage: str, fn: Callable[..., None], *args: object) -> None:
         before = _lr_port_anchor_snapshot(graph) if validate else None
         fn(graph, *args)
         if validate and before is not None:
-            _guard_anchors_frozen_during_placement(graph, before, label)
+            _guard_anchors_frozen_during_placement(
+                graph, before, f"Stage {stage} {fn.__name__}"
+            )
 
     # Stage 4.9: When --center-ports is on, redistribute fan-out siblings
     # of a section's trunk junction symmetrically around the trunk Y.
     # Scoped to fan-out side branches only: linear chains, fan-in
     # structures, and file inputs are left in place.
-    _placed("Stage 4.9 redistribute_fanout_siblings", _redistribute_fanout_siblings, y_spacing)
+    _placed("4.9", _redistribute_fanout_siblings, y_spacing)
 
     # Stage 4.10: Symmetrically fan a column of full-bundle stations
     # around the trunk Y when no unique trunk exists (e.g. Reporting's
@@ -736,11 +738,7 @@ def _compute_section_layout(
     # 4.10's port-Y anchor.  Skipping Stage 4.10 changes intermediate
     # bbox sizes and is not empty-render-diff; the two passes are
     # load-bearing in combination.
-    _placed(
-        "Stage 4.10 redistribute_full_bundle_columns",
-        _redistribute_full_bundle_columns,
-        y_spacing,
-    )
+    _placed("4.10", _redistribute_full_bundle_columns, y_spacing)
 
     # ---- Stage 5 - Pass C: Junctions & off-track lift ------------------
     # All port positions are now final; Stage 5.1 positions junctions
@@ -805,12 +803,7 @@ def _compute_section_layout(
     # for sections whose internal stations have no upward dependency
     # (no off-track band) and whose trunk Y sits below the bbox top
     # padding by more than one ``y_spacing`` slot.
-    _placed(
-        "Stage 6.1 fan_free_content_upward",
-        _fan_free_content_upward,
-        section_y_padding,
-        y_spacing,
-    )
+    _placed("6.1", _fan_free_content_upward, section_y_padding, y_spacing)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.1")
 
@@ -819,7 +812,7 @@ def _compute_section_layout(
     # source inputs (file icons with no inbound edges), lift the
     # nearest-to-trunk sources into the empty top band so the section
     # is bottom- and top-weighted instead of stacked below the trunk.
-    _placed("Stage 6.2 fan_source_inputs_upward", _fan_source_inputs_upward, y_spacing)
+    _placed("6.2", _fan_source_inputs_upward, y_spacing)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.2")
 
@@ -831,12 +824,7 @@ def _compute_section_layout(
     # them alone.  Runs before ``_snap_all_y_to_grid`` so the snap-to-
     # row-grid pass doesn't immediately undo the compaction.
     if graph.center_ports:
-        _placed(
-            "Stage 6.3 apply_half_grid_2branch_symfan",
-            _apply_half_grid_2branch_symfan,
-            y_spacing,
-            section_y_padding,
-        )
+        _placed("6.3", _apply_half_grid_2branch_symfan, y_spacing, section_y_padding)
         if validate:
             _run_pass_c_guards(graph, "after Stage 6.3")
 
@@ -892,11 +880,7 @@ def _compute_section_layout(
     # Stage 6.8 and Stage 6.9 below restore invariants the recenter
     # breaks.
     if graph.center_ports:
-        _placed(
-            "Stage 6.7 recenter_full_bundle_columns",
-            _recenter_full_bundle_columns,
-            y_spacing,
-        )
+        _placed("6.7", _recenter_full_bundle_columns, y_spacing)
 
         # Stage 6.8: Re-anchor off-track inputs after the recenter.
         # The recenter moves consumers to the final trunk-anchored Y,
@@ -933,12 +917,7 @@ def _compute_section_layout(
     # empty top band so content sits symmetrically around the trunk.
     # Runs after re-centering and terminus-Y pinning so it sees the
     # final trunk Y.  U-turn-safe and bbox-bounded.
-    _placed(
-        "Stage 6.11 balance_section_content_around_trunk",
-        _balance_section_content_around_trunk,
-        section_y_padding,
-        y_spacing,
-    )
+    _placed("6.11", _balance_section_content_around_trunk, section_y_padding, y_spacing)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.11")
 
@@ -950,7 +929,7 @@ def _compute_section_layout(
     # leave the station visibly off-centre on its horizontal loop run.
     # Reposition each side station to the midpoint of the two diagonal
     # corner Xs derived from the actual routing geometry.
-    _placed("Stage 6.12 recenter_loop_side_stations", _recenter_loop_side_stations)
+    _placed("6.12", _recenter_loop_side_stations)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.12")
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 __all__ = ["PhaseInvariantError", "compute_layout", "compute_min_y_spacing"]
 
 import warnings
+from collections.abc import Callable
 
 from nf_metro.layout.constants import (
     DESCENDER_CLEARANCE,
@@ -101,6 +102,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _bbox_guarded_stations,
     _bisection_should_run,
     _ensure_routes,
+    _guard_anchors_frozen_during_placement,
     _guard_bundle_order_preserved,
     _guard_coordinates_finite,
     _guard_explicit_grid_directions,
@@ -131,6 +133,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_stations_within_bbox,
     _guard_terminus_icons_within_bbox,
     _inter_section_backtrack_legs,
+    _lr_port_anchor_snapshot,
     _route_exit_side,
     _run_pass_c_guards,
     _section_lacks_flow_aligned_port,
@@ -704,11 +707,21 @@ def _compute_section_layout(
     # passes through at a single Y per row.  Bbox tops are preserved.
     _align_row_trunk_ys(graph)
 
+    # The trunk anchors (LR/RL port Ys) are now resolved.  The phases below
+    # position content around them and must never move one; ``_placed`` runs
+    # each so that, under ``validate``, a guard asserts the anchors stayed
+    # frozen.  See CONTRACT.md (anchor invariant).
+    def _placed(label: str, fn: Callable[..., None], *args: object) -> None:
+        before = _lr_port_anchor_snapshot(graph) if validate else None
+        fn(graph, *args)
+        if validate and before is not None:
+            _guard_anchors_frozen_during_placement(graph, before, label)
+
     # Stage 4.9: When --center-ports is on, redistribute fan-out siblings
     # of a section's trunk junction symmetrically around the trunk Y.
     # Scoped to fan-out side branches only: linear chains, fan-in
     # structures, and file inputs are left in place.
-    _redistribute_fanout_siblings(graph, y_spacing)
+    _placed("Stage 4.9 redistribute_fanout_siblings", _redistribute_fanout_siblings, y_spacing)
 
     # Stage 4.10: Symmetrically fan a column of full-bundle stations
     # around the trunk Y when no unique trunk exists (e.g. Reporting's
@@ -723,7 +736,11 @@ def _compute_section_layout(
     # 4.10's port-Y anchor.  Skipping Stage 4.10 changes intermediate
     # bbox sizes and is not empty-render-diff; the two passes are
     # load-bearing in combination.
-    _redistribute_full_bundle_columns(graph, y_spacing)
+    _placed(
+        "Stage 4.10 redistribute_full_bundle_columns",
+        _redistribute_full_bundle_columns,
+        y_spacing,
+    )
 
     # ---- Stage 5 - Pass C: Junctions & off-track lift ------------------
     # All port positions are now final; Stage 5.1 positions junctions
@@ -788,7 +805,12 @@ def _compute_section_layout(
     # for sections whose internal stations have no upward dependency
     # (no off-track band) and whose trunk Y sits below the bbox top
     # padding by more than one ``y_spacing`` slot.
-    _fan_free_content_upward(graph, section_y_padding, y_spacing)
+    _placed(
+        "Stage 6.1 fan_free_content_upward",
+        _fan_free_content_upward,
+        section_y_padding,
+        y_spacing,
+    )
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.1")
 
@@ -797,7 +819,7 @@ def _compute_section_layout(
     # source inputs (file icons with no inbound edges), lift the
     # nearest-to-trunk sources into the empty top band so the section
     # is bottom- and top-weighted instead of stacked below the trunk.
-    _fan_source_inputs_upward(graph, y_spacing)
+    _placed("Stage 6.2 fan_source_inputs_upward", _fan_source_inputs_upward, y_spacing)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.2")
 
@@ -809,7 +831,12 @@ def _compute_section_layout(
     # them alone.  Runs before ``_snap_all_y_to_grid`` so the snap-to-
     # row-grid pass doesn't immediately undo the compaction.
     if graph.center_ports:
-        _apply_half_grid_2branch_symfan(graph, y_spacing, section_y_padding)
+        _placed(
+            "Stage 6.3 apply_half_grid_2branch_symfan",
+            _apply_half_grid_2branch_symfan,
+            y_spacing,
+            section_y_padding,
+        )
         if validate:
             _run_pass_c_guards(graph, "after Stage 6.3")
 
@@ -865,7 +892,11 @@ def _compute_section_layout(
     # Stage 6.8 and Stage 6.9 below restore invariants the recenter
     # breaks.
     if graph.center_ports:
-        _recenter_full_bundle_columns(graph, y_spacing)
+        _placed(
+            "Stage 6.7 recenter_full_bundle_columns",
+            _recenter_full_bundle_columns,
+            y_spacing,
+        )
 
         # Stage 6.8: Re-anchor off-track inputs after the recenter.
         # The recenter moves consumers to the final trunk-anchored Y,
@@ -902,7 +933,12 @@ def _compute_section_layout(
     # empty top band so content sits symmetrically around the trunk.
     # Runs after re-centering and terminus-Y pinning so it sees the
     # final trunk Y.  U-turn-safe and bbox-bounded.
-    _balance_section_content_around_trunk(graph, section_y_padding, y_spacing)
+    _placed(
+        "Stage 6.11 balance_section_content_around_trunk",
+        _balance_section_content_around_trunk,
+        section_y_padding,
+        y_spacing,
+    )
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.11")
 
@@ -914,7 +950,7 @@ def _compute_section_layout(
     # leave the station visibly off-centre on its horizontal loop run.
     # Reposition each side station to the midpoint of the two diagonal
     # corner Xs derived from the actual routing geometry.
-    _recenter_loop_side_stations(graph)
+    _placed("Stage 6.12 recenter_loop_side_stations", _recenter_loop_side_stations)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.12")
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -42,6 +42,41 @@ class PhaseInvariantError(Exception):
     """Raised when a layout phase produces invalid intermediate state."""
 
 
+def _lr_port_anchor_snapshot(graph: MetroGraph) -> dict[str, float]:
+    """Y of every LR/RL port station -- the inter-section trunk anchors that
+    content placement positions content around.  Paired with
+    :func:`_guard_anchors_frozen_during_placement`."""
+    out: dict[str, float] = {}
+    for pid, st in graph.stations.items():
+        if not st.is_port:
+            continue
+        port = graph.ports.get(pid)
+        if port is not None and port.side in (PortSide.LEFT, PortSide.RIGHT):
+            out[pid] = st.y
+    return out
+
+
+def _guard_anchors_frozen_during_placement(
+    graph: MetroGraph, before: dict[str, float], phase: str
+) -> None:
+    """A content-placement phase positions content around the resolved trunk
+    anchors and must not move one.  Compare each LR/RL port Y against the
+    snapshot taken before the phase ran (via
+    :func:`_lr_port_anchor_snapshot`) and raise if any moved.  Anchors are
+    set only by port-positioning, the row trunk alignment, grid snapping, the
+    inter-row cascade and uniform translation -- never by fan / off-track /
+    band-fill / balance / recenter placement."""
+    after = _lr_port_anchor_snapshot(graph)
+    for pid, y0 in before.items():
+        y1 = after.get(pid)
+        if y1 is not None and abs(y1 - y0) > COORD_TOLERANCE:
+            raise PhaseInvariantError(
+                f"{phase}: content placement moved LR port anchor {pid!r} "
+                f"from y={y0:.2f} to y={y1:.2f} (delta {y1 - y0:+.2f}); "
+                f"placement must leave trunk anchors frozen"
+            )
+
+
 def _guard_coordinates_finite(graph: MetroGraph, phase: str) -> None:
     """After Stage 2.1+: all laid-out stations must have finite coordinates."""
     junction_ids = graph.junction_ids

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -47,12 +47,11 @@ def _lr_port_anchor_snapshot(graph: MetroGraph) -> dict[str, float]:
     content placement positions content around.  Paired with
     :func:`_guard_anchors_frozen_during_placement`."""
     out: dict[str, float] = {}
-    for pid, st in graph.stations.items():
-        if not st.is_port:
-            continue
-        port = graph.ports.get(pid)
-        if port is not None and port.side in (PortSide.LEFT, PortSide.RIGHT):
-            out[pid] = st.y
+    for pid, port in graph.ports.items():
+        if port.side in (PortSide.LEFT, PortSide.RIGHT):
+            st = graph.stations.get(pid)
+            if st is not None:
+                out[pid] = st.y
     return out
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -4587,3 +4587,82 @@ def test_partial_fan_branch_has_no_offset_gap(fixture):
         f"{fixture}: {len(violations)} partial-branch offset-gap "
         f"violation(s); first: {violations[0].message() if violations else ''}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Anchor invariant: content placement never moves a trunk (LR port) anchor
+# ---------------------------------------------------------------------------
+
+
+_DEPENDENT_PLACEMENT_PHASES = (
+    "_redistribute_fanout_siblings",
+    "_redistribute_full_bundle_columns",
+    "_fan_free_content_upward",
+    "_fan_source_inputs_upward",
+    "_apply_half_grid_2branch_symfan",
+    "_recenter_full_bundle_columns",
+    "_balance_section_content_around_trunk",
+    "_recenter_loop_side_stations",
+)
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_content_placement_leaves_lr_port_anchors_frozen(fixture, monkeypatch):
+    """Anchors-first invariant: every content-placement phase (fans,
+    off-track lift, band-fill, balance, recenter) positions content around
+    the resolved trunk anchors and must not move one.  Wrap each phase to
+    snapshot LR/RL port Ys before/after and assert none move.  Checked in
+    isolation (no full ``validate`` suite) so an unrelated guard cannot
+    pre-empt this assertion."""
+    from nf_metro.layout import engine
+    from nf_metro.layout.phases.guards import _lr_port_anchor_snapshot
+
+    moved: list[tuple[str, str, float]] = []
+
+    def _make_probe(name: str, orig):
+        def probe(graph, *args, **kwargs):
+            before = _lr_port_anchor_snapshot(graph)
+            result = orig(graph, *args, **kwargs)
+            after = _lr_port_anchor_snapshot(graph)
+            for pid, y0 in before.items():
+                y1 = after.get(pid)
+                if y1 is not None and abs(y1 - y0) > 1.0:
+                    moved.append((name, pid, round(y1 - y0, 2)))
+            return result
+
+        return probe
+
+    for name in _DEPENDENT_PLACEMENT_PHASES:
+        monkeypatch.setattr(engine, name, _make_probe(name, getattr(engine, name)))
+
+    _layout(fixture)
+    assert not moved, (
+        f"{fixture}: content placement moved LR port anchor(s): {moved[:3]}"
+    )
+
+
+def test_anchor_guard_catches_a_displaced_port(monkeypatch):
+    """The guard is meaningful, not vacuous: if a content-placement phase
+    moves an LR port anchor, ``compute_layout(validate=True)`` raises.
+    Monkeypatch the balance phase to shove the first LR port after it runs
+    and assert the guard catches it."""
+    from nf_metro.layout import engine
+    from nf_metro.layout.phases.balancing import (
+        _balance_section_content_around_trunk as _orig_balance,
+    )
+
+    def _evil(graph, *args):
+        _orig_balance(graph, *args)
+        for pid, st in graph.stations.items():
+            port = graph.ports.get(pid)
+            if (
+                st.is_port
+                and port is not None
+                and port.side in (PortSide.LEFT, PortSide.RIGHT)
+            ):
+                st.y += 50.0
+                break
+
+    monkeypatch.setattr(engine, "_balance_section_content_around_trunk", _evil)
+    with pytest.raises(PhaseInvariantError, match="LR port anchor"):
+        _layout_example("differentialabundance.mmd", validate=True)


### PR DESCRIPTION
## Summary

Stage 1 of the anchors-first work (#465). Makes the engine's latent
anchor/dependent separation explicit and machine-checked, with zero render
change.

- A new `_placed` wrapper in `_compute_section_layout` runs each
  content-placement phase (fan-out / full-bundle redistribution, band-fill,
  2-branch symfan, full-bundle recenter, balance-around-trunk, loop-side
  recenter). Under `validate=True` it asserts the phase left every LR/RL port
  anchor frozen, via the new `_guard_anchors_frozen_during_placement`.
- New `_lr_port_anchor_snapshot` + guard in `phases/guards.py`.
- `CONTRACT.md` gains an "Anchor invariant" section documenting that anchors
  are set only by structural phases (port positioning, row trunk alignment,
  grid snap, inter-row cascade, uniform translation) and never by content
  placement.
- Tests: a parametrised isolation test over multi-section fixtures (every
  content-placement phase leaves LR port anchors fixed), and a meaningfulness
  test (a phase that shoves a port is caught by the guard; verified to not
  raise on `main`).

No reorder, no behaviour change. Gallery byte-identical (63/63 SVGs).

Refs #465

## Test plan
- [x] `pytest` passes (3841 passed, incl. the new anchor tests; 6 known xfails)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] `mypy` clean
- [x] Runtime validator added (`_guard_anchors_frozen_during_placement`)
- [x] Gallery byte-identical vs `main` (local diff: 0/63 changed)
- [ ] Render-preview verdict: expecting "No visual changes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)