### PR TITLE
refactor(layout): extract Pass C into _settle_pass_c and promote _run_placement

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -478,6 +478,23 @@ def _compute_flat_layout(
         station.y = y_offset + track_rank[station.track] * y_spacing
 
 
+def _run_placement(
+    graph: MetroGraph,
+    validate: bool,
+    stage: str,
+    fn: Callable[..., None],
+    *args: object,
+) -> None:
+    """Run a content-placement phase, asserting (under validate) it left every
+    LR/RL port anchor frozen.  See CONTRACT.md (anchor invariant)."""
+    before = _lr_port_anchor_snapshot(graph) if validate else None
+    fn(graph, *args)
+    if validate and before is not None:
+        _guard_anchors_frozen_during_placement(
+            graph, before, f"Stage {stage} {fn.__name__}"
+        )
+
+
 def _compute_section_layout(
     graph: MetroGraph,
     x_spacing: float = X_SPACING,
@@ -708,22 +725,15 @@ def _compute_section_layout(
     _align_row_trunk_ys(graph)
 
     # The trunk anchors (LR/RL port Ys) are now resolved.  The phases below
-    # position content around them and must never move one; ``_placed`` runs
-    # each so that, under ``validate``, a guard asserts the anchors stayed
+    # position content around them and must never move one; ``_run_placement``
+    # runs each so that, under ``validate``, a guard asserts the anchors stayed
     # frozen.  See CONTRACT.md (anchor invariant).
-    def _placed(stage: str, fn: Callable[..., None], *args: object) -> None:
-        before = _lr_port_anchor_snapshot(graph) if validate else None
-        fn(graph, *args)
-        if validate and before is not None:
-            _guard_anchors_frozen_during_placement(
-                graph, before, f"Stage {stage} {fn.__name__}"
-            )
 
     # Stage 4.9: When --center-ports is on, redistribute fan-out siblings
     # of a section's trunk junction symmetrically around the trunk Y.
     # Scoped to fan-out side branches only: linear chains, fan-in
     # structures, and file inputs are left in place.
-    _placed("4.9", _redistribute_fanout_siblings, y_spacing)
+    _run_placement(graph, validate, "4.9", _redistribute_fanout_siblings, y_spacing)
 
     # Stage 4.10: Symmetrically fan a column of full-bundle stations
     # around the trunk Y when no unique trunk exists (e.g. Reporting's
@@ -738,8 +748,30 @@ def _compute_section_layout(
     # 4.10's port-Y anchor.  Skipping Stage 4.10 changes intermediate
     # bbox sizes and is not empty-render-diff; the two passes are
     # load-bearing in combination.
-    _placed("4.10", _redistribute_full_bundle_columns, y_spacing)
+    _run_placement(
+        graph, validate, "4.10", _redistribute_full_bundle_columns, y_spacing
+    )
 
+    _settle_pass_c(
+        graph,
+        validate=validate,
+        y_spacing=y_spacing,
+        section_y_padding=section_y_padding,
+        section_y_gap=section_y_gap,
+    )
+
+
+def _settle_pass_c(
+    graph: MetroGraph,
+    *,
+    validate: bool,
+    y_spacing: float,
+    section_y_padding: float,
+    section_y_gap: float,
+) -> None:
+    """Pass C: junction placement, off-track lift, vertical content settling,
+    the inter-row cascade, and final canvas/grid snapping.  Extracted verbatim
+    from _compute_section_layout; see CONTRACT.md for the per-stage contract."""
     # ---- Stage 5 - Pass C: Junctions & off-track lift ------------------
     # All port positions are now final; Stage 5.1 positions junctions
     # once.  Stage 5.2 lifts off-track stations; Stages 5.3 to 5.5
@@ -803,7 +835,9 @@ def _compute_section_layout(
     # for sections whose internal stations have no upward dependency
     # (no off-track band) and whose trunk Y sits below the bbox top
     # padding by more than one ``y_spacing`` slot.
-    _placed("6.1", _fan_free_content_upward, section_y_padding, y_spacing)
+    _run_placement(
+        graph, validate, "6.1", _fan_free_content_upward, section_y_padding, y_spacing
+    )
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.1")
 
@@ -812,7 +846,7 @@ def _compute_section_layout(
     # source inputs (file icons with no inbound edges), lift the
     # nearest-to-trunk sources into the empty top band so the section
     # is bottom- and top-weighted instead of stacked below the trunk.
-    _placed("6.2", _fan_source_inputs_upward, y_spacing)
+    _run_placement(graph, validate, "6.2", _fan_source_inputs_upward, y_spacing)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.2")
 
@@ -824,7 +858,14 @@ def _compute_section_layout(
     # them alone.  Runs before ``_snap_all_y_to_grid`` so the snap-to-
     # row-grid pass doesn't immediately undo the compaction.
     if graph.center_ports:
-        _placed("6.3", _apply_half_grid_2branch_symfan, y_spacing, section_y_padding)
+        _run_placement(
+            graph,
+            validate,
+            "6.3",
+            _apply_half_grid_2branch_symfan,
+            y_spacing,
+            section_y_padding,
+        )
         if validate:
             _run_pass_c_guards(graph, "after Stage 6.3")
 
@@ -880,7 +921,7 @@ def _compute_section_layout(
     # Stage 6.8 and Stage 6.9 below restore invariants the recenter
     # breaks.
     if graph.center_ports:
-        _placed("6.7", _recenter_full_bundle_columns, y_spacing)
+        _run_placement(graph, validate, "6.7", _recenter_full_bundle_columns, y_spacing)
 
         # Stage 6.8: Re-anchor off-track inputs after the recenter.
         # The recenter moves consumers to the final trunk-anchored Y,
@@ -917,7 +958,14 @@ def _compute_section_layout(
     # empty top band so content sits symmetrically around the trunk.
     # Runs after re-centering and terminus-Y pinning so it sees the
     # final trunk Y.  U-turn-safe and bbox-bounded.
-    _placed("6.11", _balance_section_content_around_trunk, section_y_padding, y_spacing)
+    _run_placement(
+        graph,
+        validate,
+        "6.11",
+        _balance_section_content_around_trunk,
+        section_y_padding,
+        y_spacing,
+    )
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.11")
 
@@ -929,7 +977,7 @@ def _compute_section_layout(
     # leave the station visibly off-centre on its horizontal loop run.
     # Reposition each side station to the midpoint of the two diagonal
     # corner Xs derived from the actual routing geometry.
-    _placed("6.12", _recenter_loop_side_stations)
+    _run_placement(graph, validate, "6.12", _recenter_loop_side_stations)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.12")
 


### PR DESCRIPTION
## Summary

Byte-identical structural refactor of `src/nf_metro/layout/engine.py`, stage 3.1 of the anchors-first reorg toward the #465 row-topological sweep. Two mechanical, behavior-preserving changes against `main`:

- **Promote the `_placed` closure to a module-level helper.** The nested `_placed` closure inside `_compute_section_layout` becomes module-level `_run_placement(graph, validate, stage, fn, *args)`, with `graph` and `validate` now passed explicitly. All 8 call sites (stages 4.9, 4.10, 6.1, 6.2, 6.3, 6.7, 6.11, 6.12) are updated.
- **Extract Pass C into `_settle_pass_c`.** The Pass C block (from the Stage 5 divider through the end of `_compute_section_layout`) moves verbatim into a new module-level `_settle_pass_c(graph, *, validate, y_spacing, section_y_padding, section_y_gap)`. `_compute_section_layout` replaces the block with a single call. Pass C references only `graph`, those three spacing params, and `validate` (the Stage 1.5 / Stage 2.1 locals are confined to earlier stages), so the extraction is closed over the new signature.

No phase reordering, no logic changes, no new narrative comments.

## Test plan

- [x] `python -m pytest -q` — 3841 passed, 38 skipped, 6 xfailed (no new failures)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean
- [x] Gallery byte-identical — 0/63 renders changed vs origin/main

refs #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)