### PR TITLE
docs(layout): drop change-narrative from _settle_pass_c docstring

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -770,8 +770,8 @@ def _settle_pass_c(
     section_y_gap: float,
 ) -> None:
     """Pass C: junction placement, off-track lift, vertical content settling,
-    the inter-row cascade, and final canvas/grid snapping.  Extracted verbatim
-    from _compute_section_layout; see CONTRACT.md for the per-stage contract."""
+    the inter-row cascade, and final canvas/grid snapping.  See CONTRACT.md for
+    the per-stage contract."""
     # ---- Stage 5 - Pass C: Junctions & off-track lift ------------------
     # All port positions are now final; Stage 5.1 positions junctions
     # once.  Stage 5.2 lifts off-track stations; Stages 5.3 to 5.5


### PR DESCRIPTION
Removes the change-narrative ("Extracted verbatim from _compute_section_layout") that slipped into the `_settle_pass_c` docstring in #479, leaving only what the function does plus the CONTRACT.md pointer. Docstring-only; no code, renders, or tests affected.

Refs #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)