### PR TITLE
refactor(layout): run Pass C content phases row-major via _scoped_sections

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -41,10 +41,12 @@ from nf_metro.layout.phases._common import (  # noqa: F401
     _expand_bbox_for_y,
     _fan_offsets,
     _grid_group_section_ids,
+    _grid_rows_top_to_bottom,
     _grow_section_bbox_upward,
     _max_stations_per_layer,
     _route_crosses_section_boundary,
     _row_contiguous_column_groups,
+    _scoped_sections,
     _section_bundle_lines,
     _section_trunk_y,
     _station_marker_bbox,
@@ -495,6 +497,25 @@ def _run_placement(
         )
 
 
+def _run_placement_per_row(
+    graph: MetroGraph,
+    validate: bool,
+    stage: str,
+    fn: Callable[..., None],
+    *args: object,
+) -> None:
+    """Run a row-local content-placement phase once per grid row, top to bottom.
+
+    Each row's sections read only coordinates within that row, and the phase
+    is translation-invariant, so scoping ``graph.sections`` to one row at a
+    time reproduces the whole-graph result.  The anchor guard from
+    :func:`_run_placement` runs per row.
+    """
+    for section_ids in _grid_rows_top_to_bottom(graph):
+        with _scoped_sections(graph, section_ids):
+            _run_placement(graph, validate, stage, fn, *args)
+
+
 def _compute_section_layout(
     graph: MetroGraph,
     x_spacing: float = X_SPACING,
@@ -867,7 +888,7 @@ def _place_pass_c_content(
     # for sections whose internal stations have no upward dependency
     # (no off-track band) and whose trunk Y sits below the bbox top
     # padding by more than one ``y_spacing`` slot.
-    _run_placement(
+    _run_placement_per_row(
         graph, validate, "6.1", _fan_free_content_upward, section_y_padding, y_spacing
     )
     if validate:
@@ -878,7 +899,7 @@ def _place_pass_c_content(
     # source inputs (file icons with no inbound edges), lift the
     # nearest-to-trunk sources into the empty top band so the section
     # is bottom- and top-weighted instead of stacked below the trunk.
-    _run_placement(graph, validate, "6.2", _fan_source_inputs_upward, y_spacing)
+    _run_placement_per_row(graph, validate, "6.2", _fan_source_inputs_upward, y_spacing)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.2")
 
@@ -890,7 +911,7 @@ def _place_pass_c_content(
     # them alone.  Runs before ``_snap_all_y_to_grid`` so the snap-to-
     # row-grid pass doesn't immediately undo the compaction.
     if graph.center_ports:
-        _run_placement(
+        _run_placement_per_row(
             graph,
             validate,
             "6.3",
@@ -953,7 +974,9 @@ def _place_pass_c_content(
     # Stage 6.8 and Stage 6.9 below restore invariants the recenter
     # breaks.
     if graph.center_ports:
-        _run_placement(graph, validate, "6.7", _recenter_full_bundle_columns, y_spacing)
+        _run_placement_per_row(
+            graph, validate, "6.7", _recenter_full_bundle_columns, y_spacing
+        )
 
         # Stage 6.8: Re-anchor off-track inputs after the recenter.
         # The recenter moves consumers to the final trunk-anchored Y,
@@ -990,7 +1013,7 @@ def _place_pass_c_content(
     # empty top band so content sits symmetrically around the trunk.
     # Runs after re-centering and terminus-Y pinning so it sees the
     # final trunk Y.  U-turn-safe and bbox-bounded.
-    _run_placement(
+    _run_placement_per_row(
         graph,
         validate,
         "6.11",
@@ -1009,7 +1032,7 @@ def _place_pass_c_content(
     # leave the station visibly off-centre on its horizontal loop run.
     # Reposition each side station to the midpoint of the two diagonal
     # corner Xs derived from the actual routing geometry.
-    _run_placement(graph, validate, "6.12", _recenter_loop_side_stations)
+    _run_placement_per_row(graph, validate, "6.12", _recenter_loop_side_stations)
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.12")
 

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 from nf_metro.layout.constants import (
     COORD_TOLERANCE,
@@ -10,6 +12,41 @@ from nf_metro.layout.constants import (
     STATION_RADIUS_APPROX,
 )
 from nf_metro.parser.model import Edge, MetroGraph, PortSide, Section, Station
+
+
+@contextmanager
+def _scoped_sections(graph: MetroGraph, section_ids: list[str]) -> Iterator[None]:
+    """Temporarily restrict ``graph.sections`` to ``section_ids``.
+
+    Row-local content phases iterate ``graph.sections`` and read only
+    coordinates within each section, so restricting the view to one grid
+    row's sections lets a whole-graph phase run row-by-row.  Station and
+    edge data on ``graph`` are untouched, so the per-station caches stay
+    valid.  Restores the original mapping on exit, including on error.
+    """
+    original = graph.sections
+    graph.sections = {sid: original[sid] for sid in section_ids if sid in original}
+    try:
+        yield
+    finally:
+        graph.sections = original
+
+
+def _grid_rows_top_to_bottom(graph: MetroGraph) -> list[list[str]]:
+    """Section ids grouped by grid row, rows ordered top-to-bottom.
+
+    Sections with no bbox or an unassigned row are dropped, matching the
+    precondition the row-local content phases already apply when they skip
+    such sections.  Ids within a row keep ascending-column order.
+    """
+    by_row: dict[int, list[Section]] = defaultdict(list)
+    for section in graph.sections.values():
+        if section.bbox_h > 0 and section.grid_row >= 0:
+            by_row[section.grid_row].append(section)
+    return [
+        [s.id for s in sorted(by_row[row], key=lambda s: s.grid_col)]
+        for row in sorted(by_row)
+    ]
 
 
 def _bbox_cols_overlap(a: Section, b: Section) -> bool:

--- a/tests/test_scoped_sections.py
+++ b/tests/test_scoped_sections.py
@@ -1,0 +1,63 @@
+"""Unit tests for the row-scoping helpers used by the row-major Pass C sweep."""
+
+from __future__ import annotations
+
+import pytest
+
+from nf_metro.layout.phases._common import (
+    _grid_rows_top_to_bottom,
+    _scoped_sections,
+)
+from nf_metro.parser.model import MetroGraph, Section
+
+
+def _graph_with_sections() -> MetroGraph:
+    graph = MetroGraph()
+    graph.sections = {
+        "a": Section(id="a", name="A", grid_row=0, grid_col=0, bbox_h=50),
+        "b": Section(id="b", name="B", grid_row=0, grid_col=1, bbox_h=50),
+        "c": Section(id="c", name="C", grid_row=1, grid_col=0, bbox_h=50),
+    }
+    return graph
+
+
+def test_scoped_sections_restricts_then_restores():
+    graph = _graph_with_sections()
+    original = graph.sections
+
+    with _scoped_sections(graph, ["a", "c"]):
+        assert set(graph.sections) == {"a", "c"}
+        assert graph.sections["a"] is original["a"]
+
+    assert graph.sections is original
+    assert set(graph.sections) == {"a", "b", "c"}
+
+
+def test_scoped_sections_ignores_unknown_ids():
+    graph = _graph_with_sections()
+    with _scoped_sections(graph, ["a", "missing"]):
+        assert set(graph.sections) == {"a"}
+
+
+def test_scoped_sections_restores_on_exception():
+    graph = _graph_with_sections()
+    original = graph.sections
+
+    with pytest.raises(RuntimeError):
+        with _scoped_sections(graph, ["b"]):
+            raise RuntimeError("boom")
+
+    assert graph.sections is original
+    assert set(graph.sections) == {"a", "b", "c"}
+
+
+def test_grid_rows_top_to_bottom_groups_and_orders():
+    graph = _graph_with_sections()
+    assert _grid_rows_top_to_bottom(graph) == [["a", "b"], ["c"]]
+
+
+def test_grid_rows_top_to_bottom_skips_empty_and_unassigned():
+    graph = _graph_with_sections()
+    graph.sections["d"] = Section(id="d", name="D", grid_row=2, grid_col=0, bbox_h=0)
+    graph.sections["e"] = Section(id="e", name="E", grid_row=-1, grid_col=0, bbox_h=50)
+    assert _grid_rows_top_to_bottom(graph) == [["a", "b"], ["c"]]


### PR DESCRIPTION
## Summary

Restructures Pass C so the row-local content-placement phases run row-major (one grid row at a time, top to bottom) instead of whole-graph, without changing any rendered output.

- Adds `_scoped_sections(graph, section_ids)`, a context manager that temporarily restricts `graph.sections` to a given set of section ids and restores the original mapping on exit (including on error). Station/edge data and their caches are untouched.
- Adds `_grid_rows_top_to_bottom(graph)`, which groups laid-out sections by grid row, ordered top to bottom, columns ascending.
- Adds `_run_placement_per_row`, which runs a content phase once per grid row inside `_scoped_sections`, preserving the per-phase anchor guard.
- The six `_run_placement`-wrapped content phases in `_place_pass_c_content` (Stages 6.1, 6.2, 6.3, 6.7, 6.11, 6.12) now go through `_run_placement_per_row`. Every global-structural inter-section phase (5.1-5.5, 6.4-6.6, 6.8-6.10) stays whole-graph in its existing position and order; `_stack_rows` and `_finalize_layout` are unchanged.

The content phases are row-local (read only coordinates within each section) and translation-invariant, so scoping the section view to one row reproduces the whole-graph result. Verified byte-identical across all 63 gallery renders.

refs #465

## Test plan
- [x] `pytest` green: 3846 passed, 6 xfailed, no new failures (adds `tests/test_scoped_sections.py`)
- [x] `ruff check` + `ruff format --check` clean on `src/` and `tests/`; `mypy` clean
- [x] Byte-identical gallery: `build_gallery.py` output compared per file against committed renders, 0 of 63 changed
- [x] `compute_layout(validate=True)` on genomic_pipeline, variantbenchmarking, differentialabundance, fold_double, fold_stacked_branch, u_turn_fold: no PhaseInvariantError

Generated with Claude Code