### PR TITLE
fix(layout): stop grid-snap collapsing same-column stations (#478)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -94,7 +94,7 @@ bisection runner skips them earlier; see `_BISECTION_FIRST_VALID` in
 | Guard | First valid checkpoint | Transient because |
 |---|---|---|
 | `_guard_stations_in_sections` | after Stage 5.3 | Stage 5.2's off-track lift moves stations above the section bbox; Stage 5.3 grows the bbox to enclose them. |
-| `_guard_no_station_overlap` | after Stage 6.6 | Stage 6.4's snap-to-grid can land an off-track terminus icon on its on-track column-mate's Y; Stage 6.6 re-anchors the off-track above its consumer. |
+| `_guard_no_station_overlap` | after Stage 6.4 | Pre-snap fan placement can sit a fraction of a pitch off the row grid; Stage 6.4's snap pulls every station onto the grid while keeping same-column stations on distinct slots, after which markers must be collision-free. |
 | `_guard_no_line_crosses_non_consumer` | after Stage 6.14 | A sparse loop-side station sits on the trunk Y until Stage 6.14 shifts it to a half-grid offset; before that, sibling line bundles pass through its marker bbox. |
 
 Three further guards are excluded from the bisection set entirely

--- a/src/nf_metro/layout/phases/grid_snap.py
+++ b/src/nf_metro/layout/phases/grid_snap.py
@@ -114,9 +114,8 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
             snapped = origin + round((y - origin) / p) * p
             return snapped if abs(snapped - y) <= h + 1e-6 else y
 
-        # A grid slot already taken by a station must not capture a second
-        # station in the same column; the later one keeps its pre-snap Y.
-        # Ports are render-invisible and excluded from the overlap invariant.
+        # Independent snapping can round two same-column stations onto one
+        # slot; the later one keeps its pre-snap Y rather than collapsing.
         column_slots: dict[float, set[float]] = {}
 
         for sec_id, port_ids in per_section_ports.items():
@@ -135,7 +134,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
                 if sid in convergence_sources:
                     continue
                 target = _snap(st.y)
-                slots = column_slots.setdefault(round(st.x, 1), set())
+                slots = column_slots.setdefault(round(st.x, 3), set())
                 if round(target, 3) in slots:
                     target = st.y
                 slots.add(round(target, 3))

--- a/src/nf_metro/layout/phases/grid_snap.py
+++ b/src/nf_metro/layout/phases/grid_snap.py
@@ -114,6 +114,11 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
             snapped = origin + round((y - origin) / p) * p
             return snapped if abs(snapped - y) <= h + 1e-6 else y
 
+        # A grid slot already taken by a station must not capture a second
+        # station in the same column; the later one keeps its pre-snap Y.
+        # Ports are render-invisible and excluded from the overlap invariant.
+        column_slots: dict[float, set[float]] = {}
+
         for sec_id, port_ids in per_section_ports.items():
             section = graph.sections.get(sec_id)
             if section is None:
@@ -129,7 +134,12 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
                     continue
                 if sid in convergence_sources:
                     continue
-                st.y = _snap(st.y)
+                target = _snap(st.y)
+                slots = column_slots.setdefault(round(st.x, 1), set())
+                if round(target, 3) in slots:
+                    target = st.y
+                slots.add(round(target, 3))
+                st.y = target
             for pid in port_ids:
                 port = graph.ports.get(pid)
                 port_st = graph.stations.get(pid)

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1391,16 +1391,17 @@ checkpoint in ``_compute_section_layout``.
 # - stations_in_sections: Stage 5.2 lifts off-track stations above their
 #   section's pre-grow bbox top; Stage 5.3's row top-align grows the
 #   bbox upward to enclose them.
-# - no_station_overlap: Stage 6.4's snap-to-grid can place an off-track
-#   terminus icon at the same coordinates as an on-track column-mate;
-#   Stage 6.6's re-anchor lifts the off-track back above its consumer.
+# - no_station_overlap: pre-snap fan placement can sit a fraction of a
+#   pitch off the row grid; Stage 6.4's snap pulls every station onto the
+#   grid and keeps same-column stations on distinct slots, after which
+#   markers must be collision-free.
 # - no_line_crosses_non_consumer: a sparse loop-side station (single
 #   line in, single line out, full-bundle row-mates) sits on the trunk
 #   Y until Stage 6.14 shifts it to a half-grid offset; before that,
 #   the sibling line bundle's route passes through its marker bbox.
 _BISECTION_FIRST_VALID: dict[str, str] = {
     "_guard_stations_in_sections": "after Stage 5.3",
-    "_guard_no_station_overlap": "after Stage 6.6",
+    "_guard_no_station_overlap": "after Stage 6.4",
     "_guard_no_line_crosses_non_consumer": "after Stage 6.14",
 }
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1821,19 +1821,16 @@ class TestPassCBisection:
 
     # Corruption-phase -> expected surfacing checkpoint.  When the
     # corruption phase is at or after the overlap-guard's first valid
-    # checkpoint (``after Stage 6.6``), bisection localises to the
-    # corruption phase itself.  Otherwise the overlap regression
-    # surfaces at ``after Stage 6.6`` (the first un-gated overlap
-    # check), which is the accepted trade-off for letting the bisection
-    # set tolerate the off-track-stranded-on-consumer transient at
-    # Stages 6.4 / 6.5 (see ``_BISECTION_FIRST_VALID`` in engine.py).
+    # checkpoint (``after Stage 6.4``), bisection localises to the
+    # corruption phase itself.  Corruptions injected before Stage 6.4
+    # surface at ``after Stage 6.4`` (the first un-gated overlap check).
     @pytest.mark.parametrize(
         "corruption_helper,expected_phase",
         [
-            ("_lift_off_track_stations", "after Stage 6.6"),
-            ("_top_align_row_bboxes_only", "after Stage 6.6"),
-            ("_compact_row_content_to_bbox_top", "after Stage 6.6"),
-            ("_snap_all_y_to_grid", "after Stage 6.6"),
+            ("_lift_off_track_stations", "after Stage 6.4"),
+            ("_top_align_row_bboxes_only", "after Stage 6.4"),
+            ("_compact_row_content_to_bbox_top", "after Stage 6.4"),
+            ("_snap_all_y_to_grid", "after Stage 6.4"),
             ("_align_terminus_to_upstream", "after Stage 6.10"),
             ("_shrink_bboxes_to_content_bottom", "after Stage 6.13"),
             ("_snap_canvas_y_to_grid", "after Stage 6.15"),
@@ -1952,7 +1949,7 @@ class TestPassCBisection:
 
         Confirms ``_BISECTION_FIRST_VALID`` only delays a guard's
         first valid checkpoint -- once past the threshold (``after
-        Stage 6.6`` for the overlap guard), the guard fires at every
+        Stage 6.4`` for the overlap guard), the guard fires at every
         subsequent bisection checkpoint.
         """
         from nf_metro.layout import engine
@@ -1977,7 +1974,7 @@ class TestPassCBisection:
         msg = str(excinfo.value)
         assert msg.startswith("after Stage 6.15:"), (
             f"Expected bisection to surface at 'after Stage 6.15' "
-            f"(overlap guard runs at every checkpoint from Stage 6.6 "
+            f"(overlap guard runs at every checkpoint from Stage 6.4 "
             f"onward), but error was: {msg!r}"
         )
 
@@ -1985,7 +1982,7 @@ class TestPassCBisection:
         "guard_name,first_valid",
         [
             ("_guard_stations_in_sections", "after Stage 5.3"),
-            ("_guard_no_station_overlap", "after Stage 6.6"),
+            ("_guard_no_station_overlap", "after Stage 6.4"),
             ("_guard_no_line_crosses_non_consumer", "after Stage 6.14"),
         ],
     )

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -539,6 +539,31 @@ def test_symfan_pairs_share_y(fixture):
 
 
 # ---------------------------------------------------------------------------
+# Grid snap keeps same-column stations on distinct slots
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_grid_snap_keeps_columns_distinct(fixture):
+    """Stage 6.4's grid snap must not pull two distinct same-column
+    stations onto one slot.
+
+    A fan-out column placed off the row pitch (e.g. a centre-ports fan at a
+    40px spread over a 41px row grid) can round two adjacent termini onto
+    the same Y, hidden later only by the centre-ports re-fan.  ``validate``
+    runs ``_guard_no_station_overlap`` from the Stage 6.4 boundary, so the
+    collapse surfaces as a position clash.
+    """
+    try:
+        _layout(fixture, validate=True)
+    except PhaseInvariantError as exc:
+        # Unrelated pre-existing invariant failures are out of scope for
+        # this test; only a station-overlap clash indicates the snap
+        # collapsed a column.
+        assert "position clash" not in str(exc), str(exc)
+
+
+# ---------------------------------------------------------------------------
 # Off-track inputs sit above their consumer
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Stage 6.4's per-section grid snap rounded each station's Y independently to the row pitch. A fan-out column placed off that pitch (a `center_ports` fan at a 40px spread over a 41px row grid) could round two adjacent termini within half a pitch of the same grid line, collapsing them onto one coordinate. The clash was masked downstream only by the `center_ports`-gated Stage 6.7 re-fan, so it surfaced only under `compute_layout(validate=True)` as a position clash after Stage 6.6 on `genomeassembly_organellar` (reported) and `genomeassembly` (sibling, same root cause).

- Make the grid snap collision-aware per column: a grid slot already claimed by a station no longer captures a second station in the same column; the later one keeps its pre-snap Y.
- With the snap now collision-free at every Pass-C boundary, tighten the `_guard_no_station_overlap` bisection threshold from `after Stage 6.6` to `after Stage 6.4` so a future snap regression fails fast at the snap. Bisection-machinery tests and CONTRACT.md updated to match.
- New parametrized invariant test `test_grid_snap_keeps_columns_distinct` over the multi-section corpus.

Layout-neutral: all 132 fixture/example layouts (both `center_ports` settings) are byte-identical to `main`.

Fixes #478

## Test plan
- [x] pytest passes (3900 passed), including the new invariant test (fails on `main`, passes here)
- [x] `ruff check` + `ruff format --check` clean on `src/ tests/`; `mypy` clean
- [x] Runtime validator: existing `_guard_no_station_overlap` now enforced from Stage 6.4
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/483/)
- [x] Layout-neutrality: 132/132 layouts byte-identical vs `main`

Generated with Claude Code
