### PR TITLE
fix(layout): complete anchor-frozen guard (all ports, both axes) (#487)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -106,10 +106,14 @@ the bisection runner is `_run_pass_c_guards`.
 
 ## Anchor invariant
 
-The **trunk anchor** of a section is the Y of its LEFT/RIGHT (LR/RL) port
-stations: the level at which the inter-section line bundle runs. Anchors are
-set only by structural phases - port positioning along the section DAG
-(align/snap entry/exit ports, inter-section port-pair snap), the row trunk
+The **anchors** of a section are its port stations: synthetic points on the
+section boundary where the inter-section line bundle crosses. A port anchors
+the trunk on whichever axis its side dictates - LEFT/RIGHT (LR/RL) ports fix
+the Y at which the bundle runs horizontally, TOP/BOTTOM (TB/BT) ports fix the
+X at which it runs vertically - and a port's cross-axis (an LR port's X, a TB
+port's Y) is likewise pinned to the section boundary by port positioning.
+Anchors are set only by structural phases - port positioning along the section
+DAG (align/snap entry/exit ports, inter-section port-pair snap), the row trunk
 alignment (4.8), grid snapping, the inter-row cascade (6.13/6.14 phase 2) and
 uniform canvas/row translation.
 
@@ -117,11 +121,15 @@ The **content-placement** phases - fan-out / full-bundle redistribution (4.9,
 4.10), band-fill (6.1, 6.2), the 2-branch symfan half-grid (6.3), full-bundle
 recenter (6.7), balance-around-trunk (6.11) and loop-side recenter (6.12) -
 position content *around* the resolved anchors and must never move one. Each
-runs through the `_placed` wrapper in `_compute_section_layout`, which under
-`validate=True` calls `_guard_anchors_frozen_during_placement` to assert the
-LR port Ys are unchanged across the phase. This separation (structural anchors
-vs. dependent placement) is what makes the layout forward-resolvable: content
-is a function of the frozen anchors, not the reverse.
+runs through the `_run_placement` wrapper in `_compute_section_layout`, which
+under `validate=True` calls `_guard_anchors_frozen_during_placement` to assert
+that no port's `(x, y)` changed across the phase. The snapshot
+(`_port_anchor_snapshot`) covers **every port on every side, on both axes** -
+not just the LR/RL-Y subset - so the guard catches any anchor movement
+regardless of port side or axis (a phase that nudged a TOP/BOTTOM port, or an
+LR port's X, would be caught too). This separation (structural anchors vs.
+dependent placement) is what makes the layout forward-resolvable: content is a
+function of the frozen anchors, not the reverse.
 
 ## Stage overview
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -136,7 +136,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_stations_within_bbox,
     _guard_terminus_icons_within_bbox,
     _inter_section_backtrack_legs,
-    _lr_port_anchor_snapshot,
+    _port_anchor_snapshot,
     _route_exit_side,
     _run_pass_c_guards,
     _section_lacks_flow_aligned_port,
@@ -489,8 +489,8 @@ def _run_placement(
     *args: object,
 ) -> None:
     """Run a content-placement phase, asserting (under validate) it left every
-    LR/RL port anchor frozen.  See CONTRACT.md (anchor invariant)."""
-    before = _lr_port_anchor_snapshot(graph) if validate else None
+    port anchor frozen.  See CONTRACT.md (anchor invariant)."""
+    before = _port_anchor_snapshot(graph) if validate else None
     fn(graph, *args)
     if validate and before is not None:
         _guard_anchors_frozen_during_placement(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -42,37 +42,50 @@ class PhaseInvariantError(Exception):
     """Raised when a layout phase produces invalid intermediate state."""
 
 
-def _lr_port_anchor_snapshot(graph: MetroGraph) -> dict[str, float]:
-    """Y of every LR/RL port station -- the inter-section trunk anchors that
-    content placement positions content around.  Paired with
+def _port_anchor_snapshot(graph: MetroGraph) -> dict[str, tuple[float, float]]:
+    """``(x, y)`` of every port station -- the inter-section anchors that
+    content placement positions content around.
+
+    A port is an anchor on whichever axis its side dictates: LR/RL ports
+    fix the trunk Y, TOP/BOTTOM ports fix the trunk X, and either side's
+    cross-axis (an LR port's X, a TB port's Y) is pinned by the structural
+    port-positioning phases too.  Snapshotting both coordinates of every
+    port therefore covers the full anchor set rather than the LR/RL-Y
+    subset, so the guard catches any anchor movement during placement
+    regardless of port side or axis.  Paired with
     :func:`_guard_anchors_frozen_during_placement`."""
-    out: dict[str, float] = {}
-    for pid, port in graph.ports.items():
-        if port.side in (PortSide.LEFT, PortSide.RIGHT):
-            st = graph.stations.get(pid)
-            if st is not None:
-                out[pid] = st.y
+    out: dict[str, tuple[float, float]] = {}
+    for pid in graph.ports:
+        st = graph.stations.get(pid)
+        if st is not None:
+            out[pid] = (st.x, st.y)
     return out
 
 
 def _guard_anchors_frozen_during_placement(
-    graph: MetroGraph, before: dict[str, float], phase: str
+    graph: MetroGraph, before: dict[str, tuple[float, float]], phase: str
 ) -> None:
-    """A content-placement phase positions content around the resolved trunk
-    anchors and must not move one.  Compare each LR/RL port Y against the
-    snapshot taken before the phase ran (via
-    :func:`_lr_port_anchor_snapshot`) and raise if any moved.  Anchors are
-    set only by port-positioning, the row trunk alignment, grid snapping, the
+    """A content-placement phase positions content around the resolved
+    anchors and must not move one.  Compare each port's ``(x, y)`` against
+    the snapshot taken before the phase ran (via
+    :func:`_port_anchor_snapshot`) and raise if any moved.  Anchors are set
+    only by port-positioning, the row trunk alignment, grid snapping, the
     inter-row cascade and uniform translation -- never by fan / off-track /
     band-fill / balance / recenter placement."""
-    after = _lr_port_anchor_snapshot(graph)
-    for pid, y0 in before.items():
-        y1 = after.get(pid)
-        if y1 is not None and abs(y1 - y0) > COORD_TOLERANCE:
+    after = _port_anchor_snapshot(graph)
+    for pid, (x0, y0) in before.items():
+        coords = after.get(pid)
+        if coords is None:
+            continue
+        x1, y1 = coords
+        if abs(x1 - x0) > COORD_TOLERANCE or abs(y1 - y0) > COORD_TOLERANCE:
+            port = graph.ports.get(pid)
+            side = port.side.value if port is not None else "?"
             raise PhaseInvariantError(
-                f"{phase}: content placement moved LR port anchor {pid!r} "
-                f"from y={y0:.2f} to y={y1:.2f} (delta {y1 - y0:+.2f}); "
-                f"placement must leave trunk anchors frozen"
+                f"{phase}: content placement moved {side} port anchor {pid!r} "
+                f"from (x={x0:.2f}, y={y0:.2f}) to (x={x1:.2f}, y={y1:.2f}) "
+                f"(delta x={x1 - x0:+.2f}, y={y1 - y0:+.2f}); "
+                f"placement must leave anchors frozen"
             )
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -4667,9 +4667,7 @@ def test_content_placement_leaves_port_anchors_frozen(fixture, monkeypatch):
         monkeypatch.setattr(engine, name, _make_probe(name, getattr(engine, name)))
 
     _layout(fixture)
-    assert not moved, (
-        f"{fixture}: content placement moved port anchor(s): {moved[:3]}"
-    )
+    assert not moved, f"{fixture}: content placement moved port anchor(s): {moved[:3]}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -4615,7 +4615,8 @@ def test_partial_fan_branch_has_no_offset_gap(fixture):
 
 
 # ---------------------------------------------------------------------------
-# Anchor invariant: content placement never moves a trunk (LR port) anchor
+# Anchor invariant: content placement never moves a port anchor (any side,
+# either axis)
 # ---------------------------------------------------------------------------
 
 
@@ -4632,27 +4633,32 @@ _DEPENDENT_PLACEMENT_PHASES = (
 
 
 @pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
-def test_content_placement_leaves_lr_port_anchors_frozen(fixture, monkeypatch):
+def test_content_placement_leaves_port_anchors_frozen(fixture, monkeypatch):
     """Anchors-first invariant: every content-placement phase (fans,
     off-track lift, band-fill, balance, recenter) positions content around
-    the resolved trunk anchors and must not move one.  Wrap each phase to
-    snapshot LR/RL port Ys before/after and assert none move.  Checked in
-    isolation (no full ``validate`` suite) so an unrelated guard cannot
-    pre-empt this assertion."""
+    the resolved anchors and must not move one.  Wrap each phase to snapshot
+    every port's ``(x, y)`` before/after and assert none move - covering all
+    port sides and both axes, not just the LR/RL-Y subset, so a phase that
+    nudged a TOP/BOTTOM port or a port's cross-axis would be caught too.
+    Checked in isolation (no full ``validate`` suite) so an unrelated guard
+    cannot pre-empt this assertion."""
     from nf_metro.layout import engine
-    from nf_metro.layout.phases.guards import _lr_port_anchor_snapshot
+    from nf_metro.layout.phases.guards import _port_anchor_snapshot
 
-    moved: list[tuple[str, str, float]] = []
+    moved: list[tuple[str, str, float, float]] = []
 
     def _make_probe(name: str, orig):
         def probe(graph, *args, **kwargs):
-            before = _lr_port_anchor_snapshot(graph)
+            before = _port_anchor_snapshot(graph)
             result = orig(graph, *args, **kwargs)
-            after = _lr_port_anchor_snapshot(graph)
-            for pid, y0 in before.items():
-                y1 = after.get(pid)
-                if y1 is not None and abs(y1 - y0) > 1.0:
-                    moved.append((name, pid, round(y1 - y0, 2)))
+            after = _port_anchor_snapshot(graph)
+            for pid, (x0, y0) in before.items():
+                coords = after.get(pid)
+                if coords is None:
+                    continue
+                x1, y1 = coords
+                if abs(x1 - x0) > 1.0 or abs(y1 - y0) > 1.0:
+                    moved.append((name, pid, round(x1 - x0, 2), round(y1 - y0, 2)))
             return result
 
         return probe
@@ -4662,15 +4668,27 @@ def test_content_placement_leaves_lr_port_anchors_frozen(fixture, monkeypatch):
 
     _layout(fixture)
     assert not moved, (
-        f"{fixture}: content placement moved LR port anchor(s): {moved[:3]}"
+        f"{fixture}: content placement moved port anchor(s): {moved[:3]}"
     )
 
 
-def test_anchor_guard_catches_a_displaced_port(monkeypatch):
+@pytest.mark.parametrize(
+    "example, sides, axis",
+    [
+        # LR/RL port Y -- the original (subset) coverage.
+        ("differentialabundance.mmd", (PortSide.LEFT, PortSide.RIGHT), "y"),
+        # TOP/BOTTOM port X -- newly covered by the widened snapshot.
+        ("rnaseq_sections.mmd", (PortSide.TOP, PortSide.BOTTOM), "x"),
+        # LR/RL port X (cross-axis) -- also newly covered.
+        ("differentialabundance.mmd", (PortSide.LEFT, PortSide.RIGHT), "x"),
+    ],
+)
+def test_anchor_guard_catches_a_displaced_port(monkeypatch, example, sides, axis):
     """The guard is meaningful, not vacuous: if a content-placement phase
-    moves an LR port anchor, ``compute_layout(validate=True)`` raises.
-    Monkeypatch the balance phase to shove the first LR port after it runs
-    and assert the guard catches it."""
+    moves any port anchor, ``compute_layout(validate=True)`` raises.
+    Monkeypatch the balance phase to shove the first matching port (by side
+    and axis) after it runs and assert the guard catches it.  Parametrised
+    across port sides and both axes to exercise the widened snapshot."""
     from nf_metro.layout import engine
     from nf_metro.layout.phases.balancing import (
         _balance_section_content_around_trunk as _orig_balance,
@@ -4680,14 +4698,13 @@ def test_anchor_guard_catches_a_displaced_port(monkeypatch):
         _orig_balance(graph, *args)
         for pid, st in graph.stations.items():
             port = graph.ports.get(pid)
-            if (
-                st.is_port
-                and port is not None
-                and port.side in (PortSide.LEFT, PortSide.RIGHT)
-            ):
-                st.y += 50.0
+            if st.is_port and port is not None and port.side in sides:
+                if axis == "y":
+                    st.y += 50.0
+                else:
+                    st.x += 50.0
                 break
 
     monkeypatch.setattr(engine, "_balance_section_content_around_trunk", _evil)
-    with pytest.raises(PhaseInvariantError, match="LR port anchor"):
-        _layout_example("differentialabundance.mmd", validate=True)
+    with pytest.raises(PhaseInvariantError, match="port anchor"):
+        _layout_example(example, validate=True)


### PR DESCRIPTION
## Summary

Widens the anchors-first invariant guard so it covers the **full anchor set**, not just the LR/RL-Y subset.

- `_lr_port_anchor_snapshot` → `_port_anchor_snapshot`: now snapshots every port station's `(x, y)` (all sides, both axes) instead of only LEFT/RIGHT port Ys.
- `_guard_anchors_frozen_during_placement` compares both coordinates of every port and reports the offending side/axis. It therefore catches a content-placement phase that moved a TOP/BOTTOM port, an LR/RL port's X (cross-axis), or the LR/RL Y it already covered.
- `CONTRACT.md` "Anchor invariant" section rewritten to describe the per-side anchor axis and the widened snapshot; `_run_placement` docstring updated.
- Parametrised tests extended: `test_content_placement_leaves_port_anchors_frozen` now probes every port's `(x, y)` across all multi-section fixtures; `test_anchor_guard_catches_a_displaced_port` parametrised over LR-Y, TB-X, and LR-X (cross-axis) to exercise the newly-snapshotted anchors.

Guard/validate + docs only — no rendering-path change.

Fixes #487. Refs #465, #365.

## Diagnostic

- Probed all 8 content-placement phases (4.9, 4.10, 6.1, 6.2, 6.3, 6.7, 6.11, 6.12) across all 59 multi-section fixtures: **no phase moves any port coordinate** (any side, x or y). Widening catches no current violation.
- `compute_layout(validate=True)` over the full 64-fixture corpus: **no anchor-guard violation**.
- Local SVG render of all 64 fixtures, branch vs `origin/main`: **byte-identical** (0 differing hashes).

## Test plan
- [x] pytest passes (3972 passed, 6 pre-existing xfails)
- [x] ruff check + ruff format clean on `src/ tests/` (CI scope)
- [x] Widened runtime validator + parametrised meaningfulness tests
- [ ] Render-preview verdict: expect "No visual changes detected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)