### PR TITLE
refactor(layout): make content-placement phases 4.9 / 6.2 idempotent (#488)

### DIFF
--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -307,11 +307,10 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         trunk_sid = trunks[0]
         trunk_y = graph.stations[trunk_sid].y
 
-        # Source set is purely structural (entry-column, strict-subset
-        # bundle, no inbound edges).  No current-Y predicate: the phase
-        # arranges this fixed set into the canonical "n_lift above the
-        # trunk, the rest below" shape regardless of the incoming Y order,
-        # so re-applying it is a no-op (idempotent under the anchor layer).
+        # No current-Y predicate in the source set: the phase arranges this
+        # fixed structural set into the canonical "n_lift above the trunk,
+        # the rest below" shape regardless of incoming Y order, so
+        # re-applying it is a no-op (idempotent under the anchor layer).
         sources = [
             s
             for s in entry_col

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -307,6 +307,11 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         trunk_sid = trunks[0]
         trunk_y = graph.stations[trunk_sid].y
 
+        # Source set is purely structural (entry-column, strict-subset
+        # bundle, no inbound edges).  No current-Y predicate: the phase
+        # arranges this fixed set into the canonical "n_lift above the
+        # trunk, the rest below" shape regardless of the incoming Y order,
+        # so re-applying it is a no-op (idempotent under the anchor layer).
         sources = [
             s
             for s in entry_col
@@ -314,7 +319,6 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
             and graph.station_lines(s)
             and set(graph.station_lines(s)) < bundle
             and not graph.edges_to(s)
-            and graph.stations[s].y > trunk_y - 0.5
         ]
         if len(sources) < 2:
             continue
@@ -333,7 +337,9 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         if n_lift == 0:
             continue
 
-        sources.sort(key=lambda s: graph.stations[s].y)
+        # Sort by track (the structural per-line ordering), not current Y,
+        # so the source->slot assignment is invariant under prior placement.
+        sources.sort(key=lambda s: (graph.stations[s].track, s))
         internal_set = set(internal_ids)
 
         # Drag each strictly-linear consumer chain so per-line tracks stay

--- a/src/nf_metro/layout/phases/fan_bundles.py
+++ b/src/nf_metro/layout/phases/fan_bundles.py
@@ -127,8 +127,11 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
     one sibling whose line set is a strict subset of the bundle.
 
     In those columns, the trunk station is pinned at its current Y and
-    the strict-subset siblings are redistributed in alternating slots
-    ``+1, -1, +2, -2, ...`` at ``y_spacing`` pitch above and below it.
+    the strict-subset siblings, ordered by their structural track, are
+    redistributed in alternating slots ``+1, -1, +2, -2, ...`` at
+    ``y_spacing`` pitch above and below it.  Ordering by track (rather
+    than current Y) makes the slot assignment invariant under prior
+    placement, so re-applying the phase is a no-op.
 
     Strict scoping: only stations in a trunk-junction column AND with
     a strict-subset line set are moved.  File inputs, processing
@@ -207,7 +210,7 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
             ]
             if not siblings:
                 continue
-            siblings.sort(key=lambda s: graph.stations[s].y)
+            siblings.sort(key=lambda s: (graph.stations[s].track, s))
             for i, sid in enumerate(siblings, 1):
                 k = (i + 1) // 2
                 sign = 1 if (i % 2 == 1) else -1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,24 @@ TWO_SECTION_TEXT = (
 )
 
 
+# --- Shared constants ---
+
+# The content-placement phases wrapped by _run_placement / _run_placement_per_row
+# in _compute_section_layout (the set guarded by _guard_anchors_frozen). Shared so
+# the anchor-frozen test and the idempotence test enumerate the same set and a new
+# phase can't be added to one without the other.
+CONTENT_PLACEMENT_PHASES = (
+    "_redistribute_fanout_siblings",  # Stage 4.9
+    "_redistribute_full_bundle_columns",  # Stage 4.10
+    "_fan_free_content_upward",  # Stage 6.1
+    "_fan_source_inputs_upward",  # Stage 6.2
+    "_apply_half_grid_2branch_symfan",  # Stage 6.3
+    "_recenter_full_bundle_columns",  # Stage 6.7
+    "_balance_section_content_around_trunk",  # Stage 6.11
+    "_recenter_loop_side_stations",  # Stage 6.12
+)
+
+
 # --- Parse/layout helpers ---
 
 

--- a/tests/test_content_placement_idempotent.py
+++ b/tests/test_content_placement_idempotent.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from conftest import CONTENT_PLACEMENT_PHASES
 
 import nf_metro.layout.engine as engine
 from nf_metro.convert import convert_nextflow_dag
@@ -33,19 +34,6 @@ TOPOLOGIES = EXAMPLES / "topologies"
 GUIDE = EXAMPLES / "guide"
 TESTS_FIXTURES = ROOT / "tests" / "fixtures"
 NEXTFLOW = TESTS_FIXTURES / "nextflow"
-
-# The content-placement phases wrapped by _run_placement / _run_placement_per_row
-# in _compute_section_layout (the set guarded by _guard_anchors_frozen).
-PLACEMENT_PHASES = [
-    "_redistribute_fanout_siblings",  # Stage 4.9
-    "_redistribute_full_bundle_columns",  # Stage 4.10
-    "_fan_free_content_upward",  # Stage 6.1
-    "_fan_source_inputs_upward",  # Stage 6.2
-    "_apply_half_grid_2branch_symfan",  # Stage 6.3
-    "_recenter_full_bundle_columns",  # Stage 6.7
-    "_balance_section_content_around_trunk",  # Stage 6.11
-    "_recenter_loop_side_stations",  # Stage 6.12
-]
 
 
 def _corpus() -> list[tuple[str, Path, bool]]:
@@ -79,12 +67,25 @@ def _coords(graph) -> dict[str, tuple[float, float]]:
     return {sid: (round(s.x, 6), round(s.y, 6)) for sid, s in graph.stations.items()}
 
 
-@pytest.mark.parametrize("phase_name", PLACEMENT_PHASES)
+# The single-pass baseline depends only on the fixture, so compute it once per
+# fixture rather than re-running it for each of the eight phases.
+_BASELINE: dict[str, dict[str, tuple[float, float]]] = {}
+
+
+def _baseline(
+    fid: str, path: Path, is_nextflow: bool
+) -> dict[str, tuple[float, float]]:
+    if fid not in _BASELINE:
+        _BASELINE[fid] = _coords(_layout(path, is_nextflow))
+    return _BASELINE[fid]
+
+
+@pytest.mark.parametrize("phase_name", CONTENT_PLACEMENT_PHASES)
 @pytest.mark.parametrize("fixture", CORPUS, ids=[fid for fid, _, _ in CORPUS])
 def test_placement_phase_is_idempotent(fixture, phase_name, monkeypatch):
     fid, path, is_nextflow = fixture
 
-    baseline = _coords(_layout(path, is_nextflow))
+    baseline = _baseline(fid, path, is_nextflow)
 
     original = getattr(engine, phase_name)
 

--- a/tests/test_content_placement_idempotent.py
+++ b/tests/test_content_placement_idempotent.py
@@ -1,0 +1,106 @@
+"""Content-placement phases are idempotent (the declarative property, #488).
+
+Post-#465 the anchor layer is structural and frozen; the content-placement
+phases position content as a function of those frozen anchors plus section
+structure.  This test locks the stronger property that each phase is also a
+*pure function of its input state*: applying it a second time, back-to-back on
+its own output, is a no-op.
+
+Mechanism: monkeypatch the engine's reference to one placement phase with a
+wrapper that invokes it twice, run the full layout (with the anchor guard
+active), and assert every station coordinate matches the single-application
+baseline.  A phase that reads its own prior output (e.g. selecting/sorting by
+current Y) diverges on the second call and fails here.
+
+Covers the whole render corpus so any fixture that exercises a phase
+participates.  Refs #488, #465.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import nf_metro.layout.engine as engine
+from nf_metro.convert import convert_nextflow_dag
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+ROOT = Path(__file__).parent.parent
+EXAMPLES = ROOT / "examples"
+TOPOLOGIES = EXAMPLES / "topologies"
+GUIDE = EXAMPLES / "guide"
+TESTS_FIXTURES = ROOT / "tests" / "fixtures"
+NEXTFLOW = TESTS_FIXTURES / "nextflow"
+
+# The content-placement phases wrapped by _run_placement / _run_placement_per_row
+# in _compute_section_layout (the set guarded by _guard_anchors_frozen).
+PLACEMENT_PHASES = [
+    "_redistribute_fanout_siblings",  # Stage 4.9
+    "_redistribute_full_bundle_columns",  # Stage 4.10
+    "_fan_free_content_upward",  # Stage 6.1
+    "_fan_source_inputs_upward",  # Stage 6.2
+    "_apply_half_grid_2branch_symfan",  # Stage 6.3
+    "_recenter_full_bundle_columns",  # Stage 6.7
+    "_balance_section_content_around_trunk",  # Stage 6.11
+    "_recenter_loop_side_stations",  # Stage 6.12
+]
+
+
+def _corpus() -> list[tuple[str, Path, bool]]:
+    items: list[tuple[str, Path, bool]] = []
+    for d, tag in [
+        (EXAMPLES, "examples"),
+        (TOPOLOGIES, "topologies"),
+        (GUIDE, "guide"),
+        (TESTS_FIXTURES, "tests"),
+    ]:
+        for p in sorted(d.glob("*.mmd")):
+            items.append((f"{tag}/{p.stem}", p, False))
+    for p in sorted(NEXTFLOW.glob("*.mmd")):
+        items.append((f"nextflow/{p.stem}", p, True))
+    return items
+
+
+CORPUS = _corpus()
+
+
+def _layout(path: Path, is_nextflow: bool):
+    text = path.read_text()
+    if is_nextflow:
+        text = convert_nextflow_dag(text)
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=True)
+    return graph
+
+
+def _coords(graph) -> dict[str, tuple[float, float]]:
+    return {sid: (round(s.x, 6), round(s.y, 6)) for sid, s in graph.stations.items()}
+
+
+@pytest.mark.parametrize("phase_name", PLACEMENT_PHASES)
+@pytest.mark.parametrize("fixture", CORPUS, ids=[fid for fid, _, _ in CORPUS])
+def test_placement_phase_is_idempotent(fixture, phase_name, monkeypatch):
+    fid, path, is_nextflow = fixture
+
+    baseline = _coords(_layout(path, is_nextflow))
+
+    original = getattr(engine, phase_name)
+
+    def run_twice(graph, *args, **kwargs):
+        original(graph, *args, **kwargs)
+        original(graph, *args, **kwargs)
+
+    monkeypatch.setattr(engine, phase_name, run_twice)
+    doubled = _coords(_layout(path, is_nextflow))
+
+    diff = {
+        k: (baseline[k], doubled.get(k))
+        for k in baseline
+        if baseline[k] != doubled.get(k)
+    }
+    assert doubled == baseline, (
+        f"{phase_name} is not idempotent on {fid}: applying it twice moved "
+        f"content. Differing stations: {diff}"
+    )

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import pytest
+from conftest import CONTENT_PLACEMENT_PHASES
 
 from nf_metro.layout.constants import (
     CURVE_RADIUS,
@@ -4620,18 +4621,6 @@ def test_partial_fan_branch_has_no_offset_gap(fixture):
 # ---------------------------------------------------------------------------
 
 
-_DEPENDENT_PLACEMENT_PHASES = (
-    "_redistribute_fanout_siblings",
-    "_redistribute_full_bundle_columns",
-    "_fan_free_content_upward",
-    "_fan_source_inputs_upward",
-    "_apply_half_grid_2branch_symfan",
-    "_recenter_full_bundle_columns",
-    "_balance_section_content_around_trunk",
-    "_recenter_loop_side_stations",
-)
-
-
 @pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
 def test_content_placement_leaves_port_anchors_frozen(fixture, monkeypatch):
     """Anchors-first invariant: every content-placement phase (fans,
@@ -4663,7 +4652,7 @@ def test_content_placement_leaves_port_anchors_frozen(fixture, monkeypatch):
 
         return probe
 
-    for name in _DEPENDENT_PLACEMENT_PHASES:
+    for name in CONTENT_PLACEMENT_PHASES:
         monkeypatch.setattr(engine, name, _make_probe(name, getattr(engine, name)))
 
     _layout(fixture)


### PR DESCRIPTION
Closes #488.

## What this does

Makes the two non-idempotent content-placement phases pure functions of (frozen anchors + section structure), so the Pass-C content layer is fully declarative: re-applying any content-placement phase is a no-op.

Investigation (probing all eight `_run_placement` / `_run_placement_per_row` phases against the full render corpus under the anchor-frozen guard) found:

- **Reordering** any adjacent placement pair (4.9↔4.10, 6.1↔6.2, 6.11↔6.12) is already byte-identical corpus-wide — no phase reads another placement phase's output.
- But **two phases read their own prior output**, so they were not pure functions of the frozen anchors:
  - **4.9 `_redistribute_fanout_siblings`** sorted siblings by *current Y* before assigning alternating slots `+1,−1,+2,−2`. A second application re-sorted the just-fanned (interleaved) Ys into a different slot mapping.
  - **6.2 `_fan_source_inputs_upward`** selected its source set with a current-Y predicate (`y > trunk_y`) and sorted by current Y, so a second application saw a smaller set (lifted sources now sit above the trunk) and re-fanned two sources onto one slot (a position clash at Stage 6.4).

## The fix

Both now order by the **structural per-line `track`** (invariant under Y moves), and 6.2 selects its source set **purely structurally** (entry-column, strict-subset bundle, no inbound edges — dropping the current-Y predicate).

The `track` order equals the incoming Y order at each phase's entry across the entire corpus, so **single-pass output is byte-identical** to `main` — this should render as "no visual changes". The change only makes re-application a fixed point.

## Test

`tests/test_content_placement_idempotent.py` monkeypatches each of the eight content-placement phases to run twice over the full corpus (70 fixtures) and asserts station coordinates are unchanged — locking the declarative property. It fails on the pre-fix code (4.9 on one fixture, 6.2 on three; 4 failures) and passes after (560 passed).

Full suite green; whole-repo ruff clean.

Refs #465, #365.