### PR TITLE
test(layout): content-placement purity probe with strict-xfail leak ledger (#491)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from nf_metro.layout.engine import compute_layout
@@ -67,6 +69,35 @@ CONTENT_PLACEMENT_PHASES = (
     "_balance_section_content_around_trunk",  # Stage 6.11
     "_recenter_loop_side_stations",  # Stage 6.12
 )
+
+
+# --- Render corpus ---
+
+_ROOT = Path(__file__).parent.parent
+_EXAMPLES = _ROOT / "examples"
+_NEXTFLOW = _ROOT / "tests" / "fixtures" / "nextflow"
+
+
+def content_corpus() -> list[tuple[str, Path, bool]]:
+    """``(fixture_id, path, is_nextflow)`` for every ``.mmd`` in the render
+    corpus -- the gallery examples, topology/guide fixtures, test fixtures and
+    the Nextflow-DAG fixtures (which need ``convert_nextflow_dag`` first).
+
+    Shared by the declarative-property tests (idempotence and purity) so they
+    exercise the same fixtures.
+    """
+    items: list[tuple[str, Path, bool]] = []
+    for d, tag in [
+        (_EXAMPLES, "examples"),
+        (_EXAMPLES / "topologies", "topologies"),
+        (_EXAMPLES / "guide", "guide"),
+        (_ROOT / "tests" / "fixtures", "tests"),
+    ]:
+        for p in sorted(d.glob("*.mmd")):
+            items.append((f"{tag}/{p.stem}", p, False))
+    for p in sorted(_NEXTFLOW.glob("*.mmd")):
+        items.append((f"nextflow/{p.stem}", p, True))
+    return items
 
 
 # --- Parse/layout helpers ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from nf_metro.convert import convert_nextflow_dag
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph
@@ -98,6 +99,17 @@ def content_corpus() -> list[tuple[str, Path, bool]]:
     for p in sorted(_NEXTFLOW.glob("*.mmd")):
         items.append((f"nextflow/{p.stem}", p, True))
     return items
+
+
+def compute_corpus_layout(path: Path, is_nextflow: bool) -> MetroGraph:
+    """Parse a corpus ``.mmd`` (converting from a Nextflow DAG first when
+    ``is_nextflow``) and run the validated layout, returning the graph."""
+    text = path.read_text()
+    if is_nextflow:
+        text = convert_nextflow_dag(text)
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=True)
+    return graph
 
 
 # --- Parse/layout helpers ---

--- a/tests/test_content_placement_idempotent.py
+++ b/tests/test_content_placement_idempotent.py
@@ -2,9 +2,12 @@
 
 Post-#465 the anchor layer is structural and frozen; the content-placement
 phases position content as a function of those frozen anchors plus section
-structure.  This test locks the stronger property that each phase is also a
-*pure function of its input state*: applying it a second time, back-to-back on
-its own output, is a no-op.
+structure.  This test locks *idempotence*: applying any one phase a second
+time, back-to-back on its own output, is a no-op (``P(P(x)) == P(x)``).
+
+Idempotence is a fixed-point property and is strictly weaker than *purity*
+(output a function of frozen anchors + structure only); the stronger property
+is checked by ``test_content_placement_pure`` (#491).
 
 Mechanism: monkeypatch the engine's reference to one placement phase with a
 wrapper that invokes it twice, run the full layout (with the anchor guard
@@ -21,37 +24,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import CONTENT_PLACEMENT_PHASES
+from conftest import CONTENT_PLACEMENT_PHASES, content_corpus
 
 import nf_metro.layout.engine as engine
 from nf_metro.convert import convert_nextflow_dag
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
 
-ROOT = Path(__file__).parent.parent
-EXAMPLES = ROOT / "examples"
-TOPOLOGIES = EXAMPLES / "topologies"
-GUIDE = EXAMPLES / "guide"
-TESTS_FIXTURES = ROOT / "tests" / "fixtures"
-NEXTFLOW = TESTS_FIXTURES / "nextflow"
-
-
-def _corpus() -> list[tuple[str, Path, bool]]:
-    items: list[tuple[str, Path, bool]] = []
-    for d, tag in [
-        (EXAMPLES, "examples"),
-        (TOPOLOGIES, "topologies"),
-        (GUIDE, "guide"),
-        (TESTS_FIXTURES, "tests"),
-    ]:
-        for p in sorted(d.glob("*.mmd")):
-            items.append((f"{tag}/{p.stem}", p, False))
-    for p in sorted(NEXTFLOW.glob("*.mmd")):
-        items.append((f"nextflow/{p.stem}", p, True))
-    return items
-
-
-CORPUS = _corpus()
+CORPUS = content_corpus()
 
 
 def _layout(path: Path, is_nextflow: bool):

--- a/tests/test_content_placement_idempotent.py
+++ b/tests/test_content_placement_idempotent.py
@@ -24,26 +24,15 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import CONTENT_PLACEMENT_PHASES, content_corpus
+from conftest import CONTENT_PLACEMENT_PHASES, compute_corpus_layout, content_corpus
 
 import nf_metro.layout.engine as engine
-from nf_metro.convert import convert_nextflow_dag
-from nf_metro.layout.engine import compute_layout
-from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
 
 CORPUS = content_corpus()
 
 
-def _layout(path: Path, is_nextflow: bool):
-    text = path.read_text()
-    if is_nextflow:
-        text = convert_nextflow_dag(text)
-    graph = parse_metro_mermaid(text)
-    compute_layout(graph, validate=True)
-    return graph
-
-
-def _coords(graph) -> dict[str, tuple[float, float]]:
+def _coords(graph: MetroGraph) -> dict[str, tuple[float, float]]:
     return {sid: (round(s.x, 6), round(s.y, 6)) for sid, s in graph.stations.items()}
 
 
@@ -56,7 +45,7 @@ def _baseline(
     fid: str, path: Path, is_nextflow: bool
 ) -> dict[str, tuple[float, float]]:
     if fid not in _BASELINE:
-        _BASELINE[fid] = _coords(_layout(path, is_nextflow))
+        _BASELINE[fid] = _coords(compute_corpus_layout(path, is_nextflow))
     return _BASELINE[fid]
 
 
@@ -74,7 +63,7 @@ def test_placement_phase_is_idempotent(fixture, phase_name, monkeypatch):
         original(graph, *args, **kwargs)
 
     monkeypatch.setattr(engine, phase_name, run_twice)
-    doubled = _coords(_layout(path, is_nextflow))
+    doubled = _coords(compute_corpus_layout(path, is_nextflow))
 
     diff = {
         k: (baseline[k], doubled.get(k))

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -1,0 +1,161 @@
+"""Content-placement phases are pure functions of (anchors + structure) (#491).
+
+Idempotence (``test_content_placement_idempotent``) only proves each phase
+reaches a fixed point: ``P(P(x)) == P(x)``.  That is strictly weaker than the
+property the anchor layer enjoys (#487): *purity*.  A phase is pure when the Y
+it assigns to every station it governs is a function of the **frozen anchors**
+(port positions, and the trunk Y derived from them) plus **structure** (tracks,
+edges, columns) ONLY -- never of the mutable, intermediate non-anchor state
+that earlier phases happen to have left behind (current station Y, section
+``bbox`` geometry).
+
+Probe: wrap a phase and run it twice from the same graph -- once on the real
+input, once after *perturbing* the non-anchor state (deterministically scramble
+every non-port station's Y and every section's bbox top/height, holding all
+port anchors frozen).  A pure phase governs the same stations and lands each at
+the same Y both times.  Any station the phase moves in either run whose final Y
+differs between the two runs is a purity leak.
+
+The remaining known leaks are pinned as strict xfails below and burned down by
+the #491 follow-up PRs (track sorts, structural slack, structural fallback
+trunks).  ``strict=True`` means a phase that *becomes* pure flips its xfail to
+an xpass and fails the suite, forcing the stale entry to be removed.
+
+Refs #491, #488, #487, #485, #465.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conftest import CONTENT_PLACEMENT_PHASES, content_corpus
+
+import nf_metro.layout.engine as engine
+from nf_metro.convert import convert_nextflow_dag
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+TOL = 1e-3
+
+CORPUS = content_corpus()
+
+KNOWN_LEAKS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("_redistribute_fanout_siblings", "examples/differentialabundance"),
+        ("_redistribute_full_bundle_columns", "topologies/terminal_symmetric_fan"),
+        ("_recenter_full_bundle_columns", "topologies/terminal_symmetric_fan"),
+        ("_fan_free_content_upward", "examples/differentialabundance_default"),
+        ("_fan_free_content_upward", "tests/da_pipeline"),
+        ("_fan_source_inputs_upward", "examples/differentialabundance"),
+        ("_fan_source_inputs_upward", "examples/differentialabundance_default"),
+        ("_fan_source_inputs_upward", "tests/da_pipeline"),
+        ("_balance_section_content_around_trunk", "examples/differentialabundance"),
+        ("_balance_section_content_around_trunk", "examples/genomic_pipeline"),
+    }
+)
+
+
+def _snapshot(graph) -> tuple[dict, dict]:
+    stations = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bboxes = {sec.id: (sec.bbox_y, sec.bbox_h) for sec in graph.sections.values()}
+    return stations, bboxes
+
+
+def _restore(graph, snap: tuple[dict, dict]) -> None:
+    stations, bboxes = snap
+    for sid, (x, y) in stations.items():
+        st = graph.stations.get(sid)
+        if st is not None:
+            st.x, st.y = x, y
+    for sid, (y, h) in bboxes.items():
+        sec = graph.sections.get(sid)
+        if sec is not None:
+            sec.bbox_y, sec.bbox_h = y, h
+
+
+def _perturb(graph) -> None:
+    """Deterministically scramble the non-anchor state.
+
+    Every non-port station's Y and every section's bbox top/height is shifted by
+    a station/section-indexed amount; port stations (the frozen inter-section
+    anchors) are left untouched, so the perturbation only stresses the mutable
+    state a pure phase must not depend on.
+    """
+    ports = set(graph.ports)
+    for i, (sid, st) in enumerate(sorted(graph.stations.items())):
+        if sid in ports:
+            continue
+        st.y += ((i % 7) - 3) * 13.0
+    for j, sec in enumerate(sorted(graph.sections.values(), key=lambda s: s.id)):
+        sec.bbox_y += ((j % 5) - 2) * 11.0
+        sec.bbox_h += ((j % 3) + 1) * 9.0
+
+
+def _layout(path: Path, is_nextflow: bool) -> None:
+    text = path.read_text()
+    if is_nextflow:
+        text = convert_nextflow_dag(text)
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=True)
+
+
+def _make_purity_probe(original, leaks: list):
+    """Wrap ``original`` so each call records any non-anchor-state dependence
+    into ``leaks`` and then leaves the genuine single-application result."""
+
+    def probe(graph, *args, **kwargs):
+        pre = _snapshot(graph)
+        before_y = {sid: s.y for sid, s in graph.stations.items()}
+
+        original(graph, *args, **kwargs)
+        base_after = {sid: s.y for sid, s in graph.stations.items()}
+        governed = {
+            sid for sid in base_after if abs(base_after[sid] - before_y[sid]) > TOL
+        }
+
+        _restore(graph, pre)
+        _perturb(graph)
+        pert_before = {sid: s.y for sid, s in graph.stations.items()}
+        original(graph, *args, **kwargs)
+        pert_after = {sid: s.y for sid, s in graph.stations.items()}
+        governed |= {
+            sid for sid in pert_after if abs(pert_after[sid] - pert_before[sid]) > TOL
+        }
+
+        for sid in governed:
+            if abs(base_after[sid] - pert_after[sid]) > TOL:
+                leaks.append((sid, base_after[sid], pert_after[sid]))
+
+        _restore(graph, pre)
+        original(graph, *args, **kwargs)
+
+    return probe
+
+
+def _cases():
+    for fid, path, is_nf in CORPUS:
+        for phase in CONTENT_PLACEMENT_PHASES:
+            marks = (
+                [pytest.mark.xfail(strict=True, reason="#491 known purity leak")]
+                if (phase, fid) in KNOWN_LEAKS
+                else []
+            )
+            yield pytest.param(
+                fid, path, is_nf, phase, id=f"{fid}-{phase}", marks=marks
+            )
+
+
+@pytest.mark.parametrize("fid,path,is_nf,phase_name", list(_cases()))
+def test_placement_phase_is_pure(fid, path, is_nf, phase_name, monkeypatch):
+    leaks: list = []
+    original = getattr(engine, phase_name)
+    monkeypatch.setattr(engine, phase_name, _make_purity_probe(original, leaks))
+    _layout(path, is_nf)
+
+    assert not leaks, (
+        f"{phase_name} is not pure on {fid}: perturbing non-anchor state "
+        f"(current Y + section bbox) changed where it placed content. "
+        f"Leaks (station: baseline_y -> perturbed_y): "
+        f"{[(s, round(a, 1), round(b, 1)) for s, a, b in leaks[:8]]}"
+    )

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -26,17 +26,15 @@ Refs #491, #488, #487, #485, #465.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
-from conftest import CONTENT_PLACEMENT_PHASES, content_corpus
+from conftest import CONTENT_PLACEMENT_PHASES, compute_corpus_layout, content_corpus
 
 import nf_metro.layout.engine as engine
-from nf_metro.convert import convert_nextflow_dag
-from nf_metro.layout.engine import compute_layout
-from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
 
 TOL = 1e-3
+
+_Coords = dict[str, tuple[float, float]]
 
 CORPUS = content_corpus()
 
@@ -56,13 +54,13 @@ KNOWN_LEAKS: frozenset[tuple[str, str]] = frozenset(
 )
 
 
-def _snapshot(graph) -> tuple[dict, dict]:
+def _snapshot(graph: MetroGraph) -> tuple[_Coords, _Coords]:
     stations = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
     bboxes = {sec.id: (sec.bbox_y, sec.bbox_h) for sec in graph.sections.values()}
     return stations, bboxes
 
 
-def _restore(graph, snap: tuple[dict, dict]) -> None:
+def _restore(graph: MetroGraph, snap: tuple[_Coords, _Coords]) -> None:
     stations, bboxes = snap
     for sid, (x, y) in stations.items():
         st = graph.stations.get(sid)
@@ -74,7 +72,7 @@ def _restore(graph, snap: tuple[dict, dict]) -> None:
             sec.bbox_y, sec.bbox_h = y, h
 
 
-def _perturb(graph) -> None:
+def _perturb(graph: MetroGraph) -> None:
     """Deterministically scramble the non-anchor state.
 
     Every non-port station's Y and every section's bbox top/height is shifted by
@@ -92,19 +90,11 @@ def _perturb(graph) -> None:
         sec.bbox_h += ((j % 3) + 1) * 9.0
 
 
-def _layout(path: Path, is_nextflow: bool) -> None:
-    text = path.read_text()
-    if is_nextflow:
-        text = convert_nextflow_dag(text)
-    graph = parse_metro_mermaid(text)
-    compute_layout(graph, validate=True)
-
-
-def _make_purity_probe(original, leaks: list):
+def _make_purity_probe(original, leaks: list[tuple[str, float, float]]):
     """Wrap ``original`` so each call records any non-anchor-state dependence
     into ``leaks`` and then leaves the genuine single-application result."""
 
-    def probe(graph, *args, **kwargs):
+    def probe(graph: MetroGraph, *args, **kwargs):
         pre = _snapshot(graph)
         before_y = {sid: s.y for sid, s in graph.stations.items()}
 
@@ -148,10 +138,10 @@ def _cases():
 
 @pytest.mark.parametrize("fid,path,is_nf,phase_name", list(_cases()))
 def test_placement_phase_is_pure(fid, path, is_nf, phase_name, monkeypatch):
-    leaks: list = []
+    leaks: list[tuple[str, float, float]] = []
     original = getattr(engine, phase_name)
     monkeypatch.setattr(engine, phase_name, _make_purity_probe(original, leaks))
-    _layout(path, is_nf)
+    compute_corpus_layout(path, is_nf)
 
     assert not leaks, (
         f"{phase_name} is not pure on {fid}: perturbing non-anchor state "


### PR DESCRIPTION
## Summary

Adds a **purity** test for the eight Pass-C content-placement phases, the diagnostic foundation for #491. Idempotence (#488) only proves each phase reaches a fixed point (`P(P(x)) == P(x)`); purity is the stronger property the anchor layer enjoys (#487): the Y a phase assigns to the stations it governs is a function of the **frozen anchors + structure only**, never of mutable intermediate non-anchor state (current station Y, section bbox geometry).

`tests/test_content_placement_pure.py` wraps each phase and runs it twice from the same graph: once on the real input, once after deterministically perturbing every non-port station Y and every section bbox top/height while holding all port anchors frozen. A pure phase governs the same stations and lands each at the same Y both times; any divergence is a purity leak. Parametrised over the whole render corpus.

The probe quantifies the leak map below. The ten leaking `(phase, fixture)` combinations are pinned as **strict xfails** and burned down by the follow-up PRs; `strict=True` turns a phase that becomes pure into an xpass failure, so a stale ledger entry must be removed.

| Stage | Phase | Worst Δy | Leaking fixtures |
|---|---|---|---|
| 4.9 | `_redistribute_fanout_siblings` | 26px | differentialabundance |
| 4.10 | `_redistribute_full_bundle_columns` | 40px | terminal_symmetric_fan |
| 6.1 | `_fan_free_content_upward` | 90.8px | differentialabundance_default, da_pipeline |
| 6.2 | `_fan_source_inputs_upward` | 136.2px | differentialabundance, differentialabundance_default, da_pipeline |
| 6.3 | `_apply_half_grid_2branch_symfan` | — | none (already pure) |
| 6.7 | `_recenter_full_bundle_columns` | 40px | terminal_symmetric_fan |
| 6.11 | `_balance_section_content_around_trunk` | 207.6px | differentialabundance, genomic_pipeline |
| 6.12 | `_recenter_loop_side_stations` | — | none (already pure, X-axis) |

Two refinements vs the issue's predicted table: 4.9 (the predicted "pure exemplar") in fact retains a 26px fallback-trunk leak, and 6.3 is already pure because its median-current-Y fallback isn't exercised by any corpus fixture.

Also hoists the render-corpus discovery and the parse/convert/layout helper into `conftest` (`content_corpus`, `compute_corpus_layout`) so the idempotence and purity tests share one fixture list, and sharpens the idempotence test docstring to distinguish the two properties.

This PR is test-only; no production layout code changes (no visual deltas expected).

Fixes #491 is **not** asserted here -- this is the first of a staged series; the issue is closed by the final PR.

Refs #491, #488, #487, #485, #465.

## Test plan
- [x] `pytest` passes (1110 pass, 10 strict-xfail on the known leaks)
- [x] Leaks verified genuine via `pytest --runxfail` (10 fail / 550 pass)
- [x] `ruff check` + `ruff format --check` clean on `src/ tests/`
- [x] `mypy` clean
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/492/)
- [ ] Render-preview verdict: expect "No visual changes" (test-only)

Generated with Claude Code
