### PR TITLE
fix(layout): make full-bundle column fans pure via structural track sort (#491)

### DIFF
--- a/src/nf_metro/layout/phases/fan_bundles.py
+++ b/src/nf_metro/layout/phases/fan_bundles.py
@@ -511,7 +511,7 @@ def _redistribute_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> No
                 if not others:
                     continue
                 trunk_y = others[len(others) // 2]
-            participants.sort(key=lambda s: pre_fan_y[s])
+            participants.sort(key=lambda s: (graph.stations[s].track, s))
             n = len(participants)
             offsets = _fan_offsets(n)
             for sid, off in zip(participants, offsets):
@@ -632,7 +632,7 @@ def _recenter_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
             participants = list(full) + (non_full if mixed_ok else [])
             if len(participants) < 2:
                 continue
-            participants.sort(key=lambda s: graph.stations[s].y)
+            participants.sort(key=lambda s: (graph.stations[s].track, s))
             n = len(participants)
             offsets = _fan_offsets(n)
             for sid, off in zip(participants, offsets):

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -41,8 +41,6 @@ CORPUS = content_corpus()
 KNOWN_LEAKS: frozenset[tuple[str, str]] = frozenset(
     {
         ("_redistribute_fanout_siblings", "examples/differentialabundance"),
-        ("_redistribute_full_bundle_columns", "topologies/terminal_symmetric_fan"),
-        ("_recenter_full_bundle_columns", "topologies/terminal_symmetric_fan"),
         ("_fan_free_content_upward", "examples/differentialabundance_default"),
         ("_fan_free_content_upward", "tests/da_pipeline"),
         ("_fan_source_inputs_upward", "examples/differentialabundance"),


### PR DESCRIPTION
## Summary

Step 1 of the #491 purity series (follow-up to #492). Makes the two full-bundle-column fan phases **pure**: order their fan participants by the structural per-line `track` (station id as tiebreak) instead of by current Y.

- `_redistribute_full_bundle_columns` (Stage 4.10)
- `_recenter_full_bundle_columns` (Stage 6.7)

Both previously sorted participants by current Y before assigning the symmetric slot offsets, so the slot each station landed in depended on mutable non-anchor state. The purity probe (#492) flagged this: perturbing the incoming Ys (port anchors and structure held fixed) permuted the fan order and moved content by up to one `y_spacing` (40px on `terminal_symmetric_fan`). The `track` key is invariant under Y moves -- the same fix #488 applied to phases 4.9 / 6.2.

Track order equals incoming-Y order across the whole corpus, so single-pass output is unchanged: all 70 corpus renders are byte-identical (verified locally; CI render-diff confirms). The change only removes the dependence on perturbed input.

Drops the two now-pure `(phase, fixture)` entries for `terminal_symmetric_fan` from the purity-probe `KNOWN_LEAKS` ledger; `strict=True` would otherwise turn the xpass into a suite failure.

Remaining ledger after this PR (8 entries): 4.9 (fallback trunk -> PR4), 6.1 (anchor+slack -> PR3), 6.2 (bbox slack -> PR3), 6.11 (section_top+bbox+counts -> PR3).

Refs #491, #488.

## Test plan
- [x] `pytest` passes (purity probe: 1112 pass / 8 strict-xfail; full suite 5084 pass)
- [x] All 70 corpus renders byte-identical to `main` (local diff)
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [ ] Render-preview verdict: expect "No visual changes"

Generated with Claude Code
