### PR TITLE
fix(layout): make Stage 6.1 / 6.2 content fans pure via a frozen placement reference (#491)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -49,6 +49,7 @@ from nf_metro.layout.phases._common import (  # noqa: F401
     _scoped_sections,
     _section_bundle_lines,
     _section_trunk_y,
+    _snapshot_placement_refs,
     _station_marker_bbox,
     first_vertical_leg_x,
     is_loop_side_branch_station,
@@ -890,6 +891,8 @@ def _place_pass_c_content(
     # for sections whose internal stations have no upward dependency
     # (no off-track band) and whose trunk Y sits below the bbox top
     # padding by more than one ``y_spacing`` slot.
+    # Frozen reference for Stages 6.1 / 6.2 (see _snapshot_placement_refs).
+    _snapshot_placement_refs(graph)
     _run_placement_per_row(
         graph, validate, "6.1", _fan_free_content_upward, section_y_padding, y_spacing
     )

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -330,6 +330,54 @@ def _row_contiguous_column_groups(
     return result
 
 
+def _section_lr_port_anchor_y(graph: MetroGraph, section: Section) -> float | None:
+    """The section's frozen trunk anchor: its LR/RL entry port Y, or the
+    exit port Y when there is no LR/RL entry port.
+
+    Unlike :func:`_section_trunk_y` (which reads an internal station's
+    current Y), this returns a port station's Y -- a frozen inter-section
+    anchor held fixed through content placement -- so content phases can
+    centre on the trunk without depending on mutable station positions.
+    Returns ``None`` when the section has no LR/RL port.
+    """
+    for ports in (section.entry_ports, section.exit_ports):
+        for pid in ports:
+            port = graph.ports.get(pid)
+            st = graph.stations.get(pid)
+            if port and st and port.side in (PortSide.LEFT, PortSide.RIGHT):
+                return st.y
+    return None
+
+
+def _snapshot_placement_refs(graph: MetroGraph) -> None:
+    """Freeze station Ys and section bbox tops as the placement reference.
+
+    Captured once right before Stage 6.1 and read by Stages 6.1 / 6.2 via
+    :func:`_ref_y` / :func:`_ref_bbox_top` for their slack and arrangement
+    decisions, so re-applying or perturbing the live geometry between the
+    snapshot and those phases can't change where they place content.  Sibling
+    of :func:`...bbox._snapshot_struct_heights_below_top` (#485).
+    """
+    graph._placement_ref_y = {sid: st.y for sid, st in graph.stations.items()}
+    graph._placement_ref_bbox_top = {
+        sec.id: sec.bbox_y for sec in graph.sections.values()
+    }
+
+
+def _ref_y(graph: MetroGraph, sid: str) -> float:
+    """Frozen reference Y for ``sid`` (see :func:`_snapshot_placement_refs`),
+    falling back to the live Y when no snapshot covers it."""
+    ref = graph._placement_ref_y.get(sid)
+    return ref if ref is not None else graph.stations[sid].y
+
+
+def _ref_bbox_top(graph: MetroGraph, section: Section) -> float:
+    """Frozen reference bbox top for ``section`` (see
+    :func:`_snapshot_placement_refs`), falling back to the live top."""
+    ref = graph._placement_ref_bbox_top.get(section.id)
+    return ref if ref is not None else section.bbox_y
+
+
 def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
     """Topmost Y of a full-bundle internal station connected to an LR port.
 

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -10,7 +10,12 @@ from nf_metro.layout.constants import (
     SECTION_Y_PADDING,
     STATION_RADIUS_APPROX,
 )
-from nf_metro.layout.phases._common import _section_bundle_lines
+from nf_metro.layout.phases._common import (
+    _ref_bbox_top,
+    _ref_y,
+    _section_bundle_lines,
+    _section_lr_port_anchor_y,
+)
 from nf_metro.layout.phases.bbox import (
     _lift_would_cause_uturn,
     _loop_corner_x,
@@ -167,9 +172,8 @@ def _fan_free_content_upward(
         ]
         if not internal_ids:
             continue
-        ys = [graph.stations[sid].y for sid in internal_ids]
-        top_y = min(ys)
-        slack = top_y - section.bbox_y - section_y_padding
+        top_y = min(_ref_y(graph, sid) for sid in internal_ids)
+        slack = top_y - _ref_bbox_top(graph, section) - section_y_padding
         if slack < y_spacing - 0.5:
             continue
         slots = int(slack // y_spacing)
@@ -181,8 +185,7 @@ def _fan_free_content_upward(
             continue
 
         # Trunk candidates: stations in the entry column carrying the
-        # full bundle.  Sort by current Y; topmost stays pinned, others
-        # stack above at y_spacing pitch.
+        # full bundle; topmost stays pinned, others stack above it.
         xs = sorted({round(graph.stations[sid].x, 3) for sid in internal_ids})
         if not xs:
             continue
@@ -204,9 +207,9 @@ def _fan_free_content_upward(
         ]
         if len(trunk_candidates) == len(entry_col_all) and graph.center_ports:
             continue
-        trunk_candidates.sort(key=lambda s: graph.stations[s].y)
+        trunk_candidates.sort(key=lambda s: _ref_y(graph, s))
         pinned = trunk_candidates[0]
-        anchor_y = graph.stations[pinned].y
+        anchor_y = _ref_y(graph, pinned)
         to_lift = [
             sid
             for sid in trunk_candidates[1 : 1 + slots]
@@ -223,6 +226,7 @@ def _shift_linear_consumer_chain(
     internal_ids: set[str],
     *,
     cycle_guard: bool = False,
+    from_ref: bool = False,
 ) -> None:
     """Walk a strictly-linear consumer chain and shift each station Y by *delta*.
 
@@ -231,6 +235,11 @@ def _shift_linear_consumer_chain(
     and an unchanged line-set across the hop.  Stops at the first hop that
     fails any of those conditions.  Pass ``cycle_guard=True`` to additionally
     bail out when the walk revisits a station.
+
+    With ``from_ref`` each member's new Y is its frozen placement-reference Y
+    plus *delta* rather than its live Y plus *delta*, so the result is a pure
+    function of the frozen reference (equal to the live shift when the
+    reference matches the current geometry).
     """
     cur = src
     src_lines = set(graph.station_lines(src))
@@ -246,7 +255,8 @@ def _shift_linear_consumer_chain(
             return
         if set(graph.station_lines(nxt)) != src_lines:
             return
-        graph.stations[nxt].y += delta
+        base = _ref_y(graph, nxt) if from_ref else graph.stations[nxt].y
+        graph.stations[nxt].y = base + delta
         if cycle_guard:
             visited.add(nxt)
         cur = nxt
@@ -305,7 +315,8 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         if len(trunks) != 1:
             continue
         trunk_sid = trunks[0]
-        trunk_y = graph.stations[trunk_sid].y
+        anchor = _section_lr_port_anchor_y(graph, section)
+        trunk_y = anchor if anchor is not None else _ref_y(graph, trunk_sid)
 
         # No current-Y predicate in the source set: the phase arranges this
         # fixed structural set into the canonical "n_lift above the trunk,
@@ -326,7 +337,7 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         # icon's vertical extent stays inside the bbox.
         any_terminus = any(graph.stations[s].is_terminus for s in sources)
         top_margin = y_spacing / 4 + (ICON_HALF_HEIGHT if any_terminus else 0.0)
-        slack = trunk_y - section.bbox_y - top_margin
+        slack = trunk_y - _ref_bbox_top(graph, section) - top_margin
         slots = int((slack + 0.5) // y_spacing)
         if slots < 1:
             continue
@@ -345,11 +356,11 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         # straight from icon to trunk junction.
         for i, src in enumerate(sources[:n_lift], 1):
             new_y = trunk_y - i * y_spacing
-            delta = new_y - graph.stations[src].y
+            delta = new_y - _ref_y(graph, src)
             if abs(delta) < 0.5:
                 continue
             graph.stations[src].y = new_y
-            _shift_linear_consumer_chain(graph, src, delta, internal_set)
+            _shift_linear_consumer_chain(graph, src, delta, internal_set, from_ref=True)
 
         # Compact the remaining below-trunk sources upward to fill the
         # rows their predecessors vacated.  Without this step, lifted
@@ -359,11 +370,11 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         # below-trunk source at ``trunk_y + i * y_spacing``.
         for i, src in enumerate(sources[n_lift:], 1):
             new_y = trunk_y + i * y_spacing
-            delta = new_y - graph.stations[src].y
+            delta = new_y - _ref_y(graph, src)
             if abs(delta) < 0.5:
                 continue
             graph.stations[src].y = new_y
-            _shift_linear_consumer_chain(graph, src, delta, internal_set)
+            _shift_linear_consumer_chain(graph, src, delta, internal_set, from_ref=True)
 
 
 def _balance_direct_external_feeder_ys(
@@ -454,13 +465,7 @@ def _balance_section_content_around_trunk(
         if not internal_ids:
             continue
 
-        trunk_y: float | None = None
-        for pid in section.entry_ports + section.exit_ports:
-            port = graph.ports.get(pid)
-            st = graph.stations.get(pid)
-            if port and st and port.side in (PortSide.LEFT, PortSide.RIGHT):
-                trunk_y = st.y
-                break
+        trunk_y = _section_lr_port_anchor_y(graph, section)
         if trunk_y is None:
             full_ys = sorted(
                 graph.stations[s].y

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -17,6 +17,7 @@ from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.phases._common import (
     _bbox_cols_overlap,
     _content_station_ys,
+    _ref_y,
     _set_section_bbox_top,
 )
 from nf_metro.layout.phases.single_section import _terminus_y_overhang
@@ -301,7 +302,7 @@ def _lift_would_cause_uturn(
                 continue
             if src.section_id == section_id:
                 continue
-            feeder_ys.append(src.y)
+            feeder_ys.append(_ref_y(graph, src_id))
 
     _collect(station_id)
     if len(feeder_ys) < 2:

--- a/src/nf_metro/layout/phases/fan_bundles.py
+++ b/src/nf_metro/layout/phases/fan_bundles.py
@@ -11,6 +11,7 @@ from nf_metro.layout.phases._common import (
     _fan_offsets,
     _grid_group_section_ids,
     _section_bundle_lines,
+    _section_lr_port_anchor_y,
 )
 from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
 
@@ -571,28 +572,11 @@ def _recenter_full_bundle_columns(graph: MetroGraph, y_spacing: float) -> None:
             for x, sids in cols.items()
         }
 
-        # Trunk anchor: prefer the entry port station's Y, which after
-        # row alignment sits on the row's bundle line.  Fall back to
-        # the exit port station, then a single-station full-bundle
-        # column (natural pass-through), then the median Y.
-        anchor_y: float | None = None
-        for pid in section.entry_ports:
-            p = graph.ports.get(pid)
-            ps = graph.stations.get(pid)
-            if p is None or ps is None:
-                continue
-            if p.side in (PortSide.LEFT, PortSide.RIGHT):
-                anchor_y = ps.y
-                break
-        if anchor_y is None:
-            for pid in section.exit_ports:
-                p = graph.ports.get(pid)
-                ps = graph.stations.get(pid)
-                if p is None or ps is None:
-                    continue
-                if p.side in (PortSide.LEFT, PortSide.RIGHT):
-                    anchor_y = ps.y
-                    break
+        # Trunk anchor: prefer the LR/RL entry (then exit) port station Y,
+        # which after row alignment sits on the row's bundle line.  Fall back
+        # to a single-station full-bundle column (natural pass-through), then
+        # the median Y.
+        anchor_y = _section_lr_port_anchor_y(graph, section)
         if anchor_y is None:
             single_ys = [
                 graph.stations[full[0]].y

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -233,6 +233,11 @@ class MetroGraph:
     # prediction rather than the post-compaction settled extent.  Empty
     # until the snapshot at the start of ``_place_pass_c_content``.
     _struct_height_below_top: dict[str, float] = field(default_factory=dict, repr=False)
+    # Frozen station Ys / section bbox tops captured before a content-balancing
+    # phase, read for its slack and arrangement decisions; see
+    # _snapshot_placement_refs.
+    _placement_ref_y: dict[str, float] = field(default_factory=dict, repr=False)
+    _placement_ref_bbox_top: dict[str, float] = field(default_factory=dict, repr=False)
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -41,11 +41,6 @@ CORPUS = content_corpus()
 KNOWN_LEAKS: frozenset[tuple[str, str]] = frozenset(
     {
         ("_redistribute_fanout_siblings", "examples/differentialabundance"),
-        ("_fan_free_content_upward", "examples/differentialabundance_default"),
-        ("_fan_free_content_upward", "tests/da_pipeline"),
-        ("_fan_source_inputs_upward", "examples/differentialabundance"),
-        ("_fan_source_inputs_upward", "examples/differentialabundance_default"),
-        ("_fan_source_inputs_upward", "tests/da_pipeline"),
         ("_balance_section_content_around_trunk", "examples/differentialabundance"),
         ("_balance_section_content_around_trunk", "examples/genomic_pipeline"),
     }


### PR DESCRIPTION
## Summary

Step 2 of the #491 purity series (follows #492, #493). Makes the two top-band content fans **pure functions of (frozen anchors + structure)**:

- `_fan_free_content_upward` (Stage 6.1)
- `_fan_source_inputs_upward` (Stage 6.2)

Both chose how many stations to lift into the empty top band, and where, from mutable non-anchor state: the live section `bbox_y` (the row-aligned top produced by the non-content row-align / compaction stages), the current `min` station Y, and the live Y of the station they anchored on. The purity probe (#492) showed perturbing that state (port anchors + structure held fixed) moved their content by up to ~135px, so they were only *masked-pure* (a slack gate bailed), not pure.

Both now read a **frozen placement reference** -- station Ys and section bbox tops snapshotted once right before Stage 6.1 (`_snapshot_placement_refs`, a sibling of #485's structural-extent snapshot) -- for their slack and arrangement decisions, via `_ref_y` / `_ref_bbox_top`. 6.2 also centres on the frozen LR/RL port trunk anchor rather than the trunk station's live Y. The two shared helpers they lean on are made reference-aware: `_lift_would_cause_uturn` reads feeder Ys from the reference, and `_shift_linear_consumer_chain` gained a `from_ref` mode.

The frozen reference equals the live geometry at capture time, so **single-pass output is unchanged: all 70 corpus renders are byte-identical** (verified locally; CI render-diff confirms). Perturbing the live state no longer changes placement.

Also consolidates the "LR/RL entry-then-exit port trunk anchor" lookup (previously inlined in Stages 6.7 and 6.11) into `_section_lr_port_anchor_y`.

Drops the five now-pure 6.1 / 6.2 entries from the purity-probe `KNOWN_LEAKS` ledger (3 remain: Stage 6.11 ×2, Stage 4.9 ×1).

### Scope note

The original PR3 target also included Stage 6.11 (`_balance_section_content_around_trunk`, the 207px leak). 6.11's loop lifts/swaps movables one at a time while re-reading the live arrangement, so making it pure requires a working-copy reformulation that **is render-changing** -- it does not belong in this byte-identical PR and will land as its own render-reviewed PR. 6.1 and 6.2 came out byte-identical and ship here.

Refs #491, #488, #485.

## Test plan
- [x] `pytest` passes (purity probe: 1117 pass / 3 strict-xfail; full suite 5089 pass)
- [x] All 70 corpus renders byte-identical to `main` (local diff)
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [ ] Render-preview verdict: expect "No visual changes"

Generated with Claude Code
