### PR TITLE
fix(layout): centre fan-out siblings on the frozen port trunk anchor (#491)

### DIFF
--- a/src/nf_metro/layout/phases/fan_bundles.py
+++ b/src/nf_metro/layout/phases/fan_bundles.py
@@ -191,7 +191,10 @@ def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
             if len(trunks) != 1:
                 continue
             trunk_sid = trunks[0]
-            trunk_y = graph.stations[trunk_sid].y
+            port_trunk = _section_lr_port_anchor_y(graph, section)
+            trunk_y = (
+                port_trunk if port_trunk is not None else graph.stations[trunk_sid].y
+            )
             # Fan-out siblings: strict subset of bundle (skip full-bundle
             # pass-throughs and orphan stations with no lines).  Require
             # at least one predecessor so source stations (file inputs

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -40,7 +40,6 @@ CORPUS = content_corpus()
 
 KNOWN_LEAKS: frozenset[tuple[str, str]] = frozenset(
     {
-        ("_redistribute_fanout_siblings", "examples/differentialabundance"),
         ("_balance_section_content_around_trunk", "examples/differentialabundance"),
         ("_balance_section_content_around_trunk", "examples/genomic_pipeline"),
     }


### PR DESCRIPTION
## Summary

Step 3 of the #491 purity series (follows #492, #493, #494). Makes the fan-out sibling distributor pure:

- `_redistribute_fanout_siblings` (Stage 4.9)

It fanned a column's strict-subset siblings around `trunk_y` read from the trunk junction station's **live Y**, so perturbing that station's Y (port anchors + structure held fixed) shifted the whole fan by up to 26px. It now centres on the section's frozen LR/RL port trunk anchor (`_section_lr_port_anchor_y`, introduced in #494), falling back to the trunk station's Y only when there is no LR/RL port.

Each column's full-bundle trunk sits on the section bundle line, which is the port Y, so **single-pass output is unchanged: all 70 corpus renders byte-identical** (verified locally; CI render-diff confirms).

Drops the last Stage 4.9 entry from the purity-probe `KNOWN_LEAKS` ledger. Only Stage 6.11 remains (2 entries); its arrangement-loop reads are render-changing and land in a separate render-reviewed PR.

The median-current-Y fallback trunks in Stages 4.10 / 6.3 / 6.7 are left as-is: they are already pure (the fallback is never exercised by the corpus), and the permanent purity guard (final PR) will catch them if a future fixture ever does.

Refs #491, #488.

## Test plan
- [x] `pytest` passes (purity probe: 1118 pass / 2 strict-xfail; full suite 5090 pass)
- [x] All 70 corpus renders byte-identical to `main` (local diff)
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [ ] Render-preview verdict: expect "No visual changes"

Generated with Claude Code
