### PR TITLE
fix(layout): make Stage 6.11 balance pure and lock the purity guard (#491)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1009,6 +1009,8 @@ def _place_pass_c_content(
     # empty top band so content sits symmetrically around the trunk.
     # Runs after re-centering and terminus-Y pinning so it sees the
     # final trunk Y.  U-turn-safe and bbox-bounded.
+    # Frozen reference for Stage 6.11 (see _snapshot_placement_refs).
+    _snapshot_placement_refs(graph)
     _run_placement_per_row(
         graph,
         validate,

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -414,7 +414,7 @@ def _balance_direct_external_feeder_ys(
             continue
         if src.section_id == section_id:
             continue
-        feeder_ys.append(src.y)
+        feeder_ys.append(_ref_y(graph, cur_id))
     return feeder_ys
 
 
@@ -445,6 +445,15 @@ def _balance_section_content_around_trunk(
         return
     if not graph.center_ports:
         return
+
+    # Decide and place from the frozen reference arrangement, not live geometry:
+    # restore each in-scope station to its reference Y so the lift/swap loop
+    # reads the same structural input regardless of any perturbation.
+    for section in graph.sections.values():
+        for sid in section.station_ids:
+            st = graph.stations.get(sid)
+            if st is not None and not st.is_port:
+                st.y = _ref_y(graph, sid)
 
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
@@ -481,7 +490,7 @@ def _balance_section_content_around_trunk(
             cols[round(graph.stations[sid].x, 3)].append(sid)
 
         section_top_y = min(graph.stations[s].y for s in internal_ids)
-        top_band = section_top_y - section.bbox_y
+        top_band = section_top_y - _ref_bbox_top(graph, section)
         if top_band <= y_spacing + 0.5:
             continue
 
@@ -528,7 +537,7 @@ def _balance_section_content_around_trunk(
         max_iters = len(movable)
         for _ in range(max_iters):
             section_top_y = min(graph.stations[s].y for s in internal_ids)
-            top_band = section_top_y - section.bbox_y
+            top_band = section_top_y - _ref_bbox_top(graph, section)
             if top_band <= y_spacing + 0.5:
                 break
             ys_by_sid = {s: graph.stations[s].y for s in movable}
@@ -560,7 +569,9 @@ def _balance_section_content_around_trunk(
             # Off-track file icons reach ~16 px above centre; on-track
             # markers reach ~9.5 px.  Use the wider reach when relevant.
             marker_clearance = 16.0 if (st and st.off_track) else 9.5
-            min_y = section.bbox_y + max(label_clearance, marker_clearance)
+            min_y = _ref_bbox_top(graph, section) + max(
+                label_clearance, marker_clearance
+            )
             if new_y < min_y - 0.5:
                 if not above:
                     break

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -16,10 +16,9 @@ port anchors frozen).  A pure phase governs the same stations and lands each at
 the same Y both times.  Any station the phase moves in either run whose final Y
 differs between the two runs is a purity leak.
 
-The remaining known leaks are pinned as strict xfails below and burned down by
-the #491 follow-up PRs (track sorts, structural slack, structural fallback
-trunks).  ``strict=True`` means a phase that *becomes* pure flips its xfail to
-an xpass and fails the suite, forcing the stale entry to be removed.
+All eight content-placement phases are pure, so this guard admits no
+exceptions: it is the machine-checked counterpart to #487's anchor-frozen guard,
+and a regression that reintroduces a non-anchor read fails it.
 
 Refs #491, #488, #487, #485, #465.
 """
@@ -37,13 +36,6 @@ TOL = 1e-3
 _Coords = dict[str, tuple[float, float]]
 
 CORPUS = content_corpus()
-
-KNOWN_LEAKS: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("_balance_section_content_around_trunk", "examples/differentialabundance"),
-        ("_balance_section_content_around_trunk", "examples/genomic_pipeline"),
-    }
-)
 
 
 def _snapshot(graph: MetroGraph) -> tuple[_Coords, _Coords]:
@@ -118,14 +110,7 @@ def _make_purity_probe(original, leaks: list[tuple[str, float, float]]):
 def _cases():
     for fid, path, is_nf in CORPUS:
         for phase in CONTENT_PLACEMENT_PHASES:
-            marks = (
-                [pytest.mark.xfail(strict=True, reason="#491 known purity leak")]
-                if (phase, fid) in KNOWN_LEAKS
-                else []
-            )
-            yield pytest.param(
-                fid, path, is_nf, phase, id=f"{fid}-{phase}", marks=marks
-            )
+            yield pytest.param(fid, path, is_nf, phase, id=f"{fid}-{phase}")
 
 
 @pytest.mark.parametrize("fid,path,is_nf,phase_name", list(_cases()))


### PR DESCRIPTION
## Summary

Final step of the #491 purity series (follows #492, #493, #494, #495). Makes the last content-placement phase pure and turns the purity probe into an unconditional guard.

### Stage 6.11 -- `_balance_section_content_around_trunk`

Decided its lifts and swaps from live geometry: the current section top (`min` station Y), the live above/below split around the trunk, the live bbox top, and external feeder Ys. Perturbing that state (port anchors + structure held fixed) changed which siblings it rebalanced, by up to ~207px -- it was the last phase that was only *masked-pure* (its loop bailed once the band filled or the counts equalised).

It now decides from the frozen placement reference (#494): an in-scope reset restores every non-port station to its reference Y before the lift/swap loop, the band gates read the reference bbox top, and the U-turn feeder check reads reference feeder Ys. The reference equals the live geometry at capture time, so **single-pass output is unchanged: all 70 corpus renders byte-identical** (verified locally; CI render-diff confirms).

### Purity guard

With all eight content-placement phases now pure, `test_content_placement_pure` drops its strict-xfail leak ledger and becomes an **unconditional guard** -- the machine-checked counterpart to #487's anchor-frozen guard. Any regression that reintroduces a non-anchor read fails the suite (560 cases: 70 fixtures × 8 phases).

### Series outcome

All eight Pass-C content-placement phases (4.9, 4.10, 6.1, 6.2, 6.3, 6.7, 6.11, 6.12) are now pure functions of (frozen anchors + structure), not merely idempotent. The whole series is byte-identical to `main`. The interleaved barriers can now be justified or dissolved on a declarative basis.

Closes #491.

## Test plan
- [x] `pytest` passes (purity guard: 560 pass, 0 xfail; full suite 5092 pass)
- [x] All 70 corpus renders byte-identical to `main` (local diff)
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [ ] Render-preview verdict: expect "No visual changes"

Generated with Claude Code
