### PR TITLE
refactor(parser): drop write-only Port.line_ids field

### DIFF
--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -1025,15 +1025,13 @@ def _create_port_stations(
     port_counter = 0
     exit_port_map: dict[str, str] = {}
 
-    for sec_id, edges in exit_group_edges.items():
+    for sec_id in exit_group_edges:
         side = section_exit_side.get(sec_id, PortSide.RIGHT)
-        all_line_ids = sorted({e.line_id for e in edges})
         port_id = f"{sec_id}__exit_{side.value}_{port_counter}"
         port = Port(
             id=port_id,
             section_id=sec_id,
             side=side,
-            line_ids=all_line_ids,
             is_entry=False,
         )
         graph.add_port(port)
@@ -1042,14 +1040,12 @@ def _create_port_stations(
 
     entry_port_map: dict[tuple[str, PortSide], str] = {}
 
-    for (sec_id, side), edges in entry_group_edges.items():
-        all_line_ids = sorted({e.line_id for e in edges})
+    for sec_id, side in entry_group_edges:
         port_id = f"{sec_id}__entry_{side.value}_{port_counter}"
         port = Port(
             id=port_id,
             section_id=sec_id,
             side=side,
-            line_ids=all_line_ids,
             is_entry=True,
         )
         graph.add_port(port)

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -104,7 +104,6 @@ class Port:
     id: str
     section_id: str
     side: PortSide
-    line_ids: list[str] = field(default_factory=list)
     is_entry: bool = True
     x: float = 0.0
     y: float = 0.0


### PR DESCRIPTION
## What

`Port.line_ids` is set in the two `Port(...)` constructions in `_create_ports` (parser/mermaid.py) but is never read as an attribute anywhere in `src/` or `tests/`. Every consumer that needs a port's line bundle reads it through the cached `graph.station_lines(pid)` accessor instead.

This PR removes the dead field and the two `all_line_ids = sorted(...)` locals that existed only to populate it, and simplifies the two loop headers whose iteration value is no longer used.

## Why

Found during a post-declarative-shift cleanup audit (an AST scan for write-only state). The field is superseded by the `station_lines()` cache; nothing references it.

## Verification

- All 63 gallery renders byte-identical (the field never affected layout/render).
- Full suite: 5092 passed, 6 xfailed.
- ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)