### PR TITLE
fix(types): enable mypy strict_optional on the layout core (#498, band 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,4 +78,4 @@ mypy_path = "src"
 explicit_package_bases = true
 python_version = "3.10"
 ignore_missing_imports = true
-strict_optional = false
+strict_optional = true

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -340,7 +340,7 @@ def compute_layout(
     """
     auto_x = x_spacing is None
     auto_y = y_spacing is None
-    if auto_y:
+    if y_spacing is None:
         y_spacing = compute_min_y_spacing(graph)
     else:
         min_required = compute_min_y_spacing(graph)
@@ -353,7 +353,7 @@ def compute_layout(
                 UserWarning,
                 stacklevel=2,
             )
-    if auto_x:
+    if x_spacing is None:
         x_spacing = X_SPACING
 
     # Optionally reorder lines by section span before layout.

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -615,7 +615,7 @@ def _equalize_fork_groups(
         line_order_map = {lid: i for i, lid in enumerate(graph.lines)}
         group.sort(
             key=lambda sid: (
-                line_order_map.get(node_primary.get(sid, ""), len(line_order_map)),
+                line_order_map.get(node_primary.get(sid) or "", len(line_order_map)),
                 tracks[sid],
             )
         )

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -469,7 +469,7 @@ def _shrink_bboxes_to_content_bottom(
             if other.id == section.id or other.bbox_h <= 0:
                 continue
             o_y_bot = other.bbox_y + other.bbox_h
-            if use_grid and other.grid_row >= 0:
+            if use_grid and my_grid_row is not None and other.grid_row >= 0:
                 o_grid_top = other.grid_row
                 o_grid_bot = other.grid_row + max(1, other.grid_row_span)
                 mate = o_grid_top <= my_grid_row < o_grid_bot

--- a/src/nf_metro/layout/phases/grid_snap.py
+++ b/src/nf_metro/layout/phases/grid_snap.py
@@ -71,9 +71,9 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
         sec_ids = list(info.get("section_ids", []))
         groups[("row", row)] = (pitch, sec_ids)
         grouped_ids.update(sec_ids)
-    for section in graph.sections.values():
-        if section.id not in grouped_ids:
-            groups[("solo", section.id)] = (y_spacing, [section.id])
+    for sec in graph.sections.values():
+        if sec.id not in grouped_ids:
+            groups[("solo", sec.id)] = (y_spacing, [sec.id])
 
     for pitch, sec_ids in groups.values():
         half = pitch / 2.0

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -795,7 +795,11 @@ def _guard_inter_section_route_no_backtrack(
     ):
         src_sec = resolve_section(graph, graph.stations[rp.edge.source])
         tgt_sec = resolve_section(graph, graph.stations[rp.edge.target])
-        rightward = tgt_sec.grid_col > src_sec.grid_col
+        rightward = (
+            src_sec is not None
+            and tgt_sec is not None
+            and tgt_sec.grid_col > src_sec.grid_col
+        )
         raise PhaseInvariantError(
             f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} "
             f"line {rp.line_id!r} backtracks x={x1:.1f}->{x2:.1f} "

--- a/src/nf_metro/layout/phases/ports.py
+++ b/src/nf_metro/layout/phases/ports.py
@@ -486,7 +486,9 @@ def _snap_sole_layer_stations_to_ports(graph: MetroGraph) -> None:
                     for edge in graph.edges_to(current):
                         if edge.source in internal_ids:
                             nexts.add(edge.source)
-                current = next(iter(nexts)) if len(nexts) == 1 else None
+                if len(nexts) != 1:
+                    break
+                current = next(iter(nexts))
 
 
 def _snap_grid_group_entry_ports(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -54,7 +54,7 @@ def vertical_direction(dy: float) -> Direction:
 
 def _sections_in_col(
     graph: MetroGraph,
-    col: int,
+    col: int | None,
     row: int | None = None,
     y_band: tuple[float, float] | None = None,
 ) -> list[Section]:
@@ -81,7 +81,7 @@ def _sections_in_col(
     return secs
 
 
-def _sections_in_row(graph: MetroGraph, row: int) -> list[Section]:
+def _sections_in_row(graph: MetroGraph, row: int | None) -> list[Section]:
     """Sections in a specific grid row with non-zero height."""
     return [s for s in graph.sections.values() if s.grid_row == row and s.bbox_h > 0]
 
@@ -97,7 +97,7 @@ def col_right_edge(
 
 
 def col_left_edge(
-    graph: MetroGraph, col: int, default: float = 0.0, row: int | None = None
+    graph: MetroGraph, col: int | None, default: float = 0.0, row: int | None = None
 ) -> float:
     """Leftmost X extent of sections in *col* (optionally a single *row*)."""
     secs = _sections_in_col(graph, col, row)
@@ -105,7 +105,7 @@ def col_left_edge(
 
 
 def row_bottom_edge(
-    graph: MetroGraph, row: int, default: float = 0.0, col: int | None = None
+    graph: MetroGraph, row: int | None, default: float = 0.0, col: int | None = None
 ) -> float:
     """Bottommost Y extent of sections in *row* (optionally a single *col*).
 
@@ -610,7 +610,7 @@ def bypass_bottom_y(
 
 def resolve_section(
     graph: MetroGraph,
-    station: Station,
+    station: Station | None,
     prefer_upstream: bool = True,
 ) -> Section | None:
     """Resolve a station's section, tracing through junctions if needed.
@@ -622,7 +622,11 @@ def resolve_section(
     When *prefer_upstream* is True (default), incoming edges are checked
     first so the junction resolves to the upstream section.  When False,
     both directions are scanned in a single pass with no preference.
+
+    A ``None`` station (e.g. an unresolved lookup) yields ``None``.
     """
+    if station is None:
+        return None
     if station.section_id:
         return graph.sections.get(station.section_id)
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -492,7 +492,7 @@ def _max_offset_at(ctx: _RoutingCtx, station_id: str) -> float:
 
 
 def _tb_x_offset(
-    ctx: _RoutingCtx, station_id: str, line_id: str, section_id: str
+    ctx: _RoutingCtx, station_id: str, line_id: str, section_id: str | None
 ) -> float:
     """Compute the TB-aware X offset for a station.
 
@@ -580,6 +580,8 @@ def _route_inter_section(
         return _route_bottom_exit_junction(edge, src, tgt, i, n, ctx)
 
     if needs_bypass:
+        # needs_bypass is only True when both columns resolved.
+        assert src_col is not None and tgt_col is not None
         # Merge dispatch: trunk gets full bypass to entry port,
         # branches get truncated descent to trunk level.
         if edge.target in ctx.merge.trunk_source:
@@ -602,8 +604,9 @@ def _route_inter_section(
             and tgt_row is not None
             and tgt_row == src_row + 1
         ):
-            exclude = {src.section_id, tgt.section_id}
-            exclude.discard(None)
+            exclude = {
+                sid for sid in (src.section_id, tgt.section_id) if sid is not None
+            }
             if not _h_segment_crosses_other_section(graph, sx, tx, ty, exclude):
                 return _route_l_shape(edge, src, tgt, i, n, ctx)
         return _route_bypass(edge, src, tgt, i, src_col, tgt_col, ctx, src_row)
@@ -684,7 +687,7 @@ def _route_inter_section(
         # source's right edge is fine even if its Y falls within the
         # source's row.
         wrap_hy = inter_row_channel_y(graph, src, tgt, sy, ty, dy, ctx.curve_radius)
-        exclude = {src.section_id} if src.section_id else set()
+        exclude = {src.section_id} if src.section_id else set[str]()
         if _h_segment_crosses_other_section(graph, sx, tx, wrap_hy, exclude):
             if _corridor_is_viable(ctx, src, tgt):
                 return _route_inter_row_gap_corridor(edge, src, tgt, tgt, i, n, ctx)
@@ -732,7 +735,7 @@ def _route_inter_section(
             # is safe even when its bbox spans the route's Y range.
             ep_port = graph.ports.get(ep_id)
             if ep_port and ep_port.side == PortSide.LEFT:
-                exclude = {src.section_id} if src.section_id else set()
+                exclude = {src.section_id} if src.section_id else set[str]()
                 if _h_segment_crosses_other_section(graph, sx, ep.x, ep.y, exclude):
                     # When a clear inter-row / inter-column corridor exists for
                     # this downward cross-row feeder, descend it instead of
@@ -1986,7 +1989,7 @@ def _corridor_is_viable(ctx: _RoutingCtx, src: Station, entry_port: Station) -> 
         return False
     src_col, src_row = _resolve_section_colrow(ctx.graph, src)
     ep_col, ep_row = _resolve_section_colrow(ctx.graph, entry_port)
-    if None in (src_row, ep_row, src_col, ep_col):
+    if src_row is None or ep_row is None or src_col is None or ep_col is None:
         return False
     if ep_row <= src_row:
         return False
@@ -2056,6 +2059,13 @@ def _route_inter_row_gap_corridor(
 
     src_col, src_row = _resolve_section_colrow(ctx.graph, src)
     ep_col, ep_row = _resolve_section_colrow(ctx.graph, entry_port)
+    # Guaranteed by the _corridor_is_viable check at every call site.
+    assert (
+        src_col is not None
+        and src_row is not None
+        and ep_col is not None
+        and ep_row is not None
+    )
 
     # Inter-row gap Y just below the source row (column-restricted so a
     # tall row-span in another column doesn't push the channel down).  Use
@@ -2098,6 +2108,8 @@ def _route_inter_row_gap_corridor(
         vx = _fan_left_entry_descent_x(ctx, ep_col, pos_n, delta)
     if vx is None:
         vx = _corridor_descent_x(ctx, ep_col, ep_row, delta)
+    # _corridor_is_viable confirmed a descent channel exists here.
+    assert vx is not None
 
     # H lead-in right of the source, clear of the source section's edge.
     # When the source is a sectionless junction, fall back to its own X as
@@ -2366,6 +2378,7 @@ def _route_right_entry_wrap(
     )
 
     if cross_row:
+        assert src_col is not None and tgt_col is not None
         hy = bypass_bottom_y(
             ctx.graph, src_col, tgt_col, BYPASS_CLEARANCE, src_row=src_row
         )
@@ -2551,6 +2564,8 @@ def _route_tb_lr_exit(
         and src.section_id == tgt.section_id
     ):
         return None
+    # tgt_is_lr_exit already established tgt_port is a real port.
+    assert tgt_port is not None
 
     src_off = _get_offset(ctx, edge.source, edge.line_id)
     max_src_off = _max_offset_at(ctx, edge.source)
@@ -3111,6 +3126,8 @@ def _apply_diagonal_spread(
     The delta translates both diagonal waypoints (indices 1 and 2) so
     the diagonal segments are parallel but horizontally spread.
     """
+    # Only reached from _spread_diagonal_bundles, which returns early on None.
+    assert ctx.station_offsets is not None
     offsets = [ctx.station_offsets.get((station_id, rp.line_id), 0.0) for rp in group]
     center = sum(offsets) / len(offsets)
 
@@ -3345,12 +3362,16 @@ def _collect_centering_candidates(
         elif in_rp:
             in_diag_end_x = in_rp.points[2][0]
         else:
+            # Reached only via the flat-in case above, which sets flat_in_rp.
+            assert flat_in_rp is not None
             in_diag_end_x = flat_in_rp.points[0][0]
 
         if not multi_diag:
             if out_rp:
                 out_diag_start_x = out_rp.points[1][0]
             else:
+                # Reached only via the flat-out case, which sets flat_out_rp.
+                assert flat_out_rp is not None
                 out_diag_start_x = flat_out_rp.points[-1][0]
 
         in_flat = station.x - in_diag_end_x

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -580,7 +580,6 @@ def _route_inter_section(
         return _route_bottom_exit_junction(edge, src, tgt, i, n, ctx)
 
     if needs_bypass:
-        # needs_bypass is only True when both columns resolved.
         assert src_col is not None and tgt_col is not None
         # Merge dispatch: trunk gets full bypass to entry port,
         # branches get truncated descent to trunk level.
@@ -2108,7 +2107,6 @@ def _route_inter_row_gap_corridor(
         vx = _fan_left_entry_descent_x(ctx, ep_col, pos_n, delta)
     if vx is None:
         vx = _corridor_descent_x(ctx, ep_col, ep_row, delta)
-    # _corridor_is_viable confirmed a descent channel exists here.
     assert vx is not None
 
     # H lead-in right of the source, clear of the source section's edge.
@@ -2564,7 +2562,6 @@ def _route_tb_lr_exit(
         and src.section_id == tgt.section_id
     ):
         return None
-    # tgt_is_lr_exit already established tgt_port is a real port.
     assert tgt_port is not None
 
     src_off = _get_offset(ctx, edge.source, edge.line_id)
@@ -3362,7 +3359,6 @@ def _collect_centering_candidates(
         elif in_rp:
             in_diag_end_x = in_rp.points[2][0]
         else:
-            # Reached only via the flat-in case above, which sets flat_in_rp.
             assert flat_in_rp is not None
             in_diag_end_x = flat_in_rp.points[0][0]
 
@@ -3370,7 +3366,6 @@ def _collect_centering_candidates(
             if out_rp:
                 out_diag_start_x = out_rp.points[1][0]
             else:
-                # Reached only via the flat-out case, which sets flat_out_rp.
                 assert flat_out_rp is not None
                 out_diag_start_x = flat_out_rp.points[-1][0]
 

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -213,12 +213,12 @@ def _reindex_section_local(ctx: _OffsetCtx) -> None:
             section_local[sec_id] = {lid: i for i, lid in enumerate(ordered)}
 
     for sid_s, station in graph.stations.items():
-        sec_id = station.section_id
-        if sec_id not in section_local:
+        st_sec = station.section_id
+        if st_sec is None or st_sec not in section_local:
             continue
-        local_pri = section_local[sec_id]
+        local_pri = section_local[st_sec]
         local_max = max(local_pri.values()) if local_pri else 0
-        reverse = sec_id in ctx.reversed_sections
+        reverse = st_sec in ctx.reversed_sections
         for lid in graph.station_lines(sid_s):
             p = local_pri.get(lid, 0)
             if reverse:
@@ -745,10 +745,10 @@ def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
             continue
         entry_offs: dict[str, float] = {}
         for lid in graph.station_lines(port_id):
-            exit_off = ctx.offsets.get((exit_port_id, lid))
-            if exit_off is not None:
-                ctx.offsets[(port_id, lid)] = exit_off
-                entry_offs[lid] = exit_off
+            paired_off = ctx.offsets.get((exit_port_id, lid))
+            if paired_off is not None:
+                ctx.offsets[(port_id, lid)] = paired_off
+                entry_offs[lid] = paired_off
         if len(entry_offs) >= 2:
             for e2 in graph.edges_from(port_id):
                 tgt_st = graph.stations.get(e2.target)
@@ -1108,9 +1108,11 @@ def _allocate_merge_ports_by_approach(ctx: _OffsetCtx) -> None:
         min_horiz = min(cur[lid] for lid in horizontal)
 
         new_offs: dict[str, float] = {}
-        for rank, lid in enumerate(sorted(below, key=cur.get), start=1):
+        for rank, lid in enumerate(sorted(below, key=lambda lid: cur[lid]), start=1):
             new_offs[lid] = max_horiz + rank * ctx.offset_step
-        for rank, lid in enumerate(sorted(above, key=cur.get, reverse=True), start=1):
+        for rank, lid in enumerate(
+            sorted(above, key=lambda lid: cur[lid], reverse=True), start=1
+        ):
             new_offs[lid] = min_horiz - rank * ctx.offset_step
 
         if all(

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -12,6 +12,7 @@ __all__ = ["place_sections", "position_ports"]
 
 import warnings
 from collections import defaultdict, deque
+from typing import TypeGuard
 
 from nf_metro.layout.constants import (
     BUNDLE_TO_BUNDLE_CLEARANCE,
@@ -310,6 +311,8 @@ def place_sections(
     if not graph.sections:
         return
 
+    # auto_layout always populates section_dag before placement runs.
+    assert graph.section_dag is not None
     section_edges = graph.section_dag.section_edges
     col_assign, row_assign = _assign_grid_layout(graph, section_edges)
     min_col, max_col = _compute_section_offsets(
@@ -337,11 +340,13 @@ def _rows_overlap(a: Section, b: Section) -> bool:
 
 def _station_column(
     graph: MetroGraph,
-    station: Station,
+    station: Station | None,
     col_assign: dict[str, int],
     junction_ids: set[str],
 ) -> int | None:
     """Resolve a station's grid column via its section or junction chain."""
+    if station is None:
+        return None
     if station.section_id and station.section_id in col_assign:
         return col_assign[station.section_id]
     # Junction: trace back to its source port's section
@@ -373,7 +378,7 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
     adjacent ``(src_row, tgt_row)`` reservation still applies.
     """
 
-    def _is_flow_section(sec: Section | None) -> bool:
+    def _is_flow_section(sec: Section | None) -> TypeGuard[Section]:
         return sec is not None and sec.grid_row_span == 1
 
     # (upper_row, lower_row) -> entry_port_id -> set of line ids
@@ -744,6 +749,8 @@ def _enforce_min_row_gaps(
         # constraint that actually drove the widening.
         if wrap_deficit > header_deficit:
             reason = "to fit an inter-row routing bundle"
+            # wrap_deficit only exceeds 0 when wrap_min was non-None.
+            assert wrap_min is not None
             required_bbox_gap = wrap_min
         else:
             reason = "to clear section headers"

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -473,7 +473,11 @@ def _parse_node(
         m = pattern.match(line)
         if m:
             node_id = m.group(1)
-            label = m.group(2).strip() if m.lastindex >= 2 else node_id
+            label = (
+                m.group(2).strip()
+                if m.lastindex is not None and m.lastindex >= 2
+                else node_id
+            )
             label = _unquote(label)
             # Convert literal \n sequences to real newlines (multi-line labels)
             if "\\n" in label:
@@ -1004,6 +1008,9 @@ def _group_inter_section_edges(
     for edge in inter_section_edges:
         src_sec = graph.section_for_station(edge.source)
         tgt_sec = graph.section_for_station(edge.target)
+        # _classify_edges only files an edge as inter-section when both
+        # endpoints resolve to a section, so neither lookup is None here.
+        assert src_sec is not None and tgt_sec is not None
         entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
 
         exit_group_edges.setdefault(src_sec, []).append(edge)
@@ -1077,6 +1084,9 @@ def _rewrite_edges_with_junctions(
     for edge in inter_section_edges:
         src_sec = graph.section_for_station(edge.source)
         tgt_sec = graph.section_for_station(edge.target)
+        # See _classify_edges: inter-section edges always have both
+        # endpoints in a section, so neither lookup is None.
+        assert src_sec is not None and tgt_sec is not None
         entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
 
         exit_port_id = exit_port_map[src_sec]

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -1084,8 +1084,6 @@ def _rewrite_edges_with_junctions(
     for edge in inter_section_edges:
         src_sec = graph.section_for_station(edge.source)
         tgt_sec = graph.section_for_station(edge.target)
-        # See _classify_edges: inter-section edges always have both
-        # endpoints in a section, so neither lookup is None.
         assert src_sec is not None and tgt_sec is not None
         entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
 


### PR DESCRIPTION
## Summary

Band 1 of #498 (tighten mypy toward strict). Flips `strict_optional = true` in `[tool.mypy]` and resolves the 63 resulting `Optional`/None errors across the layout core.

Each fix is one of:
- a real None-guard where the value can legitimately be `None`;
- a narrowing `assert` documenting an invariant established upstream (e.g. `needs_bypass`/`cross_row` only hold when the grid columns resolved; inter-section edges always have both endpoints in a section);
- a signature widening to `int | None` / `Station | None` where the callee already tolerates `None` (the grid-query helpers `col_left_edge`/`row_bottom_edge`/`_sections_in_col`/`_sections_in_row` return their `default` on an unknown col/row; `resolve_section`/`_station_column` now yield `None` for a `None` station, removing a latent crash).

`_is_flow_section` becomes a `TypeGuard[Section]` so its callers narrow.

Type/config-only: the full gallery (examples + topologies + guide + tests/fixtures + converted nextflow fixtures) renders byte-identically.

Fixes nothing on its own beyond hardening; first of a 3-band stack (imports, then generics) all refs #498.

## Test plan
- [x] mypy green (CI-faithful: `ruff mypy` only, no deps installed)
- [x] ruff check + format clean on `src/ tests/`
- [x] pytest passes (5092 passed, 6 pre-existing xfails)
- [x] Gallery byte-identical vs base
- [ ] Render-preview verdict: expect "No visual changes detected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)