### PR TITLE
docs(layout): document the anchor / content-placement split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ The `nf-metro` micromamba environment has the project installed in editable mode
 
 - Test fixtures: `tests/fixtures/`
 - Example pipelines: `examples/` (including `rnaseq_sections.mmd` with manual grid and `rnaseq_auto.mmd` with fully inferred layout)
-- Topology stress tests: `tests/fixtures/topologies/*.mmd` - 15 fixtures covering fan-out, fan-in, diamonds, folds, mixed port sides, etc. See `tests/fixtures/topologies/README.md` for full inventory and known issues.
+- Topology stress tests: `examples/topologies/*.mmd` - 30 fixtures covering fan-out, fan-in, diamonds, folds, mixed port sides, etc. See `examples/topologies/README.md` for full inventory and known issues.
 - `tests/layout_validator.py` - Programmatic layout checks (section overlap, station containment, port positioning, edge waypoints).
 - `tests/test_topology_validation.py` - Parametrized tests running all validator checks against every topology fixture.
 - `scripts/render_topologies.py` - Batch render all fixtures to `/tmp/nf_metro_topology_renders/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The diff script returns exit code 2 on "no changes" and 0 on "changes detected" 
 
 ## Runtime validators
 
-`src/nf_metro/layout/engine.py` exposes `_guard_*` functions gated by `compute_layout(graph, validate=True)`. CLI users get the default (`validate=False`); guards run primarily in tests. When you add an invariant, consider whether a matching runtime guard would catch the same class of bug earlier than CI - several guards in `engine.py` already mirror CI tests one-to-one.
+`src/nf_metro/layout/phases/guards.py` defines the `_guard_*` functions (re-exported from `engine.py`), gated by `compute_layout(graph, validate=True)`. CLI users get the default (`validate=False`); guards run primarily in tests. When you add an invariant, consider whether a matching runtime guard would catch the same class of bug earlier than CI - several guards already mirror CI tests one-to-one.
 
 ## Test fixtures
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ nf-metro render [OPTIONS] INPUT_FILE
 | `--theme [nfcore\|light]` | `nfcore` | Visual theme |
 | `--width INTEGER` | auto | SVG width in pixels |
 | `--height INTEGER` | auto | SVG height in pixels |
-| `--x-spacing FLOAT` | `60` | Horizontal spacing between layers |
-| `--y-spacing FLOAT` | `40` | Vertical spacing between tracks |
+| `--x-spacing FLOAT` | auto | Horizontal spacing between layers (widened from 60 only when wide labels would otherwise collide) |
+| `--y-spacing FLOAT` | auto | Vertical spacing between tracks (derived from the map's content so captioned icons and dense labels don't collide) |
 | `--max-layers-per-row INTEGER` | auto | Max layers before folding to next row |
 | `--animate / --no-animate` | off | Add animated balls traveling along lines |
 | `--debug / --no-debug` | off | Show debug overlay (ports, hidden stations, edge waypoints) |
@@ -134,6 +134,21 @@ Print a summary of the parsed map: sections, lines, stations, and edges.
 nf-metro info INPUT_FILE
 ```
 
+### `nf-metro convert`
+
+Convert a Nextflow `-with-dag` mermaid file to nf-metro `.mmd` format. The output can be rendered directly or hand-tuned first.
+
+```
+nf-metro convert [OPTIONS] INPUT_FILE
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-o`, `--output PATH` | stdout | Output `.mmd` file path |
+| `--title TEXT` | auto | Pipeline title for the converted output |
+
+To convert and render in one step, use the `--from-nextflow` flag on `render` instead. See [Importing from Nextflow](docs/nextflow.md) for details.
+
 ## Examples
 
 The [`examples/`](examples/) directory contains ready-to-render `.mmd` files:
@@ -146,7 +161,7 @@ The [`examples/`](examples/) directory contains ready-to-render `.mmd` files:
 
 ### Topology gallery
 
-The [`examples/topologies/`](examples/topologies/) directory has 15 examples covering a range of layout patterns. See the [topology README](examples/topologies/README.md) for descriptions and rendered previews.
+The [`examples/topologies/`](examples/topologies/) directory has 30 examples covering a range of layout patterns. See the [topology README](examples/topologies/README.md) for descriptions and rendered previews.
 
 A few highlights:
 
@@ -306,15 +321,18 @@ These are automatically rewritten into port-to-port connections with junction st
 |-----------|-------|-------------|
 | `%%metro title: <text>` | Global | Map title |
 | `%%metro logo: <path>` | Global | Logo image (replaces title text) |
+| `%%metro logo_scale: <factor>` | Global | Scale the logo within the legend block (`1.0` = auto-size); values above 1 grow the legend box to contain it |
 | `%%metro style: <name>` | Global | Theme: `dark`, `light` |
 | `%%metro line: <id> \| <name> \| <color> [\| <style>]` | Global | Define a metro line. Optional style: `solid` (default), `dashed`, `dotted` |
 | `%%metro grid: <section> \| <col>,<row>[,<rowspan>[,<colspan>]]` | Global | Pin section to grid position |
-| `%%metro legend: <position>` | Global | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, `none` |
+| `%%metro legend: <position>` | Global | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, `none` (append `\| canvas`, `\| <dx>,<dy>`, or use `<x>,<y>` for finer placement - see the [guide](docs/guide.md)) |
 | `%%metro line_order: <strategy>` | Global | Line ordering for track assignment: `definition` (default) or `span` (longest-spanning lines get inner tracks) |
-| `%%metro file: <station> \| <label>` | Global | Mark a station as a file terminus with a document icon |
-| `%%metro files: <station> \| <label>` | Global | Mark a station with a stacked-documents icon (e.g. paired files) |
-| `%%metro dir: <station> \| <label>` | Global | Mark a station with a folder icon (e.g. output directory) |
+| `%%metro file: <station> \| <label> [\| <name>]` | Global | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon |
+| `%%metro files: <station> \| <label> [\| <name>]` | Global | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption |
+| `%%metro dir: <station> \| <label> [\| <name>]` | Global | Mark a station with a folder icon (e.g. output directory). Optional `name` caption |
+| `%%metro off_track: <station>[, <station>...]` | Global | Lift the listed stations (typically `file:`/`files:`/`dir:` inputs) above the section's main track, so they drop into their consumer instead of consuming a line-track slot |
 | `%%metro compact_offsets: true` | Global | Use compact per-station offsets instead of global line-priority slots (better for dense maps with few lines) |
+| `%%metro center_ports: true` | Global | Centre inter-section ports on the shorter of the two connected sections (overridden by the `--center-ports` / `--no-center-ports` CLI flag) |
 | `%%metro legend_min_height: <pixels>` | Global | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 | `%%metro entry: <side> \| <lines>` | Section | Entry port hint |
 | `%%metro exit: <side> \| <lines>` | Section | Exit port hint |

--- a/docs/dev/layout_pipeline.md
+++ b/docs/dev/layout_pipeline.md
@@ -134,10 +134,10 @@ their consumers, then a few post-lift fixups.
 
 ### Stage 6 - Pass C: vertical settling & finishing
 
-The long settle.  15 sub-stages clean up the consequences of Stages 1
-through 5, snap everything to the grid, restore invariants broken by
-each cleanup pass, then handle the final geometric details (loop-side
-X recenter, bbox shrink, captioned-icon spacing).
+The long settle.  Seventeen sub-stages clean up the consequences of
+Stages 1 through 5, snap everything to the grid, restore invariants
+broken by each cleanup pass, then handle the final geometric details
+(loop-side X recenter, bbox shrink/grow, canvas snap, port re-align).
 
 - **Stages 6.1 to 6.3**: Fan free content / source inputs upward into
   empty top bands; collapse 2-branch symmetric fans onto half-grid
@@ -159,8 +159,23 @@ X recenter, bbox shrink, captioned-icon spacing).
   loop-side stations onto half-pitch Ys to clear bundle
   pass-throughs (the same helper pushes lower rows down internally
   when a shift grew a bbox).
-- **Stage 6.15**: Pad stacked captioned file-icon columns so
-  under-icon captions don't overlap the icon below.
+- **Stage 6.15a**: Fit bbox tops to content, symmetric with the
+  bottom shrink in Stage 6.13.  Grows a bbox top to a full
+  `section_y_padding` above its highest marker when fan
+  re-distribution lifted a branch above the line the box was sized
+  for (#406); shrinks an empty band that the transient row-top flush
+  left above content.  The upward growth re-fits the graph into the
+  canvas.
+- **Stage 6.15**: Snap the whole canvas back onto the `y_spacing`
+  grid.  Stage 6.4 snapped per-row, but the Stage 6.15a re-fit can
+  shift everything by a non-grid amount; when every station shares one
+  residue, shift back to integer multiples.
+- **Stage 6.16**: Re-align LEFT / RIGHT entry ports on TB / BT
+  sections with their feeders.  The late vertical settling drags a
+  perpendicular entry port off the feeder Y it was snapped to in
+  Stage 3.2, re-introducing an inter-section S-kink; re-run the
+  alignment (TB / BT only) and re-anchor junctions to the settled
+  port Ys.
 
 Stage 6 is where most of the historical organic-suffix sprawl (the old
 13d / 13d2 / 13h.1 / 13k2 names) lived.  The flat Stage.N scheme makes
@@ -211,7 +226,7 @@ Common scenarios and where to start looking:
 
 ## Why so many sub-stages
 
-The Pass C tail (Stages 6.1 to 6.15) looks excessive at first glance.
+The Pass C tail (Stages 6.1 to 6.16) looks excessive at first glance.
 Each sub-stage exists because:
 
 1. A bug was found in some real-world fixture.

--- a/docs/dev/layout_pipeline.md
+++ b/docs/dev/layout_pipeline.md
@@ -33,6 +33,48 @@ naturally local (each section's internal layout) and some are global
 chaining many small passes, each of which mutates the graph and
 preserves the invariants of preceding passes.
 
+## The anchor / content-placement split
+
+The passes are not an unstructured sequence of mutators.  They divide
+into two kinds, and the division is the organizing principle of the
+whole pipeline:
+
+- **Structural (anchor-setting) phases** decide where the
+  inter-section line bundle runs.  A section's **anchors** are its
+  port stations - the synthetic points on the section boundary where
+  the bundle crosses.  Port positioning, the row trunk alignment
+  (Stage 4.8), grid snapping, the inter-row cascade, and uniform
+  canvas/row translation are the only phases allowed to move an
+  anchor.
+- **Content-placement phases** position everything else *around* the
+  resolved anchors - fan-out / full-bundle redistribution (4.9, 4.10),
+  band-fill (6.1, 6.2), the symfan half-grid (6.3), full-bundle
+  recenter (6.7), balance-around-trunk (6.11), loop-side recenter
+  (6.12).  A content phase must **never** move an anchor.
+
+This split is what makes the layout **forward-resolvable**: once the
+structural phases have frozen the anchors, every content-placement
+phase is a *pure function of (frozen anchors + section structure)*.  Its
+output depends only on the anchors and the section's tracks/edges/columns,
+never on the mutable intermediate Y or bbox state an earlier phase
+happened to leave behind.  This is stronger than mere idempotence:
+re-running, re-ordering, or perturbing the non-anchor state cannot
+change a content phase's result.  Both properties are machine-checked
+- `_guard_anchors_frozen_during_placement` (runtime, via the
+`_run_placement` wrapper under `validate=True`) plus
+`test_content_placement_idempotent` (#488) and
+`test_content_placement_pure.py` (#491).
+
+When reading the stage walkthrough below, keep the two kinds apart: a
+structural phase that looks like it "moved content" is really moving an
+anchor and letting content follow; a content phase that looks
+order-dependent is, by construction, not.  The rigorous treatment -
+which phases set which anchors, how the frozen *placement reference*
+lets a content phase read an intermediate quantity without breaking
+purity - is in CONTRACT.md's
+[`## Anchor invariant`](https://github.com/pinin4fjords/nf-metro/blob/main/src/nf_metro/layout/CONTRACT.md)
+and `### Content-placement purity` sections.
+
 ## The six stages
 
 The pipeline groups into six stages.  Stage boundaries align with
@@ -238,9 +280,15 @@ Each sub-stage exists because:
 Some sub-stages exist purely to **restore** an invariant that an
 earlier sub-stage broke (e.g. Stages 6.8 and 6.9 restore the
 off-track-above-consumer and row-top-align invariants that Stage 6.7's
-full-bundle recenter breaks).  These "repair-only" sub-stages are
-candidates for being folded back into the breaking stage, but each
-fold is per-pair investigation and risks regressing other pipelines.
+full-bundle recenter breaks).  These "repair-only" sub-stages are a
+residue of the pre-declarative structure: a content phase that broke a
+sibling's placement needed an explicit fix-up afterwards.  The
+anchor / content-placement split now bounds this - the anchor-frozen
+guard guarantees a content phase can't move an anchor, so the only
+repairs that remain are between two content phases that touch the same
+non-anchor stations.  They are candidates for being folded back into
+the breaking stage, but each fold is per-pair investigation and risks
+regressing other pipelines.
 
 The flat Stage.N numbering replaces an earlier organic suffix tree
 (`Phase 13`, `13a`, `13d2`, `13h.1`, `13k2`, ...) that grew suffixes

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -432,12 +432,24 @@ These go at the top of the file, before `graph LR`.
 | `%%metro file: <station> \| <label> [\| <name>]` | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon. |
 | `%%metro files: <station> \| <label> [\| <name>]` | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption. |
 | `%%metro dir: <station> \| <label> [\| <name>]` | Mark a station with a folder icon (e.g. output directory). Optional `name` caption. |
+| `%%metro off_track: <station>[, <station>...]` | Lift the listed stations above the section's main track (see below) |
 | `%%metro compact_offsets: true` | Compact line offsets within stations (see below) |
+| `%%metro center_ports: true` | Centre inter-section ports on the shorter of the two connected sections, so lines enter/exit at the visual midpoint. Overridden by the `--center-ports` / `--no-center-ports` CLI flag. |
 | `%%metro legend_min_height: <pixels>` | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 
 **Compact offsets.** By default, each line reserves a fixed vertical slot across the whole map based on its declaration order. If you define three lines, every station that carries even one of them is sized to fit all three. This keeps bundles visually consistent but wastes space when most stations only carry one or two lines.
 
 With `%%metro compact_offsets: true`, stations are only as wide as the lines actually passing through them. A station where one line enters and a different line exits renders as a dot (zero offset) rather than a pill. This works well for maps with few lines but many stations, like the [variantbenchmarking](https://github.com/pinin4fjords/nf-metro/blob/main/examples/variantbenchmarking.mmd) example.
+
+**Off-track inputs.** Pipelines often have reference or auxiliary inputs (a FASTA, a GTF, a known-variants VCF) that feed *into* a processing step partway through a section rather than flowing along the main route. By default such an input station would claim a line-track slot on the trunk, pushing the layout around. List its station ID in `%%metro off_track:` and nf-metro lifts it above the section's main track, dropping it down into its consumer:
+
+```text
+%%metro file: ref_in | FASTA | Reference
+%%metro file: gtf_in | GTF | Annotation
+%%metro off_track: ref_in, gtf_in
+```
+
+This pairs naturally with the `file:` / `files:` / `dir:` icon directives - the lifted stations are usually file terminals. The [`off_track_convergence`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/topologies/off_track_convergence.mmd) topology and the [differentialabundance](https://github.com/pinin4fjords/nf-metro/blob/main/examples/differentialabundance.mmd) example both use it.
 
 ### Section directives
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,8 +65,8 @@ nf-metro render [OPTIONS] INPUT_FILE
 | `--theme [nfcore\|light]` | `nfcore` | Visual theme |
 | `--width INTEGER` | auto | SVG width in pixels |
 | `--height INTEGER` | auto | SVG height in pixels |
-| `--x-spacing FLOAT` | `60` | Horizontal spacing between layers |
-| `--y-spacing FLOAT` | `40` | Vertical spacing between tracks |
+| `--x-spacing FLOAT` | auto | Horizontal spacing between layers |
+| `--y-spacing FLOAT` | auto | Vertical spacing between tracks |
 | `--max-layers-per-row INTEGER` | auto | Max layers before folding to next row |
 | `--animate / --no-animate` | off | Add animated balls traveling along lines |
 | `--debug / --no-debug` | off | Show debug overlay |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,6 @@ markdown_extensions:
       permalink: true
 
 exclude_docs: |
-  REFACTOR_PLAN.md
   WEBSITE_PLAN.md
 
 nav:


### PR DESCRIPTION
Stacked on #504. The reader-facing layout walkthrough (`docs/dev/layout_pipeline.md`) predated the declarative restructure (#365 → #465 → #487/#491) and never mentioned it - a developer following the recommended entry path (CONTRIBUTING → walkthrough) learned the imperative mutation-chain model but not the **anchor / content-placement split** that is now the pipeline's organizing principle. That story lived only in CONTRACT.md.

- Adds a **"The anchor / content-placement split"** section after "What layout means here": structural (anchor-setting) phases vs content-placement phases, the forward-resolvability / purity property, the machine checks (`_guard_anchors_frozen_during_placement`, `test_content_placement_idempotent` #488, `test_content_placement_pure.py` #491), and a pointer to CONTRACT.md's `## Anchor invariant` + `### Content-placement purity` sections.
- Reframes the "repair-only sub-stages" note as a residue of the pre-declarative structure, now bounded by the anchor-frozen guard.

Docs-only; no renders affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)