### PR TITLE
fix(layout): route around sections + compact placement for complex auto-layout (#484)

### DIFF
--- a/examples/longread_variant_calling.mmd
+++ b/examples/longread_variant_calling.mmd
@@ -1,0 +1,143 @@
+%%metro title: Long-read Variant Calling
+%%metro style: dark
+%%metro files: fastq_in | FASTQ
+%%metro files: bam_in | BAM
+%%metro files: ubam_in | uBAM
+%%metro line: ubam | uBAM | #0570b0
+%%metro line: fastq | FASTQ | #2db572
+%%metro line: bam | BAM | #f5c542
+%%metro line: other | Other | #ff8c00
+%%metro line: snvvcf | SNV VCF | #e63946
+%%metro line: svvcf | SV VCF | #9d4edd
+%%metro legend: tl
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+
+        fastq_in[ ]
+        bam_in[ ]
+        ubam_in[ ]
+        cat_fastq[cat FASTQ]
+        samtools_merge[samtools\nmerge]
+        minimap2_align[minimap2]
+        samtools_sort_index[samtools\nsort/index]
+        mosdepth[mosdepth]
+
+        fastq_in -->|fastq| cat_fastq
+        ubam_in -->|ubam| samtools_merge
+        bam_in -->|bam| samtools_merge
+        cat_fastq -->|fastq| minimap2_align
+        samtools_merge -->|ubam| minimap2_align
+        minimap2_align -->|bam| samtools_sort_index
+        samtools_merge -->|bam| samtools_sort_index
+        samtools_sort_index -->|bam| mosdepth
+    end
+
+    subgraph small_variants [Small variant calling]
+
+        clair3[Clair3]
+        deepvariant[Deepvariant]
+    end
+
+    subgraph cnv_calling [CNVs]
+
+        ontspectre_cnvcaller[ont-spectre CNVCaller]
+    end
+
+    subgraph tr_calling [Repeats]
+
+        longtr[LongTR]
+        straglr[Straglr]
+        trgt[TRGT]
+    end
+
+    subgraph phasing [Phasing]
+
+        whatshap_phase[WhatsHap Phase]
+        whatshap_haplotag[WhatsHap Haplotag]
+
+        whatshap_phase -->|bam,snvvcf| whatshap_haplotag
+    end
+
+    subgraph structural_variants [Structural Variants]
+
+        sniffles[Sniffles]
+        cutesv[CuteSV]
+        jasminesv_callers[Jasmine merge callers]
+
+        sniffles -->|svvcf,bam| jasminesv_callers
+        cutesv -->|svvcf,bam| jasminesv_callers
+    end
+
+    subgraph jointcalling [Joint Calling]
+
+        jasminesv_samples[Jasmine merge samples]
+        glnexus[GLNexus]
+    end
+
+    subgraph annotation [Annotation]
+
+        vep[VEP]
+        snpeff[SnpEff]
+        annotsv[AnnotSV]
+    end
+
+    subgraph reports [Reports]
+
+        geneyx[Geneyx]
+        sv_report[SV Report]
+    end
+
+
+    %% Inter-section edges
+    samtools_sort_index -->|bam| clair3
+    samtools_sort_index -->|bam| deepvariant
+    samtools_sort_index -->|bam| longtr
+    samtools_sort_index -->|bam| straglr
+    samtools_sort_index -->|bam| trgt
+
+    mosdepth -->|other| ontspectre_cnvcaller
+
+    straglr -->|other| geneyx
+
+    clair3 -->|snvvcf| ontspectre_cnvcaller
+    deepvariant -->|snvvcf| ontspectre_cnvcaller
+
+    clair3 -->|bam,snvvcf| whatshap_phase
+    deepvariant -->|bam,snvvcf| whatshap_phase
+
+    clair3 -->|snvvcf| glnexus
+    deepvariant -->|snvvcf| glnexus
+
+    clair3 -->|snvvcf| vep
+    deepvariant -->|snvvcf| vep
+
+    whatshap_haplotag -->|bam| sniffles
+    whatshap_haplotag -->|bam| cutesv
+    whatshap_haplotag -->|bam| jasminesv_samples
+
+    ontspectre_cnvcaller -->|other| geneyx
+
+    sniffles -->|svvcf| jasminesv_samples
+    sniffles -->|svvcf| vep
+    sniffles -->|svvcf| snpeff
+    sniffles -->|svvcf| annotsv
+    sniffles -->|svvcf| geneyx
+
+    cutesv -->|svvcf| jasminesv_samples
+    cutesv -->|svvcf| vep
+    cutesv -->|svvcf| snpeff
+    cutesv -->|svvcf| annotsv
+    cutesv -->|svvcf| geneyx
+
+    jasminesv_callers -->|svvcf| jasminesv_samples
+    jasminesv_callers -->|svvcf| vep
+    jasminesv_callers -->|svvcf| snpeff
+    jasminesv_callers -->|svvcf| annotsv
+    jasminesv_callers -->|svvcf| geneyx
+    jasminesv_callers -->|svvcf| sv_report
+
+    snpeff -->|svvcf| sv_report
+    annotsv -->|svvcf| sv_report
+
+    glnexus -->|snvvcf| vep

--- a/examples/topologies/README.md
+++ b/examples/topologies/README.md
@@ -41,6 +41,10 @@ Each fixture is tagged with the layout class(es) it primarily exercises. Use thi
 | `fold_stacked_branch.mmd` | stacked branches feeding through fold |
 | `u_turn_fold.mmd` | fold with side line joining mid-trunk and leaving pre-end |
 | `wide_label_fan.mmd` | wide station labels / auto label-wrap + column-spread (issue #405) |
+| `route_around_intervening.mmd` | inter-section line detouring around an intervening section box (issue #484) |
+| `self_crossing_bridge.mmd` | same-colour self-crossing bridge glyph (issue #484) |
+| `convergence_stacked_sink.mmd` | convergence return-row stacked-sibling migration (issue #484) |
+| `cross_row_gap_wrap.mmd` | cross-row feed wrapping via the inter-row gap, no counter-flow (issue #484) |
 
 ---
 
@@ -197,3 +201,25 @@ One stacked column contains three siblings of different line counts: a 3-line br
 ### Funcprofiler Upstream
 
 Reduced upstream slice of nf-core/funcprofiler with one input section fanning out to seven profiler tools and back into a MultiQC section. Pinned via xfail in `test_no_almost_horizontal_edges` - documents a known almost-horizontal-edge defect in dense fan-out + fan-in topologies.
+
+---
+
+## #484 Regression Isolation
+
+These minimal fixtures each isolate one layout/routing mechanism that was fixed for issue #484 (a dense long-read pipeline that exposed several engine bugs). Each triggers exactly one mechanism so a future regression in it makes a test fail.
+
+### Route Around Intervening
+
+Three sections in a row (Source, Middle, Target). The `skip` line runs Source to Target directly, skipping Middle. Tests that the inter-section edge detours *around* Middle's box (dropping into the inter-row band below it) rather than slicing through its interior. Backs `test_no_route_passes_through_unrelated_section` and the `_guard_no_route_through_section` guard.
+
+### Self-Crossing Bridge
+
+A single line whose long vertical bus (Top to Bus Sink, descending one column through an intermediate row) crosses its own horizontal connector (Mid Source to Mid Sink) belonging to a separate, non-reconverging branch of the same colour. Because the two legs share a colour but never rejoin, a bridge gap is drawn where the horizontal passes under the bus. Backs `test_bridge_glyph` and `compute_bridges`.
+
+### Convergence Stacked Sink
+
+A main spine (Prep, Align, Dedup) converges at Merge, which is fed both by the spine tail and by a Prep bypass spanning non-adjacent columns. The convergence drops Merge and its successors to a return row. `Repeats` (fed from a separate Aux input so it shares no predecessor with Merge) is a lone stacked spine-sibling that would otherwise sit alone in the spine band; the convergence placer migrates it into the return row. Tests the grid-collision migration in `auto_layout._detect_convergence_split` / `_place_with_convergence`: no two sections share a grid cell and no bboxes overlap.
+
+### Cross-Row Gap Wrap
+
+A convergence layout (Ingest, Align, Dedup on row 0; Merge, Report on the return row) where the `feed` line runs from Ingest down to the rightmost return-row section. Tests that the feed wraps via the clear inter-row gap above the return row (then drops straight into the port) rather than diving under the whole return row counter to its flow. Backs `test_no_artefactual_counter_flow`, `test_entry_approach_arrives_from_port_side`, and their guards.

--- a/examples/topologies/convergence_stacked_sink.mmd
+++ b/examples/topologies/convergence_stacked_sink.mmd
@@ -1,0 +1,54 @@
+%%metro title: Convergence Stacked Sink
+%%metro style: dark
+%%metro line: main | Main | #0570b0
+
+graph LR
+    subgraph prep [Prep]
+        p1[Input]
+        p2[Output]
+        p1 -->|main| p2
+    end
+
+    subgraph aux [Aux Input]
+        x1[Load]
+        x2[Index]
+        x1 -->|main| x2
+    end
+
+    subgraph align [Align]
+        a1[Map]
+        a2[Sort]
+        a1 -->|main| a2
+    end
+
+    subgraph repeats [Repeats]
+        r1[Detect]
+        r2[Genotype]
+        r1 -->|main| r2
+    end
+
+    subgraph dedup [Dedup]
+        d1[Mark]
+        d2[Recal]
+        d1 -->|main| d2
+    end
+
+    subgraph merge_pt [Merge]
+        g1[Combine]
+        g2[Refine]
+        g1 -->|main| g2
+    end
+
+    subgraph report [Report]
+        rp1[Summarise]
+        rp2[Publish]
+        rp1 -->|main| rp2
+    end
+
+    p2 -->|main| a1
+    x2 -->|main| r1
+    a2 -->|main| d1
+    d2 -->|main| g1
+    r2 -->|main| g1
+    p2 -->|main| g1
+    g2 -->|main| rp1

--- a/examples/topologies/cross_row_gap_wrap.mmd
+++ b/examples/topologies/cross_row_gap_wrap.mmd
@@ -1,0 +1,42 @@
+%%metro title: Cross-Row Gap Wrap
+%%metro style: dark
+%%metro line: main | Main | #0570b0
+%%metro line: feed | Feed | #e63946
+
+graph LR
+    subgraph ingest [Ingest]
+        i1[Read]
+        i2[QC]
+        i1 -->|main,feed| i2
+    end
+
+    subgraph align [Align]
+        a1[Map]
+        a2[Sort]
+        a1 -->|main| a2
+    end
+
+    subgraph dedup [Dedup]
+        d1[Mark]
+        d2[Recal]
+        d1 -->|main| d2
+    end
+
+    subgraph merge_pt [Merge]
+        g1[Combine]
+        g2[Refine]
+        g1 -->|main,feed| g2
+    end
+
+    subgraph report [Report]
+        rp1[Summarise]
+        rp2[Publish]
+        rp1 -->|main| rp2
+    end
+
+    i2 -->|main| a1
+    a2 -->|main| d1
+    d2 -->|main| g1
+    i2 -->|main| g1
+    g2 -->|main| rp1
+    i2 -->|feed| g1

--- a/examples/topologies/route_around_intervening.mmd
+++ b/examples/topologies/route_around_intervening.mmd
@@ -1,0 +1,31 @@
+%%metro title: Route Around Intervening
+%%metro style: dark
+%%metro line: trunk | Trunk | #0570b0
+%%metro line: skip | Skip | #e63946
+
+%%metro grid: source | 0,0
+%%metro grid: middle | 1,0
+%%metro grid: target | 2,0
+
+graph LR
+    subgraph source [Source]
+        s1[Input]
+        s2[Output]
+        s1 -->|trunk,skip| s2
+    end
+
+    subgraph middle [Middle]
+        m1[Process]
+        m2[Output]
+        m1 -->|trunk| m2
+    end
+
+    subgraph target [Target]
+        t1[Collect]
+        t2[Report]
+        t1 -->|trunk,skip| t2
+    end
+
+    s2 -->|trunk| m1
+    m2 -->|trunk| t1
+    s2 -->|skip| t1

--- a/examples/topologies/self_crossing_bridge.mmd
+++ b/examples/topologies/self_crossing_bridge.mmd
@@ -1,0 +1,36 @@
+%%metro title: Self-Crossing Bridge
+%%metro style: dark
+%%metro line: bus | Bus | #0570b0
+
+%%metro grid: top | 0,0
+%%metro grid: bus_sink | 0,2
+%%metro grid: mid_src | 0,1
+%%metro grid: mid_sink | 1,1
+
+graph LR
+    subgraph top [Top]
+        t1[Top In]
+        t2[Top Out]
+        t1 -->|bus| t2
+    end
+
+    subgraph mid_src [Mid Source]
+        m1[Mid In]
+        m2[Mid Out]
+        m1 -->|bus| m2
+    end
+
+    subgraph mid_sink [Mid Sink]
+        ms1[Mid Collect]
+        ms2[Mid Report]
+        ms1 -->|bus| ms2
+    end
+
+    subgraph bus_sink [Bus Sink]
+        b1[Bus Collect]
+        b2[Bus Report]
+        b1 -->|bus| b2
+    end
+
+    t2 -->|bus| b1
+    m2 -->|bus| ms1

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -62,6 +62,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "collector fan-in descending a shared inter-column corridor.",
     ),
     (
+        "longread_variant_calling",
+        EXAMPLES_DIR,
+        "Dense long-read variant-calling pipeline (six lines, nine sections): "
+        "exercises inter-section routing around non-connecting section boxes, "
+        "cross-row feeds via the inter-row gap, same-line bundle coincidence, "
+        "and a same-colour crossover bridge.",
+    ),
+    (
         "differentialabundance",
         EXAMPLES_DIR,
         "nf-core/differentialabundance with four input lines, off-track "
@@ -237,6 +245,32 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "A right-exit bundle wrapping down to a left-entry in the row below. "
         "The horizontal run sits centred in the inter-row gap, clear of both "
         "the section above and the next row's header.",
+    ),
+    # --- #484 regression isolation ---
+    (
+        "route_around_intervening",
+        TOPOLOGIES_DIR,
+        "A line skips a middle section: it routes around the intervening "
+        "section's bbox rather than slicing through it.",
+    ),
+    (
+        "self_crossing_bridge",
+        TOPOLOGIES_DIR,
+        "One colour whose vertical bus crosses its own independent horizontal "
+        "connector earns a bridge gap (same-colour crossover, not a fan).",
+    ),
+    (
+        "convergence_stacked_sink",
+        TOPOLOGIES_DIR,
+        "A leaf sink that would otherwise sit alone in the spine band migrates "
+        "into the convergence return row (no grid-cell collision).",
+    ),
+    (
+        "cross_row_gap_wrap",
+        TOPOLOGIES_DIR,
+        "A cross-row feed runs its horizontal in the inter-row gap and drops "
+        "straight in, rather than diving under the return row counter to its "
+        "flow.",
     ),
 ]
 

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -381,6 +381,28 @@ def _detect_convergence_split(
         if sid_preds & convergence_preds:
             return_set.add(sid)
 
+    # Stacked-sibling migration: a section that feeds ONLY into the return
+    # set and would otherwise be a lone stacked sibling in the row-0 spine
+    # band (its topo column also holds a section that stays in row 0) is
+    # pulled onto the return row. Leaving it stacked forces an extra spine
+    # row occupied by a single small section, with a large empty band beside
+    # it (issue #484: tr_calling stacked under small_variants).
+    for sid in list(col_assign.keys()):
+        if sid in return_set:
+            continue
+        sid_succs = successors.get(sid, set())
+        if not sid_succs or not sid_succs.issubset(return_set):
+            continue
+        topo_col = col_assign[sid]
+        has_spine_sibling = any(
+            other != sid
+            and col_assign.get(other) == topo_col
+            and other not in return_set
+            for other in col_groups.get(topo_col, [])
+        )
+        if has_spine_sibling:
+            return_set.add(sid)
+
     # Only split if the return set has enough sections to justify a second row.
     # A single section (e.g. a bypass target) doesn't warrant a row split.
     if len(return_set) < 2:
@@ -407,25 +429,41 @@ def _place_with_convergence(
     sorted_cols = sorted(col_groups.keys())
     folded: dict[str, tuple[int, int]] = {}
 
-    # Place row-0 sections (non-return) left to right
+    # Place row-0 sections (non-return) left to right. A topo column with
+    # multiple spine sections stacks them downward (rows 0, 1, ...), so track
+    # the tallest stack to know which row the return band must clear.
     grid_col = 0
     max_row0_col = 0
+    row0_height = 1
     for topo_col in sorted_cols:
         row0_sids = [s for s in col_groups[topo_col] if s not in return_set]
         if not row0_sids:
             continue
         for i, sid in enumerate(row0_sids):
             folded[sid] = (grid_col, i)
+        row0_height = max(row0_height, len(row0_sids))
         max_row0_col = grid_col
         grid_col += 1
 
-    # Place row-1 sections (return set) right to left
+    # Place return-set sections right to left on the first row clear of the
+    # row-0 stack. Hardcoding row 1 collided with a stacked spine sibling
+    # whenever a row-0 column held 2+ sections (issue #484).
+    return_row = row0_height
     # Sort by topo col ascending: lowest topo col = rightmost on return row
     return_sids = sorted(return_set, key=lambda s: col_assign[s])
     grid_col = max_row0_col
     for sid in return_sids:
-        folded[sid] = (grid_col, 1)
+        folded[sid] = (grid_col, return_row)
         grid_col -= 1
+
+    # Boustrophedon normalization: a return row longer than the row-0 spine
+    # steps past column 0 into negative columns. Shift the whole grid right
+    # so the leftmost column is 0, preserving every section's relative
+    # position (mirrors the serpentine packer; issue #484).
+    if folded:
+        min_col = min(col for col, _ in folded.values())
+        if min_col < 0:
+            folded = {sid: (col - min_col, row) for sid, (col, row) in folded.items()}
 
     # Write results
     for sid, (col, row) in folded.items():
@@ -786,8 +824,18 @@ def _infer_directions(
                 section.direction = "RL"
                 continue
 
-        # TB: all successors are below
-        if succ_rows and all(r > my_row for r in succ_rows):
+        # TB: vertical bridge/serpentine turn. Only when every successor sits
+        # in the row directly below the section's bottom and no further right
+        # than the adjacent column. Successors to the left or directly below
+        # are a same-column drop or a return-row turn that TB serves cleanly;
+        # a successor down-and-to-the-right is instead reached by a flow-aligned
+        # exit plus an inter-section across+down L-shape, so the section stays
+        # horizontal. Successors a row gap away are likewise left to LR + drop.
+        my_bottom = my_row + section.grid_row_span - 1
+        if succ_rows and all(
+            sr == my_bottom + 1 and sc <= my_col + 1
+            for sc, sr in zip(succ_cols, succ_rows)
+        ):
             section.direction = "TB"
             continue
 

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -169,6 +169,16 @@ present a clear horizontal segment through their X coordinate)."""
 BYPASS_CLEARANCE: float = 25.0
 """Vertical clearance below the lowest intervening section for bypass routes."""
 
+ROW_BAND_SLACK: float = BYPASS_CLEARANCE + Y_SPACING
+"""Vertical slack a same-row inter-section route may extend past the row band.
+
+A same-row wrap routes below the row's tallest section through a bypass
+channel sitting ``BYPASS_CLEARANCE`` below the band bottom, then stacks the
+bundle's per-line nest offsets (a few ``OFFSET_STEP`` each) on top, and adds
+up to one ``Y_SPACING`` for the diagonal corner approach.  This slack bounds
+that legitimate excursion so the band guard / invariant test admit a clean
+below-row wrap while still rejecting a route that dips a full row down."""
+
 SECTION_ROUTE_CLEARANCE: float = 16.0
 """Minimum gap between a section bbox edge and an external route channel.
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -109,6 +109,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_anchors_frozen_during_placement,
     _guard_bundle_order_preserved,
     _guard_coordinates_finite,
+    _guard_entry_approach_from_port_side,
     _guard_explicit_grid_directions,
     _guard_fan_bundles_coincide_or_separate,
     _guard_fanout_junction_shares_exit_port_y,
@@ -119,9 +120,12 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_inter_section_route_no_full_width_backtrack,
     _guard_inter_section_routes_in_row_band,
     _guard_merge_port_approach_side,
+    _guard_no_artefactual_counter_flow,
+    _guard_no_collinear_distinct_lines,
     _guard_no_label_overlap,
     _guard_no_line_crosses_non_consumer,
     _guard_no_negative_grid_columns,
+    _guard_no_route_through_section,
     _guard_no_station_overlap,
     _guard_off_track_inputs_above_consumer,
     _guard_partial_branch_offset_gaps,
@@ -1144,13 +1148,21 @@ def _finalize_layout(
                 graph, phase, offsets=offsets, routes=routes
             )
             _guard_bundle_order_preserved(graph, phase, offsets=offsets, routes=routes)
+            _guard_no_collinear_distinct_lines(
+                graph, phase, offsets=offsets, routes=routes
+            )
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)
             _guard_inter_section_route_no_backtrack(graph, phase, routes=routes)
             _guard_inter_section_route_no_full_width_backtrack(
                 graph, phase, routes=routes
             )
             _guard_routes_enter_sections_at_ports(graph, phase, routes=routes)
+            _guard_no_route_through_section(
+                graph, phase, routes=routes, offsets=offsets
+            )
+            _guard_entry_approach_from_port_side(graph, phase, routes=routes)
             _guard_serpentine_no_backtrack(graph, phase, routes=routes)
+            _guard_no_artefactual_counter_flow(graph, phase, routes=routes)
             _guard_inter_row_run_clearance(graph, phase, routes=routes)
             _guard_inter_section_descent_edge_clearance(graph, phase, routes=routes)
             _guard_fan_bundles_coincide_or_separate(

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -121,6 +121,19 @@ def first_vertical_leg_x(points: list[tuple[float, float]]) -> float | None:
     return None
 
 
+def first_vertical_leg_sign(points: list[tuple[float, float]]) -> int | None:
+    """Sign of the first (near-)vertical leg of *points*.
+
+    ``-1`` when the source-side vertical channel ("V1") heads up
+    (toward smaller Y), ``+1`` when it heads down, ``None`` when no
+    vertical leg exists.
+    """
+    for (x0, y0), (x1, y1) in zip(points, points[1:]):
+        if abs(x1 - x0) < COORD_TOLERANCE and abs(y1 - y0) > COORD_TOLERANCE:
+            return -1 if y1 < y0 else 1
+    return None
+
+
 def _canvas_width(graph: MetroGraph) -> float:
     """Horizontal extent of all positioned sections (rightmost - leftmost)."""
     rights = [s.bbox_x + s.bbox_w for s in graph.sections.values() if s.bbox_w > 0]
@@ -226,6 +239,79 @@ def _route_crosses_section_boundary(
                     if not near_port(sid, bx, by):
                         return (rp, sid, bx, by)
     return None
+
+
+def routes_through_unrelated_sections(
+    graph: MetroGraph,
+    *,
+    inset: float = 2.0,
+    routes: list[RoutedPath] | None = None,
+    offsets: dict[tuple[str, str], float] | None = None,
+) -> list[tuple[RoutedPath, str]]:
+    """Return ``(route, section_id)`` for every routed segment that passes
+    through the interior of a section box the route does not belong to.
+
+    A metro line may only occupy a section's bbox coordinates where it
+    connects to a station there: that is, the section must hold the route
+    edge's source (the line starts there) or its target (the line enters
+    via that section's port).  Any other section whose box a routed
+    segment intersects is a pass-through error -- the line is plotted over
+    a section it never interacts with (issue #484).
+
+    Unlike :func:`_route_crosses_section_boundary`, this works on the final
+    rendered geometry (route offsets applied) and inspects *every* route,
+    including fan-in/-out bundle routes through ``__junction_*`` /
+    ``__merge_*`` nodes, which the boundary guard intentionally excludes.
+    Section membership is resolved via ``section_for_station`` (so a merge
+    node assigned to its target section is correctly treated as belonging
+    there).
+    """
+    from nf_metro.layout.geometry import segment_intersects_bbox
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.render.svg import apply_route_offsets
+
+    if offsets is None:
+        offsets = compute_station_offsets(graph)
+    if routes is None:
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failures surface elsewhere
+            return []
+
+    boxes = [
+        (
+            sid,
+            sec.bbox_x + inset,
+            sec.bbox_y + inset,
+            sec.bbox_x + sec.bbox_w - inset,
+            sec.bbox_y + sec.bbox_h - inset,
+        )
+        for sid, sec in graph.sections.items()
+        if sec.bbox_w > 2 * inset and sec.bbox_h > 2 * inset
+    ]
+
+    out: list[tuple[RoutedPath, str]] = []
+    for rp in routes:
+        own = {
+            graph.section_for_station(rp.edge.source),
+            graph.section_for_station(rp.edge.target),
+        }
+        pts = apply_route_offsets(rp, offsets)
+        for sid, x0, y0, x1, y1 in boxes:
+            if sid in own:
+                continue
+            if any(
+                segment_intersects_bbox(
+                    pts[i][0],
+                    pts[i][1],
+                    pts[i + 1][0],
+                    pts[i + 1][1],
+                    (x0, y0, x1, y1),
+                )
+                for i in range(len(pts) - 1)
+            ):
+                out.append((rp, sid))
+    return out
 
 
 def is_loop_side_branch_station(graph: MetroGraph, sid: str) -> bool:

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -12,10 +12,10 @@ from nf_metro.layout.constants import (
     GUARD_TOLERANCE,
     ICON_HALF_HEIGHT,
     OFFSET_STEP,
+    ROW_BAND_SLACK,
     SECTION_Y_GAP,
     STATION_RADIUS_APPROX,
     X_SPACING,
-    Y_SPACING,
 )
 from nf_metro.layout.geometry import BBoxXIndex, segment_intersects_bbox
 from nf_metro.layout.phases._common import (
@@ -24,8 +24,10 @@ from nf_metro.layout.phases._common import (
     _route_crosses_section_boundary,
     _section_bundle_lines,
     _station_marker_bbox,
+    first_vertical_leg_sign,
     first_vertical_leg_x,
     is_loop_side_branch_station,
+    routes_through_unrelated_sections,
 )
 from nf_metro.layout.phases.bbox import _section_fit_top
 from nf_metro.layout.phases.single_section import _terminus_y_overhang
@@ -641,7 +643,8 @@ def _guard_inter_section_routes_in_row_band(
 ) -> None:
     """After routing: inter-section routes whose endpoints both sit in
     grid row R must keep all waypoint Ys within a one-row band centered
-    on R, plus ``Y_SPACING`` slack for diagonal corner approach.
+    on R, plus ``ROW_BAND_SLACK`` for a clean below-row wrap channel
+    (bypass clearance + bundle nest + diagonal corner approach).
     """
     if offsets is None or routes is None:
         from nf_metro.layout.routing import compute_station_offsets, route_edges
@@ -663,7 +666,7 @@ def _guard_inter_section_routes_in_row_band(
         else:
             row_band[sec.grid_row] = (min(cur[0], top), max(cur[1], bot))
 
-    slack = Y_SPACING
+    slack = ROW_BAND_SLACK
     for r in routes:
         src = graph.stations.get(r.edge.source)
         tgt = graph.stations.get(r.edge.target)
@@ -842,23 +845,30 @@ def _guard_fan_bundles_coincide_or_separate(
     if not fan_sources:
         return
 
-    by_src_line: dict[tuple[str, str], list[float]] = {}
+    # Track each route's V1 X together with its vertical direction: two
+    # routes whose source-side channels head OPPOSITE ways (one up, one
+    # down) diverge at the junction and cannot smear, however close their
+    # X channels sit, so they are not paired.
+    by_src_line: dict[tuple[str, str], list[tuple[float, int]]] = {}
     for rp in routes:
         if not rp.is_inter_section or rp.edge.source not in fan_sources:
             continue
         vx = first_vertical_leg_x(rp.points)
-        if vx is None:
+        sign = first_vertical_leg_sign(rp.points)
+        if vx is None or sign is None:
             continue
-        by_src_line.setdefault((rp.edge.source, rp.line_id), []).append(vx)
+        by_src_line.setdefault((rp.edge.source, rp.line_id), []).append((vx, sign))
 
     # Coincide within the per-bundle stagger plus a 1px rounding epsilon;
     # GUARD_TOLERANCE (5px) would swallow the 6px smear this guards against.
     coincide_tol = OFFSET_STEP + 1.0
-    for (src, line), xs in by_src_line.items():
-        if len(xs) < 2:
+    for (src, line), entries in by_src_line.items():
+        if len(entries) < 2:
             continue
-        ordered = sorted(xs)
-        for lo, hi in zip(ordered, ordered[1:]):
+        ordered = sorted(entries)
+        for (lo, lo_sign), (hi, hi_sign) in zip(ordered, ordered[1:]):
+            if lo_sign != hi_sign:
+                continue
             gap = hi - lo
             if coincide_tol < gap < SECTION_Y_GAP:
                 raise PhaseInvariantError(
@@ -959,6 +969,229 @@ def _guard_routes_enter_sections_at_ports(
             f"line {rp.line_id!r} crosses section {sid!r} boundary at "
             f"({bx:.1f}, {by:.1f}) away from any declared port"
         )
+
+
+def _guard_no_route_through_section(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list[RoutedPath] | None = None,
+    offsets: dict[tuple[str, str], float] | None = None,
+) -> None:
+    """After routing: no routed line may pass through the interior of a
+    section box it does not connect to.
+
+    A line may only occupy a section's bbox where it interacts with a
+    station there -- i.e. the section holds the route's source (the line
+    starts there) or target (it enters via that section's port).  A
+    segment crossing any other section's box is plotting the line over a
+    section it never touches (issue #484).  Unlike
+    ``_guard_routes_enter_sections_at_ports`` this inspects the final
+    rendered geometry and every route, including fan-in/-out bundle routes
+    through junction/merge nodes.
+    """
+    offenders = routes_through_unrelated_sections(graph, routes=routes, offsets=offsets)
+    if offenders:
+        rp, sid = offenders[0]
+        raise PhaseInvariantError(
+            f"{phase}: line {rp.line_id!r} on route "
+            f"{rp.edge.source!r}->{rp.edge.target!r} passes through section "
+            f"{sid!r} without interacting with any station there "
+            f"({len(offenders)} pass-through(s) total)"
+        )
+
+
+def _entry_approach_offenders(
+    graph: MetroGraph, routes: list[RoutedPath]
+) -> list[tuple[RoutedPath, str, str]]:
+    """Routes whose final approach to an entry port crosses the target's
+    interior from the port's far side.
+
+    The final leg of a route landing on a perpendicular-axis entry port
+    (LEFT/RIGHT for the X axis, TOP/BOTTOM for the Y axis) must arrive
+    from the port's own OUTWARD side.  A RIGHT entry port must be reached
+    from ``x >= port.x`` (outside the box on the right); a route whose
+    approach leg starts INSIDE the box and runs outward to the port has
+    sliced through the section interior to get there.  Returns
+    ``(route, port_id, reason)`` for each offender.
+    """
+    offenders: list[tuple[RoutedPath, str, str]] = []
+    tol = GUARD_TOLERANCE
+    for rp in routes:
+        port = graph.ports.get(rp.edge.target)
+        if port is None or not port.is_entry:
+            continue
+        section = graph.sections.get(port.section_id) if port.section_id else None
+        if section is None or section.bbox_w <= 0 or section.bbox_h <= 0:
+            continue
+        pts = rp.points
+        if len(pts) < 2:
+            continue
+        end = pts[-1]
+        prev = pts[-2]
+        bx0, by0 = section.bbox_x, section.bbox_y
+        bx1, by1 = bx0 + section.bbox_w, by0 + section.bbox_h
+        if port.side in (PortSide.LEFT, PortSide.RIGHT):
+            # Approach must be horizontal-ish and arrive from outside.
+            if abs(prev[1] - end[1]) > tol:
+                continue
+            if port.side == PortSide.RIGHT and prev[0] < bx1 - tol:
+                offenders.append(
+                    (rp, rp.edge.target, "approaches RIGHT entry from inside box")
+                )
+            elif port.side == PortSide.LEFT and prev[0] > bx0 + tol:
+                offenders.append(
+                    (rp, rp.edge.target, "approaches LEFT entry from inside box")
+                )
+        elif port.side in (PortSide.TOP, PortSide.BOTTOM):
+            if abs(prev[0] - end[0]) > tol:
+                continue
+            if port.side == PortSide.BOTTOM and prev[1] < by1 - tol:
+                offenders.append(
+                    (rp, rp.edge.target, "approaches BOTTOM entry from inside box")
+                )
+            elif port.side == PortSide.TOP and prev[1] > by0 + tol:
+                offenders.append(
+                    (rp, rp.edge.target, "approaches TOP entry from inside box")
+                )
+    return offenders
+
+
+def _guard_entry_approach_from_port_side(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """After routing: a route's final approach to an entry port must arrive
+    from the port's own outward side, not by crossing the target section's
+    interior to reach a far-side port.
+
+    Distinct from ``_guard_no_route_through_section`` (which exempts the
+    route's own target section): this catches a route reaching its OWN
+    target's far-edge entry port by slicing through the box interior and
+    doubling back (issue #484).
+    """
+    routes = _ensure_routes(graph, routes)
+    offenders = _entry_approach_offenders(graph, routes)
+    if offenders:
+        rp, pid, reason = offenders[0]
+        raise PhaseInvariantError(
+            f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} "
+            f"line {rp.line_id!r} {reason} (entry port {pid!r}); the final "
+            f"approach leg crosses the target section interior "
+            f"({len(offenders)} offender(s) total)"
+        )
+
+
+def _row_flow_directions(graph: MetroGraph) -> dict[int, str]:
+    """Dominant horizontal flow direction (``"LR"``/``"RL"``) per grid row.
+
+    Serpentine layout alternates row flow LR/RL.  The direction of a row is
+    the majority of its ``LR``/``RL`` sections; ``TB``/``BT`` transition
+    sections are ignored (they carry no horizontal flow).  Rows with no
+    horizontal section are absent from the result.
+    """
+    counts: dict[int, dict[str, int]] = {}
+    for s in graph.sections.values():
+        if s.bbox_w <= 0 or s.direction not in ("LR", "RL"):
+            continue
+        counts.setdefault(s.grid_row, {"LR": 0, "RL": 0})[s.direction] += 1
+    return {row: ("LR" if c["LR"] >= c["RL"] else "RL") for row, c in counts.items()}
+
+
+def _guard_no_artefactual_counter_flow(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """After routing: a feed from a row ABOVE its target must not run its long
+    horizontal BELOW the target row counter to that row's flow when a clear
+    inter-row gap above the target was available.
+
+    Serpentine rows alternate flow (even rows LR, odd rows RL).  A route into
+    a RIGHT entry port whose source sits in a higher row can either run its
+    rightward traverse in the clear inter-row band just above the target row
+    (then drop straight down the target's RIGHT side into the port), or dive
+    UNDER the whole target row and run that traverse counter to the target
+    row's flow.  The latter is *artefactual* counter-flow: the routing picked
+    the wrong channel when the with-flow gap above was free (issue #484).
+
+    Some counter-flow is *topological* and allowed: a feed into a LEFT/TOP/
+    BOTTOM entry from a far source must wrap to reach the port's outward side,
+    so the counter-flow is intrinsic; and a RIGHT-entry dive whose gap-above
+    band is blocked by an intervening section had no clear alternative.  This
+    guard fires only when the with-flow gap channel above the target row was
+    genuinely free for the run's X-span yet went unused.
+    """
+    from nf_metro.layout.routing.common import (
+        _center_inter_row_channel,
+        resolve_section,
+        row_bottom_edge,
+        row_top_edge,
+    )
+    from nf_metro.layout.routing.core import _h_segment_crosses_other_section
+
+    routes = _ensure_routes(graph, routes)
+
+    tol = GUARD_TOLERANCE
+    row_flow = _row_flow_directions(graph)
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        src_sec = resolve_section(graph, graph.stations.get(rp.edge.source))
+        tgt_sec = resolve_section(graph, graph.stations.get(rp.edge.target))
+        if src_sec is None or tgt_sec is None:
+            continue
+        src_row, tgt_row = src_sec.grid_row, tgt_sec.grid_row
+        if src_row < 0 or tgt_row < 0 or src_row >= tgt_row:
+            continue
+        flow = row_flow.get(tgt_row)
+        if flow is None:
+            continue
+        # Only RIGHT entry ports: the with-flow gap-above approach (drop into
+        # the port from its own outward/right side after a clear gap run) is a
+        # genuine alternative only here.  A LEFT/TOP/BOTTOM entry fed from a far
+        # source must wrap to reach the port's outward side, so any counter-flow
+        # is intrinsic (topological), not an avoidable channel choice.
+        port = graph.ports.get(rp.edge.target)
+        if port is None or not port.is_entry or port.side != PortSide.RIGHT:
+            continue
+        tgt_top = row_top_edge(graph, tgt_row, default=tgt_sec.bbox_y)
+        pts = rp.points
+        if len(pts) < 2:
+            continue
+        # Candidate with-flow channel: the inter-row band immediately ABOVE the
+        # target row (the row above the target's bottom up to the target row's
+        # top).  Its centre Y is where the routing fix runs the rightward
+        # traverse before dropping into the RIGHT port.
+        gap_top = row_bottom_edge(graph, tgt_row - 1, default=tgt_top)
+        gap_bottom = tgt_top
+        if gap_bottom <= gap_top:
+            continue  # no inter-row band above target -> dive was forced
+        gy = _center_inter_row_channel(gap_top, gap_bottom)
+        exclude = {sid for sid in (src_sec.id, tgt_sec.id) if sid is not None}
+        for (x1, y1), (x2, y2) in zip(pts, pts[1:]):
+            if abs(y2 - y1) > tol or abs(x2 - x1) <= tol:
+                continue  # horizontal runs only
+            if y1 < tgt_top - tol:
+                continue  # run sits above the target row's top -> with-flow band
+            # (a) the run goes counter to the target row's flow.
+            counter = (x2 < x1 - tol) if flow == "LR" else (x2 > x1 + tol)
+            if not counter:
+                continue
+            # (b) the with-flow gap above the target was clear for this X-span.
+            if _h_segment_crosses_other_section(graph, x1, x2, gy, exclude):
+                continue  # gap blocked -> dive was topologically necessary
+            raise PhaseInvariantError(
+                f"{phase}: route {rp.edge.source!r}->{rp.edge.target!r} line "
+                f"{rp.line_id!r} runs its horizontal at y={y1:.1f} below target "
+                f"row {tgt_row} (top={tgt_top:.1f}) counter to that row's {flow} "
+                f"flow, but the inter-row gap above the target (y={gy:.1f}) was "
+                f"clear for x=[{min(x1, x2):.1f},{max(x1, x2):.1f}]; this is "
+                f"artefactual counter-flow (issue #484)"
+            )
 
 
 def _guard_serpentine_no_backtrack(
@@ -1163,6 +1396,44 @@ def _guard_bundle_order_preserved(
             return
 
     violations = check_bundle_order_preserved(routes)
+    if not violations:
+        return
+    first = violations[0]
+    extra = f" (+{len(violations) - 1} more)" if len(violations) > 1 else ""
+    raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
+
+
+def _guard_no_collinear_distinct_lines(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: no two distinct lines may render on top of each other.
+
+    Wraps :func:`check_no_collinear_distinct_lines`: a bundling/offset
+    defect that collapses two co-travelling lines onto one channel makes
+    one stroke obscure the other.  Operates on the final, offset-applied
+    inter-section geometry.
+    """
+    from nf_metro.layout.routing.invariants import (
+        check_no_collinear_distinct_lines,
+    )
+
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
+
+        offsets = compute_station_offsets(graph)
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+            return
+
+    violations = check_no_collinear_distinct_lines(graph, routes, offsets)
     if not violations:
         return
     first = violations[0]

--- a/src/nf_metro/layout/phases/ports.py
+++ b/src/nf_metro/layout/phases/ports.py
@@ -183,13 +183,65 @@ def _align_tb_entry_port(
         target_y = max(target_y, entry_section.bbox_y)
         target_y = min(target_y, entry_section.bbox_y + entry_section.bbox_h)
         _set_port_y(graph, port_id, target_y)
+        # A same-column source stacked directly above/below drops in
+        # vertically; align X to it (clear of internal stations) so the
+        # mixed-source case still gets a straight drop, not a jog.
+        drop_x = _vertical_drop_source_x(graph, port, sources, entry_section, my_cols)
+        if drop_x is not None:
+            _set_port_x(graph, port_id, drop_x)
         # Only nudge X for LR/RL sections where TOP/BOTTOM ports are perpendicular
-        if entry_section.direction in ("LR", "RL"):
+        elif entry_section.direction in ("LR", "RL"):
             _nudge_port_from_stations(port_id, entry_section, graph)
     else:
         # Same-column: align X with source for vertical drop
         src_x, _, _ = sources[0]
         _set_port_x(graph, port_id, src_x)
+
+
+def _vertical_drop_source_x(
+    graph: MetroGraph,
+    port: Port,
+    sources: list[tuple[float, float, str | None]],
+    entry_section: Section,
+    my_cols: set[int],
+    tolerance: float = STATION_ELBOW_TOLERANCE,
+) -> float | None:
+    """X for a clean vertical drop from a same-column stacked source.
+
+    Returns the source X if a single same-column source sits in the row
+    directly above (TOP) / below (BOTTOM) and that X is clear of the entry
+    section's internal stations; otherwise None (no straight drop available).
+    """
+    candidate_xs: set[float] = set()
+    for sx, sy, src_sid in sources:
+        src_sec = graph.sections.get(src_sid) if src_sid else None
+        if not src_sec:
+            continue
+        src_cols = set(
+            range(src_sec.grid_col, src_sec.grid_col + src_sec.grid_col_span)
+        )
+        if not (src_cols & my_cols):
+            continue
+        if port.side == PortSide.TOP and src_sec.grid_row >= entry_section.grid_row:
+            continue
+        if port.side == PortSide.BOTTOM and src_sec.grid_row <= entry_section.grid_row:
+            continue
+        candidate_xs.add(sx)
+
+    if len(candidate_xs) != 1:
+        return None
+    drop_x = next(iter(candidate_xs))
+
+    internal_ids = (
+        set(entry_section.station_ids)
+        - set(entry_section.entry_ports)
+        - set(entry_section.exit_ports)
+    )
+    for sid in internal_ids:
+        st = graph.stations.get(sid)
+        if st and not st.is_port and abs(st.x - drop_x) < tolerance:
+            return None
+    return drop_x
 
 
 def _nudge_port_from_stations(
@@ -811,6 +863,15 @@ def _align_tb_section_bbox_bottoms(graph: MetroGraph) -> None:
 
     Skipped for TB sections with BOTTOM-side exit ports (TB->TB flow)
     so the bottom-edge port placement invariant continues to hold.
+
+    Also skipped when the section's LR/RL exit port already sits well
+    above the bbox bottom (more than ``MIN_PORT_STATION_GAP``).  That
+    happens when the exit leaves near the top of the section toward a
+    target in another column/row -- the port is already contained, so
+    stretching the bbox down would only add dead space (and can overlap
+    a section in the row below).  The stretch is only needed for the
+    downward-fold case, where ``_resolve_tb_exit_y`` places the exit
+    port flush at the bbox bottom.
     """
     junction_ids = graph.junction_ids
 
@@ -844,6 +905,23 @@ def _align_tb_section_bbox_bottoms(graph: MetroGraph) -> None:
             continue
         if PortSide.BOTTOM in exit_sides:
             continue
+        current_bot = section.bbox_y + section.bbox_h
+        lr_exit_port_ys = [
+            graph.stations[pid].y
+            for pid in section.exit_ports
+            if pid in graph.ports
+            and graph.ports[pid].side in (PortSide.LEFT, PortSide.RIGHT)
+            and pid in graph.stations
+        ]
+        # Only stretch the downward-fold case, where the exit port sits
+        # flush at (or just above) the bbox bottom.  When every LR/RL
+        # exit port is already clear of the bottom, the port is contained
+        # and the stretch would add dead space.
+        if (
+            lr_exit_port_ys
+            and current_bot - max(lr_exit_port_ys) > MIN_PORT_STATION_GAP
+        ):
+            continue
         target_ids = _downstream_section_ids(section)
         if not target_ids:
             continue
@@ -855,7 +933,6 @@ def _align_tb_section_bbox_bottoms(graph: MetroGraph) -> None:
         if not target_bots:
             continue
         desired_bot = max(target_bots)
-        current_bot = section.bbox_y + section.bbox_h
         if desired_bot - current_bot <= 0.5:
             continue
         section.bbox_h = desired_bot - section.bbox_y

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -531,6 +531,7 @@ def bypass_bottom_y(
     clearance: float = BYPASS_CLEARANCE,
     src_row: int | None = None,
     cross_row: bool = False,
+    tgt_row: int | None = None,
 ) -> float:
     """Bottom Y for a bypass route around intervening sections.
 
@@ -540,6 +541,13 @@ def bypass_bottom_y(
     sections in the same row are considered so that bypass routes
     stay within their row.
 
+    When *tgt_row* is the bottommost grid row, there is nothing below
+    it to clear: routing below "everything" would dive past the canvas
+    floor and then loop back up to the target's entry port.  In that
+    case the channel is placed in the inter-row gap ABOVE the target
+    row instead, so the route descends into that gap and approaches the
+    entry without overshooting.
+
     When there are no intervening sections (adjacent-column bypass),
     falls back to the shorter of the source/target endpoint sections
     so the route hugs the smaller box rather than being pushed down
@@ -548,6 +556,14 @@ def bypass_bottom_y(
     lo, hi = min(src_col, tgt_col), max(src_col, tgt_col)
 
     if cross_row:
+        rows = [s.grid_row for s in graph.sections.values() if s.bbox_w > 0]
+        if tgt_row is not None and rows and tgt_row == max(rows) and tgt_row > 0:
+            # Target is in the bottommost row: route in the gap ABOVE it
+            # rather than below the whole canvas (which would overshoot
+            # and loop back up to the entry port).
+            upper_bottom = row_bottom_edge(graph, tgt_row - 1, default=0.0)
+            lower_top = row_top_edge(graph, tgt_row, default=upper_bottom)
+            return _center_inter_row_channel(upper_bottom, lower_top)
         # Route below ALL sections in the column range.
         all_in_range = [
             s
@@ -584,13 +600,17 @@ def bypass_bottom_y(
         else:
             return clearance
 
-    # Keep the bypass at least HEADER_CLEARANCE above any different-row
+    # Keep the bypass at least HEADER_CLEARANCE above any LOWER-row
     # section header_top; the stacked-line bundle otherwise crowds the
     # badge.  Midpoint fallback for inter-row gaps too tight to satisfy
     # both clearances (layout placement should normally prevent this).
+    # Only sections in rows BELOW the source row constrain a bypass that
+    # runs below the source row -- sections in rows above it sit far over
+    # the bypass and clamping toward them would shove the channel up
+    # through every intervening row.
     if src_row is not None:
         for s in graph.sections.values():
-            if s.bbox_w > 0 and lo <= s.grid_col <= hi and s.grid_row != src_row:
+            if s.bbox_w > 0 and lo <= s.grid_col <= hi and s.grid_row > src_row:
                 header_top = s.bbox_y - SECTION_HEADER_PROTRUSION
                 row_bottom = candidate - clearance
                 safe_cap = header_top - HEADER_CLEARANCE

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -14,6 +14,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 
 from nf_metro.layout.constants import (
+    BUNDLE_TO_BUNDLE_CLEARANCE,
     BYPASS_CLEARANCE,
     COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
@@ -30,6 +31,7 @@ from nf_metro.layout.constants import (
     MIN_STRAIGHT_EDGE,
     MIN_STRAIGHT_PORT,
     OFFSET_STEP,
+    SECTION_HEADER_PROTRUSION,
     SECTION_ROUTE_CLEARANCE,
     STATION_MOVE_TOLERANCE,
 )
@@ -60,6 +62,7 @@ from nf_metro.layout.routing.corners import (
     bypass_radii,
     corner_radius,
     l_shape_radii,
+    reference_anchored_radius,
     reversed_offset,
     tb_entry_corner,
     tb_exit_corner,
@@ -185,6 +188,9 @@ def route_edges(
     _center_bubble_stations(routes, graph)
     _spread_diagonal_bundles(routes, ctx)
     _normalize_gap_channels(routes, ctx)
+    _normalize_bypass_trunks(routes, ctx)
+    _align_peeloff_riser_gaps(routes, ctx)
+    _coincide_convergent_port_approaches(routes)
     _join_fanout_upstream_tails(routes, ctx)
 
     return routes
@@ -545,7 +551,18 @@ def _route_inter_section(
         src_col is not None
         and tgt_col is not None
         and abs(tgt_col - src_col) > 1
-        and _has_intervening_sections(graph, src_col, tgt_col, src_row)
+        and (
+            _has_intervening_sections(graph, src_col, tgt_col, src_row)
+            # A cross-row L-shape runs its horizontal leg at the target
+            # entry Y, which lands in the TARGET row; intervening sections
+            # there are plowed through even when the source row is clear.
+            or (
+                src_row is not None
+                and tgt_row is not None
+                and tgt_row != src_row
+                and _has_intervening_sections(graph, src_col, tgt_col, tgt_row)
+            )
+        )
     )
 
     if abs(dy) < COORD_TOLERANCE_FINE and not needs_bypass:
@@ -608,6 +625,36 @@ def _route_inter_section(
             }
             if not _h_segment_crosses_other_section(graph, sx, tx, ty, exclude):
                 return _route_l_shape(edge, src, tgt, i, n, ctx)
+        # A bypass into a RIGHT entry port whose source is to the LEFT
+        # would rise in the inter-column gap LEFT of the target, then run
+        # its final horizontal RIGHTWARD across the section interior to
+        # reach the right-edge port - entering the far side and doubling
+        # back.  Wrap around BELOW the target and rise on its RIGHT side
+        # so the approach arrives from the port's own outward side.
+        if (
+            tgt_port is not None
+            and tgt_port.is_entry
+            and tgt_port.side == PortSide.RIGHT
+            and sx < tx - COORD_TOLERANCE
+        ):
+            # When the source sits in a row ABOVE the target, going UNDER the
+            # whole target row would run the long horizontal counter to the
+            # target row's flow (an artefactual counter-flow run).  The clear
+            # inter-row gap between the source row and the target row is the
+            # natural, with-the-downward-transition channel: run the rightward
+            # H there, then drop straight down the RIGHT side into the port.
+            # Falls back to the around-below loop when that gap horizontal is
+            # not clear of intervening section interiors.
+            if (
+                src_row is not None
+                and tgt_row is not None
+                and src_row < tgt_row
+                and _right_entry_gap_above_is_clear(graph, src, tgt, tgt, src_row)
+            ):
+                return _route_right_entry_via_gap_above(
+                    edge, src, tgt, tgt, i, n, ctx, src_row
+                )
+            return _route_right_entry_around_below(edge, src, tgt, tgt, i, n, ctx)
         return _route_bypass(edge, src, tgt, i, src_col, tgt_col, ctx, src_row)
 
     # Near-vertical: junction to same-column entry with tiny horizontal
@@ -754,6 +801,24 @@ def _route_inter_section(
                 return _route_stepped_descent(edge, src, ep, i, n, ctx)
             return _route_l_shape(edge, src, ep, i, n, ctx)
 
+    # Standard L-shape: when its horizontal segment at the target Y would
+    # plough through an intervening same-row section to reach a RIGHT entry
+    # port from a higher row, deflect the whole route through the bypass
+    # (descend right of the obstacle, run below the row, rise into the port).
+    if (
+        tgt_port is not None
+        and tgt_port.is_entry
+        and tgt_port.side == PortSide.RIGHT
+        and src_row is not None
+        and tgt_row is not None
+        and tgt_row > src_row
+        and src_col is not None
+        and tgt_col is not None
+    ):
+        exclude = {sid for sid in (src.section_id, tgt.section_id) if sid is not None}
+        if _h_segment_crosses_other_section(graph, sx, tx, ty, exclude):
+            return _route_bypass(edge, src, tgt, i, src_col, tgt_col, ctx, src_row)
+
     # Standard L-shape
     return _route_l_shape(edge, src, tgt, i, n, ctx)
 
@@ -761,14 +826,50 @@ def _route_inter_section(
 def _route_tb_bottom_exit(
     edge: Edge, src: Station, tgt: Station, ctx: _RoutingCtx
 ) -> RoutedPath:
-    """Vertical drop from TB BOTTOM exit with X offsets."""
+    """Vertical drop from TB BOTTOM exit with X offsets.
+
+    When the target sits directly below the exit the route is a clean
+    vertical drop.  When the target X is offset (e.g. a TOP entry port a
+    few px inward of the bottom exit), a straight 2-point connector would
+    be a raw diagonal between two perpendicular ports.  Emit an orthogonal
+    drop / jog / drop with curved corners instead: down out of the BOTTOM
+    port, across the inter-row gap, then down into the target.
+    """
     x_off = _tb_x_offset(ctx, edge.source, edge.line_id, src.section_id)
+    sx = src.x + x_off
+    sy = src.y
+    tx = tgt.x + x_off
+    ty = tgt.y
+
+    if abs(tx - sx) <= COORD_TOLERANCE:
+        return RoutedPath(
+            edge=edge,
+            line_id=edge.line_id,
+            points=[(sx, sy), (tx, ty)],
+            is_inter_section=True,
+            offsets_applied=True,
+        )
+
+    # Misaligned: jog in the inter-row gap so the line leaves the BOTTOM
+    # port travelling downward, transitions across with bounded curves,
+    # then drops into the target.  Corner radii are clamped to half the
+    # horizontal jog so short jogs stay orthogonal rather than collapsing
+    # into a diagonal.
+    dy = ty - sy
+    hy = inter_row_channel_y(ctx.graph, src, tgt, sy, ty, dy, ctx.curve_radius)
+    # Keep the jog Y strictly between the two ports so both vertical legs
+    # have positive length for the corner curves to bite into.
+    lo, hi = (sy, ty) if dy >= 0 else (ty, sy)
+    hy = min(max(hy, lo + ctx.curve_radius), hi - ctx.curve_radius)
+    jog_r = min(ctx.curve_radius, abs(tx - sx) / 2)
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[(src.x + x_off, src.y), (tgt.x + x_off, tgt.y)],
+        points=[(sx, sy), (sx, hy), (tx, hy), (tx, ty)],
         is_inter_section=True,
         offsets_applied=True,
+        normalize_exempt=True,
+        curve_radii=[jog_r, jog_r],
     )
 
 
@@ -1028,6 +1129,7 @@ def _route_bypass(
         BYPASS_CLEARANCE,
         src_row=src_row,
         cross_row=cross_row,
+        tgt_row=tgt_row,
     )
 
     # Determine actual vertical direction at each gap from the geometry.
@@ -1186,6 +1288,47 @@ def _route_bypass(
         else:
             gap2_mid = gap2_base - half_g2
         gap2_x = gap2_mid + delta2
+
+    # When the descent crosses other grid rows, the source/target-row gap
+    # channel can still pierce an oversized section stacked in a crossed row
+    # (its bbox extends into the gap).  Nudge each vertical leg clear of any
+    # box its Y-span pierces, bounded to the inter-column gap so the channel
+    # stays in clear space.
+    if cross_row:
+        exclude = {sid for sid in (src.section_id, tgt.section_id) if sid is not None}
+        if horizontal is Direction.R:
+            g1_lo, g1_hi = column_gap_edges(graph, src_col, src_col + 1)
+            g2_lo, g2_hi = column_gap_edges(graph, tgt_col - 1, tgt_col)
+        else:
+            g1_lo, g1_hi = column_gap_edges(graph, src_col - 1, src_col)
+            g2_lo, g2_hi = column_gap_edges(graph, tgt_col, tgt_col + 1)
+        gap1_x = _clear_channel_x_in_band(
+            graph, gap1_x, sy, by, SECTION_ROUTE_CLEARANCE, exclude, g1_lo, g1_hi
+        )
+        gap2_x = _clear_channel_x_in_band(
+            graph, gap2_x, by, ty, SECTION_ROUTE_CLEARANCE, exclude, g2_lo, g2_hi
+        )
+        # When the source is a junction sitting at/beyond its source
+        # section's right edge and the route runs leftward, the gap1
+        # lead-in at the source Y would plough back across the source box
+        # to reach a left-side descent channel.  Drop the descent on the
+        # RIGHT of the source instead (straight down out of the junction),
+        # so the long leftward traverse happens below the row at ``by``.
+        if horizontal is Direction.L:
+            src_sec = resolve_section(graph, src)
+            if src_sec is not None and src_sec.bbox_w > 0:
+                src_right = src_sec.bbox_x + src_sec.bbox_w
+                if sx >= src_right - COORD_TOLERANCE and gap1_x < src_right:
+                    gap1_x = max(sx, src_right + SECTION_ROUTE_CLEARANCE)
+                    gap1_x = _clear_channel_x_in_band(
+                        graph,
+                        gap1_x,
+                        sy,
+                        by,
+                        SECTION_ROUTE_CLEARANCE,
+                        exclude,
+                        bound_left=gap1_x,
+                    )
 
     # Apply per-line offsets directly so the renderer doesn't have to
     # guess which waypoints belong to the source vs target side.
@@ -1532,8 +1675,11 @@ def _route_top_entry_l_shape(
     )
 
     # Compute Y for the horizontal channel in the inter-row gap.
+    # delta is the vertical-channel X offset; on the down->right corner
+    # the rightmost line (positive delta) turns inside, so it sits at
+    # the smaller (northern) horizontal Y, hence -delta here.
     mid_y = inter_row_channel_y(ctx.graph, src, tgt, sy, ty, dy, ctx.curve_radius)
-    hy = mid_y + delta
+    hy = mid_y - delta
 
     # Horizontal lead-in: a short run so the corner from horizontal to
     # vertical gets a proper curve.  When dx is large, the lead-in
@@ -1552,7 +1698,47 @@ def _route_top_entry_l_shape(
                     if js and js.is_port:
                         lead = Direction.R if js.x < src.x else Direction.L
                         break
-    lx = sx + lead.sign * r_lead
+    # A bundle that genuinely travels across columns (large dx) forms a
+    # horizontal-trunk staircase into the TOP port.  Build it as one
+    # consistent perpendicular offset of a reference line so all four bends
+    # are concentric and the per-line gap stays constant.  The near-vertical
+    # case (source roughly above target, small dx) keeps the original drop
+    # below, where the source/target offsets can differ per end.
+    if n > 1 and abs(dx) > r_lead:
+        return _route_top_entry_offset_bundle(
+            edge,
+            src,
+            tgt,
+            lx0=sx + lead.sign * r_lead,
+            hy0=mid_y,
+            offset=i * ctx.offset_step,
+            lead_sign=lead.sign,
+            base_radius=r_lead,
+        )
+
+    # delta separates bundled lines: as an X offset on the vertical
+    # channel (lx) so co-travelling lines don't overlay, and as a Y
+    # offset on the horizontal channel (hy) above.
+    lx = sx + lead.sign * r_lead + delta
+    # Lead-in corner radius for a co-travelling bundle: the lines are
+    # already separated in Y by the render offset, so an equal radius makes
+    # the arcs non-concentric and the perpendicular gap pinches through the
+    # bend.  Share the bend centre with the outermost line (the one whose
+    # vertical channel sits furthest along the lead direction, kept at base
+    # radius); inner lines turn proportionally tighter so the gap stays
+    # constant.  The short lead-in stub and the long drop both absorb the
+    # smaller radius.  Restricted to narrow bundles where the innermost
+    # radius stays generous; wider bundles keep the flat base radius.
+    max_delta = (n - 1) / 2 * ctx.offset_step
+    if n > 1 and (n - 1) * ctx.offset_step <= r_lead - ctx.offset_step:
+        # Reference line: the one whose vertical channel sits furthest along
+        # the lead direction (delta == lead.sign*max_delta), kept at base.
+        # Inner lines step down by their distance from that reference.
+        r_lead_in = reference_anchored_radius(
+            -abs(lead.sign * max_delta - delta), r_lead
+        )
+    else:
+        r_lead_in = r_lead
     # When the lead-in point is close to the target X, skip the
     # intermediate horizontal channel and drop straight down from the
     # lead-in, curving into the target at the end.  This avoids a
@@ -1564,15 +1750,108 @@ def _route_top_entry_l_shape(
             points=[(sx, sy), (lx, sy), (lx, ty), (tx, ty)],
             is_inter_section=True,
             normalize_exempt=True,
-            curve_radii=[r_lead, r_second],
+            curve_radii=[r_lead_in, r_second],
+        )
+    # Hold the per-line stagger on the final drop so a multi-line bundle
+    # stays parallel down to the port instead of overlaying; converge into
+    # the marker via a short jog only when the drop X is genuinely offset.
+    drop_x = tx + delta
+    if abs(drop_x - tx) < COORD_TOLERANCE:
+        return RoutedPath(
+            edge=edge,
+            line_id=edge.line_id,
+            points=[(sx, sy), (lx, sy), (lx, hy), (tx, hy), (tx, ty)],
+            is_inter_section=True,
+            normalize_exempt=True,
+            curve_radii=[r_lead_in, r_first, r_second],
         )
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[(sx, sy), (lx, sy), (lx, hy), (tx, hy), (tx, ty)],
+        points=[(sx, sy), (lx, sy), (lx, hy), (drop_x, hy), (drop_x, ty), (tx, ty)],
         is_inter_section=True,
         normalize_exempt=True,
-        curve_radii=[r_lead, r_first, r_second],
+        curve_radii=[r_lead_in, r_first, r_second, r_second],
+    )
+
+
+def _route_top_entry_offset_bundle(
+    edge: Edge,
+    src: Station,
+    tgt: Station,
+    *,
+    lx0: float,
+    hy0: float,
+    offset: float,
+    lead_sign: float,
+    base_radius: float,
+) -> RoutedPath:
+    """Concentric multi-line variant of the TOP-entry staircase route.
+
+    The reference line (``offset == 0``) is ``lead-in -> drop -> trunk -> drop
+    straight into the port``; it stays continuous with the rest of its bundle
+    at the junction and with the other routes leaving it.  Each further line
+    is a constant perpendicular offset of that reference: horizontal legs
+    shift down (``+offset`` in Y, matching the render-time source offset),
+    vertical legs shift toward the junction (``-offset`` in X).  The offset is
+    baked into both axes here with ``offsets_applied=True`` so
+    ``apply_route_offsets`` adds no further shift, and every 90-degree bend
+    keeps ``offset + radius = const`` so the arcs are concentric and the
+    per-line gap stays constant through the lead-in corner, the trunk corners
+    and the drop into the port.
+    """
+    sx, sy = src.x, src.y
+    tx, ty = tgt.x, tgt.y
+    lead_in_y = sy + offset
+    drop1_x = lx0 - offset
+    trunk_y = hy0 + offset
+    drop2_x = tx - offset
+
+    # The reference line drops straight into the port; offset lines step down,
+    # across and down, sitting inside the lead-in bend (radius base-offset for
+    # an East lead, base+offset for a West lead), outside the first trunk bend
+    # (base+offset) and inside the second (base-offset).  Each radius is the
+    # reference-anchored concentric form base + signed_offset.
+    r1 = reference_anchored_radius(-lead_sign * offset, base_radius)
+    r2 = reference_anchored_radius(offset, base_radius)
+    r3 = reference_anchored_radius(-offset, base_radius)
+
+    if abs(drop2_x - tx) < COORD_TOLERANCE:
+        # Reference line: no port jog, drop straight in.
+        return RoutedPath(
+            edge=edge,
+            line_id=edge.line_id,
+            points=[
+                (sx, lead_in_y),
+                (drop1_x, lead_in_y),
+                (drop1_x, trunk_y),
+                (tx, trunk_y),
+                (tx, ty),
+            ],
+            is_inter_section=True,
+            normalize_exempt=True,
+            offsets_applied=True,
+            curve_radii=[r1, r2, r3],
+        )
+
+    # Offset line: tight converging jog onto the shared port point.  The jog
+    # can drive base - offset to zero, so floor it at the coordinate tolerance.
+    r4 = reference_anchored_radius(-offset, base_radius, min_radius=COORD_TOLERANCE)
+    return RoutedPath(
+        edge=edge,
+        line_id=edge.line_id,
+        points=[
+            (sx, lead_in_y),
+            (drop1_x, lead_in_y),
+            (drop1_x, trunk_y),
+            (drop2_x, trunk_y),
+            (drop2_x, ty),
+            (tx, ty),
+        ],
+        is_inter_section=True,
+        normalize_exempt=True,
+        offsets_applied=True,
+        curve_radii=[r1, r2, r3, r4],
     )
 
 
@@ -2353,13 +2632,49 @@ def _route_right_entry_wrap(
     dy = ty - sy
     vertical = vertical_direction(dy)
 
-    delta, r_first, r_second = l_shape_radii(
-        i,
-        n,
-        vertical=vertical,
-        offset_step=ctx.offset_step,
-        base_radius=ctx.curve_radius,
-    )
+    # When this wrap shares a junction with mixed-direction siblings
+    # (e.g. another RIGHT-entry feed routed via the inter-row gap above),
+    # share the source-side first-corner X by consuming junction_fan_info
+    # exactly the way _route_left_entry_wrap / _route_right_entry_via_gap_above
+    # do.  Without this the wrap picks lx = sx + curve_radius on its own and
+    # its V1 downturn leg splays apart from the sibling's bundled channel
+    # (issue #484).
+    ekey = (edge.source, edge.target, edge.line_id)
+    fan = ctx.junction_fan_info.get(ekey)
+    if fan is not None:
+        ui, un = fan
+        fan_delta, _r_first, _ = l_shape_radii(
+            ui,
+            un,
+            vertical=vertical,
+            offset_step=ctx.offset_step,
+            base_radius=ctx.curve_radius,
+        )
+        fan_mid_x = sx + ctx.curve_radius + (un - 1) * ctx.offset_step / 2
+        delta = fan_delta
+        off_for_radius, max_off_for_radius = _radius_inputs(fan, i, n, ctx.offset_step)
+        r_first = corner_radius(
+            off_for_radius,
+            max_off_for_radius,
+            outside=True,
+            base_radius=ctx.curve_radius,
+        )
+        _, _, r_second = l_shape_radii(
+            i,
+            n,
+            vertical=vertical,
+            offset_step=ctx.offset_step,
+            base_radius=ctx.curve_radius,
+        )
+    else:
+        delta, r_first, r_second = l_shape_radii(
+            i,
+            n,
+            vertical=vertical,
+            offset_step=ctx.offset_step,
+            base_radius=ctx.curve_radius,
+        )
+        fan_mid_x = None
 
     # Detect cross-row case: use bypass-style Y just below the source
     # row's sections so the line runs horizontally under the adjacent
@@ -2399,17 +2714,283 @@ def _route_right_entry_wrap(
     extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
     vx = tx + base_gap + extra_clearance - delta
 
-    # Short horizontal lead-in so the first corner (horizontal-to-vertical)
-    # gets a smooth curve instead of a sharp right angle at the junction.
-    r_lead = ctx.curve_radius
-    lx = sx + r_lead
+    if fan_mid_x is not None:
+        # Share the source-side first-corner (V1) channel with the junction's
+        # other downturning siblings: place V1 on the fan midline staggered by
+        # this line's per-line delta, then apply the same right-edge clearance
+        # bump the sibling handlers use so all the downturn legs land in one
+        # concentric bundle rather than splaying (#484).  The route still
+        # starts at the junction (sx); the clearance manifests as a longer
+        # horizontal lead-in before C1.
+        v1_x = _v1_corner_x(ctx, src, sx, fan_mid_x + fan_delta)
+        r_lead = r_first
+    else:
+        # Short horizontal lead-in so the first corner (horizontal-to-vertical)
+        # gets a smooth curve instead of a sharp right angle at the junction.
+        r_lead = ctx.curve_radius
+        v1_x = sx + r_lead
+
+    # Bake the per-line station offset into the endpoints (mirroring
+    # _route_left_entry_wrap).  The horizontal channel ``hy`` already carries
+    # the per-line ``delta`` and the deconflicted band Y; if the offset were
+    # left for the renderer's source/target heuristic it would shift the
+    # whole horizontal leg onto a neighbouring line's channel.
+    src_off = _get_offset(ctx, edge.source, edge.line_id)
+    tgt_off = _get_offset(ctx, edge.target, edge.line_id)
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[(sx, sy), (lx, sy), (lx, hy), (vx, hy), (vx, ty), (tx, ty)],
+        points=[
+            (sx, sy + src_off),
+            (v1_x, sy + src_off),
+            (v1_x, hy),
+            (vx, hy),
+            (vx, ty + tgt_off),
+            (tx, ty + tgt_off),
+        ],
         is_inter_section=True,
         normalize_exempt=True,
         curve_radii=[r_lead, r_first, r_first, r_second],
+        offsets_applied=True,
+    )
+
+
+def _right_entry_gap_above_target_y(
+    graph: MetroGraph, src_row: int
+) -> tuple[float, float]:
+    """Return ``(gap_top, gap_bottom)`` of the inter-row band below *src_row*.
+
+    The band sits between the source row's bottom edge and the next row's
+    top edge.  Computed over all columns (not column-restricted) so the
+    long rightward traverse stays clear of every section in the span.
+    """
+    gap_top = row_bottom_edge(graph, src_row)
+    gap_bottom = row_top_edge(graph, src_row + 1, default=gap_top)
+    return gap_top, gap_bottom
+
+
+def _right_entry_gap_above_is_clear(
+    graph: MetroGraph,
+    src: Station,
+    tgt: Station,
+    entry_port: Station,
+    src_row: int,
+) -> bool:
+    """Whether a RIGHT-entry feed from above can use the inter-row gap.
+
+    The route runs its long horizontal in the band just below the source
+    row, then drops straight down the RIGHT side of the target column into
+    the port.  Viable only when that band genuinely exists (the next row's
+    top is below the source row's bottom) and the horizontal at the band's
+    centre crosses no section interior between the source and the target's
+    right edge.
+    """
+    gap_top, gap_bottom = _right_entry_gap_above_target_y(graph, src_row)
+    if gap_bottom <= gap_top:
+        return False
+    gy = _center_inter_row_channel(gap_top, gap_bottom)
+
+    ep_section = (
+        graph.sections.get(entry_port.section_id) if entry_port.section_id else None
+    )
+    section_right = (
+        ep_section.bbox_x + ep_section.bbox_w
+        if ep_section and ep_section.bbox_w > 0
+        else entry_port.x
+    )
+    # Horizontal run spans the source X out to just past the target's right
+    # edge (where the descent channel sits).  Exclude the source and target
+    # sections themselves; any OTHER section the band crosses kills the gap
+    # route (fall back to the around-below loop).
+    exclude = {sid for sid in (src.section_id, tgt.section_id) if sid is not None}
+    return not _h_segment_crosses_other_section(
+        graph, src.x, section_right, gy, exclude
+    )
+
+
+def _build_right_entry_wrap_route(
+    edge: Edge,
+    src: Station,
+    entry_port: Station,
+    i: int,
+    n: int,
+    ctx: _RoutingCtx,
+    channel_y_base: float,
+) -> RoutedPath:
+    """Build a wrap route into a RIGHT entry port from its outward side.
+
+    Shared body of :func:`_route_right_entry_via_gap_above` and
+    :func:`_route_right_entry_around_below`, which differ only in the
+    horizontal channel they pass.  Leads right out of the source, drops to
+    ``channel_y_base`` (offset by the per-line fan ``delta``), runs right
+    past the target's right edge, then turns to the entry Y and in to the
+    RIGHT port from ``vx >= ex`` (its outward side), never crossing the
+    section interior.
+    """
+    sx, sy = src.x, src.y
+    ex, ey = entry_port.x, entry_port.y
+    vertical = vertical_direction(ey - sy)
+
+    ekey = (edge.source, edge.target, edge.line_id)
+    fan = ctx.junction_fan_info.get(ekey)
+    if fan is not None:
+        ui, un = fan
+        fan_delta, _r_first, _ = l_shape_radii(
+            ui,
+            un,
+            vertical=vertical,
+            offset_step=ctx.offset_step,
+            base_radius=ctx.curve_radius,
+        )
+        fan_mid_x = sx + ctx.curve_radius + (un - 1) * ctx.offset_step / 2
+        delta = fan_delta
+    else:
+        delta, _r_first, _r_second = l_shape_radii(
+            i,
+            n,
+            vertical=vertical,
+            offset_step=ctx.offset_step,
+            base_radius=ctx.curve_radius,
+        )
+        fan_mid_x = None
+    off_for_radius, max_off_for_radius = _radius_inputs(fan, i, n, ctx.offset_step)
+    r_outer = corner_radius(
+        off_for_radius,
+        max_off_for_radius,
+        outside=True,
+        base_radius=ctx.curve_radius,
+    )
+
+    hy = channel_y_base + delta
+
+    # V_down/up channel sits just RIGHT of the target section's bbox, in the
+    # gap to the right of the target column; +delta keeps the outer line
+    # (larger radius) on the outside of both turns into the right-side port.
+    ep_section = (
+        ctx.graph.sections.get(entry_port.section_id) if entry_port.section_id else None
+    )
+    section_right = (
+        ep_section.bbox_x + ep_section.bbox_w
+        if ep_section and ep_section.bbox_w > 0
+        else ex
+    )
+    n_for_outer = fan[1] if fan is not None else n
+    base_gap = ctx.curve_radius + ctx.offset_step
+    max_delta = (n_for_outer - 1) * ctx.offset_step / 2
+    extra_clearance = max(0.0, SECTION_ROUTE_CLEARANCE - (base_gap - max_delta))
+    vx = section_right + base_gap + extra_clearance + delta
+
+    if fan_mid_x is not None:
+        corner_x = fan_mid_x + delta
+    else:
+        non_fan_mid_x = sx + ctx.curve_radius + (n - 1) * ctx.offset_step / 2
+        corner_x = non_fan_mid_x + delta
+    corner_x = _v1_corner_x(ctx, src, sx, corner_x)
+    lx = sx
+
+    src_off = _get_offset(ctx, edge.source, edge.line_id)
+    tgt_off = _get_offset(ctx, edge.target, edge.line_id)
+
+    return RoutedPath(
+        edge=edge,
+        line_id=edge.line_id,
+        points=[
+            (lx, sy + src_off),
+            (corner_x, sy + src_off),
+            (corner_x, hy),
+            (vx, hy),
+            (vx, ey + tgt_off),
+            (ex, ey + tgt_off),
+        ],
+        is_inter_section=True,
+        normalize_exempt=True,
+        curve_radii=[r_outer, r_outer, r_outer, r_outer],
+        offsets_applied=True,
+    )
+
+
+def _route_right_entry_via_gap_above(
+    edge: Edge,
+    src: Station,
+    tgt: Station,
+    entry_port: Station,
+    i: int,
+    n: int,
+    ctx: _RoutingCtx,
+    src_row: int,
+) -> RoutedPath:
+    """Route to a RIGHT entry port via the inter-row gap ABOVE the target row.
+
+    Used when the source sits in a row ABOVE the target's row.  Going UNDER
+    the whole target row (:func:`_route_right_entry_around_below`) would run
+    the long rightward horizontal counter to the target row's flow.  Instead
+    run that horizontal in the clear inter-row band just below the source
+    row, then drop straight down the RIGHT side of the target column into the
+    RIGHT entry port::
+
+        (lx, sy) -> (cx, sy)        ; H lead-in right out of the source
+        (cx, sy) -> (cx, gy)        ; V down into the inter-row gap
+        (cx, gy) -> (vx, gy)        ; H right past the target's right edge
+        (vx, gy) -> (vx, ey)        ; V down to the entry Y
+        (vx, ey) -> (ex, ey)        ; H left into the RIGHT entry port
+
+    The approach to the port arrives from ``vx >= ex`` (the port's own
+    outward side), and the horizontal never crosses a section interior
+    (guaranteed by :func:`_right_entry_gap_above_is_clear` at the call site).
+    """
+    gap_top, gap_bottom = _right_entry_gap_above_target_y(ctx.graph, src_row)
+    channel_y_base = _center_inter_row_channel(gap_top, gap_bottom)
+    return _build_right_entry_wrap_route(
+        edge, src, entry_port, i, n, ctx, channel_y_base
+    )
+
+
+def _route_right_entry_around_below(
+    edge: Edge,
+    src: Station,
+    tgt: Station,
+    entry_port: Station,
+    i: int,
+    n: int,
+    ctx: _RoutingCtx,
+) -> RoutedPath:
+    """Route to a RIGHT entry port by going AROUND BELOW the target section.
+
+    The mirror of :func:`_route_around_section_below`.  Used when the
+    source sits to the LEFT of a RIGHT entry port across intervening
+    sections, so a standard bypass would rise in the inter-column gap
+    LEFT of the target and then run its final horizontal RIGHTWARD across
+    the section interior to reach the right-edge port (the route would
+    enter the box's far side and double back).  Instead, descend past the
+    target row's bottom, run leftward-to-rightward under everything, rise
+    in the gap to the RIGHT of the target box, then enter the RIGHT port
+    from the right::
+
+        (lx, sy) -> (cx, sy)        ; H lead-in right out of the source
+        (cx, sy) -> (cx, by)        ; V down past the target row's bottom
+        (cx, by) -> (vx, by)        ; H right past the target's right edge
+        (vx, by) -> (vx, ey)        ; V up to the entry Y
+        (vx, ey) -> (ex, ey)        ; H left into the RIGHT entry port
+
+    The approach to the port arrives from ``vx >= ex`` (the port's own
+    outward side), never crossing the section interior.
+    """
+    # Bypass Y below all sections in the column range so the route clears
+    # every intervening section, including the target row.
+    src_col, src_row = _resolve_section_colrow(ctx.graph, src)
+    ep_col = _resolve_section_col(ctx.graph, entry_port)
+    bc_src_col = src_col if src_col is not None else 0
+    bc_tgt_col = ep_col if ep_col is not None else bc_src_col
+    channel_y_base = bypass_bottom_y(
+        ctx.graph,
+        bc_src_col,
+        bc_tgt_col,
+        BYPASS_CLEARANCE,
+        src_row=src_row,
+        cross_row=True,
+    )
+    return _build_right_entry_wrap_route(
+        edge, src, entry_port, i, n, ctx, channel_y_base
     )
 
 
@@ -2567,12 +3148,21 @@ def _route_tb_lr_exit(
     src_off = _get_offset(ctx, edge.source, edge.line_id)
     max_src_off = _max_offset_at(ctx, edge.source)
 
-    vert_x_off, horiz_y_off, r = tb_exit_corner(
+    vert_x_off, _horiz_y_off, r = tb_exit_corner(
         src_off,
         max_src_off,
         exit_right=(tgt_port.side == PortSide.RIGHT),
         base_radius=ctx.curve_radius,
     )
+    # The horizontal approach must arrive at the exit port at the SAME Y the
+    # outgoing port -> junction route departs (``port.y + port_offset``), or
+    # the line steps by a bundle offset exactly at the section boundary
+    # (issue #484).  ``tb_exit_corner``'s ``horiz_y_off`` is the source
+    # station's reversed offset, which only coincides with the port offset
+    # when every line at the source also exits through this port; otherwise
+    # the leg lands off the port centre.  Use the port's own offset directly
+    # so the inside and outside segments share a Y.
+    horiz_y_off = _get_offset(ctx, edge.target, edge.line_id)
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
@@ -2662,7 +3252,14 @@ def _route_perp_entry(
             edge, src, tgt, upstream_st, src_off, tgt_off, ctx
         )
 
-    if abs(dx) < COORD_TOLERANCE:
+    # When distinct lines share this port and target, hold them on parallel
+    # drop channels so they don't overlay; the port offset alone is per-line
+    # zero for a bundle through one TOP/BOTTOM port.  The stagger order tracks
+    # the target-side tgt_off so the drop->turn corner preserves bundle order.
+    drop_delta = _perp_entry_drop_delta(edge, dx, ctx)
+    drop_x = sx + src_off + drop_delta
+
+    if abs(dx) < COORD_TOLERANCE and abs(drop_delta) < COORD_TOLERANCE:
         # Nearly same X: straight vertical drop
         return RoutedPath(
             edge=edge,
@@ -2671,18 +3268,69 @@ def _route_perp_entry(
             offsets_applied=True,
         )
 
-    # L-shape: vertical drop then horizontal to station
+    # L-shape: vertical drop then horizontal to station.  With a stagger,
+    # fan out from the shared port marker so the lines converge only there.
+    if abs(drop_delta) < COORD_TOLERANCE:
+        pts = [
+            (drop_x, sy),
+            (drop_x, ty + tgt_off),
+            (tx, ty + tgt_off),
+        ]
+        radii = [ctx.curve_radius + src_off]
+    else:
+        pts = [
+            (sx + src_off, sy),
+            (drop_x, sy),
+            (drop_x, ty + tgt_off),
+            (tx, ty + tgt_off),
+        ]
+        radii = [ctx.curve_radius, ctx.curve_radius + src_off]
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[
-            (sx + src_off, sy),
-            (sx + src_off, ty + tgt_off),
-            (tx, ty + tgt_off),
-        ],
+        points=pts,
         offsets_applied=True,
-        curve_radii=[ctx.curve_radius + src_off],
+        curve_radii=radii,
     )
+
+
+def _perp_entry_drop_delta(edge: Edge, dx: float, ctx: _RoutingCtx) -> float:
+    """X stagger for this line on a multi-line perpendicular-port drop.
+
+    Lines sharing a TOP/BOTTOM port carry per-line offset zero at the port,
+    so without a stagger the parallel drops to their target collapse onto
+    one X.  Order the channels by each line's target-side Y offset and pick
+    the sign from the drop->turn handedness so the corner preserves bundle
+    order (the lower line ends inside a westbound turn, outside an eastbound
+    one).
+    """
+    siblings = sorted(
+        {
+            e.line_id
+            for e in ctx.graph.edges
+            if e.source == edge.source and e.target == edge.target
+        },
+        key=lambda lid: (_get_offset(ctx, edge.target, lid), lid),
+    )
+    n = len(siblings)
+    if n < 2:
+        return 0.0
+    # When the port-side bundle offsets already fan the siblings into distinct
+    # slots, the drop inherits that separation and an extra stagger only
+    # doubles it (a tight bundle splays apart on the way in).  Stagger only
+    # when the lines would otherwise collapse onto one drop X - i.e. their
+    # source-port offsets are effectively uniform.
+    src_offs = [_get_offset(ctx, edge.source, lid) for lid in siblings]
+    if max(src_offs) - min(src_offs) >= (n - 1) * ctx.offset_step - COORD_TOLERANCE:
+        return 0.0
+    i = siblings.index(edge.line_id)
+    # Order channels by target-side Y offset so the drop->turn corner keeps
+    # bundle order: a larger tgt_off (lower) arrives on the south side of the
+    # turn, which maps to the larger X on a westbound (D->L) descent and the
+    # smaller X on an eastbound (D->R) one.
+    centred = i - (n - 1) / 2
+    sign = 1.0 if dx < 0 else -1.0
+    return sign * centred * ctx.offset_step
 
 
 def _find_upstream_for_merge(
@@ -3894,6 +4542,778 @@ def _normalize_gap_channels(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
                 _restack_channel(ch, nx, li, n, step, ctx.curve_radius)
 
 
+@dataclass
+class _HTrunk:
+    """One horizontal bypass-trunk segment of an inter-section route.
+
+    The trunk is the interior horizontal leg of a U-shaped bypass
+    (``points[k] -> points[k+1]``), flanked by a vertical descent on each
+    side.  ``y`` is its current channel Y, ``x_lo``/``x_hi`` its X span,
+    and ``dips_down`` records whether the U dips below its flanking legs
+    (the common case: source/target sit above the trunk).
+    """
+
+    route: RoutedPath
+    idx: int
+    y: float
+    x_lo: float
+    x_hi: float
+    dips_down: bool
+    sign_x: int  # traversal direction along the trunk: +1 left->right, -1 right->left
+
+
+def _collect_htrunks(
+    routes: list[RoutedPath], *, include_exempt: bool = False
+) -> list[_HTrunk]:
+    """Find every horizontal bypass-trunk segment in inter-section routes.
+
+    A trunk is an interior horizontal segment (not the first or last leg)
+    whose two flanking neighbours are both vertical, i.e. the bottom (or
+    top) leg of a U-shaped :func:`_route_bypass` route.
+
+    With *include_exempt*, ``normalize_exempt`` routes are collected too;
+    callers use these as read-only obstacles (their geometry is owned by
+    their own handler and must not be restacked).
+    """
+    out: list[_HTrunk] = []
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        if rp.normalize_exempt and not include_exempt:
+            continue
+        pts = rp.points
+        for k in range(1, len(pts) - 2):
+            x0, y0 = pts[k]
+            x1, y1 = pts[k + 1]
+            if abs(y1 - y0) > COORD_TOLERANCE or abs(x1 - x0) <= COORD_TOLERANCE:
+                continue
+            # Both flanking neighbours must be vertical legs.
+            if abs(pts[k - 1][0] - x0) > COORD_TOLERANCE:
+                continue
+            if abs(pts[k + 2][0] - x1) > COORD_TOLERANCE:
+                continue
+            dips_down = pts[k - 1][1] < y0 - COORD_TOLERANCE
+            out.append(
+                _HTrunk(
+                    route=rp,
+                    idx=k,
+                    y=y0,
+                    x_lo=min(x0, x1),
+                    x_hi=max(x0, x1),
+                    dips_down=dips_down,
+                    sign_x=1 if x1 > x0 else -1,
+                )
+            )
+    return out
+
+
+def _group_channel_trunks(
+    trunks: list[_HTrunk], step: float, ctx: _RoutingCtx | None = None
+) -> list[list[_HTrunk]]:
+    """Group horizontal bypass trunks that visually share one channel.
+
+    Trunks belong together when they share a dip direction and transitively
+    overlap in X within one channel.  Channel membership is decided two ways:
+
+    - When *ctx* is given and both trunks fall inside the SAME inter-row gap
+      (the ``[row_bottom, next_row_top]`` envelope from
+      :func:`_inter_row_gap_band`), they share that channel however far apart
+      their current Ys sit.  Several bypass routes that dip into one inter-row
+      gap are one visual channel even when their per-bundle ``nest_offset``
+      left them a smear of distinct Ys, so they must fan into a single tight
+      ``OFFSET_STEP`` bundle rather than separate loose groups.
+    - Otherwise (no ctx, or a trunk outside every inter-row gap) membership
+      falls back to proximity to the NEAREST current member: trunks arrive
+      pre-stacked by their per-bundle ``nest_offset``, so a trunk one ``step``
+      deeper than the group's current deepest member still belongs.  A
+      genuinely separate channel a full row away (Ys far outside the chain)
+      then starts its own group.
+
+    The shared X-overlap requirement keeps distinct corridors in the same gap
+    band - different X regions that never overlap - in separate groups.
+    """
+    band = max(step, COORD_TOLERANCE)
+    gap_of = {id(t): _inter_row_gap_band(ctx, t.y) for t in trunks} if ctx else {}
+
+    def _same_channel(o: _HTrunk, t: _HTrunk) -> bool:
+        go, gt = gap_of.get(id(o)), gap_of.get(id(t))
+        if go is not None and go == gt:
+            return True
+        return abs(o.y - t.y) <= band
+
+    groups: list[list[_HTrunk]] = []
+    for t in sorted(trunks, key=lambda t: (t.dips_down, t.y, t.x_lo)):
+        placed = False
+        for grp in groups:
+            if grp[0].dips_down != t.dips_down:
+                continue
+            if not any(_same_channel(o, t) for o in grp):
+                continue
+            if any(t.x_lo < o.x_hi and o.x_lo < t.x_hi for o in grp):
+                grp.append(t)
+                placed = True
+                break
+        if not placed:
+            groups.append([t])
+    return groups
+
+
+def _align_peeloff_riser_gaps(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
+    """Match a peel-off riser bundle's spacing to its shared trunk's spacing.
+
+    When several inter-section lines travel as one concentric bundle along a
+    shared horizontal trunk (fanned ``OFFSET_STEP`` apart by
+    :func:`_normalize_bypass_trunks`) and a SUBSET of them peels off at the
+    same end - rising into a common entry port - the riser legs were
+    independently re-stacked by :func:`_normalize_gap_channels` into a
+    compacted bundle (adjacent ``OFFSET_STEP`` slots).  Two lines three slots
+    apart on the trunk (e.g. the outer two of a four-line trunk) thus rise
+    only one slot apart, so the perpendicular gap collapses through the bend
+    and the parallel lines pinch instead of staying concentric (issue #484,
+    the corner just before the leftmost Reports section).
+
+    This pass restores concentricity at the bend: for each shared trunk
+    channel, the risers that peel off at the same turning corner are re-spaced
+    so their perpendicular X-gap equals the perpendicular Y-gap they hold on
+    the trunk, preserving order (outer trunk -> outer riser).  The flanking
+    corner radii are recomputed concentrically.  Only fires when the riser
+    spacing actually disagrees with the trunk spacing, so a bundle whose
+    members are already contiguous on the trunk is left untouched.
+    """
+    step = ctx.offset_step
+    trunks = _collect_htrunks(routes)
+    if len(trunks) < 2:
+        return
+
+    for grp in _group_channel_trunks(trunks, step):
+        if len({id(t.route) for t in grp}) < 2:
+            continue
+        # A peel-off riser is the vertical segment immediately adjacent to the
+        # trunk on the turning side, followed by a horizontal lead into a port.
+        # Collect, per turning side, the (trunk Y, riser channel) of every
+        # trunk in this group that turns off there.
+        for side in ("hi", "lo"):
+            risers: list[tuple[float, _VChannel]] = []
+            for t in grp:
+                rc = _peeloff_riser(t, side)
+                if rc is not None:
+                    risers.append((t.y, rc))
+            if len(risers) < 2:
+                continue
+            # Risers that peel off at DIFFERENT X (heading to different ports)
+            # are independent bends; only those that turn off at the same place
+            # form one bundle whose spacing must be preserved.  Cluster by
+            # riser X (a turn-off is shared when the channels sit within the
+            # full fanned-trunk width of each other).
+            cluster_tol = max(t.y for t in grp) - min(t.y for t in grp) + step
+            risers.sort(key=lambda r: r[1].x)
+            cluster: list[tuple[float, _VChannel]] = []
+            for r in risers + [None]:  # sentinel flush
+                if cluster and (r is None or r[1].x - cluster[-1][1].x > cluster_tol):
+                    lines = {rc.route.line_id for _, rc in cluster}
+                    if len(cluster) >= 2 and len(lines) >= 2:
+                        _respace_risers_to_trunk(cluster, step, ctx.curve_radius)
+                    cluster = []
+                if r is not None:
+                    cluster.append(r)
+
+
+def _peeloff_riser(t: _HTrunk, side: str) -> _VChannel | None:
+    """The vertical riser segment turning off a trunk at *side* ('hi'/'lo').
+
+    Returns the ``_VChannel`` for the vertical leg flanking trunk *t* on its
+    higher-X (``side == 'hi'``) or lower-X (``'lo'``) end, but only when that
+    leg in turn leads into a horizontal segment (the port-approach lead),
+    i.e. the trunk peels UP/DOWN and then turns to enter a section.  Returns
+    ``None`` when there is no such riser-then-horizontal on that side.
+    """
+    rp = t.route
+    pts = rp.points
+    k = t.idx  # trunk is pts[k] -> pts[k+1]
+    if side == "lo":
+        # Riser precedes the trunk: pts[k-1] -> pts[k]; lead is pts[k-2].
+        vi = k - 1
+        lead_i = k - 2
+    else:
+        # Riser follows the trunk: pts[k+1] -> pts[k+2]; lead is pts[k+3].
+        vi = k + 1
+        lead_i = k + 3
+    if vi < 0 or vi + 1 >= len(pts):
+        return None
+    x0, y0 = pts[vi]
+    x1, y1 = pts[vi + 1]
+    if abs(x1 - x0) > COORD_TOLERANCE or abs(y1 - y0) <= COORD_TOLERANCE:
+        return None
+    # The riser must lead into a horizontal segment (the port approach).
+    if not (0 <= lead_i < len(pts)):
+        return None
+    lx = pts[lead_i][0]
+    # lead point shares its riser endpoint's Y -> horizontal lead present.
+    ly_idx = vi if side == "lo" else vi + 1
+    if abs(pts[lead_i][1] - pts[ly_idx][1]) > COORD_TOLERANCE:
+        return None
+    if abs(lx - pts[ly_idx][0]) <= COORD_TOLERANCE:
+        return None
+    return _VChannel(
+        route=rp,
+        idx=vi,
+        x=x0,
+        y_lo=min(y0, y1),
+        y_hi=max(y0, y1),
+        down=y1 > y0,
+    )
+
+
+def _respace_risers_to_trunk(
+    risers: list[tuple[float, _VChannel]],
+    step: float,
+    base_radius: float,
+) -> None:
+    """Re-space a peel-off riser bundle to its trunk's perpendicular spacing.
+
+    *risers* pairs each turning line's trunk Y with its riser channel.  The
+    risers all share one port (their lead horizontals converge), so the bundle
+    centre is anchored on the current mean riser X; each riser is then offset
+    from that centre by the SAME signed magnitude it sits from the trunk-bundle
+    centre (its trunk Y minus the bundle's mean Y), preserving the
+    outer-trunk -> outer-riser order and the constant perpendicular gap that
+    keeps the bend concentric.  The flanking corner radii are recomputed from
+    each riser's actual offset so the nested arcs stay an equal gap apart.
+    No-op when the riser spacing already matches the trunk spacing.
+    """
+    # Collapse to one representative per distinct LINE: same-line risers (a
+    # fan whose line feeds several targets) share one slot, so they must move
+    # together to a single X rather than each claiming a slot.
+    per_line: dict[str, tuple[float, float]] = {}
+    for ty, rc in risers:
+        lid = rc.route.line_id
+        if lid not in per_line:
+            per_line[lid] = (ty, rc.x)
+    if len(per_line) < 2:
+        return
+    lines = list(per_line)
+    trunk_ys = [per_line[lid][0] for lid in lines]
+    riser_xs = [per_line[lid][1] for lid in lines]
+    riser_mid = sum(riser_xs) / len(lines)
+    trunk_mid = sum(trunk_ys) / len(lines)
+    # Sign coupling from the current crossing-free geometry: if the currently
+    # leftmost line comes from the shallower (smaller-Y) trunk, increasing X
+    # tracks increasing trunk Y; otherwise the mapping is flipped.  Mirror the
+    # trunk's signed perpendicular offset onto X with that sign so no crossing
+    # is introduced.
+    order = sorted(range(len(lines)), key=lambda j: riser_xs[j])
+    sign = 1.0 if trunk_ys[order[0]] <= trunk_ys[order[-1]] else -1.0
+    target_x = {
+        lines[j]: riser_mid + sign * (trunk_ys[j] - trunk_mid)
+        for j in range(len(lines))
+    }
+    if all(abs(target_x[lid] - per_line[lid][1]) <= COORD_TOLERANCE for lid in lines):
+        return
+    max_off = (max(target_x.values()) - min(target_x.values())) / 2
+    for _ty, rc in risers:
+        _set_riser_x_and_radii(
+            rc, target_x[rc.route.line_id], riser_mid, max_off, base_radius
+        )
+
+
+def _corner_outside_sign(
+    turn_in: tuple[float, float], turn_out: tuple[float, float]
+) -> int:
+    """Sign of ``new_x - centre`` that puts a line OUTSIDE a riser-flanking turn.
+
+    *turn_in* / *turn_out* are the travel-direction vectors of the two segments
+    meeting at the corner.  A CCW turn (positive cross) curves outward to the
+    RIGHT of travel; a CW turn (negative cross) outward to the LEFT.  Along the
+    vertical riser leg, right-of-travel is +X when travelling DOWN and -X when
+    travelling UP.  Returns +1 when the larger-X line is the outside one, -1
+    when the smaller-X line is.
+    """
+    cross = turn_in[0] * turn_out[1] - turn_in[1] * turn_out[0]
+    v = turn_in if abs(turn_in[1]) > abs(turn_in[0]) else turn_out
+    right_is_plus_x = v[1] > 0  # DOWN travel: right-of-travel is +X
+    outside_is_right = cross < 0  # CW turn curves outward to the right
+    return 1 if (right_is_plus_x == outside_is_right) else -1
+
+
+def _set_riser_x_and_radii(
+    ch: _VChannel,
+    new_x: float,
+    centre_x: float,
+    max_off: float,
+    base_radius: float,
+) -> None:
+    """Move a riser channel to *new_x* and size its flanking corners.
+
+    Mirrors :func:`_restack_channel` but sizes each flanking corner radius
+    from the riser's actual signed offset (``new_x - centre_x``) rather than
+    an integer ``OFFSET_STEP`` slot, so a bundle spaced wider than one step -
+    inherited from a fanned trunk - keeps its nested arcs an equal
+    perpendicular gap apart.  Each corner's handedness is read from the local
+    segment directions, so a Z-step riser (whose two corners turn opposite
+    ways) gets the correct inner/outer assignment at each end.
+    """
+    rp = ch.route
+    pts = rp.points
+    k = ch.idx
+    pts[k] = (new_x, pts[k][1])
+    pts[k + 1] = (new_x, pts[k + 1][1])
+    if rp.curve_radii is None or max_off <= COORD_TOLERANCE:
+        return
+    off_signed = new_x - centre_x
+    v_dir = (0.0, 1.0) if pts[k + 1][1] > pts[k][1] else (0.0, -1.0)
+    # Lead corner (incoming H -> V) at pts[k], radius slot k-1.
+    # Trail corner (V -> outgoing H) at pts[k+1], radius slot k.
+    for corner_idx, radius_idx, is_lead in ((k, k - 1, True), (k + 1, k, False)):
+        nbr_idx = corner_idx - 1 if is_lead else corner_idx + 1
+        if not (0 <= nbr_idx < len(pts)):
+            continue
+        # X direction of the horizontal segment, away from the corner.
+        hx = 1.0 if pts[nbr_idx][0] > pts[corner_idx][0] else -1.0
+        if is_lead:
+            turn_in = (-hx, 0.0)  # H travels toward the corner
+            turn_out = v_dir
+        else:
+            turn_in = v_dir
+            turn_out = (hx, 0.0)
+        side = _corner_outside_sign(turn_in, turn_out)
+        # Outside line (offset sign matches `side`) gets the largest radius;
+        # inner edge gets base.  Magnitude measured from the innermost line.
+        r = base_radius + max_off + off_signed * side
+        if not (0 <= radius_idx < len(rp.curve_radii)):
+            continue
+        if not is_lead and not (k + 2 < len(pts)):
+            continue
+        rp.curve_radii[radius_idx] = r
+
+
+def _final_port_approach(rp: RoutedPath) -> _VChannel | None:
+    """The final vertical descent into a port, when the route ends V then H.
+
+    A converging port approach ends ``... (vx, y) -> (vx, ey) -> (ex, ey)``:
+    a vertical leg into the entry Y, then a short horizontal lead into the
+    port.  Returns the ``_VChannel`` for that vertical (``idx`` points at
+    ``points[-3]``), or ``None`` when the tail is not vertical-then-horizontal.
+    """
+    pts = rp.points
+    if len(pts) < 3:
+        return None
+    x1, y1 = pts[-1]
+    x2, y2 = pts[-2]
+    x3, y3 = pts[-3]
+    if abs(y2 - y1) > COORD_TOLERANCE or abs(x2 - x1) <= COORD_TOLERANCE:
+        return None  # last segment is not a horizontal lead
+    if abs(x3 - x2) > COORD_TOLERANCE or abs(y3 - y2) <= COORD_TOLERANCE:
+        return None  # second-to-last segment is not a vertical descent
+    return _VChannel(
+        route=rp,
+        idx=len(pts) - 3,
+        x=x2,
+        y_lo=min(y2, y3),
+        y_hi=max(y2, y3),
+        down=y2 > y3,
+    )
+
+
+def _coincide_convergent_port_approaches(routes: list[RoutedPath]) -> None:
+    """Fuse same-line vertical approaches converging on one port into one track.
+
+    Several inter-section edges of the SAME metro line can arrive at one entry
+    port as separate near-parallel vertical descents (each turning into the
+    port via its own short horizontal lead) a few pixels apart -- redundant
+    duplicate tracks of one colour into a single convergence point (#484
+    follow-up).  Where those final descents already sit in a tight band (so
+    they are genuinely the same convergence channel, not legitimately distinct
+    corridors arriving from far apart), snap them to one shared X so the line
+    arrives as a single track and splits only upstream where each feed's
+    horizontal lead peels off at its own Y.
+
+    Channels are clustered by terminal port + line + descent direction; only
+    clusters whose members fall within ``EDGE_TO_BUNDLE_CLEARANCE`` of each
+    other are fused (the band excludes widely-staggered same-line inputs that
+    descend in separate column gaps).  The merge X is the member nearest the
+    port (smallest |vx - ex|), keeping the fused track on the side the port is
+    already approached from.  Flanking corners reset to the base radius: the
+    fused descents are a single track, so the concentric-bundle radii no
+    longer apply.
+    """
+    by_port: dict[tuple[float, float, str, bool], list[_VChannel]] = defaultdict(list)
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        ch = _final_port_approach(rp)
+        if ch is None:
+            continue
+        ex, ey = rp.points[-1]
+        key = (round(ex, 1), round(ey, 1), rp.line_id, ch.down)
+        by_port[key].append(ch)
+
+    band = EDGE_TO_BUNDLE_CLEARANCE
+    for (ex, _ey, _lid, _down), chans in by_port.items():
+        if len(chans) < 2:
+            continue
+        # Cluster by descent X proximity; widely-separated descents are
+        # distinct corridors and must not be fused.
+        chans.sort(key=lambda c: c.x)
+        cluster: list[_VChannel] = []
+
+        def _flush(cluster: list[_VChannel]) -> None:
+            if len(cluster) < 2:
+                return
+            merge_x = min(cluster, key=lambda c: abs(c.x - ex)).x
+            for c in cluster:
+                if abs(c.x - merge_x) > COORD_TOLERANCE:
+                    _set_port_approach_x(c, merge_x)
+
+        for ch in chans:
+            if cluster and ch.x - cluster[-1].x > band:
+                _flush(cluster)
+                cluster = []
+            cluster.append(ch)
+        _flush(cluster)
+
+
+def _set_port_approach_x(ch: _VChannel, new_x: float) -> None:
+    """Move a final port-approach vertical to *new_x*, resetting its corners.
+
+    The fused descents form one track, so both flanking corners take the base
+    ``CURVE_RADIUS`` (no concentric nesting remains to size them apart).
+    """
+    rp = ch.route
+    pts = rp.points
+    k = ch.idx
+    pts[k] = (new_x, pts[k][1])
+    pts[k + 1] = (new_x, pts[k + 1][1])
+    if rp.curve_radii is None:
+        return
+    for radius_idx in (k - 1, k):
+        if 0 <= radius_idx < len(rp.curve_radii):
+            rp.curve_radii[radius_idx] = CURVE_RADIUS
+
+
+def _normalize_bypass_trunks(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
+    """Separate horizontal bypass trunks that share one below-row channel.
+
+    Several inter-section bypass routes can dip into the same below-row
+    channel and, with their per-line ``nest_offset`` resolved independently
+    per bundle, end up drawn at the *same* Y (overlapping) or at a loose
+    smear of distinct Ys (issue #484).  This post-pass mirrors
+    :func:`_normalize_gap_channels` for the horizontal trunk legs: trunks
+    that share a channel (same inter-row gap, same dip direction, overlapping
+    X) are fanned ``OFFSET_STEP`` apart into a concentric bundle, with the
+    widest-reaching trunk on the outside so the nesting introduces no
+    crossings.
+
+    Channel membership uses the inter-row gap envelope, so wrap-route trunks
+    placed by their own handler (``normalize_exempt``) that co-travel through
+    the same gap join the bundle too; they are only fanned when grouped with a
+    non-exempt trunk in that gap (a genuine shared multi-line channel), so a
+    pure-exempt run keeps its handler-owned Y and is left to
+    :func:`_dogleg_off_exempt_trunks`.
+
+    Trunks already at distinct Ys, or alone in their channel, are left
+    untouched; the flanking corner radii are recomputed for any trunk that
+    actually moves so the bundle stays concentric.
+    """
+    step = ctx.offset_step
+    trunks = _collect_htrunks(routes, include_exempt=True)
+    groups = _group_channel_trunks(trunks, step, ctx) if len(trunks) >= 2 else []
+
+    # Routes whose trunk this pass has placed into a concentric bundle; the
+    # dogleg pass treats exempt trunks as fixed obstacles and shoves nearby
+    # trunks clear, which would tear a freshly-fanned 3px bundle apart, so it
+    # skips any route already bundled here.
+    bundled: set[int] = set()
+
+    for grp in groups:
+        # One trunk per distinct route; a shared channel needs >1 to fan.
+        if len({id(t.route) for t in grp}) < 2:
+            continue
+        # Exempt (handler-owned) trunks only join the fan when they share the
+        # channel with a non-exempt trunk; a group of only exempt trunks keeps
+        # its handler geometry untouched here.
+        if not any(not t.route.normalize_exempt for t in grp):
+            continue
+        # Opposite-direction flows that share one inter-row channel must not be
+        # smooshed into one tight bundle (issue #484): a leftward and a rightward
+        # bundle interleaved a step apart read as one fat band and can hide a
+        # distinct line behind an exempt one.  Split the channel by traversal
+        # direction and lay each direction on its own non-overlapping Y band,
+        # with a clear visual gap between them; within a band the co-travelling
+        # same-direction trunks still fan tight (OFFSET_STEP, concentric).
+        dips = grp[0].dips_down
+        by_dir = {sign: [t for t in grp if t.sign_x == sign] for sign in (1, -1)}
+        bands = [b for b in by_dir.values() if b]
+        # Order bands top -> bottom by current vertical position so allocation
+        # moves each the least and never reorders the two flows (no new
+        # crossing).  Slot layouts (and per-band heights) are computed up front.
+        bands.sort(key=lambda b: min(t.y for t in b))
+        planned = [_plan_trunk_band(b) for b in bands]
+        gap = BUNDLE_TO_BUNDLE_CLEARANCE
+        heights = [(len(order) - 1) * step for order in planned]
+        total = sum(heights) + gap * (len(planned) - 1)
+        # Stack the bands top -> bottom with a clear gap; anchor at the current
+        # cluster top, then slide the whole stack up if its bottom would crowd
+        # the next row's header.  Sliding up (into the free upper gap) preserves
+        # the inter-band gap without pushing the lower band into the header.
+        top = min(t.y for t in grp)
+        band_top = _clamp_inter_row_band_top(ctx, top, total)
+        for order, h in zip(planned, heights):
+            _restack_trunk_band(order, band_top, dips, step, ctx, bundled)
+            band_top += h + gap
+
+    _dogleg_off_exempt_trunks(routes, ctx, skip=bundled)
+
+
+def _plan_trunk_band(band: list[_HTrunk]) -> list[list[_HTrunk]]:
+    """Order one same-direction band into concentric slots.
+
+    Bundle slots are per distinct LINE, not per trunk: two trunks of the SAME
+    line whose X-spans overlap are a fan-out/fan-in of one metro line and
+    COINCIDE on one slot (issue #484); distinct lines (and disjoint same-line
+    trunks) keep their own concentric slots.  The widest-reaching slot sorts
+    OUTERMOST (deepest into the channel) so a slot's flanking verticals never
+    cross another slot's trunk leg; ties keep incoming order.
+    """
+    slot_groups = _coincident_trunk_slots(band)
+    return sorted(
+        slot_groups,
+        key=lambda sg: (
+            -max(t.x_hi - t.x_lo for t in sg),
+            min(t.x_lo for t in sg),
+            min(t.y for t in sg),
+        ),
+    )
+
+
+def _clamp_inter_row_band_top(ctx: _RoutingCtx, top: float, total: float) -> float:
+    """Return the top Y at which to stack a *total*-tall direction-band stack.
+
+    Starts at the cluster *top* and slides the stack upward if its bottom would
+    breach the next row's header clearance (``INTER_ROW_HEADER_CLEARANCE`` below
+    the inter-row gap's lower edge), keeping the inter-band gap intact rather
+    than crowding the lower band into the header.
+    """
+    band = _inter_row_gap_band(ctx, top)
+    if band is None:
+        return top
+    _gap_top, gap_bottom = band
+    limit = gap_bottom - INTER_ROW_HEADER_CLEARANCE
+    if top + total > limit:
+        return limit - total
+    return top
+
+
+def _restack_trunk_band(
+    order: list[list[_HTrunk]],
+    band_top: float,
+    dips: bool,
+    step: float,
+    ctx: _RoutingCtx,
+    bundled: set[int],
+) -> None:
+    """Fan one planned same-direction band into its concentric slots.
+
+    The band occupies ``[band_top, band_top + (n-1)*step]``; the slot closest
+    to the channel interior (innermost) sits at the shallow edge.  All trunks
+    here -- including exempt ones grouped with a non-exempt mate -- are placed
+    so the whole band reads as one tight concentric bundle.
+    """
+    n = len(order)
+    for slot, sg in enumerate(order):
+        inner = n - 1 - slot  # 0 = innermost (shallowest); sets the corner radii
+        # Depth from ``band_top`` (the band's smallest Y).  For a downward dip
+        # the channel interior is above, so the innermost slot sits at the top;
+        # for an upward dip the interior is below, so the innermost sits at the
+        # bottom -- hence the inner/slot swap.
+        depth = inner if dips else slot
+        new_y = band_top + depth * step
+        for t in sg:
+            bundled.add(id(t.route))
+            if abs(new_y - t.y) <= COORD_TOLERANCE:
+                continue
+            _restack_htrunk(t, new_y, inner, n, step, ctx.curve_radius)
+
+
+def _inter_row_gap_band(ctx: _RoutingCtx, y: float) -> tuple[float, float] | None:
+    """Return the ``(top, bottom)`` Y envelope of the inter-row gap holding *y*.
+
+    Scans adjacent grid rows for the gap whose ``[row_bottom, next_row_top]``
+    band contains *y*; returns ``None`` when *y* doesn't fall in any gap.
+    """
+    rows = sorted({s.grid_row for s in ctx.graph.sections.values()})
+    for upper, lower in zip(rows, rows[1:]):
+        top = row_bottom_edge(ctx.graph, upper, default=None)  # type: ignore[arg-type]
+        bottom = row_top_edge(ctx.graph, lower, default=None)  # type: ignore[arg-type]
+        if top is None or bottom is None:
+            continue
+        if top - COORD_TOLERANCE <= y <= bottom + COORD_TOLERANCE:
+            return top, bottom
+    return None
+
+
+def _dogleg_off_exempt_trunks(
+    routes: list[RoutedPath], ctx: _RoutingCtx, skip: set[int] | None = None
+) -> None:
+    """Offset a non-exempt trunk drawn collinear with an exempt run.
+
+    ``normalize_exempt`` horizontal runs are placed by their own handler and
+    are not restacked, so the channel normaliser never sees them, and a
+    non-exempt bypass trunk that ends up overlapping one in X with a near-
+    equal Y is left fused on top of it.  This pass treats exempt runs as fixed
+    occupants and clears the movable trunk off them in two regimes:
+
+    - SAME line: two opposing flows of one metro line fused into a single
+      drawn track.  Shifted clear by up to one bundle clearance, picking the
+      side with room, so the two flows read as a dogleg/crossroads.
+    - DISTINCT line: a different-colour trunk drawn within a sub-bundle gap of
+      the exempt run reads as one stroke (the exempt line painted over it).
+      Nudged to a full ``OFFSET_STEP`` gap so both colours show as a tight
+      concentric bundle.  Distinct trunks already a bundle-gap or more apart
+      are a legitimate bundle and left untouched.
+
+    Both regimes clamp inside the inter-row gap, leaving the next row's header
+    protrusion clear so the trunk stays in the envelope.
+    """
+    skip = skip or set()
+    obstacles = [
+        t
+        for t in _collect_htrunks(routes, include_exempt=True)
+        if t.route.normalize_exempt and id(t.route) not in skip
+    ]
+    if not obstacles:
+        return
+    clearance = EDGE_TO_BUNDLE_CLEARANCE
+    for t in _collect_htrunks(routes):
+        if id(t.route) in skip:
+            continue
+        hit = next(
+            (
+                o
+                for o in obstacles
+                if o.route.line_id == t.route.line_id
+                and abs(o.y - t.y) <= clearance
+                and t.x_lo < o.x_hi - COORD_TOLERANCE
+                and o.x_lo < t.x_hi - COORD_TOLERANCE
+            ),
+            None,
+        )
+        if hit is None:
+            continue
+        # Lower edge reserves the next row's header protrusion.
+        band = _inter_row_gap_band(ctx, t.y)
+        if band is not None:
+            top, bottom = band
+            down_room = (bottom - SECTION_HEADER_PROTRUSION) - hit.y
+            up_room = hit.y - top
+        else:
+            down_room = up_room = clearance
+        down = min(clearance, down_room)
+        up = min(clearance, up_room)
+        min_sep = 2 * OFFSET_STEP  # below this the two strokes still fuse
+        prefer_down = up < min_sep or (down >= min_sep and t.y >= hit.y)
+        if prefer_down and down >= min_sep:
+            new_y = hit.y + down
+        elif up >= min_sep:
+            new_y = hit.y - up
+        else:
+            continue
+        _restack_htrunk(t, new_y, 0, 1, ctx.offset_step, ctx.curve_radius)
+
+    step = ctx.offset_step
+    for t in _collect_htrunks(routes):
+        if id(t.route) in skip:
+            continue
+        hit = next(
+            (
+                o
+                for o in obstacles
+                if o.route.line_id != t.route.line_id
+                and abs(o.y - t.y) < step - COORD_TOLERANCE
+                and t.x_lo < o.x_hi - COORD_TOLERANCE
+                and o.x_lo < t.x_hi - COORD_TOLERANCE
+            ),
+            None,
+        )
+        if hit is None:
+            continue
+        band = _inter_row_gap_band(ctx, t.y)
+        below, above = hit.y + step, hit.y - step
+        if band is not None:
+            top, bottom = band
+            below_ok = below <= bottom - SECTION_HEADER_PROTRUSION
+            above_ok = above >= top
+        else:
+            below_ok = above_ok = True
+        if (t.y >= hit.y and below_ok) or (not above_ok and below_ok):
+            new_y = below
+        elif above_ok:
+            new_y = above
+        else:
+            continue
+        _restack_htrunk(t, new_y, 0, 1, step, ctx.curve_radius)
+
+
+def _coincident_trunk_slots(grp: list[_HTrunk]) -> list[list[_HTrunk]]:
+    """Partition one channel group's trunks into coincident-Y slots.
+
+    Trunks carrying the SAME ``line_id`` whose X-spans overlap belong to one
+    metro line's shared path (a fan-out or fan-in) and are placed on ONE
+    slot so they coincide along their common span, de-duplicating the line
+    into a single drawn track that splits only where the spans diverge
+    (issue #484).  Every other trunk is its own slot, so distinct lines -
+    and disjoint same-line trunks - keep their separate concentric slots.
+    """
+    slots: list[list[_HTrunk]] = []
+    for t in grp:
+        for sg in slots:
+            if sg[0].route.line_id != t.route.line_id:
+                continue
+            # Opposing flows of one line are distinct paths, not a fan to merge.
+            if sg[0].sign_x != t.sign_x:
+                continue
+            if any(t.x_lo < o.x_hi and o.x_lo < t.x_hi for o in sg):
+                sg.append(t)
+                break
+        else:
+            slots.append([t])
+    return slots
+
+
+def _restack_htrunk(
+    t: _HTrunk,
+    new_y: float,
+    inner: int,
+    n: int,
+    step: float,
+    base_radius: float,
+) -> None:
+    """Move one horizontal trunk to *new_y* and recompute its flanking radii.
+
+    Shifts both trunk endpoints (which share Y) to *new_y*; the flanking
+    vertical legs stretch to meet them.  ``inner`` is the nesting index
+    (0 = innermost / shallowest); the two flanking corners are sized so the
+    bundle stays concentric, mirroring :func:`_restack_channel`.
+    """
+    rp = t.route
+    pts = rp.points
+    k = t.idx
+    pts[k] = (pts[k][0], new_y)
+    pts[k + 1] = (pts[k + 1][0], new_y)
+
+    if rp.curve_radii is None:
+        return
+    max_off = (n - 1) * step
+    off = inner * step
+    # An innermost trunk turns on the INSIDE of both flanking corners; the
+    # outermost turns on the OUTSIDE.  For a downward dip the inner line is
+    # the inside of the turn (smaller radius); same parity on both corners.
+    r = corner_radius(off, max_off, outside=False, base_radius=base_radius)
+    if 0 <= k - 1 < len(rp.curve_radii):
+        rp.curve_radii[k - 1] = r
+    if k < len(rp.curve_radii) and k + 2 < len(pts):
+        rp.curve_radii[k] = r
+
+
 def _join_fanout_upstream_tails(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
     """Snap each fan-out junction's upstream tail onto its downstream start.
 
@@ -4070,6 +5490,58 @@ def _gap_channel_base(
     return symmetric_bundle_midpoint(
         gap_left, gap_right, [max(0, n - 1) * offset_step], 0
     )
+
+
+def _clear_channel_x_in_band(
+    graph: MetroGraph,
+    x: float,
+    y_lo: float,
+    y_hi: float,
+    clearance: float,
+    exclude_section_ids: set[str],
+    bound_left: float | None = None,
+    bound_right: float | None = None,
+) -> float:
+    """Nudge a vertical channel *x* clear of every section its Y-band pierces.
+
+    A bypass channel placed in the source row's column gap can still pierce
+    an oversized section in another row that the descent crosses (its bbox
+    extends past the source-row gap edges).  Scan all sections whose bbox
+    overlaps the open vertical interval ``(y_lo, y_hi)``; if *x* sits inside
+    one, shift it to the nearer cleared edge (``bbox_x - clearance`` or
+    ``bbox_x + bbox_w + clearance``).  Iterate so a single shift that lands
+    inside an adjacent box is resolved.  ``bound_left`` / ``bound_right``
+    cap the search so the channel never leaves the inter-column gap; when a
+    clear position can't be found within the bounds the original *x* is
+    returned (the normalization pass / overlap guards remain the backstop).
+    """
+    lo_y, hi_y = (y_lo, y_hi) if y_lo <= y_hi else (y_hi, y_lo)
+    for _ in range(8):
+        blocker = None
+        for s in graph.sections.values():
+            if s.bbox_w <= 0 or s.id in exclude_section_ids:
+                continue
+            sx_l = s.bbox_x
+            sx_r = s.bbox_x + s.bbox_w
+            if not (sx_l - clearance < x < sx_r + clearance):
+                continue
+            if lo_y < s.bbox_y + s.bbox_h and s.bbox_y < hi_y:
+                blocker = (sx_l, sx_r)
+                break
+        if blocker is None:
+            return x
+        sx_l, sx_r = blocker
+        left_x = sx_l - clearance
+        right_x = sx_r + clearance
+        left_ok = bound_left is None or left_x >= bound_left
+        right_ok = bound_right is None or right_x <= bound_right
+        if left_ok and (not right_ok or abs(left_x - x) <= abs(right_x - x)):
+            x = left_x
+        elif right_ok:
+            x = right_x
+        else:
+            return x
+    return x
 
 
 def _has_intervening_sections(
@@ -4300,6 +5772,13 @@ def _compute_junction_fan_info(
         has_lshape = False
         has_bypass = False
         has_wrap = False
+        # Source-side channels anchored NEAR the junction (no resolvable
+        # inter-column gap to centre in) keyed by their rounded X.  These are
+        # NOT touched by ``_normalize_gap_channels`` (which only re-stacks
+        # channels inside a real column gap), so two distinct lines to two
+        # distinct targets that resolve to the same near-source X overlay
+        # there; the unified fan is the only thing that separates them.
+        near_src_channel: dict[int, set[tuple[str, str]]] = defaultdict(set)
         for edge in graph.edges_from(jid):
             tgt = graph.stations.get(edge.target)
             if not tgt or not (tgt.is_port or edge.target in junction_ids):
@@ -4330,21 +5809,39 @@ def _compute_junction_fan_info(
                 has_wrap = True
             else:
                 has_lshape = True
+            # A plain L-shape into an ADJACENT column gets a true inter-column
+            # gap channel that _normalize_gap_channels centres + separates, so
+            # it is not a near-source overlay.  Every other source-anchored
+            # case - a non-adjacent / same-column L-shape (near-source
+            # fallback) or a wrap (source-side V1 hugging the junction, exempt
+            # from gap-normalise) - hugs the source with no gap to normalise.
+            lshape_gap_channel = not is_wrap and abs(tgt_col - src_col) == 1
+            if not is_bypass and not lshape_gap_channel:
+                near_src_channel[round(jst.x)].add((edge.line_id, edge.target))
             if (edge.source, edge.target, edge.line_id) not in _skip:
                 outgoing.append(edge)
 
-        # Unified fan-out only when handlers would otherwise pick
-        # different source-side channel Xs:
+        # A near-source channel shared by 2+ distinct lines headed to 2+
+        # distinct targets overlays those lines (no gap-normalise pass
+        # reaches it); the unified fan gives each line its own slot.
+        near_src_collision = any(
+            len({lid for lid, _ in members}) >= 2 and len({t for _, t in members}) >= 2
+            for members in near_src_channel.values()
+        )
+
+        # Unified fan-out only when source-side channels would otherwise
+        # overlay distinct lines:
         #   * lshape + bypass: the legacy condition.
         #   * wrap + anything else: extends the same idea to wrap routes.
-        # Pure lshape-only or pure bypass-only junctions don't need the
-        # shared first corner - the single active handler picks one
-        # corridor on its own.  Widening this predicate further (e.g.
-        # `category_count >= 2`) is a no-op for pure-X junctions but
-        # was observed to perturb simple gallery fixtures, so keep the
-        # condition explicit.
-        needs_unified = (has_lshape and has_bypass) or (
-            has_wrap and (has_lshape or has_bypass)
+        #   * near_src_collision: distinct lines to distinct targets sharing
+        #     one source-hugging channel that no gap-normalise pass reaches.
+        # A junction whose source-side channels are all distinct (e.g. a pure
+        # adjacent-column L-shape fan whose gap channels _normalize_gap_channels
+        # separates) needs no shared first corner.
+        needs_unified = (
+            (has_lshape and has_bypass)
+            or (has_wrap and (has_lshape or has_bypass))
+            or near_src_collision
         )
         if not outgoing or not needs_unified:
             continue

--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -157,6 +157,52 @@ def corner_radius(
     return base_radius + eff
 
 
+def reference_anchored_radius(
+    signed_offset: float,
+    base_radius: float = CURVE_RADIUS,
+    *,
+    min_radius: float | None = None,
+) -> float:
+    """Concentric arc radius anchored on a *reference* line, not the innermost.
+
+    ``corner_radius`` anchors the bundle's innermost line at *base_radius* so
+    every radius is ``>= base_radius``.  The TOP-entry staircase into a port
+    instead anchors a chosen **reference line** (the one kept continuous with
+    its bundle-mates at the upstream junction) at *base_radius*, then offsets
+    every other line by its signed perpendicular displacement from that
+    reference.  Because that reference is interior to the bundle, lines on the
+    inside of a turn fall **below** the base radius (``signed_offset < 0``).
+
+    Both forms encode the same concentricity invariant ``radius - displacement
+    = const``; they differ only in which line is pinned to *base_radius*.  This
+    helper is the single source of truth for the reference-anchored variant.
+
+    Parameters
+    ----------
+    signed_offset : float
+        Perpendicular displacement of this line from the reference line at the
+        corner, signed by the inside/outside sense of the turn (positive on the
+        outside, negative on the inside).  The reference line itself has
+        ``signed_offset == 0`` and therefore radius *base_radius*.
+    base_radius : float
+        Reference-line radius (the bundle-wide concentric centre offset).
+    min_radius : float or None
+        Optional floor.  Tight converging jogs onto a shared port point can
+        drive ``base_radius + signed_offset`` to zero or below; pass a small
+        positive floor (e.g. ``COORD_TOLERANCE``) to keep the arc renderable.
+        ``None`` (default) applies no floor.
+
+    Returns
+    -------
+    float
+        ``base_radius + signed_offset`` (clamped up to *min_radius* if given).
+    """
+    r = base_radius + signed_offset
+    if min_radius is not None:
+        return max(min_radius, r)
+    return r
+
+
 # ---------------------------------------------------------------------------
 # Standard inter-section L-shape (horizontal -> vertical -> horizontal)
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from nf_metro.layout.constants import (
+    COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
     OFFSET_STEP,
     SAME_Y_TOLERANCE,
@@ -593,6 +594,180 @@ class PartialBranchGapViolation:
         )
 
 
+@dataclass(frozen=True)
+class CollinearOverlapViolation:
+    """Two distinct-line inter-section segments drawn on top of each other.
+
+    ``axis`` is ``"V"`` or ``"H"``; ``coord`` is the shared channel
+    position (X for vertical, Y for horizontal); ``span`` is the
+    overlapping length along the axis.
+    """
+
+    line_a: str
+    line_b: str
+    edge_a: tuple[str, str]
+    edge_b: tuple[str, str]
+    axis: str
+    coord: float
+    span: float
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        return (
+            f"collinear overlay: line {self.line_a!r} "
+            f"({self.edge_a[0]}->{self.edge_a[1]}) and line {self.line_b!r} "
+            f"({self.edge_b[0]}->{self.edge_b[1]}) coincide on the {self.axis} "
+            f"channel at {self.coord:.1f} over {self.span:.1f}px"
+        )
+
+
+_COLLINEAR_LATERAL_TOL = 1.0
+_COLLINEAR_MIN_SPAN = 40.0
+
+
+def _axis_aligned(
+    p1: tuple[float, float], p2: tuple[float, float]
+) -> tuple[str | None, float]:
+    """Classify a segment as vertical/horizontal and return its channel coord."""
+    (x1, y1), (x2, y2) = p1, p2
+    if abs(x1 - x2) < COORD_TOLERANCE_FINE and abs(y1 - y2) > _COLLINEAR_LATERAL_TOL:
+        return "V", (x1 + x2) * 0.5
+    if abs(y1 - y2) < COORD_TOLERANCE_FINE and abs(x1 - x2) > _COLLINEAR_LATERAL_TOL:
+        return "H", (y1 + y2) * 0.5
+    return None, 0.0
+
+
+def _route_render_points(
+    rp: RoutedPath, offsets: dict[tuple[str, str], float]
+) -> list[tuple[float, float]]:
+    """Final render geometry for a route (mirrors render.apply_route_offsets)."""
+    if rp.offsets_applied:
+        return list(rp.points)
+    src_off = offsets.get((rp.edge.source, rp.line_id), 0.0)
+    tgt_off = offsets.get((rp.edge.target, rp.line_id), 0.0)
+    orig_sy = rp.points[0][1]
+    orig_ty = rp.points[-1][1]
+    out: list[tuple[float, float]] = []
+    last = len(rp.points) - 1
+    for k, (x, y) in enumerate(rp.points):
+        if k == 0:
+            out.append((x, y + src_off))
+        elif k == last:
+            out.append((x, y + tgt_off))
+        elif abs(y - orig_sy) <= abs(y - orig_ty):
+            out.append((x, y + src_off))
+        else:
+            out.append((x, y + tgt_off))
+    return out
+
+
+def check_no_collinear_distinct_lines(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[CollinearOverlapViolation]:
+    """Return distinct-line inter-section segments drawn exactly on top.
+
+    Two co-travelling lines that share a bundle must occupy distinct
+    parallel slots (at least ``OFFSET_STEP`` apart laterally).  When a
+    bundling/offset defect collapses them to the same channel they
+    render as one stroke obscuring the other.  This check looks at the
+    final, offset-applied geometry: it flags pairs of DIFFERENT-line
+    axis-aligned inter-section segments whose channel coordinate
+    coincides within ``_COLLINEAR_LATERAL_TOL`` and whose overlap along
+    the axis exceeds ``_COLLINEAR_MIN_SPAN``.
+
+    Legitimate cases are excluded: lines converging onto a shared
+    endpoint port (an unavoidable single approach), tight parallel
+    bundles (>= one ``OFFSET_STEP`` apart never coincide), and short
+    trunk-level lead-ins below the min span.
+    """
+    port_xy = {
+        pid: (graph.stations[pid].x, graph.stations[pid].y)
+        for pid in graph.ports
+        if pid in graph.stations
+    }
+
+    segs: list[tuple[str, tuple[str, str], str, float, float, float]] = []
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        pts = _route_render_points(rp, offsets)
+        edge = (rp.edge.source, rp.edge.target)
+        for p1, p2 in zip(pts, pts[1:]):
+            axis, coord = _axis_aligned(p1, p2)
+            if axis is None:
+                continue
+            if axis == "V":
+                lo, hi = sorted((p1[1], p2[1]))
+            else:
+                lo, hi = sorted((p1[0], p2[0]))
+            segs.append((rp.line_id, edge, axis, coord, lo, hi))
+
+    violations: list[CollinearOverlapViolation] = []
+    for i in range(len(segs)):
+        la, ea, ax_a, c_a, lo_a, hi_a = segs[i]
+        for j in range(i + 1, len(segs)):
+            lb, eb, ax_b, c_b, lo_b, hi_b = segs[j]
+            if la == lb or ax_a != ax_b:
+                continue
+            if abs(c_a - c_b) > _COLLINEAR_LATERAL_TOL:
+                continue
+            olo, ohi = max(lo_a, lo_b), min(hi_a, hi_b)
+            span = ohi - olo
+            if span <= _COLLINEAR_MIN_SPAN:
+                continue
+            if _converges_at_shared_port(port_xy, ea, eb, ax_a, c_a, olo, ohi):
+                continue
+            violations.append(
+                CollinearOverlapViolation(
+                    line_a=la,
+                    line_b=lb,
+                    edge_a=ea,
+                    edge_b=eb,
+                    axis=ax_a,
+                    coord=c_a,
+                    span=span,
+                )
+            )
+    return violations
+
+
+def _converges_at_shared_port(
+    port_xy: dict[str, tuple[float, float]],
+    edge_a: tuple[str, str],
+    edge_b: tuple[str, str],
+    axis: str,
+    coord: float,
+    olo: float,
+    ohi: float,
+) -> bool:
+    """True when the overlap is a brief convergence onto a shared port.
+
+    Distinct lines may touch at a shared endpoint port (an unavoidable
+    single point), but a long co-run alongside the port is a real overlay:
+    the convergence must collapse to the port, not run parallel-on-top for
+    a meaningful length.  Excuse the overlap only when it reaches the port
+    marker AND extends no further than ``_COLLINEAR_MIN_SPAN`` from it.
+    """
+    tol = COORD_TOLERANCE + _COLLINEAR_LATERAL_TOL
+    for pid in (set(edge_a) & set(edge_b)) & port_xy.keys():
+        px, py = port_xy[pid]
+        if axis == "V":
+            anchor = py
+            on_channel = abs(px - coord) <= tol
+        else:
+            anchor = px
+            on_channel = abs(py - coord) <= tol
+        if not on_channel or not (olo - tol <= anchor <= ohi + tol):
+            continue
+        # Distance the overlap reaches away from the port along the axis.
+        reach = max(anchor - olo, ohi - anchor)
+        if reach <= _COLLINEAR_MIN_SPAN:
+            return True
+    return False
+
+
 def check_partial_branch_offset_gaps(
     graph: MetroGraph,
     offsets: dict[tuple[str, str], float],
@@ -636,6 +811,7 @@ def check_partial_branch_offset_gaps(
 
 __all__ = [
     "BundleOrderViolation",
+    "CollinearOverlapViolation",
     "FanoutTailGap",
     "MergePortApproachViolation",
     "PartialBranchGapViolation",
@@ -643,6 +819,7 @@ __all__ = [
     "check_bundle_order_preserved",
     "check_fanout_tail_join",
     "check_merge_port_approach_side",
+    "check_no_collinear_distinct_lines",
     "check_partial_branch_offset_gaps",
     "classify_merge_port_feeders",
     "distinct_offset_levels",

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -802,26 +802,43 @@ def position_ports(section: Section, graph: MetroGraph) -> None:
                 port_ids, bottom_y, section, graph, fixed_axis="y"
             )
 
-    # TB sections: move LEFT/RIGHT exit ports just below the last
-    # internal station (not the section bottom) so lines don't detour
-    # to the bottom when the successor is at a similar Y level.
+    # TB sections: clamp LEFT/RIGHT ports to the station band rather than
+    # the (often tall) section edges.  Exit ports sit just below the last
+    # internal station and entry ports just above the first, so lines flow
+    # straight into the station fan instead of running along a trunk near
+    # the box edge and jogging back to the pills.  The reserved top band
+    # (entry_shift) keeps the entry port clear of the first station.
     if section.direction == "TB":
+        entry_set = set(section.entry_ports)
         exit_set = set(section.exit_ports)
-        internal_ids = set(section.station_ids) - set(section.entry_ports) - exit_set
+        internal_ids = set(section.station_ids) - entry_set - exit_set
         internal_ys = [
             graph.stations[sid].y
             for sid in internal_ids
             if sid in graph.stations and not graph.stations[sid].is_port
         ]
-        last_y = max(internal_ys) if internal_ys else section.bbox_y + section.bbox_h
-        target_y = last_y + MIN_PORT_STATION_GAP
+        if internal_ys:
+            last_y = max(internal_ys)
+            first_y = min(internal_ys)
+        else:
+            last_y = section.bbox_y + section.bbox_h
+            first_y = section.bbox_y
+        exit_target_y = last_y + MIN_PORT_STATION_GAP
+        entry_target_y = first_y - MIN_PORT_STATION_GAP
         for pid in exit_set:
             port = graph.ports.get(pid)
             if port and port.side in (PortSide.LEFT, PortSide.RIGHT):
                 station = graph.stations.get(pid)
                 if station:
-                    station.y = target_y
-                port.y = target_y
+                    station.y = exit_target_y
+                port.y = exit_target_y
+        for pid in entry_set:
+            port = graph.ports.get(pid)
+            if port and port.side in (PortSide.LEFT, PortSide.RIGHT):
+                station = graph.stations.get(pid)
+                if station:
+                    station.y = entry_target_y
+                port.y = entry_target_y
 
 
 def _position_ports_on_boundary(

--- a/src/nf_metro/render/bridges.py
+++ b/src/nf_metro/render/bridges.py
@@ -13,8 +13,10 @@ under-route, the gap span to break.  The drawing half lives in ``svg.py``.
 A crossing is genuine only when:
 
 * the two lines differ;
-* the two crossing edges share no endpoint node (fan-out/fan-in/diamond
-  reordering emanates from a shared fork and is not a crossing);
+* the two crossing edges share no endpoint node, and (when same-line) are not
+  a fan-out/fan-in (legs that both fork from a shared ancestor and rejoin on a
+  shared descendant); same-line legs with no common ancestor that only meet
+  again at the common sink are independent arms that genuinely cross;
 * the intersection is not within ``BRIDGE_NODE_TOLERANCE`` of any node the
   layout places (interchanges happen *at* nodes);
 * the two segments are not near-parallel (offset bundle slivers barely
@@ -130,6 +132,73 @@ def _shares_endpoint(e1: Edge, e2: Edge) -> bool:
     return bool({e1.source, e1.target} & {e2.source, e2.target})
 
 
+def _line_adj(graph: MetroGraph) -> dict[str, dict[str, set[str]]]:
+    """Per-line forward adjacency: ``succ[line_id][node]`` is the set of nodes
+    that node feeds along that line."""
+    succ: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for e in graph.edges:
+        succ[e.line_id][e.source].add(e.target)
+    return succ
+
+
+_line_succ = _line_adj
+
+
+def _reachable(adj: dict[str, set[str]], start: str) -> set[str]:
+    seen = {start}
+    stack = [start]
+    while stack:
+        n = stack.pop()
+        for m in adj.get(n, ()):
+            if m not in seen:
+                seen.add(m)
+                stack.append(m)
+    return seen
+
+
+def _same_line_is_fan(
+    e1: Edge,
+    e2: Edge,
+    line_succ: dict[str, dict[str, set[str]]],
+    *,
+    line_pred: dict[str, dict[str, set[str]]] | None = None,
+) -> bool:
+    """True when two same-line edges are one fan-out/fan-in rather than a
+    genuine crossover.
+
+    A fan is a fork-and-rejoin: the legs diverge from a shared ancestor on the
+    line *and* reconverge on a shared descendant.  The original test checked
+    only the rejoin, but in a convergence everything rejoins at the common sink
+    - so two independent arms (no shared ancestor, meeting only far downstream)
+    were misread as a fan.  Requiring a shared *fork* as well separates them:
+    independent arms lack a common ancestor (or rejoin only at the sink with no
+    fork), so they read as a genuine crossover and earn a bridge.
+
+    Edges sharing an endpoint are trivially one fork/join.  Otherwise both a
+    common ancestor (fork) and a common descendant (rejoin) on the line must
+    exist; reconvergence alone is not enough."""
+    if _shares_endpoint(e1, e2):
+        return True
+    succ = line_succ.get(e1.line_id, {})
+    if line_pred is None:
+        line_pred = _line_pred_from_succ(line_succ)
+    pred = line_pred.get(e1.line_id, {})
+    rejoins = not _reachable(succ, e1.target).isdisjoint(_reachable(succ, e2.target))
+    forks = not _reachable(pred, e1.source).isdisjoint(_reachable(pred, e2.source))
+    return rejoins and forks
+
+
+def _line_pred_from_succ(
+    line_succ: dict[str, dict[str, set[str]]],
+) -> dict[str, dict[str, set[str]]]:
+    pred: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for lid, adj in line_succ.items():
+        for src, tgts in adj.items():
+            for t in tgts:
+                pred[lid][t].add(src)
+    return pred
+
+
 def _near_node(pt: Point, node_xy: list[Point]) -> bool:
     return any(
         abs(pt[0] - nx) < BRIDGE_NODE_TOLERANCE
@@ -157,7 +226,11 @@ def compute_bridges(
         for s in graph.stations.values()
         if not s.is_port and not s.is_hidden and not s.id.startswith("__")
     }
-    crossings = _find_crossings(routes, polylines, node_xy, station_xy)
+    line_succ = _line_adj(graph)
+    line_pred = _line_pred_from_succ(line_succ)
+    crossings = _find_crossings(
+        routes, polylines, node_xy, station_xy, line_succ, line_pred
+    )
     clusters = _cluster_crossings(crossings)
 
     line_priority = {lid: i for i, lid in enumerate(graph.lines)}
@@ -236,14 +309,27 @@ def _find_crossings(
     polylines: list[list[Point]],
     node_xy: list[Point],
     station_xy: dict[str, Point],
+    line_succ: dict[str, dict[str, set[str]]],
+    line_pred: dict[str, dict[str, set[str]]],
 ) -> list[_Crossing]:
-    """All genuine non-merging segment crossings between distinct lines."""
+    """All genuine non-merging segment crossings.
+
+    Crossings between distinct lines always qualify (subject to the node/join
+    /angle filters below).  Same-line crossings qualify only when the two
+    routes are independent legs heading to separate destinations (a genuine
+    crossover); same-line crossings that are a fan-out/fan-in/loop reordering
+    are skipped (``_same_line_is_fan``) since their legs belong to one fork and
+    rejoin rather than cross."""
     out: list[_Crossing] = []
     for a in range(len(routes)):
         ra, pa = routes[a], polylines[a]
         for b in range(a + 1, len(routes)):
             rb, pb = routes[b], polylines[b]
-            if ra.line_id == rb.line_id or _shares_endpoint(ra.edge, rb.edge):
+            if _shares_endpoint(ra.edge, rb.edge):
+                continue
+            if ra.line_id == rb.line_id and _same_line_is_fan(
+                ra.edge, rb.edge, line_succ, line_pred=line_pred
+            ):
                 continue
             endpoints = (ra.edge.source, ra.edge.target, rb.edge.source, rb.edge.target)
             for i in range(len(pa) - 1):

--- a/tests/test_bridge_glyph.py
+++ b/tests/test_bridge_glyph.py
@@ -23,7 +23,13 @@ from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.parser.mermaid import parse_metro_mermaid
-from nf_metro.render.bridges import BRIDGE_NODE_TOLERANCE, compute_bridges
+from nf_metro.parser.model import Edge, MetroGraph
+from nf_metro.render.bridges import (
+    BRIDGE_NODE_TOLERANCE,
+    _line_succ,
+    _same_line_is_fan,
+    compute_bridges,
+)
 from nf_metro.render.svg import apply_route_offsets, render_svg
 from nf_metro.themes import NFCORE_THEME
 
@@ -208,6 +214,68 @@ def test_animation_paths_flow_over_gaps():
         )
     )
     assert on and on == off
+
+
+def test_same_line_fan_legs_are_not_a_crossover():
+    """Two same-line edges whose legs fork and rejoin (a fan-out / fan-in /
+    loop) are a fan, not a crossover - even when their geometry crosses."""
+    g = MetroGraph(
+        edges=[
+            Edge("fork", "left", "x"),
+            Edge("fork", "right", "x"),
+            Edge("left", "join", "x"),
+            Edge("right", "join", "x"),
+        ]
+    )
+    succ = _line_succ(g)
+    e_left = Edge("fork", "left", "x")
+    e_right = Edge("fork", "right", "x")
+    # Distinct legs that rejoin downstream at "join" -> a fan, not a crossover.
+    assert _same_line_is_fan(
+        Edge("left", "join", "x"), Edge("right", "join", "x"), succ
+    )
+    # Edges sharing the fork node are also a fan.
+    assert _same_line_is_fan(e_left, e_right, succ)
+
+
+def test_same_line_independent_legs_are_a_crossover():
+    """Two same-line edges that head to destinations which never reconverge are
+    a genuine crossover and must be eligible for a bridge."""
+    g = MetroGraph(
+        edges=[
+            Edge("hub", "a1", "x"),
+            Edge("a1", "a2", "x"),
+            Edge("hub", "b1", "x"),
+            Edge("b1", "b2", "x"),
+        ]
+    )
+    succ = _line_succ(g)
+    # a1->a2 and b1->b2 share no endpoint and never reconverge downstream.
+    assert not _same_line_is_fan(Edge("a1", "a2", "x"), Edge("b1", "b2", "x"), succ)
+
+
+def test_issue484_same_colour_crossover_is_bridged():
+    """issue #484: a horizontal bam run crosses a vertical bam drop below the
+    Small-variant/Phasing sections - a genuine same-colour crossover whose legs
+    head to separate, never-reconverging destinations.  A bridge must fire."""
+    path = Path(__file__).parent.parent / "issue484.mmd"
+    if not path.exists():
+        pytest.skip("issue484.mmd repro fixture not present")
+    _, routes, _, bridges = _bridges(path)
+    by_id = {id(r): r for r in routes}
+    bam_breaks = [
+        (bk, by_id[rid])
+        for rid, breaks in bridges.items()
+        for bk in breaks
+        if by_id[rid].line_id == "bam"
+    ]
+    assert bam_breaks, "expected a bam crossover bridge in issue484"
+    # The documented crossing is at (~1616, 263); the gap is centred there.
+    assert any(
+        abs((bk.cut_a[0] + bk.cut_b[0]) / 2 - 1616) < 30
+        and abs((bk.cut_a[1] + bk.cut_b[1]) / 2 - 263) < 30
+        for bk, _ in bam_breaks
+    )
 
 
 def _motion_paths(svg: str) -> list[str]:

--- a/tests/test_corners.py
+++ b/tests/test_corners.py
@@ -19,6 +19,7 @@ from nf_metro.layout.routing.corners import (
     bypass_radii,
     corner_radius,
     l_shape_radii,
+    reference_anchored_radius,
     resolve_curve_radii,
     reversed_offset,
     tb_entry_corner,
@@ -96,6 +97,48 @@ class TestCornerRadius:
             else:
                 assert corner_radius(off, max_off, outside=False) == pytest.approx(r1)
                 assert corner_radius(off, max_off, outside=True) == pytest.approx(r2)
+
+
+class TestReferenceAnchoredRadius:
+    """Reference-anchored concentric radius for the TOP-entry staircase.
+
+    Unlike ``corner_radius`` (innermost line at base, radii always >= base),
+    this anchors a *reference* line at base and offsets every other line by its
+    signed perpendicular displacement, so inside-of-turn lines fall below base.
+    """
+
+    def test_reference_line_is_base(self):
+        assert reference_anchored_radius(0.0) == CURVE_RADIUS
+
+    def test_outside_adds_offset(self):
+        assert reference_anchored_radius(3.0) == CURVE_RADIUS + 3.0
+
+    def test_inside_goes_below_base(self):
+        assert reference_anchored_radius(-3.0) == CURVE_RADIUS - 3.0
+
+    def test_custom_base(self):
+        assert reference_anchored_radius(-2.0, base_radius=5.0) == 3.0
+
+    def test_min_radius_floors_a_tight_jog(self):
+        # base - offset would be negative; the floor keeps it renderable.
+        assert reference_anchored_radius(-12.0, base_radius=10.0, min_radius=0.1) == 0.1
+
+    def test_min_radius_inactive_when_above_floor(self):
+        assert reference_anchored_radius(2.0, base_radius=10.0, min_radius=0.1) == 12.0
+
+    def test_concentricity_invariant(self):
+        # radius - signed_offset == base for every line: arcs share a centre.
+        base = CURVE_RADIUS
+        for so in (-6.0, -3.0, 0.0, 3.0, 6.0):
+            assert reference_anchored_radius(so, base) - so == pytest.approx(base)
+
+    def test_matches_offset_bundle_arithmetic(self):
+        # The four #484 offset-bundle radii (East lead, lead_sign=+1).
+        base = CURVE_RADIUS
+        for offset in (0.0, OFFSET_STEP, 2 * OFFSET_STEP):
+            assert reference_anchored_radius(-1.0 * offset, base) == base - offset
+            assert reference_anchored_radius(offset, base) == base + offset
+            assert reference_anchored_radius(-offset, base) == base - offset
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -23,6 +23,7 @@ from nf_metro.layout.constants import (
     CURVE_RADIUS,
     EDGE_TO_BUNDLE_CLEARANCE,
     MIN_STATION_FLAT_LENGTH,
+    ROW_BAND_SLACK,
     SECTION_HEADER_PROTRUSION,
     SECTION_Y_GAP,
     SECTION_Y_PADDING,
@@ -562,6 +563,290 @@ def test_grid_snap_keeps_columns_distinct(fixture):
         # this test; only a station-overlap clash indicates the snap
         # collapsed a column.
         assert "position clash" not in str(exc), str(exc)
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_no_collinear_distinct_lines(fixture):
+    """Two different lines must never render exactly on top of each other.
+
+    A bundling/offset defect that collapses co-travelling lines onto one
+    channel draws one stroke over the other.  Uses the final,
+    offset-applied geometry.
+    """
+    from nf_metro.layout.routing.invariants import (
+        check_no_collinear_distinct_lines,
+    )
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    violations = check_no_collinear_distinct_lines(graph, routes, offsets)
+    assert not violations, "; ".join(v.message() for v in violations)
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
+def test_distinct_trunk_not_hidden_behind_exempt(fixture):
+    """A distinct-line bypass trunk must not sit within a bundle gap of an
+    exempt trunk it overlaps in X.
+
+    ``normalize_exempt`` runs are placed by their own handler and the channel
+    normaliser never sees them, so a different-line trunk drawn less than one
+    ``OFFSET_STEP`` away (the stroke width) is painted over by the exempt run
+    and hidden (issue #484: a whole stretch of the SNV-VCF line vanished under
+    the BAM line).  ``_dogleg_off_exempt_trunks`` nudges it to a full gap.
+    """
+    from nf_metro.layout.constants import OFFSET_STEP
+    from nf_metro.layout.routing.core import _collect_htrunks
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    movable = _collect_htrunks(routes)
+    exempt = [
+        t
+        for t in _collect_htrunks(routes, include_exempt=True)
+        if t.route.normalize_exempt
+    ]
+    for t in movable:
+        for o in exempt:
+            if o.route.line_id == t.route.line_id:
+                continue
+            overlap = min(t.x_hi, o.x_hi) - max(t.x_lo, o.x_lo)
+            if overlap <= EDGE_TO_BUNDLE_CLEARANCE:
+                continue
+            assert abs(o.y - t.y) >= OFFSET_STEP - 0.1, (
+                f"{fixture}: '{t.route.line_id}' trunk @{t.y:.1f} hidden behind "
+                f"exempt '{o.route.line_id}' @{o.y:.1f} over {overlap:.0f}px"
+            )
+
+
+_PERP_ENTRY_BUNDLE_FIXTURES = [
+    "fold_fan_across.mmd",
+    "rnaseq_auto.mmd",
+]
+
+
+@pytest.mark.parametrize("fixture", _PERP_ENTRY_BUNDLE_FIXTURES)
+def test_perp_entry_bundle_not_overspread(fixture):
+    """A multi-line TOP/BOTTOM-port drop already separated by its port-side
+    bundle offsets must stay one ``OFFSET_STEP`` apart, not double it.
+
+    When the lines arrive at a shared perpendicular entry port pre-fanned into
+    distinct slots, the per-line drop stagger is redundant; applying it anyway
+    splays a tight bundle apart on the way into the section (issue #484
+    follow-up).  The first vertical leg of each sibling route must therefore be
+    spaced exactly one ``OFFSET_STEP`` from the next.
+    """
+    from nf_metro.layout.constants import OFFSET_STEP
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    by_key: dict[tuple[str, str], list[float]] = {}
+    for rp in routes:
+        port = graph.ports.get(rp.edge.source)
+        if port is None or port.side not in (PortSide.TOP, PortSide.BOTTOM):
+            continue
+        # The drop channel is the first vertical leg out of the port; the
+        # stagger (if any) widens THIS X, not the bare port lead-in point.
+        drop_x = next(
+            (
+                a[0]
+                for a, b in zip(rp.points, rp.points[1:])
+                if abs(a[0] - b[0]) < 0.1 and abs(a[1] - b[1]) > 0.1
+            ),
+            None,
+        )
+        if drop_x is None:
+            continue
+        by_key.setdefault((rp.edge.source, rp.edge.target), []).append(drop_x)
+
+    checked = False
+    for (src, tgt), xs in by_key.items():
+        if len(xs) < 2:
+            continue
+        checked = True
+        xs = sorted(xs)
+        gaps = [round(b - a, 1) for a, b in zip(xs, xs[1:])]
+        assert all(abs(g - OFFSET_STEP) < 0.1 for g in gaps), (
+            f"{fixture}: {src}->{tgt} drop Xs {xs} not one OFFSET_STEP apart "
+            f"(gaps {gaps})"
+        )
+    assert checked, f"{fixture}: no multi-line perpendicular-port drop found"
+
+
+_MIDBAND_BUNDLE_FIXTURES = [
+    "longread_variant_calling.mmd",
+]
+
+_OPPOSITE_BAND_FIXTURES = [
+    "longread_variant_calling.mmd",
+    "topologies/convergence_stacked_sink.mmd",
+]
+
+
+@pytest.mark.parametrize("fixture", _MIDBAND_BUNDLE_FIXTURES)
+def test_inter_row_trunks_bundle_tightly(fixture):
+    """Same-direction trunks co-travelling through one inter-row gap form a
+    tight bundle; opposite-direction flows sit on separate, clear bands.
+
+    Several bypass routes dipping into the same inter-row channel used to land
+    at a loose smear of distinct Ys (issue #484).  ``_normalize_bypass_trunks``
+    now splits the channel by traversal direction (``sign_x``) and lays each
+    direction on its own band: SAME-direction co-travellers fan tight
+    (``OFFSET_STEP``), while OPPOSITE-direction flows are pushed onto separate
+    bands with a clear ``BUNDLE_TO_BUNDLE_CLEARANCE`` gap so they never smoosh
+    together (and no distinct line is hidden behind another).  Opposite
+    directions are NOT counted as bundle-mates.
+    """
+    from nf_metro.layout.constants import CURVE_RADIUS, DIAGONAL_RUN, OFFSET_STEP
+    from nf_metro.layout.routing.core import (
+        _build_routing_context,
+        _collect_htrunks,
+        _inter_row_gap_band,
+    )
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
+
+    trunks = _collect_htrunks(routes, include_exempt=True)
+
+    # SAME-direction co-travellers this pass bundles (the checked trunk is
+    # non-exempt, i.e. movable by the normaliser) must be no more than one
+    # slot apart.  A larger gap means a line was left stranded outside the
+    # bundle (the loose smear the fix removed).
+    budget = OFFSET_STEP + 1.5
+    tight_checked = False
+    for i, t in enumerate(trunks):
+        if t.route.normalize_exempt:
+            continue
+        gap = _inter_row_gap_band(ctx, t.y)
+        if gap is None:
+            continue
+        nearest = None
+        for j, o in enumerate(trunks):
+            if i == j or o.route.line_id == t.route.line_id or o.sign_x != t.sign_x:
+                continue
+            if t.dips_down != o.dips_down or _inter_row_gap_band(ctx, o.y) != gap:
+                continue
+            if not (t.x_lo < o.x_hi and o.x_lo < t.x_hi):
+                continue
+            if min(t.x_hi, o.x_hi) - max(t.x_lo, o.x_lo) <= EDGE_TO_BUNDLE_CLEARANCE:
+                continue
+            d = abs(o.y - t.y)
+            nearest = d if nearest is None else min(nearest, d)
+        if nearest is None:
+            continue
+        tight_checked = True
+        assert nearest <= budget, (
+            f"{fixture}: '{t.route.line_id}' trunk @{t.y:.1f} stranded "
+            f"{nearest:.1f}px from its nearest same-direction bundle-mate "
+            f"(budget {budget:.1f}px)"
+        )
+    assert tight_checked, f"{fixture}: no same-direction co-travelling trunks found"
+
+
+@pytest.mark.parametrize("fixture", _OPPOSITE_BAND_FIXTURES)
+def test_opposite_direction_trunks_on_separate_bands(fixture):
+    """Opposite-direction flows sharing one inter-row gap must sit on separate,
+    clear bands - never smooshed into one tight bundle (issue #484).
+
+    ``_normalize_bypass_trunks`` splits a shared inter-row channel by traversal
+    direction (``sign_x``) and lays each direction on its own band with a clear
+    ``BUNDLE_TO_BUNDLE_CLEARANCE`` gap.  Two overlapping trunks of OPPOSITE
+    direction must therefore never fan to within one ``OFFSET_STEP`` of each
+    other; they stay at least a bundle gap apart.
+    """
+    from nf_metro.layout.constants import (
+        BUNDLE_TO_BUNDLE_CLEARANCE,
+        CURVE_RADIUS,
+        DIAGONAL_RUN,
+    )
+    from nf_metro.layout.routing.core import (
+        _build_routing_context,
+        _collect_htrunks,
+        _inter_row_gap_band,
+    )
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
+
+    trunks = _collect_htrunks(routes, include_exempt=True)
+    sep_checked = False
+    for i, t in enumerate(trunks):
+        gap = _inter_row_gap_band(ctx, t.y)
+        if gap is None:
+            continue
+        for j, o in enumerate(trunks):
+            if j <= i or o.sign_x == t.sign_x:
+                continue
+            if t.dips_down != o.dips_down or _inter_row_gap_band(ctx, o.y) != gap:
+                continue
+            if not (t.x_lo < o.x_hi and o.x_lo < t.x_hi):
+                continue
+            if min(t.x_hi, o.x_hi) - max(t.x_lo, o.x_lo) <= EDGE_TO_BUNDLE_CLEARANCE:
+                continue
+            sep_checked = True
+            d = abs(o.y - t.y)
+            assert d >= BUNDLE_TO_BUNDLE_CLEARANCE - 0.1, (
+                f"{fixture}: opposite-direction trunks '{t.route.line_id}' "
+                f"@{t.y:.1f} (sign {t.sign_x}) and '{o.route.line_id}' "
+                f"@{o.y:.1f} (sign {o.sign_x}) only {d:.1f}px apart - smooshed"
+            )
+    assert sep_checked, f"{fixture}: no opposite-direction overlapping trunks found"
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_top_entry_lead_corner_concentric(fixture):
+    """A multi-line TOP-entry L-shape must turn its lead-in corner
+    concentrically: co-routed lines share one bend centre.
+
+    The lines are already separated in Y by the render offset, so an equal
+    lead-in radius leaves the arcs non-concentric and the perpendicular gap
+    pinches through the bend (issue #484, cross_row turn-down after section 1).
+    The fix keeps the outermost line at the base radius and shrinks each inner
+    line's lead-in radius by one ``OFFSET_STEP`` so all arcs nest about a
+    common centre.  Encoded as: within a shared (source TOP-entry, target)
+    bundle, the first-corner radii sorted descending must step down by exactly
+    ``OFFSET_STEP``.  Only checks narrow bundles where the fix applies.
+    """
+    from nf_metro.layout.constants import CURVE_RADIUS, OFFSET_STEP
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    by_key: dict[tuple[str, str], list[float]] = {}
+    for rp in routes:
+        port = graph.ports.get(rp.edge.target)
+        if port is None or not port.is_entry or port.side != PortSide.TOP:
+            continue
+        if not rp.normalize_exempt or not rp.curve_radii:
+            continue
+        by_key.setdefault((rp.edge.source, rp.edge.target), []).append(
+            rp.curve_radii[0]
+        )
+
+    for (src, tgt), radii in by_key.items():
+        n = len(radii)
+        # Gate matches the handler: only narrow bundles get concentric radii.
+        if n < 2 or (n - 1) * OFFSET_STEP > CURVE_RADIUS - OFFSET_STEP:
+            continue
+        radii = sorted(radii, reverse=True)
+        assert abs(radii[0] - CURVE_RADIUS) < 0.1, (
+            f"{fixture}: {src}->{tgt} outermost lead radius {radii[0]} "
+            f"!= base {CURVE_RADIUS}"
+        )
+        steps = [round(a - b, 1) for a, b in zip(radii, radii[1:])]
+        assert all(abs(s - OFFSET_STEP) < 0.1 for s in steps), (
+            f"{fixture}: {src}->{tgt} lead-corner radii {radii} not concentric "
+            f"(steps {steps})"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1281,6 +1566,7 @@ def test_junction_same_line_fans_coincide_or_separate(fixture):
     """
     from nf_metro.layout.constants import CURVE_RADIUS, DIAGONAL_RUN, OFFSET_STEP
     from nf_metro.layout.engine import first_vertical_leg_x
+    from nf_metro.layout.phases._common import first_vertical_leg_sign
     from nf_metro.layout.routing.core import _build_routing_context
 
     graph = _layout(fixture)
@@ -1289,23 +1575,27 @@ def test_junction_same_line_fans_coincide_or_separate(fixture):
     ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
     fan_sources = {key[0] for key in ctx.junction_fan_info}
 
-    # Group inter-section routes by (junction source, line).
+    # Group inter-section routes by (junction source, line), tracking the V1
+    # vertical direction; opposite-direction channels diverge and can't smear.
     by_src_line: dict[tuple[str, str], list] = defaultdict(list)
     for rp in routes:
         if not rp.is_inter_section or rp.edge.source not in fan_sources:
             continue
         vx = first_vertical_leg_x(rp.points)
-        if vx is None:
+        sign = first_vertical_leg_sign(rp.points)
+        if vx is None or sign is None:
             continue
-        by_src_line[(rp.edge.source, rp.line_id)].append((rp, vx))
+        by_src_line[(rp.edge.source, rp.line_id)].append((vx, sign))
 
     coincide_tol = OFFSET_STEP + _Y_TOL
     separate_min = SECTION_Y_GAP
     for (src, line), entries in by_src_line.items():
         if len(entries) < 2:
             continue
-        xs = sorted(vx for _rp, vx in entries)
-        for lo, hi in zip(xs, xs[1:]):
+        ordered = sorted(entries)
+        for (lo, lo_sign), (hi, hi_sign) in zip(ordered, ordered[1:]):
+            if lo_sign != hi_sign:
+                continue
             gap = hi - lo
             assert gap <= coincide_tol or gap >= separate_min, (
                 f"{fixture}: junction {src} line {line} fans two routes "
@@ -1411,6 +1701,87 @@ def test_routes_enter_sections_only_at_ports(fixture):
         if hit is not None
         else ""
     )
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION_PLUS_STACK)
+def test_no_route_passes_through_unrelated_section(fixture):
+    """A line may only occupy a section's bbox where it connects to a
+    station there (#484).
+
+    The route edge's source section (the line starts there) and target
+    section (it enters via that section's port) are the only boxes a route
+    may intersect.  A segment crossing any other section's interior plots
+    the line over a section it never interacts with -- the long-range
+    pass-through that makes a dense diagram unreadable.  Unlike
+    ``test_routes_enter_sections_only_at_ports`` this checks the final
+    rendered geometry for *every* route, including fan-in/-out bundle
+    routes through junction/merge nodes.
+    """
+    from nf_metro.layout.phases._common import routes_through_unrelated_sections
+
+    graph = _layout(fixture)
+    offenders = routes_through_unrelated_sections(graph)
+    assert not offenders, f"{fixture}: " + "; ".join(
+        f"{rp.line_id} {rp.edge.source}->{rp.edge.target} through {sid!r}"
+        for rp, sid in offenders[:5]
+    )
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION_PLUS_STACK)
+def test_entry_approach_arrives_from_port_side(fixture):
+    """A route's final approach to an entry port must arrive from the
+    port's own outward side, not by crossing the target section interior
+    to reach a far-side port (#484).
+
+    A RIGHT entry port must be reached from ``x >= section_right`` and a
+    LEFT entry port from ``x <= section_left``; the perpendicular TOP /
+    BOTTOM ports from above / below.  A route whose final approach leg
+    starts inside the target box and runs outward to the port has sliced
+    through the interior and doubled back.  Distinct from
+    ``test_no_route_passes_through_unrelated_section`` (which exempts the
+    route's own target section), this catches the route crossing its OWN
+    target's interior.
+    """
+    from nf_metro.layout.phases.guards import _entry_approach_offenders
+    from nf_metro.layout.routing import route_edges
+
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+    offenders = _entry_approach_offenders(graph, routes)
+    assert not offenders, f"{fixture}: " + "; ".join(
+        f"{rp.line_id} {rp.edge.source}->{rp.edge.target}: {reason}"
+        for rp, _pid, reason in offenders[:5]
+    )
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION_PLUS_STACK)
+def test_no_artefactual_counter_flow(fixture):
+    """A feed from a row above its target must not dive below the target row
+    and run its long horizontal counter to that row's flow when a clear
+    inter-row gap above the target was free (#484).
+
+    Serpentine rows alternate flow (even LR, odd RL).  A route into a RIGHT
+    entry port from a higher row can run its rightward traverse in the clear
+    band just above the target row, then drop straight into the port from the
+    right.  Diving under the whole target row instead runs that traverse
+    against the row's flow -- artefactual counter-flow caused by the routing
+    picking the wrong channel.  Topological counter-flow (LEFT/TOP/BOTTOM
+    entry wraps, or a dive whose gap-above band is blocked) is exempt; the
+    guard fires only when the with-flow gap above the target was genuinely
+    available yet unused.
+    """
+    from nf_metro.layout.phases.guards import (
+        PhaseInvariantError,
+        _guard_no_artefactual_counter_flow,
+    )
+    from nf_metro.layout.routing import route_edges
+
+    graph = _layout(fixture)
+    routes = route_edges(graph)
+    try:
+        _guard_no_artefactual_counter_flow(graph, fixture, routes=routes)
+    except PhaseInvariantError as exc:
+        pytest.fail(str(exc))
 
 
 # ---------------------------------------------------------------------------
@@ -3569,8 +3940,9 @@ def test_inter_section_route_y_stays_within_row_band(fixture):
         else:
             row_band[sec.grid_row] = (min(cur[0], top), max(cur[1], bot))
 
-    # Slack: one y_spacing for diagonal corner approach.
-    SLACK = 60.0
+    # Slack: a clean below-row wrap channel (bypass clearance + bundle
+    # nest + diagonal corner approach), shared with the runtime band guard.
+    SLACK = ROW_BAND_SLACK
 
     offenders: list[str] = []
     for r in routes:
@@ -4695,3 +5067,82 @@ def test_anchor_guard_catches_a_displaced_port(monkeypatch, example, sides, axis
     monkeypatch.setattr(engine, "_balance_section_content_around_trunk", _evil)
     with pytest.raises(PhaseInvariantError, match="port anchor"):
         _layout_example(example, validate=True)
+
+
+# ---------------------------------------------------------------------------
+# TOP-entry cross-column bundle: concentric corners
+# ---------------------------------------------------------------------------
+
+
+def _corner_arc_center(p_prev, p_corner, p_next, radius):
+    """Arc centre that fits ``radius`` into the bend at ``p_corner``."""
+    import math
+
+    v1 = (p_prev[0] - p_corner[0], p_prev[1] - p_corner[1])
+    v2 = (p_next[0] - p_corner[0], p_next[1] - p_corner[1])
+    n1 = math.hypot(*v1)
+    n2 = math.hypot(*v2)
+    if n1 == 0 or n2 == 0:
+        return None
+    u1 = (v1[0] / n1, v1[1] / n1)
+    u2 = (v2[0] / n2, v2[1] / n2)
+    bis = (u1[0] + u2[0], u1[1] + u2[1])
+    nb = math.hypot(*bis)
+    if nb == 0:
+        return None
+    ub = (bis[0] / nb, bis[1] / nb)
+    dot = max(-1.0, min(1.0, u1[0] * u2[0] + u1[1] * u2[1]))
+    half = math.acos(dot) / 2.0
+    if math.sin(half) == 0:
+        return None
+    dist = radius / math.sin(half)
+    return (p_corner[0] + ub[0] * dist, p_corner[1] + ub[1] * dist)
+
+
+def test_cross_row_top_entry_bundle_corners_are_concentric():
+    """The multi-line U-route into a TOP entry port must bend concentrically.
+
+    ``cross_row_gap_wrap`` carries ``main`` and ``feed`` from a junction in
+    row 0 across and down into the ``merge_pt`` TOP entry port in row 1.  The
+    two lines must keep a constant perpendicular gap through the lead-in
+    corner and the two trunk corners: their arc centres must coincide there
+    (the final jog onto the shared port point is exempt, as both lines must
+    converge on one marker).
+    """
+    import math
+
+    graph = _layout("topologies/cross_row_gap_wrap.mmd")
+    routes = route_edges(graph)
+    offsets = compute_station_offsets(graph)
+
+    from nf_metro.render.svg import apply_route_offsets
+
+    bundle = [
+        r
+        for r in routes
+        if r.edge.source == "__junction_8" and r.edge.target == "merge_pt__entry_top_6"
+    ]
+    assert len(bundle) == 2, f"expected 2 lines, got {len(bundle)}"
+    bundle.sort(key=lambda r: r.line_id)
+
+    rendered = [(r, apply_route_offsets(r, offsets)) for r in bundle]
+    # The reference line drops straight into the port (no jog, 5 points); the
+    # offset line steps across with a converging jog (6 points).  Compare the
+    # three shared bends C1 (lead-in), C2 and C3 (trunk).
+    centers = []
+    for r, pts in rendered:
+        cs = [
+            _corner_arc_center(pts[k - 1], pts[k], pts[k + 1], r.curve_radii[k - 1])
+            for k in range(1, 4)
+        ]
+        centers.append(cs)
+
+    for k in range(3):
+        a = centers[0][k]
+        b = centers[1][k]
+        assert a is not None and b is not None
+        gap = math.hypot(a[0] - b[0], a[1] - b[1])
+        assert gap <= 1.0, (
+            f"corner C{k + 1} arc centres are {gap:.2f}px apart "
+            f"(non-concentric): {a} vs {b}"
+        )

--- a/tests/test_struct_extent_predictor.py
+++ b/tests/test_struct_extent_predictor.py
@@ -42,6 +42,7 @@ KNOWN_DIVERGENT: dict[str, float] = {
     "variantbenchmarking.mmd": 20.0,
     "variantbenchmarking_auto.mmd": 20.0,
     "genomic_pipeline.mmd": 5.0,
+    "longread_variant_calling.mmd": 20.0,
 }
 
 


### PR DESCRIPTION
## Summary

Fixes the badly-rendered auto-layout reported in #484 (a dense long-read variant-calling pipeline: 6 lines, 9 sections). The diagram previously rendered with overlapping section boxes and inter-section lines slicing through unrelated sections; it now lays out as a compact, readable map that passes `compute_layout(validate=True)`.

### Layout (`auto_layout.py`, `section_placement.py`, `phases/ports.py`)
- Convergence return-row no longer collides a stacked spine sibling into an occupied grid cell, and normalizes its leftward-stepping columns (no negative columns).
- A lone stacked spine-sibling that feeds only the return set migrates into the return row, collapsing a redundant near-empty spine row (canvas height cut ~30%).
- TB section boxes no longer stretch their bottom to a downstream target when the exit port is already clear of the bottom edge (eliminates dead space and a phantom box overlap); TB perpendicular entry ports snap just above the first station.

### Routing (`routing/core.py`, `routing/common.py`)
- Inter-section lines route **around** non-connecting section boxes (inter-column / inter-row / below-row channels) instead of through their interiors.
- A cross-row feed into a far-side RIGHT entry port wraps to approach from the port's outward side; when the source is in the row above, the horizontal runs in the inter-row gap rather than diving under the target row counter to its flow.
- Co-travelling fan branches keep their vertical downturn legs bundled; same-line bypass trunks coincide on one track and split only at divergence; overlapping bypass trunks fan into a concentric bundle; peel-off risers hold the same perpendicular gap as their trunk; a TB exit-port leg stays continuous through the port.

### Rendering (`render/bridges.py`)
- Same-colour crossovers (a line crossing its own independent branch) now get a bridge gap; the previous blanket same-line skip is replaced with a fan/loop reconvergence test so fan-out divergence is not gapped.

### Invariant guards + tests
- New runtime guards (under `validate=True`): no route through an unrelated section, entry approach from the port's outward side, no artefactual counter-flow. Each backed by a parametrized invariant test over the multi-section corpus.
- 4 minimal topology regression fixtures (`examples/topologies/`) isolating route-around, same-colour crossover bridge, convergence stacked-sink migration, and cross-row gap-wrap.
- Bridge crossover regression tests.

### Gallery
- New `examples/longread_variant_calling.mmd` gallery example (anonymised from the issue's pipeline), registered in the gallery build.

Fixes #484

## Test plan
- [ ] `pytest` green (5652 passed; includes new invariant + topology + bridge tests)
- [ ] `ruff check` + `ruff format --check` clean
- [ ] New `validate=True` guards: route-through-section, entry-approach-side, artefactual-counter-flow
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/507/)

Generated with Claude Code
