### PR TITLE
fix(routing): centralise corner-radius computation on corners.py (#508)

### DIFF
--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -1452,16 +1452,16 @@ def _route_stepped_descent(
         (chan_x, ey + tgt_off),
         (ex, ey + tgt_off),
     ]
-    # Each line's vertical legs (and the step_y rung) sit ``spread`` to the
-    # right of / below the innermost line, so the four bends fan as nested
-    # concentric arcs.  Size every corner through the one direction-driven
-    # routine, reading the turn from the route's own geometry; ``spread == 0``
-    # for the innermost line keeps the single-line case at the base radius.
+    # Each line's vertical legs sit ``spread`` to the right of the innermost
+    # line, so the four bends fan as nested arcs (the two middle rungs are
+    # genuinely concentric; the outer two are transition corners).  Size every
+    # corner through the one direction-driven routine, reading the turn from the
+    # route's own geometry; ``spread == 0`` for the innermost line keeps the
+    # single-line case at the base radius.
     radii = [
         concentric_corner_radius(
             _unit_step(points[k - 1], points[k]),
             _unit_step(points[k], points[k + 1]),
-            spread,
             spread,
             ctx.curve_radius,
             min_radius=COORD_TOLERANCE,

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -60,6 +60,8 @@ from nf_metro.layout.routing.common import (
 )
 from nf_metro.layout.routing.corners import (
     bypass_radii,
+    concentric_corner_radius,
+    corner_outside_sign,
     corner_radius,
     l_shape_radii,
     reference_anchored_radius,
@@ -886,7 +888,7 @@ def _route_bottom_exit_junction(
         x_off = ((n - 1) / 2 - i) * ctx.offset_step
 
     tgt_off = _get_offset(ctx, edge.target, edge.line_id)
-    r = ctx.curve_radius + x_off
+    r = reference_anchored_radius(x_off, ctx.curve_radius)
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
@@ -944,6 +946,8 @@ def _route_merge_branch(
             (tail_x, by),
         ],
         is_inter_section=True,
+        # One branch line per call: a single descent, so both corners take the
+        # base radius (no bundle to fan concentrically).
         curve_radii=[ctx.curve_radius, ctx.curve_radius],
         offsets_applied=True,
     )
@@ -1380,6 +1384,14 @@ def _nested_target_clear_channel_x(
     return max(s.bbox_x + s.bbox_w for s in secs) + clearance
 
 
+def _unit_step(p: tuple[float, float], q: tuple[float, float]) -> tuple[float, float]:
+    """Unit travel direction from *p* to *q* for an axis-aligned segment."""
+    dx, dy = q[0] - p[0], q[1] - p[1]
+    if abs(dx) >= abs(dy):
+        return (1.0 if dx > 0 else -1.0, 0.0)
+    return (0.0, 1.0 if dy > 0 else -1.0)
+
+
 def _route_stepped_descent(
     edge: Edge,
     src: Station,
@@ -1432,20 +1444,38 @@ def _route_stepped_descent(
         chan_x = ex + SECTION_ROUTE_CLEARANCE
     chan_x += spread
 
+    points = [
+        (sx, sy + src_off),
+        (corner_x, sy + src_off),
+        (corner_x, step_y),
+        (chan_x, step_y),
+        (chan_x, ey + tgt_off),
+        (ex, ey + tgt_off),
+    ]
+    # Each line's vertical legs (and the step_y rung) sit ``spread`` to the
+    # right of / below the innermost line, so the four bends fan as nested
+    # concentric arcs.  Size every corner through the one direction-driven
+    # routine, reading the turn from the route's own geometry; ``spread == 0``
+    # for the innermost line keeps the single-line case at the base radius.
+    radii = [
+        concentric_corner_radius(
+            _unit_step(points[k - 1], points[k]),
+            _unit_step(points[k], points[k + 1]),
+            spread,
+            spread,
+            ctx.curve_radius,
+            min_radius=COORD_TOLERANCE,
+        )
+        for k in range(1, 5)
+    ]
+
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[
-            (sx, sy + src_off),
-            (corner_x, sy + src_off),
-            (corner_x, step_y),
-            (chan_x, step_y),
-            (chan_x, ey + tgt_off),
-            (ex, ey + tgt_off),
-        ],
+        points=points,
         is_inter_section=True,
         normalize_exempt=True,
-        curve_radii=[r, r, r, r],
+        curve_radii=radii,
         offsets_applied=True,
     )
 
@@ -3276,7 +3306,7 @@ def _route_perp_entry(
             (drop_x, ty + tgt_off),
             (tx, ty + tgt_off),
         ]
-        radii = [ctx.curve_radius + src_off]
+        radii = [reference_anchored_radius(src_off, ctx.curve_radius)]
     else:
         pts = [
             (sx + src_off, sy),
@@ -3284,7 +3314,10 @@ def _route_perp_entry(
             (drop_x, ty + tgt_off),
             (tx, ty + tgt_off),
         ]
-        radii = [ctx.curve_radius, ctx.curve_radius + src_off]
+        radii = [
+            reference_anchored_radius(0.0, ctx.curve_radius),
+            reference_anchored_radius(src_off, ctx.curve_radius),
+        ]
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
@@ -3405,7 +3438,10 @@ def _route_perp_entry_merged(
                 (tx, ty + tgt_off),
             ],
             offsets_applied=True,
-            curve_radii=[ctx.curve_radius, ctx.curve_radius + src_off],
+            curve_radii=[
+                reference_anchored_radius(0.0, ctx.curve_radius),
+                reference_anchored_radius(src_off, ctx.curve_radius),
+            ],
         )
 
     # Different X (cross-column entry): 3-point L-shape
@@ -4816,25 +4852,6 @@ def _respace_risers_to_trunk(
         )
 
 
-def _corner_outside_sign(
-    turn_in: tuple[float, float], turn_out: tuple[float, float]
-) -> int:
-    """Sign of ``new_x - centre`` that puts a line OUTSIDE a riser-flanking turn.
-
-    *turn_in* / *turn_out* are the travel-direction vectors of the two segments
-    meeting at the corner.  A CCW turn (positive cross) curves outward to the
-    RIGHT of travel; a CW turn (negative cross) outward to the LEFT.  Along the
-    vertical riser leg, right-of-travel is +X when travelling DOWN and -X when
-    travelling UP.  Returns +1 when the larger-X line is the outside one, -1
-    when the smaller-X line is.
-    """
-    cross = turn_in[0] * turn_out[1] - turn_in[1] * turn_out[0]
-    v = turn_in if abs(turn_in[1]) > abs(turn_in[0]) else turn_out
-    right_is_plus_x = v[1] > 0  # DOWN travel: right-of-travel is +X
-    outside_is_right = cross < 0  # CW turn curves outward to the right
-    return 1 if (right_is_plus_x == outside_is_right) else -1
-
-
 def _set_riser_x_and_radii(
     ch: _VChannel,
     new_x: float,
@@ -4875,10 +4892,10 @@ def _set_riser_x_and_radii(
         else:
             turn_in = v_dir
             turn_out = (hx, 0.0)
-        side = _corner_outside_sign(turn_in, turn_out)
+        side = corner_outside_sign(turn_in, turn_out)
         # Outside line (offset sign matches `side`) gets the largest radius;
-        # inner edge gets base.  Magnitude measured from the innermost line.
-        r = base_radius + max_off + off_signed * side
+        # inner edge gets base.  Anchored on the bundle centre (base + max_off).
+        r = reference_anchored_radius(off_signed * side, base_radius + max_off)
         if not (0 <= radius_idx < len(rp.curve_radii)):
             continue
         if not is_lead and not (k + 2 < len(pts)):

--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -154,7 +154,87 @@ def corner_radius(
         ``base_radius + (max_offset - offset)`` when False.
     """
     eff = offset if outside else reversed_offset(offset, max_offset)
-    return base_radius + eff
+    return reference_anchored_radius(eff, base_radius)
+
+
+def corner_outside_sign(
+    turn_in: tuple[float, float], turn_out: tuple[float, float]
+) -> int:
+    """Sign of ``new_x - centre`` that puts a line OUTSIDE a riser-flanking turn.
+
+    A *riser* is a vertical channel whose flanking horizontal legs are held at
+    a shared Y and simply *stretch* to reach each line's vertical X.  Such a
+    corner is NOT a nested-arc bundle (shared-Y horizontals cannot share an arc
+    centre); each line gets its own rounded corner, and this returns the sign
+    that makes the line further OUT (along the channel's perpendicular) take the
+    larger radius.  For nestable bundles whose corner translates wholesale, use
+    :func:`concentric_corner_radius` instead.
+
+    *turn_in* / *turn_out* are the travel-direction vectors of the two segments
+    meeting at the corner.  A CCW turn (positive cross) curves outward to the
+    RIGHT of travel; a CW turn (negative cross) outward to the LEFT.  Along the
+    vertical riser leg, right-of-travel is +X when travelling DOWN and -X when
+    travelling UP.  Returns +1 when the larger-X line is the outside one, -1
+    when the smaller-X line is.
+    """
+    cross = turn_in[0] * turn_out[1] - turn_in[1] * turn_out[0]
+    v = turn_in if abs(turn_in[1]) > abs(turn_in[0]) else turn_out
+    right_is_plus_x = v[1] > 0  # DOWN travel: right-of-travel is +X
+    outside_is_right = cross < 0  # CW turn curves outward to the right
+    return 1 if (right_is_plus_x == outside_is_right) else -1
+
+
+def concentric_corner_radius(
+    turn_in: tuple[float, float],
+    turn_out: tuple[float, float],
+    dx: float,
+    dy: float = 0.0,
+    base_radius: float = CURVE_RADIUS,
+    *,
+    min_radius: float | None = None,
+) -> float:
+    """Concentric arc radius for one line of a wholesale-translated 90° corner.
+
+    When a bundle of parallel lines turns a 90° corner and the *entire* corner
+    (both flanking legs) is translated per line by ``(dx, dy)`` from a chosen
+    reference line, the arcs share a common centre iff::
+
+        radius = base_radius - dx * (turn_out_x - turn_in_x)
+               = base_radius - dy * (turn_out_y - turn_in_y)
+
+    (derived by equating every line's arc centre ``corner + radius *
+    (turn_out - turn_in)``).  This is the single direction-driven entry point
+    for nestable corners: any orientation - right-then-down, down-then-left,
+    etc. - is mapped to the correct signed offset purely from the two travel
+    vectors, so the same routine sizes every such corner regardless of compass
+    direction.  Unlike :func:`corner_outside_sign` (risers, shared-Y stretch),
+    this keeps the bundle's arcs genuinely concentric.
+
+    Parameters
+    ----------
+    turn_in, turn_out : tuple of float
+        Unit travel-direction vectors into and out of the corner (axis-aligned;
+        ``turn_out - turn_in`` has both components +/-1 for a real 90° turn).
+    dx, dy : float
+        This line's corner displacement from the bundle's reference line.  The
+        X projection drives the radius for any 90° turn (``turn_out_x !=
+        turn_in_x`` always holds); *dy* is the fallback for a degenerate corner
+        with no X extent.
+    base_radius : float
+        Reference-line radius.
+    min_radius : float or None
+        Optional floor (see :func:`reference_anchored_radius`); inside-of-turn
+        lines fall below *base_radius* and a deep bundle can drive it to zero.
+
+    Returns
+    -------
+    float
+        The concentric radius via :func:`reference_anchored_radius`.
+    """
+    ux = turn_out[0] - turn_in[0]
+    uy = turn_out[1] - turn_in[1]
+    signed = -dx * ux if ux != 0 else -dy * uy
+    return reference_anchored_radius(signed, base_radius, min_radius=min_radius)
 
 
 def reference_anchored_radius(

--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -188,7 +188,6 @@ def concentric_corner_radius(
     turn_in: tuple[float, float],
     turn_out: tuple[float, float],
     dx: float,
-    dy: float = 0.0,
     base_radius: float = CURVE_RADIUS,
     *,
     min_radius: float | None = None,
@@ -196,30 +195,34 @@ def concentric_corner_radius(
     """Concentric arc radius for one line of a wholesale-translated 90° corner.
 
     When a bundle of parallel lines turns a 90° corner and the *entire* corner
-    (both flanking legs) is translated per line by ``(dx, dy)`` from a chosen
-    reference line, the arcs share a common centre iff::
+    is translated per line so this line's vertical leg sits *dx* to the side of
+    the reference line, the arcs share a common centre iff::
 
         radius = base_radius - dx * (turn_out_x - turn_in_x)
-               = base_radius - dy * (turn_out_y - turn_in_y)
 
     (derived by equating every line's arc centre ``corner + radius *
-    (turn_out - turn_in)``).  This is the single direction-driven entry point
-    for nestable corners: any orientation - right-then-down, down-then-left,
-    etc. - is mapped to the correct signed offset purely from the two travel
-    vectors, so the same routine sizes every such corner regardless of compass
-    direction.  Unlike :func:`corner_outside_sign` (risers, shared-Y stretch),
-    this keeps the bundle's arcs genuinely concentric.
+    (turn_out - turn_in)``; ``turn_out_x - turn_in_x`` is always +/-1 for a real
+    90° turn, and a valid bundle must fan in X since a pure-Y translation would
+    overlap the vertical legs - so the X displacement alone fixes the radius).
+    This is the single direction-driven entry point for nestable corners: any
+    orientation - right-then-down, down-then-left, etc. - is mapped to the
+    correct signed offset purely from the two travel vectors, so the same
+    routine sizes every such corner regardless of compass direction.
+
+    The arcs are genuinely concentric only when the *whole* corner translates
+    together.  At a *transition* corner - one flanking leg fanned by *dx*, the
+    other pinned at a fixed (e.g. port) offset - this still returns a sensibly
+    nested radius (sized to the fanned leg) but the arcs do not share a centre.
+    Unlike :func:`corner_outside_sign` (risers, shared-Y stretch), this never
+    flattens the bundle to a single radius.
 
     Parameters
     ----------
     turn_in, turn_out : tuple of float
         Unit travel-direction vectors into and out of the corner (axis-aligned;
         ``turn_out - turn_in`` has both components +/-1 for a real 90° turn).
-    dx, dy : float
-        This line's corner displacement from the bundle's reference line.  The
-        X projection drives the radius for any 90° turn (``turn_out_x !=
-        turn_in_x`` always holds); *dy* is the fallback for a degenerate corner
-        with no X extent.
+    dx : float
+        This line's signed X displacement from the bundle's reference line.
     base_radius : float
         Reference-line radius.
     min_radius : float or None
@@ -232,9 +235,7 @@ def concentric_corner_radius(
         The concentric radius via :func:`reference_anchored_radius`.
     """
     ux = turn_out[0] - turn_in[0]
-    uy = turn_out[1] - turn_in[1]
-    signed = -dx * ux if ux != 0 else -dy * uy
-    return reference_anchored_radius(signed, base_radius, min_radius=min_radius)
+    return reference_anchored_radius(-dx * ux, base_radius, min_radius=min_radius)
 
 
 def reference_anchored_radius(

--- a/tests/test_corners.py
+++ b/tests/test_corners.py
@@ -624,12 +624,13 @@ class TestConcentricCornerRadius:
 
     def test_reference_line_is_base(self):
         for turn_in, turn_out in ALL_TURNS:
-            assert concentric_corner_radius(turn_in, turn_out, 0.0, 0.0) == CURVE_RADIUS
+            assert concentric_corner_radius(turn_in, turn_out, 0.0) == CURVE_RADIUS
 
     def test_arcs_are_concentric_in_every_orientation(self):
-        # The concentric fan direction is turn-specific: translating each line
-        # along ``(ux, uy) = turn_out - turn_in`` keeps every arc centre fixed.
-        # Verified in EVERY turn orientation against the independent centre.
+        # The concentric fan direction is turn-specific: translating each line's
+        # whole corner along ``(ux, uy) = turn_out - turn_in`` keeps every arc
+        # centre fixed.  The routine takes only the X displacement; verified in
+        # EVERY turn orientation against the independent centre.
         base = CURVE_RADIUS
         corner0 = (100.0, 100.0)
         for turn_in, turn_out in ALL_TURNS:
@@ -638,7 +639,7 @@ class TestConcentricCornerRadius:
             centres = []
             for k in range(4):
                 dx, dy = k * OFFSET_STEP * ux, k * OFFSET_STEP * uy
-                r = concentric_corner_radius(turn_in, turn_out, dx, dy, base)
+                r = concentric_corner_radius(turn_in, turn_out, dx, base)
                 centre = _arc_centre(
                     turn_in, turn_out, (corner0[0] + dx, corner0[1] + dy), r
                 )
@@ -653,11 +654,8 @@ class TestConcentricCornerRadius:
         base = CURVE_RADIUS
         for turn_in, turn_out in ALL_TURNS:
             ux = turn_out[0] - turn_in[0]
-            uy = turn_out[1] - turn_in[1]
             radii = [
-                concentric_corner_radius(
-                    turn_in, turn_out, k * OFFSET_STEP * ux, k * OFFSET_STEP * uy, base
-                )
+                concentric_corner_radius(turn_in, turn_out, k * OFFSET_STEP * ux, base)
                 for k in range(4)
             ]
             diffs = [abs(b - a) for a, b in zip(radii, radii[1:])]
@@ -669,22 +667,24 @@ class TestConcentricCornerRadius:
         # travel (either order) is sized by the SAME routine and is concentric.
         base = CURVE_RADIUS
         for turn_in, turn_out in ((RIGHT, DOWN), (DOWN, RIGHT)):
-            r_inner = concentric_corner_radius(turn_in, turn_out, 0.0, 0.0, base)
+            ux = turn_out[0] - turn_in[0]
+            r_inner = concentric_corner_radius(turn_in, turn_out, 0.0, base)
             r_outer = concentric_corner_radius(
-                turn_in, turn_out, OFFSET_STEP, OFFSET_STEP, base
+                turn_in, turn_out, OFFSET_STEP * ux, base
             )
             assert r_inner == base
             assert abs(r_outer - r_inner) == pytest.approx(OFFSET_STEP)
 
-    def test_x_and_y_projection_agree_when_concentric(self):
-        # For a concentric fan (translation along (ux, uy)), the X- and Y-axis
-        # radius projections agree: base - dx*ux == base - dy*uy.
+    def test_radius_matches_both_axis_projections(self):
+        # For a concentric fan (whole corner translated along (ux, uy)) the
+        # X- and Y-axis radius derivations agree: base - dx*ux == base - dy*uy.
+        # The routine uses the X projection; this pins that they coincide.
         base = CURVE_RADIUS
         for turn_in, turn_out in ALL_TURNS:
             ux = turn_out[0] - turn_in[0]
             uy = turn_out[1] - turn_in[1]
             dx, dy = 2 * OFFSET_STEP * ux, 2 * OFFSET_STEP * uy
-            r = concentric_corner_radius(turn_in, turn_out, dx, dy, base)
+            r = concentric_corner_radius(turn_in, turn_out, dx, base)
             assert r == pytest.approx(base - dx * ux)
             assert r == pytest.approx(base - dy * uy)
 
@@ -692,7 +692,7 @@ class TestConcentricCornerRadius:
         # An inside-of-turn line in a deep bundle can drive radius below zero.
         base = CURVE_RADIUS
         # DOWN->RIGHT: ux = +1, so positive dx subtracts -> can go negative.
-        r = concentric_corner_radius(DOWN, RIGHT, 100.0, 100.0, base, min_radius=0.1)
+        r = concentric_corner_radius(DOWN, RIGHT, 100.0, base, min_radius=0.1)
         assert r == 0.1
 
 

--- a/tests/test_corners.py
+++ b/tests/test_corners.py
@@ -17,6 +17,8 @@ from nf_metro.layout.constants import CURVE_RADIUS, OFFSET_STEP
 from nf_metro.layout.routing.common import Direction
 from nf_metro.layout.routing.corners import (
     bypass_radii,
+    concentric_corner_radius,
+    corner_outside_sign,
     corner_radius,
     l_shape_radii,
     reference_anchored_radius,
@@ -25,6 +27,24 @@ from nf_metro.layout.routing.corners import (
     tb_entry_corner,
     tb_exit_corner,
 )
+
+# Unit travel vectors for the four cardinal directions (screen coords, +y down).
+RIGHT = (1.0, 0.0)
+LEFT = (-1.0, 0.0)
+DOWN = (0.0, 1.0)
+UP = (0.0, -1.0)
+
+# The eight axis-aligned 90-degree turns, as (turn_in, turn_out).
+ALL_TURNS = [
+    (RIGHT, DOWN),
+    (RIGHT, UP),
+    (LEFT, DOWN),
+    (LEFT, UP),
+    (DOWN, RIGHT),
+    (DOWN, LEFT),
+    (UP, RIGHT),
+    (UP, LEFT),
+]
 
 # ---------------------------------------------------------------------------
 # reversed_offset
@@ -573,3 +593,136 @@ class TestResolveCurveRadii:
         # All should be achievable given 50+ px segments
         for r_eff, r_des in zip(result, radii):
             assert r_eff == pytest.approx(r_des)
+
+
+# ---------------------------------------------------------------------------
+# concentric_corner_radius: the direction-driven nestable-corner routine
+# ---------------------------------------------------------------------------
+
+
+def _arc_centre(
+    turn_in: tuple[float, float],
+    turn_out: tuple[float, float],
+    corner: tuple[float, float],
+    r: float,
+) -> tuple[float, float]:
+    """Centre of the rounded-corner arc.
+
+    For a 90-degree corner the inscribed arc of radius *r* is tangent to both
+    legs and its centre sits at ``corner + r * (turn_out - turn_in)``.  This is
+    the independent ground truth against which concentric radii are checked:
+    a bundle's arcs are concentric iff every line's centre coincides.
+    """
+    ux = turn_out[0] - turn_in[0]
+    uy = turn_out[1] - turn_in[1]
+    return (corner[0] + r * ux, corner[1] + r * uy)
+
+
+class TestConcentricCornerRadius:
+    """The single direction-driven routine for nestable (wholesale-translated)
+    90-degree corners, used in every compass orientation."""
+
+    def test_reference_line_is_base(self):
+        for turn_in, turn_out in ALL_TURNS:
+            assert concentric_corner_radius(turn_in, turn_out, 0.0, 0.0) == CURVE_RADIUS
+
+    def test_arcs_are_concentric_in_every_orientation(self):
+        # The concentric fan direction is turn-specific: translating each line
+        # along ``(ux, uy) = turn_out - turn_in`` keeps every arc centre fixed.
+        # Verified in EVERY turn orientation against the independent centre.
+        base = CURVE_RADIUS
+        corner0 = (100.0, 100.0)
+        for turn_in, turn_out in ALL_TURNS:
+            ux = turn_out[0] - turn_in[0]
+            uy = turn_out[1] - turn_in[1]
+            centres = []
+            for k in range(4):
+                dx, dy = k * OFFSET_STEP * ux, k * OFFSET_STEP * uy
+                r = concentric_corner_radius(turn_in, turn_out, dx, dy, base)
+                centre = _arc_centre(
+                    turn_in, turn_out, (corner0[0] + dx, corner0[1] + dy), r
+                )
+                centres.append(centre)
+            for c in centres[1:]:
+                assert c[0] == pytest.approx(centres[0][0])
+                assert c[1] == pytest.approx(centres[0][1])
+
+    def test_bundle_is_nested_step_spaced(self):
+        # Adjacent lines differ by exactly one offset step at every corner, so
+        # arcs nest and never cross (monotonic radii), in every orientation.
+        base = CURVE_RADIUS
+        for turn_in, turn_out in ALL_TURNS:
+            ux = turn_out[0] - turn_in[0]
+            uy = turn_out[1] - turn_in[1]
+            radii = [
+                concentric_corner_radius(
+                    turn_in, turn_out, k * OFFSET_STEP * ux, k * OFFSET_STEP * uy, base
+                )
+                for k in range(4)
+            ]
+            diffs = [abs(b - a) for a, b in zip(radii, radii[1:])]
+            for diff in diffs:
+                assert diff == pytest.approx(OFFSET_STEP)
+
+    def test_down_and_right_goes_through_one_routine(self):
+        # The user's litmus: a bundle turning between rightward and downward
+        # travel (either order) is sized by the SAME routine and is concentric.
+        base = CURVE_RADIUS
+        for turn_in, turn_out in ((RIGHT, DOWN), (DOWN, RIGHT)):
+            r_inner = concentric_corner_radius(turn_in, turn_out, 0.0, 0.0, base)
+            r_outer = concentric_corner_radius(
+                turn_in, turn_out, OFFSET_STEP, OFFSET_STEP, base
+            )
+            assert r_inner == base
+            assert abs(r_outer - r_inner) == pytest.approx(OFFSET_STEP)
+
+    def test_x_and_y_projection_agree_when_concentric(self):
+        # For a concentric fan (translation along (ux, uy)), the X- and Y-axis
+        # radius projections agree: base - dx*ux == base - dy*uy.
+        base = CURVE_RADIUS
+        for turn_in, turn_out in ALL_TURNS:
+            ux = turn_out[0] - turn_in[0]
+            uy = turn_out[1] - turn_in[1]
+            dx, dy = 2 * OFFSET_STEP * ux, 2 * OFFSET_STEP * uy
+            r = concentric_corner_radius(turn_in, turn_out, dx, dy, base)
+            assert r == pytest.approx(base - dx * ux)
+            assert r == pytest.approx(base - dy * uy)
+
+    def test_min_radius_floors_deep_inside_lines(self):
+        # An inside-of-turn line in a deep bundle can drive radius below zero.
+        base = CURVE_RADIUS
+        # DOWN->RIGHT: ux = +1, so positive dx subtracts -> can go negative.
+        r = concentric_corner_radius(DOWN, RIGHT, 100.0, 100.0, base, min_radius=0.1)
+        assert r == 0.1
+
+
+class TestCornerOutsideSign:
+    """Riser handedness: which side of the channel takes the larger radius."""
+
+    def test_returns_unit_sign_in_every_orientation(self):
+        for turn_in, turn_out in ALL_TURNS:
+            assert corner_outside_sign(turn_in, turn_out) in (-1, 1)
+
+    def test_matches_reference_formula(self):
+        # Lock-in oracle: re-derive the documented cross-product rule and assert
+        # the routine matches it in every orientation (catches accidental edits).
+        for turn_in, turn_out in ALL_TURNS:
+            cross = turn_in[0] * turn_out[1] - turn_in[1] * turn_out[0]
+            v = turn_in if abs(turn_in[1]) > abs(turn_in[0]) else turn_out
+            expected = 1 if ((v[1] > 0) == (cross < 0)) else -1
+            assert corner_outside_sign(turn_in, turn_out) == expected
+
+    def test_hand_checked_cases(self):
+        # Full handedness table (larger-X line outside = +1, inside = -1).
+        expected = {
+            (RIGHT, DOWN): -1,
+            (RIGHT, UP): -1,
+            (LEFT, DOWN): 1,
+            (LEFT, UP): 1,
+            (DOWN, RIGHT): 1,
+            (DOWN, LEFT): -1,
+            (UP, RIGHT): 1,
+            (UP, LEFT): -1,
+        }
+        for (turn_in, turn_out), want in expected.items():
+            assert corner_outside_sign(turn_in, turn_out) == want

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -359,3 +359,128 @@ def test_around_section_below_dispatched_for_cross_row_left_entry():
             f"around-section corners must share one radius (CW loop); "
             f"got {r.curve_radii}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Stepped-descent concentric bundling (#508)
+# ---------------------------------------------------------------------------
+
+
+def _stepped_descent_ctx(line_ids):
+    """Minimal _RoutingCtx + stations triggering a nested stepped descent.
+
+    An oversized source section (col 0) whose right edge sits well right of a
+    narrow target column (col 1) entry port, junction-sourced, so a multi-line
+    bundle fans down through the stepped staircase.
+    """
+    from nf_metro.layout.routing import core
+    from nf_metro.parser.model import (
+        MetroGraph,
+        Port,
+        PortSide,
+        Section,
+        Station,
+    )
+
+    g = MetroGraph(title="t", style="nfcore")
+    g.sections["A"] = Section(
+        id="A",
+        name="A",
+        grid_col=0,
+        grid_row=0,
+        bbox_x=0.0,
+        bbox_y=0.0,
+        bbox_w=400.0,
+        bbox_h=100.0,
+    )
+    g.sections["B"] = Section(
+        id="B",
+        name="B",
+        grid_col=1,
+        grid_row=0,
+        bbox_x=120.0,
+        bbox_y=200.0,
+        bbox_w=60.0,
+        bbox_h=80.0,
+    )
+    src = Station(id="J", label="", section_id="A", x=50.0, y=50.0)
+    g.stations["J"] = src
+    ep = Station(id="P", label="", section_id="B", is_port=True, x=150.0, y=230.0)
+    g.stations["P"] = ep
+    g.ports["P"] = Port(
+        id="P", section_id="B", side=PortSide.RIGHT, is_entry=True, x=150.0, y=230.0
+    )
+    offs = {("J", lid): (k - 1) * 3.0 for k, lid in enumerate(line_ids)}
+    offs.update({("P", lid): (k - 1) * 3.0 for k, lid in enumerate(line_ids)})
+    ctx = core._RoutingCtx(
+        graph=g,
+        fold_x=0.0,
+        junction_ids={"J"},
+        bottom_exit_junctions=set(),
+        bottom_exit_junction_ports={},
+        offset_step=3.0,
+        fork_stations=set(),
+        join_stations=set(),
+        tb_sections=set(),
+        tb_right_entry=set(),
+        bundle_info={},
+        bypass_gap_idx={},
+        station_offsets=offs,
+        diagonal_run=20.0,
+        curve_radius=10.0,
+    )
+    return core, ctx, src, ep
+
+
+def _arc_centre_from_points(pts, corner_idx, r):
+    """Arc centre at points[corner_idx+1] for a 90-degree rounded corner."""
+    a, c, b = pts[corner_idx], pts[corner_idx + 1], pts[corner_idx + 2]
+
+    def unit(p, q):
+        dx, dy = q[0] - p[0], q[1] - p[1]
+        m = (dx * dx + dy * dy) ** 0.5 or 1.0
+        return dx / m, dy / m
+
+    ti = unit(a, c)
+    to = unit(c, b)
+    return (c[0] + r * (to[0] - ti[0]), c[1] + r * (to[1] - ti[1]))
+
+
+def test_stepped_descent_single_line_uses_base_radius():
+    from nf_metro.parser.model import Edge
+
+    core, ctx, src, ep = _stepped_descent_ctx(["solo"])
+    assert core._should_step_descent(ctx.graph, src, ep, ctx.graph.ports["P"])
+    rp = core._route_stepped_descent(Edge("J", "P", "solo"), src, ep, 0, 1, ctx)
+    assert rp.curve_radii == [ctx.curve_radius] * 4
+
+
+def test_stepped_descent_bundle_is_concentric():
+    from nf_metro.parser.model import Edge
+
+    lines = ["l0", "l1", "l2"]
+    core, ctx, src, ep = _stepped_descent_ctx(lines)
+    n = len(lines)
+    routes = [
+        core._route_stepped_descent(Edge("J", "P", lid), src, ep, i, n, ctx)
+        for i, lid in enumerate(lines)
+    ]
+    # The two middle rungs (corners 1 and 2: down->left, left->down) are fanned
+    # by ``spread`` on BOTH legs, so they are genuinely concentric - every
+    # line's arc centre must coincide.  (Corners 0 and 3 join a spread-fanned
+    # vertical to a port-offset horizontal, so they are transition corners,
+    # sized to keep the vertical legs aligned rather than to share a centre.)
+    for corner_idx in (1, 2):
+        centres = [
+            _arc_centre_from_points(rp.points, corner_idx, rp.curve_radii[corner_idx])
+            for rp in routes
+        ]
+        for cx, cy in centres[1:]:
+            assert abs(cx - centres[0][0]) < 1e-6
+            assert abs(cy - centres[0][1]) < 1e-6
+    # All four corners stay nested (radii monotonic across the bundle), so the
+    # arcs never cross regardless of the transition-corner sizing.
+    for corner_idx in range(4):
+        radii = [rp.curve_radii[corner_idx] for rp in routes]
+        diffs = [b - a for a, b in zip(radii, radii[1:])]
+        assert all(d > 0 for d in diffs) or all(d < 0 for d in diffs)


### PR DESCRIPTION
## Summary

Routes every corner-radius computation in `routing/core.py` through the central concentric-curve family in `routing/corners.py`, so there is a single source of truth for corner radii.

- **`reference_anchored_radius` is the one radius formula** (`radius = base + signed_offset`). `corner_radius` now delegates to it, making the shared invariant explicit.
- **New direction-driven `concentric_corner_radius(turn_in, turn_out, dx)`** maps any 90-degree turn orientation to the concentric signed offset (derived from "all arc centres coincide": `radius = base − dx·(turn_out_x − turn_in_x)`) and delegates to `reference_anchored_radius`. This is the routine that guarantees a bundle turning a given way (e.g. down-then-right) is sized identically wherever it occurs.
- **`corner_outside_sign`** (the riser handedness primitive, a distinct shared-Y-stretch model that cannot share an arc centre) moves into `corners.py` as the tested home for that logic; `_set_riser_x_and_radii` calls it.
- Inline `base + offset` radius arithmetic replaced by `reference_anchored_radius` in `_route_bottom_exit_junction`, `_route_perp_entry`, `_route_perp_entry_merged`, and `_set_riser_x_and_radii`.
- **`_route_stepped_descent`** previously emitted `[base]*4`, which is not concentric for a multi-line bundle. Its corners are now sized via `concentric_corner_radius`: the two middle rungs become genuinely concentric; the outer two are transition corners (one leg fanned by `spread`, the other pinned at a port offset) sized to keep their vertical legs aligned.
- `_route_merge_branch` confirmed single-line (no bundle to fan); documented.

No inline corner-radius arithmetic remains in `routing/core.py`; every `curve_radii` value derives from a `corners.py` helper.

### Tests

- `concentric_corner_radius` and `corner_outside_sign` exercised across all eight 90-degree turn orientations, with arc-centre coincidence checked against an independent ground-truth formula.
- Direct concentricity test for `_route_stepped_descent` (asserts the middle-rung arc centres coincide and all four corners stay nested); verified failing on `main` before the fix.

Gallery renders are byte-for-byte identical to `main` (the centralisations re-express the same arithmetic; the stepped-descent value change affects a path no gallery fixture exercises).

Fixes #508

## Test plan
- [x] pytest passes (5874 passed; new invariant tests included)
- [x] ruff check + ruff format clean on `src/ tests/`
- [x] Gallery render diff: byte-for-byte identical vs `main`
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/511/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
