### PR TITLE
feat(layout): guard intra-section collinear distinct-line overlays

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -122,6 +122,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_merge_port_approach_side,
     _guard_no_artefactual_counter_flow,
     _guard_no_collinear_distinct_lines,
+    _guard_no_intra_section_collinear_distinct_lines,
     _guard_no_label_overlap,
     _guard_no_line_crosses_non_consumer,
     _guard_no_negative_grid_columns,
@@ -1149,6 +1150,9 @@ def _finalize_layout(
             )
             _guard_bundle_order_preserved(graph, phase, offsets=offsets, routes=routes)
             _guard_no_collinear_distinct_lines(
+                graph, phase, offsets=offsets, routes=routes
+            )
+            _guard_no_intra_section_collinear_distinct_lines(
                 graph, phase, offsets=offsets, routes=routes
             )
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
@@ -38,6 +39,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from nf_metro.layout.routing.common import RoutedPath
+    from nf_metro.layout.routing.invariants import CollinearOverlapViolation
 
 
 class PhaseInvariantError(Exception):
@@ -1421,6 +1423,45 @@ def _guard_no_collinear_distinct_lines(
         check_no_collinear_distinct_lines,
     )
 
+    _raise_on_collinear_overlay(
+        graph, phase, check_no_collinear_distinct_lines, offsets, routes
+    )
+
+
+def _guard_no_intra_section_collinear_distinct_lines(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: no two distinct lines may render on top within a section.
+
+    Wraps :func:`check_intra_section_collinear_distinct_lines`, the
+    intra-section counterpart to :func:`_guard_no_collinear_distinct_lines`.
+    A bundling/offset defect that collapses two co-travelling lines onto one
+    channel *inside* a section hides one line behind the other.
+    """
+    from nf_metro.layout.routing.invariants import (
+        check_intra_section_collinear_distinct_lines,
+    )
+
+    _raise_on_collinear_overlay(
+        graph, phase, check_intra_section_collinear_distinct_lines, offsets, routes
+    )
+
+
+def _raise_on_collinear_overlay(
+    graph: MetroGraph,
+    phase: str,
+    check: Callable[
+        [MetroGraph, list[RoutedPath], dict[tuple[str, str], float]],
+        list[CollinearOverlapViolation],
+    ],
+    offsets: dict[tuple[str, str], float] | None,
+    routes: list[RoutedPath] | None,
+) -> None:
+    """Run a collinear-overlay *check* and raise on the first violation."""
     if offsets is None:
         from nf_metro.layout.routing import compute_station_offsets
 
@@ -1433,7 +1474,7 @@ def _guard_no_collinear_distinct_lines(
         except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
             return
 
-    violations = check_no_collinear_distinct_lines(graph, routes, offsets)
+    violations = check(graph, routes, offsets)
     if not violations:
         return
     first = violations[0]

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -661,36 +661,27 @@ def _route_render_points(
     return out
 
 
-def check_no_collinear_distinct_lines(
-    graph: MetroGraph,
+def _collinear_overlay_violations(
     routes: list[RoutedPath],
     offsets: dict[tuple[str, str], float],
+    endpoint_xy: dict[str, tuple[float, float]],
+    *,
+    inter_section: bool,
 ) -> list[CollinearOverlapViolation]:
-    """Return distinct-line inter-section segments drawn exactly on top.
+    """Pairs of distinct-line axis-aligned segments drawn exactly on top.
 
-    Two co-travelling lines that share a bundle must occupy distinct
-    parallel slots (at least ``OFFSET_STEP`` apart laterally).  When a
-    bundling/offset defect collapses them to the same channel they
-    render as one stroke obscuring the other.  This check looks at the
-    final, offset-applied geometry: it flags pairs of DIFFERENT-line
-    axis-aligned inter-section segments whose channel coordinate
-    coincides within ``_COLLINEAR_LATERAL_TOL`` and whose overlap along
-    the axis exceeds ``_COLLINEAR_MIN_SPAN``.
-
-    Legitimate cases are excluded: lines converging onto a shared
-    endpoint port (an unavoidable single approach), tight parallel
-    bundles (>= one ``OFFSET_STEP`` apart never coincide), and short
-    trunk-level lead-ins below the min span.
+    Shared core of the inter- and intra-section collinear-overlay checks.
+    Scans the ``is_inter_section == inter_section`` routes, builds their
+    final offset-applied axis-aligned segments, and flags any
+    different-line pair whose channel coordinate coincides within
+    ``_COLLINEAR_LATERAL_TOL`` and whose overlap along the axis exceeds
+    ``_COLLINEAR_MIN_SPAN``.  Overlaps that merely converge onto a shared
+    endpoint in ``endpoint_xy`` (a port for inter-section routes, any
+    station for intra-section routes) are excused.
     """
-    port_xy = {
-        pid: (graph.stations[pid].x, graph.stations[pid].y)
-        for pid in graph.ports
-        if pid in graph.stations
-    }
-
     segs: list[tuple[str, tuple[str, str], str, float, float, float]] = []
     for rp in routes:
-        if not rp.is_inter_section:
+        if rp.is_inter_section != inter_section:
             continue
         pts = _route_render_points(rp, offsets)
         edge = (rp.edge.source, rp.edge.target)
@@ -717,7 +708,7 @@ def check_no_collinear_distinct_lines(
             span = ohi - olo
             if span <= _COLLINEAR_MIN_SPAN:
                 continue
-            if _converges_at_shared_port(port_xy, ea, eb, ax_a, c_a, olo, ohi):
+            if _converges_at_shared_port(endpoint_xy, ea, eb, ax_a, c_a, olo, ohi):
                 continue
             violations.append(
                 CollinearOverlapViolation(
@@ -731,6 +722,56 @@ def check_no_collinear_distinct_lines(
                 )
             )
     return violations
+
+
+def check_no_collinear_distinct_lines(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[CollinearOverlapViolation]:
+    """Return distinct-line inter-section segments drawn exactly on top.
+
+    Two co-travelling lines that share a bundle must occupy distinct
+    parallel slots (at least ``OFFSET_STEP`` apart laterally).  When a
+    bundling/offset defect collapses them to the same channel they
+    render as one stroke obscuring the other.  This check looks at the
+    final, offset-applied geometry: it flags pairs of DIFFERENT-line
+    axis-aligned inter-section segments whose channel coordinate
+    coincides within ``_COLLINEAR_LATERAL_TOL`` and whose overlap along
+    the axis exceeds ``_COLLINEAR_MIN_SPAN``.
+
+    Legitimate cases are excluded: lines converging onto a shared
+    endpoint port (an unavoidable single approach), tight parallel
+    bundles (>= one ``OFFSET_STEP`` apart never coincide), and short
+    trunk-level lead-ins below the min span.
+    """
+    port_xy = {
+        pid: (graph.stations[pid].x, graph.stations[pid].y)
+        for pid in graph.ports
+        if pid in graph.stations
+    }
+    return _collinear_overlay_violations(routes, offsets, port_xy, inter_section=True)
+
+
+def check_intra_section_collinear_distinct_lines(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[CollinearOverlapViolation]:
+    """Return distinct-line *intra-section* segments drawn exactly on top.
+
+    The intra-section counterpart to
+    :func:`check_no_collinear_distinct_lines` (which only scans
+    ``is_inter_section`` routes).  Two distinct lines running inside one
+    section must keep their parallel slots there too; a collapse hides one
+    line behind another within the section body.  Convergence onto a
+    shared endpoint station (a real merge/fork node, not a boundary port)
+    is excused, so genuine reconvergences are not flagged.
+    """
+    station_xy = {sid: (st.x, st.y) for sid, st in graph.stations.items()}
+    return _collinear_overlay_violations(
+        routes, offsets, station_xy, inter_section=False
+    )
 
 
 def _converges_at_shared_port(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -584,6 +584,60 @@ def test_no_collinear_distinct_lines(fixture):
     assert not violations, "; ".join(v.message() for v in violations)
 
 
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_no_intra_section_collinear_distinct_lines(fixture):
+    """Two different lines must never render on top of each other *within*
+    a section either.
+
+    The intra-section counterpart to ``test_no_collinear_distinct_lines``:
+    ``check_no_collinear_distinct_lines`` only scans inter-section routes,
+    so a defect that collapsed two co-travelling lines onto one channel
+    inside a section body would slip through.  Uses the final,
+    offset-applied geometry.
+    """
+    from nf_metro.layout.routing.invariants import (
+        check_intra_section_collinear_distinct_lines,
+    )
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    violations = check_intra_section_collinear_distinct_lines(graph, routes, offsets)
+    assert not violations, "; ".join(v.message() for v in violations)
+
+
+def test_intra_section_collinear_check_detects_overlay():
+    """Meaningfulness guard: the intra-section check fires when two distinct
+    lines genuinely coincide on one channel.
+
+    Locks the detector so the corpus test above is not vacuously green: two
+    different-line intra-section runs sharing a horizontal channel over more
+    than ``_COLLINEAR_MIN_SPAN``, with no shared endpoint, must be flagged.
+    """
+    from types import SimpleNamespace
+
+    from nf_metro.layout.routing.common import RoutedPath
+    from nf_metro.layout.routing.invariants import (
+        check_intra_section_collinear_distinct_lines,
+    )
+    from nf_metro.parser.model import Edge
+
+    def _run(src, tgt, line):
+        return RoutedPath(
+            edge=Edge(source=src, target=tgt, line_id=line),
+            line_id=line,
+            points=[(0.0, 100.0), (200.0, 100.0)],
+            is_inter_section=False,
+            offsets_applied=True,
+        )
+
+    graph = SimpleNamespace(stations={})  # no endpoints => no convergence excuse
+    routes = [_run("a", "b", "red"), _run("c", "d", "blue")]
+    violations = check_intra_section_collinear_distinct_lines(graph, routes, {})
+    assert violations, "expected a collinear overlay to be detected"
+    assert {violations[0].line_a, violations[0].line_b} == {"red", "blue"}
+
+
 @pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
 def test_distinct_trunk_not_hidden_behind_exempt(fixture):
     """A distinct-line bypass trunk must not sit within a bundle gap of an


### PR DESCRIPTION
## Summary

Extends the collinear distinct-line overlay guard (landed in #507, inter-section only) to cover **intra-section** routes, so two co-travelling lines collapsing onto one channel *inside* a section body is also caught.

- Factor the segment scan into shared `_collinear_overlay_violations(routes, offsets, endpoint_xy, *, inter_section)`.
- New `check_intra_section_collinear_distinct_lines` (convergence excused at shared real-station endpoints) + wired runtime guard `_guard_no_intra_section_collinear_distinct_lines`.
- Corpus invariant test over all fixtures + a synthetic meaningfulness test that locks the detector.

Clean across the whole fixture corpus (0 violations) → gallery byte-identical, no xfails. Detection-only; changes no coordinates.

Fixes #509

## Test plan
- [x] pytest passes (5933 passed, pre-existing xfails only)
- [x] ruff check + ruff format clean on src/ tests/
- [x] mypy clean
- [x] Runtime validator added and wired into compute_layout's validate block
- [ ] Render-preview verdict: expected "No visual changes detected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)