### PR TITLE
fix(layout): align fan-out column-mates excluded from loop recenter (#514)

### DIFF
--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -897,12 +897,12 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
         for key, members in columns.items():
             if len(members) < 2:
                 continue
-            trunk_members: list[str] = []
+            movers: list[str] = []
             anchor_xs: list[float] = []
             for sid in members:
                 st = graph.stations[sid]
                 if abs(st.y - section_trunk_y) <= 0.5:
-                    trunk_members.append(sid)
+                    movers.append(sid)
                     continue
                 # Anchor X must come from a station pass-1 already
                 # placed at the loop midpoint; restrict to the same
@@ -925,14 +925,20 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
                 ]
                 if len(visible_ins) == 1 and len(visible_outs) == 1:
                     anchor_xs.append(st.x)
-            if not trunk_members or not anchor_xs:
+                else:
+                    # Off-trunk column-mate whose extra edge (e.g. an
+                    # exit-port feed alongside the trunk rejoin) failed
+                    # pass 1's single-in/single-out filter.  It still
+                    # belongs to the column and must follow the anchors.
+                    movers.append(sid)
+            if not movers or not anchor_xs:
                 continue
             target_x = sum(anchor_xs) / len(anchor_xs)
             pred_x, succ_x = key
             lo, hi = min(pred_x, succ_x), max(pred_x, succ_x)
             if not (lo <= target_x <= hi):
                 continue
-            for sid in trunk_members:
+            for sid in movers:
                 graph.stations[sid].x = target_x
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -4305,13 +4305,7 @@ def test_label_x_anchored_to_station_marker_on_horizontal_runs(fixture):
 # Visual stack stations share their column X (issue #348)
 # ---------------------------------------------------------------------------
 
-_XFAIL_VISUAL_STACK: dict[str, str] = {
-    "differentialabundance_default.mmd": (
-        "issue #348: gprofiler2 aligns with upstream input layer rather "
-        "than visual stack-mate grea below it; revisit when stack "
-        "alignment vs upstream alignment is decided"
-    ),
-}
+_XFAIL_VISUAL_STACK: dict[str, str] = {}
 
 
 @pytest.mark.parametrize(
@@ -4322,8 +4316,16 @@ def test_visual_stack_station_xs_share_column(fixture):
     """Stations forming a visual stack must agree in X within 1 px.
 
     A visual stack is a group of stations in the same section sharing
-    predecessor set, successor set, and layer, where at least one pair
-    sits 0 < ΔY <= ``STACK_Y_WINDOW`` (2 * Y_SPACING = 80 px) apart.
+    predecessor set and layer, where at least one pair sits
+    0 < ΔY <= ``STACK_Y_WINDOW`` (2 * Y_SPACING = 80 px) apart.
+
+    The grouping key deliberately omits the successor set: stations in a
+    fan-out column share their feed and layer but routinely differ in
+    where they go next (one rejoins the trunk, another also exits the
+    section).  Keying on successors splits such a column into singletons
+    and lets a mis-placed member slip past (issue #514: ``propd`` shares
+    the ``differential`` column with ``dream``/``limma``/``deseq2`` but
+    its extra exit-port edge gave it a distinct successor set).
 
     The Y-window distinguishes visually-stacked stations (close enough
     in Y that a viewer reads them as a column) from:
@@ -4349,26 +4351,22 @@ def test_visual_stack_station_xs_share_column(fixture):
 
     graph = _layout(fixture)
     preds: dict[str, set[str]] = defaultdict(set)
-    succs: dict[str, set[str]] = defaultdict(set)
     for e in graph.edges:
         preds[e.target].add(e.source)
-        succs[e.source].add(e.target)
 
     offenders: list[str] = []
     for sec in graph.sections.values():
         if sec.bbox_h <= 0:
             continue
         port_ids = set(sec.entry_ports) | set(sec.exit_ports)
-        groups: dict[tuple[frozenset[str], frozenset[str], int], list[str]] = (
-            defaultdict(list)
-        )
+        groups: dict[tuple[frozenset[str], int], list[str]] = defaultdict(list)
         for sid in sec.station_ids:
             if sid in port_ids:
                 continue
             st = graph.stations.get(sid)
             if st is None or st.is_port or st.is_hidden:
                 continue
-            key = (frozenset(preds[sid]), frozenset(succs[sid]), st.layer)
+            key = (frozenset(preds[sid]), st.layer)
             groups[key].append(sid)
         for members in groups.values():
             if len(members) < 2:


### PR DESCRIPTION
## Summary

In `da_pipeline`'s `differential` section the `dream`/`limma`/`deseq2`/`propd` column shares layer 0, but `propd` sat ~17.5px left of its three stack-mates. Stage 6.12 `_recenter_loop_side_stations` pass 2 snapped only the trunk-row station to the loop column's `target_x`; off-trunk column-mates that failed pass 1's single-in/single-out anchor filter (like `propd`, which also feeds an exit port) were left stranded at their layer-grid X.

- **Fix** (`balancing.py`): pass 2 now also moves those disqualified off-trunk siblings onto `target_x`, matching the helper's already-documented intent ("snap ... the trunk-row station **and any off-trunk siblings whose multi-edge topology disqualified them from pass 1**").
- **Invariant** (`test_visual_stack_station_xs_share_column`): the grouping key is broadened from `(predecessors, successors, layer)` to `(predecessors, layer)`. Column-mates routinely differ in successors, so keying on them split the column into singletons and let the misalignment slip past. The broadened check fails on `main` for `propd` and passes after the fix.

The same root cause also left `gprofiler2` off-column from `grea` in the differentialabundance fixtures; the fix resolves it, so the prior `#348` xfail on `differentialabundance_default` is removed and now passes.

Fixes #514

## Test plan
- [x] `pytest` passes (5945 passed; broadened invariant fails on `main`, passes after fix; `#348` xfail flipped to passing)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/516/)
- [x] Render-preview verdict: 3 fixtures change, all improvements - `da_pipeline` (`propd` joins its column + `gprofiler2` aligns with `grea`), `differentialabundance` / `differentialabundance_default` (`gprofiler2` aligns with `grea`)

Generated with Claude Code
