### PR TITLE
fix(routing): machine-enforce corner radii route through corners.py (#515)

### DIFF
--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -863,7 +863,7 @@ def _route_tb_bottom_exit(
     # have positive length for the corner curves to bite into.
     lo, hi = (sy, ty) if dy >= 0 else (ty, sy)
     hy = min(max(hy, lo + ctx.curve_radius), hi - ctx.curve_radius)
-    jog_r = min(ctx.curve_radius, abs(tx - sx) / 2)
+    jog_r = reference_anchored_radius(0.0, min(ctx.curve_radius, abs(tx - sx) / 2))
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
@@ -936,6 +936,7 @@ def _route_merge_branch(
         lead_x = min(lead_x, min_lead)
     tail_x = lead_x + horizontal.sign * ctx.curve_radius * 2
 
+    r_base = reference_anchored_radius(0.0, ctx.curve_radius)
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
@@ -948,7 +949,7 @@ def _route_merge_branch(
         is_inter_section=True,
         # One branch line per call: a single descent, so both corners take the
         # base radius (no bundle to fan concentrically).
-        curve_radii=[ctx.curve_radius, ctx.curve_radius],
+        curve_radii=[r_base, r_base],
         offsets_applied=True,
     )
 
@@ -1651,7 +1652,7 @@ def _route_l_shape(
     if fan is not None:
         src_off = _get_offset(ctx, edge.source, edge.line_id)
         tgt_off = _get_offset(ctx, edge.target, edge.line_id)
-        r_lead = ctx.curve_radius
+        r_lead = reference_anchored_radius(0.0, ctx.curve_radius)
         return RoutedPath(
             edge=edge,
             line_id=edge.line_id,
@@ -1716,7 +1717,7 @@ def _route_top_entry_l_shape(
     # direction matches dx.  When dx is near-zero (source directly
     # above target), infer direction from the upstream exit port so the
     # line continues with the bundle flow before curving down.
-    r_lead = ctx.curve_radius
+    r_lead = reference_anchored_radius(0.0, ctx.curve_radius)
     if abs(dx) > r_lead:
         lead = horizontal_direction(dx)
     else:
@@ -2757,7 +2758,7 @@ def _route_right_entry_wrap(
     else:
         # Short horizontal lead-in so the first corner (horizontal-to-vertical)
         # gets a smooth curve instead of a sharp right angle at the junction.
-        r_lead = ctx.curve_radius
+        r_lead = reference_anchored_radius(0.0, ctx.curve_radius)
         v1_x = sx + r_lead
 
     # Bake the per-line station offset into the endpoints (mirroring
@@ -5004,7 +5005,7 @@ def _set_port_approach_x(ch: _VChannel, new_x: float) -> None:
         return
     for radius_idx in (k - 1, k):
         if 0 <= radius_idx < len(rp.curve_radii):
-            rp.curve_radii[radius_idx] = CURVE_RADIUS
+            rp.curve_radii[radius_idx] = reference_anchored_radius(0.0, CURVE_RADIUS)
 
 
 def _normalize_bypass_trunks(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:

--- a/tests/test_corner_radius_ratchet.py
+++ b/tests/test_corner_radius_ratchet.py
@@ -45,6 +45,15 @@ APPROVED_RADIUS_HELPERS = frozenset(
 )
 
 
+def _is_curve_radii_slot(target: ast.expr) -> bool:
+    """True for a ``<...>.curve_radii[idx]`` subscript assignment target."""
+    return (
+        isinstance(target, ast.Subscript)
+        and isinstance(target.value, ast.Attribute)
+        and target.value.attr == "curve_radii"
+    )
+
+
 def _called_name(call: ast.Call) -> str | None:
     """Return the simple name of a call's callee (``foo`` or ``mod.foo``)."""
     func = call.func
@@ -111,15 +120,28 @@ def _walk_same_scope(node: ast.AST) -> list[ast.AST]:
 
 
 def _record_targets(scope: _Scope, node: ast.AST) -> None:
-    if not isinstance(node, ast.Assign):
+    """Bind names assigned in *node*, modelling plain, annotated and augmented
+    assignment.  ``r += off`` binds ``r`` to a ``BinOp`` so it never resolves to
+    a helper - augmenting a radius is arithmetic by definition, so the slot is
+    rejected whatever the operand."""
+    if isinstance(node, ast.Assign):
+        targets, value = node.targets, node.value
+    elif isinstance(node, ast.AnnAssign):
+        if node.value is None:
+            return  # bare annotation, no binding
+        targets, value = [node.target], node.value
+    elif isinstance(node, ast.AugAssign):
+        targets = [node.target]
+        value = ast.BinOp(left=node.target, op=node.op, right=node.value)
+    else:
         return
-    for target in node.targets:
+    for target in targets:
         if isinstance(target, ast.Name):
-            scope.bind(target.id, node.value)
+            scope.bind(target.id, value)
         elif isinstance(target, (ast.Tuple, ast.List)):
             for elt in target.elts:
                 if isinstance(elt, ast.Name):
-                    scope.bind(elt.id, node.value)
+                    scope.bind(elt.id, value)
 
 
 def _resolves_to_helper(
@@ -193,12 +215,16 @@ class _RadiusSlotFinder(ast.NodeVisitor):
     def visit_Assign(self, node: ast.Assign) -> None:
         # ``rp.curve_radii[idx] = expr`` mutations.
         for target in node.targets:
-            if (
-                isinstance(target, ast.Subscript)
-                and isinstance(target.value, ast.Attribute)
-                and target.value.attr == "curve_radii"
-            ):
+            if _is_curve_radii_slot(target):
                 self.slots.append((node.value.lineno, node.value, self.scope))
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        # ``rp.curve_radii[idx] += expr`` mutations are arithmetic by
+        # definition; record the augmented value so the slot is rejected.
+        if _is_curve_radii_slot(node.target):
+            value = ast.BinOp(left=node.target, op=node.op, right=node.value)
+            self.slots.append((node.value.lineno, value, self.scope))
         self.generic_visit(node)
 
 
@@ -261,6 +287,11 @@ _ACCEPTED = {
             rr = r
             return P(curve_radii=[rr])
     """,
+    "annotated-helper-assignment": """
+        def f():
+            r: float = corner_radius(o, m)
+            return P(curve_radii=[r])
+    """,
     "list-comp-via-name": """
         def f():
             radii = [reference_anchored_radius(0.0, b) for _ in items]
@@ -290,6 +321,17 @@ _REJECTED = {
     "arithmetic-hidden-in-variable": """
         def f():
             r = ctx.curve_radius + off
+            return P(curve_radii=[r])
+    """,
+    "augmented-assignment-on-helper-result": """
+        def f():
+            r = corner_radius(o, m)
+            r += off
+            return P(curve_radii=[r])
+    """,
+    "annotated-arithmetic": """
+        def f():
+            r: float = ctx.curve_radius + off
             return P(curve_radii=[r])
     """,
     "non-helper-call": """

--- a/tests/test_corner_radius_ratchet.py
+++ b/tests/test_corner_radius_ratchet.py
@@ -1,0 +1,318 @@
+"""Ratchet: every corner radius in routing/core.py comes from corners.py.
+
+#508 centralised all corner-radius computation onto the ``routing/corners.py``
+helper family (``reference_anchored_radius`` as the single formula).  This test
+machine-enforces that it *stays* centralised: every value that reaches a
+``RoutedPath.curve_radii`` slot in ``routing/core.py`` must trace back -
+directly, through a same-scope name/alias hop, or through a tuple-unpack - to a
+call of one of those helpers.  Inline ``base +/- offset`` arithmetic (or a bare
+``ctx.curve_radius`` / ``CURVE_RADIUS`` literal) feeding a radius slot fails,
+whether written inline in the ``curve_radii=[...]`` list or hidden in an
+intermediate variable.
+
+Without this, a future handler could write ``curve_radii=[ctx.curve_radius +
+off]`` again and nothing would catch the un-centralised, potentially
+non-concentric nesting (issue #515, follow-up to #508).
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+CORE_PATH = Path(__file__).resolve().parents[1] / (
+    "src/nf_metro/layout/routing/core.py"
+)
+
+# corners.py entry points that legitimately *produce* (or clamp) a corner
+# radius.  ``reference_anchored_radius`` is the single underlying formula; the
+# others delegate to it.  ``corner_outside_sign``/``reversed_offset`` return a
+# sign/offset (an *input* to a radius), not a radius, so are intentionally out.
+APPROVED_RADIUS_HELPERS = frozenset(
+    {
+        "corner_radius",
+        "l_shape_radii",
+        "bypass_radii",
+        "tb_exit_corner",
+        "tb_entry_corner",
+        "concentric_corner_radius",
+        "reference_anchored_radius",
+        "resolve_curve_radii",
+    }
+)
+
+
+def _called_name(call: ast.Call) -> str | None:
+    """Return the simple name of a call's callee (``foo`` or ``mod.foo``)."""
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+class _Scope:
+    """Lexical scope: maps a local name to the RHS expressions bound to it.
+
+    A tuple-unpack target (``_, r_first, r_second = l_shape_radii(...)``) records
+    the source ``Call`` so the unpacked radius traces to its producing helper.
+    """
+
+    def __init__(self, parent: "_Scope | None") -> None:
+        self.parent = parent
+        self.bindings: dict[str, list[ast.expr]] = {}
+
+    def bind(self, name: str, value: ast.expr) -> None:
+        self.bindings.setdefault(name, []).append(value)
+
+    def lookup(self, name: str) -> list[ast.expr] | None:
+        scope: _Scope | None = self
+        while scope is not None:
+            if name in scope.bindings:
+                return scope.bindings[name]
+            scope = scope.parent
+        return None
+
+
+def _collect_assignments(scope: _Scope, body: list[ast.stmt]) -> None:
+    """Record every name binding in *body* at any depth (if/for/with/...),
+    without crossing into a nested function's own scope."""
+    for stmt in body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue  # a nested def/class owns a separate scope
+        for node in _walk_same_scope(stmt):
+            _record_targets(scope, node)
+
+
+def _walk_same_scope(node: ast.AST) -> list[ast.AST]:
+    """All descendants of *node* that share its function scope (stops at a
+    nested def / lambda / comprehension boundary, which introduce new scopes)."""
+    out: list[ast.AST] = [node]
+    for child in ast.iter_child_nodes(node):
+        if isinstance(
+            child,
+            (
+                ast.FunctionDef,
+                ast.AsyncFunctionDef,
+                ast.Lambda,
+                ast.ListComp,
+                ast.SetComp,
+                ast.DictComp,
+                ast.GeneratorExp,
+            ),
+        ):
+            continue
+        out.extend(_walk_same_scope(child))
+    return out
+
+
+def _record_targets(scope: _Scope, node: ast.AST) -> None:
+    if not isinstance(node, ast.Assign):
+        return
+    for target in node.targets:
+        if isinstance(target, ast.Name):
+            scope.bind(target.id, node.value)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                if isinstance(elt, ast.Name):
+                    scope.bind(elt.id, node.value)
+
+
+def _resolves_to_helper(
+    node: ast.expr, scope: _Scope, seen_names: frozenset[str] = frozenset()
+) -> bool:
+    """True if *node* (a value feeding ``curve_radii``) derives from a helper.
+
+    Recurses through containers (list / list-comp / if-expr / tuple), name and
+    alias hops (resolved against the lexical *scope*), and subscripts of helper
+    results.  A ``Call`` must target an approved helper; a ``BinOp`` / numeric
+    constant / bare attribute (``ctx.curve_radius``) or an unbound name
+    (``CURVE_RADIUS`` module constant) is a raw radius and fails.
+
+    *seen_names* breaks alias cycles (``a = b; b = a``); it tracks visited names
+    only, so a node shared by sibling branches (one helper ``Call`` unpacked
+    into several names) is judged independently down each branch.
+    """
+    if isinstance(node, ast.Call):
+        return _called_name(node) in APPROVED_RADIUS_HELPERS
+    if isinstance(node, ast.Name):
+        if node.id in seen_names:
+            return False  # alias cycle: never anchored on a helper
+        bindings = scope.lookup(node.id)
+        if not bindings:
+            return False  # module constant / param / undefined: raw radius
+        deeper = seen_names | {node.id}
+        return all(_resolves_to_helper(b, scope, deeper) for b in bindings)
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return all(_resolves_to_helper(e, scope, seen_names) for e in node.elts)
+    if isinstance(node, ast.ListComp):
+        return _resolves_to_helper(node.elt, scope, seen_names)
+    if isinstance(node, ast.IfExp):
+        return _resolves_to_helper(
+            node.body, scope, seen_names
+        ) and _resolves_to_helper(node.orelse, scope, seen_names)
+    if isinstance(node, (ast.Subscript, ast.Starred)):
+        inner = node.value
+        return isinstance(inner, ast.expr) and _resolves_to_helper(
+            inner, scope, seen_names
+        )
+    return False
+
+
+class _RadiusSlotFinder(ast.NodeVisitor):
+    """Find every value feeding a ``curve_radii`` slot, paired with its scope."""
+
+    def __init__(self) -> None:
+        self.scope = _Scope(None)
+        # (lineno, value_node, scope) for each radius slot.
+        self.slots: list[tuple[int, ast.expr, _Scope]] = []
+
+    def _enter(self, node: ast.AST) -> None:
+        child = _Scope(self.scope)
+        _collect_assignments(child, node.body)  # type: ignore[attr-defined]
+        prev, self.scope = self.scope, child
+        self.generic_visit(node)
+        self.scope = prev
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._enter(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._enter(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        for kw in node.keywords:
+            if kw.arg == "curve_radii":
+                self.slots.append((kw.value.lineno, kw.value, self.scope))
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        # ``rp.curve_radii[idx] = expr`` mutations.
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Attribute)
+                and target.value.attr == "curve_radii"
+            ):
+                self.slots.append((node.value.lineno, node.value, self.scope))
+        self.generic_visit(node)
+
+
+def _find_radius_slots() -> list[tuple[int, ast.expr, _Scope]]:
+    # Module-level assignments share the root scope.
+    tree = ast.parse(CORE_PATH.read_text(), filename=str(CORE_PATH))
+    finder = _RadiusSlotFinder()
+    _collect_assignments(finder.scope, tree.body)
+    finder.visit(tree)
+    return finder.slots
+
+
+def test_every_curve_radius_traces_to_a_corners_helper() -> None:
+    slots = _find_radius_slots()
+
+    # Guard against the finder silently matching nothing (e.g. core.py moved).
+    assert len(slots) >= 18, (
+        f"expected to find many curve_radii sites, found {len(slots)} - "
+        "the finder may be broken or core.py restructured"
+    )
+
+    violations = [
+        lineno
+        for lineno, value, scope in slots
+        if not _resolves_to_helper(value, scope)
+    ]
+    assert not violations, (
+        "curve_radii values not traceable to a corners.py helper at "
+        f"{CORE_PATH.name} lines {sorted(violations)}. Every corner radius must "
+        "flow through one of "
+        f"{sorted(APPROVED_RADIUS_HELPERS)} (#508/#515); wrap a bare base radius "
+        "as reference_anchored_radius(0.0, base) rather than using it raw or "
+        "writing inline base +/- offset arithmetic."
+    )
+
+
+# --- the guard, verified against its own positive/negative cases ------------
+#
+# Each case is a complete function whose single ``curve_radii=[...]`` slot is
+# resolved by the same finder used above, so these exercise the real
+# scope/alias/container/tuple-unpack machinery rather than a hand-built AST.
+
+_ACCEPTED = {
+    "direct-helper-call": """
+        def f():
+            return P(curve_radii=[corner_radius(o, m, base_radius=b)])
+    """,
+    "wrapped-base-literal": """
+        def f():
+            return P(curve_radii=[reference_anchored_radius(0.0, b)])
+    """,
+    "tuple-unpack": """
+        def f():
+            _, r_first, r_second = l_shape_radii(i, n, v)
+            return P(curve_radii=[r_first, r_second])
+    """,
+    "alias-hop": """
+        def f():
+            r = concentric_corner_radius(a, b, dx)
+            rr = r
+            return P(curve_radii=[rr])
+    """,
+    "list-comp-via-name": """
+        def f():
+            radii = [reference_anchored_radius(0.0, b) for _ in items]
+            return P(curve_radii=radii)
+    """,
+    "if-expr-branches": """
+        def f():
+            return P(curve_radii=[
+                corner_radius(o, m) if cond else reference_anchored_radius(0.0, b)
+            ])
+    """,
+}
+
+_REJECTED = {
+    "inline-arithmetic": """
+        def f():
+            return P(curve_radii=[ctx.curve_radius + off])
+    """,
+    "bare-attribute-literal": """
+        def f():
+            return P(curve_radii=[ctx.curve_radius])
+    """,
+    "module-constant-literal": """
+        def f():
+            return P(curve_radii=[CURVE_RADIUS])
+    """,
+    "arithmetic-hidden-in-variable": """
+        def f():
+            r = ctx.curve_radius + off
+            return P(curve_radii=[r])
+    """,
+    "non-helper-call": """
+        def f():
+            return P(curve_radii=[min(ctx.curve_radius, half)])
+    """,
+}
+
+
+def _slot_resolves(source: str) -> bool:
+    tree = ast.parse(textwrap.dedent(source))
+    finder = _RadiusSlotFinder()
+    finder.visit(tree)
+    assert len(finder.slots) == 1, f"want one slot, got {len(finder.slots)}"
+    _, value, scope = finder.slots[0]
+    return _resolves_to_helper(value, scope)
+
+
+@pytest.mark.parametrize("source", _ACCEPTED.values(), ids=_ACCEPTED.keys())
+def test_helper_derived_radii_accepted(source: str) -> None:
+    assert _slot_resolves(source), "helper-derived radius should be accepted"
+
+
+@pytest.mark.parametrize("source", _REJECTED.values(), ids=_REJECTED.keys())
+def test_raw_radii_rejected(source: str) -> None:
+    assert not _slot_resolves(source), "raw radius should be rejected"


### PR DESCRIPTION
## Summary

Machine-enforces #508's centralisation of corner-radius computation onto the `routing/corners.py` helper family, so a future edit can't silently reintroduce un-centralised (potentially non-concentric) curve nesting.

- New `tests/test_corner_radius_ratchet.py`: an AST ratchet over `routing/core.py`. It finds every value that reaches a `RoutedPath.curve_radii` slot (both `curve_radii=[...]` constructions and `*.curve_radii[idx] =/+=` mutations) and asserts each traces - directly, via a same-scope name/alias hop, or via a tuple-unpack - to a call of an approved `corners.py` helper (`reference_anchored_radius`, `corner_radius`, `l_shape_radii`, `bypass_radii`, `tb_exit_corner`, `tb_entry_corner`, `concentric_corner_radius`, `resolve_curve_radii`). Inline `curve_radius +/- offset` arithmetic, a bare `ctx.curve_radius` / `CURVE_RADIUS` literal, or a non-helper call now fails, whether written inline or hidden behind a plain/annotated/augmented assignment. The test carries its own accepted/rejected corpus so the guard is itself verified.
- `routing/core.py`: the remaining bare base-radius literals at non-fanning corners (the bottom-port jog, the `_route_merge_branch` single descent, the junction-handoff lead-ins, the port-approach reset) are wrapped through `reference_anchored_radius(0.0, base)`. That call returns `base` unchanged, so there are no raw constants left to allowlist and no runtime behaviour change.

This is option (a) from the issue (the syntactic ratchet). The optional runtime concentricity guard (option b) is intentionally not included.

The change is byte-identical: the full gallery render hash is unchanged.

Fixes #515

## Test plan
- [x] pytest passes (5959 passed; new ratchet test fails on the unmodified base for exactly the bare-literal sites, passes after the wraps)
- [x] ruff check + ruff format clean on `src/ tests/` (CI lint scope)
- [ ] N/A runtime validator - acceptance criterion #1 is a source-level concern a runtime guard can't see; the ratchet is necessarily a static AST test
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/517/)
- [x] Render-preview verdict: expected "No visual changes" (gallery hash unchanged locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
