### PR TITLE
test(tracking): repoint variant_calling defect xfails from closed #318 to #453

### DIFF
--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -4035,13 +4035,13 @@ def test_inter_section_route_y_stays_within_row_band(fixture):
 
 # ---------------------------------------------------------------------------
 # Topologically-equivalent siblings share Y or sit symmetrically
-# (audit item 15 / issue #318)
+# (audit item 15 / issue #453)
 # ---------------------------------------------------------------------------
 
 
 # Fixtures known to fail ``test_topological_siblings_share_y_or_symmetric``
-# (audit item 15 / open issue #318).  Tracked separately - the test is
-# added to lock in the invariant so a future fix XPASSes here.
+# (audit item 15).  The sibling-Y defect this dict tracked is resolved, so
+# no fixture is currently exempted; the invariant now holds gallery-wide.
 _XFAIL_SIBLINGS: dict[str, str] = {}
 
 
@@ -4054,9 +4054,9 @@ def test_topological_siblings_share_y_or_symmetric(fixture):
     line_set)`` should share Y, or for >= 3 members be symmetrically
     distributed around their mean Y.
 
-    Catches issue #318: gatk and deepvariant have the same predecessors,
-    successors, and consumed lines but end up at different Ys when they
-    should be mirrored around the trunk.
+    Catches the audit-15 defect (tracked in #453): gatk and deepvariant
+    have the same predecessors, successors, and consumed lines but end up
+    at different Ys when they should be mirrored around the trunk.
     """
     graph = _layout(fixture)
     preds: dict[str, set[str]] = defaultdict(set)

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -279,7 +279,7 @@ class TestFuncprofilerUpstreamDefects:
 #    it, keeping bwa_mem -> samtools_sort -> samtools_index straight.
 # 2. Section 3 (Variant Calling) excessive column gap - GATK
 #    HaplotypeCaller and DeepVariant share column x=772 but are 80px
-#    apart with one empty grid row between them. STILL OPEN (#318).
+#    apart with one empty grid row between them. STILL OPEN (#453).
 # 3. Section 1 -> Section 2/4 inter-section line crossing - Main and
 #    QC Reporting both fanned out from junction __junction_6 and crossed
 #    on the way to their respective targets. FIXED as a side effect of
@@ -293,7 +293,7 @@ VARIANT_CALLING_FILE = EXAMPLES_DIR / "variant_calling.mmd"
 
 _VARIANT_CALLING_XFAIL = pytest.mark.xfail(
     strict=True,
-    reason="known variant_calling layout defect; tracked in #318",
+    reason="known variant_calling layout defect; tracked in #453",
 )
 
 


### PR DESCRIPTION
## Summary

Re-establishes a live tracking issue for the variant_calling layout-defect xfails, which referenced the now-closed #318. Comment/test-text only; no behaviour change.

- `tests/test_topology_validation.py`: repoint the surviving strict xfail reason string (`test_no_excessive_column_gaps`) and the inline defect comment from #318 to #453. `strict=True` and the defect descriptions are unchanged.
- `tests/test_layout_invariants.py`: drop the dangling closed-issue reference around `_XFAIL_SIBLINGS` (now empty `{}`, the sibling-Y defect is resolved); repoint the section-header and docstring #318 references to #453.

The underlying variant_calling layout fixes remain out of scope and are tracked in #453.

Fixes #453

## Test plan
- [x] Affected tests unchanged: `TestVariantCallingDefects` + `test_topological_siblings_share_y_or_symmetric` -> 71 passed, 1 xfailed (same as before; xfail reason now reads "tracked in #453")
- [x] Full suite: 5944 passed, 39 skipped, 6 xfailed
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean (CI scope)
- [x] No `src/` changes -> gallery byte-identical
- [ ] Render-preview verdict: expected "No visual changes detected"

Generated with Claude Code