### PR TITLE
test(layout): completeness guard for content-placement phase set (#503)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -487,6 +487,18 @@ def _compute_flat_layout(
         station.y = y_offset + track_rank[station.track] * y_spacing
 
 
+# Names of the content-placement phases observed running through
+# :func:`_run_placement` on the most recent ``_compute_section_layout`` pass.
+# ``_run_placement`` is the single chokepoint every content phase flows through
+# (directly or via :func:`_run_placement_per_row`), so this set is the ground
+# truth for "which phases were actually placed".  The completeness meta-test
+# (``test_content_placement_phases_complete``) asserts it equals the guarded
+# ``CONTENT_PLACEMENT_PHASES`` set, so a new phase wired through the wrapper but
+# left unregistered -- hence outside the purity / anchor-frozen guards -- fails
+# CI.  See CONTRACT.md (anchor invariant) and #503.
+_PLACEMENT_PHASES_RUN: set[str] = set()
+
+
 def _run_placement(
     graph: MetroGraph,
     validate: bool,
@@ -496,6 +508,7 @@ def _run_placement(
 ) -> None:
     """Run a content-placement phase, asserting (under validate) it left every
     port anchor frozen.  See CONTRACT.md (anchor invariant)."""
+    _PLACEMENT_PHASES_RUN.add(fn.__name__)
     before = _port_anchor_snapshot(graph) if validate else None
     fn(graph, *args)
     if validate and before is not None:

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -113,6 +113,44 @@ def _cases():
             yield pytest.param(fid, path, is_nf, phase, id=f"{fid}-{phase}")
 
 
+def test_content_placement_phases_complete():
+    """Completeness guard (#503): the set of phases actually run through the
+    ``_run_placement`` wrapper in ``_compute_section_layout`` must equal the
+    guarded ``CONTENT_PLACEMENT_PHASES`` set.
+
+    ``_run_placement`` is the single chokepoint every content-placement phase
+    flows through, and it records each ``fn.__name__`` into
+    ``engine._PLACEMENT_PHASES_RUN``.  Rendering the whole corpus (which
+    includes ``center_ports`` fixtures, exercising the gated 6.3 / 6.7 phases)
+    accumulates the ground-truth run set.  Asserting it equals the guarded set
+    means:
+
+    - A new content phase wired through ``_run_placement`` but left out of
+      ``CONTENT_PLACEMENT_PHASES`` shows up as *run but unguarded* and fails
+      here -- forcing the dev to register it, at which point the purity and
+      anchor-frozen guards make it declarative.
+    - A stale name in ``CONTENT_PLACEMENT_PHASES`` that no longer runs shows up
+      as *guarded but never run* and fails too.
+    """
+    engine._PLACEMENT_PHASES_RUN.clear()
+    for _, path, is_nf in CORPUS:
+        compute_corpus_layout(path, is_nf)
+    run = set(engine._PLACEMENT_PHASES_RUN)
+    guarded = set(CONTENT_PLACEMENT_PHASES)
+
+    run_not_guarded = run - guarded
+    guarded_not_run = guarded - run
+    assert not run_not_guarded, (
+        "content-placement phase(s) run through _run_placement but missing from "
+        f"CONTENT_PLACEMENT_PHASES (so unguarded by purity / anchor-frozen): "
+        f"{sorted(run_not_guarded)}. Register them in tests/conftest.py."
+    )
+    assert not guarded_not_run, (
+        "CONTENT_PLACEMENT_PHASES lists phase(s) never run via _run_placement on "
+        f"the corpus (stale entry?): {sorted(guarded_not_run)}."
+    )
+
+
 @pytest.mark.parametrize("fid,path,is_nf,phase_name", list(_cases()))
 def test_placement_phase_is_pure(fid, path, is_nf, phase_name, monkeypatch):
     leaks: list[tuple[str, float, float]] = []


### PR DESCRIPTION
## Summary
- Add `engine._PLACEMENT_PHASES_RUN`, populated by the `_run_placement` chokepoint (the single wrapper every content-placement phase flows through, directly or via `_run_placement_per_row`). It records each phase's `fn.__name__` as it runs.
- Add `test_content_placement_phases_complete`: renders the whole corpus (including `center_ports` fixtures that exercise the gated 6.3 / 6.7 phases) and asserts the recorded run-set equals the guarded `CONTENT_PLACEMENT_PHASES` set.
- Closes the "unregistered new phase" hole in the declarative-layout guards (#365 / #487 / #491): a content phase wired through `_run_placement` but left out of `CONTENT_PLACEMENT_PHASES` (hence outside the purity + anchor-frozen guards) now fails the test, forcing registration. A stale list entry that no longer runs fails too.

Test/structure only; no behaviour change.

Fixes #503

## Test plan
- [x] `pytest` passes (5945 passed, 39 skipped, 6 xfailed), including the new `test_content_placement_phases_complete`
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] Teeth verified: monkeypatching an unregistered phase through `_run_placement` makes the assertion fail
- [x] Gallery byte-identical vs branch base (213c28a): all 68 SVGs match
- [ ] Render-preview verdict: expected "No visual changes detected"

Generated with Claude Code