### PR TITLE
feat(layout): per-phase coordinate snapshots for regression localisation (#363)

### DIFF
--- a/scripts/diff_phase_snapshots.py
+++ b/scripts/diff_phase_snapshots.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Diff two per-phase coordinate-snapshot trees to localise a regression.
+
+Phase snapshots are produced by ``compute_layout`` when
+``NF_METRO_PHASE_SNAPSHOTS=1`` is set (see issue #363).  Each fixture's
+snapshots land under ``<root>/<fixture>/<phase>.json``.  This tool compares
+the same fixture across two trees (e.g. a base render and a PR render) and
+reports the first phase at which station coords, port positions, or section
+bboxes diverge.
+
+Usage:
+    NF_METRO_PHASE_SNAPSHOTS=1 NF_METRO_PHASE_SNAPSHOT_DIR=/tmp/base \\
+        python -m nf_metro render examples/rnaseq_sections.mmd -o /tmp/base.svg
+    NF_METRO_PHASE_SNAPSHOTS=1 NF_METRO_PHASE_SNAPSHOT_DIR=/tmp/pr \\
+        python -m nf_metro render examples/rnaseq_sections.mmd -o /tmp/pr.svg
+    python scripts/diff_phase_snapshots.py /tmp/base /tmp/pr --fixture rnaseq_sections
+
+Without ``--fixture`` every fixture present in both trees is compared.
+Exit status is 1 when any divergence is found, 0 otherwise, so the tool is
+usable as a CI gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Phase ordering for "first phase to diverge".  Mirrors the call order in
+# engine.compute_layout.  Phases not listed (or the sectionless "flat"
+# layout) are appended afterward in lexicographic order so the tool still
+# works if the pipeline gains a phase before this list is updated.
+_PHASE_ORDER = [
+    "flat",
+    "1.1",
+    "1.2",
+    "1.3",
+    "1.4",
+    "1.5",
+    "2.1",
+    "3.1",
+    "3.2",
+    "3.3",
+    "3.4",
+    "3.5",
+    "4.1",
+    "4.2",
+    "4.3",
+    "4.4",
+    "4.5",
+    "4.6",
+    "4.7",
+    "4.8",
+    "4.9",
+    "4.10",
+    "5.1",
+    "5.2",
+    "5.3",
+    "5.4",
+    "5.5",
+    "6.1",
+    "6.2",
+    "6.3",
+    "6.4",
+    "6.5",
+    "6.6",
+    "6.7",
+    "6.8",
+    "6.9",
+    "6.10",
+    "6.11",
+    "6.12",
+    "6.13",
+    "6.14",
+    "6.15a",
+    "6.15",
+    "6.16",
+    "final",
+]
+
+
+def _phase_sort_key(phase: str) -> tuple[int, str]:
+    try:
+        return (_PHASE_ORDER.index(phase), "")
+    except ValueError:
+        return (len(_PHASE_ORDER), phase)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _fixtures(root: Path) -> set[str]:
+    return {p.name for p in root.iterdir() if p.is_dir()} if root.is_dir() else set()
+
+
+def _phases(fixture_dir: Path) -> dict[str, Path]:
+    return {p.stem: p for p in sorted(fixture_dir.glob("*.json"))}
+
+
+def _diff_payloads(base: dict[str, Any], pr: dict[str, Any]) -> list[str]:
+    """Return human-readable lines describing each coord difference."""
+    diffs: list[str] = []
+    for kind in ("stations", "ports", "sections"):
+        base_items = base.get(kind, {})
+        pr_items = pr.get(kind, {})
+        for key in sorted(set(base_items) | set(pr_items)):
+            b = base_items.get(key)
+            p = pr_items.get(key)
+            if b is None:
+                diffs.append(f"  {kind}/{key}: only in PR")
+                continue
+            if p is None:
+                diffs.append(f"  {kind}/{key}: only in base")
+                continue
+            for field in sorted(set(b) | set(p)):
+                bv = b.get(field)
+                pv = p.get(field)
+                if bv != pv:
+                    diffs.append(f"  {kind}/{key}.{field}: {bv} -> {pv}")
+    return diffs
+
+
+def diff_fixture(base_dir: Path, pr_dir: Path, fixture: str) -> bool:
+    """Compare one fixture's snapshot trees.  Returns True if it diverged."""
+    base_fix = base_dir / fixture
+    pr_fix = pr_dir / fixture
+    base_phases = _phases(base_fix)
+    pr_phases = _phases(pr_fix)
+
+    if not base_phases and not pr_phases:
+        print(f"[{fixture}] no snapshots found in either tree")
+        return False
+
+    only_base = set(base_phases) - set(pr_phases)
+    only_pr = set(pr_phases) - set(base_phases)
+    common = sorted(set(base_phases) & set(pr_phases), key=_phase_sort_key)
+
+    diverged = False
+    for phase in common:
+        diffs = _diff_payloads(_load(base_phases[phase]), _load(pr_phases[phase]))
+        if diffs:
+            print(f"[{fixture}] FIRST DIVERGENCE at phase {phase}:")
+            for line in diffs[:40]:
+                print(line)
+            if len(diffs) > 40:
+                print(f"  ... and {len(diffs) - 40} more")
+            diverged = True
+            break
+
+    if not diverged:
+        if only_base or only_pr:
+            print(
+                f"[{fixture}] coords match on all shared phases; "
+                f"phase sets differ (base-only={sorted(only_base)}, "
+                f"pr-only={sorted(only_pr)})"
+            )
+            diverged = True
+        else:
+            print(f"[{fixture}] no divergence across {len(common)} phases")
+    return diverged
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("base", type=Path, help="base snapshot tree root")
+    parser.add_argument("pr", type=Path, help="PR snapshot tree root")
+    parser.add_argument(
+        "--fixture",
+        help="fixture slug to compare; omit to compare all shared fixtures",
+    )
+    args = parser.parse_args(argv)
+
+    if args.fixture:
+        fixtures = [args.fixture]
+    else:
+        fixtures = sorted(_fixtures(args.base) & _fixtures(args.pr))
+        if not fixtures:
+            print("no shared fixtures between the two trees")
+            return 1
+
+    any_diverged = False
+    for fixture in fixtures:
+        if diff_fixture(args.base, args.pr, fixture):
+            any_diverged = True
+    return 1 if any_diverged else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -219,6 +219,10 @@ from nf_metro.layout.phases.single_section import (  # noqa: F401
     _terminus_icons_extend_forward,
     _terminus_y_overhang,
 )
+from nf_metro.layout.phases.snapshots import (
+    capture_phase_snapshot,
+    phase_snapshots_enabled,
+)
 from nf_metro.layout.phases.spacing import (  # noqa: F401
     _MAX_SPREAD_ITERS,
     _SPREAD_SLACK,
@@ -343,6 +347,11 @@ def compute_layout(
     key phases.  Violations raise ``PhaseInvariantError`` instead of
     silently producing broken layouts.
     """
+    # Read the phase-snapshot enable flag once (issue #363) and stash it on
+    # the graph so per-stage call sites can snapshot without signature churn.
+    # Off by default: when unset, each _snap call is a single attribute read.
+    graph._phase_snapshots_enabled = phase_snapshots_enabled()
+
     auto_x = x_spacing is None
     auto_y = y_spacing is None
     if y_spacing is None:
@@ -408,9 +417,22 @@ def compute_layout(
     # render path so an unsupported directive combination fails loudly
     # instead of shipping a silently-broken diagram (issue #424).
     _guard_stations_within_bbox(graph, "final")
+    _snap(graph, "final")
 
     if validate:
         _guard_no_label_overlap(graph, "final")
+
+
+def _snap(graph: MetroGraph, phase_id: str) -> None:
+    """Capture a per-phase coordinate snapshot when enabled (issue #363).
+
+    The enable flag is read once in ``compute_layout`` and stashed on the
+    graph so the per-stage call sites stay signature-free; when disabled
+    this is a single attribute read plus an early return.
+    """
+    capture_phase_snapshot(
+        graph, phase_id, getattr(graph, "_phase_snapshots_enabled", False)
+    )
 
 
 def _layout_once(
@@ -485,6 +507,8 @@ def _compute_flat_layout(
             x_offset + station.layer * x_spacing + layer_extra.get(station.layer, 0)
         )
         station.y = y_offset + track_rank[station.track] * y_spacing
+
+    _snap(graph, "flat")
 
 
 def _run_placement(
@@ -592,6 +616,7 @@ def _compute_section_layout(
         if sub is not None:
             section_subgraphs[sec_id] = sub
 
+    _snap(graph, "1.1")
     if validate:
         _guard_section_bboxes_positive(graph, "after Stage 1.1")
         _guard_no_negative_grid_columns(graph, "after Stage 1.1")
@@ -599,12 +624,15 @@ def _compute_section_layout(
 
     # Stage 1.2: Align Y grids across same-row, same-direction sections
     _align_row_y_grids(graph, section_subgraphs, y_spacing, section_y_padding)
+    _snap(graph, "1.2")
 
     # Stage 1.3: Place sections on the canvas
     place_sections(graph, section_x_gap, section_y_gap)
+    _snap(graph, "1.3")
 
     # Stage 1.4: Renumber sections by visual reading order (row, col)
     _renumber_sections_by_grid(graph)
+    _snap(graph, "1.4")
 
     # Stage 1.5: Adapt x/y_offset for left/top overshoot.
     # Section bboxes extend left of the local origin by at least
@@ -639,6 +667,8 @@ def _compute_section_layout(
             standard_margin = y_offset - section_y_padding
             y_offset += standard_margin - global_top
 
+    _snap(graph, "1.5")
+
     # ---- Stage 2 - Globalise (local -> global coords) ------------------
     # The coord-regime transition.  Owns the post-Stage-2.1 guard
     # checkpoint (finite coords, stations-in-sections, bboxes-positive).
@@ -660,6 +690,7 @@ def _compute_section_layout(
         section.bbox_x += section.offset_x + x_offset
         section.bbox_y += section.offset_y + y_offset
 
+    _snap(graph, "2.1")
     if validate:
         _guard_coordinates_finite(graph, "after Stage 2.1")
         _guard_stations_in_sections(graph, "after Stage 2.1")
@@ -675,6 +706,7 @@ def _compute_section_layout(
     for sec_id, section in graph.sections.items():
         position_ports(section, graph)
 
+    _snap(graph, "3.1")
     if validate:
         _guard_ports_on_boundaries(graph, "after Stage 3.1")
 
@@ -683,24 +715,28 @@ def _compute_section_layout(
     # Uses _resolve_source_xy() to derive junction coordinates
     # on-the-fly, removing the dependency on pre-positioned junctions.
     _align_entry_ports(graph)
+    _snap(graph, "3.2")
 
     # Stage 3.3: Shift internal stations in LR/RL sections with
     # perpendicular (TOP/BOTTOM) entry away from the port.  Needs the
     # aligned port X from Stage 3.2; only moves internal station X, not
     # ports or bboxes.
     _shift_lr_perp_entry_stations(graph, x_spacing)
+    _snap(graph, "3.3")
 
     # Stage 3.4: Align LEFT/RIGHT exit ports on row-spanning (fold)
     # sections with their target's Y so the exit is at the return row.
     # May push target sections down (via _resolve_tb_exit_y), which
     # top-align in the next step corrects.
     _align_exit_ports(graph)
+    _snap(graph, "3.4")
 
     # Stage 3.5: Top-align sections within each grid row.
     # Runs after fold-exit alignment so it corrects any bbox_y shifts
     # from Stage 3.4's target-section push.  Same-row port pairs shift
     # by the same delta, preserving entry-port alignment.
     _top_align_row_sections(graph)
+    _snap(graph, "3.5")
 
     if validate:
         _guard_ports_on_boundaries(graph, "after top-align")
@@ -714,26 +750,31 @@ def _compute_section_layout(
     # Stage 4.1: For non-fold LR/RL sections, pull exit-entry port pairs
     # toward the downstream section's stations so lines flow directly.
     _align_ports_to_downstream(graph)
+    _snap(graph, "4.1")
 
     # Stage 4.2: When a port-connected station is the sole occupant of its
     # layer, snap it to the port Y so the connection is horizontal.
     _snap_sole_layer_stations_to_ports(graph)
+    _snap(graph, "4.2")
 
     # Stage 4.3: For grid-group sections (where Stage 4.2 is skipped), snap
     # entry ports to the Y of their first connected internal station.
     # This produces a straight horizontal port-to-station connection
     # instead of a diagonal from the upstream junction Y.
     _snap_grid_group_entry_ports(graph)
+    _snap(graph, "4.3")
 
     # Stage 4.4: Mirror of Stage 4.3 for exit ports.  Move exit ports of
     # grid-group sections to the Y of the downstream entry port (which
     # Stage 4.3 already snapped to a grid station).  This eliminates detours
     # where lines leave at the section midpoint then route back.
     _snap_grid_group_exit_ports(graph)
+    _snap(graph, "4.4")
 
     # Stage 4.5: Ensure ports maintain at least y_spacing from terminus
     # stations in their section so file icons don't overlap routed lines.
     _space_ports_from_termini(graph, y_spacing)
+    _snap(graph, "4.5")
 
     # Stage 4.6: Recompute bboxes for grid-aligned sections.  Earlier
     # stages (3.2, 3.4, 4.5) may have expanded bboxes for temporary port
@@ -741,16 +782,19 @@ def _compute_section_layout(
     # back toward downstream stations).  Recompute with symmetric
     # padding around the final non-port station range.
     _recompute_grid_group_bboxes(graph)
+    _snap(graph, "4.6")
 
     # Stage 4.7: Re-run top-align after Stage 4.5 may have shifted
     # individual section bbox_y values (via _expand_bbox_for_y) so
     # bbox tops within each row stay flush after port-terminus spacing.
     _top_align_row_sections(graph)
+    _snap(graph, "4.7")
 
     # Stage 4.8: Align trunk Ys across same-row sections.  Shifts
     # content downward in shallower sections so the inter-section bundle
     # passes through at a single Y per row.  Bbox tops are preserved.
     _align_row_trunk_ys(graph)
+    _snap(graph, "4.8")
 
     # The trunk anchors (LR/RL port Ys) are now resolved.  The phases below
     # position content around them and must never move one; ``_run_placement``
@@ -762,6 +806,7 @@ def _compute_section_layout(
     # Scoped to fan-out side branches only: linear chains, fan-in
     # structures, and file inputs are left in place.
     _run_placement(graph, validate, "4.9", _redistribute_fanout_siblings, y_spacing)
+    _snap(graph, "4.9")
 
     # Stage 4.10: Symmetrically fan a column of full-bundle stations
     # around the trunk Y when no unique trunk exists (e.g. Reporting's
@@ -779,6 +824,7 @@ def _compute_section_layout(
     _run_placement(
         graph, validate, "4.10", _redistribute_full_bundle_columns, y_spacing
     )
+    _snap(graph, "4.10")
 
     _settle_pass_c(
         graph,
@@ -846,6 +892,7 @@ def _place_pass_c_content(
 
     # Stage 5.1: Position junction stations in the inter-section gap.
     _position_junctions(graph)
+    _snap(graph, "5.1")
 
     # Stage 5.2: Lift off_track stations above their section's top track.
     # Runs last so it operates on finalised station Ys and bboxes.
@@ -854,6 +901,7 @@ def _place_pass_c_content(
     # the canvas top margin set by Stage 1.5; shift the whole graph
     # down to restore the margin.  No-op when no section overflowed.
     _shift_graph_into_canvas(graph, section_y_padding)
+    _snap(graph, "5.2")
     if validate:
         _run_pass_c_guards(graph, "after Stage 5.2")
 
@@ -863,6 +911,7 @@ def _place_pass_c_content(
     # the empty input-band space lines up across the row.  Station Ys
     # in unlifted sections are preserved.
     _top_align_row_bboxes_only(graph)
+    _snap(graph, "5.3")
     if validate:
         _run_pass_c_guards(graph, "after Stage 5.3")
 
@@ -871,6 +920,7 @@ def _place_pass_c_content(
     # smallest above-content slack, preserving trunk alignment.  Bbox
     # heights shrink correspondingly so the empty top space disappears.
     _compact_row_content_to_bbox_top(graph, section_y_padding, y_spacing)
+    _snap(graph, "5.4")
     if validate:
         _run_pass_c_guards(graph, "after Stage 5.4")
 
@@ -879,6 +929,7 @@ def _place_pass_c_content(
     # Picks the downstream entry port's Y as the anchor since it sits
     # on the row's aligned trunk grid.
     _snap_inter_section_port_pairs(graph)
+    _snap(graph, "5.5")
     if validate:
         _run_pass_c_guards(graph, "after Stage 5.5")
 
@@ -901,6 +952,7 @@ def _place_pass_c_content(
     _run_placement_per_row(
         graph, validate, "6.1", _fan_free_content_upward, section_y_padding, y_spacing
     )
+    _snap(graph, "6.1")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.1")
 
@@ -910,6 +962,7 @@ def _place_pass_c_content(
     # nearest-to-trunk sources into the empty top band so the section
     # is bottom- and top-weighted instead of stacked below the trunk.
     _run_placement_per_row(graph, validate, "6.2", _fan_source_inputs_upward, y_spacing)
+    _snap(graph, "6.2")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.2")
 
@@ -929,6 +982,7 @@ def _place_pass_c_content(
             y_spacing,
             section_y_padding,
         )
+        _snap(graph, "6.3")
         if validate:
             _run_pass_c_guards(graph, "after Stage 6.3")
 
@@ -941,6 +995,7 @@ def _place_pass_c_content(
     # On-track consumer Ys are now final/grid-snapped; the off-track
     # reanchor (Stage 6.6 / 6.8) may run from here on.
     graph._consumers_grid_snapped = True
+    _snap(graph, "6.4")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.4")
 
@@ -949,6 +1004,7 @@ def _place_pass_c_content(
     # section's bbox ends right at the inter-section exit port Y,
     # making the line look pinned to the section edge.
     _align_tb_section_bbox_bottoms(graph)
+    _snap(graph, "6.5")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.5")
 
@@ -963,6 +1019,7 @@ def _place_pass_c_content(
     # Same canvas-fit safeguard as after Stage 5.2: a reanchor-driven
     # bbox grow can push the topmost section above the canvas top.
     _shift_graph_into_canvas(graph, section_y_padding)
+    _snap(graph, "6.6")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.6")
 
@@ -982,6 +1039,7 @@ def _place_pass_c_content(
         _run_placement_per_row(
             graph, validate, "6.7", _recenter_full_bundle_columns, y_spacing
         )
+        _snap(graph, "6.7")
 
         # Stage 6.8: Re-anchor off-track inputs after the recenter.
         # The recenter moves consumers to the final trunk-anchored Y,
@@ -991,12 +1049,14 @@ def _place_pass_c_content(
         # recenter Y as the new anchor and grows the section bbox
         # upward when the lifted band moves above its current top.
         _reanchor_off_track_to_consumer(graph, y_spacing, section_y_padding)
+        _snap(graph, "6.8")
 
         # Stage 6.9: Re-run row top-align.  A Stage 6.8 reanchor-
         # driven bbox grow leaves the section's bbox above its row
         # mates'; pull row mates' bbox tops up to match so the section
         # row stays flush along its top edge.
         _top_align_row_bboxes_only(graph)
+        _snap(graph, "6.9")
         if validate:
             _run_pass_c_guards(graph, "after Stage 6.9")
 
@@ -1005,6 +1065,7 @@ def _place_pass_c_content(
     # pre-fan Y while their sole upstream moved to the trunk.  Pin
     # them back onto the source Y so the connection stays horizontal.
     _align_terminus_to_upstream(graph)
+    _snap(graph, "6.10")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.10")
 
@@ -1024,6 +1085,7 @@ def _place_pass_c_content(
         section_y_padding,
         y_spacing,
     )
+    _snap(graph, "6.11")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.11")
 
@@ -1036,6 +1098,7 @@ def _place_pass_c_content(
     # Reposition each side station to the midpoint of the two diagonal
     # corner Xs derived from the actual routing geometry.
     _run_placement_per_row(graph, validate, "6.12", _recenter_loop_side_stations)
+    _snap(graph, "6.12")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.12")
 
@@ -1058,6 +1121,7 @@ def _stack_rows(
     # trunk alignment is unaffected; tighten only fires where a rowspan
     # section's content fell short of its row claim.
     _shrink_and_tighten_rows(graph, section_y_padding, section_y_gap)
+    _snap(graph, "6.13")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.13")
 
@@ -1071,6 +1135,7 @@ def _stack_rows(
     _shift_and_propagate_loop_stations(
         graph, y_spacing, section_y_padding, section_y_gap
     )
+    _snap(graph, "6.14")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.14")
 
@@ -1098,6 +1163,7 @@ def _finalize_layout(
     # canvas snap below.
     _fit_bboxes_to_content_top(graph, section_y_padding, section_y_gap)
     _shift_graph_into_canvas(graph, section_y_padding)
+    _snap(graph, "6.15a")
 
     # Stage 6.15: Restore canvas-wide grid alignment after all settling.
     # Stage 6.4 snaps to a per-row grid; later helpers (notably
@@ -1109,6 +1175,7 @@ def _finalize_layout(
     # to integer multiples of ``y_spacing``.  No-op when residues are
     # mixed.
     _snap_canvas_y_to_grid(graph, y_spacing, section_y_padding)
+    _snap(graph, "6.15")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.15")
 
@@ -1125,6 +1192,7 @@ def _finalize_layout(
     # (otherwise a fan-out bundle dips to a stale junction Y and back).
     _align_entry_ports(graph, tb_only=True)
     _position_junctions(graph)
+    _snap(graph, "6.16")
     if validate:
         _run_pass_c_guards(graph, "after Stage 6.16")
 

--- a/src/nf_metro/layout/phases/snapshots.py
+++ b/src/nf_metro/layout/phases/snapshots.py
@@ -1,0 +1,116 @@
+"""Per-phase coordinate snapshots for regression localisation (issue #363).
+
+``compute_layout`` runs 20+ mutating phases, each writing directly onto
+``Station.x``/``.y``, ``Port.x``/``.y`` and ``Section`` bbox state.  When a
+layout regression appears with no guard violation, "which phase caused it"
+is a manual bisect through ``engine.py``.
+
+This module captures a serialised snapshot of the mutable coordinate state
+after each phase, keyed by phase id, so two layout runs (e.g. base vs PR)
+can be diffed to surface the first phase at which coordinates diverge.
+
+Capture is **off by default** and gated on the ``NF_METRO_PHASE_SNAPSHOTS``
+environment variable.  When unset, :func:`capture_phase_snapshot` does no
+work beyond a single cheap boolean check, so normal renders pay no cost and
+behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nf_metro.parser.model import MetroGraph
+
+# Root of the snapshot tree.  Overridable via NF_METRO_PHASE_SNAPSHOT_DIR so
+# tests and CI can redirect the dump without touching /tmp.
+_DEFAULT_SNAPSHOT_ROOT = Path("/tmp/nf_metro_phase_snapshots")
+
+_ENABLE_ENV = "NF_METRO_PHASE_SNAPSHOTS"
+_DIR_ENV = "NF_METRO_PHASE_SNAPSHOT_DIR"
+
+# Coordinates are rounded to this many decimals before serialising so a
+# float-formatting wobble never masquerades as a layout divergence.
+_COORD_DECIMALS = 4
+
+
+def phase_snapshots_enabled() -> bool:
+    """True when ``NF_METRO_PHASE_SNAPSHOTS`` requests phase dumps.
+
+    Read once at the start of ``compute_layout`` and threaded through as a
+    plain bool so the hot path never re-reads the environment.
+    """
+    return os.environ.get(_ENABLE_ENV) == "1"
+
+
+def _snapshot_root() -> Path:
+    override = os.environ.get(_DIR_ENV)
+    return Path(override) if override else _DEFAULT_SNAPSHOT_ROOT
+
+
+def _fixture_slug(graph: MetroGraph) -> str:
+    """A filesystem-safe directory name identifying the rendered graph.
+
+    Uses the graph title when present (the human-facing fixture name),
+    falling back to ``untitled`` so a title-less graph still snapshots.
+    """
+    raw = (graph.title or "untitled").strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "_", raw).strip("_")
+    return slug or "untitled"
+
+
+def serialise_graph_coords(graph: MetroGraph) -> dict[str, Any]:
+    """Serialise the mutable coordinate state of *graph* to plain data.
+
+    Captures station coords (and the off-track flag, which a phase can flip),
+    port positions, and section bboxes.  Per-route/per-edge state is
+    deliberately excluded (out of scope per #363); stations + ports + bboxes
+    are sufficient for regression localisation.
+    """
+
+    def r(value: float) -> float:
+        return round(float(value), _COORD_DECIMALS)
+
+    # Key order is normalised by json.dumps(sort_keys=True) at write time.
+    stations = {
+        sid: {
+            "x": r(st.x),
+            "y": r(st.y),
+            "is_port": st.is_port,
+            "off_track": st.off_track,
+        }
+        for sid, st in graph.stations.items()
+    }
+    ports = {pid: {"x": r(p.x), "y": r(p.y)} for pid, p in graph.ports.items()}
+    sections = {
+        sec_id: {
+            "bbox_x": r(sec.bbox_x),
+            "bbox_y": r(sec.bbox_y),
+            "bbox_w": r(sec.bbox_w),
+            "bbox_h": r(sec.bbox_h),
+        }
+        for sec_id, sec in graph.sections.items()
+    }
+    return {"stations": stations, "ports": ports, "sections": sections}
+
+
+def capture_phase_snapshot(graph: MetroGraph, phase_id: str, enabled: bool) -> None:
+    """Write a coordinate snapshot for *phase_id* when *enabled*.
+
+    A no-op (single boolean test, no serialisation, no I/O) when *enabled*
+    is False, which is the default.  When True, dumps
+    ``<root>/<fixture>/<phase_id>.json``.
+    """
+    if not enabled:
+        return
+    out_dir = _snapshot_root() / _fixture_slug(graph)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    safe_phase = re.sub(r"[^A-Za-z0-9._-]+", "_", phase_id)
+    payload = serialise_graph_coords(graph)
+    (out_dir / f"{safe_phase}.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    )

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -247,6 +247,10 @@ class MetroGraph:
     # _snapshot_placement_refs.
     _placement_ref_y: dict[str, float] = field(default_factory=dict, repr=False)
     _placement_ref_bbox_top: dict[str, float] = field(default_factory=dict, repr=False)
+    # Per-phase coordinate-snapshot enable flag (issue #363).  Set once in
+    # compute_layout from the NF_METRO_PHASE_SNAPSHOTS env var; read by the
+    # _snap hook after each phase.  Off by default (pure observation).
+    _phase_snapshots_enabled: bool = field(default=False, repr=False)
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""

--- a/tests/test_phase_snapshots.py
+++ b/tests/test_phase_snapshots.py
@@ -1,0 +1,118 @@
+"""Tests for per-phase coordinate snapshots (issue #363).
+
+Snapshots are pure observation: enabling them must not perturb layout, and
+re-rendering the same fixture twice must produce byte-identical snapshots.
+The diff CLI must report no divergence for identical trees and localise the
+first phase for a perturbed one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.phases.snapshots import (
+    capture_phase_snapshot,
+    phase_snapshots_enabled,
+    serialise_graph_coords,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+FIXTURES = [
+    "examples/rnaseq_sections.mmd",
+    "examples/rnaseq_auto.mmd",
+]
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DIFF_SCRIPT = _REPO_ROOT / "scripts" / "diff_phase_snapshots.py"
+
+
+def _load_diff_module():
+    spec = importlib.util.spec_from_file_location("diff_phase_snapshots", _DIFF_SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _laid_out_graph(fixture: str):
+    graph = parse_metro_mermaid((_REPO_ROOT / fixture).read_text())
+    compute_layout(graph)
+    return graph
+
+
+def test_enable_flag_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NF_METRO_PHASE_SNAPSHOTS", raising=False)
+    assert phase_snapshots_enabled() is False
+    monkeypatch.setenv("NF_METRO_PHASE_SNAPSHOTS", "1")
+    assert phase_snapshots_enabled() is True
+    monkeypatch.setenv("NF_METRO_PHASE_SNAPSHOTS", "0")
+    assert phase_snapshots_enabled() is False
+
+
+def test_capture_is_noop_when_disabled(tmp_path: Path) -> None:
+    graph = _laid_out_graph(FIXTURES[0])
+    capture_phase_snapshot(graph, "final", enabled=False)
+    # No files written, no directories created.
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_snapshots_dont_perturb_layout(
+    fixture: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Enabling snapshots must leave final coords byte-identical."""
+    monkeypatch.delenv("NF_METRO_PHASE_SNAPSHOTS", raising=False)
+    plain = serialise_graph_coords(_laid_out_graph(fixture))
+
+    monkeypatch.setenv("NF_METRO_PHASE_SNAPSHOTS", "1")
+    monkeypatch.setenv("NF_METRO_PHASE_SNAPSHOT_DIR", str(tmp_path))
+    snapped = serialise_graph_coords(_laid_out_graph(fixture))
+
+    assert plain == snapped
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_diff_reports_no_divergence_for_identical_runs(
+    fixture: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NF_METRO_PHASE_SNAPSHOTS", "1")
+    base = tmp_path / "base"
+    pr = tmp_path / "pr"
+    for root in (base, pr):
+        monkeypatch.setenv("NF_METRO_PHASE_SNAPSHOT_DIR", str(root))
+        _laid_out_graph(fixture)
+
+    fixtures = {p.name for p in base.iterdir()}
+    assert len(fixtures) == 1
+    slug = next(iter(fixtures))
+    # A meaningful number of phases were captured.
+    assert len(list((base / slug).glob("*.json"))) >= 30
+
+    diff = _load_diff_module()
+    assert diff.diff_fixture(base, pr, slug) is False
+
+
+def test_diff_localises_first_divergent_phase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NF_METRO_PHASE_SNAPSHOTS", "1")
+    base = tmp_path / "base"
+    pr = tmp_path / "pr"
+    for root in (base, pr):
+        monkeypatch.setenv("NF_METRO_PHASE_SNAPSHOT_DIR", str(root))
+        _laid_out_graph(FIXTURES[0])
+
+    slug = next(iter(p.name for p in base.iterdir()))
+    target = pr / slug / "6.4.json"
+    data = json.loads(target.read_text())
+    a_station = next(iter(data["stations"]))
+    data["stations"][a_station]["y"] += 19.0
+    target.write_text(json.dumps(data, indent=2, sort_keys=True))
+
+    diff = _load_diff_module()
+    assert diff.diff_fixture(base, pr, slug) is True


### PR DESCRIPTION
## Summary

Adds opt-in per-phase coordinate snapshots so layout regressions can be localised to the phase that introduced them, without changing any layout logic (pure observation).

- New `src/nf_metro/layout/phases/snapshots.py`: `phase_snapshots_enabled()` (reads `NF_METRO_PHASE_SNAPSHOTS`), `serialise_graph_coords()` (station coords + `is_port`/`off_track` flags, port positions, section bboxes; rounded for stable diffs), and `capture_phase_snapshot()` (writes `<root>/<fixture>/<phase>.json`).
- `compute_layout` reads the enable flag once and stashes it on the graph; a `_snap(graph, phase_id)` hook after each phase boundary captures the state. When the env var is unset, `_snap` is a single attribute read plus early return, so there is no extra work on the normal render path.
- Snapshot root defaults to `/tmp/nf_metro_phase_snapshots`, overridable via `NF_METRO_PHASE_SNAPSHOT_DIR` (used by tests / CI).
- New `scripts/diff_phase_snapshots.py base/ pr/ [--fixture X]`: compares two snapshot trees, reports the first phase at which coords diverge, exits 1 on divergence (CI-gate friendly).
- New `tests/test_phase_snapshots.py`: enable-flag, no-op-when-disabled, layout-unperturbed-when-enabled, identical-tree-no-divergence, and first-divergent-phase localisation.

Capture covers all sequenced phases (40 captured for a typical fixture; `center_ports`-gated phases 6.3/6.7/6.8/6.9 appear only when they run) plus the sectionless `flat` layout and the `final` settled state.

Fixes #363

## Test plan
- [x] `pytest` passes (5951 passed, incl. new snapshot tests)
- [x] `ruff check` + `ruff format --check` clean on `src/ tests/ scripts/`; `mypy` clean
- [x] Gallery byte-identical with the env var unset (default): all 68 rendered SVGs identical vs the branch base
- [x] Snapshot + diff CLI self-verified: rendering a fixture twice yields no divergence; perturbing one phase's JSON makes the CLI report that phase as the first divergence