### PR TITLE
fix(layout): make Pass C guards observational so the validate flag is idempotent (#518)

### DIFF
--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1757,6 +1757,39 @@ def _bisection_should_run(guard_name: str, phase: str) -> bool:
         return True
 
 
+def _guard_routing_preserves_non_x(
+    graph: MetroGraph,
+    phase: str,
+    saved_xy: dict[str, tuple[float, float]],
+    saved_bbox: dict[str, tuple[float, float, float, float]],
+) -> None:
+    """Raise if a guard's ``route_edges`` call mutated anything but ``Station.x``.
+
+    ``_run_pass_c_guards`` snapshots and restores only ``Station.x`` because
+    that is the sole graph state ``route_edges`` mutates.  If a future routing
+    change starts moving ``Station.y`` or a section bbox, the X-only restore
+    would leak that mutation into later Pass C stages, silently making
+    ``validate=True`` non-idempotent again (#518).  This fails loudly instead.
+    """
+    for sid, station in graph.stations.items():
+        if abs(station.y - saved_xy[sid][1]) > 1e-6:
+            raise PhaseInvariantError(
+                f"{phase}: guard's route_edges call moved station {sid!r} in Y "
+                f"({saved_xy[sid][1]:.3f} -> {station.y:.3f}); the guard snapshot "
+                "restores X only. Extend the snapshot/restore in "
+                "_run_pass_c_guards to keep the validate flag observational."
+            )
+    for sid, sec in graph.sections.items():
+        now = (sec.bbox_x, sec.bbox_y, sec.bbox_w, sec.bbox_h)
+        if now != saved_bbox[sid]:
+            raise PhaseInvariantError(
+                f"{phase}: guard's route_edges call mutated section {sid!r} bbox "
+                f"({saved_bbox[sid]} -> {now}); the guard snapshot restores "
+                "station X only. Extend the snapshot/restore in "
+                "_run_pass_c_guards to keep the validate flag observational."
+            )
+
+
 def _run_pass_c_guards(
     graph: MetroGraph,
     phase: str,
@@ -1801,10 +1834,26 @@ def _run_pass_c_guards(
     if offsets is None:
         offsets = compute_station_offsets(graph)
     if routes is None:
+        # route_edges' diagonal-centring pass mutates Station.x in place.
+        # That is intended on the final render path (validate=False never
+        # calls this), but a guard must be observational: running it
+        # mid-pipeline would change the input to later Pass C stages.
+        # Snapshot and restore station X around the call.  The snapshot
+        # covers only X because route_edges touches no other graph state;
+        # _guard_routing_preserves_non_x verifies that contract still holds.
+        saved_xy = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+        saved_bbox = {
+            sid: (sec.bbox_x, sec.bbox_y, sec.bbox_w, sec.bbox_h)
+            for sid, sec in graph.sections.items()
+        }
         try:
             routes = route_edges(graph, station_offsets=offsets)
         except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
             routes = None
+        finally:
+            _guard_routing_preserves_non_x(graph, phase, saved_xy, saved_bbox)
+            for sid, (x, _) in saved_xy.items():
+                graph.stations[sid].x = x
 
     _guard_coordinates_finite(graph, phase)
     _guard_section_bboxes_positive(graph, phase)

--- a/tests/test_validate_flag_idempotent.py
+++ b/tests/test_validate_flag_idempotent.py
@@ -1,0 +1,83 @@
+"""The ``validate`` flag of ``compute_layout`` is observational (#518).
+
+``compute_layout(graph, validate=True)`` must produce *identical* final
+station geometry to ``compute_layout(graph, validate=False)``.  The flag is
+supposed to add invariant checks only; it must never perturb the layout.
+
+A regression here was caused by ``_run_pass_c_guards`` calling
+``route_edges``, whose diagonal-centring pass mutates ``Station.x`` in
+place.  Run mid-pipeline under ``validate=True``, that mutation changed the
+input to later stages, splitting same-column stations (e.g. ``gatk`` and
+``deepvariant`` in ``variant_calling.mmd``).  The fix makes the guard
+snapshot/restore station state so it stays non-mutating.
+
+The render path (``render_svg``) runs with ``validate=False``, so the
+perturbed geometry never shipped, but it blocked adding tight runtime
+column/alignment guards (they fired on the ``validate=True`` artifact).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conftest import content_corpus
+
+from nf_metro.convert import convert_nextflow_dag
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
+
+CORPUS = content_corpus()
+
+
+def _layout(path: Path, is_nextflow: bool, *, validate: bool) -> MetroGraph:
+    text = path.read_text()
+    if is_nextflow:
+        text = convert_nextflow_dag(text)
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=validate)
+    return graph
+
+
+def _coords(graph: MetroGraph) -> dict[str, tuple[float, float]]:
+    return {sid: (round(s.x, 6), round(s.y, 6)) for sid, s in graph.stations.items()}
+
+
+@pytest.mark.parametrize("fixture", CORPUS, ids=[fid for fid, _, _ in CORPUS])
+def test_validate_flag_does_not_change_geometry(fixture):
+    fid, path, is_nextflow = fixture
+
+    unvalidated = _coords(_layout(path, is_nextflow, validate=False))
+    validated = _coords(_layout(path, is_nextflow, validate=True))
+
+    diffs = {
+        sid: (unvalidated[sid], validated[sid])
+        for sid in unvalidated
+        if unvalidated[sid] != validated.get(sid)
+    }
+    assert not diffs, (
+        f"{fid}: validate=True perturbed station geometry vs validate=False; "
+        f"the flag must be observational. Differing stations "
+        f"(validate=False -> validate=True): {diffs}"
+    )
+
+
+@pytest.mark.parametrize("name", ["variant_calling", "variant_calling_tuned"])
+def test_shared_column_survives_validate(name):
+    """``gatk``/``deepvariant`` share a column; ``validate=True`` must keep it.
+
+    Pins the exact pair named in #518 so the regression has a focused guard
+    independent of the corpus parametrisation above.
+    """
+    path = Path(__file__).resolve().parent.parent / "examples" / f"{name}.mmd"
+    unvalidated = _layout(path, False, validate=False)
+    validated = _layout(path, False, validate=True)
+
+    for sid in ("gatk", "deepvariant"):
+        assert validated.stations[sid].x == pytest.approx(
+            unvalidated.stations[sid].x
+        ), f"{name}: {sid}.x diverged under validate=True"
+    assert validated.stations["gatk"].x == pytest.approx(
+        validated.stations["deepvariant"].x
+    ), f"{name}: gatk/deepvariant must share their column under validate=True"


### PR DESCRIPTION
## Summary

`compute_layout(graph, validate=True)` produced different final station geometry than `validate=False`: in `variant_calling.mmd`, `gatk`/`deepvariant` ended up split 22.5px apart (749.5 / 772.0) instead of sharing their column at 781.5.

The cause was `_run_pass_c_guards` calling `route_edges` at every Pass C checkpoint to build routes for the bisection guards. `route_edges`' diagonal-centring pass mutates `Station.x` in place; run mid-pipeline under `validate=True`, that mutation persisted and changed the input to later Pass C stages. The render path (`render_svg`) and the layout-invariant suite run with `validate=False`, so the perturbation never shipped, but it blocked adding tight runtime column/alignment guards.

This PR makes the guard observational:

- `_run_pass_c_guards` snapshots and restores `Station.x` around its `route_edges` call. `route_edges` mutates no other graph state (verified across the whole gallery).
- New `_guard_routing_preserves_non_x` fails loudly if a future routing change starts mutating `Station.y` or a section bbox, since the X-only restore would otherwise silently re-introduce the bug.
- New `tests/test_validate_flag_idempotent.py` asserts `validate=True` and `validate=False` produce identical station geometry across the whole render corpus, plus a focused check pinning `gatk`/`deepvariant` shared-column on `variant_calling` and `variant_calling_tuned`. The corpus test fails on `main` (12 fixtures) and passes here.

The change is entirely inside `_run_pass_c_guards`, which is only reached when `validate=True`, so the `validate=False` render path is byte-identical (the rendered gallery is unchanged, verified with `build_gallery.py` before/after).

Fixes #518

## Test plan
- [x] pytest passes (6038 passed; including the new corpus idempotence test)
- [x] ruff check + ruff format --check clean on whole repo
- [x] Runtime validator added (`_guard_routing_preserves_non_x`)
- [x] Gallery byte-identical under `validate=False` (build_gallery diff: no differences)
- [ ] Visual review of render preview

Generated with Claude Code