### PR TITLE
fix(labels): suppress node-name label on file-icon stations (#524)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -114,6 +114,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_fan_bundles_coincide_or_separate,
     _guard_fanout_junction_shares_exit_port_y,
     _guard_fanout_tail_join,
+    _guard_file_icon_no_name_label,
     _guard_inter_row_run_clearance,
     _guard_inter_section_descent_edge_clearance,
     _guard_inter_section_route_no_backtrack,
@@ -421,6 +422,7 @@ def compute_layout(
 
     if validate:
         _guard_no_label_overlap(graph, "final")
+        _guard_file_icon_no_name_label(graph, "final")
 
 
 def _snap(graph: MetroGraph, phase_id: str) -> None:

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -556,7 +556,10 @@ def place_labels(
         (
             s
             for s in graph.stations.values()
-            if not s.is_port and not s.is_hidden and s.label.strip()
+            if not s.is_port
+            and not s.is_hidden
+            and not s.is_terminus
+            and s.label.strip()
         ),
         key=lambda s: (s.layer, s.track),
     )

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -32,7 +32,10 @@ from nf_metro.layout.phases._common import (
 )
 from nf_metro.layout.phases.bbox import _section_fit_top
 from nf_metro.layout.phases.single_section import _terminus_y_overhang
-from nf_metro.layout.phases.spacing import _residual_label_overlaps
+from nf_metro.layout.phases.spacing import (
+    _placed_name_label_station_ids,
+    _residual_label_overlaps,
+)
 from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
 
 if TYPE_CHECKING:
@@ -1890,3 +1893,24 @@ def _guard_no_label_overlap(graph: MetroGraph, phase: str) -> None:
         f"{kind} {ov.b!r} by ({ov.ox:.1f}, {ov.oy:.1f})px after wrapping and "
         f"spreading; {len(residual)} overlap(s) total"
     )
+
+
+def _guard_file_icon_no_name_label(graph: MetroGraph, phase: str) -> None:
+    """Raise if a file-icon station also receives a separate name label.
+
+    A ``%%metro file:`` station renders its caption(s) beneath the icon
+    (``terminus_names``); per #93 the file directive owns the station's
+    labelling entirely.  A second node-name label would overprint that
+    caption and the converging tracks, so no ``is_terminus`` station may
+    appear among the placed name labels regardless of its node label text.
+    """
+    terminus_ids = {s.id for s in graph.stations.values() if s.is_terminus}
+    if not terminus_ids:
+        return
+    offenders = sorted(terminus_ids & _placed_name_label_station_ids(graph))
+    if offenders:
+        raise PhaseInvariantError(
+            f"{phase}: file-icon station(s) {offenders} also got a separate "
+            f"name label, overprinting the icon caption and tracks; a "
+            f"%%metro file: station must not carry a node-name label"
+        )

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from nf_metro.parser.model import MetroGraph
 
 if TYPE_CHECKING:
-    from nf_metro.layout.labels import LabelOverlap
+    from nf_metro.layout.labels import LabelOverlap, LabelPlacement
 
 # Cap on spread-loop passes.  Each pass strictly widens the binding axis,
 # so a handful suffices to clear any realistic crowding before giving up.
@@ -18,29 +18,23 @@ _MAX_SPREAD_ITERS = 6
 _SPREAD_SLACK = 4.0
 
 
-def _residual_label_overlaps(
+def _probe_label_placements(
     graph: MetroGraph, *, allow_hyphenation: bool
-) -> list[LabelOverlap]:
-    """Place labels at the current layout and report leftover overlaps.
+) -> tuple[dict[tuple[str, str], float], list[LabelPlacement]] | None:
+    """Run the renderer's offset/route/label pipeline at the current layout.
 
-    Runs the same offset/route/label pipeline the renderer uses (so the
-    wrapping pass has already fired) and returns the overlaps that wrapping
-    could not resolve.  Returns an empty list if routing/placement raises,
-    so a transient routing failure never blocks layout.
+    Returns the computed ``(station_offsets, placements)`` so callers can
+    inspect the settled labelling the renderer would draw, or ``None`` if
+    routing/placement raises (a transient failure never blocks layout).
 
-    The spread loop calls this with ``allow_hyphenation=False`` so residual
-    overlaps surface (to be cleared by widening spacing rather than by
-    hard-breaking words); the final guard calls it with True to validate the
-    settled, fully wrapped state the renderer will draw.
+    Routing and placement mutate the graph (route_edges nudges station X for
+    bundle separation; place_labels expands section bboxes to fit labels).
+    This probe snapshots station coordinates and section bboxes and restores
+    them, so it never leaks those mutations into the positioned state.
     """
-    from nf_metro.layout.labels import find_label_overlaps, place_labels
+    from nf_metro.layout.labels import place_labels
     from nf_metro.layout.routing import compute_station_offsets, route_edges
 
-    # Routing and placement mutate the graph (route_edges nudges station X
-    # for bundle separation; place_labels expands section bboxes to fit
-    # labels).  This probe must not leak those mutations, or a clean graph
-    # would drift from its positioned state.  Snapshot station coordinates
-    # and section bboxes, and restore them after measuring.
     pos_snapshot = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
     bbox_snapshot = {
         sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
@@ -55,9 +49,9 @@ def _residual_label_overlaps(
             routes=routes,
             allow_hyphenation=allow_hyphenation,
         )
-        return find_label_overlaps(graph, placements, offsets)
+        return offsets, placements
     except Exception:
-        return []
+        return None
     finally:
         for sid, (x, y) in pos_snapshot.items():
             st = graph.stations.get(sid)
@@ -67,40 +61,42 @@ def _residual_label_overlaps(
             s = graph.sections.get(sid)
             if s is not None:
                 s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+
+
+def _residual_label_overlaps(
+    graph: MetroGraph, *, allow_hyphenation: bool
+) -> list[LabelOverlap]:
+    """Place labels at the current layout and report leftover overlaps.
+
+    Returns the overlaps that wrapping could not resolve, or an empty list if
+    routing/placement raises.
+
+    The spread loop calls this with ``allow_hyphenation=False`` so residual
+    overlaps surface (to be cleared by widening spacing rather than by
+    hard-breaking words); the final guard calls it with True to validate the
+    settled, fully wrapped state the renderer will draw.
+    """
+    from nf_metro.layout.labels import find_label_overlaps
+
+    probe = _probe_label_placements(graph, allow_hyphenation=allow_hyphenation)
+    if probe is None:
+        return []
+    offsets, placements = probe
+    return find_label_overlaps(graph, placements, offsets)
 
 
 def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:
     """Return station ids that ``place_labels`` emits a name label for.
 
-    Runs the same offset/route/label pipeline the renderer uses, snapshotting
-    and restoring station coordinates and section bboxes so the probe leaves
-    no geometry behind (mirroring :func:`_residual_label_overlaps`).  Returns
-    an empty set if routing/placement raises.
+    Probes with the renderer-faithful ``allow_hyphenation=True`` so the result
+    reflects the settled labelling that will actually be drawn.  Returns an
+    empty set if routing/placement raises.
     """
-    from nf_metro.layout.labels import place_labels
-    from nf_metro.layout.routing import compute_station_offsets, route_edges
-
-    pos_snapshot = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bbox_snapshot = {
-        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
-        for sid, s in graph.sections.items()
-    }
-    try:
-        offsets = compute_station_offsets(graph)
-        routes = route_edges(graph, station_offsets=offsets)
-        placements = place_labels(graph, station_offsets=offsets, routes=routes)
-        return {p.station_id for p in placements if p.station_id}
-    except Exception:
+    probe = _probe_label_placements(graph, allow_hyphenation=True)
+    if probe is None:
         return set()
-    finally:
-        for sid, (x, y) in pos_snapshot.items():
-            st = graph.stations.get(sid)
-            if st is not None:
-                st.x, st.y = x, y
-        for sid, (bx, by, bw, bh) in bbox_snapshot.items():
-            s = graph.sections.get(sid)
-            if s is not None:
-                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+    _offsets, placements = probe
+    return {p.station_id for p in placements if p.station_id}
 
 
 def _spread_bump(

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -69,6 +69,40 @@ def _residual_label_overlaps(
                 s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
 
 
+def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:
+    """Return station ids that ``place_labels`` emits a name label for.
+
+    Runs the same offset/route/label pipeline the renderer uses, snapshotting
+    and restoring station coordinates and section bboxes so the probe leaves
+    no geometry behind (mirroring :func:`_residual_label_overlaps`).  Returns
+    an empty set if routing/placement raises.
+    """
+    from nf_metro.layout.labels import place_labels
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    pos_snapshot = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bbox_snapshot = {
+        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
+        for sid, s in graph.sections.items()
+    }
+    try:
+        offsets = compute_station_offsets(graph)
+        routes = route_edges(graph, station_offsets=offsets)
+        placements = place_labels(graph, station_offsets=offsets, routes=routes)
+        return {p.station_id for p in placements if p.station_id}
+    except Exception:
+        return set()
+    finally:
+        for sid, (x, y) in pos_snapshot.items():
+            st = graph.stations.get(sid)
+            if st is not None:
+                st.x, st.y = x, y
+        for sid, (bx, by, bw, bh) in bbox_snapshot.items():
+            s = graph.sections.get(sid)
+            if s is not None:
+                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+
+
 def _spread_bump(
     graph: MetroGraph,
     residual: list[LabelOverlap],

--- a/tests/fixtures/file_icon_fanin.mmd
+++ b/tests/fixtures/file_icon_fanin.mmd
@@ -1,0 +1,42 @@
+%%metro title: Reference Bundle Fan-In
+%%metro style: dark
+%%metro line: sample | Sample | #2db572
+%%metro line: somatic | Somatic | #e63946
+%%metro line: germline | Germline | #457b9d
+%%metro file: ref_fa | FASTA | Reference
+%%metro file: dbsnp | VCF | dbSNP
+%%metro file: intervals | BED | Targets
+%%metro file: pon | VCF | PoN
+
+graph LR
+    subgraph prep [Read Prep]
+        reads[Reads]
+        trim[Trim]
+        reads -->|sample,somatic,germline| trim
+    end
+
+    subgraph refbuild [Reference Resources]
+        ref_fa[Reference]
+        dbsnp[dbSNP]
+        intervals[Targets]
+        pon[PoN]
+        index[Build Index]
+        ref_fa -->|sample,somatic,germline| index
+        dbsnp -->|somatic,germline| index
+        intervals -->|sample,somatic,germline| index
+        pon -->|somatic| index
+    end
+
+    subgraph call [Variant Calling]
+        align[Align]
+        somatic_call[Mutect2]
+        germline_call[HaplotypeCaller]
+        merge[Merge]
+        align -->|sample,somatic,germline| somatic_call
+        align -->|germline| germline_call
+        somatic_call -->|somatic| merge
+        germline_call -->|germline| merge
+    end
+
+    trim -->|sample,somatic,germline| align
+    index -->|sample,somatic,germline| align

--- a/tests/test_file_icon_label_suppression.py
+++ b/tests/test_file_icon_label_suppression.py
@@ -1,0 +1,81 @@
+"""Invariant: a file-icon station owns its own labelling (issue #524).
+
+`%%metro file:` stations render their caption(s) beneath the icon
+(``terminus_names``).  Per #93, the file directive should *entirely*
+own the station's labelling, so such a station must never also receive
+a separate node-name label from ``place_labels`` - that second label
+overprints the caption and the converging tracks.
+
+The clean corpus idiom is a blank node label (``node[ ]``), which
+side-steps the candidate filter.  These tests pin the stronger
+invariant: a non-blank label on a file station is suppressed too.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.labels import place_labels
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph, Station
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+# Fixtures containing `%%metro file:` stations.  file_icon_fanin gives the
+# offending case a non-blank node label; the two examples use the clean
+# blank-label idiom and guard against a regression in the common path.
+_FILE_ICON_FIXTURES = [
+    FIXTURES / "file_icon_fanin.mmd",
+    EXAMPLES / "differentialabundance_default.mmd",
+    EXAMPLES / "genomeassembly_staggered.mmd",
+]
+
+
+def _placed_label_ids(graph: MetroGraph) -> set[str]:
+    """Return station ids that ``place_labels`` emits a name label for."""
+    compute_layout(graph)
+    station_offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=station_offsets)
+    placements = place_labels(graph, station_offsets=station_offsets, routes=routes)
+    return {p.station_id for p in placements if p.station_id}
+
+
+@pytest.mark.parametrize(
+    "fixture", _FILE_ICON_FIXTURES, ids=lambda p: p.name
+)
+def test_file_icon_stations_have_no_name_label(fixture: Path) -> None:
+    """A file-icon station must not also receive a node-name label."""
+    graph = parse_metro_mermaid(fixture.read_text())
+    terminus_ids = {s.id for s in graph.stations.values() if s.is_terminus}
+    assert terminus_ids, f"{fixture.name} has no file-icon stations to exercise"
+
+    labelled = _placed_label_ids(graph)
+    offenders = sorted(terminus_ids & labelled)
+    assert not offenders, (
+        f"{fixture.name}: file-icon stations also got a name label "
+        f"(overlaps caption/tracks): {offenders}"
+    )
+
+
+def test_terminus_label_suppressed_even_with_nonblank_label() -> None:
+    """Unit: a terminus station with a non-blank label is filtered out."""
+    graph = MetroGraph()
+    graph.stations["f"] = Station(
+        id="f",
+        label="FASTA",
+        x=100.0,
+        y=100.0,
+        terminus_labels=["FASTA"],
+        terminus_names=["Reference"],
+    )
+    graph.stations["s"] = Station(id="s", label="Align", x=200.0, y=100.0)
+
+    placements = place_labels(graph)
+    placed = {p.station_id for p in placements if p.station_id}
+    assert "f" not in placed
+    assert "s" in placed

--- a/tests/test_file_icon_label_suppression.py
+++ b/tests/test_file_icon_label_suppression.py
@@ -19,7 +19,7 @@ import pytest
 
 from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.labels import place_labels
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.phases.spacing import _placed_name_label_station_ids
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph, Station
 
@@ -36,26 +36,15 @@ _FILE_ICON_FIXTURES = [
 ]
 
 
-def _placed_label_ids(graph: MetroGraph) -> set[str]:
-    """Return station ids that ``place_labels`` emits a name label for."""
-    compute_layout(graph)
-    station_offsets = compute_station_offsets(graph)
-    routes = route_edges(graph, station_offsets=station_offsets)
-    placements = place_labels(graph, station_offsets=station_offsets, routes=routes)
-    return {p.station_id for p in placements if p.station_id}
-
-
-@pytest.mark.parametrize(
-    "fixture", _FILE_ICON_FIXTURES, ids=lambda p: p.name
-)
+@pytest.mark.parametrize("fixture", _FILE_ICON_FIXTURES, ids=lambda p: p.name)
 def test_file_icon_stations_have_no_name_label(fixture: Path) -> None:
     """A file-icon station must not also receive a node-name label."""
     graph = parse_metro_mermaid(fixture.read_text())
     terminus_ids = {s.id for s in graph.stations.values() if s.is_terminus}
     assert terminus_ids, f"{fixture.name} has no file-icon stations to exercise"
 
-    labelled = _placed_label_ids(graph)
-    offenders = sorted(terminus_ids & labelled)
+    compute_layout(graph)
+    offenders = sorted(terminus_ids & _placed_name_label_station_ids(graph))
     assert not offenders, (
         f"{fixture.name}: file-icon stations also got a name label "
         f"(overlaps caption/tracks): {offenders}"


### PR DESCRIPTION
## Summary

A station declared with `%%metro file:` rendered its own node-name label **in addition to** the file-icon caption whenever the node carried a non-blank `[Label]`, overprinting the caption and the converging line tracks. This completes #93's intent that the file directive entirely own a station's labelling, which previously only held when the node label was left blank.

- `labels.place_labels`: exclude `is_terminus` (file-icon) stations from the name-label candidate filter, alongside the existing port/hidden exclusions.
- New `_guard_file_icon_no_name_label`, wired into `compute_layout`'s validate block, fails loudly if a terminus station also receives a name label.
- Refactor: both `_residual_label_overlaps` and the new station-id probe now share one `_probe_label_placements` helper (snapshot -> offsets/route/place -> restore).
- New `tests/fixtures/file_icon_fanin.mmd` reproduction plus invariant tests parametrised over it and the blank-label gallery fixtures (`differentialabundance_default`, `genomeassembly_staggered`).

The gallery corpus uses the blank-label idiom for file stations, so the fix is latent there; the render gallery is expected to be byte-identical.

Fixes #524

## Test plan
- [x] pytest passes (6111 passed; new invariant + unit tests included)
- [x] ruff check + ruff format clean on whole repo
- [x] mypy clean
- [x] Runtime validator added (`_guard_file_icon_no_name_label`, verified it fires on the unfixed filter)
- [x] Render-preview verdict: No visual changes detected

Generated with Claude Code
