### PR TITLE
fix(parser): warn when graph primary direction is not LR (#525)

### DIFF
--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -48,6 +48,32 @@ def _check_unsupported_input(text: str) -> None:
         )
 
 
+_GRAPH_DIRECTION_PATTERN = re.compile(r"^graph\s+([A-Za-z]{2})\b")
+
+
+def _warn_if_non_lr_primary(graph_line: str) -> None:
+    """Warn when the `graph` header declares a primary direction other than LR.
+
+    nf-metro lays the section meta-graph out left-to-right; any other Mermaid
+    direction (TB/TD/BT/RL) is not honoured. A bare ``graph`` (no direction,
+    Mermaid-defaults to LR) is fine and warns nothing. Per-section
+    flow is controlled separately by ``%%metro direction:`` and is unaffected.
+    """
+    m = _GRAPH_DIRECTION_PATTERN.match(graph_line)
+    if not m:
+        return
+    direction = m.group(1).upper()
+    if direction == "LR":
+        return
+    warnings.warn(
+        f"nf-metro honours only 'graph LR' as the primary layout direction; "
+        f"the declared direction '{direction}' was ignored and the map is laid "
+        f"out left-to-right. Use per-section '%%metro direction:' directives to "
+        f"control individual section flow.",
+        stacklevel=2,
+    )
+
+
 def _validate_edge_annotations(graph: MetroGraph) -> None:
     """Validate that all edges have metro line annotations.
 
@@ -131,8 +157,13 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
             _parse_directive(stripped, graph, current_section_id)
             continue
 
-        # Skip regular comments and graph declaration
-        if stripped.startswith("%%") or stripped.startswith("graph "):
+        # Graph declaration
+        if stripped.startswith("graph "):
+            _warn_if_non_lr_primary(stripped)
+            continue
+
+        # Skip regular comments
+        if stripped.startswith("%%"):
             continue
 
         # Try edge first (contains arrow)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -977,3 +977,29 @@ def test_no_duplicate_edges_after_resolve_sections():
     assert len(edge_keys) == len(set(edge_keys)), (
         f"Duplicate edges found: {[k for k in edge_keys if edge_keys.count(k) > 1]}"
     )
+
+
+@pytest.mark.parametrize("direction", ["TB", "TD", "BT", "RL"])
+def test_non_lr_primary_direction_warns(direction):
+    """A non-LR `graph` header warns that only LR primary is honoured (#525)."""
+    text = (
+        "%%metro line: a | A | #0570b0\n"
+        f"graph {direction}\n"
+        "    subgraph s1 [One]\n"
+        "        x[X]\n"
+        "        y[Y]\n"
+        "        x -->|a| y\n"
+        "    end\n"
+    )
+    with pytest.warns(UserWarning, match=f"'{direction}'.*ignored"):
+        parse_metro_mermaid(text)
+
+
+@pytest.mark.parametrize("header", ["graph LR", "graph", "graph    LR"])
+def test_lr_primary_direction_does_not_warn(header, recwarn):
+    """`graph LR` (or a bare `graph`) is the honoured primary; no warning (#525)."""
+    parse_metro_mermaid(f"{header}\n    subgraph s1 [One]\n        x[X]\n    end\n")
+    direction_warnings = [
+        w for w in recwarn.list if "primary layout direction" in str(w.message)
+    ]
+    assert direction_warnings == []


### PR DESCRIPTION
## Summary

A `graph TB` / `TD` / `BT` / `RL` header was parsed identically to `graph LR` with no signal that the declared primary direction was dropped. This detects the direction token on the `graph` header and emits a one-line warning that only LR primary is honoured, mirroring the existing `flowchart` guidance in the parser. The map is still laid out left-to-right; per-section `%%metro direction:` flow is unaffected.

- `parser/mermaid.py`: new `_warn_if_non_lr_primary` + module-level `_GRAPH_DIRECTION_PATTERN`; the combined `graph `/`%%` skip is split so `graph ` headers are inspected. A bare `graph` (Mermaid-defaults to LR) warns nothing.
- `tests/test_parser.py`: parametrized warn test over TB/TD/BT/RL and a no-warn test over `graph LR`, bare `graph`, and multi-space `graph    LR`.

Honouring the direction for real (a genuine top-down layout) is tracked separately in #533.

Fixes #525

## Test plan
- [x] pytest passes (incl. new parametrized parser tests); full suite green
- [x] ruff check + ruff format clean on whole repo
- [ ] Runtime validator added - N/A: parse-time author warning, not a layout-geometry invariant; the warning is itself the loud signal
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/534/)
- [x] Render-preview verdict: No visual changes detected (all renders match main)

Generated with Claude Code
