### PR TITLE
feat(labels): opt-in diagonal station labels for dense trunks (#527)

### DIFF
--- a/examples/diagonal_labels.mmd
+++ b/examples/diagonal_labels.mmd
@@ -11,6 +11,7 @@
 
 graph LR
     subgraph preprocessing [Pre-processing]
+        %%metro exit: right | germline, tumor_only, somatic
         fastq_in[ ]
         fastqc[FastQC]
         fastp[FastP]

--- a/examples/diagonal_labels.mmd
+++ b/examples/diagonal_labels.mmd
@@ -1,0 +1,36 @@
+%%metro title: Diagonal Labels (dense trunk)
+%%metro style: dark
+%%metro label_angle: 45
+%%metro line: germline | Germline | #0570b0
+%%metro line: tumor_only | Tumor only | #d62728
+%%metro line: somatic | Tumor-normal pair | #756bb1
+%%metro file: fastq_in | FASTQ
+%%metro file: cram_out | CRAM
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        fastq_in[ ]
+        fastqc[FastQC]
+        fastp[FastP]
+        umi[UMI consensus]
+        bwa[BWA-MEM]
+        merge_index[samtools merge/index]
+        markdup[MarkDuplicates]
+        bqsr[BaseRecalibrator]
+        applybqsr[ApplyBQSR]
+        mosdepth[mosdepth]
+        ngscheckmate[NGSCheckmate]
+        cram_out[ ]
+
+        fastq_in -->|germline,tumor_only,somatic| fastqc
+        fastqc -->|germline,tumor_only,somatic| fastp
+        fastp -->|germline,tumor_only,somatic| umi
+        umi -->|germline,tumor_only,somatic| bwa
+        bwa -->|germline,tumor_only,somatic| merge_index
+        merge_index -->|germline,tumor_only,somatic| markdup
+        markdup -->|germline,tumor_only,somatic| bqsr
+        bqsr -->|germline,tumor_only,somatic| applybqsr
+        applybqsr -->|germline,tumor_only,somatic| mosdepth
+        mosdepth -->|germline,tumor_only,somatic| ngscheckmate
+        ngscheckmate -->|germline,tumor_only,somatic| cram_out
+    end

--- a/examples/diagonal_labels.mmd
+++ b/examples/diagonal_labels.mmd
@@ -5,7 +5,9 @@
 %%metro line: tumor_only | Tumor only | #d62728
 %%metro line: somatic | Tumor-normal pair | #756bb1
 %%metro file: fastq_in | FASTQ
-%%metro file: cram_out | CRAM
+%%metro file: vcf_out | VCF
+%%metro grid: preprocessing | 0,0
+%%metro grid: variant_calling | 0,1
 
 graph LR
     subgraph preprocessing [Pre-processing]
@@ -20,7 +22,6 @@ graph LR
         applybqsr[ApplyBQSR]
         mosdepth[mosdepth]
         ngscheckmate[NGSCheckmate]
-        cram_out[ ]
 
         fastq_in -->|germline,tumor_only,somatic| fastqc
         fastqc -->|germline,tumor_only,somatic| fastp
@@ -32,5 +33,28 @@ graph LR
         bqsr -->|germline,tumor_only,somatic| applybqsr
         applybqsr -->|germline,tumor_only,somatic| mosdepth
         mosdepth -->|germline,tumor_only,somatic| ngscheckmate
-        ngscheckmate -->|germline,tumor_only,somatic| cram_out
     end
+
+    subgraph variant_calling [Variant calling]
+        %%metro entry: left | germline, tumor_only, somatic
+        split[split by analysis]
+        deepvariant[GATK]
+        mutect[Mutect2]
+        strelka[Strelka2]
+        merge_vcf[merge VCFs]
+        vcf_out[ ]
+
+        split -->|germline| deepvariant
+        split -->|tumor_only| mutect
+        split -->|somatic| strelka
+        deepvariant -->|germline| merge_vcf
+        mutect -->|tumor_only| merge_vcf
+        strelka -->|somatic| merge_vcf
+        merge_vcf -->|germline,tumor_only,somatic| vcf_out
+    end
+
+    %% The dense angled-label trunk feeds the variant-calling section in the
+    %% row below, which fans out to three callers (one per line) and fans
+    %% back in at merge VCFs -- exercising the vertical room the hanging
+    %% angled labels need above the row below.
+    ngscheckmate -->|germline,tumor_only,somatic| split

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -65,8 +65,10 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "diagonal_labels",
         EXAMPLES_DIR,
         "Opt-in diagonal station labels (#527) via `%%metro label_angle: 45`: a "
-        "dense single-trunk pre-processing section whose station names tilt "
-        "below the line so closely-spaced stations stay legible.",
+        "dense pre-processing trunk whose tilted names pack tighter than "
+        "horizontal labels would, feeding a variant-calling section in the row "
+        "below that fans out to three callers and back in -- the reserved "
+        "vertical room keeps the hanging labels clear of the row beneath.",
     ),
     (
         "longread_variant_calling",

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -62,6 +62,13 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "collector fan-in descending a shared inter-column corridor.",
     ),
     (
+        "diagonal_labels",
+        EXAMPLES_DIR,
+        "Opt-in diagonal station labels (#527) via `%%metro label_angle: 45`: a "
+        "dense single-trunk pre-processing section whose station names tilt "
+        "below the line so closely-spaced stations stay legible.",
+    ),
+    (
         "longread_variant_calling",
         EXAMPLES_DIR,
         "Dense long-read variant-calling pipeline (six lines, nine sections): "

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -232,12 +232,24 @@ Section headers (numbered circle + label) are rendered above bbox_y by
 approximately SECTION_HEADER_PROTRUSION (~26px).  This constant adds a
 small margin so routing channels don't overlap the header zone."""
 
-INTER_ROW_HEADER_CLEARANCE: float = SECTION_HEADER_PROTRUSION + EDGE_TO_BUNDLE_CLEARANCE
+INTER_ROW_EDGE_CLEARANCE: float = 26.0
+"""Minimum distance between an inter-row wrap channel and the *box edge*
+it runs beneath (the upper section's bbox bottom).
+
+The universal ``EDGE_TO_BUNDLE_CLEARANCE`` (16px) is the floor for a line
+sitting beside a bundle; a horizontal inter-row run sitting that close to
+a *section box edge* reads as running flush along the underside of the
+box.  This wider margin gives the run a visibly clear gap below the box.
+It is the box-edge counterpart of ``INTER_ROW_HEADER_CLEARANCE`` on the
+lower side, keeping the channel's two margins symmetric about the real
+obstacles (box edge above, header badge below)."""
+
+INTER_ROW_HEADER_CLEARANCE: float = SECTION_HEADER_PROTRUSION + INTER_ROW_EDGE_CLEARANCE
 """Distance from a section's bbox top to an inter-row channel above it.
 
 An adjacent-row wrap channel approaching a section from above must clear
 the header *badge* (which protrudes ``SECTION_HEADER_PROTRUSION`` above
-``bbox_y``) by ``EDGE_TO_BUNDLE_CLEARANCE``, the same margin the source
+``bbox_y``) by ``INTER_ROW_EDGE_CLEARANCE``, the same margin the source
 side keeps from its bbox bottom.  Section placement reserves this band
 (``_wrap_bundle_row_minimums``) and routing centres within it
 (``_center_inter_row_channel``); the single definition keeps the two in

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -311,6 +311,14 @@ SVG ``dominant-baseline: auto`` places the alphabetic baseline at the
 label's Y coordinate; descenders extend below.  This constant accounts
 for that so the visual gap matches ``LABEL_OFFSET``."""
 
+DIAGONAL_LABEL_OFFSET: float = 9.0
+"""Extra downward drop for angled labels (#527), on top of ``LABEL_OFFSET``.
+
+Angled labels are anchored below the pill and tilt down-right; their text
+baseline starts at the anchor, so without an extra drop the first glyph
+sits too close to the marker.  This bumps the anchor down a touch so there
+is a clear gap between the pill and the tilted text."""
+
 TB_PILL_EDGE_OFFSET: float = 5.0
 """Pill edge offset for TB vertical station labels."""
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -354,6 +354,24 @@ def compute_layout(
     # Off by default: when unset, each _snap call is a single attribute read.
     graph._phase_snapshots_enabled = phase_snapshots_enabled()
 
+    # Diagonal labels are a horizontal-trunk feature: a TB section places its
+    # labels beside vertical pills, where the same tilt doesn't read, so an
+    # angled graph that also has a TB section would mix tilted and horizontal
+    # labels on one map.  Decline the angle outright in that case (warn and
+    # fall back to horizontal everywhere) rather than ship a mixed-orientation
+    # map.  Mutating graph.label_angle makes both layout and the renderer agree.
+    if graph.label_angle and any(
+        sec.direction == "TB" for sec in graph.sections.values()
+    ):
+        warnings.warn(
+            f"label_angle={graph.label_angle!r} ignored: diagonal labels are "
+            f"not applied to a graph containing a TB section (the whole map "
+            f"would need to tilt to stay consistent). Labels stay horizontal.",
+            UserWarning,
+            stacklevel=2,
+        )
+        graph.label_angle = 0.0
+
     # A diagonal label angle drives one graph-wide column pitch shared by every
     # section, so spacing is a property of the whole render, not of any one
     # section.  Used as the default x_spacing when the caller didn't pin one.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -354,6 +354,13 @@ def compute_layout(
     # Off by default: when unset, each _snap call is a single attribute read.
     graph._phase_snapshots_enabled = phase_snapshots_enabled()
 
+    # A diagonal label angle drives one graph-wide column pitch shared by every
+    # section, so spacing is a property of the whole render, not of any one
+    # section.  Used as the default x_spacing when the caller didn't pin one.
+    from nf_metro.layout.labels import diagonal_label_pitch
+
+    default_x_spacing = diagonal_label_pitch(graph, X_SPACING)
+
     auto_x = x_spacing is None
     auto_y = y_spacing is None
     if y_spacing is None:
@@ -370,7 +377,7 @@ def compute_layout(
                 stacklevel=2,
             )
     if x_spacing is None:
-        x_spacing = X_SPACING
+        x_spacing = default_x_spacing
 
     # Optionally reorder lines by section span before layout.
     # Must happen here (on the full graph) before section subgraphs are

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -114,6 +114,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_fan_bundles_coincide_or_separate,
     _guard_fanout_junction_shares_exit_port_y,
     _guard_fanout_tail_join,
+    _guard_feeder_exits_section_through_side,
     _guard_file_icon_no_name_label,
     _guard_inter_row_run_clearance,
     _guard_inter_section_descent_edge_clearance,
@@ -1245,6 +1246,9 @@ def _finalize_layout(
             )
             _guard_routes_enter_sections_at_ports(graph, phase, routes=routes)
             _guard_no_route_through_section(
+                graph, phase, routes=routes, offsets=offsets
+            )
+            _guard_feeder_exits_section_through_side(
                 graph, phase, routes=routes, offsets=offsets
             )
             _guard_entry_approach_from_port_side(graph, phase, routes=routes)

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -22,6 +22,7 @@ from nf_metro.layout.constants import (
     CHAR_WIDTH,
     COLLISION_MULTIPLIER,
     DESCENDER_CLEARANCE,
+    DIAGONAL_LABEL_OFFSET,
     FONT_HEIGHT,
     LABEL_BBOX_MARGIN,
     LABEL_LINE_HEIGHT,
@@ -147,18 +148,99 @@ def _rotated_label_bbox(
     return (min(xs), min(ys), max(xs), max(ys))
 
 
+def _label_corners(
+    placement: LabelPlacement,
+) -> list[tuple[float, float]]:
+    """Return the four corners of a label's (possibly rotated) box.
+
+    For an angled label the corners are the upright text box rotated about
+    its anchor, matching the renderer's ``rotate(angle, x, y)`` transform.
+    For a horizontal label (or one carrying an explicit ``obstacle_bbox``)
+    the corners are those of its axis-aligned bounding box.  Used by the
+    oriented overlap test so densely-spaced parallel diagonal labels pack
+    by their true (narrow) footprint rather than their enclosing AABB.
+    """
+    if placement.obstacle_bbox is not None or not placement.angle:
+        x0, y0, x1, y1 = _label_bbox(placement)
+        return [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+    w = label_text_width(placement.text)
+    text_h = _label_text_height(placement.text)
+    corners = [
+        (placement.x, placement.y - text_h),
+        (placement.x + w, placement.y - text_h),
+        (placement.x + w, placement.y),
+        (placement.x, placement.y),
+    ]
+    rad = math.radians(placement.angle)
+    cos_a, sin_a = math.cos(rad), math.sin(rad)
+    ax, ay = placement.x, placement.y
+    out: list[tuple[float, float]] = []
+    for cx, cy in corners:
+        dx, dy = cx - ax, cy - ay
+        out.append((ax + dx * cos_a - dy * sin_a, ay + dx * sin_a + dy * cos_a))
+    return out
+
+
+def _obb_separation(
+    a: list[tuple[float, float]],
+    b: list[tuple[float, float]],
+) -> float:
+    """Minimum separating gap between two convex quads via SAT.
+
+    Returns the largest gap found over all candidate separating axes
+    (positive when the quads are apart, <= 0 when they overlap).  Both
+    quads are convex (label rectangles), so the separating-axis theorem
+    using each quad's edge normals is exact.
+    """
+
+    def axes(quad: list[tuple[float, float]]) -> list[tuple[float, float]]:
+        res = []
+        for i in range(len(quad)):
+            x1, y1 = quad[i]
+            x2, y2 = quad[(i + 1) % len(quad)]
+            nx, ny = -(y2 - y1), (x2 - x1)
+            length = math.hypot(nx, ny)
+            if length > 1e-9:
+                res.append((nx / length, ny / length))
+        return res
+
+    best_gap = -math.inf
+    for ax, ay in axes(a) + axes(b):
+        a_proj = [px * ax + py * ay for px, py in a]
+        b_proj = [px * ax + py * ay for px, py in b]
+        gap = max(min(b_proj) - max(a_proj), min(a_proj) - max(b_proj))
+        best_gap = max(best_gap, gap)
+    return best_gap
+
+
 def _boxes_overlap(
     a: tuple[float, float, float, float],
     b: tuple[float, float, float, float],
     margin: float = LABEL_MARGIN,
 ) -> bool:
-    """Check if two bounding boxes overlap."""
+    """Check if two axis-aligned bounding boxes overlap."""
     return not (
         a[2] + margin < b[0]
         or b[2] + margin < a[0]
         or a[3] + margin < b[1]
         or b[3] + margin < a[1]
     )
+
+
+def _placements_overlap(
+    a: LabelPlacement,
+    b: LabelPlacement,
+    margin: float = LABEL_MARGIN,
+) -> bool:
+    """Overlap test honouring label rotation.
+
+    When either label is angled, an oriented (separating-axis) test packs
+    parallel diagonal labels by their true footprint; otherwise it falls
+    back to the cheap AABB test so horizontal layouts are unchanged.
+    """
+    if a.angle or b.angle:
+        return _obb_separation(_label_corners(a), _label_corners(b)) < margin
+    return _boxes_overlap(_label_bbox(a), _label_bbox(b), margin)
 
 
 class LabelOverlap(NamedTuple):
@@ -221,10 +303,18 @@ def find_label_overlaps(
         for j in range(i + 1, len(boxes)):
             pb, bb = boxes[j]
             ox, oy = _intrusion(ba, bb)
-            if ox > eps and oy > eps:
-                overlaps.append(
-                    LabelOverlap("label", pa.station_id, pb.station_id, ox, oy)
-                )
+            if ox <= eps or oy <= eps:
+                continue
+            # Angled labels pack as parallel diagonal strips: the AABBs
+            # overlap long before the tilted text does, so confirm with the
+            # oriented test before reporting (and spreading).  The reported
+            # ox/oy stay the AABB intrusion -- a safe upper bound for the
+            # spread bump.
+            if (pa.angle or pb.angle) and _obb_separation(
+                _label_corners(pa), _label_corners(pb)
+            ) >= LABEL_MARGIN:
+                continue
+            overlaps.append(LabelOverlap("label", pa.station_id, pb.station_id, ox, oy))
 
     # Reuse the engine's pill geometry (returns None for ports, hidden
     # stations, and junctions, none of which render a marker to collide with).
@@ -754,7 +844,7 @@ def place_labels(
                 station_id=station.id,
                 text=station.label,
                 x=station.x,
-                y=station.y + max_off + label_offset,
+                y=station.y + max_off + label_offset + DIAGONAL_LABEL_OFFSET,
                 above=False,
                 angle=label_angle,
                 text_anchor="start",
@@ -1357,8 +1447,7 @@ def _has_collision(
     existing: list[LabelPlacement],
 ) -> bool:
     """Check if a candidate label collides with any existing placement."""
-    cbox = _label_bbox(candidate)
     for placed in existing:
-        if _boxes_overlap(cbox, _label_bbox(placed)):
+        if _placements_overlap(candidate, placed):
             return True
     return False

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -35,6 +35,7 @@ from nf_metro.layout.constants import (
     TB_LABEL_H_SPACING,
     TB_LINE_Y_OFFSET,
     TB_PILL_EDGE_OFFSET,
+    X_SPACING,
 )
 from nf_metro.layout.geometry import segment_intersects_bbox
 from nf_metro.parser.model import MetroGraph
@@ -57,6 +58,45 @@ def _label_text_height(label: str) -> float:
     if n == 1:
         return FONT_HEIGHT
     return FONT_HEIGHT + (n - 1) * FONT_HEIGHT * LABEL_LINE_HEIGHT
+
+
+def diagonal_label_pitch(graph: "MetroGraph", fallback: float) -> float:
+    """Graph-wide column pitch for diagonal (angled) station labels.
+
+    All diagonal labels are drawn at the same angle, so adjacent columns'
+    labels are PARALLEL and collide only by their PERPENDICULAR separation, not
+    along their length.  Giving adjacent labels a clear text-row of space
+    between them means a perpendicular separation of ~2x the label height (the
+    row itself plus an equal gap); the column pitch that yields that is
+    ``2 * height / sin(angle)``, floored at a marker-collision minimum.
+
+    This is computed once over the whole graph (the tallest label drives it) so
+    every section shares one consistent pitch rather than each section sizing
+    its own.  Returns *fallback* when no label angle is set or no labels exist.
+    """
+    import math
+
+    from nf_metro.layout.constants import STATION_RADIUS_APPROX
+
+    angle = graph.label_angle or 0.0
+    if not angle:
+        return fallback
+    sin_a = abs(math.sin(math.radians(angle)))
+    if sin_a < 1e-6:
+        return fallback
+    tallest = 0.0
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden or st.off_track:
+            continue
+        if st.is_terminus and not st.label.strip():
+            continue
+        if not st.label.strip():
+            continue
+        tallest = max(tallest, _label_text_height(st.label))
+    if tallest <= 0.0:
+        return fallback
+    marker_floor = STATION_RADIUS_APPROX * 3.0
+    return max(marker_floor, (tallest * 2.0) / sin_a)
 
 
 @dataclass
@@ -510,6 +550,38 @@ def _compute_port_label_preference(
     return result
 
 
+def _diagonal_prefer_above(graph: MetroGraph, station: Station) -> bool:
+    """Whether a tilted label should flip above the trunk for *station*.
+
+    Diagonal labels otherwise always hang below the trunk.  When a fork
+    sibling sits directly below a station (same column, a lower track) and
+    nothing sits above it, the below label would cross that branch's route, so
+    flip it above where it is clear.  Conservative: fires only for a station
+    that is the top of a same-column stack in an LR/RL section.
+    """
+    if not station.section_id:
+        return False
+    sec = graph.sections.get(station.section_id)
+    if sec is None or sec.direction not in ("LR", "RL"):
+        return False
+    below = above = False
+    for other in graph.stations.values():
+        if (
+            other is station
+            or other.is_port
+            or other.is_hidden
+            or other.section_id != station.section_id
+        ):
+            continue
+        if abs(other.x - station.x) > X_SPACING * 0.5:
+            continue
+        if other.y > station.y + 1:
+            below = True
+        elif other.y < station.y - 1:
+            above = True
+    return below and not above
+
+
 def _apply_edge_override(
     station: Station,
     start_above: bool,
@@ -840,15 +912,28 @@ def place_labels(
         # which lets densely-spaced stations share a compact horizontal
         # line without their long names colliding.
         if label_angle:
-            candidate = LabelPlacement(
-                station_id=station.id,
-                text=station.label,
-                x=station.x,
-                y=station.y + max_off + label_offset + DIAGONAL_LABEL_OFFSET,
-                above=False,
-                angle=label_angle,
-                text_anchor="start",
-            )
+            if _diagonal_prefer_above(graph, station):
+                # Mirror the tilt across the trunk: anchor at the pill top and
+                # read up-and-to-the-right, clearing a fork sibling below.
+                candidate = LabelPlacement(
+                    station_id=station.id,
+                    text=station.label,
+                    x=station.x,
+                    y=station.y + min_off - label_offset - DIAGONAL_LABEL_OFFSET,
+                    above=True,
+                    angle=-label_angle,
+                    text_anchor="start",
+                )
+            else:
+                candidate = LabelPlacement(
+                    station_id=station.id,
+                    text=station.label,
+                    x=station.x,
+                    y=station.y + max_off + label_offset + DIAGONAL_LABEL_OFFSET,
+                    above=False,
+                    angle=label_angle,
+                    text_anchor="start",
+                )
             if station.section_id:
                 sec = graph.sections.get(station.section_id)
                 if sec is not None and sec.bbox_w > 0:

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -14,6 +14,7 @@ __all__ = [
     "place_labels",
 ]
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
@@ -78,6 +79,8 @@ def _label_bbox(
     """Return (x_min, y_min, x_max, y_max) bounding box for a label."""
     if placement.obstacle_bbox is not None:
         return placement.obstacle_bbox
+    if placement.angle:
+        return _rotated_label_bbox(placement)
     w = label_text_width(placement.text)
     text_h = _label_text_height(placement.text)
 
@@ -104,6 +107,44 @@ def _label_bbox(
         y_max = placement.y + text_h
 
     return (x_min, y_min, x_max, y_max)
+
+
+def _rotated_label_bbox(
+    placement: LabelPlacement,
+) -> tuple[float, float, float, float]:
+    """Axis-aligned bounding box of a label rotated about its anchor.
+
+    The label text starts at the anchor ``(x, y)`` (``text_anchor="start"``)
+    and reads horizontally before being rotated clockwise by ``angle``
+    degrees about that anchor -- matching the SVG ``rotate(angle, x, y)``
+    transform the renderer emits.  We rotate the four corners of the
+    upright text box and take their min/max as the collision box, so the
+    diagonal footprint is approximated by its enclosing rectangle.
+    """
+    w = label_text_width(placement.text)
+    text_h = _label_text_height(placement.text)
+    # Upright box for text_anchor="start", baseline at y: text occupies
+    # x in [x, x+w] and y in roughly [y - text_h, y] (ascenders above the
+    # baseline).  Centre the box vertically on the baseline a touch so the
+    # footprint is symmetric enough for collision purposes.
+    corners = [
+        (placement.x, placement.y - text_h),
+        (placement.x + w, placement.y - text_h),
+        (placement.x + w, placement.y),
+        (placement.x, placement.y),
+    ]
+    rad = math.radians(placement.angle)
+    cos_a, sin_a = math.cos(rad), math.sin(rad)
+    ax, ay = placement.x, placement.y
+    xs: list[float] = []
+    ys: list[float] = []
+    for cx, cy in corners:
+        dx, dy = cx - ax, cy - ay
+        rx = ax + dx * cos_a - dy * sin_a
+        ry = ay + dx * sin_a + dy * cos_a
+        xs.append(rx)
+        ys.append(ry)
+    return (min(xs), min(ys), max(xs), max(ys))
 
 
 def _boxes_overlap(
@@ -540,6 +581,7 @@ def place_labels(
     icon_obstacles: list[tuple[float, float, float, float]] | None = None,
     routes: list["RoutedPath"] | None = None,
     allow_hyphenation: bool = True,
+    label_angle: float = 0.0,
 ) -> list[LabelPlacement]:
     """Place horizontal labels alternating above/below stations.
 
@@ -699,6 +741,28 @@ def place_labels(
                         tb_sec.bbox_w = old_right - lx_min
                     if lx_max > tb_sec.bbox_x + tb_sec.bbox_w:
                         tb_sec.bbox_w = lx_max - tb_sec.bbox_x
+            placements.append(candidate)
+            continue
+
+        # Opt-in diagonal labels (#527): for non-TB sections, anchor the
+        # label at the bottom of the pill and tilt it.  All angled labels
+        # sit below the trunk on the same side (like real transit maps),
+        # which lets densely-spaced stations share a compact horizontal
+        # line without their long names colliding.
+        if label_angle:
+            candidate = LabelPlacement(
+                station_id=station.id,
+                text=station.label,
+                x=station.x,
+                y=station.y + max_off + label_offset,
+                above=False,
+                angle=label_angle,
+                text_anchor="start",
+            )
+            if station.section_id:
+                sec = graph.sections.get(station.section_id)
+                if sec is not None and sec.bbox_w > 0:
+                    _grow_section_for_box(sec, _label_bbox(candidate))
             placements.append(candidate)
             continue
 
@@ -881,8 +945,9 @@ def _wrap_overlapping_labels(
         and p.obstacle_bbox is None
         and graph.stations.get(p.station_id) is not None
     }
-    # Only re-flow single-line labels; respect any author-chosen breaks.
-    wrappable = {sid for sid, p in by_id.items() if "\n" not in p.text}
+    # Only re-flow single-line, un-rotated labels; respect any author-chosen
+    # breaks and leave angled labels (#527) to spread rather than wrap.
+    wrappable = {sid for sid, p in by_id.items() if "\n" not in p.text and not p.angle}
     if not wrappable:
         return
 
@@ -956,6 +1021,27 @@ def _expand_sections_for_wrapped_labels(
             sec.bbox_y = y_min - margin
         if y_max + margin > sec.bbox_y + sec.bbox_h:
             sec.bbox_h = (y_max + margin) - sec.bbox_y
+
+
+def _grow_section_for_box(
+    sec: Section,
+    box: tuple[float, float, float, float],
+    margin: float = LABEL_BBOX_MARGIN,
+) -> None:
+    """Grow a section bbox so it contains the given label box (plus margin)."""
+    x_min, y_min, x_max, y_max = box
+    if x_min - margin < sec.bbox_x:
+        old_right = sec.bbox_x + sec.bbox_w
+        sec.bbox_x = x_min - margin
+        sec.bbox_w = old_right - sec.bbox_x
+    if x_max + margin > sec.bbox_x + sec.bbox_w:
+        sec.bbox_w = (x_max + margin) - sec.bbox_x
+    if y_min - margin < sec.bbox_y:
+        old_bottom = sec.bbox_y + sec.bbox_h
+        sec.bbox_y = y_min - margin
+        sec.bbox_h = old_bottom - sec.bbox_y
+    if y_max + margin > sec.bbox_y + sec.bbox_h:
+        sec.bbox_h = (y_max + margin) - sec.bbox_y
 
 
 def _avoid_diagonal_routes(

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -74,8 +74,6 @@ def diagonal_label_pitch(graph: "MetroGraph", fallback: float) -> float:
     every section shares one consistent pitch rather than each section sizing
     its own.  Returns *fallback* when no label angle is set or no labels exist.
     """
-    import math
-
     from nf_metro.layout.constants import STATION_RADIUS_APPROX
 
     angle = graph.label_angle or 0.0
@@ -158,33 +156,12 @@ def _rotated_label_bbox(
     The label text starts at the anchor ``(x, y)`` (``text_anchor="start"``)
     and reads horizontally before being rotated clockwise by ``angle``
     degrees about that anchor -- matching the SVG ``rotate(angle, x, y)``
-    transform the renderer emits.  We rotate the four corners of the
-    upright text box and take their min/max as the collision box, so the
-    diagonal footprint is approximated by its enclosing rectangle.
+    transform the renderer emits.  The enclosing rectangle of the rotated
+    corners approximates the diagonal footprint for collision purposes.
     """
-    w = label_text_width(placement.text)
-    text_h = _label_text_height(placement.text)
-    # Upright box for text_anchor="start", baseline at y: text occupies
-    # x in [x, x+w] and y in roughly [y - text_h, y] (ascenders above the
-    # baseline).  Centre the box vertically on the baseline a touch so the
-    # footprint is symmetric enough for collision purposes.
-    corners = [
-        (placement.x, placement.y - text_h),
-        (placement.x + w, placement.y - text_h),
-        (placement.x + w, placement.y),
-        (placement.x, placement.y),
-    ]
-    rad = math.radians(placement.angle)
-    cos_a, sin_a = math.cos(rad), math.sin(rad)
-    ax, ay = placement.x, placement.y
-    xs: list[float] = []
-    ys: list[float] = []
-    for cx, cy in corners:
-        dx, dy = cx - ax, cy - ay
-        rx = ax + dx * cos_a - dy * sin_a
-        ry = ay + dx * sin_a + dy * cos_a
-        xs.append(rx)
-        ys.append(ry)
+    corners = _label_corners(placement)
+    xs = [c[0] for c in corners]
+    ys = [c[1] for c in corners]
     return (min(xs), min(ys), max(xs), max(ys))
 
 
@@ -745,7 +722,7 @@ def place_labels(
     allow_hyphenation: bool = True,
     label_angle: float = 0.0,
 ) -> list[LabelPlacement]:
-    """Place horizontal labels alternating above/below stations.
+    """Place station labels, alternating above/below stations.
 
     Strategy:
     1. Default: alternate above/below based on layer index.
@@ -755,6 +732,10 @@ def place_labels(
     Per-section trial: for each LR/RL section with multiple stations,
     both alternation patterns are tested and the one with fewer
     collisions is used.
+
+    When ``label_angle`` is non-zero, LR/RL section labels are instead
+    anchored at the pill and tilted (transit-map style); they hang on one
+    side and pack by their narrow rotated footprint.
     """
     sorted_stations = sorted(
         (

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -20,7 +20,10 @@ from nf_metro.layout.phases._common import (
     _ref_y,
     _set_section_bbox_top,
 )
-from nf_metro.layout.phases.single_section import _terminus_y_overhang
+from nf_metro.layout.phases.single_section import (
+    _terminus_y_overhang,
+    angled_label_reach,
+)
 from nf_metro.parser.model import MetroGraph, Section, Station
 
 
@@ -371,11 +374,16 @@ def _predict_section_content_bottom(
     from a structural extent.
     """
     section_dir = section.direction or "LR"
+    # Angled labels (#527) hang below LR/RL stations; their reach must be
+    # part of the content bottom so the shrink phase and the inter-row
+    # cascade keep the row below clear.  0 for horizontal-label layouts.
+    label_angle = graph.label_angle or 0.0 if section_dir in ("LR", "RL") else 0.0
     content_bots = [
         graph.stations[sid].y
         + max(
             section_y_padding,
             _terminus_y_overhang(graph.stations[sid], section_dir, graph)[1],
+            angled_label_reach(graph.stations[sid], label_angle),
         )
         for sid in section.station_ids
         if (

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -12,6 +12,7 @@ from nf_metro.layout.constants import (
     EDGE_TO_BUNDLE_CLEARANCE,
     GUARD_TOLERANCE,
     ICON_HALF_HEIGHT,
+    INTER_ROW_EDGE_CLEARANCE,
     OFFSET_STEP,
     ROW_BAND_SLACK,
     SECTION_Y_GAP,
@@ -1259,7 +1260,7 @@ def _guard_inter_row_run_clearance(
     routes: list[RoutedPath] | None = None,
 ) -> None:
     """After routing: a horizontal leg of an inter-*row* route must keep
-    ``EDGE_TO_BUNDLE_CLEARANCE`` from its source section's near bbox edge.
+    ``INTER_ROW_EDGE_CLEARANCE`` from its source section's near bbox edge.
 
     An inter-section bundle that crosses grid rows (e.g. a right-exit
     wrapping down to a left-entry below) lands its horizontal run in the
@@ -1294,19 +1295,19 @@ def _guard_inter_row_run_clearance(
             if xhi <= left + tol or xlo >= right - tol:
                 continue  # run doesn't overlap the source section in X
             y = y0
-            if bottom + tol < y < bottom + EDGE_TO_BUNDLE_CLEARANCE - tol:
+            if bottom + tol < y < bottom + INTER_ROW_EDGE_CLEARANCE - tol:
                 raise PhaseInvariantError(
                     f"{phase}: inter-row run of {rp.edge.source!r}->"
                     f"{rp.edge.target!r} line {rp.line_id!r} at y={y:.1f} sits "
                     f"{y - bottom:.1f}px below source section {src_sec.id!r} "
-                    f"bottom={bottom:.1f} (< {EDGE_TO_BUNDLE_CLEARANCE})"
+                    f"bottom={bottom:.1f} (< {INTER_ROW_EDGE_CLEARANCE})"
                 )
-            if top - EDGE_TO_BUNDLE_CLEARANCE + tol < y < top - tol:
+            if top - INTER_ROW_EDGE_CLEARANCE + tol < y < top - tol:
                 raise PhaseInvariantError(
                     f"{phase}: inter-row run of {rp.edge.source!r}->"
                     f"{rp.edge.target!r} line {rp.line_id!r} at y={y:.1f} sits "
                     f"{top - y:.1f}px above source section {src_sec.id!r} "
-                    f"top={top:.1f} (< {EDGE_TO_BUNDLE_CLEARANCE})"
+                    f"top={top:.1f} (< {INTER_ROW_EDGE_CLEARANCE})"
                 )
 
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1007,6 +1007,91 @@ def _guard_no_route_through_section(
         )
 
 
+def _guard_feeder_exits_section_through_side(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list[RoutedPath] | None = None,
+    offsets: dict[tuple[str, str], float] | None = None,
+) -> None:
+    """After routing: an inter-section feeder must leave its source section
+    through a vertical side, never across the box's top or bottom edge.
+
+    A feeder that turns down out of its source section to reach a row below
+    must do so *outside* the section's drawn right (or left) edge, then loop
+    around -- otherwise its vertical run crosses the box's bottom edge while
+    inside the box's x-range and visibly passes through the section frame.
+
+    The source section bbox grows to contain the rightmost station's angled
+    label (#527), so the feeder's turn-down X must clear that grown edge.
+    Detected by checking whether any route segment crosses the source
+    section's horizontal top/bottom edge line strictly inside the box's
+    x-range (issue #527, feeder-through-bottom).
+    """
+    from nf_metro.layout.constants import LABEL_BBOX_MARGIN
+    from nf_metro.layout.phases.single_section import (
+        angled_label_reach,
+        angled_label_right_reach,
+    )
+
+    label_angle = graph.label_angle or 0.0
+
+    def _drawn_box(sec: Section) -> tuple[float, float, float, float]:
+        """Box edges as the renderer will draw them, including the right/
+        bottom growth for the section's angled labels (#527).  Measuring
+        against the *grown* box gives the guard teeth even if a future change
+        drops the layout-time growth: the feeder must clear the rendered box.
+        """
+        bx0, by0 = sec.bbox_x, sec.bbox_y
+        bx1 = bx0 + sec.bbox_w
+        by1 = by0 + sec.bbox_h
+        if label_angle and sec.direction in ("LR", "RL"):
+            for sid in sec.station_ids:
+                st = graph.stations.get(sid)
+                if st is None:
+                    continue
+                right = st.x + angled_label_right_reach(st, label_angle)
+                if right + LABEL_BBOX_MARGIN > bx1:
+                    bx1 = right + LABEL_BBOX_MARGIN
+                bot = st.y + angled_label_reach(st, label_angle)
+                if bot + LABEL_BBOX_MARGIN > by1:
+                    by1 = bot + LABEL_BBOX_MARGIN
+        return bx0, by0, bx1, by1
+
+    routes = _ensure_routes(graph, routes)
+    tol = GUARD_TOLERANCE
+    for rp in routes:
+        src = graph.stations.get(rp.edge.source)
+        tgt = graph.stations.get(rp.edge.target)
+        if src is None or tgt is None or src.section_id is None:
+            continue
+        if src.section_id == tgt.section_id:
+            continue
+        sec = graph.sections.get(src.section_id)
+        if sec is None or sec.bbox_w <= 0 or sec.bbox_h <= 0:
+            continue
+        bx0, by0, bx1, by1 = _drawn_box(sec)
+        pts = rp.points
+        for i in range(len(pts) - 1):
+            (x0, y0), (x1, y1) = pts[i], pts[i + 1]
+            for edge_y, name in ((by0, "top"), (by1, "bottom")):
+                lo, hi = min(y0, y1), max(y0, y1)
+                if not (lo < edge_y - tol and hi > edge_y + tol):
+                    continue  # segment does not straddle this edge line
+                if abs(y1 - y0) < tol:
+                    continue
+                t = (edge_y - y0) / (y1 - y0)
+                cross_x = x0 + t * (x1 - x0)
+                if bx0 + tol < cross_x < bx1 - tol:
+                    raise PhaseInvariantError(
+                        f"{phase}: feeder {rp.edge.source!r}->{rp.edge.target!r} "
+                        f"line {rp.line_id!r} crosses section {src.section_id!r} "
+                        f"{name} edge (y={edge_y:.1f}) at x={cross_x:.1f} inside "
+                        f"the box x-range [{bx0:.1f}, {bx1:.1f}]; it must exit "
+                        f"through a vertical side, clear of the drawn box"
+                    )
+
+
 def _entry_approach_offenders(
     graph: MetroGraph, routes: list[RoutedPath]
 ) -> list[tuple[RoutedPath, str, str]]:

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections import defaultdict
 
 from nf_metro.layout.constants import (
@@ -116,6 +117,8 @@ def _compute_fork_join_gaps(
     divergences are suppressed because there are no diagonal transitions
     and the extra spacing is purely wasteful.
     """
+    label_angle = (full_graph or sub).label_angle or 0.0
+
     out_targets: dict[str, set[str]] = defaultdict(set)
     in_sources: dict[str, set[str]] = defaultdict(set)
 
@@ -283,6 +286,28 @@ def _compute_fork_join_gaps(
         bubble_extra = max(
             0.0, (bubble_label_half * 2 + DIAGONAL_RUN - x_spacing) / 1.5
         )
+
+        # Angled labels (label_angle) hang to the lower-right of each fan
+        # caller; the fan-out/fan-in diagonal on that side must start past
+        # the tilted text or it rakes the label.  Reserve the caller
+        # label's rightward reach (the narrow rotated footprint, not the
+        # full horizontal width) as extra column room.  Unlike the
+        # horizontal-label case above this applies to any multi-track fan,
+        # not only wide (3+) ones, since a single hanging name is enough to
+        # clash with the convergence diagonal.
+        if label_angle:
+            cos_a = abs(math.cos(math.radians(label_angle)))
+            adj_layer = layer + 1 if layer in fork_layers else layer - 1
+            angled_reach = 0.0
+            for sid, lyr in layers.items():
+                if lyr == adj_layer and sid in tracks and tracks[sid] not in fj_tracks:
+                    station = sub.stations.get(sid)
+                    if station and station.label.strip():
+                        angled_reach = max(
+                            angled_reach, label_text_width(station.label) * cos_a
+                        )
+            bubble_extra = max(bubble_extra, angled_reach)
+
         layer_gap[layer] = max(base_gap, fj_label_half + bubble_extra)
 
     cumulative = 0.0

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import math
+
 from nf_metro.layout.constants import (
     CURVE_RADIUS,
+    DIAGONAL_LABEL_OFFSET,
     ENTRY_SHIFT_LR,
     ENTRY_SHIFT_TB,
     ENTRY_SHIFT_TB_CROSS,
@@ -237,6 +240,12 @@ def _layout_single_section(
     section.bbox_w = (max(xs) - min(xs)) + section_x_padding * 2
     bbox_top = y_min - y_pad
     bbox_bot = y_max + y_pad
+    # Angled labels (#527) hang below the lowest stations; reserve their
+    # vertical reach so section/row placement keeps the row below clear.
+    if section.direction in ("LR", "RL"):
+        angled_pad = _angled_label_bottom_padding(sub, graph.label_angle or 0.0)
+        if angled_pad > 0:
+            bbox_bot = max(bbox_bot, y_max + section_y_padding + angled_pad)
     if bypass_v_ys:
         # When V sits beyond the real-station extent, use curve-only
         # clearance rather than full label padding: V has no marker,
@@ -347,6 +356,39 @@ def _multiline_label_padding(sub: MetroGraph) -> float:
             extra = n * FONT_HEIGHT * LABEL_LINE_HEIGHT
             max_extra = max(max_extra, extra)
     return max_extra
+
+
+def angled_label_reach(station: Station, label_angle: float) -> float:
+    """Vertical reach below a station's marker of its hanging angled label.
+
+    Angled labels (#527) anchor below the pill and tilt down, so a long
+    name reaches well below the marker by ``anchor_drop + width*sin(angle)``.
+    Returns 0 when the angle is 0 or the station carries no name label, so
+    horizontal-label layouts are unaffected.
+    """
+    if not label_angle:
+        return 0.0
+    if station.is_port or station.is_hidden or station.is_terminus:
+        return 0.0
+    if not station.label.strip():
+        return 0.0
+    sin_a = abs(math.sin(math.radians(label_angle)))
+    return (
+        LABEL_OFFSET + DIAGONAL_LABEL_OFFSET + label_text_width(station.label) * sin_a
+    )
+
+
+def _angled_label_bottom_padding(sub: MetroGraph, label_angle: float) -> float:
+    """Worst-case angled-label reach below the lowest station in a section.
+
+    Used during single-section layout to reserve the vertical extent the
+    hanging angled labels need, so section/row placement keeps the row below
+    clear.  0 when no labels are angled.
+    """
+    return max(
+        (angled_label_reach(s, label_angle) for s in sub.stations.values()),
+        default=0.0,
+    )
 
 
 def _normalize_min(sub: MetroGraph, axis: str) -> None:

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -28,7 +28,7 @@ from nf_metro.layout.constants import (
     TERMINUS_ICON_CLEARANCE_V,
     TERMINUS_WIDTH,
 )
-from nf_metro.layout.labels import label_text_width
+from nf_metro.layout.labels import _label_text_height, label_text_width
 from nf_metro.layout.layers import assign_layers
 from nf_metro.layout.ordering import assign_tracks
 from nf_metro.layout.phases._common import _build_section_subgraph
@@ -243,9 +243,19 @@ def _layout_single_section(
     # Angled labels (#527) hang below the lowest stations; reserve their
     # vertical reach so section/row placement keeps the row below clear.
     if section.direction in ("LR", "RL"):
-        angled_pad = _angled_label_bottom_padding(sub, graph.label_angle or 0.0)
+        label_angle = graph.label_angle or 0.0
+        angled_pad = _angled_label_bottom_padding(sub, label_angle)
         if angled_pad > 0:
             bbox_bot = max(bbox_bot, y_max + section_y_padding + angled_pad)
+        # The angled label of the rightmost station overhangs to the right;
+        # grow the bbox right edge so it matches the rendered box and the
+        # inter-section feeder routes outside it (#527).
+        angled_right_edge = _angled_label_right_edge(sub, label_angle)
+        if angled_right_edge > 0:
+            right_edge = max(
+                section.bbox_x + section.bbox_w, angled_right_edge + LABEL_BBOX_MARGIN
+            )
+            section.bbox_w = right_edge - section.bbox_x
     if bypass_v_ys:
         # When V sits beyond the real-station extent, use curve-only
         # clearance rather than full label padding: V has no marker,
@@ -375,6 +385,43 @@ def angled_label_reach(station: Station, label_angle: float) -> float:
     sin_a = abs(math.sin(math.radians(label_angle)))
     return (
         LABEL_OFFSET + DIAGONAL_LABEL_OFFSET + label_text_width(station.label) * sin_a
+    )
+
+
+def angled_label_right_reach(station: Station, label_angle: float) -> float:
+    """Horizontal reach to the right of a station's marker of its angled label.
+
+    An angled label (#527) is anchored at the station X and tilted clockwise,
+    so its rotated text box extends right of the marker.  The renderer grows
+    the section bbox to contain that box; computing the same reach here lets
+    layout finalise the section's right edge *before* routing runs, so the
+    inter-section feeder turns down outside the drawn box rather than crossing
+    its bottom edge.  Matches the rotated-AABB right extent used by the
+    renderer (``width*cos(angle) + height*sin(angle)``).  Returns 0 when the
+    angle is 0 or the station carries no name label.
+    """
+    if not label_angle:
+        return 0.0
+    if station.is_port or station.is_hidden or station.is_terminus:
+        return 0.0
+    if not station.label.strip():
+        return 0.0
+    rad = math.radians(label_angle)
+    return label_text_width(station.label) * abs(math.cos(rad)) + _label_text_height(
+        station.label
+    ) * abs(math.sin(rad))
+
+
+def _angled_label_right_edge(sub: MetroGraph, label_angle: float) -> float:
+    """Rightmost X any station's angled label reaches (absolute, not a delta).
+
+    Each station's reach is measured from its own X, so the section's required
+    right edge is ``max(station.x + reach)``.  Returns 0 when no labels are
+    angled.
+    """
+    return max(
+        (s.x + angled_label_right_reach(s, label_angle) for s in sub.stations.values()),
+        default=0.0,
     )
 
 

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -35,6 +35,12 @@ def _probe_label_placements(
     from nf_metro.layout.labels import place_labels
     from nf_metro.layout.routing import compute_station_offsets, route_edges
 
+    # Resolve the effective label angle so the spread search sizes column
+    # spacing for the same (possibly rotated, hence narrower) footprint the
+    # renderer will draw.  graph.label_angle is None when no directive set it;
+    # the theme default is horizontal (0), so None -> 0 here (#527).
+    label_angle = graph.label_angle or 0.0
+
     pos_snapshot = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
     bbox_snapshot = {
         sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
@@ -48,6 +54,7 @@ def _probe_label_placements(
             station_offsets=offsets,
             routes=routes,
             allow_hyphenation=allow_hyphenation,
+            label_angle=label_angle,
         )
         return offsets, placements
     except Exception:

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -14,6 +14,7 @@ from nf_metro.layout.constants import (
     DEFAULT_LINE_PRIORITY,
     EDGE_TO_BUNDLE_CLEARANCE,
     HEADER_CLEARANCE,
+    INTER_ROW_EDGE_CLEARANCE,
     INTER_ROW_HEADER_CLEARANCE,
     OFFSET_STEP,
     SECTION_HEADER_PROTRUSION,
@@ -741,14 +742,14 @@ def _center_inter_row_channel(upper_bottom: float, lower_top: float) -> float:
     """Y for a horizontal channel in the gap between two stacked rows.
 
     The channel is centred in the band that keeps
-    :data:`EDGE_TO_BUNDLE_CLEARANCE` ("constant A") above the bbox bottom
-    of the row above and :data:`INTER_ROW_HEADER_CLEARANCE` above the row
-    below -- the latter clears the *header badge* (numbered circle +
-    label) rather than just the bbox edge, so the run doesn't graze the
-    next-row label.  When the gap is too narrow to satisfy both margins
-    the channel biases to ``hi`` so it still clears the badge.
+    :data:`INTER_ROW_EDGE_CLEARANCE` above the bbox bottom of the row
+    above and :data:`INTER_ROW_HEADER_CLEARANCE` above the row below --
+    the latter clears the *header badge* (numbered circle + label) rather
+    than just the bbox edge, so the run doesn't graze the next-row label.
+    When the gap is too narrow to satisfy both margins the channel biases
+    to ``hi`` so it still clears the badge.
     """
-    lo = upper_bottom + EDGE_TO_BUNDLE_CLEARANCE
+    lo = upper_bottom + INTER_ROW_EDGE_CLEARANCE
     hi = lower_top - INTER_ROW_HEADER_CLEARANCE
     if lo <= hi:
         return (lo + hi) / 2

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -24,6 +24,7 @@ from nf_metro.layout.constants import (
     EDGE_TO_BUNDLE_CLEARANCE,
     FOLD_MARGIN,
     ICON_TERMINUS_FORK_LEAD,
+    INTER_ROW_EDGE_CLEARANCE,
     INTER_ROW_HEADER_CLEARANCE,
     JUNCTION_MARGIN,
     MERGE_ROUTE_MARGIN,
@@ -2393,18 +2394,18 @@ def _route_inter_row_gap_corridor(
     elif gap_bottom > gap_top:
         gy_base = _center_inter_row_channel(gap_top, gap_bottom)
     else:
-        gy_base = gap_top + EDGE_TO_BUNDLE_CLEARANCE
+        gy_base = gap_top + INTER_ROW_EDGE_CLEARANCE
     # Outer line sits at LARGER y in this leftward run (CW D->L corner).
     gy = gy_base + delta
     # Keep every staggered line inside the clearance band: at least
-    # EDGE_TO_BUNDLE_CLEARANCE below the source-row bottom and clear of the
+    # INTER_ROW_EDGE_CLEARANCE below the source-row bottom and clear of the
     # next row's header badge.  In a tight gap the band is narrower than the
     # bundle, so the per-line stagger collapses rather than grazing an edge.
     # Skipped for fan feeders, which share the wrap sibling's (unclamped)
     # band so the two bundles' H legs coincide.
     if fan is None and gap_bottom > gap_top:
         gy = min(
-            max(gy, gap_top + EDGE_TO_BUNDLE_CLEARANCE),
+            max(gy, gap_top + INTER_ROW_EDGE_CLEARANCE),
             gap_bottom - INTER_ROW_HEADER_CLEARANCE,
         )
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -5323,10 +5323,14 @@ def _restack_htrunk(
         return
     max_off = (n - 1) * step
     off = inner * step
-    # An innermost trunk turns on the INSIDE of both flanking corners; the
-    # outermost turns on the OUTSIDE.  For a downward dip the inner line is
-    # the inside of the turn (smaller radius); same parity on both corners.
-    r = corner_radius(off, max_off, outside=False, base_radius=base_radius)
+    # An innermost trunk turns on the INSIDE of both flanking corners (smaller
+    # radius), the outermost on the OUTSIDE (larger); same parity on both
+    # corners of a dip.  ``off`` grows from 0 at the innermost line, so the
+    # radius is base_radius + off (innermost = base_radius, the tightest) --
+    # the concentric nesting.  Using the reversed (outside=False) offset here
+    # inverts that, giving the inside line the LARGEST radius and tearing the
+    # bundle apart at the dip corners.
+    r = corner_radius(off, max_off, outside=True, base_radius=base_radius)
     if 0 <= k - 1 < len(rp.curve_radii):
         rp.curve_radii[k - 1] = r
     if k < len(rp.curve_radii) and k + 2 < len(pts):

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -17,6 +17,7 @@ from typing import TypeGuard
 from nf_metro.layout.constants import (
     BUNDLE_TO_BUNDLE_CLEARANCE,
     EDGE_TO_BUNDLE_CLEARANCE,
+    INTER_ROW_EDGE_CLEARANCE,
     INTER_ROW_HEADER_CLEARANCE,
     MERGE_GAP_MIN,
     MIN_INTER_SECTION_GAP,
@@ -365,7 +366,7 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
     (LEFT/RIGHT) entry port wraps through the inter-row gap as a
     horizontal run (see ``_route_left_entry_wrap``).  To keep that run
     clear of both bounding obstacles it needs a band of
-    ``EDGE_TO_BUNDLE_CLEARANCE`` below the upper bbox bottom, the bundle
+    ``INTER_ROW_EDGE_CLEARANCE`` below the upper bbox bottom, the bundle
     span, and ``INTER_ROW_HEADER_CLEARANCE`` above the lower row (clearing
     its header badge, not just the bbox edge); a narrow gap squeezes the
     bundle flush against a box.  Returns, per adjacent
@@ -430,7 +431,7 @@ def _wrap_bundle_row_minimums(graph: MetroGraph) -> dict[tuple[int, int], float]
     for gap, ports in per_gap.items():
         widest = max(len(lines) for lines in ports.values())
         span = (widest - 1) * OFFSET_STEP
-        minimums[gap] = EDGE_TO_BUNDLE_CLEARANCE + span + INTER_ROW_HEADER_CLEARANCE
+        minimums[gap] = INTER_ROW_EDGE_CLEARANCE + span + INTER_ROW_HEADER_CLEARANCE
     return minimums
 
 

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -259,6 +259,11 @@ def _parse_directive(
     elif content.startswith("center_ports:"):
         val = content[len("center_ports:") :].strip().lower()
         graph.center_ports = val in ("true", "yes", "1")
+    elif content.startswith("label_angle:"):
+        try:
+            graph.label_angle = float(content[len("label_angle:") :].strip())
+        except ValueError:
+            pass
     elif content.startswith("legend_min_height:"):
         try:
             graph.legend_min_height = float(

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -198,6 +198,9 @@ class MetroGraph:
     center_ports: bool = False
     legend_position: str = "bottom"
     legend_min_height: float = 0.0
+    # Opt-in diagonal station labels (#527). None means "use the theme
+    # default" (0 = horizontal); a directive value overrides the theme.
+    label_angle: float | None = None
     # Placement modifiers for the bundled legend+logo block. The corner/edge
     # keyword lives in legend_position; these refine where that block lands.
     legend_anchor: str = "content"  # "content" (section bbox) or "canvas"

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -28,11 +28,6 @@ class Theme:
     label_font_family: str
     label_font_size: float
     label_font_weight: str
-    # Station label rotation in degrees, clockwise (#527).  0 keeps the
-    # historical horizontal labels; a positive angle tilts text downward to
-    # the right so dense trunks fit on a compact horizontal line.  A
-    # %%metro label_angle: directive overrides this per-diagram.
-    label_angle: float = 0.0
     title_color: str
     title_font_size: float
     section_fill: str

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -28,6 +28,11 @@ class Theme:
     label_font_family: str
     label_font_size: float
     label_font_weight: str
+    # Station label rotation in degrees, clockwise (#527).  0 keeps the
+    # historical horizontal labels; a positive angle tilts text downward to
+    # the right so dense trunks fit on a compact horizontal line.  A
+    # %%metro label_angle: directive overrides this per-diagram.
+    label_angle: float = 0.0
     title_color: str
     title_font_size: float
     section_fill: str

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -358,15 +358,12 @@ def render_svg(
     # Compute labels early so section bbox expansions are applied
     # before section boxes are drawn and canvas bounds are computed.
     icon_obstacles = _compute_icon_obstacles(graph, theme, station_offsets)
-    label_angle = (
-        graph.label_angle if graph.label_angle is not None else theme.label_angle
-    )
     labels = place_labels(
         graph,
         station_offsets=station_offsets,
         icon_obstacles=icon_obstacles,
         routes=routes,
-        label_angle=label_angle,
+        label_angle=graph.label_angle or 0.0,
     )
 
     max_x, max_y = _compute_canvas_bounds(graph, routes, debug)

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -358,11 +358,15 @@ def render_svg(
     # Compute labels early so section bbox expansions are applied
     # before section boxes are drawn and canvas bounds are computed.
     icon_obstacles = _compute_icon_obstacles(graph, theme, station_offsets)
+    label_angle = (
+        graph.label_angle if graph.label_angle is not None else theme.label_angle
+    )
     labels = place_labels(
         graph,
         station_offsets=station_offsets,
         icon_obstacles=icon_obstacles,
         routes=routes,
+        label_angle=label_angle,
     )
 
     max_x, max_y = _compute_canvas_bounds(graph, routes, debug)
@@ -1257,7 +1261,27 @@ def _render_labels(
             label_data["data-station-id"] = label.station_id
             label_data["class_"] = "nf-metro-station-label"
 
-        if label.dominant_baseline:
+        if label.angle:
+            # Diagonal labels (#527): anchor at the pill and rotate about
+            # the anchor.  text-anchor=start so the tilted text trails
+            # away from the station.
+            d.append(
+                draw.Text(
+                    text,
+                    theme.label_font_size,
+                    label.x,
+                    label.y,
+                    fill=theme.label_color,
+                    font_family=theme.label_font_family,
+                    font_weight=theme.label_font_weight,
+                    text_anchor=label.text_anchor or "start",
+                    dominant_baseline="auto",
+                    line_height=LABEL_LINE_HEIGHT,
+                    transform=f"rotate({label.angle},{label.x},{label.y})",
+                    **label_data,
+                )
+            )
+        elif label.dominant_baseline:
             # Custom placement (e.g. TB vertical stations: right-side labels)
             d.append(
                 draw.Text(

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -323,7 +323,12 @@ def check_label_overlap(
         offsets, routes = precomputed
 
     try:
-        placements = place_labels(graph, station_offsets=offsets, routes=routes)
+        placements = place_labels(
+            graph,
+            station_offsets=offsets,
+            routes=routes,
+            label_angle=graph.label_angle or 0.0,
+        )
     except Exception as e:
         return [
             Violation(

--- a/tests/test_diagonal_labels.py
+++ b/tests/test_diagonal_labels.py
@@ -1,0 +1,137 @@
+"""Layout/placement behaviour for opt-in diagonal station labels (#527)."""
+
+from __future__ import annotations
+
+from nf_metro.layout.constants import DIAGONAL_LABEL_OFFSET, LABEL_OFFSET
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.labels import find_label_overlaps, place_labels
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+_DENSE_TRUNK = """\
+%%metro line: main | Main | #ff0000
+graph LR
+    subgraph s [Section]
+        a[AlignmentStep]
+        b[MarkDuplicates]
+        c[BaseRecalibrator]
+        d[NGSCheckmate]
+        e[VariantCaller]
+        a -->|main| b
+        b -->|main| c
+        c -->|main| d
+        d -->|main| e
+    end
+"""
+
+
+def _trunk_pitch(label_angle: float) -> float:
+    """Mean adjacent-station X pitch for the dense trunk at a given angle."""
+    text = (
+        f"%%metro label_angle: {label_angle}\n{_DENSE_TRUNK}"
+        if label_angle
+        else _DENSE_TRUNK
+    )
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=True)
+    xs = sorted(
+        s.x
+        for s in graph.stations.values()
+        if not s.is_port and not s.is_hidden and s.label.strip()
+    )
+    deltas = [xs[i + 1] - xs[i] for i in range(len(xs) - 1)]
+    return sum(deltas) / len(deltas)
+
+
+def test_angled_trunk_packs_tighter_than_horizontal():
+    """Angled labels must let a dense trunk pack tighter horizontally (#527).
+
+    The whole point of diagonal labels: their narrow horizontal footprint
+    lets closely-spaced stations share one line, so the angled trunk's
+    column pitch is strictly smaller than the horizontal-label equivalent.
+    """
+    horizontal = _trunk_pitch(0.0)
+    angled = _trunk_pitch(45.0)
+    assert angled < horizontal, (
+        f"angled pitch {angled:.1f} not tighter than horizontal {horizontal:.1f}"
+    )
+
+
+def test_angled_label_offset_clears_pill():
+    """Angled labels anchor below the pill with the extra diagonal drop (#3)."""
+    graph = parse_metro_mermaid(f"%%metro label_angle: 45\n{_DENSE_TRUNK}")
+    compute_layout(graph, validate=True)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    placements = place_labels(
+        graph, station_offsets=offsets, routes=routes, label_angle=45.0
+    )
+    by_sid = {p.station_id: p for p in placements}
+    for sid in ("a", "b", "c", "d", "e"):
+        lp = by_sid[sid]
+        st = graph.stations[sid]
+        assert lp.angle == 45.0
+        # Anchor sits at least LABEL_OFFSET + DIAGONAL_LABEL_OFFSET below the
+        # marker centre, so there is a visible gap between pill and text.
+        assert lp.y - st.y >= LABEL_OFFSET + DIAGONAL_LABEL_OFFSET - 0.5
+
+
+def test_angled_labels_reserve_room_above_row_below():
+    """A section below an angled-label trunk must clear the hanging labels (#2).
+
+    The dense trunk's tilted names hang well below their markers; the engine
+    must reserve that vertical extent so the lower section's bbox starts
+    below the trunk section's bbox (which has grown to contain the labels).
+    """
+    text = """\
+%%metro label_angle: 45
+%%metro line: main | Main | #ff0000
+%%metro grid: top | 0,0
+%%metro grid: bottom | 0,1
+graph LR
+    subgraph top [Top]
+        a[AlignmentStep]
+        b[MarkDuplicates]
+        c[BaseRecalibrator]
+        d[NGSCheckmate]
+        a -->|main| b
+        b -->|main| c
+        c -->|main| d
+    end
+    subgraph bottom [Bottom]
+        %%metro entry: left | main
+        e[Downstream]
+        f[Output]
+        e -->|main| f
+    end
+    d -->|main| e
+"""
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=True)
+
+    # No label overlaps the row below at the angle the renderer draws.
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    placements = place_labels(
+        graph, station_offsets=offsets, routes=routes, label_angle=45.0
+    )
+    assert not find_label_overlaps(graph, placements, offsets)
+
+    # The grown trunk bbox (containing the hanging labels) clears the bottom.
+    top = graph.sections["top"]
+    for p in placements:
+        st = graph.stations.get(p.station_id)
+        if st is None or st.section_id != "top":
+            continue
+        _x0, _y0, _x1, label_bottom = _label_box(p)
+        bottom = graph.sections["bottom"]
+        assert label_bottom <= bottom.bbox_y + 1.0, (
+            f"angled label {p.station_id!r} hangs into the row below"
+        )
+    assert top.bbox_y + top.bbox_h <= graph.sections["bottom"].bbox_y + 1.0
+
+
+def _label_box(placement):
+    from nf_metro.layout.labels import _label_bbox
+
+    return _label_bbox(placement)

--- a/tests/test_diagonal_labels.py
+++ b/tests/test_diagonal_labels.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 from nf_metro.layout.constants import DIAGONAL_LABEL_OFFSET, LABEL_OFFSET
 from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.labels import find_label_overlaps, place_labels
@@ -62,6 +64,43 @@ def test_angled_trunk_packs_tighter_than_horizontal():
     assert angled < horizontal, (
         f"angled pitch {angled:.1f} not tighter than horizontal {horizontal:.1f}"
     )
+
+
+def test_label_angle_declined_on_tb_section():
+    """A graph with any TB section ignores label_angle and stays horizontal.
+
+    Diagonal labels suit horizontal trunks; a TB section labels vertical pills
+    side-on, where the same tilt reads wrong.  Rather than mix tilted and
+    horizontal labels on one map, the engine declines the angle entirely
+    (warns and falls back to horizontal everywhere).
+    """
+    text = """\
+%%metro label_angle: 45
+%%metro line: main | Main | #ff0000
+%%metro grid: flow | 0,0
+%%metro grid: qc | 0,1
+graph LR
+    subgraph flow [Flow]
+        a[AlignmentStep]
+        b[MarkDuplicates]
+        a -->|main| b
+    end
+    subgraph qc [QC]
+        %%metro direction: TB
+        %%metro entry: top | main
+        q1[MultiQC]
+        q2[Report]
+        q1 -->|main| q2
+    end
+    b -->|main| q1
+"""
+    graph = parse_metro_mermaid(text)
+    with pytest.warns(UserWarning, match="TB section"):
+        compute_layout(graph)
+    assert graph.label_angle == 0.0
+
+    svg = render_svg(graph, NFCORE_THEME)
+    assert "rotate(" not in svg
 
 
 def test_angled_label_offset_clears_pill():

--- a/tests/test_diagonal_labels.py
+++ b/tests/test_diagonal_labels.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from nf_metro.layout.constants import DIAGONAL_LABEL_OFFSET, LABEL_OFFSET
 from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.labels import find_label_overlaps, place_labels
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.svg import render_svg
+from nf_metro.themes.nfcore import NFCORE_THEME
+
+_EXAMPLE = Path(__file__).resolve().parents[1] / "examples" / "diagonal_labels.mmd"
 
 _DENSE_TRUNK = """\
 %%metro line: main | Main | #ff0000
@@ -135,3 +142,131 @@ def _label_box(placement):
     from nf_metro.layout.labels import _label_bbox
 
     return _label_bbox(placement)
+
+
+def _svg_rects(svg: str) -> list[tuple[float, float, float, float]]:
+    """Parse ``<rect>`` elements as (x0, y0, x1, y1) tuples."""
+    rects = []
+    for tag in re.findall(r"<rect\b[^>]*?/?>", svg):
+        attrs = {
+            k: float(v)
+            for k in ("x", "y", "width", "height")
+            if (m := re.search(rf'\b{k}="(-?[\d.]+)"', tag))
+            for v in (m.group(1),)
+        }
+        if len(attrs) == 4:
+            x, y = attrs["x"], attrs["y"]
+            rects.append((x, y, x + attrs["width"], y + attrs["height"]))
+    return rects
+
+
+def _svg_path_points(svg: str) -> list[list[tuple[float, float]]]:
+    """Parse the polyline vertices of every ``<path>`` in the SVG."""
+    paths = []
+    for d in re.findall(r'<path\b[^>]*\bd="([^"]+)"', svg):
+        pts = [
+            (float(a), float(b))
+            for a, b in re.findall(r"(-?\d+\.?\d*)[ ,]+(-?\d+\.?\d*)", d)
+        ]
+        if pts:
+            paths.append(pts)
+    return paths
+
+
+def test_feeder_exits_right_of_section_box_not_through_bottom():
+    """The inter-section feeder must clear the section's full drawn extent (#1).
+
+    The section bbox grows to the right to contain the rightmost station's
+    angled label.  The feeder that descends out of the section to the row
+    below must turn down *outside* that grown right edge -- otherwise its
+    vertical run sits inside the drawn box and visibly crosses the box's
+    bottom edge.  Measured against the rendered SVG (the drawn ``<rect>`` and
+    the feeder ``<path>``), not against routing waypoints or ``bbox_*``.
+    """
+    graph = parse_metro_mermaid(_EXAMPLE.read_text())
+    compute_layout(graph, validate=True)
+    svg = render_svg(graph, NFCORE_THEME)
+
+    # Section 1 (Pre-processing) is the topmost wide section rect.  Exclude
+    # the full-canvas background rect (anchored at the origin).
+    section_rects = [
+        r
+        for r in _svg_rects(svg)
+        if (r[2] - r[0]) > 200 and (r[3] - r[1]) > 100 and not (r[0] == 0 and r[1] == 0)
+    ]
+    section_rects.sort(key=lambda r: r[1])
+    rx0, ry0, rx1, ry1 = section_rects[0]
+
+    # Identify the feeder descents: vertical (constant-x) runs that cross the
+    # section bottom edge ``ry1`` on their way to the row below, on the right.
+    descent_xs: list[float] = []
+    for pts in _svg_path_points(svg):
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        if not (max(ys) > ry1 + 10 and min(ys) < ry1 and max(xs) > rx1 - 60):
+            continue
+        for i in range(len(pts) - 1):
+            (x0, y0), (x1, y1) = pts[i], pts[i + 1]
+            if abs(x0 - x1) < 0.5 and min(y0, y1) < ry1 < max(y0, y1) + 0.1:
+                descent_xs.append(x0)
+
+    assert descent_xs, "no feeder descent crossing the section bottom found"
+
+    # (a) Every descending run is right of the drawn box edge (with clearance).
+    for x in descent_xs:
+        assert x >= rx1 - 0.5, (
+            f"feeder descends at x={x:.1f} inside the drawn box "
+            f"(right edge rx1={rx1:.1f}); it must clear the grown right edge"
+        )
+
+    # (b) No feeder point lies on the section bottom-edge band while inside the
+    #     box's x-range -- i.e. nothing crosses the bottom edge within the box.
+    for pts in _svg_path_points(svg):
+        for x, y in pts:
+            if abs(y - ry1) < 8 and rx0 < x < rx1 - 0.5:
+                raise AssertionError(
+                    f"feeder point ({x:.1f}, {y:.1f}) crosses the section "
+                    f"bottom edge (ry1={ry1:.1f}) inside the box x-range "
+                    f"[{rx0:.1f}, {rx1:.1f}]"
+                )
+
+
+def test_angled_trunk_pitch_at_marker_floor():
+    """Angled-label trunk packs to the marker+gap floor, not the label width (#2).
+
+    Parallel diagonal labels collide only on their perpendicular separation,
+    not their length, so a dense angled trunk packs to the column-pitch floor
+    regardless of how long the names are -- and far tighter than the rotated
+    label's horizontal-width projection would allow.  Measured on the rendered
+    example's trunk station X pitch.
+    """
+    graph = parse_metro_mermaid(_EXAMPLE.read_text())
+    compute_layout(graph, validate=True)
+
+    trunk = [
+        "fastqc",
+        "fastp",
+        "umi",
+        "bwa",
+        "merge_index",
+        "markdup",
+        "bqsr",
+        "applybqsr",
+        "mosdepth",
+        "ngscheckmate",
+    ]
+    xs = [graph.stations[s].x for s in trunk]
+    pitches = [xs[i + 1] - xs[i] for i in range(len(xs) - 1)]
+    mean_pitch = sum(pitches) / len(pitches)
+
+    # Well under the rotated-label horizontal projection (~127px for these
+    # names): the perpendicular-footprint packing keeps the trunk at the floor.
+    assert mean_pitch < 90.0, f"angled trunk pitch {mean_pitch:.1f} too wide"
+
+    # And no two angled labels actually overlap at that pitch.
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    placements = place_labels(
+        graph, station_offsets=offsets, routes=routes, label_angle=45.0
+    )
+    assert not find_label_overlaps(graph, placements, offsets)

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -22,6 +22,7 @@ from conftest import CONTENT_PLACEMENT_PHASES
 from nf_metro.layout.constants import (
     CURVE_RADIUS,
     EDGE_TO_BUNDLE_CLEARANCE,
+    INTER_ROW_EDGE_CLEARANCE,
     MIN_STATION_FLAT_LENGTH,
     ROW_BAND_SLACK,
     SECTION_HEADER_PROTRUSION,
@@ -1861,12 +1862,12 @@ def test_inter_row_run_clears_source_section(fixture):
     When an inter-section bundle crosses grid rows (e.g. a right-exit that
     wraps down to a left-entry in the row below), its horizontal run lands
     in the inter-row gap.  That run must keep at least
-    ``EDGE_TO_BUNDLE_CLEARANCE`` from the source section's near edge so it
+    ``INTER_ROW_EDGE_CLEARANCE`` from the source section's near edge so it
     doesn't read as "running along under the box".
     """
     graph = _layout(fixture)
     routes = route_edges(graph)
-    A = EDGE_TO_BUNDLE_CLEARANCE
+    A = INTER_ROW_EDGE_CLEARANCE
     for rp in routes:
         if not rp.is_inter_section:
             continue

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2162,7 +2162,12 @@ def test_no_label_overlap(fixture):
     graph = _layout(fixture)
     offsets = compute_station_offsets(graph)
     routes = route_edges(graph, station_offsets=offsets)
-    placements = place_labels(graph, station_offsets=offsets, routes=routes)
+    placements = place_labels(
+        graph,
+        station_offsets=offsets,
+        routes=routes,
+        label_angle=graph.label_angle or 0.0,
+    )
     overlaps = find_label_overlaps(graph, placements, offsets)
     assert not overlaps, "; ".join(
         f"{ov.a!r} overlaps {ov.kind} {ov.b!r} by ({ov.ox:.1f}, {ov.oy:.1f})px"
@@ -4249,7 +4254,9 @@ def test_label_x_anchored_to_station_marker_on_horizontal_runs(fixture):
     graph = _layout(fixture)
     offsets = compute_station_offsets(graph)
     routes = route_edges(graph, station_offsets=offsets)
-    labels = place_labels(graph, station_offsets=offsets)
+    labels = place_labels(
+        graph, station_offsets=offsets, label_angle=graph.label_angle or 0.0
+    )
     label_by_sid = {lp.station_id: lp for lp in labels}
 
     in_routes: dict[str, list] = defaultdict(list)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,6 +33,24 @@ def test_parse_line_order_default():
     assert graph.line_order == "definition"
 
 
+def test_parse_label_angle():
+    text = "%%metro label_angle: 45\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.label_angle == 45.0
+
+
+def test_parse_label_angle_default_none():
+    text = "graph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.label_angle is None
+
+
+def test_parse_label_angle_invalid_ignored():
+    text = "%%metro label_angle: sideways\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.label_angle is None
+
+
 def test_parse_line_order_invalid_ignored():
     text = "%%metro line_order: invalid\ngraph LR\n"
     graph = parse_metro_mermaid(text)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -45,6 +45,25 @@ def test_render_contains_line_color():
     assert "#ff0000" in svg
 
 
+def test_label_angle_emits_rotate_transform():
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro label_angle: 45\n"
+        "graph LR\n"
+        "    a[Alpha]\n"
+        "    b[Beta]\n"
+        "    a -->|main| b\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    assert "rotate(45" in svg
+
+
+def test_label_angle_default_no_rotate():
+    svg = _render_simple()
+    assert "rotate(" not in svg
+
+
 def test_render_nfcore_theme_background():
     svg = _render_simple()
     assert NFCORE_THEME.background_color in svg


### PR DESCRIPTION
## What this adds

Opt-in diagonal (angled) station labels, so densely-spaced stations on a single horizontal trunk stay legible, matching the style of hand-drawn transit maps (e.g. the nf-core/sarek subway map, where ~45 degree labels pack a dozen stations onto one pre-processing line).

- **`%%metro label_angle: <deg>`** directive (default `0` = horizontal): a per-diagram station-label rotation in degrees clockwise. This is the single control surface; absent the directive, layout and rendering are unchanged.
- **Renderer** (`render/svg.py`): angled labels are anchored at the pill and emitted with an SVG `rotate(angle, x, y)` transform and `text-anchor="start"`, so the tilted text trails away from the station.
- **Placement** (`layout/labels.py`): when an angle is set, non-TB section labels are anchored below the trunk on a single side (transit-map convention). Collision uses an oriented (separating-axis) test on the rotated label box, so parallel diagonal labels pack by their true narrow footprint rather than their enclosing axis-aligned box. Angled labels are excluded from the line-wrapping pass.

## Dense trunks pack tighter

The auto-spacing search (`layout/phases/spacing.py`) sizes column spacing for the same rotated footprint the renderer draws, so an angled trunk lays out visibly tighter than the horizontal-label equivalent (column pitch falls to the minimum where the parallel diagonal labels just clear) instead of being spaced apart by full horizontal label width.

## Fan sections keep room for the hanging label

A fan caller's angled label hangs to the lower-right and would rake the fan-in/fan-out diagonal when the tight trunk pitch leaves the caller almost no horizontal flat. `_compute_fork_join_gaps` (`layout/phases/off_track.py`) reserves each caller's rotated-label rightward reach as extra column room, for any multi-track fan, so the convergence diagonals start clear of the tilted text.

## Vertical room for the hanging labels

Angled labels trail below their markers, so a long name reaches well below the pill. That vertical reach is folded into each LR/RL section's content bottom (`layout/phases/bbox.py`, `layout/phases/single_section.py`), so section/row placement reserves the space and a section in the row below stays clear of the hanging labels (no overlap with the box, markers, or routes below).

## Clearer pill-to-label gap

Angled labels are dropped an extra `DIAGONAL_LABEL_OFFSET` below the marker so there is a visible gap between the pill and the tilted text.

## Consistency

To avoid a mixed-orientation map, diagonal labels are gated to LR-only graphs: TB sections label vertical pills side-on, where the same tilt reads wrong, so if `label_angle` is set on a graph that contains any TB section, `compute_layout` warns and falls back to horizontal labels everywhere. (TB support is tracked in #556.)

## Demo fixture

`examples/diagonal_labels.mmd` is a dense pre-processing trunk (`label_angle: 45`) feeding a variant-calling section in the row below that fans out to three callers and fans back in. It shows the tighter trunk packing, the reserved vertical room, the fan-caller flats, and clean clearance over the row beneath.

## Back-compatibility

The feature is default-off. With no `label_angle` directive, label placement, spacing, and rendering are unchanged and the existing gallery renders byte-identically.

## Limitations

- Rotated-label collision uses an oriented bounding rectangle of the text, not exact glyph outlines.
- Diagonal labels apply to LR/RL trunks only; a graph with a TB section keeps horizontal labels throughout (see #556).

Closes #527
Closes #554
