### PR TITLE
feat(render): intra-section station group band labels (#531)

### DIFF
--- a/examples/group_labels.mmd
+++ b/examples/group_labels.mmd
@@ -1,0 +1,34 @@
+%%metro title: Variant Calling with Group Bands
+%%metro style: dark
+%%metro line: caller | Variant Calling | #2db572
+
+%%metro group: SNPs & Indels | freebayes, haplotypecaller, mutect2
+%%metro group: SV & CNV | manta, cnvkit
+%%metro group: MSI | msisensorpro
+
+graph LR
+    subgraph preprocess [Pre-processing]
+        markdup[MarkDuplicates]
+        recal[BaseRecalibrator]
+
+        markdup -->|caller| recal
+    end
+
+    subgraph calling [Variant Calling]
+        freebayes[FreeBayes]
+        haplotypecaller[HaplotypeCaller]
+        mutect2[Mutect2]
+        manta[Manta]
+        cnvkit[CNVkit]
+        msisensorpro[MSIsensorpro]
+
+        %% The callers sit in one horizontal row; the group bands beneath
+        %% caption contiguous families along the x-axis (sarek-style).
+        freebayes -->|caller| haplotypecaller
+        haplotypecaller -->|caller| mutect2
+        mutect2 -->|caller| manta
+        manta -->|caller| cnvkit
+        cnvkit -->|caller| msisensorpro
+    end
+
+    recal -->|caller| freebayes

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -81,7 +81,7 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
     (
         "diagonal_labels",
         EXAMPLES_DIR,
-        "Opt-in diagonal station labels (#527) via `%%metro label_angle: 45`: a "
+        "Opt-in diagonal station labels via `%%metro label_angle: 45`: a "
         "dense pre-processing trunk whose tilted names pack tighter than "
         "horizontal labels would, feeding a variant-calling section in the row "
         "below that fans out to three callers and back in -- the reserved "
@@ -122,7 +122,7 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
     (
         "file_icons",
         EXAMPLES_DIR,
-        "Terminus icon variants for #532: single-sheet `%%metro file:`, "
+        "Terminus icon variants: single-sheet `%%metro file:`, "
         "stacked `%%metro files:` for multiplicity, the `%%metro dir:` folder, "
         "and the optional `| banner` format strip.",
     ),
@@ -139,15 +139,22 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "tb_file_termini",
         EXAMPLES_DIR,
         "A `%%metro direction: TB` reporting section whose file outputs are "
-        "line termini. Regression fixture for #254 (terminus file icons now "
-        "orient to a vertical flow, with the connector entering from the top).",
+        "line termini. Regression fixture: terminus file icons orient to a "
+        "vertical flow, with the connector entering from the top.",
     ),
     (
         "genomeassembly_staggered",
         EXAMPLES_DIR,
         "sanger-tol/genomeassembly with explicit `%%metro grid:` directives "
-        "stacking each section in its own grid row. Regression fixture for "
-        "#250 (cross-column junction routes were going backward in X).",
+        "stacking each section in its own grid row. Regression fixture: "
+        "cross-column junction routes were going backward in X.",
+    ),
+    (
+        "group_labels",
+        EXAMPLES_DIR,
+        "Annotative `%%metro group:` band captions labelling sarek-style "
+        "sub-families of callers (SNPs & Indels / SV & CNV / MSI) within a "
+        "single section, without splitting them apart.",
     ),
     (
         "disconnected_components",
@@ -209,7 +216,7 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         TOPOLOGIES_DIR,
         "A two-column fan whose station labels are wider than the column "
         "pitch; the engine wraps the labels and widens spacing so they "
-        "don't collide (issue #405).",
+        "don't collide.",
     ),
     # --- Branching and multipath ---
     (
@@ -297,7 +304,7 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "The horizontal run sits centred in the inter-row gap, clear of both "
         "the section above and the next row's header.",
     ),
-    # --- #484 regression isolation ---
+    # --- Complex auto-layout regression isolation ---
     (
         "route_around_intervening",
         TOPOLOGIES_DIR,

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import re
 import warnings
+from typing import Literal
 
 from nf_metro.parser.model import (
     MARKER_FILL_OPEN,
@@ -28,6 +29,7 @@ from nf_metro.parser.model import (
     PortSide,
     Section,
     Station,
+    StationGroup,
 )
 
 
@@ -325,6 +327,8 @@ def _parse_directive(
     elif content.startswith("off_track:"):
         ids = [s.strip() for s in content[len("off_track:") :].split(",")]
         graph._pending_off_track.extend(sid for sid in ids if sid)
+    elif content.startswith("group:"):
+        _parse_group_directive(content[len("group:") :].strip(), graph)
     elif content.startswith("marker_legend:"):
         _parse_marker_legend_directive(content[len("marker_legend:") :].strip(), graph)
     elif content.startswith("marker:"):
@@ -481,6 +485,47 @@ def _parse_legend_directive(value: str, graph: MetroGraph) -> None:
             "'dx,dy'. Ignoring.",
             stacklevel=2,
         )
+
+
+def _parse_group_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro group: Label | station1, station2[, ...] [| above|below].
+
+    Stores an annotative caption spanning the listed stations.  The optional
+    third field selects whether the caption renders ``below`` (default) or
+    ``above`` the spanned stations.  Purely decorative; does not affect layout.
+    """
+    parts = value.split("|")
+    if len(parts) < 2:
+        warnings.warn(
+            f"group directive {value!r} needs 'Label | station1, station2'. Ignoring.",
+            stacklevel=2,
+        )
+        return
+    label = _unquote(parts[0].strip())
+    station_ids = [s.strip() for s in parts[1].split(",") if s.strip()]
+    if not label or not station_ids:
+        warnings.warn(
+            f"group directive {value!r} needs a label and at least one station. "
+            "Ignoring.",
+            stacklevel=2,
+        )
+        return
+    position: Literal["above", "below"] = "below"
+    if len(parts) >= 3:
+        raw_pos = parts[2].strip().lower()
+        if raw_pos == "above":
+            position = "above"
+        elif raw_pos == "below":
+            position = "below"
+        elif raw_pos:
+            warnings.warn(
+                f"group position {raw_pos!r} not recognised; expected "
+                "'above' or 'below'. Using 'below'.",
+                stacklevel=2,
+            )
+    graph.groups.append(
+        StationGroup(label=label, station_ids=station_ids, position=position)
+    )
 
 
 def _parse_legend_combo_directive(value: str, graph: MetroGraph) -> None:

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 
 class RowGridInfo(TypedDict):
@@ -187,6 +187,20 @@ class Edge:
 
 
 @dataclass
+class StationGroup:
+    """An annotative caption spanning a set of stations within a section.
+
+    Purely decorative: it groups related stations (e.g. variant-caller
+    families) under a shared caption rendered beneath (or above) the
+    spanned stations' x-extent.  It does not influence layout coordinates.
+    """
+
+    label: str
+    station_ids: list[str] = field(default_factory=list)
+    position: Literal["above", "below"] = "below"
+
+
+@dataclass
 class Port:
     """A synthetic entry/exit point on a section boundary.
 
@@ -270,6 +284,7 @@ class MetroGraph:
     sections: dict[str, Section] = field(default_factory=dict)
     ports: dict[str, Port] = field(default_factory=dict)
     junctions: list[str] = field(default_factory=list)
+    groups: list[StationGroup] = field(default_factory=list)
     grid_overrides: dict[str, tuple[int, int, int, int]] = field(default_factory=dict)
     # Section IDs that received an explicit %%metro grid: directive (i.e.
     # the user laid out the grid manually, as opposed to auto_layout
@@ -288,7 +303,7 @@ class MetroGraph:
     line_spread_overrides: dict[str, LineSpread] = field(default_factory=dict)
     legend_position: str = "bottom"
     legend_min_height: float = 0.0
-    # Opt-in diagonal station labels (#527). None means "use the theme
+    # Opt-in diagonal station labels. None means "use the theme
     # default" (0 = horizontal); a directive value overrides the theme.
     label_angle: float | None = None
     # %%metro legend_combo entries: (line_ids, label) pairs.
@@ -300,7 +315,7 @@ class MetroGraph:
     legend_at: tuple[float, float] | None = None  # absolute top-left override
     logo_path: str = ""
     logo_scale: float = 1.0  # multiplies the logo size within the legend block
-    # Marker-key captions from %%metro marker_legend: (issue #530). When
+    # Marker-key captions from %%metro marker_legend:. When
     # non-empty, the legend renders a marker key below the line key.
     marker_legend: list[MarkerLegendEntry] = field(default_factory=list)
     # Section dependency graph (populated by auto_layout)
@@ -349,7 +364,7 @@ class MetroGraph:
     # _snapshot_placement_refs.
     _placement_ref_y: dict[str, float] = field(default_factory=dict, repr=False)
     _placement_ref_bbox_top: dict[str, float] = field(default_factory=dict, repr=False)
-    # Per-phase coordinate-snapshot enable flag (issue #363).  Set once in
+    # Per-phase coordinate-snapshot enable flag.  Set once in
     # compute_layout from the NF_METRO_PHASE_SNAPSHOTS env var; read by the
     # _snap hook after each phase.  Off by default (pure observation).
     _phase_snapshots_enabled: bool = field(default=False, repr=False)

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -266,6 +266,45 @@ ANIMATION_BALL_OPACITY: float = 0.9
 SECTION_LABEL_REGION_RATIO: float = 0.5
 """Fraction of section width used as the label region."""
 
+# ---------------------------------------------------------------------------
+# Intra-section station group captions
+# ---------------------------------------------------------------------------
+GROUP_LABEL_FONT_SCALE: float = 0.95
+"""Group caption font size as a fraction of the station label font size."""
+
+GROUP_LABEL_GAP: float = 34.0
+"""Gap between the spanned stations' marker extent and the group caption.
+
+Wide enough to clear a station-label row placed on the same side as the
+caption, so the band reads as a separate annotation."""
+
+GROUP_LABEL_LABEL_CLEARANCE: float = 8.0
+"""Gap between the deepest spanned station *label* and the group caption.
+
+Used in place of ``GROUP_LABEL_GAP`` when the band is positioned off the
+station labels' own extent (the labels already carry their full footprint, so
+only a small clearance is needed) -- keeps the band hugging the labels rather
+than the larger marker-row gap, which over-shoots for diagonal labels."""
+
+GROUP_LABEL_UNDERLINE_GAP: float = 5.0
+"""Gap between the group caption text and its bracket rule."""
+
+GROUP_LABEL_UNDERLINE_OPACITY: float = 0.45
+"""Opacity of the subtle bracket rule drawn for a group caption."""
+
+GROUP_LABEL_UNDERLINE_WIDTH: float = 1.5
+"""Stroke width of the group caption bracket rule."""
+
+GROUP_LABEL_TICK_LENGTH: float = 5.0
+"""Length of the inward end-ticks that turn a group rule into a bracket.
+
+The ticks point back towards the spanned stations so the bracket reads as
+embracing exactly that contiguous run."""
+
+GROUP_LABEL_BAND_PADDING: float = 10.0
+"""Clearance reserved between the lowest group-band element and the bottom
+edge of the enclosing section box, so the band always sits inside the box."""
+
 ICON_CLEARANCE_MARGIN: float = 4.0
 """Extra clearance around terminus icons when computing section bounds."""
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -8,13 +8,13 @@ import html
 import textwrap
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import drawsvg as draw
 
 from nf_metro.layout.constants import LABEL_LINE_HEIGHT
 from nf_metro.layout.geometry import segment_intersects_bbox
-from nf_metro.layout.labels import LabelPlacement, place_labels
+from nf_metro.layout.labels import LabelPlacement, _label_bbox, place_labels
 from nf_metro.layout.routing import RoutedPath, compute_station_offsets, route_edges
 from nf_metro.layout.routing.corners import resolve_curve_radii
 from nf_metro.parser.model import (
@@ -44,6 +44,14 @@ from nf_metro.render.constants import (
     DEBUG_WAYPOINT_RADIUS,
     FALLBACK_LINE_COLOR,
     FILES_ICON_OFFSET_RATIO,
+    GROUP_LABEL_BAND_PADDING,
+    GROUP_LABEL_FONT_SCALE,
+    GROUP_LABEL_GAP,
+    GROUP_LABEL_LABEL_CLEARANCE,
+    GROUP_LABEL_TICK_LENGTH,
+    GROUP_LABEL_UNDERLINE_GAP,
+    GROUP_LABEL_UNDERLINE_OPACITY,
+    GROUP_LABEL_UNDERLINE_WIDTH,
     ICON_BBOX_MARGIN,
     ICON_CLEARANCE_MARGIN,
     ICON_INTER_GAP,
@@ -377,7 +385,33 @@ def render_svg(
         label_angle=graph.label_angle or 0.0,
     )
 
+    # Per-station rendered label (top, bottom) Y, so group bands clear the
+    # (possibly diagonal) station labels rather than just the markers.
+    label_extents: dict[str, tuple[float, float]] = {}
+    for p in labels:
+        if p.station_id:
+            _, ly0, _, ly1 = _label_bbox(p)
+            label_extents[p.station_id] = (ly0, ly1)
+
+    group_bands = (
+        _group_bands(graph, theme, station_offsets, label_extents)
+        if graph.groups
+        else []
+    )
+
+    # Reserve room inside section boxes for below group bands before bboxes
+    # feed the section render and the canvas-bounds computation.
+    if group_bands:
+        _reserve_section_space_for_groups(graph, group_bands)
+
     max_x, max_y = _compute_canvas_bounds(graph, routes, debug)
+
+    # Group captions can extend below/right of the content; grow the canvas
+    # so they are not clipped.
+    if group_bands:
+        g_max_x, g_max_y = _group_caption_bounds(group_bands)
+        max_x = max(max_x, g_max_x)
+        max_y = max(max_y, g_max_y)
 
     # Compute legend and logo dimensions
     logo_w, logo_h = (0.0, 0.0)
@@ -473,6 +507,10 @@ def render_svg(
 
     # Draw labels
     _render_labels(d, labels, theme)
+
+    # Annotative intra-section group captions.
+    if group_bands:
+        _render_station_groups(d, theme, group_bands)
 
     # Debug overlay (ports, hidden stations, edge waypoints)
     if debug:
@@ -1504,7 +1542,7 @@ def _render_labels(
             label_data["class_"] = "nf-metro-station-label"
 
         if label.angle:
-            # Diagonal labels (#527): anchor at the pill and rotate about
+            # Diagonal labels: anchor at the pill and rotate about
             # the anchor.  text-anchor=start so the tilted text trails
             # away from the station.
             d.append(
@@ -1557,6 +1595,350 @@ def _render_labels(
                     **label_data,
                 )
             )
+
+
+def _station_marker_extent(
+    station: Station,
+    graph: MetroGraph,
+    theme: Theme,
+    station_offsets: dict[tuple[str, str], float],
+) -> tuple[float, float, float, float]:
+    """Return ``(x_left, x_right, y_top, y_bottom)`` of a station's marker.
+
+    Mirrors the pill geometry in ``_render_stations`` so group captions can
+    clear the actual rendered marker, including the per-line offset spread.
+    """
+    r = theme.station_radius
+    is_tb = False
+    if station.section_id:
+        sec = graph.sections.get(station.section_id)
+        if sec and sec.direction == "TB":
+            is_tb = True
+
+    line_offsets = [
+        station_offsets.get((station.id, lid), 0.0)
+        for lid in graph.station_lines(station.id)
+    ]
+    min_off = min(line_offsets) if line_offsets else 0.0
+    max_off = max(line_offsets) if line_offsets else 0.0
+
+    x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb)
+    return (x, x + w, y, y + h)
+
+
+class _GroupBand(NamedTuple):
+    """Resolved render geometry for one annotative station-group caption.
+
+    ``rule_y`` is the bracket rule (drawn directly against the spanned run);
+    ``tick_dy`` is the signed length of the inward end-ticks (pointing back
+    towards the stations); ``text_y``/``baseline`` place the caption clear of
+    the rule on the far side; ``band_far_y`` is the band's outermost edge
+    (largest ``y`` for a below band, smallest for an above band) used for
+    bbox/canvas reservation.
+    """
+
+    label: str
+    x_left: float
+    x_right: float
+    rule_y: float
+    tick_dy: float
+    text_y: float
+    baseline: str
+    band_far_y: float
+    section_id: str | None
+
+
+class _RawGroup(NamedTuple):
+    """A group's resolved horizontal span and outer reference Y, before the
+    bracket gap and common-rule alignment are applied."""
+
+    label: str
+    x_left: float
+    x_right: float
+    section_id: str | None
+    position: str
+    ref: float
+    ref_is_label: bool
+
+
+def _group_bands(
+    graph: MetroGraph,
+    theme: Theme,
+    station_offsets: dict[tuple[str, str], float],
+    label_extents: dict[str, tuple[float, float]] | None = None,
+) -> list[_GroupBand]:
+    """Resolve per-group band geometry.
+
+    For a ``below`` band the bracket rule hugs the bottom of the spanned
+    run, its end-ticks point up towards the stations, and the caption sits
+    beneath the rule; an ``above`` band mirrors this. Groups whose members
+    are all missing/hidden are skipped.
+
+    ``label_extents`` maps a station id to its rendered label's ``(top, bottom)``
+    Y.  When given, a below band is dropped beneath the deepest member label
+    (and an above band lifted above the highest), so diagonal station labels
+    that hang past the markers do not collide with the band.
+    """
+    caption_font = theme.label_font_size * GROUP_LABEL_FONT_SCALE
+
+    # First pass: resolve each group's horizontal span and the natural outer
+    # reference (deepest member label/marker for a below band, highest for an
+    # above band) before the bracket gap is applied.
+    raw: list[_RawGroup] = []
+    for group in graph.groups:
+        members = [
+            graph.stations[sid]
+            for sid in group.station_ids
+            if sid in graph.stations
+            and not graph.stations[sid].is_port
+            and not graph.stations[sid].is_hidden
+        ]
+        if not members:
+            continue
+        extents = [
+            _station_marker_extent(s, graph, theme, station_offsets) for s in members
+        ]
+
+        x_left = min(e[0] for e in extents)
+        x_right = max(e[1] for e in extents)
+        section_id = members[0].section_id
+
+        # Member label extremes, so the band clears the (possibly diagonal)
+        # station labels rather than just the markers.
+        member_label_tops = [
+            label_extents[s.id][0]
+            for s in members
+            if label_extents and s.id in label_extents
+        ]
+        member_label_bottoms = [
+            label_extents[s.id][1]
+            for s in members
+            if label_extents and s.id in label_extents
+        ]
+
+        if group.position == "above":
+            marker_top = min(e[2] for e in extents)
+            label_ref = min(member_label_tops) if member_label_tops else None
+            ref = min([marker_top, *member_label_tops])
+            ref_is_label = label_ref is not None and label_ref <= marker_top
+        else:
+            marker_bottom = max(e[3] for e in extents)
+            label_ref = max(member_label_bottoms) if member_label_bottoms else None
+            ref = max([marker_bottom, *member_label_bottoms])
+            ref_is_label = label_ref is not None and label_ref >= marker_bottom
+        raw.append(
+            _RawGroup(
+                label=group.label,
+                x_left=x_left,
+                x_right=x_right,
+                section_id=section_id,
+                position=group.position,
+                ref=ref,
+                ref_is_label=ref_is_label,
+            )
+        )
+
+    # Align all bands sharing a (section, side) to a common rule line, so a
+    # row of group captions reads off one level rather than stepping with each
+    # group's own member-label depth.  Below bands align to the deepest ref,
+    # above bands to the highest.  Track whether that common extreme is a
+    # station label (vs a bare marker): a label already carries its full
+    # footprint, so the band hugs it with a small clearance instead of the
+    # wider marker-row gap, which over-shoots for diagonal labels.
+    common_ref: dict[tuple[str | None, str], float] = {}
+    common_is_label: dict[tuple[str | None, str], bool] = {}
+    for rec in raw:
+        key = (rec.section_id, rec.position)
+        ref = rec.ref
+        more_extreme = (
+            key not in common_ref
+            or (rec.position == "above" and ref < common_ref[key])
+            or (rec.position != "above" and ref > common_ref[key])
+        )
+        if rec.position == "above":
+            common_ref[key] = min(common_ref.get(key, ref), ref)
+        else:
+            common_ref[key] = max(common_ref.get(key, ref), ref)
+        if more_extreme:
+            common_is_label[key] = rec.ref_is_label
+
+    out: list[_GroupBand] = []
+    for rec in raw:
+        key = (rec.section_id, rec.position)
+        ref = common_ref[key]
+        gap = (
+            GROUP_LABEL_LABEL_CLEARANCE if common_is_label.get(key) else GROUP_LABEL_GAP
+        )
+        if rec.position == "above":
+            rule_y = ref - gap
+            tick_dy = GROUP_LABEL_TICK_LENGTH  # ticks point down to stations
+            text_y = rule_y - GROUP_LABEL_UNDERLINE_GAP
+            baseline = "auto"
+            band_far_y = text_y - caption_font
+        else:
+            rule_y = ref + gap
+            tick_dy = -GROUP_LABEL_TICK_LENGTH  # ticks point up to stations
+            text_y = rule_y + GROUP_LABEL_UNDERLINE_GAP
+            baseline = "hanging"
+            band_far_y = text_y + caption_font
+        out.append(
+            _GroupBand(
+                rec.label,
+                rec.x_left,
+                rec.x_right,
+                rule_y,
+                tick_dy,
+                text_y,
+                baseline,
+                band_far_y,
+                rec.section_id,
+            )
+        )
+    return out
+
+
+def _group_caption_bounds(bands: list[_GroupBand]) -> tuple[float, float]:
+    """Return the max ``(x, y)`` reached by any group band."""
+    max_x = 0.0
+    max_y = 0.0
+    for band in bands:
+        max_x = max(max_x, band.x_right)
+        max_y = max(max_y, band.rule_y, band.text_y, band.band_far_y)
+    return max_x, max_y
+
+
+def _reserve_section_space_for_groups(
+    graph: MetroGraph,
+    bands: list[_GroupBand],
+) -> None:
+    """Grow section bboxes so each ``below`` group band sits inside its box.
+
+    Annotative bands are placed at render time from station coordinates, so
+    the layout engine has no chance to reserve room for them.  Without this
+    the caption and bracket overlap (or fall outside) the section's bottom
+    edge.
+    """
+    needed_bottom: dict[str, float] = {}
+    for band in bands:
+        if band.section_id is None or band.tick_dy >= 0:
+            continue  # above bands grow upward; handled via canvas bounds
+        needed_bottom[band.section_id] = max(
+            needed_bottom.get(band.section_id, band.band_far_y),
+            band.band_far_y,
+        )
+    for sid, far_y in needed_bottom.items():
+        sec = graph.sections.get(sid)
+        if sec is None or sec.is_implicit:
+            continue
+        target_bottom = far_y + GROUP_LABEL_BAND_PADDING
+        if target_bottom > sec.bbox_y + sec.bbox_h:
+            sec.bbox_h = target_bottom - sec.bbox_y
+
+
+def _reserve_rail_space_for_termini(graph: MetroGraph, theme: Theme) -> None:
+    """Grow rail-section boxes to contain their terminus file icons.
+
+    Rail-section bboxes are sized to the station columns only, so a terminus
+    station's icons (which march outward past the last station) can be cut by
+    the box edge.  Grow the box so the icons sit inside with clearance.  Gated
+    on rail sections, leaving normal-mode fixtures byte-identical.
+    """
+    if not graph.has_rail_sections:
+        return
+    clearance = ICON_STATION_GAP * 2
+    r = theme.station_radius
+    hw = theme.terminus_width / 2
+    hh = theme.terminus_height / 2
+    caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
+    for station in graph.stations.values():
+        if not (graph.station_is_rail(station.id) and station.is_terminus):
+            continue
+        sec = graph.sections.get(station.section_id) if station.section_id else None
+        if sec is None or sec.is_implicit:
+            continue
+        n = len(station.terminus_labels)
+        names = station.terminus_names or [""] * n
+        name_widths = [
+            len(nm) * caption_font_size * 0.55 if nm else 0.0 for nm in names
+        ]
+        is_tb = sec.direction in ("TB", "BT")
+        if is_tb:
+            step = theme.terminus_height + ICON_INTER_GAP
+            half_flow = hh
+        else:
+            step = caption_aware_icon_step(names, name_widths, theme.terminus_width)
+            half_flow = hw
+        centers = _terminus_icon_centers(
+            station,
+            sec.direction,
+            not graph.edges_to(station.id),
+            n,
+            r + ICON_STATION_GAP + half_flow,
+            step,
+            0.0,
+            is_rail=True,
+        )
+        for cx, cy in centers:
+            left, right = cx - hw - clearance, cx + hw + clearance
+            top, bot = cy - hh - clearance, cy + hh + clearance
+            if left < sec.bbox_x:
+                sec.bbox_w = sec.bbox_x + sec.bbox_w - left
+                sec.bbox_x = left
+            if right > sec.bbox_x + sec.bbox_w:
+                sec.bbox_w = right - sec.bbox_x
+            if top < sec.bbox_y:
+                sec.bbox_h = sec.bbox_y + sec.bbox_h - top
+                sec.bbox_y = top
+            if bot > sec.bbox_y + sec.bbox_h:
+                sec.bbox_h = bot - sec.bbox_y
+
+
+def _render_station_groups(
+    d: draw.Drawing,
+    theme: Theme,
+    bands: list[_GroupBand],
+) -> None:
+    """Render annotative captions spanning groups of stations.
+
+    Each group's caption is centred on the x-extent of its (visible) member
+    stations.  A bracket rule (with inward end-ticks) hugs the spanned run so
+    the band reads as embracing exactly those stations, with the caption set
+    clear of the rule on the far side.  Coordinates are read-only: this never
+    moves stations.
+    """
+    caption_font = theme.label_font_size * GROUP_LABEL_FONT_SCALE
+    for band in bands:
+        cx = (band.x_left + band.x_right) / 2
+        # Bracket: a horizontal rule across the run with short inward end-ticks
+        # pointing back towards the stations.
+        bracket = draw.Path(
+            stroke=theme.section_label_color,
+            stroke_width=GROUP_LABEL_UNDERLINE_WIDTH,
+            stroke_opacity=GROUP_LABEL_UNDERLINE_OPACITY,
+            fill="none",
+            stroke_linecap="round",
+            stroke_linejoin="round",
+            class_="nf-metro-group-underline",
+        )
+        bracket.M(band.x_left, band.rule_y + band.tick_dy)
+        bracket.L(band.x_left, band.rule_y)
+        bracket.L(band.x_right, band.rule_y)
+        bracket.L(band.x_right, band.rule_y + band.tick_dy)
+        d.append(bracket)
+        d.append(
+            draw.Text(
+                band.label,
+                caption_font,
+                cx,
+                band.text_y,
+                fill=theme.section_label_color,
+                font_family=theme.label_font_family,
+                font_weight="bold",
+                text_anchor="middle",
+                dominant_baseline=band.baseline,
+                class_="nf-metro-group-label",
+            )
+        )
 
 
 def _grid_bbox_bounds(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -178,7 +178,7 @@ def test_parse_edges():
 
 
 def test_parse_edges_no_label():
-    """Unannotated edges raise a clear error (issue #75)."""
+    """Unannotated edges raise a clear error."""
     text = "graph LR\n    a --> b\n"
     with pytest.raises(ValueError, match="no metro line annotation"):
         parse_metro_mermaid(text)
@@ -502,8 +502,8 @@ def test_empty_section_removed():
 def test_empty_section_removed_render():
     """An empty-section graph can be rendered without error.
 
-    End-to-end regression test for issue #51: ensure the full
-    parse -> layout -> render pipeline doesn't crash.
+    End-to-end regression test: ensure the full parse -> layout -> render
+    pipeline doesn't crash.
     """
     from nf_metro.layout.engine import compute_layout
     from nf_metro.render.svg import render_svg
@@ -594,7 +594,7 @@ def test_hidden_station_in_section():
     assert graph.stations["_branch"].section_id == "sec1"
 
 
-# --- Edge validation tests (issue #75) ---
+# --- Edge validation tests ---
 
 
 def test_unannotated_edge_error_message_includes_stations():
@@ -997,9 +997,47 @@ def test_no_duplicate_edges_after_resolve_sections():
     )
 
 
+def test_parse_group_directive():
+    text = (
+        "%%metro group: SNPs & Indels | a, b, c\n"
+        "%%metro group: SV & CNV | d, e | above\n"
+        "graph LR\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert len(graph.groups) == 2
+    g0, g1 = graph.groups
+    assert g0.label == "SNPs & Indels"
+    assert g0.station_ids == ["a", "b", "c"]
+    assert g0.position == "below"
+    assert g1.label == "SV & CNV"
+    assert g1.station_ids == ["d", "e"]
+    assert g1.position == "above"
+
+
+def test_parse_group_directive_quoted_label():
+    text = '%%metro group: "Callers (somatic)" | x\ngraph LR\n'
+    graph = parse_metro_mermaid(text)
+    assert len(graph.groups) == 1
+    assert graph.groups[0].label == "Callers (somatic)"
+
+
+def test_parse_group_directive_invalid_ignored():
+    text = "%%metro group: NoStations\ngraph LR\n"
+    with pytest.warns(UserWarning):
+        graph = parse_metro_mermaid(text)
+    assert graph.groups == []
+
+
+def test_parse_group_directive_bad_position_defaults_below():
+    text = "%%metro group: G | a | sideways\ngraph LR\n"
+    with pytest.warns(UserWarning):
+        graph = parse_metro_mermaid(text)
+    assert graph.groups[0].position == "below"
+
+
 @pytest.mark.parametrize("direction", ["TB", "TD", "BT", "RL"])
 def test_non_lr_primary_direction_warns(direction):
-    """A non-LR `graph` header warns that only LR primary is honoured (#525)."""
+    """A non-LR `graph` header warns that only LR primary is honoured."""
     text = (
         "%%metro line: a | A | #0570b0\n"
         f"graph {direction}\n"
@@ -1015,7 +1053,7 @@ def test_non_lr_primary_direction_warns(direction):
 
 @pytest.mark.parametrize("header", ["graph LR", "graph", "graph    LR"])
 def test_lr_primary_direction_does_not_warn(header, recwarn):
-    """`graph LR` (or a bare `graph`) is the honoured primary; no warning (#525)."""
+    """`graph LR` (or a bare `graph`) is the honoured primary; no warning."""
     parse_metro_mermaid(f"{header}\n    subgraph s1 [One]\n        x[X]\n    end\n")
     direction_warnings = [
         w for w in recwarn.list if "primary layout direction" in str(w.message)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,5 +1,6 @@
 """Tests for SVG rendering."""
 
+import re
 import xml.etree.ElementTree as ET
 
 from nf_metro.layout.engine import compute_layout
@@ -568,7 +569,7 @@ def test_render_icon_type_guide_fixtures():
         assert root.tag.endswith("svg") or "svg" in root.tag
 
 
-# --- Terminus icon orientation (issue #254) ---
+# --- Terminus icon orientation ---
 
 
 def _station(x=100.0, y=50.0):
@@ -602,9 +603,8 @@ def test_terminus_icons_rl_mirror_lr():
 def test_terminus_icons_tb_march_along_y():
     """TB termini stack icons vertically, centred on the bundle X.
 
-    Regression test for #254: in a TB section the line arrives from
-    above/below, so icons must be displaced along Y (the flow axis), not
-    along X as for LR.
+    In a TB section the line arrives from above/below, so icons must be
+    displaced along Y (the flow axis), not along X as for LR.
     """
     st = _station()
     # Sink at the bottom of a TB flow: icons extend downward.
@@ -694,3 +694,96 @@ def test_render_tb_terminus_pill_is_horizontal():
     width = float(re.search(r'width="([0-9.]+)"', rect).group(1))
     height = float(re.search(r'height="([0-9.]+)"', rect).group(1))
     assert width > height, f"TB terminus pill not horizontal: {width=} {height=}"
+
+
+def test_render_group_label_caption_and_underline():
+    """A %%metro group: directive emits a caption and underline; layout
+    coordinates are untouched relative to the same graph without groups."""
+    base_src = (
+        "%%metro line: main | Main | #2db572\n"
+        "graph LR\n"
+        "    subgraph s [Callers]\n"
+        "        a[Alpha]\n"
+        "        b[Beta]\n"
+        "        a -->|main| b\n"
+        "    end\n"
+    )
+    grouped_src = "%%metro group: Family | a, b\n" + base_src
+
+    base_graph = parse_metro_mermaid(base_src)
+    compute_layout(base_graph)
+    base_svg = render_svg(base_graph, NFCORE_THEME)
+
+    grouped_graph = parse_metro_mermaid(grouped_src)
+    compute_layout(grouped_graph)
+    # Station coordinates must be identical: groups are purely annotative.
+    assert {sid: (st.x, st.y) for sid, st in grouped_graph.stations.items()} == {
+        sid: (st.x, st.y) for sid, st in base_graph.stations.items()
+    }
+
+    grouped_svg = render_svg(grouped_graph, NFCORE_THEME)
+    assert "Family" in grouped_svg
+    assert "nf-metro-group-label" in grouped_svg
+    assert "nf-metro-group-underline" in grouped_svg
+    # The base render has neither marker.
+    assert "nf-metro-group-label" not in base_svg
+
+
+def _section_box_bottoms(svg: str) -> dict[str, float]:
+    """Map each rendered section box id to its bbox bottom edge (y + h)."""
+    bottoms: dict[str, float] = {}
+    for m in re.finditer(
+        r'<rect x="([\d.]+)" y="([\d.]+)" width="([\d.]+)" '
+        r'height="([\d.]+)"[^>]*nf-metro-section-box[^>]*'
+        r'data-section-id="(\w+)"',
+        svg,
+    ):
+        _x, y, _w, h, sid = m.groups()
+        bottoms[sid] = float(y) + float(h)
+    return bottoms
+
+
+def test_render_group_band_stays_inside_section_box():
+    """A below group band (bracket + caption) must sit clear of the section
+    box's bottom edge: the engine grows the bbox to reserve room so the band
+    never overlaps or crosses the boundary."""
+    src = (
+        "%%metro line: main | Main | #2db572\n"
+        "%%metro group: Callers | a, b, c\n"
+        "graph LR\n"
+        "    subgraph s [Variant Calling]\n"
+        "        a[Alpha]\n"
+        "        b[Beta]\n"
+        "        c[Gamma]\n"
+        "        a -->|main| b\n"
+        "        b -->|main| c\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(src)
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+
+    section_bottom = _section_box_bottoms(svg)["s"]
+
+    # Caption text: hanging baseline, so its bottom edge is text_y + font_size.
+    cap = re.search(
+        r'<text x="[\d.]+" y="([\d.]+)" font-size="([\d.]+)"'
+        r"[^>]*nf-metro-group-label",
+        svg,
+    )
+    assert cap is not None
+    caption_bottom = float(cap.group(1)) + float(cap.group(2))
+
+    # Bracket rule + ticks: gather every y coordinate in the path data.
+    bracket = re.search(r'<path d="([^"]*)"[^>]*nf-metro-group-underline', svg)
+    assert bracket is not None
+    ys = [
+        float(v.split(",")[1]) for v in re.findall(r"[\d.]+,[\d.]+", bracket.group(1))
+    ]
+    bracket_bottom = max(ys)
+
+    band_bottom = max(caption_bottom, bracket_bottom)
+    assert band_bottom <= section_bottom, (
+        f"group band bottom {band_bottom:.1f} crosses section box bottom "
+        f"{section_bottom:.1f}"
+    )


### PR DESCRIPTION
## Summary

Adds a `%%metro group:` directive that captions a set of stations within a single section with a centred band label spanning the listed stations' x-extent. This mirrors the nf-core/sarek subway map's "SNPs & Indels" / "SV & CNV" / "MSI" caller bands, which group related stations without splitting them into separate sections.

The feature is annotative and default-off:
- It does not move station coordinates.
- Section boxes and the canvas grow to fit captions only when groups are present.
- Diagrams that use no `group:` directive render byte-identically.

## Directive

```
%%metro group: SNPs & Indels | freebayes, haplotypecaller, mutect2
%%metro group: SV & CNV | manta, cnvkit | above
```

`Label | station1, station2[, ...]` with an optional third field `above`/`below` (default `below`). Invalid forms warn and are ignored.

## Rendering

Each group renders as a centred caption with a bracket rule (a horizontal line with short inward end-ticks) hugging the spanned stations' x-extent, set above or below the run. Bands that share a `(section, side)` align to a common rule line so a row of captions reads off one level rather than stepping per group, and the rule clears the members' (possibly diagonal) station labels rather than just the markers.

## Changes

- `parser/model.py`: new `StationGroup` dataclass (label, station ids, `Literal["above", "below"]` position) and `MetroGraph.groups`.
- `parser/mermaid.py`: `_parse_group_directive` wired into the directive dispatcher.
- `render/svg.py`: `_group_bands` resolves per-group geometry (read-only); `_render_station_groups` draws the bracket + caption; `_reserve_section_space_for_groups` grows section bboxes for below bands; canvas bounds account for caption extent. All gated on the presence of groups.
- `render/constants.py`: group caption styling constants.
- `examples/group_labels.mmd`: demo fixture (sarek-style caller families on one line, three group bands), registered in `scripts/build_gallery.py` `GALLERY_ENTRIES`.
- Tests: parser tests for the directive (position qualifier, quoting, invalid-input warnings) and a render test asserting the caption/bracket appear with station coordinates unchanged vs the same graph without groups.
- Drops stale `#NNN` issue-number references from comments, test docstrings, and gallery captions in the touched files.

## Limitations

- The band reads best when group members sit in a single horizontal row; widely scattered or vertically stacked members produce a band centred on their combined extent, which can sit close to alternating station labels. The fixed caption gap clears one station-label row.

Closes #531
