### PR TITLE
feat(icons): banner format-strip labels + file_icons demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,8 @@ These are automatically rewritten into port-to-port connections with junction st
 | `%%metro grid: <section> \| <col>,<row>[,<rowspan>[,<colspan>]]` | Global | Pin section to grid position |
 | `%%metro legend: <position>` | Global | Legend position: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, `none` (append `\| canvas`, `\| <dx>,<dy>`, or use `<x>,<y>` for finer placement - see the [guide](docs/guide.md)) |
 | `%%metro line_order: <strategy>` | Global | Line ordering for track assignment: `definition` (default) or `span` (longest-spanning lines get inner tracks) |
-| `%%metro file: <station> \| <label> [\| <name>]` | Global | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon |
-| `%%metro files: <station> \| <label> [\| <name>]` | Global | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption |
+| `%%metro file: <station> \| <label> [\| <name>] [\| banner]` | Global | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon; optional `banner` draws the label on a dark strip across the icon |
+| `%%metro files: <station> \| <label> [\| <name>] [\| banner]` | Global | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption; optional `banner` strip |
 | `%%metro dir: <station> \| <label> [\| <name>]` | Global | Mark a station with a folder icon (e.g. output directory). Optional `name` caption |
 | `%%metro off_track: <station>[, <station>...]` | Global | Lift the listed stations (typically `file:`/`files:`/`dir:` inputs) above the section's main track, so they drop into their consumer instead of consuming a line-track slot |
 | `%%metro compact_offsets: true` | Global | Use compact per-station offsets instead of global line-priority slots (better for dense maps with few lines) |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -333,6 +333,18 @@ The label inside an icon is meant for a short type chip (e.g. `CSV`, `FASTQ`). T
 
 The name is rendered as a caption directly below the icon. If multiple labels are listed (`FASTQ, BAM`), the same name applies to all of them.
 
+### Banner labels
+
+To make a format stand out, add `banner` as a fourth field to a `file:` or `files:` directive. The format label then renders as bold white text on a dark strip across the lower part of the icon, transit-map "format chip" style, while the white document stays visible:
+
+```text
+%%metro files: aln_out | BAM | Alignments | banner
+```
+
+![Banner labels example](assets/renders/05f_banner_labels.svg)
+
+Any `name` caption (third field) still renders below the icon, so `| <name> | banner` keeps the caption and `| | banner` applies the strip with no caption. `banner` is not supported on `dir:` (folder) icons.
+
 ## 6. Per-station markers
 
 By default every station is drawn as a uniform pill. The `%%metro marker:` directive overrides one station's marker so it can encode a tool attribute - mandatory vs optional, hardware-accelerated, expanded in another diagram - through its shape and fill:
@@ -502,8 +514,8 @@ These go at the top of the file, before `graph LR`.
 | `%%metro grid: <section> \| <col>,<row>[,<rowspan>[,<colspan>]]` | Pin a section to a grid position |
 | `%%metro legend: <position>` | Position the legend (and its embedded logo). Keyword: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, or `none` (a bare keyword auto-relocates if it would overlap a section or route). Add `\| canvas` to anchor the keyword to the canvas margin, or `\| <dx>,<dy>` to nudge it; both pin the block exactly (warning on overlap rather than relocating). Use `<x>,<y>` for absolute top-left coordinates. |
 | `%%metro line_order: <strategy>` | Line ordering for track assignment: `definition` (default, preserves `.mmd` order) or `span` (longest-spanning lines get inner tracks) |
-| `%%metro file: <station> \| <label> [\| <name>]` | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon. |
-| `%%metro files: <station> \| <label> [\| <name>]` | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption. |
+| `%%metro file: <station> \| <label> [\| <name>] [\| banner]` | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon; optional `banner` draws the label on a dark strip across the icon. |
+| `%%metro files: <station> \| <label> [\| <name>] [\| banner]` | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption; optional `banner` strip. |
 | `%%metro dir: <station> \| <label> [\| <name>]` | Mark a station with a folder icon (e.g. output directory). Optional `name` caption. |
 | `%%metro off_track: <station>[, <station>...]` | Lift the listed stations above the section's main track (see below) |
 | `%%metro compact_offsets: true` | Compact line offsets within stations (see below) |

--- a/docs/nextflow.md
+++ b/docs/nextflow.md
@@ -340,6 +340,8 @@ Two additional icon variants are available for common Nextflow patterns:
 - **`%%metro files:`** renders a stacked-documents icon, useful for paired-end reads or multi-file inputs (e.g. `%%metro files: reads_in | FASTQ`)
 - **`%%metro dir:`** renders a folder icon, useful for directory outputs like `publishDir` results (e.g. `%%metro dir: results_out | Results`)
 
+Add `banner` as a fourth field to a `file:` or `files:` directive to draw the format label on a dark strip across the icon, for when the format should stand out (e.g. `%%metro files: aln_out | BAM | Alignments | banner`).
+
 ## How the converter works
 
 Nextflow's `-with-dag` output contains three types of nodes: processes (the actual pipeline steps), channels/values (data plumbing), and operators (Nextflow internals like `mix` and `collect`). Here is the raw DAG for the flat pipeline example:

--- a/examples/file_icons.mmd
+++ b/examples/file_icons.mmd
@@ -1,0 +1,31 @@
+%%metro title: File Icon Variants (#532)
+%%metro style: dark
+%%metro line: main | Pipeline | #4CAF50
+
+%%metro file: ref_in | FASTA | Reference
+%%metro files: reads_in | FASTQ | Reads
+%%metro files: aln_out | BAM | Alignments | banner
+%%metro file: report_out | HTML | Report
+%%metro dir: results_out | Results
+
+graph LR
+    subgraph inputs [Inputs]
+        ref_in[ ]
+        reads_in[ ]
+        align[Align]
+        ref_in -->|main| align
+        reads_in -->|main| align
+    end
+
+    subgraph outputs [Outputs]
+        %%metro entry: left | main
+        collect[Collect]
+        aln_out[ ]
+        report_out[ ]
+        results_out[ ]
+        collect -->|main| aln_out
+        collect -->|main| report_out
+        collect -->|main| results_out
+    end
+
+    align -->|main| collect

--- a/examples/guide/05f_banner_labels.mmd
+++ b/examples/guide/05f_banner_labels.mmd
@@ -1,0 +1,28 @@
+%%metro title: Banner Labels
+%%metro style: dark
+%%metro file: reads_in | FASTQ | Reads
+%%metro files: aln_out | BAM | Alignments | banner
+%%metro file: report_out | HTML | Report
+%%metro line: main | Main | #4CAF50
+%%metro line: qc | Quality Control | #2196F3
+
+graph LR
+    subgraph analysis [Analysis]
+        reads_in[ ]
+        trim[Trimming]
+        align[Alignment]
+        quant[Quantification]
+        reads_in -->|main,qc| trim
+        trim -->|main| align
+        align -->|main| quant
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+        aln_out[ ]
+        report_out[ ]
+        align -->|main| aln_out
+        trim -->|qc| multiqc
+        quant -->|qc| multiqc
+        multiqc -->|qc| report_out
+    end

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -111,6 +111,13 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "cross-column feeder dropping straight into its consumer section.",
     ),
     (
+        "file_icons",
+        EXAMPLES_DIR,
+        "Terminus icon variants for #532: single-sheet `%%metro file:`, "
+        "stacked `%%metro files:` for multiplicity, the `%%metro dir:` folder, "
+        "and the optional `| banner` format strip.",
+    ),
+    (
         "legend_combo",
         EXAMPLES_DIR,
         "Demonstrates `%%metro legend_combo:`: a normal (blue) and tumor (red) "

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -210,9 +210,10 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
             continue
         if graph.edges_to(station_id) and graph.edges_from(station_id):
             continue
-        station.terminus_labels = [label for label, _, _ in entries]
-        station.terminus_icon_types = [icon_type for _, icon_type, _ in entries]
-        station.terminus_names = [name for _, _, name in entries]
+        station.terminus_labels = [label for label, _, _, _ in entries]
+        station.terminus_icon_types = [icon_type for _, icon_type, _, _ in entries]
+        station.terminus_names = [name for _, _, name, _ in entries]
+        station.terminus_icon_banners = [banner for _, _, _, banner in entries]
 
     # Apply pending off-track marks
     for station_id in graph._pending_off_track:
@@ -335,8 +336,16 @@ def _parse_directive(
             # Optional third field: human-readable caption rendered below the
             # icon. A single name applies to all labels from this directive.
             name = parts[2].strip() if len(parts) >= 3 else ""
+            # Optional fourth field: comma-separated icon options. "banner"
+            # renders the format label as bold white text on a dark banner.
+            options = (
+                {o.strip().lower() for o in parts[3].split(",")}
+                if len(parts) >= 4
+                else set()
+            )
+            banner = "banner" in options
             graph._pending_terminus.setdefault(station_id, []).extend(
-                (label, icon_type, name) for label in labels
+                (label, icon_type, name, banner) for label in labels
             )
 
 

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -58,7 +58,11 @@ MARKER_FILL_SOLID = "solid"
 ICON_TYPE_FILE = "file"
 ICON_TYPE_FILES = "files"
 ICON_TYPE_DIR = "dir"
-VALID_ICON_TYPES = (ICON_TYPE_FILE, ICON_TYPE_FILES, ICON_TYPE_DIR)
+VALID_ICON_TYPES = (
+    ICON_TYPE_FILE,
+    ICON_TYPE_FILES,
+    ICON_TYPE_DIR,
+)
 
 
 @dataclass
@@ -116,6 +120,10 @@ class Station:
     # caption outside the icon (e.g. "Samples" below a CSV file icon).
     # Parallel list to terminus_labels; empty string means no caption.
     terminus_names: list[str] = field(default_factory=list)
+    # Per-icon flag (parallel to terminus_labels): render the format label as
+    # bold white text on a dark banner inside the icon (transit-map style).
+    # Default False keeps the plain centred label.
+    terminus_icon_banners: list[bool] = field(default_factory=list)
     # Populated by layout engine
     x: float = 0.0
     y: float = 0.0
@@ -252,8 +260,9 @@ class MetroGraph:
     section_dag: SectionDAG | None = None
     # Section IDs that had explicit %%metro direction: directives
     _explicit_directions: set[str] = field(default_factory=set)
-    # Pending terminus designations: station_id -> list of (label, icon_type)
-    _pending_terminus: dict[str, list[tuple[str, str, str]]] = field(
+    # Pending terminus designations: station_id ->
+    # list of (label, icon_type, name, banner)
+    _pending_terminus: dict[str, list[tuple[str, str, str, bool]]] = field(
         default_factory=dict
     )
     # Pending off-track marks: station_ids to lift above section top track

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -219,6 +219,14 @@ ICON_FOLD_CREASE_RATIO: float = 0.6
 ICON_TEXT_OFFSET_RATIO: float = 0.15
 """Vertical text offset as a fraction of icon height."""
 
+ICON_LABEL_CHAR_WIDTH_RATIO: float = 0.6
+"""Estimated glyph width as a fraction of font size, used to shrink the icon
+label font so it keeps clear of the icon's left/right edges."""
+
+ICON_LABEL_CLEARANCE: float = 2.5
+"""Minimum horizontal clearance (px per side) between the icon label and the
+icon's left/right edges; the label font shrinks to honour it."""
+
 FILES_ICON_OFFSET_RATIO: float = 0.15
 """Offset of the back page as a fraction of icon width/height (stacked files icon)."""
 
@@ -227,6 +235,18 @@ FOLDER_TAB_HEIGHT_RATIO: float = 0.2
 
 FOLDER_TAB_WIDTH_RATIO: float = 0.4
 """Width of the folder tab as a fraction of total icon width."""
+
+ICON_BANNER_HEIGHT_RATIO: float = 0.38
+"""Height of the banner strip as a fraction of icon height (banner style)."""
+
+ICON_BANNER_BOTTOM_MARGIN_RATIO: float = 0.16
+"""White space left below the banner strip, as a fraction of icon height."""
+
+ICON_BANNER_FILL: str = "#222222"
+"""Fill colour of the banner strip drawn across the icon foot (banner style)."""
+
+ICON_BANNER_TEXT_COLOR: str = "#ffffff"
+"""Text colour of the bold label on the banner strip (banner style)."""
 
 # ---------------------------------------------------------------------------
 # Animation styling

--- a/src/nf_metro/render/icons.py
+++ b/src/nf_metro/render/icons.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-__all__ = ["render_file_icon", "render_files_icon", "render_folder_icon"]
+__all__ = [
+    "render_file_icon",
+    "render_files_icon",
+    "render_folder_icon",
+]
 
 import drawsvg as draw
 
@@ -10,11 +14,99 @@ from nf_metro.render.constants import (
     FILES_ICON_OFFSET_RATIO,
     FOLDER_TAB_HEIGHT_RATIO,
     FOLDER_TAB_WIDTH_RATIO,
+    ICON_BANNER_BOTTOM_MARGIN_RATIO,
+    ICON_BANNER_FILL,
+    ICON_BANNER_HEIGHT_RATIO,
+    ICON_BANNER_TEXT_COLOR,
     ICON_FOLD_CREASE_RATIO,
     ICON_FOLD_OVERLAY_OPACITY,
+    ICON_LABEL_CHAR_WIDTH_RATIO,
+    ICON_LABEL_CLEARANCE,
     ICON_TEXT_OFFSET_RATIO,
     TEXT_VCENTER_DY,
 )
+
+
+def _fit_label_font(label: str, font_size: float, width: float) -> float:
+    """Shrink ``font_size`` so ``label`` keeps ``ICON_LABEL_CLEARANCE`` clear of
+    the icon's left/right edges; returns ``font_size`` unchanged when it fits."""
+    max_width = width - 2 * ICON_LABEL_CLEARANCE
+    text_width = len(label) * font_size * ICON_LABEL_CHAR_WIDTH_RATIO
+    if max_width > 0 and text_width > max_width:
+        return font_size * max_width / text_width
+    return font_size
+
+
+def _append_icon_label(
+    d: draw.Drawing,
+    label: str,
+    cx: float,
+    text_y: float,
+    width: float,
+    font_size: float,
+    font_color: str,
+    font_family: str,
+) -> None:
+    """Render the format label as bold coloured text centred at ``text_y``,
+    shrinking the font to stay clear of the icon's left/right edges."""
+    if not label:
+        return
+    d.append(
+        draw.Text(
+            label,
+            _fit_label_font(label, font_size, width),
+            cx,
+            text_y,
+            fill=font_color,
+            font_family=font_family,
+            font_weight="bold",
+            text_anchor="middle",
+            dy=TEXT_VCENTER_DY,
+        )
+    )
+
+
+def _append_icon_banner_band(
+    d: draw.Drawing,
+    label: str,
+    cx: float,
+    cy: float,
+    width: float,
+    height: float,
+    font_size: float,
+    font_family: str,
+) -> None:
+    """Render a dark banner strip with bold white text across the icon.
+
+    The strip spans the icon width and sits in the lower portion, leaving
+    white document visible both above and below it. Used when a terminus
+    directive sets the ``banner`` option.
+    """
+    if not label:
+        return
+    band_h = height * ICON_BANNER_HEIGHT_RATIO
+    band_bottom = cy + height / 2 - height * ICON_BANNER_BOTTOM_MARGIN_RATIO
+    band_top = band_bottom - band_h
+    d.append(
+        draw.Rectangle(
+            cx - width / 2,
+            band_top,
+            width,
+            band_h,
+            fill=ICON_BANNER_FILL,
+            stroke="none",
+        )
+    )
+    _append_icon_label(
+        d,
+        label,
+        cx,
+        (band_top + band_bottom) / 2,
+        width,
+        font_size,
+        ICON_BANNER_TEXT_COLOR,
+        font_family,
+    )
 
 
 def train_icon_path(x: float, y: float, size: float = 12.0) -> str:
@@ -39,6 +131,7 @@ def render_file_icon(
     font_size: float,
     font_color: str,
     font_family: str,
+    banner: bool = False,
 ) -> None:
     """Render a file/document icon with a dog-ear fold at top-right.
 
@@ -105,22 +198,16 @@ def render_file_icon(
     crease.L(x1, y0 + f)
     d.append(crease)
 
-    # Extension label centered in the body (shifted down slightly to
-    # account for fold taking up top-right space)
-    text_y = cy + f * ICON_TEXT_OFFSET_RATIO
-    d.append(
-        draw.Text(
-            label,
-            font_size,
-            cx,
-            text_y,
-            fill=font_color,
-            font_family=font_family,
-            font_weight="bold",
-            text_anchor="middle",
-            dy=TEXT_VCENTER_DY,
+    if banner:
+        _append_icon_banner_band(
+            d, label, cx, cy, width, height, font_size, font_family
         )
-    )
+    else:
+        # Label centred in the body, shifted down slightly to clear the fold.
+        text_y = cy + f * ICON_TEXT_OFFSET_RATIO
+        _append_icon_label(
+            d, label, cx, text_y, width, font_size, font_color, font_family
+        )
 
 
 def render_files_icon(
@@ -138,6 +225,7 @@ def render_files_icon(
     font_size: float,
     font_color: str,
     font_family: str,
+    banner: bool = False,
 ) -> None:
     """Render a stacked-files icon (two overlapping documents).
 
@@ -180,6 +268,7 @@ def render_files_icon(
         font_size=font_size,
         font_color=font_color,
         font_family=font_family,
+        banner=banner,
     )
 
 
@@ -255,16 +344,4 @@ def render_folder_icon(
 
     # Label centered in the body
     text_y = (body_top + y1) / 2
-    d.append(
-        draw.Text(
-            label,
-            font_size,
-            cx,
-            text_y,
-            fill=font_color,
-            font_family=font_family,
-            font_weight="bold",
-            text_anchor="middle",
-            dy=TEXT_VCENTER_DY,
-        )
-    )
+    _append_icon_label(d, label, cx, text_y, width, font_size, font_color, font_family)

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1184,6 +1184,7 @@ def _render_terminus_icons(
         station.terminus_labels
     )
     names = station.terminus_names or [""] * len(station.terminus_labels)
+    banners = station.terminus_icon_banners or [False] * len(station.terminus_labels)
 
     caption_font_size = theme.label_font_size * ICON_NAME_FONT_SCALE
     name_widths = [len(n) * caption_font_size * 0.55 if n else 0.0 for n in names]
@@ -1221,6 +1222,7 @@ def _render_terminus_icons(
     for i, label in enumerate(station.terminus_labels):
         icon_type = icon_types[i] if i < len(icon_types) else ICON_TYPE_FILE
         name = names[i] if i < len(names) else ""
+        banner = banners[i] if i < len(banners) else False
 
         icon_cx, icon_cy = centers[i]
 
@@ -1257,9 +1259,13 @@ def _render_terminus_icons(
         if icon_type == ICON_TYPE_DIR:
             render_folder_icon(d, **common)
         elif icon_type == ICON_TYPE_FILES:
-            render_files_icon(d, **common, fold_size=theme.terminus_fold_size)
+            render_files_icon(
+                d, **common, fold_size=theme.terminus_fold_size, banner=banner
+            )
         else:
-            render_file_icon(d, **common, fold_size=theme.terminus_fold_size)
+            render_file_icon(
+                d, **common, fold_size=theme.terminus_fold_size, banner=banner
+            )
 
         # Optional caption rendered below the icon so the type chip
         # inside the icon stays readable.

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -509,12 +509,55 @@ def test_render_mixed_icon_types():
     assert root.tag.endswith("svg") or "svg" in root.tag
 
 
+def test_file_icon_banner_option():
+    """The `| banner` option flips the per-icon banner flag and styling."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: aln_out | BAM | Alignments | banner\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        run[Run]\n"
+        "        aln_out[ ]\n"
+        "        run -->|main| aln_out\n"
+        "    end\n"
+    )
+    station = graph.stations["aln_out"]
+    assert station.terminus_icon_banners == [True]
+    # The caption (third field) is still parsed alongside the banner option.
+    assert station.terminus_names == ["Alignments"]
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    from nf_metro.render.constants import ICON_BANNER_FILL
+
+    assert ICON_BANNER_FILL in svg
+
+
+def test_file_icon_no_banner_by_default():
+    """A plain %%metro file: directive does not enable the banner."""
+    graph = parse_metro_mermaid(
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro file: reads_in | FASTQ\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        "        reads_in[ ]\n"
+        "        trim[Trim]\n"
+        "        reads_in -->|main| trim\n"
+        "    end\n"
+    )
+    station = graph.stations["reads_in"]
+    assert station.terminus_icon_banners == [False]
+
+
 def test_render_icon_type_guide_fixtures():
     """Guide examples for files and dir icons render without errors."""
     from pathlib import Path
 
     examples = Path(__file__).parent.parent / "examples" / "guide"
-    for fname in ("05c_files_icon.mmd", "05d_folder_icon.mmd"):
+    for fname in (
+        "05c_files_icon.mmd",
+        "05d_folder_icon.mmd",
+        "05f_banner_labels.mmd",
+    ):
         fpath = examples / fname
         assert fpath.exists(), f"Missing fixture: {fpath}"
         text = fpath.read_text()


### PR DESCRIPTION
Adds an optional `| banner` style for terminus file icons, an icon-label edge-clearance fix, and a `file_icons` demo, per #532.

## Changes

- **`| banner` format strip** - an optional fourth field on `%%metro file:` and `%%metro files:` directives. The format label renders as bold white text on a dark strip across the lower part of the white icon, with the document still visible above and below it, for outputs where the format should stand out. Any `name` caption still renders below the icon. Not supported on `dir:`.
- **Label edge clearance** - icon labels now shrink to keep a minimum margin from the icon's left/right edges, so long labels (for example a `Results` folder) no longer touch the edges.
- **`examples/file_icons.mmd`** - a demo showing the single-sheet (`file:`), stacked (`files:`), folder (`dir:`) and `| banner` variants, registered in `scripts/build_gallery.py` for the render preview.

## Compatibility

Plain `file:` / `files:` / `dir:` directives are unchanged. The label-clearance shrink only affects labels long enough to crowd the icon edges; in the gallery that is just the `05d_folder_icon` "Results" example. All other renders are byte-identical against `main`.

Tests added for the banner option and the demo fixtures; the full suite, `ruff` and `mypy` pass.

Closes #532
