### PR TITLE
feat: per-station marker shapes/fills and a marker legend key

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -333,7 +333,80 @@ The label inside an icon is meant for a short type chip (e.g. `CSV`, `FASTQ`). T
 
 The name is rendered as a caption directly below the icon. If multiple labels are listed (`FASTQ, BAM`), the same name applies to all of them.
 
-## 6. Hidden stations
+## 6. Per-station markers
+
+By default every station is drawn as a uniform pill. The `%%metro marker:` directive overrides one station's marker so it can encode a tool attribute - mandatory vs optional, hardware-accelerated, expanded in another diagram - through its shape and fill:
+
+```text
+%%metro marker: node_id | shape, fill
+```
+
+- **`shape`** is `circle` (fully rounded), `square` (sharp corners), or `pill` (a flat-edged capsule running along the line, handy for flagging a step whose detail is shown in a separate diagram). Every shape still spans the line bundle, so it covers all the lines passing through the station.
+- **`fill`** is `open` (a hollow marker in the background colour), `solid` (the default station fill), or any literal colour - a name (`red`) or hex (`#4CAF50`).
+
+`shape` defaults to `circle` and `fill` to `solid`, so `%%metro marker: node_id |` gives a solid circle. The directive may appear before or after the node is defined.
+
+To explain the markers, add a key below the line legend with `%%metro marker_legend:`, one row per shape/fill combination:
+
+```text
+%%metro marker_legend: shape, fill | Caption
+```
+
+Here a two-line variant-calling pipeline uses square (mandatory), open-circle (optional), pill (expanded elsewhere) and coloured-square (hardware-accelerated) markers, with a matching key:
+
+```text
+%%metro title: Per-station marker styles
+%%metro style: dark
+%%metro line: germline | Germline calling | #0570b0
+%%metro line: somatic | Somatic calling | #e63946
+%%metro legend: bl
+
+%%metro marker: bwa | square, solid
+%%metro marker: markdup | square, solid
+%%metro marker: bqsr | square, #4CAF50
+%%metro marker: haplotypecaller | square, #4CAF50
+%%metro marker: mutect2 | square, #1f4e79
+%%metro marker: cnvkit | pill, open
+%%metro marker: vep | circle, open
+%%metro marker: snpeff | circle, open
+
+%%metro marker_legend: square, solid | Mandatory
+%%metro marker_legend: circle, open | Optional
+%%metro marker_legend: pill, open | Expanded elsewhere
+%%metro marker_legend: square, #4CAF50 | Parabricks accelerated
+%%metro marker_legend: square, #1f4e79 | Sentieon accelerated
+
+graph LR
+    subgraph alignment [Alignment & preprocessing]
+        bwa[BWA-MEM]
+        markdup[MarkDuplicates]
+        bqsr[BQSR]
+
+        bwa -->|germline,somatic| markdup
+        markdup -->|germline,somatic| bqsr
+    end
+
+    subgraph calling [Variant calling & annotation]
+        haplotypecaller[HaplotypeCaller]
+        mutect2[Mutect2]
+        cnvkit[CNVkit]
+        snpeff[SnpEff]
+        vep[VEP]
+
+        haplotypecaller -->|germline| snpeff
+        mutect2 -->|somatic| vep
+        mutect2 -->|somatic| cnvkit
+    end
+
+    bqsr -->|germline| haplotypecaller
+    bqsr -->|somatic| mutect2
+```
+
+![Per-station markers](assets/renders/marker_styles.svg)
+
+Stations with no `%%metro marker:` keep the default pill, so the feature is entirely opt-in.
+
+## 7. Hidden stations
 
 Sometimes you need a branching or merging point in the graph that doesn't represent a real pipeline step. For example, lines might diverge at a point where no tool is actually run. Adding a visible station there clutters the diagram with a meaningless marker.
 
@@ -397,7 +470,7 @@ The lines still fork at the same point, but there is no marker or label. This gi
 
 Use `--debug` to see hidden stations as dashed circles: `nf-metro render --debug pipeline.mmd -o debug.svg`
 
-## 7. Putting it all together
+## 8. Putting it all together
 
 The nf-core/rnaseq example at [`examples/rnaseq_auto.mmd`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/rnaseq_auto.mmd) combines all of these patterns in a real-world pipeline:
 

--- a/examples/marker_styles.mmd
+++ b/examples/marker_styles.mmd
@@ -1,0 +1,50 @@
+%%metro title: Per-station marker styles
+%%metro style: dark
+%%metro line: germline | Germline calling | #0570b0
+%%metro line: somatic | Somatic calling | #e63946
+%%metro legend: bl
+
+%% Per-station marker shapes & fills: square = mandatory, circle = optional,
+%% coloured square = hardware-accelerated, pill = a step whose detail is
+%% expanded in a separate panel.
+%%metro marker: bwa | square, solid
+%%metro marker: markdup | square, solid
+%%metro marker: bqsr | square, #4CAF50
+%%metro marker: haplotypecaller | square, #4CAF50
+%%metro marker: mutect2 | square, #1f4e79
+%%metro marker: cnvkit | pill, open
+%%metro marker: vep | circle, open
+%%metro marker: snpeff | circle, open
+
+%% Marker key captions.
+%%metro marker_legend: square, solid | Mandatory
+%%metro marker_legend: circle, open | Optional
+%%metro marker_legend: pill, open | Expanded elsewhere
+%%metro marker_legend: square, #4CAF50 | Parabricks accelerated
+%%metro marker_legend: square, #1f4e79 | Sentieon accelerated
+
+graph LR
+    subgraph alignment [Alignment & preprocessing]
+        bwa[BWA-MEM]
+        markdup[MarkDuplicates]
+        bqsr[BQSR]
+
+        bwa -->|germline,somatic| markdup
+        markdup -->|germline,somatic| bqsr
+    end
+
+    subgraph calling [Variant calling & annotation]
+        haplotypecaller[HaplotypeCaller]
+        mutect2[Mutect2]
+        cnvkit[CNVkit]
+        snpeff[SnpEff]
+        vep[VEP]
+
+        haplotypecaller -->|germline| snpeff
+        mutect2 -->|somatic| vep
+        mutect2 -->|somatic| cnvkit
+    end
+
+    %% Inter-section edges
+    bqsr -->|germline| haplotypecaller
+    bqsr -->|somatic| mutect2

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -62,6 +62,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "collector fan-in descending a shared inter-column corridor.",
     ),
     (
+        "marker_styles",
+        EXAMPLES_DIR,
+        "Per-station marker shapes & fills encoding tool attributes "
+        "(mandatory/optional/accelerated/expanded-elsewhere) with a marker key "
+        "alongside the line legend. Demonstrates `%%metro marker:` and "
+        "`%%metro marker_legend:`.",
+    ),
+    (
         "diagonal_labels",
         EXAMPLES_DIR,
         "Opt-in diagonal station labels (#527) via `%%metro label_angle: 45`: a "
@@ -385,7 +393,12 @@ def render_guide_examples() -> None:
             print(f"  {mmd_path.stem}: FAIL - {e}")
 
     # Top-level examples referenced directly from the guide
-    for stem in ("rnaseq_auto", "variantbenchmarking", "variantbenchmarking_auto"):
+    for stem in (
+        "rnaseq_auto",
+        "variantbenchmarking",
+        "variantbenchmarking_auto",
+        "marker_styles",
+    ):
         mmd_path = EXAMPLES_DIR / f"{stem}.mmd"
         if not mmd_path.exists():
             continue

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -12,9 +12,15 @@ import re
 import warnings
 
 from nf_metro.parser.model import (
+    MARKER_FILL_OPEN,
+    MARKER_FILL_SOLID,
+    MARKER_SHAPE_CIRCLE,
     VALID_ICON_TYPES,
     VALID_LINE_STYLES,
+    VALID_MARKER_SHAPES,
     Edge,
+    MarkerLegendEntry,
+    MarkerStyle,
     MetroGraph,
     MetroLine,
     Port,
@@ -214,6 +220,12 @@ def parse_metro_mermaid(text: str, max_station_columns: int = 15) -> MetroGraph:
         if station:
             station.off_track = True
 
+    # Apply pending per-station marker styles
+    for station_id, marker in graph._pending_markers.items():
+        station = graph.stations.get(station_id)
+        if station:
+            station.marker = marker
+
     return graph
 
 
@@ -309,6 +321,10 @@ def _parse_directive(
     elif content.startswith("off_track:"):
         ids = [s.strip() for s in content[len("off_track:") :].split(",")]
         graph._pending_off_track.extend(sid for sid in ids if sid)
+    elif content.startswith("marker_legend:"):
+        _parse_marker_legend_directive(content[len("marker_legend:") :].strip(), graph)
+    elif content.startswith("marker:"):
+        _parse_marker_directive(content[len("marker:") :].strip(), graph)
     elif ":" in content and content.split(":", 1)[0] in VALID_ICON_TYPES:
         icon_type, rest = content.split(":", 1)
         parts = rest.strip().split("|")
@@ -472,6 +488,56 @@ def _parse_logo_scale_directive(value: str, graph: MetroGraph) -> None:
         )
         return
     graph.logo_scale = scale
+
+
+def _parse_marker_style(spec: str) -> MarkerStyle | None:
+    """Parse a ``shape, fill`` marker spec into a MarkerStyle.
+
+    ``shape`` defaults to ``circle`` and ``fill`` to ``solid`` when omitted.
+    An unknown shape is rejected (returns None with a warning); any fill
+    string other than ``open``/``solid`` is taken as a literal colour.
+    """
+    parts = [p.strip() for p in spec.split(",")]
+    shape = parts[0].lower() if parts and parts[0] else MARKER_SHAPE_CIRCLE
+    fill = parts[1] if len(parts) >= 2 and parts[1] else MARKER_FILL_SOLID
+    if shape not in VALID_MARKER_SHAPES:
+        warnings.warn(
+            f"Unknown marker shape {shape!r}; expected one of "
+            f"{'/'.join(VALID_MARKER_SHAPES)}. Ignoring.",
+            stacklevel=2,
+        )
+        return None
+    # Normalise the fill keywords to lowercase; leave literal colours as-is.
+    if fill.lower() in (MARKER_FILL_OPEN, MARKER_FILL_SOLID):
+        fill = fill.lower()
+    return MarkerStyle(shape=shape, fill=fill)
+
+
+def _parse_marker_directive(value: str, graph: MetroGraph) -> None:
+    """Parse ``%%metro marker: node_id | shape, fill``."""
+    node_part, sep, style_part = value.partition("|")
+    node_id = node_part.strip()
+    if not node_id:
+        return
+    style = _parse_marker_style(style_part.strip() if sep else "")
+    if style is not None:
+        graph._pending_markers[node_id] = style
+
+
+def _parse_marker_legend_directive(value: str, graph: MetroGraph) -> None:
+    """Parse ``%%metro marker_legend: shape, fill | Caption``."""
+    style_part, sep, caption = value.partition("|")
+    if not sep:
+        warnings.warn(
+            "marker_legend directive needs a caption: "
+            "'shape, fill | Caption'. Ignoring.",
+            stacklevel=2,
+        )
+        return
+    style = _parse_marker_style(style_part.strip())
+    caption = caption.strip()
+    if style is not None and caption:
+        graph.marker_legend.append(MarkerLegendEntry(style=style, caption=caption))
 
 
 def _parse_legend_combo_directive(value: str, graph: MetroGraph) -> None:

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -46,6 +46,15 @@ class PortSide(Enum):
 
 VALID_LINE_STYLES = ("solid", "dashed", "dotted")
 
+MARKER_SHAPE_CIRCLE = "circle"
+MARKER_SHAPE_SQUARE = "square"
+MARKER_SHAPE_PILL = "pill"
+VALID_MARKER_SHAPES = (MARKER_SHAPE_CIRCLE, MARKER_SHAPE_SQUARE, MARKER_SHAPE_PILL)
+
+# Fill keywords; any other value is treated as a literal colour (named or hex).
+MARKER_FILL_OPEN = "open"
+MARKER_FILL_SOLID = "solid"
+
 ICON_TYPE_FILE = "file"
 ICON_TYPE_FILES = "files"
 ICON_TYPE_DIR = "dir"
@@ -62,6 +71,30 @@ class MetroLine:
     style: str = "solid"
 
 
+@dataclass(frozen=True)
+class MarkerStyle:
+    """Per-station marker shape and fill.
+
+    ``shape`` is one of :data:`VALID_MARKER_SHAPES`: ``circle`` (fully rounded),
+    ``square`` (sharp corners), or ``pill`` (a flat-edged capsule elongated
+    along the line, used to flag a station whose detail is shown elsewhere).
+    ``fill`` is ``open`` (background-coloured interior), ``solid`` (the theme's
+    default station fill), or a literal colour (named or hex). When ``fill`` is
+    a literal colour the marker is drawn filled with that colour.
+    """
+
+    shape: str = MARKER_SHAPE_CIRCLE
+    fill: str = MARKER_FILL_SOLID
+
+
+@dataclass
+class MarkerLegendEntry:
+    """A caption for a marker shape/fill combination in the marker key."""
+
+    style: MarkerStyle
+    caption: str
+
+
 @dataclass
 class Station:
     """A node/station in the metro map."""
@@ -71,6 +104,8 @@ class Station:
     section_id: str | None = None
     is_port: bool = False
     is_hidden: bool = False
+    # Per-station marker style from %%metro marker:; None = default pill.
+    marker: MarkerStyle | None = None
     # When True, the station is lifted above the section's top track in a
     # final layout phase.  Used for file-input nodes that would otherwise
     # consume a line-track Y slot.
@@ -210,6 +245,9 @@ class MetroGraph:
     legend_at: tuple[float, float] | None = None  # absolute top-left override
     logo_path: str = ""
     logo_scale: float = 1.0  # multiplies the logo size within the legend block
+    # Marker-key captions from %%metro marker_legend: (issue #530). When
+    # non-empty, the legend renders a marker key below the line key.
+    marker_legend: list[MarkerLegendEntry] = field(default_factory=list)
     # Section dependency graph (populated by auto_layout)
     section_dag: SectionDAG | None = None
     # Section IDs that had explicit %%metro direction: directives
@@ -220,6 +258,9 @@ class MetroGraph:
     )
     # Pending off-track marks: station_ids to lift above section top track
     _pending_off_track: list[str] = field(default_factory=list)
+    # Pending per-station marker styles: station_id -> MarkerStyle, applied
+    # after parse so directives may precede or follow the node definition.
+    _pending_markers: dict[str, MarkerStyle] = field(default_factory=dict)
     # Lazy caches keyed off the edge list; invalidated on edge mutation.
     _station_lines_cache: dict[str, list[str]] | None = field(default=None, repr=False)
     _edges_from_cache: dict[str, list[Edge]] | None = field(default=None, repr=False)

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -56,6 +56,18 @@ LOGO_GAP: float = 12.0
 LEGEND_BORDER_RADIUS: int = 6
 """Corner radius for legend background rectangle."""
 
+LEGEND_MARKER_GAP: float = 10.0
+"""Vertical gap between the line key and the marker key."""
+
+LEGEND_MARKER_RADIUS: float = 6.0
+"""Half-size of a marker-key swatch glyph."""
+
+LEGEND_MARKER_PILL_RATIO: float = 1.7
+"""Half-width of a ``pill`` swatch as a multiple of the swatch half-size."""
+
+MARKER_PILL_LENGTH_RATIO: float = 4.0
+"""Length of a ``pill`` marker along the line, as a multiple of the station radius."""
+
 # ---------------------------------------------------------------------------
 # SVG drawing
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -2,17 +2,34 @@
 
 from __future__ import annotations
 
-__all__ = ["compute_legend_dimensions", "render_legend"]
+__all__ = [
+    "compute_legend_dimensions",
+    "marker_corner_radius",
+    "marker_fill_color",
+    "marker_stroke_color",
+    "render_legend",
+]
 
 from dataclasses import dataclass
 
 import drawsvg as draw
 
-from nf_metro.parser.model import MetroGraph, MetroLine
+from nf_metro.parser.model import (
+    MARKER_FILL_OPEN,
+    MARKER_FILL_SOLID,
+    MARKER_SHAPE_CIRCLE,
+    MARKER_SHAPE_PILL,
+    MARKER_SHAPE_SQUARE,
+    MetroGraph,
+    MetroLine,
+)
 from nf_metro.render.constants import (
     LEGEND_BORDER_RADIUS,
     LEGEND_CHAR_WIDTH_RATIO,
     LEGEND_LINE_HEIGHT,
+    LEGEND_MARKER_GAP,
+    LEGEND_MARKER_PILL_RATIO,
+    LEGEND_MARKER_RADIUS,
     LEGEND_PADDING,
     LEGEND_SWATCH_WIDTH,
     LEGEND_TEXT_GAP,
@@ -22,6 +39,42 @@ from nf_metro.render.constants import (
     line_style_kwargs,
 )
 from nf_metro.render.style import Theme
+
+
+def marker_fill_color(fill: str, theme: Theme) -> str:
+    """Resolve a marker fill keyword/colour to an SVG fill value.
+
+    ``open`` renders the theme's open-marker interior (falling back to the
+    background, or white on transparent themes); ``solid`` uses the default
+    station fill; anything else is taken as a literal colour.
+    """
+    if fill == MARKER_FILL_OPEN:
+        if theme.marker_open_fill:
+            return theme.marker_open_fill
+        if theme.background_color and theme.background_color != "none":
+            return theme.background_color
+        return "#ffffff"
+    if fill == MARKER_FILL_SOLID:
+        return theme.station_fill
+    return fill
+
+
+def marker_corner_radius(shape: str, r: float) -> float:
+    """Corner radius for a marker glyph of half-size ``r``.
+
+    ``square`` is left with sharp corners; every other shape rounds fully
+    (``r``), giving circles, capsules and stadium-ended pills.
+    """
+    return 0.0 if shape == MARKER_SHAPE_SQUARE else r
+
+
+def marker_stroke_color(theme: Theme) -> str:
+    """Resolve the outline colour for marker glyphs and their swatches.
+
+    A dedicated light outline keeps dark-filled markers visible against a
+    dark background; an empty ``marker_stroke`` inherits ``station_stroke``.
+    """
+    return theme.marker_stroke or theme.station_stroke
 
 
 @dataclass
@@ -109,7 +162,13 @@ def _legend_metrics(
     text block and a (possibly enlarged) logo.
     """
     line_height = LEGEND_LINE_HEIGHT
-    text_block_h = max(len(rows) * line_height, graph.legend_min_height)
+    line_block_h = len(rows) * line_height
+    marker_block_h = (
+        LEGEND_MARKER_GAP + len(graph.marker_legend) * line_height
+        if graph.marker_legend
+        else 0.0
+    )
+    text_block_h = max(line_block_h + marker_block_h, graph.legend_min_height)
     logo_w = logo_h = 0.0
     if logo_size:
         logo_w, logo_h = _scale_logo_to_content(
@@ -145,6 +204,8 @@ def compute_legend_dimensions(
     text_offset = swatch_width + LEGEND_TEXT_GAP
 
     max_name_len = max(len(row.label) for row in rows)
+    if graph.marker_legend:
+        max_name_len = max(max_name_len, *(len(e.caption) for e in graph.marker_legend))
     char_width = theme.legend_font_size * LEGEND_CHAR_WIDTH_RATIO
 
     _text_h, content_height, logo_w, _logo_h = _legend_metrics(graph, rows, logo_size)
@@ -278,6 +339,77 @@ def render_legend(
                 row.label,
                 theme.legend_font_size,
                 x + padding + logo_offset + text_offset,
+                entry_y,
+                fill=theme.legend_text_color,
+                font_family=theme.label_font_family,
+                dy=TEXT_VCENTER_DY,
+            )
+        )
+
+    if graph.marker_legend:
+        _render_marker_key(
+            d,
+            graph,
+            theme,
+            x + padding + logo_offset,
+            text_top + len(rows) * line_height + LEGEND_MARKER_GAP,
+            text_offset,
+            line_height,
+        )
+
+
+def _render_marker_key(
+    d: draw.Drawing,
+    graph: MetroGraph,
+    theme: Theme,
+    left_x: float,
+    top_y: float,
+    text_offset: float,
+    line_height: float,
+) -> None:
+    """Render the marker shape/fill key rows below the line legend."""
+    swatch_cx = left_x + LEGEND_SWATCH_WIDTH / 2
+    r = LEGEND_MARKER_RADIUS
+    stroke = marker_stroke_color(theme)
+    for i, entry in enumerate(graph.marker_legend):
+        entry_y = top_y + i * line_height + line_height / 2
+        fill = marker_fill_color(entry.style.fill, theme)
+        if entry.style.shape == MARKER_SHAPE_CIRCLE:
+            d.append(
+                draw.Circle(
+                    swatch_cx,
+                    entry_y,
+                    r,
+                    fill=fill,
+                    stroke=stroke,
+                    stroke_width=theme.station_stroke_width,
+                )
+            )
+        else:
+            half_w = (
+                r * LEGEND_MARKER_PILL_RATIO
+                if entry.style.shape == MARKER_SHAPE_PILL
+                else r
+            )
+            rx = marker_corner_radius(entry.style.shape, r)
+            d.append(
+                draw.Rectangle(
+                    swatch_cx - half_w,
+                    entry_y - r,
+                    half_w * 2,
+                    r * 2,
+                    rx=rx,
+                    ry=rx,
+                    fill=fill,
+                    stroke=stroke,
+                    stroke_width=theme.station_stroke_width,
+                )
+            )
+        d.append(
+            draw.Text(
+                entry.caption,
+                theme.legend_font_size,
+                left_x + text_offset,
                 entry_y,
                 fill=theme.legend_text_color,
                 font_family=theme.label_font_family,

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -56,3 +56,10 @@ class Theme:
     terminus_font_color: str = ""  # empty = inherit label_color
     # Bridge glyph at non-merging line crossings
     bridge_glyph: bool = True
+    # Interior fill for "open" markers (%%metro marker: ... | open). Empty
+    # falls back to the background colour, or white on transparent themes.
+    marker_open_fill: str = ""
+    # Outline for marker glyphs (%%metro marker:) and their legend swatches.
+    # A light outline keeps dark-filled markers visible against a dark
+    # background. Empty inherits station_stroke.
+    marker_stroke: str = ""

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -21,6 +21,8 @@ from nf_metro.parser.model import (
     ICON_TYPE_DIR,
     ICON_TYPE_FILE,
     ICON_TYPE_FILES,
+    MARKER_SHAPE_PILL,
+    MarkerStyle,
     MetroGraph,
     PortSide,
     Section,
@@ -52,6 +54,7 @@ from nf_metro.render.constants import (
     LEGEND_INSET,
     LEGEND_ROUTE_CLEARANCE,
     LOGO_Y_STANDALONE,
+    MARKER_PILL_LENGTH_RATIO,
     SECTION_BOX_RADIUS,
     SECTION_LABEL_REGION_RATIO,
     SECTION_LABEL_TEXT_OFFSET,
@@ -73,7 +76,13 @@ from nf_metro.render.icons import (
     render_files_icon,
     render_folder_icon,
 )
-from nf_metro.render.legend import compute_legend_dimensions, render_legend
+from nf_metro.render.legend import (
+    compute_legend_dimensions,
+    marker_corner_radius,
+    marker_fill_color,
+    marker_stroke_color,
+    render_legend,
+)
 from nf_metro.render.style import Theme
 
 
@@ -889,6 +898,88 @@ def _render_bridged_edge(
     d.append(path)
 
 
+def _pill_box(
+    station: Station,
+    r: float,
+    min_off: float,
+    max_off: float,
+    is_tb_vert: bool,
+    flow_len: float | None = None,
+) -> tuple[float, float, float, float]:
+    """Return ``(x, y, w, h)`` for the bundle-spanning pill at a station.
+
+    The pill covers every line passing through the station: it spans the line
+    bundle across the section's flow axis (wide for TB sections where lines
+    arrive vertically, tall otherwise) and is centred on the bundle mid-offset.
+    ``flow_len`` overrides the extent along the flow axis (default ``2 * r``),
+    elongating the glyph along the line.
+    """
+    span = max_off - min_off
+    mid = (min_off + max_off) / 2
+    flow = r * 2 if flow_len is None else flow_len
+    if is_tb_vert:
+        w, h = span + r * 2, flow
+        cx, cy = station.x + mid, station.y
+    else:
+        w, h = flow, span + r * 2
+        cx, cy = station.x, station.y + mid
+    return cx - w / 2, cy - h / 2, w, h
+
+
+def _append_terminus_icons(
+    d: draw.Drawing,
+    station: Station,
+    graph: MetroGraph,
+    theme: Theme,
+    r: float,
+    min_off: float,
+    max_off: float,
+) -> None:
+    """Render a station's terminus icons into their own data-tagged group."""
+    icon_group = draw.Group(**{"data-station-id": station.id})
+    _render_terminus_icons(icon_group, station, graph, theme, r, min_off, max_off)
+    d.append(icon_group)
+
+
+def _render_marker_station(
+    d: draw.Drawing,
+    marker: MarkerStyle,
+    theme: Theme,
+    station: Station,
+    r: float,
+    min_off: float,
+    max_off: float,
+    is_tb_vert: bool,
+    station_data: dict[str, str],
+) -> None:
+    """Draw a shape/fill marker glyph over the station's line bundle.
+
+    ``circle`` and ``square`` keep the bundle-spanning pill geometry, varying
+    only the corner rounding. ``pill`` is elongated along the line (a capsule
+    in the opposite orientation to the default station pill) while still
+    growing across the bundle to cover every track it spans.
+    """
+    flow_len = (
+        r * MARKER_PILL_LENGTH_RATIO if marker.shape == MARKER_SHAPE_PILL else None
+    )
+    x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb_vert, flow_len=flow_len)
+    rx = marker_corner_radius(marker.shape, r)
+    d.append(
+        draw.Rectangle(
+            x,
+            y,
+            w,
+            h,
+            rx=rx,
+            ry=rx,
+            fill=marker_fill_color(marker.fill, theme),
+            stroke=marker_stroke_color(theme),
+            stroke_width=theme.station_stroke_width,
+            **station_data,
+        )
+    )
+
+
 def _render_stations(
     d: draw.Drawing,
     graph: MetroGraph,
@@ -929,8 +1020,6 @@ def _render_stations(
         else:
             min_off = max_off = 0.0
 
-        span = max_off - min_off
-
         # Hand-escape values that flow from user content into XML attributes.
         # drawsvg does not escape unknown kwargs, so an unescaped "&" or "<"
         # in a section name or station label breaks XML well-formedness.
@@ -946,47 +1035,33 @@ def _render_stations(
             if sec_obj:
                 station_data["data-section-name"] = html.escape(sec_obj.name)
 
-        # Non-process terminus stations: filled rectangle
-        # (same size as pill, no rounding)
+        if station.marker is not None:
+            _render_marker_station(
+                d,
+                station.marker,
+                theme,
+                station,
+                r,
+                min_off,
+                max_off,
+                is_tb_vert,
+                station_data,
+            )
+            if station.is_terminus:
+                _append_terminus_icons(d, station, graph, theme, r, min_off, max_off)
+            continue
+
+        x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb_vert)
+
+        # Blank terminus stations get an unrounded nub; everything else a pill.
         is_blank_terminus = station.is_terminus and not station.label.strip()
         if is_blank_terminus:
-            # Match the section flow axis: a horizontal nub for TB/BT (lines
-            # arrive vertically), a vertical nub otherwise.
-            if is_tb_vert:
-                w = span + r * 2
-                h = r * 2
-                cx = station.x + (min_off + max_off) / 2
-                cy = station.y
-            else:
-                w = r * 2
-                h = span + r * 2
-                cx = station.x
-                cy = station.y + (min_off + max_off) / 2
             d.append(
                 draw.Rectangle(
-                    cx - w / 2,
-                    cy - h / 2,
+                    x,
+                    y,
                     w,
                     h,
-                    fill=theme.station_fill,
-                    stroke=theme.station_stroke,
-                    stroke_width=theme.station_stroke_width,
-                    **station_data,
-                )
-            )
-        elif is_tb_vert:
-            # Horizontal pill: lines spread along X axis
-            w = span + r * 2
-            h = r * 2
-            cx = station.x + (min_off + max_off) / 2
-            d.append(
-                draw.Rectangle(
-                    cx - w / 2,
-                    station.y - h / 2,
-                    w,
-                    h,
-                    rx=r,
-                    ry=r,
                     fill=theme.station_fill,
                     stroke=theme.station_stroke,
                     stroke_width=theme.station_stroke_width,
@@ -994,14 +1069,10 @@ def _render_stations(
                 )
             )
         else:
-            # Vertical pill: lines spread along Y axis
-            w = r * 2
-            h = span + r * 2
-            cy = station.y + (min_off + max_off) / 2
             d.append(
                 draw.Rectangle(
-                    station.x - w / 2,
-                    cy - h / 2,
+                    x,
+                    y,
                     w,
                     h,
                     rx=r,
@@ -1014,11 +1085,7 @@ def _render_stations(
             )
 
         if station.is_terminus:
-            icon_group = draw.Group(**{"data-station-id": station.id})
-            _render_terminus_icons(
-                icon_group, station, graph, theme, r, min_off, max_off
-            )
-            d.append(icon_group)
+            _append_terminus_icons(d, station, graph, theme, r, min_off, max_off)
 
 
 def caption_aware_icon_step(

--- a/src/nf_metro/themes/nfcore.py
+++ b/src/nf_metro/themes/nfcore.py
@@ -7,6 +7,7 @@ NFCORE_THEME = Theme(
     background_color="#2b2b2b",
     station_fill="#ffffff",
     station_stroke="#333333",
+    marker_stroke="#f0f0f0",
     station_stroke_width=1.5,
     line_width=3.0,
     label_color="#e0e0e0",

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,0 +1,249 @@
+"""Tests for per-station marker styles and the marker legend."""
+
+import xml.etree.ElementTree as ET
+from dataclasses import replace
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MarkerStyle
+from nf_metro.render.constants import MARKER_PILL_LENGTH_RATIO
+from nf_metro.render.legend import (
+    marker_corner_radius,
+    marker_fill_color,
+    marker_stroke_color,
+)
+from nf_metro.render.svg import render_svg
+from nf_metro.themes import NFCORE_THEME
+
+_BASE = (
+    "%%metro line: a | Line A | #4CAF50\n"
+    "graph LR\n"
+    "    n1[One]\n"
+    "    n2[Two]\n"
+    "    n3[Three]\n"
+    "    n1 -->|a| n2\n"
+    "    n2 -->|a| n3\n"
+)
+
+
+def _parse(extra: str = ""):
+    return parse_metro_mermaid(extra + _BASE)
+
+
+# --- Parser: per-station marker directive ------------------------------------
+
+
+def test_marker_directive_sets_shape_and_fill():
+    g = _parse("%%metro marker: n2 | square, open\n")
+    assert g.stations["n2"].marker == MarkerStyle(shape="square", fill="open")
+
+
+def test_marker_directive_literal_colour_fill():
+    g = _parse("%%metro marker: n2 | square, #4CAF50\n")
+    assert g.stations["n2"].marker == MarkerStyle(shape="square", fill="#4CAF50")
+
+
+def test_marker_directive_defaults_circle_solid():
+    g = _parse("%%metro marker: n2 |\n")
+    assert g.stations["n2"].marker == MarkerStyle(shape="circle", fill="solid")
+
+
+def test_marker_directive_unmarked_station_has_no_marker():
+    g = _parse("%%metro marker: n2 | square, solid\n")
+    assert g.stations["n1"].marker is None
+    assert g.stations["n3"].marker is None
+
+
+def test_marker_directive_unknown_shape_warns_and_ignores():
+    with pytest.warns(UserWarning):
+        g = _parse("%%metro marker: n2 | triangle, solid\n")
+    assert g.stations["n2"].marker is None
+
+
+def test_marker_directive_precedes_node_definition():
+    # Directive can appear before the node is parsed.
+    g = parse_metro_mermaid(
+        "%%metro line: a | Line A | #4CAF50\n"
+        "%%metro marker: n2 | square, open\n"
+        "graph LR\n"
+        "    n1[One]\n"
+        "    n2[Two]\n"
+        "    n1 -->|a| n2\n"
+    )
+    assert g.stations["n2"].marker == MarkerStyle(shape="square", fill="open")
+
+
+# --- Parser: marker legend directive -----------------------------------------
+
+
+def test_marker_legend_directive_collects_entries():
+    g = _parse(
+        "%%metro marker_legend: square, solid | Mandatory\n"
+        "%%metro marker_legend: circle, open | Optional\n"
+    )
+    assert [e.caption for e in g.marker_legend] == ["Mandatory", "Optional"]
+    assert g.marker_legend[0].style == MarkerStyle(shape="square", fill="solid")
+
+
+def test_marker_legend_directive_requires_caption():
+    with pytest.warns(UserWarning):
+        g = _parse("%%metro marker_legend: square, solid\n")
+    assert g.marker_legend == []
+
+
+def test_marker_legend_default_empty():
+    g = _parse()
+    assert g.marker_legend == []
+
+
+# --- Fill resolution ---------------------------------------------------------
+
+
+def test_marker_fill_color_keywords_and_literal():
+    assert marker_fill_color("solid", NFCORE_THEME) == NFCORE_THEME.station_fill
+    assert marker_fill_color("#abcdef", NFCORE_THEME) == "#abcdef"
+    # open falls back to the background colour on the dark theme.
+    assert marker_fill_color("open", NFCORE_THEME) == NFCORE_THEME.background_color
+
+
+# --- Pill shape --------------------------------------------------------------
+
+
+def test_marker_corner_radius_per_shape():
+    r = 5.0
+    assert marker_corner_radius("circle", r) == r
+    assert marker_corner_radius("pill", r) == r
+    assert marker_corner_radius("square", r) == 0.0
+
+
+def test_pill_marker_directive_parses():
+    g = _parse("%%metro marker: n2 | pill, solid\n")
+    assert g.stations["n2"].marker == MarkerStyle(shape="pill", fill="solid")
+
+
+def test_pill_marker_is_capsule_elongated_along_the_line():
+    # On a single-line LR station a pill is a horizontal capsule: a fully
+    # rounded rect (rx == r) wider than it is tall, elongated along the line.
+    g = _parse("%%metro marker: n2 | pill, #4CAF50\n")
+    compute_layout(g)
+    svg = render_svg(g, NFCORE_THEME)
+    root = ET.fromstring(svg)
+    ns = "{http://www.w3.org/2000/svg}"
+    pills = [
+        el
+        for el in root.iter(f"{ns}rect")
+        if el.get("data-station-id") == "n2" and el.get("fill") == "#4CAF50"
+    ]
+    assert pills, "expected a pill marker rect"
+    r = NFCORE_THEME.station_radius
+    for el in pills:
+        w, h = float(el.get("width")), float(el.get("height"))
+        assert float(el.get("rx")) == r
+        assert w == r * MARKER_PILL_LENGTH_RATIO
+        assert w > h  # flat-edged capsule lying along the line
+
+
+def test_pill_marker_grows_across_multiple_tracks():
+    # When the station carries several lines, the pill widens across the
+    # bundle (its cross-axis extent) instead of staying one track tall.
+    multi = (
+        "%%metro line: a | A | #4CAF50\n"
+        "%%metro line: b | B | #e63946\n"
+        "%%metro marker: n2 | pill, solid\n"
+        "graph LR\n"
+        "    n1[One]\n"
+        "    n2[Two]\n"
+        "    n3[Three]\n"
+        "    n1 -->|a,b| n2\n"
+        "    n2 -->|a,b| n3\n"
+    )
+    g = parse_metro_mermaid(multi)
+    compute_layout(g)
+    svg = render_svg(g, NFCORE_THEME)
+    root = ET.fromstring(svg)
+    ns = "{http://www.w3.org/2000/svg}"
+    pills = [el for el in root.iter(f"{ns}rect") if el.get("data-station-id") == "n2"]
+    assert pills, "expected a pill marker rect"
+    # Two tracks => taller than a single-track pill (> 2r).
+    assert any(
+        float(el.get("height")) > 2 * NFCORE_THEME.station_radius for el in pills
+    )
+
+
+# --- Rendering ---------------------------------------------------------------
+
+
+def test_marker_station_renders_valid_svg():
+    g = _parse(
+        "%%metro marker: n2 | square, #4CAF50\n"
+        "%%metro marker_legend: square, #4CAF50 | Accelerated\n"
+    )
+    compute_layout(g)
+    svg = render_svg(g, NFCORE_THEME)
+    ET.fromstring(svg)  # well-formed
+    assert "#4CAF50" in svg
+    assert "Accelerated" in svg
+
+
+def test_no_marker_directives_byte_identical():
+    # A diagram with no marker directives must render exactly as before the
+    # feature: markers default-off.
+    g_plain = _parse()
+    g_with = _parse("%%metro marker: n2 | square, solid\n")
+    # Remove the marker so the only difference is the (now-cleared) directive.
+    g_with.stations["n2"].marker = None
+    compute_layout(g_plain)
+    compute_layout(g_with)
+    assert render_svg(g_plain, NFCORE_THEME) == render_svg(g_with, NFCORE_THEME)
+
+
+# --- Marker outline visibility ----------------------------------------------
+
+
+def test_marker_stroke_color_uses_theme_marker_stroke():
+    # The dark theme sets a dedicated light marker outline so dark-filled
+    # markers stay visible against the background.
+    assert NFCORE_THEME.marker_stroke
+    assert marker_stroke_color(NFCORE_THEME) == NFCORE_THEME.marker_stroke
+    assert marker_stroke_color(NFCORE_THEME) != NFCORE_THEME.station_stroke
+
+
+def test_marker_stroke_color_falls_back_to_station_stroke():
+    # A theme that does not set marker_stroke inherits station_stroke.
+    theme = replace(NFCORE_THEME, marker_stroke="")
+    assert marker_stroke_color(theme) == theme.station_stroke
+
+
+def test_dark_marker_glyph_has_light_outline():
+    # A dark-filled marker pill must be drawn with the light marker stroke,
+    # not the dark station stroke, so it stands out on the dark background.
+    g = _parse("%%metro marker: n2 | square, #1f4e79\n")
+    compute_layout(g)
+    svg = render_svg(g, NFCORE_THEME)
+    root = ET.fromstring(svg)
+    ns = "{http://www.w3.org/2000/svg}"
+    marker_rects = [
+        el
+        for el in root.iter(f"{ns}rect")
+        if el.get("data-station-id") == "n2" and el.get("fill") == "#1f4e79"
+    ]
+    assert marker_rects, "expected a dark-filled marker rect"
+    for el in marker_rects:
+        assert el.get("stroke") == NFCORE_THEME.marker_stroke
+        assert el.get("stroke") != NFCORE_THEME.station_stroke
+
+
+def test_marker_legend_swatch_has_light_outline():
+    # The legend key swatch for a dark marker must also carry the light
+    # outline so the legend matches the map.
+    g = _parse("%%metro marker_legend: square, #1f4e79 | Accelerated\n")
+    compute_layout(g)
+    svg = render_svg(g, NFCORE_THEME)
+    root = ET.fromstring(svg)
+    ns = "{http://www.w3.org/2000/svg}"
+    swatches = [el for el in root.iter(f"{ns}rect") if el.get("fill") == "#1f4e79"]
+    assert swatches, "expected a dark-filled legend swatch"
+    for el in swatches:
+        assert el.get("stroke") == NFCORE_THEME.marker_stroke


### PR DESCRIPTION
## Summary

Adds the ability to encode per-station tool attributes via marker shape and fill, plus a marker key in the legend explaining them.

## Per-station markers (#528)

- New directive `%%metro marker: node_id | shape, fill`.
  - `shape` is `circle` (fully rounded), `square` (sharp corners), or `pill` (a flat-edged capsule elongated along the line - the multi-track station pill in the opposite orientation - used to flag a station whose detail is shown in a separate panel).
  - `fill` is `open` (interior in the theme's open colour, falling back to the background / white), `solid` (the default station fill), or any literal colour (named or hex).
- `MarkerStyle` carried on the `Station` model; resolved and drawn in station rendering. `circle` and `square` keep the bundle-spanning pill geometry, varying only corner rounding; `pill` is elongated along the line and grows across the bundle to cover every track it spans. `fill` chooses the interior.

## Marker legend (#530)

- New directive `%%metro marker_legend: shape, fill | Caption`.
- When present, the legend renders a marker key (shape/fill swatch + caption) below the existing line key. Legend dimensions account for the extra rows and the captions' width, and the existing legend positioning grammar is unchanged.

## Demo fixture

- `examples/marker_styles.mmd`: a small two-line variant-calling pipeline using square (mandatory), coloured-square (Parabricks/Sentieon accelerated), open-circle (optional) and pill (expanded-elsewhere) markers, with a marker key alongside the line legend. Registered in the gallery for the CI render preview.

## Defaults unchanged

Markers are additive and default-off: a diagram with no marker directives renders byte-identically. A regression test asserts byte-identity when no marker is set.

## Tests

`tests/test_markers.py` covers parsing (shape/fill, literal colour, defaults, unknown-shape warning, directive ordering, marker-legend collection and caption requirement), fill resolution, corner-radius per shape, the pill capsule geometry (elongated along the line, growing across multiple tracks), valid-SVG rendering, marker-outline visibility, and the byte-identical default.

Closes #528
Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
