### PR TITLE
feat(render): striped / composite multi-colour line style (#529)

### DIFF
--- a/examples/striped_line.mmd
+++ b/examples/striped_line.mmd
@@ -6,30 +6,27 @@
 %%metro legend: bl
 
 graph LR
-    subgraph qc [QC & Trimming]
-        cat_fastq[cat fastq]
-        fastqc[FastQC]
-        trim[Trim Galore!]
+    subgraph prep [Per-sample prep]
+        %%metro exit: right | tumor, normal
+        tumor_align[Align tumor]
+        tumor_markdup[MarkDup tumor]
+        normal_align[Align normal]
+        normal_markdup[MarkDup normal]
 
-        cat_fastq -->|tumor,normal| fastqc
-        fastqc -->|tumor,normal| trim
+        tumor_align -->|tumor| tumor_markdup
+        normal_align -->|normal| normal_markdup
     end
 
-    subgraph align [Alignment]
-        bwa[BWA-MEM]
-        markdup[MarkDuplicates]
-
-        bwa -->|tumor,normal| markdup
-    end
-
-    subgraph calling [Somatic Variant Calling]
+    subgraph calling [Paired somatic calling]
+        %%metro entry: left | tumor, normal
+        %%metro exit: right | pair
+        match[Match tumor-normal]
         mutect2[Mutect2]
-        filter[FilterMutectCalls]
         annotate[VEP]
 
-        mutect2 -->|pair| filter
-        filter -->|pair| annotate
+        match -->|pair| mutect2
+        mutect2 -->|pair| annotate
     end
 
-    trim -->|tumor,normal| bwa
-    markdup -->|pair| mutect2
+    tumor_markdup -->|tumor| match
+    normal_markdup -->|normal| match

--- a/examples/striped_line.mmd
+++ b/examples/striped_line.mmd
@@ -1,0 +1,35 @@
+%%metro title: Striped line demo (#529)
+%%metro style: dark
+%%metro line: tumor | Tumor (somatic) | #d62728
+%%metro line: normal | Normal (germline) | #0570b0
+%%metro line: pair | Tumor-normal pair | #d62728,#0570b0
+%%metro legend: bl
+
+graph LR
+    subgraph qc [QC & Trimming]
+        cat_fastq[cat fastq]
+        fastqc[FastQC]
+        trim[Trim Galore!]
+
+        cat_fastq -->|tumor,normal| fastqc
+        fastqc -->|tumor,normal| trim
+    end
+
+    subgraph align [Alignment]
+        bwa[BWA-MEM]
+        markdup[MarkDuplicates]
+
+        bwa -->|tumor,normal| markdup
+    end
+
+    subgraph calling [Somatic Variant Calling]
+        mutect2[Mutect2]
+        filter[FilterMutectCalls]
+        annotate[VEP]
+
+        mutect2 -->|pair| filter
+        filter -->|pair| annotate
+    end
+
+    trim -->|tumor,normal| bwa
+    markdup -->|pair| mutect2

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -43,6 +43,13 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "Minimal two-line pipeline with no sections.",
     ),
     (
+        "striped_line",
+        EXAMPLES_DIR,
+        "Striped / composite multi-colour line (#529): the tumor-normal pair "
+        "route renders as two adjacent coloured ribbons (red + blue) alongside "
+        "normal single-colour lines.",
+    ),
+    (
         "rnaseq_auto",
         EXAMPLES_DIR,
         "Demonstrates fully auto-inferred layout: no `%%metro grid:` directives "

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -45,9 +45,10 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
     (
         "striped_line",
         EXAMPLES_DIR,
-        "Striped / composite multi-colour line (#529): the tumor-normal pair "
-        "route renders as two adjacent coloured ribbons (red + blue) alongside "
-        "normal single-colour lines.",
+        "Striped / composite multi-colour line (#529): the tumor (red) and "
+        "normal (blue) samples run on separate single-colour routes, then "
+        "converge into a striped tumor-normal pair line drawn as two adjacent "
+        "coloured ribbons (red + blue) through paired somatic calling.",
     ),
     (
         "rnaseq_auto",

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -227,12 +227,14 @@ def _parse_directive(
                 raw_style = parts[3].strip().lower()
                 if raw_style in VALID_LINE_STYLES:
                     style = raw_style
+            colors = [c.strip() for c in parts[2].split(",") if c.strip()]
             graph.add_line(
                 MetroLine(
                     id=parts[0].strip(),
                     display_name=parts[1].strip(),
-                    color=parts[2].strip(),
+                    color=colors[0] if colors else parts[2].strip(),
                     style=style,
+                    colors=colors,
                 )
             )
     elif content.startswith("entry:"):

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -54,12 +54,32 @@ VALID_ICON_TYPES = (ICON_TYPE_FILE, ICON_TYPE_FILES, ICON_TYPE_DIR)
 
 @dataclass
 class MetroLine:
-    """A metro line (colored route through the graph)."""
+    """A metro line (colored route through the graph).
+
+    A line is normally a single colour. To express a striped / composite
+    multi-colour line (e.g. nf-core/sarek's "tumor-normal pair"), the colour
+    field may carry several comma-separated colours; the parser splits them
+    into ``colors`` and ``color`` keeps the first for single-colour callers.
+    """
 
     id: str
     display_name: str
     color: str
     style: str = "solid"
+    # All colours for this line; one entry for a normal line, two or more for
+    # a striped/composite line. ``color`` is always ``colors[0]``.
+    colors: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.colors:
+            self.colors = [self.color]
+        else:
+            self.color = self.colors[0]
+
+    @property
+    def is_striped(self) -> bool:
+        """True when the line renders as parallel multi-colour ribbons."""
+        return len(self.colors) > 1
 
 
 @dataclass

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -165,6 +165,13 @@ WATERMARK_Y_INSET: float = 8.0
 FALLBACK_LINE_COLOR: str = "#888888"
 """Color used when a line has no explicit color defined."""
 
+STRIPE_RIBBON_WIDTH_RATIO: float = 0.8
+"""Per-ribbon width (as a fraction of line_width) for a striped/composite line.
+
+Ribbons sit edge-to-edge centred on the route, so an n-colour line spans
+``n * STRIPE_RIBBON_WIDTH_RATIO * line_width``.
+"""
+
 TERMINUS_FONT_COLOR: str = "#000000"
 """Font color for terminus file icon labels."""
 

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -16,6 +16,7 @@ from nf_metro.render.constants import (
     LEGEND_TEXT_GAP,
     LOGO_GAP,
     LOGO_SCALE_FACTOR,
+    STRIPE_RIBBON_WIDTH_RATIO,
     TEXT_VCENTER_DY,
     line_style_kwargs,
 )
@@ -153,20 +154,31 @@ def render_legend(
     for i, metro_line in enumerate(graph.lines.values()):
         entry_y = text_top + i * line_height + line_height / 2
 
-        # Color swatch (line segment)
+        # Color swatch (line segment). A striped/composite line draws one
+        # thinner segment per colour, stacked to span the normal line width.
         dash_kw = line_style_kwargs(metro_line.style)
-        d.append(
-            draw.Line(
-                x + padding + logo_offset,
-                entry_y,
-                x + padding + logo_offset + swatch_width,
-                entry_y,
-                stroke=metro_line.color,
-                stroke_width=theme.line_width,
-                stroke_linecap="round",
-                **dash_kw,
-            )
+        swatch_x0 = x + padding + logo_offset
+        swatch_x1 = swatch_x0 + swatch_width
+        n_colors = len(metro_line.colors)
+        ribbon_w = (
+            theme.line_width
+            if n_colors == 1
+            else theme.line_width * STRIPE_RIBBON_WIDTH_RATIO
         )
+        for i, color in enumerate(metro_line.colors):
+            ribbon_y = entry_y + (i - (n_colors - 1) / 2.0) * ribbon_w
+            d.append(
+                draw.Line(
+                    swatch_x0,
+                    ribbon_y,
+                    swatch_x1,
+                    ribbon_y,
+                    stroke=color,
+                    stroke_width=ribbon_w,
+                    stroke_linecap="round" if n_colors == 1 else "butt",
+                    **dash_kw,
+                )
+            )
 
         # Label
         d.append(

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -59,6 +59,7 @@ from nf_metro.render.constants import (
     SECTION_NUM_FONT_SIZE,
     SECTION_NUM_Y_OFFSET,
     SECTION_STROKE_WIDTH,
+    STRIPE_RIBBON_WIDTH_RATIO,
     SVG_CURVE_RADIUS,
     TERMINUS_FONT_COLOR,
     TEXT_VCENTER_DY,
@@ -752,57 +753,169 @@ def _render_edges(
 
     for route, pts in zip(routes, polylines):
         line = graph.lines.get(route.line_id)
-        color = line.color if line else FALLBACK_LINE_COLOR
+        colors = line.colors if line else [FALLBACK_LINE_COLOR]
         style_kw = line_style_kwargs(line.style) if line else {}
         class_name = f"metro-line-{route.line_id}"
         breaks = bridges.get(id(route))
 
-        if breaks:
-            _render_bridged_edge(
-                d, pts, route, breaks, color, style_kw, class_name, theme, curve_radius
+        # For a striped/composite line, paint one parallel ribbon per colour,
+        # each thinner and shifted perpendicular to the route so the ribbons
+        # sit side by side and span roughly the normal line width. A single
+        # colour falls through unchanged (offset 0.0, full width).
+        for color, offset, width in _ribbon_layers(colors, theme.line_width):
+            ribbon_pts = _offset_polyline(pts, offset)
+            _draw_ribbon(
+                d,
+                ribbon_pts,
+                route,
+                breaks,
+                color,
+                width,
+                style_kw,
+                class_name,
+                theme,
+                curve_radius,
             )
-        elif len(pts) == 2:
-            d.append(
-                draw.Line(
-                    pts[0][0],
-                    pts[0][1],
-                    pts[1][0],
-                    pts[1][1],
-                    stroke=color,
-                    stroke_width=theme.line_width,
-                    stroke_linecap="round",
-                    class_=class_name,
-                    **{"data-line-id": route.line_id},
-                    **style_kw,
-                )
-            )
-        elif len(pts) >= 3:
-            path = draw.Path(
+
+
+def _ribbon_layers(
+    colors: list[str], line_width: float
+) -> list[tuple[str, float, float]]:
+    """Return ``(color, perp_offset, stroke_width)`` per ribbon for a line.
+
+    A single colour yields one full-width ribbon at zero offset (identical to
+    the historical render). Multiple colours render as ``n`` adjacent ribbons
+    centred on the route. Each ribbon is a touch narrower than a normal line
+    and the ribbons sit edge-to-edge, so the composite reads clearly as two
+    (or more) parallel coloured lines.
+    """
+    n = len(colors)
+    if n <= 1:
+        return [(colors[0], 0.0, line_width)]
+    ribbon_w = line_width * STRIPE_RIBBON_WIDTH_RATIO
+    layers: list[tuple[str, float, float]] = []
+    for i, color in enumerate(colors):
+        offset = (i - (n - 1) / 2.0) * ribbon_w
+        layers.append((color, offset, ribbon_w))
+    return layers
+
+
+def _offset_polyline(
+    pts: list[tuple[float, float]], offset: float
+) -> list[tuple[float, float]]:
+    """Shift a polyline by a constant perpendicular distance.
+
+    Each vertex moves along the averaged normal of its adjacent segments so
+    the offset path stays roughly parallel through corners. This is a simple
+    constant-offset approximation (issue #529); on tight corners the ribbons
+    can converge slightly, which is acceptable for the striped demo.
+    """
+    if offset == 0.0 or len(pts) < 2:
+        return pts
+
+    def seg_normal(
+        a: tuple[float, float], b: tuple[float, float]
+    ) -> tuple[float, float]:
+        dx, dy = b[0] - a[0], b[1] - a[1]
+        length = (dx * dx + dy * dy) ** 0.5
+        if length == 0:
+            return (0.0, 0.0)
+        # Left-hand normal of the direction (dx, dy).
+        return (-dy / length, dx / length)
+
+    out: list[tuple[float, float]] = []
+    n = len(pts)
+    for i in range(n):
+        if i == 0:
+            nx, ny = seg_normal(pts[0], pts[1])
+        elif i == n - 1:
+            nx, ny = seg_normal(pts[-2], pts[-1])
+        else:
+            n1 = seg_normal(pts[i - 1], pts[i])
+            n2 = seg_normal(pts[i], pts[i + 1])
+            mx, my = n1[0] + n2[0], n1[1] + n2[1]
+            mlen = (mx * mx + my * my) ** 0.5
+            if mlen == 0:
+                nx, ny = n1
+            else:
+                # Scale by 1/cos(half-angle) so the offset path keeps a
+                # constant perpendicular distance through the corner.
+                nx, ny = mx / mlen, my / mlen
+                cos_half = nx * n1[0] + ny * n1[1]
+                if cos_half > 1e-6:
+                    nx, ny = nx / cos_half, ny / cos_half
+        out.append((pts[i][0] + nx * offset, pts[i][1] + ny * offset))
+    return out
+
+
+def _draw_ribbon(
+    d: draw.Drawing,
+    pts: list[tuple[float, float]],
+    route: RoutedPath,
+    breaks: list[BridgeBreak] | None,
+    color: str,
+    width: float,
+    style_kw: dict[str, str],
+    class_name: str,
+    theme: Theme,
+    curve_radius: float,
+) -> None:
+    """Draw a single coloured ribbon for a route at the given stroke width."""
+    if breaks:
+        _render_bridged_edge(
+            d,
+            pts,
+            route,
+            breaks,
+            color,
+            width,
+            style_kw,
+            class_name,
+            theme,
+            curve_radius,
+        )
+    elif len(pts) == 2:
+        d.append(
+            draw.Line(
+                pts[0][0],
+                pts[0][1],
+                pts[1][0],
+                pts[1][1],
                 stroke=color,
-                stroke_width=theme.line_width,
-                fill="none",
+                stroke_width=width,
                 stroke_linecap="round",
-                stroke_linejoin="round",
                 class_=class_name,
                 **{"data-line-id": route.line_id},
                 **style_kw,
             )
-            path.M(*pts[0])
+        )
+    elif len(pts) >= 3:
+        path = draw.Path(
+            stroke=color,
+            stroke_width=width,
+            fill="none",
+            stroke_linecap="round",
+            stroke_linejoin="round",
+            class_=class_name,
+            **{"data-line-id": route.line_id},
+            **style_kw,
+        )
+        path.M(*pts[0])
 
-            resolved = resolve_curve_radii(
-                pts, route.curve_radii, default_radius=curve_radius
-            )
-            before, after, curved = _curve_tangents(pts, resolved)
+        resolved = resolve_curve_radii(
+            pts, route.curve_radii, default_radius=curve_radius
+        )
+        before, after, curved = _curve_tangents(pts, resolved)
 
-            for i in range(1, len(pts) - 1):
-                if curved[i]:
-                    path.L(*before[i])
-                    path.Q(pts[i][0], pts[i][1], *after[i])
-                else:
-                    path.L(*pts[i])
+        for i in range(1, len(pts) - 1):
+            if curved[i]:
+                path.L(*before[i])
+                path.Q(pts[i][0], pts[i][1], *after[i])
+            else:
+                path.L(*pts[i])
 
-            path.L(*pts[-1])
-            d.append(path)
+        path.L(*pts[-1])
+        d.append(path)
 
 
 def _curve_tangents(
@@ -844,6 +957,7 @@ def _render_bridged_edge(
     route: RoutedPath,
     breaks: list[BridgeBreak],
     color: str,
+    width: float,
     style_kw: dict[str, str],
     class_name: str,
     theme: Theme,
@@ -861,7 +975,7 @@ def _render_bridged_edge(
 
     path = draw.Path(
         stroke=color,
-        stroke_width=theme.line_width,
+        stroke_width=width,
         fill="none",
         stroke_linecap="round",
         stroke_linejoin="round",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -72,6 +72,33 @@ def test_parse_lines():
     assert graph.lines["alt"].color == "#0000ff"
 
 
+def test_parse_single_color_line_not_striped():
+    text = "%%metro line: main | Main Line | #ff0000\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    line = graph.lines["main"]
+    assert line.colors == ["#ff0000"]
+    assert line.color == "#ff0000"
+    assert line.is_striped is False
+
+
+def test_parse_multi_color_striped_line():
+    text = "%%metro line: pair | Tumor-normal | #d62728,#0570b0\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    line = graph.lines["pair"]
+    assert line.colors == ["#d62728", "#0570b0"]
+    # color keeps the first colour for single-colour callers.
+    assert line.color == "#d62728"
+    assert line.is_striped is True
+
+
+def test_parse_multi_color_striped_line_with_style():
+    text = "%%metro line: pair | Pair | #d62728, #0570b0 | dashed\ngraph LR\n"
+    graph = parse_metro_mermaid(text)
+    line = graph.lines["pair"]
+    assert line.colors == ["#d62728", "#0570b0"]
+    assert line.style == "dashed"
+
+
 def test_parse_line_style_dashed():
     text = "%%metro line: opt | Optional | #aaaaaa | dashed\ngraph LR\n"
     graph = parse_metro_mermaid(text)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -109,6 +109,39 @@ def test_render_solid_line_no_dasharray():
     assert "stroke-dasharray" not in svg
 
 
+def test_render_striped_line_draws_both_colors():
+    """A multi-colour line paints a ribbon of each colour (#529)."""
+    graph = parse_metro_mermaid(
+        "%%metro title: Stripe Test\n"
+        "%%metro line: pair | Pair | #d62728,#0570b0\n"
+        "graph LR\n"
+        "    a[Input]\n"
+        "    b[Output]\n"
+        "    a -->|pair| b\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    # Both ribbon colours present (edge ribbons + legend swatch).
+    assert svg.count("#d62728") >= 2
+    assert svg.count("#0570b0") >= 2
+
+
+def test_render_single_color_line_one_stroke():
+    """A single-colour line still paints exactly one stroke per route+swatch."""
+    graph = parse_metro_mermaid(
+        "%%metro title: Solo Test\n"
+        "%%metro line: main | Main | #abcdef\n"
+        "graph LR\n"
+        "    a[Input]\n"
+        "    b[Output]\n"
+        "    a -->|main| b\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    # One edge stroke + one legend swatch.
+    assert svg.count("#abcdef") == 2
+
+
 def test_render_empty_graph():
     graph = parse_metro_mermaid("graph LR\n")
     svg = render_svg(graph, NFCORE_THEME)


### PR DESCRIPTION
## Summary

Adds a striped / composite multi-colour line style: a line's colour may now be a comma-separated list, and the line renders as two (or more) parallel adjacent coloured ribbons instead of a single stroke. This gives the nf-core/sarek "tumor-normal pair" look (red + blue side by side).

```
%%metro line: pair | Tumor-normal pair | #d62728,#0570b0
```

## What changed

- **Model** (`parser/model.py`): `MetroLine` gains a `colors: list[str]` field and an `is_striped` property. `color` continues to hold the first colour for single-colour callers; `__post_init__` keeps the two in sync.
- **Parser** (`parser/mermaid.py`): the colour field of a `%%metro line:` directive is split on commas into `colors`.
- **Render** (`render/svg.py`): each route is painted once per colour, offset perpendicular to the routed path so the ribbons run parallel. A single-colour line takes the zero-offset, full-width path and is unchanged. Each ribbon is `STRIPE_RIBBON_WIDTH_RATIO` of the normal line width, with ribbons centred edge-to-edge on the route.
- **Legend** (`render/legend.py`): a striped line's swatch is drawn as the matching stack of parallel coloured segments.
- **Demo fixture** `examples/striped_line.mmd`: a small somatic variant-calling pipeline where the tumor (red) and normal (blue) samples run on their own separate single-colour routes through per-sample prep, then converge into a striped tumor-normal pair line through paired somatic calling. Routing the single lines apart from the stripe makes the composite unambiguous. Registered in `scripts/build_gallery.py` for the render preview.
- Tests for the multi-colour parse and the striped/single render paths.

Single-colour lines render exactly as before; the existing gallery is byte-identical (verified by rendering `rnaseq_auto` and `genomic_pipeline` against `main`).

## Limitations

- The perpendicular offset is a simple constant-distance approximation applied to the already-routed path (vertex normals scaled by `1/cos(half-angle)` to keep spacing through corners). It is not a full routing-offset rework. On tight corners the ribbons can converge slightly. The demo's ribbons are straight/horizontal so stay cleanly parallel.

Closes #529

