### PR TITLE
Opt-in rail mode: parallel rails with spanning stations

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -436,7 +436,7 @@ These go at the top of the file, before `graph LR`.
 | `%%metro compact_offsets: true` | Compact line offsets within stations (see below) |
 | `%%metro center_ports: true` | Centre inter-section ports on the shorter of the two connected sections, so lines enter/exit at the visual midpoint. Overridden by the `--center-ports` / `--no-center-ports` CLI flag. |
 | `%%metro legend_min_height: <pixels>` | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
-| `%%metro rail_mode: true` | Lay the whole graph out as fixed parallel rails with spanning pills (see below) |
+| `%%metro rail_mode: true` | Lay the whole graph out as fixed parallel rails with interchange-style stations (see below) |
 | `%%metro rail_section: <id>[, <id>...]` | Lay only the listed section(s) out in rail mode; the rest of the map uses normal layout (repeatable) |
 
 **Compact offsets.** By default, each line reserves a fixed vertical slot across the whole map based on its declaration order. If you define three lines, every station that carries even one of them is sized to fit all three. This keeps bundles visually consistent but wastes space when most stations only carry one or two lines.
@@ -453,7 +453,7 @@ With `%%metro compact_offsets: true`, stations are only as wide as the lines act
 
 This pairs naturally with the `file:` / `files:` / `dir:` icon directives - the lifted stations are usually file terminals. The [`off_track_convergence`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/topologies/off_track_convergence.mmd) topology and the [differentialabundance](https://github.com/pinin4fjords/nf-metro/blob/main/examples/differentialabundance.mmd) example both use it.
 
-**Rail mode.** In normal layout a station shared by several lines is a single point and the lines converge to it. *Rail mode* instead gives each line a fixed, evenly-spaced horizontal rail and renders a multi-line station as one vertical pill spanning the rails it serves - the rails never converge (the nf-core/sarek "Example analysis pathways" subway idiom). Turn it on for the whole map with `%%metro rail_mode: true` (see the [`rail_mode`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/rail_mode.mmd) example).
+**Rail mode.** In normal layout a station shared by several lines is a single point and the lines converge to it. *Rail mode* instead gives each line a fixed, evenly-spaced horizontal rail and renders a multi-line station as the classic metro interchange: a white circle on each rail the station uses, joined by a straight connector segment - the rails never converge (the nf-core/sarek "Example analysis pathways" subway idiom). Station labels alternate above and below the rails so dense runs stay readable. Turn it on for the whole map with `%%metro rail_mode: true` (see the [`rail_mode`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/rail_mode.mmd) example).
 
 To mix the two styles in one map, mark individual sections instead:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -436,6 +436,8 @@ These go at the top of the file, before `graph LR`.
 | `%%metro compact_offsets: true` | Compact line offsets within stations (see below) |
 | `%%metro center_ports: true` | Centre inter-section ports on the shorter of the two connected sections, so lines enter/exit at the visual midpoint. Overridden by the `--center-ports` / `--no-center-ports` CLI flag. |
 | `%%metro legend_min_height: <pixels>` | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
+| `%%metro rail_mode: true` | Lay the whole graph out as fixed parallel rails with spanning pills (see below) |
+| `%%metro rail_section: <id>[, <id>...]` | Lay only the listed section(s) out in rail mode; the rest of the map uses normal layout (repeatable) |
 
 **Compact offsets.** By default, each line reserves a fixed vertical slot across the whole map based on its declaration order. If you define three lines, every station that carries even one of them is sized to fit all three. This keeps bundles visually consistent but wastes space when most stations only carry one or two lines.
 
@@ -450,6 +452,16 @@ With `%%metro compact_offsets: true`, stations are only as wide as the lines act
 ```
 
 This pairs naturally with the `file:` / `files:` / `dir:` icon directives - the lifted stations are usually file terminals. The [`off_track_convergence`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/topologies/off_track_convergence.mmd) topology and the [differentialabundance](https://github.com/pinin4fjords/nf-metro/blob/main/examples/differentialabundance.mmd) example both use it.
+
+**Rail mode.** In normal layout a station shared by several lines is a single point and the lines converge to it. *Rail mode* instead gives each line a fixed, evenly-spaced horizontal rail and renders a multi-line station as one vertical pill spanning the rails it serves - the rails never converge (the nf-core/sarek "Example analysis pathways" subway idiom). Turn it on for the whole map with `%%metro rail_mode: true` (see the [`rail_mode`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/rail_mode.mmd) example).
+
+To mix the two styles in one map, mark individual sections instead:
+
+```text
+%%metro rail_section: pathways
+```
+
+The named section is laid out as parallel rails while every other section keeps the normal converging-trunk layout, and ordinary section placement positions both. This suits a connected processing trunk alongside a separate, disconnected analysis panel (see the [`rail_section`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/rail_section.mmd) example). Inter-section edges into or out of a rail section are not yet supported - a rail section should be self-contained.
 
 ### Section directives
 

--- a/examples/rail_mode.mmd
+++ b/examples/rail_mode.mmd
@@ -5,28 +5,41 @@
 %%metro line: haplotypecaller | HaplotypeCaller (GATK) | #0570b0
 %%metro line: strelka | Strelka2 | #e63946
 %%metro legend: bl
+%%metro file: cram_in | CRAM
+%%metro file: samples_csv | CSV | Samples
+%%metro file: vcf_out | VCF
+%%metro off_track: samples_csv
 
 graph LR
-    subgraph calling [Example analysis pathways]
+    subgraph calling [Variant calling]
+        cram_in[ ]
         align[Alignment]
         markdup[Mark duplicates]
         bqsr[BQSR]
+        samples_csv[ ]
         dv[DeepVariant]
         hc[HaplotypeCaller]
         strelka_call[Strelka2]
-        norm[Normalize]
-        vep[Annotate]
+        concord[SNP concordance]
 
+        cram_in -->|deepvariant,haplotypecaller,strelka| align
         align -->|deepvariant,haplotypecaller,strelka| markdup
         markdup -->|deepvariant,haplotypecaller,strelka| bqsr
+        samples_csv -->|haplotypecaller| bqsr
 
         bqsr -->|deepvariant| dv
         bqsr -->|haplotypecaller| hc
         bqsr -->|strelka| strelka_call
 
-        dv -->|deepvariant| norm
-        hc -->|haplotypecaller| norm
-        strelka_call -->|strelka| norm
+        dv -->|deepvariant| concord
+        strelka_call -->|strelka| concord
+    end
+
+    subgraph annotate [Annotation and output]
+        norm[Normalize]
+        vep[Annotate]
+        vcf_out[ ]
 
         norm -->|deepvariant,haplotypecaller,strelka| vep
+        vep -->|deepvariant,haplotypecaller,strelka| vcf_out
     end

--- a/examples/rail_mode.mmd
+++ b/examples/rail_mode.mmd
@@ -1,10 +1,12 @@
-%%metro title: Rail mode: variant-calling pathways
+%%metro title: Rail mode: variant-calling sample routes
 %%metro style: dark
 %%metro rail_mode: true
 %%metro label_angle: 45
-%%metro line: deepvariant | DeepVariant | #2db572
-%%metro line: haplotypecaller | HaplotypeCaller (GATK) | #0570b0
-%%metro line: strelka | Strelka2 | #e63946
+%%metro line: germline | Germline | #2db572
+%%metro line: tumor_only | Tumour-only | #f4a300
+%%metro line: pair_n | Pair (normal) | #0570b0
+%%metro line: pair_t | Pair (tumour) | #e63946
+%%metro legend_combo: pair_n, pair_t | Tumour-normal pair
 %%metro legend: bl
 %%metro file: cram_in | CRAM
 %%metro file: samples_csv | CSV | Samples
@@ -18,22 +20,19 @@ graph LR
         markdup[Mark duplicates]
         bqsr[BQSR]
         samples_csv[ ]
-        dv[DeepVariant]
-        hc[HaplotypeCaller]
-        strelka_call[Strelka2]
-        concord[SNP concordance]
+        callvar[Call variants]
+        somatic[Somatic filter]
+        concord[Concordance]
 
-        cram_in -->|deepvariant,haplotypecaller,strelka| align
-        align -->|deepvariant,haplotypecaller,strelka| markdup
-        markdup -->|deepvariant,haplotypecaller,strelka| bqsr
-        samples_csv -->|haplotypecaller| bqsr
+        cram_in -->|germline,tumor_only,pair_n,pair_t| align
+        align -->|germline,tumor_only,pair_n,pair_t| markdup
+        markdup -->|germline,tumor_only,pair_n,pair_t| bqsr
+        samples_csv -->|pair_n,pair_t| bqsr
 
-        bqsr -->|deepvariant| dv
-        bqsr -->|haplotypecaller| hc
-        bqsr -->|strelka| strelka_call
-
-        dv -->|deepvariant| concord
-        strelka_call -->|strelka| concord
+        bqsr -->|germline,tumor_only,pair_n,pair_t| callvar
+        callvar -->|tumor_only,pair_n,pair_t| somatic
+        callvar -->|germline| concord
+        somatic -->|pair_n,pair_t| concord
     end
 
     subgraph annotate [Annotation and output]
@@ -41,6 +40,6 @@ graph LR
         vep[Annotate]
         vcf_out[ ]
 
-        norm -->|deepvariant,haplotypecaller,strelka| vep
-        vep -->|deepvariant,haplotypecaller,strelka| vcf_out
+        norm -->|germline,tumor_only,pair_n,pair_t| vep
+        vep -->|germline,tumor_only,pair_n,pair_t| vcf_out
     end

--- a/examples/rail_mode.mmd
+++ b/examples/rail_mode.mmd
@@ -1,6 +1,7 @@
 %%metro title: Rail mode: variant-calling pathways
 %%metro style: dark
 %%metro rail_mode: true
+%%metro label_angle: 45
 %%metro line: deepvariant | DeepVariant | #2db572
 %%metro line: haplotypecaller | HaplotypeCaller (GATK) | #0570b0
 %%metro line: strelka | Strelka2 | #e63946

--- a/examples/rail_mode.mmd
+++ b/examples/rail_mode.mmd
@@ -1,0 +1,32 @@
+%%metro title: Rail mode: variant-calling pathways
+%%metro style: dark
+%%metro rail_mode: true
+%%metro line: deepvariant | DeepVariant | #2db572
+%%metro line: haplotypecaller | HaplotypeCaller (GATK) | #0570b0
+%%metro line: strelka | Strelka2 | #e63946
+%%metro legend: bl
+
+graph LR
+    subgraph calling [Example analysis pathways]
+        align[Alignment]
+        markdup[Mark duplicates]
+        bqsr[BQSR]
+        dv[DeepVariant]
+        hc[HaplotypeCaller]
+        strelka_call[Strelka2]
+        norm[Normalize]
+        vep[Annotate]
+
+        align -->|deepvariant,haplotypecaller,strelka| markdup
+        markdup -->|deepvariant,haplotypecaller,strelka| bqsr
+
+        bqsr -->|deepvariant| dv
+        bqsr -->|haplotypecaller| hc
+        bqsr -->|strelka| strelka_call
+
+        dv -->|deepvariant| norm
+        hc -->|haplotypecaller| norm
+        strelka_call -->|strelka| norm
+
+        norm -->|deepvariant,haplotypecaller,strelka| vep
+    end

--- a/examples/rail_section.mmd
+++ b/examples/rail_section.mmd
@@ -1,0 +1,61 @@
+%%metro title: Mixed mode: connected trunk + rail panel
+%%metro style: dark
+%%metro line: dna | DNA workflow | #0570b0
+%%metro line: rna | RNA workflow | #2db572
+%%metro line: deepvariant | DeepVariant | #2db572
+%%metro line: haplotypecaller | HaplotypeCaller | #0570b0
+%%metro line: strelka | Strelka2 | #e63946
+%%metro legend: bl
+%%metro file: reads_in | FASTQ
+%%metro file: report_out | Report
+
+%%metro rail_section: pathways
+
+%%metro grid: preprocess | 0,0
+%%metro grid: calling | 1,0
+%%metro grid: annotate | 2,0
+%%metro grid: pathways | 0,1
+
+graph LR
+    subgraph preprocess [Pre-processing]
+        reads_in[ ]
+        trim[Trim adapters]
+        align[Align]
+
+        reads_in -->|dna,rna| trim
+        trim -->|dna,rna| align
+    end
+
+    subgraph calling [Variant calling]
+        markdup[Mark duplicates]
+        bqsr[BQSR]
+        callvar[Call variants]
+
+        markdup -->|dna,rna| bqsr
+        bqsr -->|dna,rna| callvar
+    end
+
+    subgraph annotate [Annotation]
+        norm[Normalize]
+        vep[Annotate]
+        report_out[ ]
+
+        norm -->|dna,rna| vep
+        vep -->|dna,rna| report_out
+    end
+
+    align -->|dna,rna| markdup
+    callvar -->|dna,rna| norm
+
+    subgraph pathways [Pathway analysis]
+        gene_in[Gene sets]
+        score[Score]
+        enrich[Enrichment]
+        summary[Summary]
+
+        gene_in -->|deepvariant,haplotypecaller,strelka| score
+        score -->|deepvariant,haplotypecaller,strelka| enrich
+        enrich -->|deepvariant| summary
+        enrich -->|haplotypecaller| summary
+        enrich -->|strelka| summary
+    end

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -107,6 +107,15 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "stacking each section in its own grid row. Regression fixture for "
         "#250 (cross-column junction routes were going backward in X).",
     ),
+    (
+        "rail_mode",
+        EXAMPLES_DIR,
+        "Opt-in `%%metro rail_mode: true`: lines run as fixed parallel "
+        "horizontal rails and a station shared by several lines draws as one "
+        "vertical pill spanning those rails (the nf-core/sarek "
+        '"Example analysis pathways" subway idiom). Line-exclusive callers '
+        "sit on their own rail; the rails never converge to a point.",
+    ),
     # --- Simple topologies ---
     (
         "single_section",

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -116,6 +116,15 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         '"Example analysis pathways" subway idiom). Line-exclusive callers '
         "sit on their own rail; the rails never converge to a point.",
     ),
+    (
+        "rail_section",
+        EXAMPLES_DIR,
+        "Per-section rail mode (`%%metro rail_section: <id>`): a connected "
+        "trunk of three normal sections renders with the usual converging "
+        "metro routing, while a separate disconnected panel is laid out as "
+        "parallel rails with spanning pills. Mixed normal + rail layout in one "
+        "map.",
+    ),
     # --- Simple topologies ---
     (
         "single_section",

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -434,6 +434,27 @@ def compute_layout(
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y
 
+    # Per-section rail mode: the normal pipeline has positioned every
+    # section's bbox and inter-section ports.  Now overwrite the *internal*
+    # geometry of each rail-flagged section with the rail-mode layout (rails
+    # + spanning pills), anchored at the bbox the placement chose.  Non-rail
+    # sections and all inter-section placement keep the normal machinery.
+    if graph.rail_sections and not graph.rail_mode:
+        from nf_metro.layout.rail_mode import retrofit_section_rails
+
+        for sid in graph.rail_sections:
+            section = graph.sections.get(sid)
+            if section is None:
+                continue
+            retrofit_section_rails(
+                graph,
+                section,
+                x_spacing=x_spacing,
+                y_spacing=y_spacing,
+                section_x_padding=section_x_padding,
+                section_y_padding=section_y_padding,
+            )
+
     # Always-on backstop (independent of ``validate``): the settled layout
     # must never leave a station outside its own section bbox.  Runs on the
     # render path so an unsupported directive combination fails loudly

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -353,6 +353,27 @@ def compute_layout(
     # Off by default: when unset, each _snap call is a single attribute read.
     graph._phase_snapshots_enabled = phase_snapshots_enabled()
 
+    # Opt-in rail mode runs a dedicated, self-contained layout pipeline and
+    # returns early so the normal phase pipeline below is never touched when
+    # rail mode is off (default).  See layout/rail_mode.py.
+    if graph.rail_mode:
+        from nf_metro.layout.rail_mode import compute_rail_layout
+
+        rail_y = y_spacing if y_spacing is not None else compute_min_y_spacing(graph)
+        rail_x = x_spacing if x_spacing is not None else X_SPACING
+        compute_rail_layout(
+            graph,
+            x_spacing=rail_x,
+            y_spacing=rail_y,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+            section_y_gap=section_y_gap,
+        )
+        _guard_stations_within_bbox(graph, "final")
+        return
+
     auto_x = x_spacing is None
     auto_y = y_spacing is None
     if y_spacing is None:

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -72,6 +72,19 @@ class LabelPlacement:
     obstacle_bbox: tuple[float, float, float, float] | None = None
 
 
+def _rail_span_offsets(station: "Station") -> tuple[float, float] | None:
+    """Return (min_off, max_off) of a rail-mode spanning station's pill.
+
+    In rail mode a multi-line station's pill spans from ``rail_top_y`` to
+    ``rail_bottom_y``; offsetting a label from those edges (rather than from
+    ``station.y`` at the pill centre) keeps the label clear of every rail the
+    pill crosses.  Returns None for non-rail / single-rail stations.
+    """
+    if station.rail_top_y is None or station.rail_bottom_y is None:
+        return None
+    return (station.rail_top_y - station.y, station.rail_bottom_y - station.y)
+
+
 def _label_bbox(
     placement: LabelPlacement,
 ) -> tuple[float, float, float, float]:
@@ -468,6 +481,9 @@ def _trial_cost(
             max_off = max(line_offs) if line_offs else 0.0
         else:
             min_off = max_off = 0.0
+        rail_span = _rail_span_offsets(station)
+        if rail_span is not None:
+            min_off, max_off = rail_span
 
         start_above = station.layer % 2 == 1
         if flip:
@@ -651,6 +667,9 @@ def place_labels(
             max_off = max(line_offs) if line_offs else 0.0
         else:
             min_off = max_off = 0.0
+        rail_span = _rail_span_offsets(station)
+        if rail_span is not None:
+            min_off, max_off = rail_span
 
         # Check if this is a TB section station (horizontal pill)
         is_tb_vert = False

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -85,6 +85,54 @@ def _rail_span_offsets(station: "Station") -> tuple[float, float] | None:
     return (station.rail_top_y - station.y, station.rail_bottom_y - station.y)
 
 
+def _rail_panel_extents(graph: "MetroGraph") -> dict[str, tuple[float, float]]:
+    """Per-rail-section (top_rail_y, bottom_rail_y) from the rail Y map.
+
+    Used to offset rail-mode station labels to the whole panel's outer edge
+    so a label always clears every rail rather than landing between two of
+    them.  Returns an empty map when the graph has no rail sections.
+    """
+    rail_y = getattr(graph, "_rail_y", None)
+    extents: dict[str, tuple[float, float]] = {}
+    if not rail_y:
+        return extents
+    for sec_id, per_line in rail_y.items():
+        if not per_line:
+            continue
+        ys = list(per_line.values())
+        extents[sec_id] = (min(ys), max(ys))
+    return extents
+
+
+def _rail_label_side(
+    station: "Station",
+    panel_extents: dict[str, tuple[float, float]],
+) -> bool | None:
+    """Forced above/below side for a rail-mode single-rail station label.
+
+    A label sitting between two rails reads as noise in the bundle, so each
+    single-rail station's label is pushed *outward*: a station on (or above)
+    the panel's mid-line labels above its own rail, one below the mid-line
+    labels below.  This keeps a column of single-rail stations from stacking
+    their labels on one panel edge while still avoiding the inter-rail gaps.
+    Returns True (above) / False (below), or None when the rule doesn't apply
+    (non-rail section, or a multi-rail spanning station which uses its span).
+    """
+    if not station.section_id:
+        return None
+    if station.rail_top_y is not None and station.rail_bottom_y is not None:
+        return None  # spanning pill: handled by _rail_span_offsets
+    extent = panel_extents.get(station.section_id)
+    if extent is None:
+        return None
+    top_y, bot_y = extent
+    mid = (top_y + bot_y) / 2
+    # Top-half rails label above their own rail, bottom-half below.  The
+    # mid rail (== mid) defaults to below so it never overlaps a top-rail
+    # label that drops down into the gap.
+    return station.y < mid - 0.5
+
+
 def _label_bbox(
     placement: LabelPlacement,
 ) -> tuple[float, float, float, float]:
@@ -450,6 +498,7 @@ def _trial_cost(
     flip: bool,
     icon_obstacles: list[tuple[float, float, float, float]] | None = None,
     port_pref: dict[str, bool] | None = None,
+    panel_extents: dict[str, tuple[float, float]] | None = None,
 ) -> float:
     """Count label collision cost for a section using the given alternation.
 
@@ -489,6 +538,12 @@ def _trial_cost(
         if flip:
             start_above = not start_above
 
+        rail_side = (
+            _rail_label_side(station, panel_extents)
+            if panel_extents is not None
+            else None
+        )
+
         start_above = _apply_edge_override(
             station,
             start_above,
@@ -499,6 +554,9 @@ def _trial_cost(
 
         if port_pref and station.id in port_pref:
             start_above = port_pref[station.id]
+
+        if rail_side is not None:
+            start_above = rail_side
 
         candidate = _try_place(
             station, label_offset, start_above, placements, min_off, max_off
@@ -621,6 +679,10 @@ def place_labels(
     # off-Y ports, so labels avoid overlapping diagonal port routes.
     port_pref = _compute_port_label_preference(graph, max_dx=PORT_LABEL_MAX_DX)
 
+    # Rail-mode panels: offset labels to the whole panel's outer edge so they
+    # alternate above the top rail / below the bottom rail (never between rails).
+    panel_extents = _rail_panel_extents(graph)
+
     # Trial both alternation patterns per section, pick the better one.
     section_flip: dict[str, bool] = {}
     sec_groups: dict[str, list[Station]] = {}
@@ -639,10 +701,18 @@ def place_labels(
             sections_with_multiline,
         )
         cost_default = _trial_cost(
-            *args, flip=False, icon_obstacles=icon_obstacles, port_pref=port_pref
+            *args,
+            flip=False,
+            icon_obstacles=icon_obstacles,
+            port_pref=port_pref,
+            panel_extents=panel_extents,
         )
         cost_flipped = _trial_cost(
-            *args, flip=True, icon_obstacles=icon_obstacles, port_pref=port_pref
+            *args,
+            flip=True,
+            icon_obstacles=icon_obstacles,
+            port_pref=port_pref,
+            panel_extents=panel_extents,
         )
         if cost_flipped < cost_default:
             section_flip[sec_id] = True
@@ -670,6 +740,7 @@ def place_labels(
         rail_span = _rail_span_offsets(station)
         if rail_span is not None:
             min_off, max_off = rail_span
+        rail_side = _rail_label_side(station, panel_extents)
 
         # Check if this is a TB section station (horizontal pill)
         is_tb_vert = False
@@ -741,6 +812,12 @@ def place_labels(
         # Override when a port route would clash with the label.
         if station.id in port_pref:
             start_above = port_pref[station.id]
+
+        # Rail mode: force single-rail labels outward (above their own rail in
+        # the top half, below in the bottom half) so they never sit between
+        # rails and a column of branch stations spreads its labels vertically.
+        if rail_side is not None:
+            start_above = rail_side
 
         safe_above, safe_below = safe_offsets.get(
             station.id, (label_offset, label_offset)

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -72,19 +72,6 @@ class LabelPlacement:
     obstacle_bbox: tuple[float, float, float, float] | None = None
 
 
-def _rail_span_offsets(station: "Station") -> tuple[float, float] | None:
-    """Return (min_off, max_off) of a rail-mode spanning station's pill.
-
-    In rail mode a multi-line station's pill spans from ``rail_top_y`` to
-    ``rail_bottom_y``; offsetting a label from those edges (rather than from
-    ``station.y`` at the pill centre) keeps the label clear of every rail the
-    pill crosses.  Returns None for non-rail / single-rail stations.
-    """
-    if station.rail_top_y is None or station.rail_bottom_y is None:
-        return None
-    return (station.rail_top_y - station.y, station.rail_bottom_y - station.y)
-
-
 def _rail_panel_extents(graph: "MetroGraph") -> dict[str, tuple[float, float]]:
     """Per-rail-section (top_rail_y, bottom_rail_y) from the rail Y map.
 
@@ -110,27 +97,50 @@ def _rail_label_side(
 ) -> bool | None:
     """Forced above/below side for a rail-mode single-rail station label.
 
-    A label sitting between two rails reads as noise in the bundle, so each
-    single-rail station's label is pushed *outward*: a station on (or above)
-    the panel's mid-line labels above its own rail, one below the mid-line
-    labels below.  This keeps a column of single-rail stations from stacking
-    their labels on one panel edge while still avoiding the inter-rail gaps.
-    Returns True (above) / False (below), or None when the rule doesn't apply
-    (non-rail section, or a multi-rail spanning station which uses its span).
+    A label beside a middle rail reads as noise in the bundle, so each
+    single-rail station's label is pushed *outward* to the panel edge (see
+    ``_rail_panel_label_offsets``): a station in the panel's top half labels
+    above (clearing the topmost rail), one in the bottom half labels below
+    (clearing the bottommost rail).  Splitting by half keeps a column of
+    single-rail stations from stacking every label on one panel edge.  Returns
+    True (above) / False (below), or None when the rule doesn't apply (non-rail
+    section, or a multi-rail spanning station which keeps layer alternation).
     """
     if not station.section_id:
         return None
     if station.rail_top_y is not None and station.rail_bottom_y is not None:
-        return None  # spanning pill: handled by _rail_span_offsets
+        return None  # spanning pill: keeps layer alternation
     extent = panel_extents.get(station.section_id)
     if extent is None:
         return None
     top_y, bot_y = extent
     mid = (top_y + bot_y) / 2
-    # Top-half rails label above their own rail, bottom-half below.  The
-    # mid rail (== mid) defaults to below so it never overlaps a top-rail
-    # label that drops down into the gap.
+    # Top-half rails label above (out the top of the panel), bottom-half below.
+    # The mid rail (== mid) defaults to below so it never collides with a
+    # top-half label dropping into the panel.
     return station.y < mid - 0.5
+
+
+def _rail_panel_label_offsets(
+    station: "Station",
+    panel_extents: dict[str, tuple[float, float]],
+) -> tuple[float, float] | None:
+    """Label offsets (min_off, max_off) clearing the WHOLE rail panel.
+
+    A rail-mode label must never sit beside a middle rail: an above label has
+    to clear the panel's topmost rail and a below label its bottommost rail,
+    whatever rail(s) the station itself occupies.  Returns offsets measured
+    from ``station.y`` to the panel's top/bottom rail (so ``_try_place`` lands
+    the label outside the rail stack), or None when the station is not in a
+    known rail panel.
+    """
+    if not station.section_id:
+        return None
+    extent = panel_extents.get(station.section_id)
+    if extent is None:
+        return None
+    top_y, bot_y = extent
+    return (top_y - station.y, bot_y - station.y)
 
 
 def _label_bbox(
@@ -530,9 +540,13 @@ def _trial_cost(
             max_off = max(line_offs) if line_offs else 0.0
         else:
             min_off = max_off = 0.0
-        rail_span = _rail_span_offsets(station)
-        if rail_span is not None:
-            min_off, max_off = rail_span
+        rail_panel = (
+            _rail_panel_label_offsets(station, panel_extents)
+            if panel_extents is not None
+            else None
+        )
+        if rail_panel is not None:
+            min_off, max_off = rail_panel
 
         start_above = station.layer % 2 == 1
         if flip:
@@ -737,9 +751,9 @@ def place_labels(
             max_off = max(line_offs) if line_offs else 0.0
         else:
             min_off = max_off = 0.0
-        rail_span = _rail_span_offsets(station)
-        if rail_span is not None:
-            min_off, max_off = rail_span
+        rail_panel = _rail_panel_label_offsets(station, panel_extents)
+        if rail_panel is not None:
+            min_off, max_off = rail_panel
         rail_side = _rail_label_side(station, panel_extents)
 
         # Check if this is a TB section station (horizontal pill)

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -937,7 +937,40 @@ def place_labels(
         placements, graph, station_offsets, allow_hyphenation=allow_hyphenation
     )
 
+    if graph.label_angle:
+        _apply_rail_label_angle(placements, graph, float(graph.label_angle))
+
     return [p for p in placements if p.obstacle_bbox is None]
+
+
+def _apply_rail_label_angle(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+    label_angle: float,
+) -> None:
+    """Tilt rail-section station labels by *label_angle* degrees.
+
+    Only rail-mode panels are affected (the normal layout path has its own
+    diagonal-label machinery).  An angled label is anchored at the pill X and
+    its current vertical offset and rotated about that anchor with
+    ``text-anchor=start`` so the tilted text trails away from the station;
+    the rail column step is sized for the rotated label's horizontal
+    projection by ``_label_aware_x_spacing`` so the panel packs tighter.
+    """
+    for p in placements:
+        if p.obstacle_bbox is not None or not p.station_id:
+            continue
+        st = graph.stations.get(p.station_id)
+        if st is None or st.is_port:
+            continue
+        if not (st.section_id and graph.is_rail_section(st.section_id)):
+            continue
+        # Blank termini render as icons, not text; leave them alone.
+        if st.is_terminus and not st.label.strip():
+            continue
+        p.angle = label_angle
+        p.text_anchor = "start"
+        p.x = st.x
 
 
 # Upper bound on wrapping rounds.  Each round narrows one offending label by

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -1,0 +1,261 @@
+"""Opt-in "rail mode" layout (the nf-core/sarek subway idiom).
+
+In normal layout a station shared by several metro lines is a single point
+and the lines converge (bundle) to that one Y.  Rail mode instead lays each
+line out as a fixed, evenly-spaced horizontal *rail* across the section and
+renders a multi-line station as one vertical *pill* spanning the rails it
+serves.  The rails do not converge: a line runs straight along its rail and
+only the station pill bridges across rails.
+
+This module is a self-contained pipeline, run by ``compute_layout`` only when
+``MetroGraph.rail_mode`` is True, so the normal layout path is untouched.
+
+Scope (MVP): LR sections.  Each section's lines get rails centred about the
+section trunk Y; stations are placed by longest-path layer (X) and anchored to
+span their lines' rail range (Y).  Sections are stacked vertically in grid-row
+order.  Ports/junctions are positioned at their connecting rail Y so that the
+dedicated rail-mode router (see ``routing/rail.py``) can draw straight rails.
+"""
+
+from __future__ import annotations
+
+__all__ = ["compute_rail_layout"]
+
+from nf_metro.layout.constants import (
+    SECTION_HEADER_PROTRUSION,
+    SECTION_X_PADDING,
+    SECTION_Y_GAP,
+    SECTION_Y_PADDING,
+    X_OFFSET,
+    X_SPACING,
+    Y_OFFSET,
+)
+from nf_metro.parser.model import MetroGraph, PortSide, Section
+
+
+def _section_lines_in_order(graph: MetroGraph, section: Section) -> list[str]:
+    """Lines present in *section*, ordered by line-definition priority.
+
+    A line is "present" if any of the section's stations carry it.  Ports
+    and junctions don't define which lines belong to the section's rail
+    set on their own, so they're excluded here.
+    """
+    present: set[str] = set()
+    for sid in section.station_ids:
+        st = graph.stations.get(sid)
+        if st is None or st.is_port:
+            continue
+        present.update(graph.station_lines(sid))
+    return [lid for lid in graph.lines if lid in present]
+
+
+def _station_lines_in_order(graph: MetroGraph, station_id: str) -> list[str]:
+    """Lines on a station, in line-definition priority order."""
+    lines = set(graph.station_lines(station_id))
+    return [lid for lid in graph.lines if lid in lines]
+
+
+def compute_rail_layout(
+    graph: MetroGraph,
+    *,
+    x_spacing: float = X_SPACING,
+    y_spacing: float,
+    x_offset: float = X_OFFSET,
+    y_offset: float = Y_OFFSET,
+    section_x_padding: float = SECTION_X_PADDING,
+    section_y_padding: float = SECTION_Y_PADDING,
+    section_y_gap: float = SECTION_Y_GAP,
+) -> None:
+    """Lay the whole graph out in rail mode.
+
+    Writes ``x``/``y`` onto every station, ``rail_top_y``/``rail_bottom_y``
+    onto multi-line stations, port/junction Ys onto their connecting rail,
+    and section bboxes.  Sections stack top-to-bottom in grid-row order
+    (then by grid-col, then by section number) so the result is a vertically
+    stacked set of parallel-rail panels.
+    """
+    # Sort sections into a stable top-to-bottom reading order.  When the
+    # auto-layout / explicit grid set grid_row, honour it; otherwise fall
+    # back to declaration order via the section number.
+    sections = [
+        s for s in graph.sections.values() if not s.is_implicit or s.station_ids
+    ]
+    ordered = sorted(
+        sections,
+        key=lambda s: (
+            s.grid_row if s.grid_row >= 0 else 0,
+            s.grid_col if s.grid_col >= 0 else 0,
+            s.number,
+        ),
+    )
+
+    # Per-section rail Y maps, keyed by section id then line id.
+    rail_y: dict[str, dict[str, float]] = {}
+
+    cursor_top = y_offset
+    for section in ordered:
+        bottom = _layout_section_rails(
+            graph,
+            section,
+            rail_y,
+            x_spacing=x_spacing,
+            x_offset=x_offset,
+            section_top=cursor_top,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+            y_spacing=y_spacing,
+        )
+        cursor_top = bottom + section_y_gap
+
+    _position_ports_and_junctions(graph, rail_y)
+
+
+def _layout_section_rails(
+    graph: MetroGraph,
+    section: Section,
+    rail_y: dict[str, dict[str, float]],
+    *,
+    x_spacing: float,
+    x_offset: float,
+    section_top: float,
+    section_x_padding: float,
+    section_y_padding: float,
+    y_spacing: float,
+) -> float:
+    """Lay out one section's rails and stations; return its bbox bottom Y."""
+    lines = _section_lines_in_order(graph, section)
+    n_rails = max(1, len(lines))
+
+    # The section-number badge renders just above the bbox top edge (outside
+    # the box), so the box itself hugs content: the top rail sits exactly
+    # section_y_padding below the bbox top.  A header band above the box is
+    # reserved by advancing section_top by SECTION_HEADER_PROTRUSION before
+    # this section's bbox begins.
+    box_top = section_top + SECTION_HEADER_PROTRUSION
+    rails_top = box_top + section_y_padding
+    per_line_y = {lid: rails_top + i * y_spacing for i, lid in enumerate(lines)}
+    rail_y[section.id] = per_line_y
+
+    # X by longest-path layer over the *whole* graph restricted to this
+    # section's stations, so a station's column reflects its in-section depth.
+    layers = _section_layers(graph, section)
+
+    # Place real stations.
+    real_ids = [
+        sid
+        for sid in section.station_ids
+        if (st := graph.stations.get(sid)) is not None and not st.is_port
+    ]
+    for sid in real_ids:
+        st = graph.stations[sid]
+        layer = layers.get(sid, 0)
+        st.layer = layer
+        st.x = x_offset + section_x_padding + layer * x_spacing
+
+        st_lines = _station_lines_in_order(graph, sid)
+        ys = [per_line_y[lid] for lid in st_lines if lid in per_line_y]
+        if not ys:
+            # A station with no recognised line (shouldn't happen post-parse);
+            # park it on the first rail.
+            ys = [rails_top]
+        top_y = min(ys)
+        bot_y = max(ys)
+        st.y = (top_y + bot_y) / 2
+        st.track = 0.0
+        if len(set(ys)) > 1:
+            st.rail_top_y = top_y
+            st.rail_bottom_y = bot_y
+        else:
+            st.rail_top_y = None
+            st.rail_bottom_y = None
+
+    # Section bbox: span columns and rails with symmetric padding.
+    max_layer = max((layers.get(sid, 0) for sid in real_ids), default=0)
+    bbox_x = x_offset
+    bbox_w = section_x_padding * 2 + max_layer * x_spacing
+    rails_bottom = rails_top + (n_rails - 1) * y_spacing
+    bbox_y = box_top
+    bbox_h = section_y_padding + (rails_bottom - rails_top) + section_y_padding
+    section.bbox_x = bbox_x
+    section.bbox_y = bbox_y
+    section.bbox_w = bbox_w
+    section.bbox_h = bbox_h
+    section.direction = "LR"
+
+    return bbox_y + bbox_h
+
+
+def _section_layers(graph: MetroGraph, section: Section) -> dict[str, int]:
+    """Longest-path layers for a single section's internal real stations."""
+    import networkx as nx
+
+    station_ids = {
+        sid
+        for sid in section.station_ids
+        if (st := graph.stations.get(sid)) is not None and not st.is_port
+    }
+    sub: nx.DiGraph[str] = nx.DiGraph()
+    for sid in station_ids:
+        sub.add_node(sid)
+    for edge in graph.edges:
+        if edge.source in station_ids and edge.target in station_ids:
+            sub.add_edge(edge.source, edge.target)
+    try:
+        topo = list(nx.topological_sort(sub))
+    except nx.NetworkXUnfeasible:
+        return dict.fromkeys(station_ids, 0)
+    layers: dict[str, int] = {}
+    for node in topo:
+        preds = list(sub.predecessors(node))
+        layers[node] = max((layers[p] for p in preds), default=-1) + 1 if preds else 0
+    return layers
+
+
+def _position_ports_and_junctions(
+    graph: MetroGraph,
+    rail_y: dict[str, dict[str, float]],
+) -> None:
+    """Place ports and junctions at the rail Y of the line(s) they carry.
+
+    Ports sit on their section's boundary edge (X from the bbox) at the Y of
+    their connecting line's rail.  Junctions sit in the inter-section gap at
+    the Y of one of their lines.  This keeps the dedicated rail router's
+    inter-section legs horizontal where possible.
+    """
+    for port_id, port in graph.ports.items():
+        st = graph.stations.get(port_id)
+        if st is None:
+            continue
+        section = graph.sections.get(port.section_id)
+        per_line = rail_y.get(port.section_id, {})
+        lines = _station_lines_in_order(graph, port_id)
+        ys = [per_line[lid] for lid in lines if lid in per_line]
+        st.y = sum(ys) / len(ys) if ys else (section.bbox_y if section else 0.0)
+        if section is not None:
+            if port.side in (PortSide.LEFT,):
+                st.x = section.bbox_x
+            elif port.side in (PortSide.RIGHT,):
+                st.x = section.bbox_x + section.bbox_w
+            else:
+                st.x = section.bbox_x + section.bbox_w / 2
+        port.x = st.x
+        port.y = st.y
+
+    for jid in graph.junctions:
+        st = graph.stations.get(jid)
+        if st is None:
+            continue
+        # Place the junction midway between its predecessors and successors
+        # in X, at the average rail Y of the lines passing through it.
+        neighbours = [graph.stations.get(e.source) for e in graph.edges_to(jid)] + [
+            graph.stations.get(e.target) for e in graph.edges_from(jid)
+        ]
+        xs = [n.x for n in neighbours if n is not None]
+        st.x = sum(xs) / len(xs) if xs else 0.0
+        # Junction Y: average of its lines' rails across whichever section
+        # rail map contains them (use the target section's map if present).
+        line_ids = _station_lines_in_order(graph, jid)
+        jys: list[float] = []
+        for per_line in rail_y.values():
+            jys.extend(per_line[lid] for lid in line_ids if lid in per_line)
+        st.y = sum(jys) / len(jys) if jys else 0.0

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -107,6 +107,11 @@ def compute_rail_layout(
         )
         cursor_top = bottom + section_y_gap
 
+    # Stash the per-section rail map so the dedicated router can resolve a
+    # port's Y to its line's rail (rather than the port's stored average Y),
+    # keeping inter-section legs on the right rail per line.
+    graph._rail_y = rail_y  # type: ignore[attr-defined]
+
     _position_ports_and_junctions(graph, rail_y)
 
 
@@ -146,11 +151,32 @@ def _layout_section_rails(
         for sid in section.station_ids
         if (st := graph.stations.get(sid)) is not None and not st.is_port
     ]
+    # Off-track input stations sit ABOVE the top rail and feed in with an
+    # S-curve (see routing/rail.py), so reserve a band above the rails for
+    # them.  rails_top is shifted down by that band; the off-track band Y is
+    # computed from the original box-content top.
+    off_track_ids = [sid for sid in real_ids if graph.stations[sid].off_track]
+    off_track_band = y_spacing if off_track_ids else 0.0
+    rails_top += off_track_band
+    if off_track_band:
+        per_line_y = {lid: rails_top + i * y_spacing for i, lid in enumerate(lines)}
+        rail_y[section.id] = per_line_y
+    off_track_y = box_top + section_y_padding
+
     for sid in real_ids:
         st = graph.stations[sid]
         layer = layers.get(sid, 0)
         st.layer = layer
         st.x = x_offset + section_x_padding + layer * x_spacing
+
+        if st.off_track:
+            # Park above the rails; the router draws the S-curve feeder.
+            st.y = off_track_y
+            st.track = 0.0
+            st.rail_used_ys = []
+            st.rail_top_y = None
+            st.rail_bottom_y = None
+            continue
 
         st_lines = _station_lines_in_order(graph, sid)
         ys = [per_line_y[lid] for lid in st_lines if lid in per_line_y]
@@ -162,20 +188,35 @@ def _layout_section_rails(
         bot_y = max(ys)
         st.y = (top_y + bot_y) / 2
         st.track = 0.0
-        if len(set(ys)) > 1:
-            st.rail_top_y = top_y
-            st.rail_bottom_y = bot_y
-        else:
+        # A blank terminus (file/dir/report icon with no text label) renders
+        # as its icon at the rail convergence, so the lines meet at a single
+        # point rather than spanning a pill: no span, no per-rail knobs.
+        is_blank_terminus = st.is_terminus and not st.label.strip()
+        if is_blank_terminus:
+            st.rail_used_ys = [st.y for _ in ys]
             st.rail_top_y = None
             st.rail_bottom_y = None
+        else:
+            # Record the rails this station actually uses (in line order) so
+            # the renderer can draw a knob on each; rails that merely pass
+            # behind the pill get no knob.
+            st.rail_used_ys = list(ys)
+            if len(set(ys)) > 1:
+                st.rail_top_y = top_y
+                st.rail_bottom_y = bot_y
+            else:
+                st.rail_top_y = None
+                st.rail_bottom_y = None
 
-    # Section bbox: span columns and rails with symmetric padding.
+    # Section bbox: span columns and rails with symmetric padding.  rails_top
+    # already includes the off-track band, so the box top stays at box_top and
+    # the box height covers padding + band + rails + padding.
     max_layer = max((layers.get(sid, 0) for sid in real_ids), default=0)
     bbox_x = x_offset
     bbox_w = section_x_padding * 2 + max_layer * x_spacing
     rails_bottom = rails_top + (n_rails - 1) * y_spacing
     bbox_y = box_top
-    bbox_h = section_y_padding + (rails_bottom - rails_top) + section_y_padding
+    bbox_h = (rails_bottom - box_top) + section_y_padding
     section.bbox_x = bbox_x
     section.bbox_y = bbox_y
     section.bbox_w = bbox_w

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -333,8 +333,17 @@ def _label_aware_x_spacing(
     it plus half its neighbour (i.e. the full widest label, plus a small gap)
     keeps every label on one line while the rails stay evenly spaced.
     """
+    import math
+
     from nf_metro.layout.constants import LABEL_MARGIN
     from nf_metro.layout.labels import label_text_width
+
+    # A diagonal (angled) label's HORIZONTAL footprint is its width times
+    # cos(angle), so an angled-label panel only needs to seat that projection
+    # between columns and can pack noticeably tighter than horizontal text.
+    # Gated on angle != 0 so non-angled panels are unchanged.
+    angle = graph.label_angle or 0.0
+    h_factor = abs(math.cos(math.radians(angle))) if angle else 1.0
 
     widest = 0.0
     for sid in real_ids:
@@ -344,7 +353,7 @@ def _label_aware_x_spacing(
         # Blank termini render as icons, not text labels, so don't size to them.
         if st.is_terminus and not st.label.strip():
             continue
-        widest = max(widest, label_text_width(st.label))
+        widest = max(widest, label_text_width(st.label) * h_factor)
     if widest <= 0.0:
         return x_spacing
     return max(x_spacing, widest + LABEL_MARGIN * 2)

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -202,7 +202,10 @@ def _layout_section_rails(
 ) -> float:
     """Lay out one section's rails and stations; return its bbox bottom Y."""
     lines = _section_lines_in_order(graph, section)
-    n_rails = max(1, len(lines))
+    # Lines sharing a legend_combo collapse onto a single rail slot (a tight
+    # bundle), so the slot count - not the line count - drives rail spacing and
+    # the bbox height.  With no combos this is one slot per line as before.
+    slot_offset, _n_slots = _rail_slot_offsets(graph, lines, y_spacing)
 
     # The section-number badge renders just above the bbox top edge (outside
     # the box), so the box itself hugs content: the top rail sits exactly
@@ -211,7 +214,7 @@ def _layout_section_rails(
     # this section's bbox begins.
     box_top = section_top + SECTION_HEADER_PROTRUSION
     rails_top = box_top + section_y_padding
-    per_line_y = {lid: rails_top + i * y_spacing for i, lid in enumerate(lines)}
+    per_line_y = {lid: rails_top + slot_offset[lid] for lid in lines}
     rail_y[section.id] = per_line_y
 
     # X by longest-path layer over the *whole* graph restricted to this
@@ -239,7 +242,7 @@ def _layout_section_rails(
     off_track_band = y_spacing if off_track_ids else 0.0
     rails_top += off_track_band
     if off_track_band:
-        per_line_y = {lid: rails_top + i * y_spacing for i, lid in enumerate(lines)}
+        per_line_y = {lid: rails_top + slot_offset[lid] for lid in lines}
         rail_y[section.id] = per_line_y
     off_track_y = box_top + section_y_padding
 
@@ -307,7 +310,10 @@ def _layout_section_rails(
     max_layer = max((layers.get(sid, 0) for sid in real_ids), default=0)
     bbox_x = x_offset
     bbox_w = section_x_padding * 2 + max_layer * x_spacing
-    rails_bottom = rails_top + (n_rails - 1) * y_spacing
+    # The lowest rail Y is the largest per-line offset below rails_top (which
+    # is a bundle sub-rail when the bottom slot is a combo), not simply the
+    # last slot centre.
+    rails_bottom = rails_top + (max(slot_offset.values()) if slot_offset else 0.0)
     bbox_y = box_top
     bbox_h = (rails_bottom - box_top) + section_y_padding
     section.bbox_x = bbox_x
@@ -357,6 +363,69 @@ def _label_aware_x_spacing(
     if widest <= 0.0:
         return x_spacing
     return max(x_spacing, widest + LABEL_MARGIN * 2)
+
+
+def _rail_slot_offsets(
+    graph: MetroGraph,
+    lines: list[str],
+    y_spacing: float,
+) -> tuple[dict[str, float], int]:
+    """Map each line to a Y offset (from the top rail) and return the slot count.
+
+    Each line normally occupies its own evenly-spaced rail slot.  Lines that
+    are members of the same ``legend_combo`` instead share a SINGLE slot,
+    drawn as a tight adjacent bundle: the slot's lines hug each other with a
+    small sub-offset about the slot centre rather than spreading across full
+    rail pitches.  With no combos this is exactly ``i * y_spacing`` per line in
+    order, identical to the un-bundled layout.
+
+    Returns ``(per_line_offset, n_slots)`` where ``n_slots`` is the number of
+    distinct rail slots (non-combo lines + one per combo with members present).
+    """
+    # Build line -> combo-key, keeping only combos whose members appear here.
+    line_combo: dict[str, int] = {}
+    for ci, (combo_ids, _label) in enumerate(graph.legend_combos):
+        members = [lid for lid in combo_ids if lid in lines]
+        if len(members) >= 2:
+            for lid in members:
+                line_combo[lid] = ci
+
+    # Walk the lines in order, allocating one slot per non-combo line and one
+    # slot per combo (at the position of its first-encountered member).
+    slot_of_combo: dict[int, int] = {}
+    slot_index: dict[str, int] = {}
+    n_slots = 0
+    for lid in lines:
+        ci = line_combo.get(lid)
+        if ci is None:
+            slot_index[lid] = n_slots
+            n_slots += 1
+        elif ci in slot_of_combo:
+            slot_index[lid] = slot_of_combo[ci]
+        else:
+            slot_of_combo[ci] = n_slots
+            slot_index[lid] = n_slots
+            n_slots += 1
+
+    # A combo's members hug within their shared slot: spread them symmetrically
+    # about the slot centre with a tight gap (a fraction of the rail pitch) so
+    # the bundle reads as two/few adjacent lines, not separate rails.
+    bundle_gap = min(y_spacing * 0.18, 6.0)
+    members_in_slot: dict[int, list[str]] = {}
+    for lid in lines:
+        members_in_slot.setdefault(slot_index[lid], []).append(lid)
+
+    per_line_offset: dict[str, float] = {}
+    for lid in lines:
+        slot = slot_index[lid]
+        members = members_in_slot[slot]
+        base = slot * y_spacing
+        if len(members) == 1:
+            per_line_offset[lid] = base
+        else:
+            k = members.index(lid)
+            per_line_offset[lid] = base + (k - (len(members) - 1) / 2.0) * bundle_gap
+    return per_line_offset, max(1, n_slots)
 
 
 def _section_layers(graph: MetroGraph, section: Section) -> dict[str, int]:

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -115,6 +115,78 @@ def compute_rail_layout(
     _position_ports_and_junctions(graph, rail_y)
 
 
+def retrofit_section_rails(
+    graph: MetroGraph,
+    section: Section,
+    *,
+    x_spacing: float = X_SPACING,
+    y_spacing: float,
+    section_x_padding: float = SECTION_X_PADDING,
+    section_y_padding: float = SECTION_Y_PADDING,
+) -> None:
+    """Re-lay one already-placed section as parallel rails (per-section mode).
+
+    The normal layout pipeline has already positioned this section's bbox via
+    section placement.  This function overwrites the section's *internal*
+    geometry (station X/Y, rail spans, used-Ys) and its internal edge routing
+    with the rail-mode layout, anchored at the section's existing bbox
+    top-left, and resizes the bbox to hug the resulting rails.  Inter-section
+    placement, ports, and routing are left to the normal machinery.
+
+    Used by ``compute_layout`` when ``graph.is_rail_section(section.id)`` is
+    True but the graph is not in the legacy global rail mode.
+    """
+    # ``_layout_section_rails`` anchors the box top at
+    # ``section_top + SECTION_HEADER_PROTRUSION`` and positions stations from
+    # ``x_offset``; feeding it the placement-chosen bbox top-left (offsetting
+    # the header protrusion back out) keeps the box where placement put it
+    # while the rails fill it.
+    box_left = section.bbox_x
+    box_top = section.bbox_y
+    rail_y = graph._rail_y  # type: ignore[attr-defined]
+    _layout_section_rails(
+        graph,
+        section,
+        rail_y,
+        x_spacing=x_spacing,
+        x_offset=box_left,
+        section_top=box_top - SECTION_HEADER_PROTRUSION,
+        section_x_padding=section_x_padding,
+        section_y_padding=section_y_padding,
+        y_spacing=y_spacing,
+    )
+
+    # Re-position this section's own ports onto their line rails so the normal
+    # router still draws sensible inter-section legs (no-op when the rail
+    # section is disconnected, which is the supported case).
+    _position_section_ports(graph, section, rail_y.get(section.id, {}))
+
+
+def _position_section_ports(
+    graph: MetroGraph,
+    section: Section,
+    per_line: dict[str, float],
+) -> None:
+    """Snap one rail section's boundary ports onto their connecting line rail."""
+    for port_id in section.port_ids:
+        port = graph.ports.get(port_id)
+        st = graph.stations.get(port_id)
+        if port is None or st is None:
+            continue
+        lines = _station_lines_in_order(graph, port_id)
+        ys = [per_line[lid] for lid in lines if lid in per_line]
+        if ys:
+            st.y = sum(ys) / len(ys)
+        if port.side is PortSide.LEFT:
+            st.x = section.bbox_x
+        elif port.side is PortSide.RIGHT:
+            st.x = section.bbox_x + section.bbox_w
+        else:
+            st.x = section.bbox_x + section.bbox_w / 2
+        port.x = st.x
+        port.y = st.y
+
+
 def _layout_section_rails(
     graph: MetroGraph,
     section: Section,

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -315,7 +315,15 @@ def _layout_section_rails(
     # last slot centre.
     rails_bottom = rails_top + (max(slot_offset.values()) if slot_offset else 0.0)
     bbox_y = box_top
-    bbox_h = (rails_bottom - box_top) + section_y_padding
+    # Below-rail station labels hang under the bottom rail; the bbox must
+    # contain them so a section stacked below this one clears them (the
+    # stacking gap is measured bbox-to-bbox).  Reserve max(section_y_padding,
+    # below-rail label band) so the box always wraps its labels.  With the
+    # default 50px padding this is a no-op for short/level labels, but it grows
+    # the box for a long or steeply-angled label whose footprint exceeds the
+    # padding.
+    bottom_pad = max(section_y_padding, _below_rail_label_band(graph, real_ids))
+    bbox_h = (rails_bottom - box_top) + bottom_pad
     section.bbox_x = bbox_x
     section.bbox_y = bbox_y
     section.bbox_w = bbox_w
@@ -323,6 +331,41 @@ def _layout_section_rails(
     section.direction = "LR"
 
     return bbox_y + bbox_h
+
+
+def _below_rail_label_band(
+    graph: MetroGraph,
+    real_ids: list[str],
+) -> float:
+    """Vertical room a section's below-rail labels need under the bottom rail.
+
+    A rail label is offset ``LABEL_OFFSET`` from the rail then occupies its own
+    text footprint.  For an angled (diagonal) label the footprint that hangs
+    downward is ``height*cos(angle) + width*sin(angle)``.  Returns the worst
+    such band over the section's labelled stations (0 if none), so the caller
+    can keep the section bbox tall enough to contain every hanging label.
+    """
+    import math
+
+    from nf_metro.layout.constants import LABEL_OFFSET
+    from nf_metro.layout.labels import _label_text_height, label_text_width
+
+    angle = abs(graph.label_angle or 0.0)
+    cos_a = abs(math.cos(math.radians(angle)))
+    sin_a = abs(math.sin(math.radians(angle)))
+
+    band = 0.0
+    for sid in real_ids:
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.off_track:
+            continue
+        if st.is_terminus and not st.label.strip():
+            continue
+        h = _label_text_height(st.label)
+        w = label_text_width(st.label)
+        footprint = h * cos_a + w * sin_a if angle else h
+        band = max(band, LABEL_OFFSET + footprint)
+    return band
 
 
 def _label_aware_x_spacing(
@@ -408,9 +451,12 @@ def _rail_slot_offsets(
             n_slots += 1
 
     # A combo's members hug within their shared slot: spread them symmetrically
-    # about the slot centre with a tight gap (a fraction of the rail pitch) so
-    # the bundle reads as two/few adjacent lines, not separate rails.
-    bundle_gap = min(y_spacing * 0.18, 6.0)
+    # about the slot centre, one OFFSET_STEP apart (the same pitch the normal
+    # router uses for parallel lines in a bundle), so the sub-lines abut and the
+    # bundle reads as a single track rather than separate rails.
+    from nf_metro.layout.constants import OFFSET_STEP
+
+    bundle_gap = OFFSET_STEP
     members_in_slot: dict[int, list[str]] = {}
     for lid in lines:
         members_in_slot.setdefault(slot_index[lid], []).append(lid)

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -3,9 +3,10 @@
 In normal layout a station shared by several metro lines is a single point
 and the lines converge (bundle) to that one Y.  Rail mode instead lays each
 line out as a fixed, evenly-spaced horizontal *rail* across the section and
-renders a multi-line station as one vertical *pill* spanning the rails it
-serves.  The rails do not converge: a line runs straight along its rail and
-only the station pill bridges across rails.
+renders a multi-line station as the classic metro *interchange*: a circle on
+each rail the station uses, joined by a straight connector segment.  The
+rails do not converge: a line runs straight along its rail and only the
+interchange connector bridges across rails.
 
 This module is a self-contained pipeline, run by ``compute_layout`` only when
 ``MetroGraph.rail_mode`` is True, so the normal layout path is untouched.
@@ -223,6 +224,13 @@ def _layout_section_rails(
         for sid in section.station_ids
         if (st := graph.stations.get(sid)) is not None and not st.is_port
     ]
+
+    # Widen the column step so a column's widest label fits between its
+    # neighbours without wrapping.  Labels sit above/below the rails centred
+    # on the station X, so a column needs roughly half the widest label of it
+    # and of each neighbour to clear; using the per-column widest label as the
+    # step keeps the rails evenly spaced while giving long names room.
+    x_spacing = _label_aware_x_spacing(graph, real_ids, layers, x_spacing)
     # Off-track input stations sit ABOVE the top rail and feed in with an
     # S-curve (see routing/rail.py), so reserve a band above the rails for
     # them.  rails_top is shifted down by that band; the off-track band Y is
@@ -242,7 +250,20 @@ def _layout_section_rails(
         st.x = x_offset + section_x_padding + layer * x_spacing
 
         if st.off_track:
-            # Park above the rails; the router draws the S-curve feeder.
+            # Park above the rails just to the left of the consumer column, so
+            # the router draws a short, clean S-curve down into the rail rather
+            # than a long diagonal traverse from layer 0.  The consumer's layer
+            # determines the X; the off-track input sits half a column before it.
+            consumer_layer = min(
+                (
+                    layers.get(e.target, layer)
+                    for e in graph.edges_from(sid)
+                    if e.target in layers
+                ),
+                default=layer + 1,
+            )
+            feed_layer = max(0.0, consumer_layer - 0.5)
+            st.x = x_offset + section_x_padding + feed_layer * x_spacing
             st.y = off_track_y
             st.track = 0.0
             st.rail_used_ys = []
@@ -296,6 +317,37 @@ def _layout_section_rails(
     section.direction = "LR"
 
     return bbox_y + bbox_h
+
+
+def _label_aware_x_spacing(
+    graph: MetroGraph,
+    real_ids: list[str],
+    layers: dict[str, int],
+    x_spacing: float,
+) -> float:
+    """Return a column step wide enough that no column's label wraps.
+
+    Labels render centred on a station's X, so two adjacent columns' labels
+    each consume half their own width either side of the column line.  Taking
+    the widest label across the section and requiring the step to seat half of
+    it plus half its neighbour (i.e. the full widest label, plus a small gap)
+    keeps every label on one line while the rails stay evenly spaced.
+    """
+    from nf_metro.layout.constants import LABEL_MARGIN
+    from nf_metro.layout.labels import label_text_width
+
+    widest = 0.0
+    for sid in real_ids:
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.off_track:
+            continue
+        # Blank termini render as icons, not text labels, so don't size to them.
+        if st.is_terminus and not st.label.strip():
+            continue
+        widest = max(widest, label_text_width(st.label))
+    if widest <= 0.0:
+        return x_spacing
+    return max(x_spacing, widest + LABEL_MARGIN * 2)
 
 
 def _section_layers(graph: MetroGraph, section: Section) -> dict[str, int]:

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -161,11 +161,37 @@ def route_edges(
 
         return route_rail_edges(graph)
 
+    # Per-section rail mode: route each rail section's internal edges with the
+    # dedicated rail router (straight rails, no bundling) and let the normal
+    # router handle every other edge.  An edge is "internal" to a rail section
+    # when both endpoints are non-port stations of that section.
+    rail_routes: list[RoutedPath] = []
+    rail_internal: set[tuple[str, str, str]] = set()
+    if graph.rail_sections:
+        from nf_metro.layout.routing.rail import route_rail_edges
+
+        rail_edges = []
+        for edge in graph.edges:
+            src = graph.stations.get(edge.source)
+            tgt = graph.stations.get(edge.target)
+            if src is None or tgt is None or src.is_port or tgt.is_port:
+                continue
+            if (
+                src.section_id == tgt.section_id
+                and src.section_id is not None
+                and graph.is_rail_section(src.section_id)
+            ):
+                rail_edges.append(edge)
+                rail_internal.add((edge.source, edge.target, edge.line_id))
+        rail_routes = route_rail_edges(graph, rail_edges)
+
     ctx = _build_routing_context(graph, diagonal_run, curve_radius, station_offsets)
-    routes: list[RoutedPath] = []
+    routes: list[RoutedPath] = list(rail_routes)
 
     for edge in graph.edges:
         if (edge.source, edge.target, edge.line_id) in ctx.skip_edges:
+            continue
+        if (edge.source, edge.target, edge.line_id) in rail_internal:
             continue
 
         src = graph.stations.get(edge.source)

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -156,6 +156,11 @@ def route_edges(
     Detects cross-row edges (large Y gap relative to X gap) and routes
     them through a vertical connector at the fold edge.
     """
+    if graph.rail_mode:
+        from nf_metro.layout.routing.rail import route_rail_edges
+
+        return route_rail_edges(graph)
+
     ctx = _build_routing_context(graph, diagonal_run, curve_radius, station_offsets)
     routes: list[RoutedPath] = []
 

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -37,7 +37,7 @@ from nf_metro.layout.routing.common import (
     horizontal_direction,
     vertical_direction,
 )
-from nf_metro.parser.model import MetroGraph, PortSide
+from nf_metro.parser.model import Edge, MetroGraph, PortSide
 
 # Segments shorter than this are sub-pixel artefacts of per-line
 # offsets and carry no meaningful direction of travel.
@@ -769,8 +769,27 @@ def check_intra_section_collinear_distinct_lines(
     is excused, so genuine reconvergences are not flagged.
     """
     station_xy = {sid: (st.x, st.y) for sid, st in graph.stations.items()}
+    # Edges internal to a rail-mode section legitimately run several
+    # co-travelling lines on parallel rails; the rail router (not this
+    # normal-pass geometry) renders them, so they are not an overlay defect.
+    # Drop them before the overlay scan.
+    if getattr(graph, "has_rail_sections", False):
+        routes = [r for r in routes if not _edge_in_rail_section(graph, r.edge)]
     return _collinear_overlay_violations(
         routes, offsets, station_xy, inter_section=False
+    )
+
+
+def _edge_in_rail_section(graph: MetroGraph, edge: Edge) -> bool:
+    """True when both endpoints of *edge* are real stations of one rail section."""
+    src = graph.stations.get(edge.source)
+    tgt = graph.stations.get(edge.target)
+    if src is None or tgt is None or src.is_port or tgt.is_port:
+        return False
+    return (
+        src.section_id is not None
+        and src.section_id == tgt.section_id
+        and graph.is_rail_section(src.section_id)
     )
 
 

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -1307,6 +1307,11 @@ def compute_station_offsets(
 
     Returns dict mapping (station_id, line_id) -> y_offset.
     """
+    # Rail mode bakes absolute rail Ys into the route points and the pill
+    # span, so per-line offsets are not used; return an empty map.
+    if graph.rail_mode:
+        return {}
+
     ctx = _build_offset_ctx(graph, offset_step)
     _compute_base_offsets(ctx)
     _reindex_section_local(ctx)

--- a/src/nf_metro/layout/routing/rail.py
+++ b/src/nf_metro/layout/routing/rail.py
@@ -56,17 +56,24 @@ def _line_rail_y(graph: MetroGraph, station_id: str, line_id: str) -> float:
     return st.y
 
 
-def route_rail_edges(graph: MetroGraph) -> list[RoutedPath]:
-    """Route every edge as a straight horizontal run along its line's rail.
+def route_rail_edges(
+    graph: MetroGraph,
+    edges: list | None = None,
+) -> list[RoutedPath]:
+    """Route edges as straight horizontal runs along their line's rail.
 
     The two endpoints of an edge are on the same line, hence the same rail,
     so each route is two points at a common Y.  When the endpoints' resolved
     rail Ys differ slightly (e.g. a port at a section's mid rail vs. a pill's
     own rail), a short vertical jog at the source X joins them so the run
     stays axis-aligned rather than diagonal.
+
+    When *edges* is None every edge in the graph is routed (legacy global
+    rail mode).  In per-section rail mode the caller passes just that
+    section's internal edges so the normal router handles the rest.
     """
     routes: list[RoutedPath] = []
-    for edge in graph.edges:
+    for edge in edges if edges is not None else graph.edges:
         src = graph.stations.get(edge.source)
         tgt = graph.stations.get(edge.target)
         if src is None or tgt is None:

--- a/src/nf_metro/layout/routing/rail.py
+++ b/src/nf_metro/layout/routing/rail.py
@@ -1,0 +1,95 @@
+"""Dedicated edge router for opt-in rail mode.
+
+In rail mode each metro line runs along a single fixed horizontal rail Y
+(see ``layout/rail_mode.py``).  An edge therefore connects two points that
+both sit on *this line's* rail, so the route is a straight horizontal run at
+that rail Y from the source X to the target X.  The station pills (drawn by
+the renderer) bridge across rails; the rails themselves never converge.
+
+A line that uses a station meets that station's pill at its own rail Y.  A
+line that does not use a station simply passes straight along its rail; if
+that rail falls between two rails the station spans, the rail visually
+crosses the pill (acceptable for v1 - see the feature notes).
+"""
+
+from __future__ import annotations
+
+__all__ = ["route_rail_edges"]
+
+from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.parser.model import MetroGraph
+
+
+def _line_rail_y(graph: MetroGraph, station_id: str, line_id: str) -> float:
+    """Return the Y at which *line_id* meets *station_id* in rail mode.
+
+    A single-rail station sits at its ``y``.  A multi-rail (spanning) station
+    stores its rail range on ``rail_top_y``/``rail_bottom_y``; the line meets
+    the pill at the rail Y for that line, which is recoverable from the
+    station's served lines and the even rail spacing.  When the rail span is
+    unknown the station's own ``y`` is used (single-rail fallback).
+    """
+    from nf_metro.layout.rail_mode import _station_lines_in_order
+
+    st = graph.stations.get(station_id)
+    if st is None:
+        return 0.0
+    if st.rail_top_y is None or st.rail_bottom_y is None:
+        return st.y
+
+    # Recover this line's rail within the station's span.  The station's
+    # served lines are evenly spaced from rail_top_y to rail_bottom_y in
+    # line-definition order, so interpolate the line's index.
+    served = _station_lines_in_order(graph, station_id)
+    if line_id not in served:
+        return st.y
+    n = len(served)
+    if n <= 1:
+        return st.y
+    idx = served.index(line_id)
+    frac = idx / (n - 1)
+    return st.rail_top_y + frac * (st.rail_bottom_y - st.rail_top_y)
+
+
+def route_rail_edges(graph: MetroGraph) -> list[RoutedPath]:
+    """Route every edge as a straight horizontal run along its line's rail.
+
+    The two endpoints of an edge are on the same line, hence the same rail,
+    so each route is two points at a common Y.  When the endpoints' resolved
+    rail Ys differ slightly (e.g. a port at a section's mid rail vs. a pill's
+    own rail), a short vertical jog at the source X joins them so the run
+    stays axis-aligned rather than diagonal.
+    """
+    routes: list[RoutedPath] = []
+    for edge in graph.edges:
+        src = graph.stations.get(edge.source)
+        tgt = graph.stations.get(edge.target)
+        if src is None or tgt is None:
+            continue
+
+        y_src = _line_rail_y(graph, edge.source, edge.line_id)
+        y_tgt = _line_rail_y(graph, edge.target, edge.line_id)
+
+        if abs(y_src - y_tgt) < 0.5:
+            points = [(src.x, y_src), (tgt.x, y_src)]
+        else:
+            # Run horizontally at the source rail, then a short vertical jog
+            # near the target, then into the target.  Keeps every leg
+            # axis-aligned (no diagonal) so the rail look is preserved.
+            mid_x = (src.x + tgt.x) / 2
+            points = [
+                (src.x, y_src),
+                (mid_x, y_src),
+                (mid_x, y_tgt),
+                (tgt.x, y_tgt),
+            ]
+
+        routes.append(
+            RoutedPath(
+                edge=edge,
+                line_id=edge.line_id,
+                points=points,
+                offsets_applied=True,
+            )
+        )
+    return routes

--- a/src/nf_metro/layout/routing/rail.py
+++ b/src/nf_metro/layout/routing/rail.py
@@ -57,6 +57,47 @@ def _line_rail_y(graph: MetroGraph, station_id: str, line_id: str) -> float:
     return st.y
 
 
+def _off_track_drop_stagger(
+    graph: MetroGraph,
+    feeder: object,
+    edge: object,
+    rail_y: float,
+) -> float:
+    """Horizontal offset for an off-track feeder line's vertical drop.
+
+    Several lines feeding the same consumer from one off-track input would
+    otherwise drop on the same X and overlap in the vertical leg (merging into
+    one fat line).  Each feeding line instead drops on its own X, ordered by
+    its target rail Y (top rail leftmost), one OFFSET_STEP apart and centred on
+    the feeder, so the bundle stays as parallel lines and the elbows form a
+    tidy staircase into the rails.
+    """
+    from nf_metro.layout.constants import OFFSET_STEP
+
+    feeder_id = feeder.id  # type: ignore[attr-defined]
+    consumer_id = (
+        edge.target if edge.source == feeder_id else edge.source  # type: ignore[attr-defined]
+    )
+    # Sibling feeder lines: every line carried by an edge between this feeder
+    # and the same consumer, ordered by their target rail Y.
+    sib_rails: list[tuple[float, str]] = []
+    for e in graph.edges:
+        if {e.source, e.target} != {feeder_id, consumer_id}:
+            continue
+        on_rail_id = e.target if e.source == feeder_id else e.source
+        sib_rails.append((_line_rail_y(graph, on_rail_id, e.line_id), e.line_id))
+    # Order the drop Xs so the bundle does NOT twist through the drop->rail
+    # elbow: the line landing on the LOWER rail (larger Y) drops on the LEFT
+    # (smaller X), matching the left/right ordering the rightward outgoing run
+    # expects (a D->R corner maps the down run's left side to the run's bottom).
+    sib_rails.sort(reverse=True)
+    order = [lid for _y, lid in sib_rails]
+    if edge.line_id not in order or len(order) <= 1:  # type: ignore[attr-defined]
+        return 0.0
+    k = order.index(edge.line_id)  # type: ignore[attr-defined]
+    return (k - (len(order) - 1) / 2.0) * OFFSET_STEP
+
+
 def _diagonal_placement(
     sx: float,
     tx: float,
@@ -120,31 +161,31 @@ def route_rail_edges(
             continue
 
         # Off-track input: the source sits above the rails and feeds into the
-        # target's rail with an S-curve (drop, then a curved transition into
-        # the rail) rather than a flat run on the rail.
+        # target's rail.  Drop straight down (a clean perpendicular crossing of
+        # any rails above the target reads far better than a steep diagonal
+        # merge), then turn onto the rail with a rounded elbow and run flat into
+        # the consumer.  Sibling feeder lines (a bundle feeding the same
+        # consumer) drop on staggered Xs - one per rail, lower rails turning
+        # later - so the bundle stays two parallel lines and never merges.
         off_src = src.off_track and not tgt.off_track
         off_tgt = tgt.off_track and not src.off_track
         if off_src or off_tgt:
             feeder = src if off_src else tgt
             on_rail = tgt if off_src else src
             rail_y = _line_rail_y(graph, on_rail.id, edge.line_id)
-            # An S-curve: leave the feeder vertically, curve through a midpoint
-            # X, then arrive horizontally onto the rail.  The two interior
-            # waypoints give the corner-smoother two bends (an S).
-            mid_x = (feeder.x + on_rail.x) / 2
-            s_points = [
-                (feeder.x, feeder.y),
-                (feeder.x, (feeder.y + rail_y) / 2),
-                (mid_x, rail_y),
+            drop_x = feeder.x + _off_track_drop_stagger(graph, feeder, edge, rail_y)
+            l_points = [
+                (drop_x, feeder.y),
+                (drop_x, rail_y),
                 (on_rail.x, rail_y),
             ]
             if off_tgt:
-                s_points.reverse()
+                l_points.reverse()
             routes.append(
                 RoutedPath(
                     edge=edge,
                     line_id=edge.line_id,
-                    points=s_points,
+                    points=l_points,
                     offsets_applied=True,
                 )
             )

--- a/src/nf_metro/layout/routing/rail.py
+++ b/src/nf_metro/layout/routing/rail.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 __all__ = ["route_rail_edges"]
 
+from nf_metro.layout.constants import DIAGONAL_RUN, MIN_STRAIGHT_EDGE
 from nf_metro.layout.routing.common import RoutedPath
 from nf_metro.parser.model import MetroGraph
 
@@ -54,6 +55,45 @@ def _line_rail_y(graph: MetroGraph, station_id: str, line_id: str) -> float:
     if line_id in served and len(st.rail_used_ys) == len(served):
         return st.rail_used_ys[served.index(line_id)]
     return st.y
+
+
+def _diagonal_placement(
+    sx: float,
+    tx: float,
+    sy: float,
+    ty: float,
+    is_fork: bool,
+    is_join: bool,
+) -> tuple[float, float]:
+    """X coordinates of a 45-degree diagonal joining two rails along an X run.
+
+    The diagonal climbs/falls between rail Ys at 45 degrees, so its horizontal
+    span equals the vertical rail separation ``|ty - sy|`` (clamped to the
+    available run so it never inverts).  The flat lead-in/out keeps a minimum
+    straight stub at each end; the diagonal is biased toward the fan's shared
+    convergence point (the fork source or the join target) so a rail eases off
+    the fan early and runs flat the rest of the column.
+    """
+    dx = tx - sx
+    sign = 1.0 if dx >= 0 else -1.0
+    span = abs(dx)
+    diag = min(abs(ty - sy), DIAGONAL_RUN)
+    # Keep a straight stub at each end, shrinking the diagonal if the column is
+    # too narrow to seat both stubs plus the diagonal.
+    stub = MIN_STRAIGHT_EDGE
+    if diag + 2 * stub > span:
+        diag = max(0.0, span - 2 * stub)
+        if diag <= 0.0:
+            stub = span / 2
+    if is_fork and not is_join:
+        diag_start = sx + sign * stub
+    elif is_join and not is_fork:
+        diag_start = tx - sign * (stub + diag)
+    else:
+        mid = (sx + tx) / 2
+        diag_start = mid - sign * diag / 2
+    diag_end = diag_start + sign * diag
+    return diag_start, diag_end
 
 
 def route_rail_edges(
@@ -116,14 +156,23 @@ def route_rail_edges(
         if abs(y_src - y_tgt) < 0.5:
             points = [(src.x, y_src), (tgt.x, y_src)]
         else:
-            # Run horizontally at the source rail, then a short vertical jog
-            # near the target, then into the target.  Keeps every leg
-            # axis-aligned (no diagonal) so the rail look is preserved.
-            mid_x = (src.x + tgt.x) / 2
+            # The endpoints sit on different rails: this is a fan-out (the
+            # source is a shared convergence point, e.g. the CRAM input) or a
+            # fan-in (the target is a shared collector, e.g. the VCF output).
+            # Ease between the two rails with a 45-degree diagonal transition -
+            # the metro-map convention used by the normal router - rather than
+            # a square right-angle jog.  Bias the diagonal toward whichever
+            # endpoint is the shared convergence point so the rail leaves/joins
+            # the fan on a diagonal and runs flat the rest of the way.
+            is_fork = len(graph.edges_from(edge.source)) > 1
+            is_join = len(graph.edges_to(edge.target)) > 1
+            diag_start_x, diag_end_x = _diagonal_placement(
+                src.x, tgt.x, y_src, y_tgt, is_fork, is_join
+            )
             points = [
                 (src.x, y_src),
-                (mid_x, y_src),
-                (mid_x, y_tgt),
+                (diag_start_x, y_src),
+                (diag_end_x, y_tgt),
                 (tgt.x, y_tgt),
             ]
 

--- a/src/nf_metro/layout/routing/rail.py
+++ b/src/nf_metro/layout/routing/rail.py
@@ -34,21 +34,26 @@ def _line_rail_y(graph: MetroGraph, station_id: str, line_id: str) -> float:
     st = graph.stations.get(station_id)
     if st is None:
         return 0.0
+
+    # Ports carry an averaged Y; resolve to the line's own rail in the port's
+    # section so inter-section legs stay on the correct rail per line.
+    port = graph.ports.get(station_id)
+    if port is not None:
+        section_rails = graph._rail_y.get(port.section_id, {})
+        if line_id in section_rails:
+            return section_rails[line_id]
+
     if st.rail_top_y is None or st.rail_bottom_y is None:
         return st.y
 
-    # Recover this line's rail within the station's span.  The station's
-    # served lines are evenly spaced from rail_top_y to rail_bottom_y in
-    # line-definition order, so interpolate the line's index.
+    # Each served line's rail Y is recorded directly in rail_used_ys, parallel
+    # to the station's served-line order, so look it up rather than assuming
+    # the used rails evenly fill the span (a station may span a rail it does
+    # not use, which would break an interpolated estimate).
     served = _station_lines_in_order(graph, station_id)
-    if line_id not in served:
-        return st.y
-    n = len(served)
-    if n <= 1:
-        return st.y
-    idx = served.index(line_id)
-    frac = idx / (n - 1)
-    return st.rail_top_y + frac * (st.rail_bottom_y - st.rail_top_y)
+    if line_id in served and len(st.rail_used_ys) == len(served):
+        return st.rail_used_ys[served.index(line_id)]
+    return st.y
 
 
 def route_rail_edges(graph: MetroGraph) -> list[RoutedPath]:
@@ -65,6 +70,37 @@ def route_rail_edges(graph: MetroGraph) -> list[RoutedPath]:
         src = graph.stations.get(edge.source)
         tgt = graph.stations.get(edge.target)
         if src is None or tgt is None:
+            continue
+
+        # Off-track input: the source sits above the rails and feeds into the
+        # target's rail with an S-curve (drop, then a curved transition into
+        # the rail) rather than a flat run on the rail.
+        off_src = src.off_track and not tgt.off_track
+        off_tgt = tgt.off_track and not src.off_track
+        if off_src or off_tgt:
+            feeder = src if off_src else tgt
+            on_rail = tgt if off_src else src
+            rail_y = _line_rail_y(graph, on_rail.id, edge.line_id)
+            # An S-curve: leave the feeder vertically, curve through a midpoint
+            # X, then arrive horizontally onto the rail.  The two interior
+            # waypoints give the corner-smoother two bends (an S).
+            mid_x = (feeder.x + on_rail.x) / 2
+            s_points = [
+                (feeder.x, feeder.y),
+                (feeder.x, (feeder.y + rail_y) / 2),
+                (mid_x, rail_y),
+                (on_rail.x, rail_y),
+            ]
+            if off_tgt:
+                s_points.reverse()
+            routes.append(
+                RoutedPath(
+                    edge=edge,
+                    line_id=edge.line_id,
+                    points=s_points,
+                    offsets_applied=True,
+                )
+            )
             continue
 
         y_src = _line_rail_y(graph, edge.source, edge.line_id)

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -293,6 +293,9 @@ def _parse_directive(
     elif content.startswith("rail_mode:"):
         val = content[len("rail_mode:") :].strip().lower()
         graph.rail_mode = val in ("true", "yes", "1")
+    elif content.startswith("rail_section:"):
+        ids = [s.strip() for s in content[len("rail_section:") :].split(",")]
+        graph.rail_sections.update(sid for sid in ids if sid)
     elif content.startswith("legend_min_height:"):
         try:
             graph.legend_min_height = float(

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -308,6 +308,8 @@ def _parse_directive(
             )
         except ValueError:
             pass
+    elif content.startswith("legend_combo:"):
+        _parse_legend_combo_directive(content[len("legend_combo:") :].strip(), graph)
     elif content.startswith("legend:"):
         _parse_legend_directive(content[len("legend:") :].strip(), graph)
     elif content.startswith("off_track:"):
@@ -457,6 +459,48 @@ def _parse_legend_directive(value: str, graph: MetroGraph) -> None:
             "'dx,dy'. Ignoring.",
             stacklevel=2,
         )
+
+
+def _parse_legend_combo_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro legend_combo: lineA, lineB[, ...] | Display Label.
+
+    Stores a (line_ids, label) entry on ``graph.legend_combos``. The named
+    lines are rendered as a single combined legend row and (in rail mode)
+    share a single rail slot. A combo referencing unknown lines is warned
+    about and ignored; unknown members of an otherwise-valid combo are
+    dropped (with a warning) and the remaining members kept.
+    """
+    parts = value.split("|", 1)
+    if len(parts) != 2:
+        warnings.warn(
+            f"Invalid legend_combo {value!r}; expected 'lineA, lineB | Display Label'.",
+            stacklevel=2,
+        )
+        return
+    ids_raw, label = parts[0], parts[1].strip()
+    line_ids = [s.strip() for s in ids_raw.split(",") if s.strip()]
+    if len(line_ids) < 2 or not label:
+        warnings.warn(
+            f"Invalid legend_combo {value!r}; expected at least two line IDs "
+            "and a non-empty label.",
+            stacklevel=2,
+        )
+        return
+    known = [lid for lid in line_ids if lid in graph.lines]
+    unknown = [lid for lid in line_ids if lid not in graph.lines]
+    if unknown:
+        warnings.warn(
+            f"legend_combo {label!r} references unknown line(s) "
+            f"{', '.join(unknown)}; ignoring those.",
+            stacklevel=2,
+        )
+    if len(known) < 2:
+        warnings.warn(
+            f"legend_combo {label!r} has fewer than two known lines; ignoring.",
+            stacklevel=2,
+        )
+        return
+    graph.legend_combos.append((tuple(known), label))
 
 
 def _parse_logo_scale_directive(value: str, graph: MetroGraph) -> None:

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -290,6 +290,9 @@ def _parse_directive(
     elif content.startswith("center_ports:"):
         val = content[len("center_ports:") :].strip().lower()
         graph.center_ports = val in ("true", "yes", "1")
+    elif content.startswith("rail_mode:"):
+        val = content[len("rail_mode:") :].strip().lower()
+        graph.rail_mode = val in ("true", "yes", "1")
     elif content.startswith("legend_min_height:"):
         try:
             graph.legend_min_height = float(

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -290,6 +290,11 @@ def _parse_directive(
     elif content.startswith("center_ports:"):
         val = content[len("center_ports:") :].strip().lower()
         graph.center_ports = val in ("true", "yes", "1")
+    elif content.startswith("label_angle:"):
+        try:
+            graph.label_angle = float(content[len("label_angle:") :].strip())
+        except ValueError:
+            pass
     elif content.startswith("rail_mode:"):
         val = content[len("rail_mode:") :].strip().lower()
         graph.rail_mode = val in ("true", "yes", "1")

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -221,6 +221,12 @@ class MetroGraph:
     # ``rail_mode: true`` flag is equivalent to "every section is a rail
     # section".  Use ``is_rail_section``/``has_rail_sections`` to query.
     rail_sections: set[str] = field(default_factory=set)
+    # Combined-lines legend entries (%%metro legend_combo:). Each is a
+    # (line_ids, label) tuple: the named lines render as one combined legend
+    # row, and in rail mode they share a single rail slot drawn as a tight
+    # adjacent bundle instead of separate evenly-spaced rails. Empty (and
+    # therefore inert) unless a legend_combo directive is present.
+    legend_combos: list[tuple[tuple[str, ...], str]] = field(default_factory=list)
     # Station label rotation in degrees, clockwise.  None means "horizontal".
     # In rail mode an angled label's horizontal footprint is its width times
     # cos(angle), so angled-label rail panels pack tighter than horizontal ones.

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -215,6 +215,12 @@ class MetroGraph:
     # lines converging to a point.  Off by default; the normal layout /
     # render path is untouched when False.  See docs and examples/rail_mode.mmd.
     rail_mode: bool = False
+    # Per-section rail mode (opt-in).  Section IDs listed here are laid out as
+    # parallel rails with spanning pills (the rail-mode geometry) while the
+    # rest of the graph uses the normal layout pipeline.  The legacy global
+    # ``rail_mode: true`` flag is equivalent to "every section is a rail
+    # section".  Use ``is_rail_section``/``has_rail_sections`` to query.
+    rail_sections: set[str] = field(default_factory=set)
     legend_position: str = "bottom"
     legend_min_height: float = 0.0
     # Placement modifiers for the bundled legend+logo block. The corner/edge
@@ -383,6 +389,31 @@ class MetroGraph:
                     stations.append(edge.target)
                     seen.add(edge.target)
         return stations
+
+    @property
+    def has_rail_sections(self) -> bool:
+        """True if any section is laid out in rail mode (global flag or per-section)."""
+        return self.rail_mode or bool(self.rail_sections)
+
+    def is_rail_section(self, section_id: str) -> bool:
+        """True if *section_id* should be laid out in rail mode.
+
+        The legacy global ``rail_mode`` flag treats every section as a rail
+        section; otherwise only sections named via ``%%metro rail_section:``
+        (collected in ``rail_sections``) are rail sections.
+        """
+        return self.rail_mode or section_id in self.rail_sections
+
+    def station_is_rail(self, station_id: str) -> bool:
+        """True if a station belongs to a rail-mode section."""
+        if self.rail_mode:
+            return True
+        st = self.stations.get(station_id)
+        return (
+            st is not None
+            and st.section_id is not None
+            and st.section_id in self.rail_sections
+        )
 
     def section_for_station(self, station_id: str) -> str | None:
         """Return the section ID containing a station, or None."""

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -93,6 +93,12 @@ class Station:
     # station was not laid out in rail mode (normal pill rules apply).
     rail_top_y: float | None = None
     rail_bottom_y: float | None = None
+    # Rail Ys this station actually *uses* (one per line it carries), set
+    # alongside rail_top_y/rail_bottom_y in rail mode.  A spanning pill draws
+    # a knob at each of these Ys; a rail that falls within the pill's span but
+    # is absent here belongs to a line the station does not use and passes
+    # behind the pill with no knob.  Empty when not laid out in rail mode.
+    rail_used_ys: list[float] = field(default_factory=list)
 
     @property
     def is_terminus(self) -> bool:
@@ -264,6 +270,10 @@ class MetroGraph:
     # compute_layout from the NF_METRO_PHASE_SNAPSHOTS env var; read by the
     # _snap hook after each phase.  Off by default (pure observation).
     _phase_snapshots_enabled: bool = field(default=False, repr=False)
+    # Per-section rail-Y map (section_id -> {line_id: rail_y}), set by the
+    # rail-mode layout so the dedicated router can resolve a port's per-line
+    # rail Y.  Empty when rail mode is off.
+    _rail_y: dict[str, dict[str, float]] = field(default_factory=dict, repr=False)
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -221,6 +221,10 @@ class MetroGraph:
     # ``rail_mode: true`` flag is equivalent to "every section is a rail
     # section".  Use ``is_rail_section``/``has_rail_sections`` to query.
     rail_sections: set[str] = field(default_factory=set)
+    # Station label rotation in degrees, clockwise.  None means "horizontal".
+    # In rail mode an angled label's horizontal footprint is its width times
+    # cos(angle), so angled-label rail panels pack tighter than horizontal ones.
+    label_angle: float | None = None
     legend_position: str = "bottom"
     legend_min_height: float = 0.0
     # Placement modifiers for the bundled legend+logo block. The corner/edge

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -86,6 +86,13 @@ class Station:
     y: float = 0.0
     layer: int = 0
     track: float = 0.0
+    # Rail-mode span (set by the rail-mode layout when MetroGraph.rail_mode
+    # is on).  ``rail_top_y``/``rail_bottom_y`` are the Y of the topmost and
+    # bottommost rails this station's lines occupy; when they differ the
+    # renderer draws one vertical pill spanning that range.  None means the
+    # station was not laid out in rail mode (normal pill rules apply).
+    rail_top_y: float | None = None
+    rail_bottom_y: float | None = None
 
     @property
     def is_terminus(self) -> bool:
@@ -196,6 +203,12 @@ class MetroGraph:
     diamond_style: str = "straight"  # "straight" or "symmetric"
     compact_offsets: bool = False
     center_ports: bool = False
+    # Opt-in "rail mode": LR sections are laid out as fixed parallel
+    # horizontal rails (one per line) and a multi-line station renders as a
+    # single vertical pill spanning the rails it serves, instead of the
+    # lines converging to a point.  Off by default; the normal layout /
+    # render path is untouched when False.  See docs and examples/rail_mode.mmd.
+    rail_mode: bool = False
     legend_position: str = "bottom"
     legend_min_height: float = 0.0
     # Placement modifiers for the bundled legend+logo block. The corner/edge

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 __all__ = ["compute_legend_dimensions", "render_legend"]
 
+from dataclasses import dataclass
+
 import drawsvg as draw
 
-from nf_metro.parser.model import MetroGraph
+from nf_metro.parser.model import MetroGraph, MetroLine
 from nf_metro.render.constants import (
     LEGEND_BORDER_RADIUS,
     LEGEND_CHAR_WIDTH_RATIO,
@@ -20,6 +22,42 @@ from nf_metro.render.constants import (
     line_style_kwargs,
 )
 from nf_metro.render.style import Theme
+
+
+@dataclass
+class _LegendRow:
+    """One row of the legend: a label plus the line(s) its swatch shows."""
+
+    label: str
+    lines: tuple[MetroLine, ...]
+
+
+def _legend_rows(graph: MetroGraph) -> list[_LegendRow]:
+    """Return the ordered legend rows for a graph.
+
+    Each metro line that is not part of a ``legend_combo`` gets its own row
+    (preserving definition order, as before). Each combo named in
+    ``graph.legend_combos`` becomes a single row whose swatch shows all the
+    constituent lines as adjacent stripes; the constituent lines are omitted
+    from their own individual rows. With no combos this is exactly one row per
+    line, byte-identical to the prior behaviour.
+    """
+    combined_ids: set[str] = set()
+    for line_ids, _label in graph.legend_combos:
+        combined_ids.update(line_ids)
+
+    rows: list[_LegendRow] = []
+    for ml in graph.lines.values():
+        if ml.id in combined_ids:
+            continue
+        rows.append(_LegendRow(label=ml.display_name, lines=(ml,)))
+
+    for line_ids, label in graph.legend_combos:
+        members = tuple(graph.lines[lid] for lid in line_ids if lid in graph.lines)
+        if members:
+            rows.append(_LegendRow(label=label, lines=members))
+
+    return rows
 
 
 def _scale_logo_to_content(
@@ -42,6 +80,7 @@ def _scale_logo_to_content(
 
 def _legend_metrics(
     graph: MetroGraph,
+    rows: list[_LegendRow],
     logo_size: tuple[float, float] | None,
 ) -> tuple[float, float, float, float]:
     """Return (text_block_h, content_h, logo_w, logo_h) for the legend.
@@ -50,7 +89,7 @@ def _legend_metrics(
     text block and a (possibly enlarged) logo.
     """
     line_height = LEGEND_LINE_HEIGHT
-    text_block_h = max(len(graph.lines) * line_height, graph.legend_min_height)
+    text_block_h = max(len(rows) * line_height, graph.legend_min_height)
     logo_w = logo_h = 0.0
     if logo_size:
         logo_w, logo_h = _scale_logo_to_content(
@@ -73,19 +112,62 @@ def compute_legend_dimensions(
     if not graph.lines:
         return (0.0, 0.0)
 
+    rows = _legend_rows(graph)
+    if not rows:
+        return (0.0, 0.0)
+
     padding = LEGEND_PADDING
     swatch_width = LEGEND_SWATCH_WIDTH
     text_offset = swatch_width + LEGEND_TEXT_GAP
 
-    max_name_len = max(len(ml.display_name) for ml in graph.lines.values())
+    max_name_len = max(len(row.label) for row in rows)
     char_width = theme.legend_font_size * LEGEND_CHAR_WIDTH_RATIO
 
-    _text_h, content_height, logo_w, _logo_h = _legend_metrics(graph, logo_size)
+    _text_h, content_height, logo_w, _logo_h = _legend_metrics(graph, rows, logo_size)
     logo_gap = LOGO_GAP if logo_size else 0.0
 
     width = padding * 2 + logo_w + logo_gap + text_offset + max_name_len * char_width
     height = padding * 2 + content_height
     return (width, height)
+
+
+def _render_swatch(
+    d: draw.Drawing,
+    row: _LegendRow,
+    theme: Theme,
+    x0: float,
+    entry_y: float,
+    swatch_width: float,
+) -> None:
+    """Draw the colour swatch for a row.
+
+    A single-line row draws one horizontal segment (as before). A combo row
+    draws each constituent line as a stripe at a small vertical offset, so the
+    swatch reads as a little bundle of adjacent lines, each honouring its style.
+    """
+    n = len(row.lines)
+    if n == 1:
+        offsets = [0.0]
+    else:
+        # Spread the stripes symmetrically about the entry centre, packed
+        # tightly so they read as a single travelling-together bundle.
+        spacing = min(theme.line_width + 1.0, LEGEND_LINE_HEIGHT / (n + 1))
+        offsets = [(i - (n - 1) / 2.0) * spacing for i in range(n)]
+
+    for ml, dy in zip(row.lines, offsets):
+        dash_kw = line_style_kwargs(ml.style)
+        d.append(
+            draw.Line(
+                x0,
+                entry_y + dy,
+                x0 + swatch_width,
+                entry_y + dy,
+                stroke=ml.color,
+                stroke_width=theme.line_width,
+                stroke_linecap="round",
+                **dash_kw,
+            )
+        )
 
 
 def render_legend(
@@ -106,12 +188,18 @@ def render_legend(
     if not graph.lines:
         return
 
+    rows = _legend_rows(graph)
+    if not rows:
+        return
+
     line_height = LEGEND_LINE_HEIGHT
     padding = LEGEND_PADDING
     swatch_width = LEGEND_SWATCH_WIDTH
     text_offset = swatch_width + LEGEND_TEXT_GAP
 
-    text_block_h, content_height, scaled_w, scaled_h = _legend_metrics(graph, logo_size)
+    text_block_h, content_height, scaled_w, scaled_h = _legend_metrics(
+        graph, rows, logo_size
+    )
 
     legend_width, legend_height = compute_legend_dimensions(
         graph, theme, logo_size=logo_size
@@ -150,28 +238,22 @@ def render_legend(
     # Line entries, vertically centred within the content area (which can be
     # taller than the text block when an enlarged logo grows the box).
     text_top = y + padding + (content_height - text_block_h) / 2
-    for i, metro_line in enumerate(graph.lines.values()):
+    for i, row in enumerate(rows):
         entry_y = text_top + i * line_height + line_height / 2
 
-        # Color swatch (line segment)
-        dash_kw = line_style_kwargs(metro_line.style)
-        d.append(
-            draw.Line(
-                x + padding + logo_offset,
-                entry_y,
-                x + padding + logo_offset + swatch_width,
-                entry_y,
-                stroke=metro_line.color,
-                stroke_width=theme.line_width,
-                stroke_linecap="round",
-                **dash_kw,
-            )
+        _render_swatch(
+            d,
+            row,
+            theme,
+            x + padding + logo_offset,
+            entry_y,
+            swatch_width,
         )
 
         # Label
         d.append(
             draw.Text(
-                metro_line.display_name,
+                row.label,
                 theme.legend_font_size,
                 x + padding + logo_offset + text_offset,
                 entry_y,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1184,6 +1184,7 @@ def _terminus_icon_centers(
     first_offset: float,
     step: float,
     bundle_center: float,
+    is_rail: bool = False,
 ) -> list[tuple[float, float]]:
     """Centre coordinates for a terminus station's file icons.
 
@@ -1194,6 +1195,13 @@ def _terminus_icon_centers(
     the outside of the diagram.
     """
     is_tb = section_dir in ("TB", "BT")
+    # A rail-mode off-track input parks above the rails and feeds straight down
+    # into its consumer's rail (see routing/rail.py), so its icon sits directly
+    # on the station coordinate (centred on the drop X) rather than marching
+    # sideways.  Gated on the rail flag so normal-mode off-track feeders (which
+    # the standard router handles) are untouched.
+    if station.off_track and is_rail:
+        return [(station.x, station.y - (first_offset + i * step)) for i in range(n)]
     # Sinks sit at the end of the flow and extend forwards; sources sit at
     # the start and extend backwards.  RL/BT reverse the forward direction.
     extends_forward = is_source if section_dir in ("RL", "BT") else not is_source
@@ -1263,6 +1271,7 @@ def _render_terminus_icons(
         icon_gap + icon_half_flow,
         icon_step,
         bundle_center,
+        is_rail=graph.station_is_rail(station.id),
     )
 
     # Captions sitting at the same Y overlap when their estimated

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -888,6 +888,59 @@ def _render_bridged_edge(
     d.append(path)
 
 
+def _station_data_attrs(graph: MetroGraph, station: Station) -> dict[str, str]:
+    """SVG data-attributes shared by every station marker.
+
+    Values that flow from user content (label, section name) are HTML-escaped
+    because drawsvg does not escape unknown kwargs.
+    """
+    data = {
+        "class_": "nf-metro-station",
+        "data-station-id": station.id,
+        "data-station-lines": ",".join(graph.station_lines(station.id)),
+        "data-station-label": html.escape(station.label or station.id),
+    }
+    if station.section_id:
+        data["data-section-id"] = station.section_id
+        sec_obj = graph.sections.get(station.section_id)
+        if sec_obj:
+            data["data-section-name"] = html.escape(sec_obj.name)
+    return data
+
+
+def _render_rail_pill(
+    d: draw.Drawing,
+    graph: MetroGraph,
+    station: Station,
+    theme: Theme,
+    r: float,
+) -> None:
+    """Render a rail-mode spanning station as one vertical pill.
+
+    The pill runs from the station's top rail Y to its bottom rail Y at the
+    station's column X, so it visibly bridges every rail the station serves.
+    """
+    top_y = station.rail_top_y if station.rail_top_y is not None else station.y
+    bot_y = station.rail_bottom_y if station.rail_bottom_y is not None else station.y
+    w = r * 2
+    h = (bot_y - top_y) + r * 2
+    station_data = _station_data_attrs(graph, station)
+    d.append(
+        draw.Rectangle(
+            station.x - w / 2,
+            top_y - r,
+            w,
+            h,
+            rx=r,
+            ry=r,
+            fill=theme.station_fill,
+            stroke=theme.station_stroke,
+            stroke_width=theme.station_stroke_width,
+            **station_data,
+        )
+    )
+
+
 def _render_stations(
     d: draw.Drawing,
     graph: MetroGraph,
@@ -907,6 +960,13 @@ def _render_stations(
             continue
 
         r = theme.station_radius
+
+        # Rail mode: a station spanning more than one rail draws as a single
+        # vertical pill from its top rail Y to its bottom rail Y.  Single-rail
+        # stations fall through to the normal (zero-span) pill below.
+        if station.rail_top_y is not None and station.rail_bottom_y is not None:
+            _render_rail_pill(d, graph, station, theme, r)
+            continue
 
         # Determine if this is a TB vertical station (rotated pill)
         is_tb_vert = False
@@ -930,20 +990,7 @@ def _render_stations(
 
         span = max_off - min_off
 
-        # Hand-escape values that flow from user content into XML attributes.
-        # drawsvg does not escape unknown kwargs, so an unescaped "&" or "<"
-        # in a section name or station label breaks XML well-formedness.
-        station_data = {
-            "class_": "nf-metro-station",
-            "data-station-id": station.id,
-            "data-station-lines": ",".join(graph.station_lines(station.id)),
-            "data-station-label": html.escape(station.label or station.id),
-        }
-        if station.section_id:
-            station_data["data-section-id"] = station.section_id
-            sec_obj = graph.sections.get(station.section_id)
-            if sec_obj:
-                station_data["data-section-name"] = html.escape(sec_obj.name)
+        station_data = _station_data_attrs(graph, station)
 
         # Non-process terminus stations: filled rectangle
         # (same size as pill, no rounding)

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -915,10 +915,13 @@ def _render_rail_pill(
     theme: Theme,
     r: float,
 ) -> None:
-    """Render a rail-mode spanning station as one vertical pill.
+    """Render a rail-mode spanning station as one vertical pill with knobs.
 
     The pill runs from the station's top rail Y to its bottom rail Y at the
-    station's column X, so it visibly bridges every rail the station serves.
+    station's column X, so it visibly bridges every rail in that range.  A
+    small filled knob is drawn where the pill meets each rail the station
+    *uses* (``rail_used_ys``); a rail that falls within the span but is not
+    used carries no knob and reads as passing behind the pill.
     """
     top_y = station.rail_top_y if station.rail_top_y is not None else station.y
     bot_y = station.rail_bottom_y if station.rail_bottom_y is not None else station.y
@@ -940,6 +943,29 @@ def _render_rail_pill(
         )
     )
 
+    # Knobs: one per used rail, coloured by the line that uses it.  Keyed by
+    # the station's served-line order, which is parallel to rail_used_ys.
+    served = graph.station_lines(station.id)
+    knob_r = r * 0.62
+    for lid, y in zip(served, station.rail_used_ys):
+        line = graph.lines.get(lid)
+        knob_fill = line.color if line else FALLBACK_LINE_COLOR
+        d.append(
+            draw.Circle(
+                station.x,
+                y,
+                knob_r,
+                fill=knob_fill,
+                stroke=theme.station_stroke,
+                stroke_width=theme.station_stroke_width,
+                **{
+                    "class_": "nf-metro-rail-knob",
+                    "data-station-id": station.id,
+                    "data-line-id": lid,
+                },
+            )
+        )
+
 
 def _render_stations(
     d: draw.Drawing,
@@ -960,6 +986,15 @@ def _render_stations(
             continue
 
         r = theme.station_radius
+
+        # Rail mode: a blank terminus (file/dir/report node with no text
+        # label) renders as its icon at the rail convergence, not a bare pill,
+        # with the rails meeting at the icon (as in normal mode).
+        if graph.rail_mode and station.is_terminus and not station.label.strip():
+            icon_group = draw.Group(**{"data-station-id": station.id})
+            _render_terminus_icons(icon_group, station, graph, theme, r, 0.0, 0.0)
+            d.append(icon_group)
+            continue
 
         # Rail mode: a station spanning more than one rail draws as a single
         # vertical pill from its top rail Y to its bottom rail Y.  Single-rail

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1346,7 +1346,26 @@ def _render_labels(
             label_data["data-station-id"] = label.station_id
             label_data["class_"] = "nf-metro-station-label"
 
-        if label.dominant_baseline:
+        if label.angle:
+            # Diagonal labels: anchor at the pill and rotate about the anchor
+            # so the tilted text trails away from the station.
+            d.append(
+                draw.Text(
+                    text,
+                    theme.label_font_size,
+                    label.x,
+                    label.y,
+                    fill=theme.label_color,
+                    font_family=theme.label_font_family,
+                    font_weight=theme.label_font_weight,
+                    text_anchor=label.text_anchor or "start",
+                    dominant_baseline="auto",
+                    line_height=LABEL_LINE_HEIGHT,
+                    transform=f"rotate({label.angle},{label.x},{label.y})",
+                    **label_data,
+                )
+            )
+        elif label.dominant_baseline:
             # Custom placement (e.g. TB vertical stations: right-side labels)
             d.append(
                 draw.Text(

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -915,47 +915,50 @@ def _render_rail_pill(
     theme: Theme,
     r: float,
 ) -> None:
-    """Render a rail-mode spanning station as one vertical pill with knobs.
+    """Render a rail-mode multi-rail station as the metro interchange idiom.
 
-    The pill runs from the station's top rail Y to its bottom rail Y at the
-    station's column X, so it visibly bridges every rail in that range.  A
-    small filled knob is drawn where the pill meets each rail the station
-    *uses* (``rail_used_ys``); a rail that falls within the span but is not
-    used carries no knob and reads as passing behind the pill.
+    Instead of one capsule the station draws as a *white circle on each rail
+    it uses* joined by a thin straight connector segment running between the
+    topmost and bottommost used rails (the classic metro / nf-core-sarek
+    interchange link).  A rail that falls within the span but is NOT used by
+    the station gets no circle; the connector passes behind it without a knob.
     """
-    top_y = station.rail_top_y if station.rail_top_y is not None else station.y
-    bot_y = station.rail_bottom_y if station.rail_bottom_y is not None else station.y
-    w = r * 2
-    h = (bot_y - top_y) + r * 2
+    used_ys = [y for y in station.rail_used_ys] or [station.y]
+    top_y = min(used_ys)
+    bot_y = max(used_ys)
     station_data = _station_data_attrs(graph, station)
-    d.append(
-        draw.Rectangle(
-            station.x - w / 2,
-            top_y - r,
-            w,
-            h,
-            rx=r,
-            ry=r,
-            fill=theme.station_fill,
-            stroke=theme.station_stroke,
-            stroke_width=theme.station_stroke_width,
-            **station_data,
-        )
-    )
 
-    # Knobs: one per used rail, coloured by the line that uses it.  Keyed by
-    # the station's served-line order, which is parallel to rail_used_ys.
+    # The interchange connector: a thin neutral straight segment behind the
+    # circles, spanning only the rails the station actually uses.  It carries
+    # the station data attrs (id, label, section) so the multi-rail station
+    # stays identifiable for hover/selection now that there is no pill rect.
+    if bot_y - top_y > 0.5:
+        d.append(
+            draw.Line(
+                station.x,
+                top_y,
+                station.x,
+                bot_y,
+                stroke=theme.station_stroke,
+                stroke_width=theme.station_stroke_width * 2,
+                **{
+                    **station_data,
+                    "class_": "nf-metro-rail-connector",
+                },
+            )
+        )
+
+    # A white circle at each used rail (matching the normal station marker:
+    # white fill, theme station stroke).  Keyed by the station's served-line
+    # order, which is parallel to rail_used_ys.
     served = graph.station_lines(station.id)
-    knob_r = r * 0.62
     for lid, y in zip(served, station.rail_used_ys):
-        line = graph.lines.get(lid)
-        knob_fill = line.color if line else FALLBACK_LINE_COLOR
         d.append(
             draw.Circle(
                 station.x,
                 y,
-                knob_r,
-                fill=knob_fill,
+                r,
+                fill=theme.station_fill,
                 stroke=theme.station_stroke,
                 stroke_width=theme.station_stroke_width,
                 **{

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -990,7 +990,11 @@ def _render_stations(
         # Rail mode: a blank terminus (file/dir/report node with no text
         # label) renders as its icon at the rail convergence, not a bare pill,
         # with the rails meeting at the icon (as in normal mode).
-        if graph.rail_mode and station.is_terminus and not station.label.strip():
+        if (
+            graph.station_is_rail(station.id)
+            and station.is_terminus
+            and not station.label.strip()
+        ):
             icon_group = draw.Group(**{"data-station-id": station.id})
             _render_terminus_icons(icon_group, station, graph, theme, r, 0.0, 0.0)
             d.append(icon_group)

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -917,57 +917,95 @@ def _render_rail_pill(
 ) -> None:
     """Render a rail-mode multi-rail station as the metro interchange idiom.
 
-    Instead of one capsule the station draws as a *white circle on each rail
-    it uses* joined by a thin straight connector segment running between the
-    topmost and bottommost used rails (the classic metro / nf-core-sarek
-    interchange link).  A rail that falls within the span but is NOT used by
-    the station gets no circle; the connector passes behind it without a knob.
+    The station draws as a *white circle on each rail it uses* joined by a
+    *white link* running between the topmost and bottommost used rails - a
+    continuous outlined white interchange (the classic metro / nf-core-sarek
+    idiom).  The link is the station fill colour (not a dark stroke), so it
+    reads as connecting the circles; the dark station stroke forms the OUTER
+    boundary of the whole circles+link glyph rather than cutting across it.
+
+    The glyph is built in two stacked layers so the dark outline is continuous
+    and never gaps where the link meets a circle: first a dark layer (the link
+    bar plus a disc at each used rail, each grown by the stroke width) paints
+    the union's outer boundary, then a white layer of the same shapes (at the
+    true radii) paints the interior on top.  A rail that falls within the span
+    but is NOT used by the station gets no circle; the link passes behind it.
     """
     used_ys = [y for y in station.rail_used_ys] or [station.y]
     top_y = min(used_ys)
     bot_y = max(used_ys)
     station_data = _station_data_attrs(graph, station)
 
-    # The interchange connector: a thin neutral straight segment behind the
-    # circles, spanning only the rails the station actually uses.  It carries
-    # the station data attrs (id, label, section) so the multi-rail station
-    # stays identifiable for hover/selection now that there is no pill rect.
-    if bot_y - top_y > 0.5:
+    sw = theme.station_stroke_width
+    # Circles are slightly larger than the bare marker so each used rail reads
+    # as a distinct knob along the white link; the link bar is a touch narrower
+    # than the circles so the knobs bulge out of it like a real interchange.
+    knob_r = r * 1.2
+    bar_half = r * 0.85
+    # rail_used_ys is recorded parallel to the line-definition order (see
+    # rail_mode._layout_section_rails), so zip the knobs against that same
+    # order rather than the edge-discovery order of graph.station_lines.
+    from nf_metro.layout.rail_mode import _station_lines_in_order
+
+    served = _station_lines_in_order(graph, station.id)
+
+    def _link_bar(width: float, stroke: str, **extra: object) -> None:
+        # A round-capped line of the given width is a capsule; used here only
+        # for its straight body between top and bottom used rails (the caps are
+        # covered by the circles), so it joins the knobs with no seam.
+        if bot_y - top_y <= 0.5:
+            return
         d.append(
             draw.Line(
                 station.x,
                 top_y,
                 station.x,
                 bot_y,
-                stroke=theme.station_stroke,
-                stroke_width=theme.station_stroke_width * 2,
-                **{
-                    **station_data,
-                    "class_": "nf-metro-rail-connector",
-                },
+                stroke=stroke,
+                stroke_width=width,
+                stroke_linecap="round",
+                **extra,
             )
         )
 
-    # A white circle at each used rail (matching the normal station marker:
-    # white fill, theme station stroke).  Keyed by the station's served-line
-    # order, which is parallel to rail_used_ys.
-    served = graph.station_lines(station.id)
-    for lid, y in zip(served, station.rail_used_ys):
-        d.append(
-            draw.Circle(
-                station.x,
-                y,
-                r,
-                fill=theme.station_fill,
-                stroke=theme.station_stroke,
-                stroke_width=theme.station_stroke_width,
-                **{
-                    "class_": "nf-metro-rail-knob",
-                    "data-station-id": station.id,
-                    "data-line-id": lid,
-                },
+    def _knobs(radius: float, fill: str, stroke: str, **extra: object) -> None:
+        for lid, y in zip(served, station.rail_used_ys):
+            d.append(
+                draw.Circle(
+                    station.x,
+                    y,
+                    radius,
+                    fill=fill,
+                    stroke=stroke,
+                    stroke_width=0,
+                    **{**extra, "data-line-id": lid},
+                )
             )
-        )
+
+    # Dark outer-boundary layer: the link bar and the knob discs grown by the
+    # stroke width, all painted in the station stroke colour.  Their union is
+    # the continuous dark outline of the finished glyph.
+    _link_bar(
+        (bar_half + sw) * 2,
+        theme.station_stroke,
+        **{**station_data, "class_": "nf-metro-rail-connector"},
+    )
+    _knobs(
+        knob_r + sw,
+        theme.station_stroke,
+        theme.station_stroke,
+        **{"class_": "nf-metro-rail-knob-outline", "data-station-id": station.id},
+    )
+
+    # White interior layer: the same shapes at their true radii, filling the
+    # interior of the outlined union with the station fill.
+    _link_bar(bar_half * 2, theme.station_fill)
+    _knobs(
+        knob_r,
+        theme.station_fill,
+        theme.station_fill,
+        **{"class_": "nf-metro-rail-knob", "data-station-id": station.id},
+    )
 
 
 def _render_stations(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -132,7 +132,11 @@ def _discover_fixtures() -> list[str]:
     (those are parser inputs, not layout inputs), any file lacking a
     ``%%metro`` directive, and opt-in rail-mode fixtures (which run a
     dedicated layout pipeline with its own geometry contract; see
-    ``tests/test_rail_mode.py``).
+    ``tests/test_rail_mode.py``).  This covers both the global
+    ``rail_mode: true`` flag and per-section ``rail_section:`` directives:
+    a mixed fixture's rail sections carry spanning-pill geometry the corpus
+    invariants don't model, so the whole fixture is routed to the dedicated
+    rail tests instead.
     """
     roots = [
         (FIXTURES, ""),
@@ -150,7 +154,7 @@ def _discover_fixtures() -> list[str]:
             text = p.read_text(errors="ignore")
             if "%%metro" not in text:
                 continue
-            if "rail_mode: true" in text:
+            if "rail_mode: true" in text or "rail_section:" in text:
                 continue
             # Address all examples paths through the ``examples`` resolver
             # without the leading ``examples/`` so tests can pick up either

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -129,8 +129,10 @@ def _discover_fixtures() -> list[str]:
     examples, addressable via :func:`_resolve_fixture`.
 
     Excludes Nextflow-format flowcharts under ``tests/fixtures/nextflow/``
-    (those are parser inputs, not layout inputs) and any file lacking a
-    ``%%metro`` directive.
+    (those are parser inputs, not layout inputs), any file lacking a
+    ``%%metro`` directive, and opt-in rail-mode fixtures (which run a
+    dedicated layout pipeline with its own geometry contract; see
+    ``tests/test_rail_mode.py``).
     """
     roots = [
         (FIXTURES, ""),
@@ -147,6 +149,8 @@ def _discover_fixtures() -> list[str]:
         for p in sorted(root.glob("*.mmd")):
             text = p.read_text(errors="ignore")
             if "%%metro" not in text:
+                continue
+            if "rail_mode: true" in text:
                 continue
             # Address all examples paths through the ``examples`` resolver
             # without the leading ``examples/`` so tests can pick up either

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -576,3 +576,136 @@ def test_no_rail_directive_default_off_byte_identical():
         s.rail_top_y is None and s.rail_bottom_y is None for s in g.stations.values()
     )
     assert "nf-metro-rail-knob" not in svg
+
+
+# ---------------------------------------------------------------------------
+# Convergence corners: 45-degree diagonals, not square right-angle bends
+# ---------------------------------------------------------------------------
+
+
+def _is_axis_aligned(p0, p1) -> bool:
+    """True when the segment p0->p1 is purely horizontal or purely vertical."""
+    return abs(p0[0] - p1[0]) < 0.5 or abs(p0[1] - p1[1]) < 0.5
+
+
+def test_rail_convergence_segments_are_diagonal_not_square():
+    """Where rails fan out from a single input or fan in to a single output,
+    the rail eases between rail Ys on a 45-degree diagonal segment (a segment
+    that changes BOTH x and y), not a square right-angle vertical jog."""
+    graph = _rail_graph()
+    from nf_metro.layout.routing import route_edges
+
+    routes = route_edges(graph)
+    diagonals = 0
+    for route in routes:
+        src = graph.stations.get(route.edge.source)
+        tgt = graph.stations.get(route.edge.target)
+        # Off-track feeders deliberately use an S-curve; not a convergence.
+        if (src and src.off_track) or (tgt and tgt.off_track):
+            continue
+        pts = route.points
+        # A convergence route changes rail Y between its endpoints.
+        if abs(pts[0][1] - pts[-1][1]) < 0.5:
+            continue
+        # Some interior segment must be a true diagonal (changes both x and y);
+        # a square jog would have only axis-aligned segments.
+        has_diag = any(not _is_axis_aligned(a, b) for a, b in zip(pts, pts[1:]))
+        assert has_diag, (
+            f"convergence {route.edge.source}->{route.edge.target} "
+            f"({route.line_id}) uses square bends, not a diagonal: {pts}"
+        )
+        # And no purely-vertical interior jog between the rails (the old
+        # square-bend signature).
+        interior = list(zip(pts, pts[1:]))[1:-1]
+        for a, b in interior:
+            assert not (abs(a[0] - b[0]) < 0.5 and abs(a[1] - b[1]) >= 0.5), (
+                f"convergence {route.edge.source}->{route.edge.target} "
+                f"has a square vertical jog {a}->{b}"
+            )
+        diagonals += 1
+    assert diagonals > 0, "expected at least one diagonal convergence route"
+
+
+def test_rail_fan_out_diagonal_eases_off_the_shared_input():
+    """The CRAM fan-out rails (deepvariant up, strelka down) leave the shared
+    input point on a diagonal then run flat -- the diagonal is biased early
+    (toward the fork) so most of the column is a straight rail."""
+    graph = _rail_graph()
+    from nf_metro.layout.routing import route_edges
+
+    routes = {(r.edge.source, r.edge.target, r.line_id): r for r in route_edges(graph)}
+    # cram_in -> align carries deepvariant (top) and strelka (bottom): both
+    # change rail Y and must contain a diagonal.
+    for line in ("deepvariant", "strelka"):
+        rp = routes.get(("cram_in", "align", line))
+        assert rp is not None, f"missing cram_in->align route for {line}"
+        pts = rp.points
+        assert abs(pts[0][1] - pts[-1][1]) > 0.5, "expected a rail-Y change"
+        assert any(not _is_axis_aligned(a, b) for a, b in zip(pts, pts[1:])), (
+            f"cram_in->align ({line}) is not diagonal: {pts}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Angled labels: tighter column spacing via the rotated horizontal projection
+# ---------------------------------------------------------------------------
+
+
+def _calling_column_step(angle: float) -> float:
+    g = parse_metro_mermaid(RAIL_MMD.read_text())
+    g.label_angle = angle
+    compute_layout(g)
+    xs = sorted(
+        {
+            round(s.x, 2)
+            for s in g.stations.values()
+            if s.section_id == "calling" and not s.is_port and not s.off_track
+        }
+    )
+    steps = [b - a for a, b in zip(xs, xs[1:])]
+    assert steps, "expected multiple columns in the calling section"
+    return steps[0]
+
+
+def test_angled_label_column_pitch_is_tighter_than_horizontal():
+    """An angled-label rail panel packs columns tighter than the same panel
+    with horizontal labels, because a diagonal label's horizontal footprint
+    is width*cos(angle)."""
+    horizontal = _calling_column_step(0.0)
+    angled = _calling_column_step(45.0)
+    assert angled < horizontal - 1.0, (
+        f"angled pitch {angled:.1f} not tighter than horizontal {horizontal:.1f}"
+    )
+
+
+def test_label_angle_directive_parses():
+    g = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert g.label_angle == 45.0
+
+
+def test_angled_rail_labels_render_rotated():
+    """With label_angle set, rail-section station labels render with a
+    rotate() transform (so the tilted text is actually drawn)."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    g = _rail_graph()
+    assert g.label_angle == 45.0
+    svg = render_svg(g, THEMES["nfcore"])
+    assert "rotate(45" in svg, "expected rotated label transforms in the SVG"
+
+
+def test_label_angle_default_off_byte_identical():
+    """label_angle support must not change a render with no directive: a graph
+    without label_angle produces an identical SVG before and after this change
+    (label_angle is None -> no rotation, no spacing change)."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
+    g = parse_metro_mermaid(src)
+    assert g.label_angle is None
+    compute_layout(g)
+    svg = render_svg(g, THEMES["nfcore"])
+    assert "rotate(45" not in svg
+    assert "rotate(" not in svg

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -198,9 +198,12 @@ def test_rail_mode_stations_within_bbox():
         )
 
 
-def test_spanning_pill_has_a_knob_per_used_rail():
-    """A multi-line spanning station records one used-rail Y per line it
-    carries, and the renderer draws a knob (a circle) at each."""
+def test_spanning_station_draws_one_circle_per_used_rail_plus_connector():
+    """A multi-rail station renders as the interchange idiom: one white
+    circle on each rail it uses, joined by a single straight connector
+    segment -- not as one filled capsule (pill)."""
+    import re
+
     from nf_metro.render import render_svg
     from nf_metro.themes import THEMES
 
@@ -212,17 +215,33 @@ def test_spanning_pill_has_a_knob_per_used_rail():
         for st in graph.stations.values()
         if st.rail_top_y is not None and st.rail_bottom_y is not None
     ]
-    assert spanning, "demo must contain at least one spanning pill"
+    assert spanning, "demo must contain at least one multi-rail station"
     for st in spanning:
         used = graph.station_lines(st.id)
         assert len(st.rail_used_ys) == len(used), (
             f"{st.id}: rail_used_ys {st.rail_used_ys} not parallel to lines {used}"
         )
-        # One knob marker per used line for this station.
-        knobs = svg.count(f'data-station-id="{st.id}"')
-        # The pill rect + one knob per used line all carry the station id.
-        assert knobs >= len(used) + 1, (
-            f"{st.id}: expected pill + {len(used)} knobs, found {knobs} markers"
+        # One circle (knob) per used rail.
+        knob_count = svg.count(f'class="nf-metro-rail-knob" data-station-id="{st.id}"')
+        assert knob_count == len(used), (
+            f"{st.id}: expected {len(used)} rail circles, found {knob_count}"
+        )
+        # Exactly one straight connector segment for the multi-rail station.
+        connectors = svg.count(
+            f'class="nf-metro-rail-connector" data-station-id="{st.id}"'
+        )
+        assert connectors == 1, (
+            f"{st.id}: expected one interchange connector, found {connectors}"
+        )
+
+    # The multi-rail marker must NOT be a filled capsule: no rounded rect
+    # (rx/ry) carries a rail station id.  (Single-rail circles use <circle>.)
+    for st in spanning:
+        rect_pat = re.compile(
+            rf'<rect[^>]*rx="[^"]+"[^>]*data-station-id="{re.escape(st.id)}"'
+        )
+        assert not rect_pat.search(svg), (
+            f"{st.id}: multi-rail station still renders as a capsule rect"
         )
 
 
@@ -316,6 +335,87 @@ def test_off_track_input_sits_above_the_rails():
             f"{st.id}: off_track station at {st.y} not above rails "
             f"{sorted(section_rails.values())}"
         )
+
+
+def test_rail_mode_labels_alternate_above_and_below():
+    """Rail-mode station labels alternate above/below the rails so dense
+    label runs don't pile on one edge: a section with several labelled
+    stations must use BOTH sides, and no label sits between two rails."""
+    from nf_metro.layout.labels import place_labels
+
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    placements = place_labels(graph)
+
+    by_section: dict[str, list] = {}
+    for lp in placements:
+        st = graph.stations.get(lp.station_id)
+        if st is None or st.is_port or st.is_terminus or not st.label.strip():
+            continue
+        by_section.setdefault(st.section_id, []).append(lp)
+
+    saw_multi = False
+    for sec_id, lps in by_section.items():
+        if len(lps) < 2:
+            continue
+        saw_multi = True
+        sides = {lp.above for lp in lps}
+        assert sides == {True, False}, (
+            f"{sec_id}: labels all on one side ({sides}); expected alternation"
+        )
+        # Each label stays close to its own station's rail span (it does not
+        # drift off into the middle of the inter-rail bundle): the baseline is
+        # within ~2 row-gaps of the nearest rail the station sits on.
+        section_rails = rails.get(sec_id, {})
+        for lp in lps:
+            st = graph.stations[lp.station_id]
+            own_top = st.rail_top_y if st.rail_top_y is not None else st.y
+            own_bot = st.rail_bottom_y if st.rail_bottom_y is not None else st.y
+            ys = sorted(section_rails.values())
+            gap = (ys[1] - ys[0]) if len(ys) >= 2 else 40.0
+            assert own_top - 2 * gap <= lp.y <= own_bot + 2 * gap, (
+                f"{sec_id}/{lp.station_id}: label at {lp.y} drifts far from its "
+                f"own rail span [{own_top}, {own_bot}]"
+            )
+    assert saw_multi, "demo must contain a section with several station labels"
+
+
+def test_off_track_input_feeds_in_with_short_clean_s_curve():
+    """An off-track input parks just left of (and above) its consumer column
+    so the feeder is a short S-curve, not a long diagonal traverse from the
+    section's left edge."""
+    from nf_metro.layout.routing import route_edges
+
+    graph = _rail_graph()
+    routes = route_edges(graph)
+    off_tracks = {st.id for st in graph.stations.values() if st.off_track}
+    assert off_tracks, "demo must contain an off_track input"
+
+    checked = 0
+    for rp in routes:
+        src = graph.stations.get(rp.edge.source)
+        tgt = graph.stations.get(rp.edge.target)
+        if src is None or tgt is None:
+            continue
+        if rp.edge.source not in off_tracks and rp.edge.target not in off_tracks:
+            continue
+        feeder = src if rp.edge.source in off_tracks else tgt
+        consumer = tgt if rp.edge.source in off_tracks else src
+        checked += 1
+        # The feeder must sit close to its consumer in X (within one column),
+        # so the drop is a short S-curve rather than a long diagonal.
+        assert abs(feeder.x - consumer.x) <= consumer.x, "sanity"
+        # Multi-point S-curve, and the horizontal reach is modest (< the full
+        # section width) -- the feeder is near the consumer, not at layer 0.
+        assert len(rp.points) >= 3
+        xs = [x for x, _ in rp.points]
+        sec = graph.sections.get(consumer.section_id)
+        if sec and sec.bbox_w > 0:
+            assert (max(xs) - min(xs)) < sec.bbox_w, (
+                f"off-track feeder spans {max(xs) - min(xs)}px across a "
+                f"{sec.bbox_w}px section -- too long a traverse"
+            )
+    assert checked, "expected at least one off-track feeder edge"
 
 
 def test_rail_mode_off_by_default_leaves_graph_unchanged():

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1,0 +1,195 @@
+"""Invariant tests for opt-in rail mode (parallel rails + spanning pills)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nf_metro.layout import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+RAIL_MMD = EXAMPLES / "rail_mode.mmd"
+
+
+def _rail_graph():
+    graph = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert graph.rail_mode is True
+    compute_layout(graph, validate=True)
+    return graph
+
+
+def _section_line_rails(graph):
+    """Map each section id -> {line_id: rail_y} derived from station Ys.
+
+    A line's rail Y is the common Y at which every station carrying ONLY that
+    line sits.  We reconstruct it from single-line stations plus the spanning
+    pills' top/bottom rails.
+    """
+    rails: dict[str, dict[str, float]] = {}
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden:
+            continue
+        lines = graph.station_lines(st.id)
+        if len(lines) == 1:
+            rails.setdefault(st.section_id, {})[lines[0]] = st.y
+    return rails
+
+
+def test_rail_mode_parses_directive():
+    graph = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert graph.rail_mode is True
+
+
+def test_each_line_runs_on_a_single_fixed_rail():
+    """Every station carrying a given line meets it at that line's fixed
+    rail Y, so the line is a straight horizontal run across the section."""
+    graph = _rail_graph()
+
+    # Per-section, per-line, collect the Y at which each station meets the
+    # line: single-rail stations contribute their y; spanning pills
+    # contribute the interpolated rail Y for the line within their span.
+    from nf_metro.layout.routing.rail import _line_rail_y
+
+    by_section_line: dict[tuple[str, str], set[float]] = {}
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden:
+            continue
+        for lid in graph.station_lines(st.id):
+            y = _line_rail_y(graph, st.id, lid)
+            by_section_line.setdefault((st.section_id, lid), set()).add(round(y, 2))
+
+    offenders = [
+        f"{sec}/{lid}: rails at {sorted(ys)}"
+        for (sec, lid), ys in by_section_line.items()
+        if len(ys) > 1
+    ]
+    assert not offenders, (
+        "each line must meet every station on a single fixed rail Y: "
+        + "; ".join(offenders)
+    )
+
+
+def test_rails_are_evenly_spaced_and_distinct():
+    """A section's lines occupy distinct, evenly-spaced rails."""
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    assert rails, "expected at least one section with single-line stations"
+    for sec_id, line_rails in rails.items():
+        ys = sorted(line_rails.values())
+        assert len(set(ys)) == len(ys), f"{sec_id}: rails not distinct: {ys}"
+        if len(ys) >= 3:
+            gaps = [round(b - a, 2) for a, b in zip(ys, ys[1:])]
+            assert len(set(gaps)) == 1, f"{sec_id}: rails not evenly spaced: {gaps}"
+
+
+def test_multi_line_station_span_covers_exactly_its_lines_rails():
+    """A spanning pill's drawn span (rail_top_y..rail_bottom_y) equals the
+    Y range of the rails its lines occupy -- no more, no less."""
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden:
+            continue
+        lines = graph.station_lines(st.id)
+        line_rails = rails.get(st.section_id, {})
+        used_ys = [line_rails[lid] for lid in lines if lid in line_rails]
+        if len(used_ys) < 2:
+            # Single-rail station: must not be a spanning pill.
+            assert st.rail_top_y is None and st.rail_bottom_y is None, (
+                f"{st.id}: single-rail station marked as spanning"
+            )
+            continue
+        assert st.rail_top_y is not None and st.rail_bottom_y is not None, (
+            f"{st.id}: multi-line station not marked spanning"
+        )
+        assert abs(st.rail_top_y - min(used_ys)) < 1.0, (
+            f"{st.id}: top rail {st.rail_top_y} != min used rail {min(used_ys)}"
+        )
+        assert abs(st.rail_bottom_y - max(used_ys)) < 1.0, (
+            f"{st.id}: bottom rail {st.rail_bottom_y} != max used rail {max(used_ys)}"
+        )
+
+
+def test_lines_do_not_converge_to_a_point():
+    """In rail mode no two distinct rails collapse to a shared Y at any
+    station -- the hallmark of the parallel-rails (non-converging) look."""
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    for sec_id, line_rails in rails.items():
+        ys = list(line_rails.values())
+        assert len(set(round(y, 2) for y in ys)) == len(ys), (
+            f"{sec_id}: rails converged to shared Ys: {sorted(ys)}"
+        )
+
+
+def test_rail_routes_are_straight_horizontal_at_rail_y():
+    """Every routed edge in rail mode is a straight horizontal run at its
+    line's rail Y (all waypoints share one Y)."""
+    graph = _rail_graph()
+    from nf_metro.layout.routing import route_edges
+    from nf_metro.layout.routing.rail import _line_rail_y
+
+    routes = route_edges(graph)
+    assert routes
+    for route in routes:
+        ys = {round(y, 2) for _, y in route.points}
+        src_y = _line_rail_y(graph, route.edge.source, route.line_id)
+        tgt_y = _line_rail_y(graph, route.edge.target, route.line_id)
+        if abs(src_y - tgt_y) < 0.5:
+            assert len(ys) == 1, (
+                f"{route.edge.source}->{route.edge.target} ({route.line_id}) "
+                f"not horizontal: Ys {ys}"
+            )
+        else:
+            # endpoints on different rails: jog uses exactly the two rail Ys
+            assert ys <= {round(src_y, 2), round(tgt_y, 2)}, (
+                f"jog uses unexpected Ys {ys}"
+            )
+
+
+def test_rail_mode_stations_within_bbox():
+    """All stations (incl. spanning pill extents) stay within their section
+    bbox -- the always-on containment guard passes under validate=True (run
+    in _rail_graph) and pills don't overflow."""
+    graph = _rail_graph()
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden or not st.section_id:
+            continue
+        sec = graph.sections.get(st.section_id)
+        if sec is None or sec.bbox_w <= 0:
+            continue
+        top = st.rail_top_y if st.rail_top_y is not None else st.y
+        bot = st.rail_bottom_y if st.rail_bottom_y is not None else st.y
+        assert sec.bbox_y - 1.0 <= top, f"{st.id} top {top} above bbox {sec.bbox_y}"
+        assert bot <= sec.bbox_y + sec.bbox_h + 1.0, (
+            f"{st.id} bottom {bot} below bbox {sec.bbox_y + sec.bbox_h}"
+        )
+
+
+def test_rail_mode_off_by_default_leaves_graph_unchanged():
+    """A representative graph laid out with rail mode OFF is byte-for-byte
+    the same as today: no rail spans are set, and the same SVG is produced
+    whether or not the (unset) rail_mode flag is touched."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
+
+    g1 = parse_metro_mermaid(src)
+    assert g1.rail_mode is False
+    compute_layout(g1)
+    svg1 = render_svg(g1, THEMES["nfcore"])
+
+    # No station should carry a rail span when rail mode is off.
+    assert all(
+        s.rail_top_y is None and s.rail_bottom_y is None for s in g1.stations.values()
+    )
+
+    g2 = parse_metro_mermaid(src)
+    g2.rail_mode = False  # explicit no-op
+    compute_layout(g2)
+    svg2 = render_svg(g2, THEMES["nfcore"])
+
+    assert svg1 == svg2

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -26,6 +26,8 @@ def _section_line_rails(graph):
     line sits.  We reconstruct it from single-line stations plus the spanning
     pills' top/bottom rails.
     """
+    from nf_metro.layout.rail_mode import _station_lines_in_order
+
     rails: dict[str, dict[str, float]] = {}
     for st in graph.stations.values():
         if st.is_port or st.is_hidden:
@@ -33,7 +35,9 @@ def _section_line_rails(graph):
         if st.off_track or (st.is_terminus and not st.label.strip()):
             # Converge to a point; contribute no rail evidence.
             continue
-        lines = graph.station_lines(st.id)
+        # rail_used_ys is parallel to the line-definition order, so reconstruct
+        # rails with that ordering (not edge-discovery order).
+        lines = _station_lines_in_order(graph, st.id)
         if len(lines) == 1:
             rails.setdefault(st.section_id, {})[lines[0]] = st.y
         elif st.rail_used_ys and len(st.rail_used_ys) == len(lines):
@@ -83,17 +87,40 @@ def test_each_line_runs_on_a_single_fixed_rail():
     )
 
 
+def _combo_member_ids(graph) -> set[str]:
+    members: set[str] = set()
+    for line_ids, _label in graph.legend_combos:
+        if len([lid for lid in line_ids if lid in graph.lines]) >= 2:
+            members.update(line_ids)
+    return members
+
+
 def test_rails_are_evenly_spaced_and_distinct():
-    """A section's lines occupy distinct, evenly-spaced rails."""
+    """A section's rail SLOTS are distinct and evenly spaced.
+
+    Each non-combo line occupies its own slot; combo members share one slot
+    (a tight bundle), so even spacing is asserted over the slot CENTRES (one
+    Y per non-combo line plus the bundle centre), not over every line's rail.
+    """
     graph = _rail_graph()
     rails = _section_line_rails(graph)
+    members = _combo_member_ids(graph)
     assert rails, "expected at least one section with single-line stations"
     for sec_id, line_rails in rails.items():
-        ys = sorted(line_rails.values())
-        assert len(set(ys)) == len(ys), f"{sec_id}: rails not distinct: {ys}"
+        # Collapse combo members in this section to their bundle centre.
+        bundle_ys = [y for lid, y in line_rails.items() if lid in members]
+        slot_ys = [y for lid, y in line_rails.items() if lid not in members]
+        if bundle_ys:
+            slot_ys.append(sum(bundle_ys) / len(bundle_ys))
+        ys = sorted(slot_ys)
+        assert len(set(round(y, 2) for y in ys)) == len(ys), (
+            f"{sec_id}: rail slots not distinct: {ys}"
+        )
         if len(ys) >= 3:
             gaps = [round(b - a, 2) for a, b in zip(ys, ys[1:])]
-            assert len(set(gaps)) == 1, f"{sec_id}: rails not evenly spaced: {gaps}"
+            assert max(gaps) - min(gaps) < 1.0, (
+                f"{sec_id}: rail slots not evenly spaced: {gaps}"
+            )
 
 
 def test_multi_line_station_span_covers_exactly_its_lines_rails():
@@ -627,16 +654,16 @@ def test_rail_convergence_segments_are_diagonal_not_square():
 
 
 def test_rail_fan_out_diagonal_eases_off_the_shared_input():
-    """The CRAM fan-out rails (deepvariant up, strelka down) leave the shared
+    """The CRAM fan-out rails (germline up, pair_t down) leave the shared
     input point on a diagonal then run flat -- the diagonal is biased early
     (toward the fork) so most of the column is a straight rail."""
     graph = _rail_graph()
     from nf_metro.layout.routing import route_edges
 
     routes = {(r.edge.source, r.edge.target, r.line_id): r for r in route_edges(graph)}
-    # cram_in -> align carries deepvariant (top) and strelka (bottom): both
+    # cram_in -> align carries germline (top) and pair_t (bottom): both
     # change rail Y and must contain a diagonal.
-    for line in ("deepvariant", "strelka"):
+    for line in ("germline", "pair_t"):
         rp = routes.get(("cram_in", "align", line))
         assert rp is not None, f"missing cram_in->align route for {line}"
         pts = rp.points
@@ -709,3 +736,135 @@ def test_label_angle_default_off_byte_identical():
     svg = render_svg(g, THEMES["nfcore"])
     assert "rotate(45" not in svg
     assert "rotate(" not in svg
+
+
+# ---------------------------------------------------------------------------
+# legend_combo bundling: combo lines share ONE rail slot (a tight bundle)
+# ---------------------------------------------------------------------------
+
+
+def test_legend_combo_directive_parses():
+    g = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert g.legend_combos == [(("pair_n", "pair_t"), "Tumour-normal pair")]
+
+
+def test_combo_lines_share_one_rail_slot():
+    """Lines that are members of a legend_combo occupy a single rail slot
+    drawn as a tight adjacent bundle, so the rail-slot count equals the
+    distinct non-combo lines plus one slot per combo -- not one per line."""
+    from nf_metro.layout.rail_mode import _rail_slot_offsets, _section_lines_in_order
+
+    graph = _rail_graph()
+    y_spacing = 40.0
+    section = graph.sections["calling"]
+    lines = _section_lines_in_order(graph, section)
+    members = _combo_member_ids(graph)
+    assert members, "demo must contain a legend_combo"
+
+    slot_offset, n_slots = _rail_slot_offsets(graph, lines, y_spacing)
+
+    expected = len([lid for lid in lines if lid not in members]) + 1
+    assert n_slots == expected, (
+        f"expected {expected} rail slots (non-combo lines + 1 per combo), got {n_slots}"
+    )
+    # All combo members in the section land on the SAME slot centre: their
+    # offsets differ by less than a full rail pitch (they hug as a bundle).
+    member_offsets = [slot_offset[lid] for lid in members if lid in slot_offset]
+    assert len(member_offsets) >= 2
+    assert max(member_offsets) - min(member_offsets) < y_spacing, (
+        f"combo members did not bundle onto one slot: {member_offsets}"
+    )
+    # ...and they are NOT coincident (a visible two-line bundle, not one rail).
+    assert max(member_offsets) - min(member_offsets) > 0.5, (
+        "combo members collapsed to a single coincident rail"
+    )
+    # A non-combo line is a full rail pitch away from the bundle centre.
+    bundle_centre = sum(member_offsets) / len(member_offsets)
+    non_combo = [
+        slot_offset[lid] for lid in lines if lid not in members and lid in slot_offset
+    ]
+    assert all(abs(o - bundle_centre) >= y_spacing - 1.0 for o in non_combo), (
+        "a non-combo rail is closer than a full pitch to the bundle"
+    )
+
+
+def test_cross_track_station_knob_spans_the_bundle():
+    """A cross-track (spanning) station that uses the bundle draws a knob on
+    each of the bundle's hugging sub-rails -- its span reaches the bundle
+    slot."""
+    from nf_metro.layout.rail_mode import _station_lines_in_order
+
+    graph = _rail_graph()
+    members = _combo_member_ids(graph)
+    # `align` carries every line, so it must place a knob on each bundle sub-rail.
+    st = graph.stations["align"]
+    served = _station_lines_in_order(graph, st.id)
+    member_ys = [y for lid, y in zip(served, st.rail_used_ys) if lid in members]
+    assert len(member_ys) == len(members), (
+        f"spanning station missing a bundle knob: {member_ys}"
+    )
+    # The bundle knobs are adjacent (within a pitch) and distinct.
+    assert 0.5 < max(member_ys) - min(member_ys) < 40.0
+
+
+def test_interchange_link_uses_station_fill_not_dark_stroke():
+    """The cross-track interchange link renders WHITE (the station fill), not
+    the dark station stroke -- the dark stroke is only the outer boundary.
+
+    The white link bar fills the interior; a separate dark layer paints the
+    outline.  Assert the white interior bar is present (station fill stroke)
+    and that the connector is no longer a lone dark line cutting across."""
+    import re
+
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = _rail_graph()
+    theme = THEMES["nfcore"]
+    svg = render_svg(graph, theme)
+
+    spanning = [
+        st
+        for st in graph.stations.values()
+        if st.rail_top_y is not None and st.rail_bottom_y is not None
+    ]
+    assert spanning, "demo must contain a multi-rail (cross-track) station"
+
+    # The link bars render as round-capped <path> elements (drawsvg emits Line
+    # as a path).  A white (station-fill) interior bar must be drawn for the
+    # glyph, joining the circles in white rather than dark.
+    fill = re.escape(theme.station_fill)
+    white_vbar = re.compile(rf'<path[^>]*stroke="{fill}"[^>]*stroke-linecap="round"')
+    assert white_vbar.search(svg), (
+        f"expected a white ({theme.station_fill}) interchange link bar; "
+        "the connector must render with the station fill, not the dark stroke"
+    )
+
+    # The dark outline layer carries the connector class so the glyph keeps a
+    # continuous dark outer boundary behind the white interior.
+    stroke = re.escape(theme.station_stroke)
+    dark_connector = re.compile(
+        rf'stroke="{stroke}"[^>]*stroke-linecap="round"[^>]*nf-metro-rail-connector'
+    )
+    assert dark_connector.search(svg), (
+        "expected a dark outline layer (connector class) behind the white link"
+    )
+
+
+def test_legend_combo_default_off_byte_identical():
+    """Adding legend_combo parsing/render must not change a render that has no
+    legend_combo directive: byte-for-byte identical SVG, no combo state."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
+    g = parse_metro_mermaid(src)
+    assert g.legend_combos == []
+    compute_layout(g)
+    svg1 = render_svg(g, THEMES["nfcore"])
+
+    g2 = parse_metro_mermaid(src)
+    g2.legend_combos = []  # explicit no-op
+    compute_layout(g2)
+    svg2 = render_svg(g2, THEMES["nfcore"])
+    assert svg1 == svg2

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -343,3 +343,136 @@ def test_rail_mode_off_by_default_leaves_graph_unchanged():
     svg2 = render_svg(g2, THEMES["nfcore"])
 
     assert svg1 == svg2
+
+
+# ---------------------------------------------------------------------------
+# Per-section rail mode (%%metro rail_section: <id>)
+# ---------------------------------------------------------------------------
+
+RAIL_SECTION_MMD = EXAMPLES / "rail_section.mmd"
+
+
+def _rail_section_graph():
+    graph = parse_metro_mermaid(RAIL_SECTION_MMD.read_text())
+    compute_layout(graph, validate=True)
+    return graph
+
+
+def test_rail_section_directive_parses():
+    graph = parse_metro_mermaid(RAIL_SECTION_MMD.read_text())
+    assert graph.rail_mode is False
+    assert graph.rail_sections == {"pathways"}
+    assert graph.has_rail_sections is True
+    assert graph.is_rail_section("pathways") is True
+    assert graph.is_rail_section("calling") is False
+
+
+def test_global_rail_mode_treats_all_sections_as_rail():
+    """The legacy global flag means every section is a rail section."""
+    graph = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert graph.rail_mode is True
+    # Every declared section reports as a rail section under the global flag.
+    for sid in graph.sections:
+        assert graph.is_rail_section(sid) is True
+    # ...even though rail_sections was never populated explicitly.
+    assert graph.rail_sections == set()
+
+
+def test_flagged_section_gets_rail_spans():
+    """Stations in the flagged section span multiple rails (pills)."""
+    graph = _rail_section_graph()
+    pathways = graph.sections["pathways"]
+    spanning = [
+        graph.stations[sid]
+        for sid in pathways.station_ids
+        if not graph.stations[sid].is_port
+    ]
+    # The multi-line pathway stations all carry 3 lines, so each spans rails.
+    assert spanning, "pathways section should have real stations"
+    assert all(
+        st.rail_top_y is not None and st.rail_bottom_y is not None
+        for st in spanning
+        if len(graph.station_lines(st.id)) > 1
+    )
+    # Used rails recorded per station match the lines they carry.
+    for st in spanning:
+        lines = graph.station_lines(st.id)
+        if len(lines) > 1:
+            assert len(st.rail_used_ys) == len(lines)
+
+
+def test_normal_section_keeps_per_line_tracks_not_rail_spans():
+    """A non-flagged connected section keeps normal layout: no rail spans."""
+    graph = _rail_section_graph()
+    for sid in ("preprocess", "calling", "annotate"):
+        section = graph.sections[sid]
+        for st_id in section.station_ids:
+            st = graph.stations[st_id]
+            assert st.rail_top_y is None, f"{st_id} unexpectedly has a rail span"
+            assert st.rail_bottom_y is None
+            assert st.rail_used_ys == []
+
+
+def test_normal_section_lines_share_a_trunk():
+    """The connected trunk's co-travelling lines bundle (converge), unlike
+    rail mode where they stay on separate fixed rails."""
+    graph = _rail_section_graph()
+    # In the calling section, markdup carries both dna and rna; in normal
+    # (non-rail) layout that station sits at a single Y (the trunk), not a
+    # multi-rail pill.
+    markdup = graph.stations["markdup"]
+    assert markdup.rail_top_y is None
+    # Rail-section pathway stations DO span; assert the contrast holds.
+    score = graph.stations["score"]
+    assert score.rail_top_y is not None
+
+
+def test_rail_section_internal_edges_routed_as_straight_rails():
+    """Internal edges of the rail section render as flat horizontal runs."""
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    graph = _rail_section_graph()
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    pathway_ids = set(graph.sections["pathways"].station_ids)
+    seen_internal = 0
+    for rp in routes:
+        if rp.edge.source in pathway_ids and rp.edge.target in pathway_ids:
+            ys = {round(y, 2) for _, y in rp.points}
+            assert len(ys) == 1, (
+                f"rail edge {rp.edge.source}->{rp.edge.target} is not a "
+                f"flat horizontal run: Ys {ys}"
+            )
+            seen_internal += 1
+    assert seen_internal > 0, "expected some routed internal rail edges"
+
+
+def test_per_section_rail_validates_and_contains():
+    """validate=True passes and rail stations stay within their bbox."""
+    graph = _rail_section_graph()  # compute_layout(validate=True) inside
+    pathways = graph.sections["pathways"]
+    for st_id in pathways.station_ids:
+        st = graph.stations[st_id]
+        if st.is_port:
+            continue
+        top = st.rail_top_y if st.rail_top_y is not None else st.y
+        bot = st.rail_bottom_y if st.rail_bottom_y is not None else st.y
+        assert top >= pathways.bbox_y - 1e-6
+        assert bot <= pathways.bbox_y + pathways.bbox_h + 1e-6
+
+
+def test_no_rail_directive_default_off_byte_identical():
+    """Adding per-section rail support must not change a normal render."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
+    g = parse_metro_mermaid(src)
+    assert g.has_rail_sections is False
+    compute_layout(g)
+    svg = render_svg(g, THEMES["nfcore"])
+    # No rail span leaks into a normal graph.
+    assert all(
+        s.rail_top_y is None and s.rail_bottom_y is None for s in g.stations.values()
+    )
+    assert "nf-metro-rail-knob" not in svg

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -30,9 +30,18 @@ def _section_line_rails(graph):
     for st in graph.stations.values():
         if st.is_port or st.is_hidden:
             continue
+        if st.off_track or (st.is_terminus and not st.label.strip()):
+            # Converge to a point; contribute no rail evidence.
+            continue
         lines = graph.station_lines(st.id)
         if len(lines) == 1:
             rails.setdefault(st.section_id, {})[lines[0]] = st.y
+        elif st.rail_used_ys and len(st.rail_used_ys) == len(lines):
+            # A spanning pill records each used line's rail Y directly, which
+            # lets us reconstruct rails even in sections with no single-line
+            # stations.
+            for lid, y in zip(lines, st.rail_used_ys):
+                rails.setdefault(st.section_id, {})[lid] = y
     return rails
 
 
@@ -54,6 +63,10 @@ def test_each_line_runs_on_a_single_fixed_rail():
     by_section_line: dict[tuple[str, str], set[float]] = {}
     for st in graph.stations.values():
         if st.is_port or st.is_hidden:
+            continue
+        # Off-track inputs sit above the rails and blank termini converge the
+        # rails to their icon; both legitimately meet lines off the rail Y.
+        if st.off_track or (st.is_terminus and not st.label.strip()):
             continue
         for lid in graph.station_lines(st.id):
             y = _line_rail_y(graph, st.id, lid)
@@ -91,6 +104,13 @@ def test_multi_line_station_span_covers_exactly_its_lines_rails():
 
     for st in graph.stations.values():
         if st.is_port or st.is_hidden:
+            continue
+        # Off-track inputs and blank termini converge to a point (an icon /
+        # an above-rail feeder), so they are deliberately not spanning pills.
+        if st.off_track or (st.is_terminus and not st.label.strip()):
+            assert st.rail_top_y is None and st.rail_bottom_y is None, (
+                f"{st.id}: off-track/blank-terminus must not be a spanning pill"
+            )
             continue
         lines = graph.station_lines(st.id)
         line_rails = rails.get(st.section_id, {})
@@ -134,6 +154,16 @@ def test_rail_routes_are_straight_horizontal_at_rail_y():
     routes = route_edges(graph)
     assert routes
     for route in routes:
+        src = graph.stations.get(route.edge.source)
+        tgt = graph.stations.get(route.edge.target)
+        # Off-track feeders deliberately leave the rail with an S-curve;
+        # exempt them from the straight-horizontal invariant.
+        if (src and src.off_track) or (tgt and tgt.off_track):
+            assert len(route.points) >= 3, (
+                f"off_track feeder {route.edge.source}->{route.edge.target} "
+                "should be a multi-point S-curve"
+            )
+            continue
         ys = {round(y, 2) for _, y in route.points}
         src_y = _line_rail_y(graph, route.edge.source, route.line_id)
         tgt_y = _line_rail_y(graph, route.edge.target, route.line_id)
@@ -165,6 +195,126 @@ def test_rail_mode_stations_within_bbox():
         assert sec.bbox_y - 1.0 <= top, f"{st.id} top {top} above bbox {sec.bbox_y}"
         assert bot <= sec.bbox_y + sec.bbox_h + 1.0, (
             f"{st.id} bottom {bot} below bbox {sec.bbox_y + sec.bbox_h}"
+        )
+
+
+def test_spanning_pill_has_a_knob_per_used_rail():
+    """A multi-line spanning station records one used-rail Y per line it
+    carries, and the renderer draws a knob (a circle) at each."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = _rail_graph()
+    svg = render_svg(graph, THEMES["nfcore"])
+
+    spanning = [
+        st
+        for st in graph.stations.values()
+        if st.rail_top_y is not None and st.rail_bottom_y is not None
+    ]
+    assert spanning, "demo must contain at least one spanning pill"
+    for st in spanning:
+        used = graph.station_lines(st.id)
+        assert len(st.rail_used_ys) == len(used), (
+            f"{st.id}: rail_used_ys {st.rail_used_ys} not parallel to lines {used}"
+        )
+        # One knob marker per used line for this station.
+        knobs = svg.count(f'data-station-id="{st.id}"')
+        # The pill rect + one knob per used line all carry the station id.
+        assert knobs >= len(used) + 1, (
+            f"{st.id}: expected pill + {len(used)} knobs, found {knobs} markers"
+        )
+
+
+def test_knob_absent_on_a_rail_the_span_crosses_but_does_not_use():
+    """A pill that spans a rail belonging to a line it does NOT use draws no
+    knob on that rail -- the rail reads as passing behind the pill."""
+    graph = _rail_graph()
+
+    rails = _section_line_rails(graph)
+    found = False
+    for st in graph.stations.values():
+        if st.rail_top_y is None or st.rail_bottom_y is None:
+            continue
+        used = set(graph.station_lines(st.id))
+        line_rails = rails.get(st.section_id, {})
+        # Lines whose rail falls strictly inside this pill's span.
+        crossing = {
+            lid
+            for lid, y in line_rails.items()
+            if st.rail_top_y - 0.5 < y < st.rail_bottom_y + 0.5
+        }
+        passing_behind = crossing - used
+        if not passing_behind:
+            continue
+        found = True
+        # None of the passing-behind lines may have a used-rail Y on this
+        # station (no knob), while every used line must.
+        for lid in passing_behind:
+            assert line_rails[lid] not in [
+                round(y, 2) for y in (round(v, 2) for v in st.rail_used_ys)
+            ], f"{st.id}: knob drawn on non-used rail for {lid}"
+    assert found, "demo must contain a pill that spans a rail of a line it does not use"
+
+
+def test_blank_terminus_renders_icon_not_pill():
+    """A blank file-terminus serving several lines renders as its file icon
+    (a path with the terminus fold), not as a bare spanning pill."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = _rail_graph()
+    svg = render_svg(graph, THEMES["nfcore"])
+
+    blank_termini = [
+        st
+        for st in graph.stations.values()
+        if st.is_terminus and not st.label.strip() and not st.is_port
+    ]
+    assert blank_termini, "demo must contain a blank file-terminus"
+    for st in blank_termini:
+        # A blank terminus must not be marked as a spanning pill.
+        assert st.rail_top_y is None and st.rail_bottom_y is None, (
+            f"{st.id}: blank terminus marked as spanning pill"
+        )
+    # The CRAM/CSV/VCF icon chip labels must appear as rendered text.
+    for chip in ("CRAM", "CSV", "VCF"):
+        assert chip in svg, f"expected file-icon chip {chip!r} in rail-mode SVG"
+
+
+def test_stacked_sections_do_not_overlap():
+    """Two or more stacked rail-mode sections occupy disjoint vertical bands
+    (bbox-wise), so neither section's content reaches into the other."""
+    graph = _rail_graph()
+    boxes = sorted(
+        (
+            (s.bbox_y, s.bbox_y + s.bbox_h, s.id)
+            for s in graph.sections.values()
+            if s.bbox_h > 0 and (not s.is_implicit or s.station_ids)
+        ),
+        key=lambda b: b[0],
+    )
+    assert len(boxes) >= 2, "demo must contain at least two stacked sections"
+    for (top_a, bot_a, id_a), (top_b, bot_b, id_b) in zip(boxes, boxes[1:]):
+        assert bot_a <= top_b + 0.5, (
+            f"sections {id_a} and {id_b} overlap: {bot_a} > {top_b}"
+        )
+
+
+def test_off_track_input_sits_above_the_rails():
+    """An off_track input station is parked above every rail in its section
+    (it feeds in with an S-curve rather than sitting on a rail)."""
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    off_tracks = [st for st in graph.stations.values() if st.off_track]
+    assert off_tracks, "demo must contain an off_track input"
+    for st in off_tracks:
+        section_rails = rails.get(st.section_id, {})
+        if not section_rails:
+            continue
+        assert st.y < min(section_rails.values()) - 0.5, (
+            f"{st.id}: off_track station at {st.y} not above rails "
+            f"{sorted(section_rails.values())}"
         )
 
 

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -407,10 +407,10 @@ def test_rail_mode_labels_alternate_above_and_below():
     assert saw_multi, "demo must contain a section with several station labels"
 
 
-def test_off_track_input_feeds_in_with_short_clean_s_curve():
-    """An off-track input parks just left of (and above) its consumer column
-    so the feeder is a short S-curve, not a long diagonal traverse from the
-    section's left edge."""
+def test_off_track_input_feeds_in_with_clean_drop_and_elbow():
+    """An off-track input drops straight down from its icon then turns onto the
+    consumer's rail with a single elbow: a clean L (vertical leg + horizontal
+    leg), near its consumer, not a long diagonal traverse from the left edge."""
     from nf_metro.layout.routing import route_edges
 
     graph = _rail_graph()
@@ -426,16 +426,16 @@ def test_off_track_input_feeds_in_with_short_clean_s_curve():
             continue
         if rp.edge.source not in off_tracks and rp.edge.target not in off_tracks:
             continue
-        feeder = src if rp.edge.source in off_tracks else tgt
         consumer = tgt if rp.edge.source in off_tracks else src
         checked += 1
-        # The feeder must sit close to its consumer in X (within one column),
-        # so the drop is a short S-curve rather than a long diagonal.
-        assert abs(feeder.x - consumer.x) <= consumer.x, "sanity"
-        # Multi-point S-curve, and the horizontal reach is modest (< the full
-        # section width) -- the feeder is near the consumer, not at layer 0.
-        assert len(rp.points) >= 3
-        xs = [x for x, _ in rp.points]
+        # An off-track feed is exactly drop + elbow + horizontal: three points,
+        # a vertical first leg (shared X) and a horizontal last leg (shared Y).
+        pts = rp.points if rp.edge.source in off_tracks else list(reversed(rp.points))
+        assert len(pts) == 3, f"off-track feed not a 3-point L: {pts}"
+        assert abs(pts[0][0] - pts[1][0]) < 0.5, f"first leg not vertical: {pts}"
+        assert abs(pts[1][1] - pts[2][1]) < 0.5, f"last leg not horizontal: {pts}"
+        # The horizontal reach stays within the section (feeder near consumer).
+        xs = [x for x, _ in pts]
         sec = graph.sections.get(consumer.section_id)
         if sec and sec.bbox_w > 0:
             assert (max(xs) - min(xs)) < sec.bbox_w, (
@@ -443,6 +443,114 @@ def test_off_track_input_feeds_in_with_short_clean_s_curve():
                 f"{sec.bbox_w}px section -- too long a traverse"
             )
     assert checked, "expected at least one off-track feeder edge"
+
+
+def test_off_track_bundle_feeders_do_not_merge():
+    """Several lines feeding from one off-track input each drop on their own X
+    (one per target rail), so the bundle stays distinct parallel lines in the
+    vertical leg rather than collapsing into one fat merged line."""
+    from nf_metro.layout.routing import route_edges
+
+    graph = _rail_graph()
+    routes = route_edges(graph)
+    off_tracks = {st.id for st in graph.stations.values() if st.off_track}
+
+    # Group off-track feeds by (feeder, consumer); the demo's samples_csv feeds
+    # bqsr on two lines (pair_n, pair_t) -- a 2-line bundle.
+    drops: dict[tuple[str, str], list[float]] = {}
+    for rp in routes:
+        if rp.edge.source not in off_tracks and rp.edge.target not in off_tracks:
+            continue
+        feeder = rp.edge.source if rp.edge.source in off_tracks else rp.edge.target
+        consumer = rp.edge.target if rp.edge.source in off_tracks else rp.edge.source
+        pts = rp.points if rp.edge.source in off_tracks else list(reversed(rp.points))
+        drops.setdefault((feeder, consumer), []).append(round(pts[0][0], 2))
+
+    multi = {k: v for k, v in drops.items() if len(v) >= 2}
+    assert multi, "demo must contain a multi-line off-track bundle feed"
+    for key, drop_xs in multi.items():
+        assert len(set(drop_xs)) == len(drop_xs), (
+            f"{key}: bundle feeder lines share a drop X {drop_xs} -- they merge"
+        )
+
+
+def test_rail_labels_clear_the_whole_panel_never_beside_a_middle_rail():
+    """Every rail-mode station label sits ABOVE the panel's topmost rail or
+    BELOW its bottommost rail - never beside a middle rail (which would have
+    the label collide with the lines).  This holds even for a station that
+    only occupies middle rails (its label still clears the outer rails)."""
+    from nf_metro.layout.labels import _label_bbox, place_labels
+
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    placements = place_labels(graph)
+
+    checked = 0
+    for lp in placements:
+        st = graph.stations.get(lp.station_id)
+        if st is None or st.is_port or not st.label.strip():
+            continue
+        if st.is_terminus and not st.label.strip():
+            continue
+        section_rails = rails.get(st.section_id)
+        if not section_rails or len(section_rails) < 2:
+            continue
+        top_rail = min(section_rails.values())
+        bot_rail = max(section_rails.values())
+        x0, y0, x1, y1 = _label_bbox(lp)
+        # The label's nearest edge to the rail band must be outside it: an
+        # above label's bottom edge is at/above the top rail; a below label's
+        # top edge is at/below the bottom rail.  A small tolerance covers the
+        # descender clearance baked into placement.
+        tol = 6.0
+        clears_top = y1 <= top_rail + tol
+        clears_bottom = y0 >= bot_rail - tol
+        assert clears_top or clears_bottom, (
+            f"{st.section_id}/{st.id}: label y[{y0:.1f},{y1:.1f}] sits beside a "
+            f"middle rail (rail band [{top_rail:.1f},{bot_rail:.1f}])"
+        )
+        checked += 1
+    assert checked, "expected at least one labelled rail station"
+
+
+def test_stacked_rail_section_bbox_contains_hanging_labels():
+    """A rail section's bbox reserves room for its below-rail labels so a
+    section stacked beneath it clears them.  A long, steeply-angled label whose
+    footprint exceeds the default padding grows the box; a section below then
+    keeps a positive header gap (no clash)."""
+    from nf_metro.layout import compute_layout
+    from nf_metro.layout.constants import SECTION_HEADER_PROTRUSION
+
+    src = (
+        "%%metro title: t\n"
+        "%%metro style: dark\n"
+        "%%metro rail_mode: true\n"
+        "%%metro label_angle: 45\n"
+        "%%metro line: a | A | #2db572\n"
+        "%%metro line: b | B | #0570b0\n"
+        "%%metro grid: top | 0,0\n"
+        "%%metro grid: bot | 0,1\n"
+        "graph LR\n"
+        "    subgraph top [Top]\n"
+        "        t1[Start]\n"
+        "        t2[An extremely long station label name to overflow the pad]\n"
+        "        t1 -->|a,b| t2\n"
+        "    end\n"
+        "    subgraph bot [Bottom]\n"
+        "        u1[Go]\n"
+        "        u2[End]\n"
+        "        u1 -->|a,b| u2\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(src)
+    compute_layout(graph, validate=True)
+    top = graph.sections["top"]
+    bot = graph.sections["bot"]
+    # The long-label section's bbox grew well past a bare two-rail panel.
+    assert top.bbox_h > 200, f"top bbox did not reserve label band: {top.bbox_h}"
+    # The lower section's header (badge top) clears the upper section's box.
+    gap = (bot.bbox_y - SECTION_HEADER_PROTRUSION) - (top.bbox_y + top.bbox_h)
+    assert gap >= 0, f"lower header overlaps the section above: gap {gap:.1f}px"
 
 
 def test_rail_mode_off_by_default_leaves_graph_unchanged():
@@ -785,6 +893,27 @@ def test_combo_lines_share_one_rail_slot():
     ]
     assert all(abs(o - bundle_centre) >= y_spacing - 1.0 for o in non_combo), (
         "a non-combo rail is closer than a full pitch to the bundle"
+    )
+
+
+def test_combo_bundle_sublines_hug_at_one_offset_step():
+    """A legend_combo bundle's sub-lines sit exactly one OFFSET_STEP apart -
+    the same tight pitch the normal router uses for parallel lines in a bundle -
+    so the bundle reads as a single track, not two spaced-apart rails."""
+    from nf_metro.layout.constants import OFFSET_STEP
+    from nf_metro.layout.rail_mode import _rail_slot_offsets, _section_lines_in_order
+
+    graph = _rail_graph()
+    section = graph.sections["calling"]
+    lines = _section_lines_in_order(graph, section)
+    members = _combo_member_ids(graph)
+    slot_offset, _ = _rail_slot_offsets(graph, lines, 40.0)
+
+    member_offsets = sorted(slot_offset[lid] for lid in members if lid in slot_offset)
+    assert len(member_offsets) == 2, "demo's combo bundle has two members"
+    gap = member_offsets[1] - member_offsets[0]
+    assert abs(gap - OFFSET_STEP) < 1e-6, (
+        f"combo sub-lines {gap}px apart; expected one OFFSET_STEP ({OFFSET_STEP}px)"
     )
 
 


### PR DESCRIPTION
Adds an opt-in **rail mode** that reproduces the nf-core/sarek "Example analysis pathways" subway idiom: metro lines run as fixed parallel horizontal rails and a station shared by several lines draws as one vertical pill spanning the rails it serves, instead of the lines converging to a single point.

## What it does

Enabled per-diagram with `%%metro rail_mode: true`. For LR sections:

- **Rails**: each line present in a section gets a fixed, evenly-spaced rail Y (centred about the section trunk, ordered by line definition). A line is a straight horizontal run along its rail across the section.
- **Station X**: unchanged - longest-path layer -> column.
- **Station Y / span**: a station spans the rail-Y range of the lines it carries; the span is stored on the station for the renderer. Single-line stations sit on that line's rail.
- **Render**: a station whose lines cover more than one rail draws as one vertical pill from its top rail Y to its bottom rail Y. Single-rail stations render as today. Labels are offset from the pill span so they clear every rail.
- **Routing**: a dedicated rail router draws each line as a straight horizontal run at its rail Y. A line that does not use a station passes straight along its rail; if a non-using line's rail falls between the rails a pill spans, that rail crosses the pill (accepted for v1).

## Gating

The entire rail-mode path is gated on `MetroGraph.rail_mode`:

- `compute_layout` dispatches to the self-contained `layout/rail_mode.py` pipeline and returns early, so the normal phase pipeline never runs in rail mode.
- `route_edges` and `compute_station_offsets` short-circuit to the rail router / empty offsets.
- The renderer only draws a spanning pill when a station has a rail span set.

With the flag off (default), the full existing gallery renders **byte-identical** to `main` (verified by building the gallery on both and diffing every SVG; only the new `rail_mode.svg` is added).

## Demo

`examples/rail_mode.mmd` - a compact 3-line variant-calling weave (DeepVariant / HaplotypeCaller / Strelka2) with shared callers (Alignment, Mark duplicates, BQSR, Normalize, Annotate) as spanning pills and line-exclusive callers on their own rail. Registered in the gallery.

## Tests

`tests/test_rail_mode.py` asserts: each line sits on a single fixed rail Y; a multi-line station's drawn span covers exactly its lines' rails; rails are distinct and evenly spaced; lines never converge; rail routes are straight horizontal at the rail Y; bbox containment holds; and a representative graph laid out with rail mode off is byte-identical to today.

`compute_layout(validate=True)` passes on the demo.

## Known limitations / rough edges

- **Scope is single LR-section panels.** Multi-section rail-mode graphs lay out and render without error, but inter-section port/junction routing is rough (cross-section legs can wander); the polished idiom is the single-section panel.
- A line that does not use a station but whose rail falls between two rails the station spans crosses the pill (acceptable for v1).
- Pill labels use the existing label placer (offset from the pill span); single-rail exclusive-station labels can sit close to their own rail dot.
- TB/RL sections are not specially handled in rail mode (treated as LR rails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)