### PR TITLE
feat(layout): place disconnected section components independently

### DIFF
--- a/examples/disconnected_components.mmd
+++ b/examples/disconnected_components.mmd
@@ -1,0 +1,40 @@
+%%metro title: Disconnected Components
+%%metro style: dark
+%%metro line: main | Main Pipeline | #e63946
+%%metro line: aux | Auxiliary Report | #0570b0
+
+graph LR
+    subgraph ingest [Ingest]
+        in1[Read Input]
+        in2[Validate]
+        in1 -->|main| in2
+    end
+
+    subgraph process [Process]
+        pr1[Align]
+        pr2[Filter]
+        pr1 -->|main| pr2
+    end
+
+    subgraph results [Results]
+        re1[Summarise]
+        re2[Publish]
+        re1 -->|main| re2
+    end
+
+    subgraph wide_report [Standalone QC Report]
+        w1[Collect]
+        w2[Aggregate]
+        w3[Annotate]
+        w4[Normalise]
+        w5[Visualise]
+        w6[Export]
+        w1 -->|aux| w2
+        w2 -->|aux| w3
+        w3 -->|aux| w4
+        w4 -->|aux| w5
+        w5 -->|aux| w6
+    end
+
+    in2 -->|main| pr1
+    pr2 -->|main| re1

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -133,6 +133,15 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "stacking each section in its own grid row. Regression fixture for "
         "#250 (cross-column junction routes were going backward in X).",
     ),
+    (
+        "disconnected_components",
+        EXAMPLES_DIR,
+        "A connected three-section trunk plus a separate, wide disconnected "
+        "section. Each weakly-connected component of the section graph is "
+        "placed in its own local column grid and the components are stacked "
+        "vertically, so the wide panel never inflates the trunk's columns or "
+        "flings its later sections to the right.",
+    ),
     # --- Simple topologies ---
     (
         "single_section",

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -212,8 +212,19 @@ in pipeline order.
   positions from `auto_layout`. Still all local-coord.
 - **Postcondition**: Every section has `offset_x`, `offset_y` set such
   that `(local + offset)` lands sections on a non-overlapping grid.
+- **Disconnected graphs**: When the section meta-graph has 2+
+  weakly-connected components and the author pinned no explicit
+  `%%metro grid:` positions, each component is placed in its own local
+  column grid (so a wide component never inflates another's columns)
+  and the components are stacked vertically in a deterministic order
+  (ascending min original row, then descending size, then smallest
+  section id), left-aligned and separated by `section_y_gap`. Any
+  explicit grid override falls back to the shared single-grid path.
 - **Invariants preserved**: Station local coords unchanged. Bboxes
   still local-coord.
+- **Runtime guard**: `_guard_independent_components_disjoint` (under
+  `validate=True`) asserts stacked components occupy disjoint vertical
+  bands.
 - **Lifecycle:** invariant - the section grid (column/row placement,
   non-overlap) holds at the final boundary.
 

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -481,6 +481,10 @@ from untouched ones when checking column-companion consensus."""
 GUARD_TOLERANCE: float = 5.0
 """Tolerance for stage-boundary invariant checks (port-on-boundary, etc.)."""
 
+COMPONENT_BAND_OVERLAP_TOLERANCE: float = 0.5
+"""Slack permitted when checking that independently-stacked disconnected
+components occupy disjoint vertical bands."""
+
 # ---------------------------------------------------------------------------
 # Canvas-wide grid snap
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -116,6 +116,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_fanout_tail_join,
     _guard_feeder_exits_section_through_side,
     _guard_file_icon_no_name_label,
+    _guard_independent_components_disjoint,
     _guard_inter_row_run_clearance,
     _guard_inter_section_descent_edge_clearance,
     _guard_inter_section_route_no_backtrack,
@@ -670,6 +671,8 @@ def _compute_section_layout(
     # Stage 1.3: Place sections on the canvas
     place_sections(graph, section_x_gap, section_y_gap)
     _snap(graph, "1.3")
+    if validate:
+        _guard_independent_components_disjoint(graph, "after Stage 1.3")
 
     # Stage 1.4: Renumber sections by visual reading order (row, col)
     _renumber_sections_by_grid(graph)

--- a/src/nf_metro/layout/phases/canvas.py
+++ b/src/nf_metro/layout/phases/canvas.py
@@ -67,11 +67,14 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
             sweep[sid] = 0
 
     # Disconnected components: number each flow fully before the next,
-    # ordered by the root's grid_row so top flows come first.
+    # ordered by the topmost grid_row so top flows come first.
+    from nf_metro.layout.section_placement import _weakly_connected_components
+
+    section_edges = graph.section_dag.section_edges if graph.section_dag else set()
     comp_idx: dict[str, int] = {}
     for rank, comp in enumerate(
         sorted(
-            nx.weakly_connected_components(dag),
+            _weakly_connected_components(graph, section_edges),
             key=lambda c: min(graph.sections[sid].grid_row for sid in c),
         )
     ):

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
+    COMPONENT_BAND_OVERLAP_TOLERANCE,
     COORD_TOLERANCE,
     EDGE_TO_BUNDLE_CLEARANCE,
     GUARD_TOLERANCE,
@@ -289,6 +290,49 @@ def _guard_no_negative_grid_columns(graph: MetroGraph, phase: str) -> None:
             f"{phase}: sections at negative grid columns "
             f"(serpentine packer ran off the left edge): {offenders}"
         )
+
+
+def _guard_independent_components_disjoint(graph: MetroGraph, phase: str) -> None:
+    """After Stage 1.3: independently-stacked components must not overlap.
+
+    When the section meta-graph splits into 2+ weakly-connected components
+    and the author pinned no explicit ``%%metro grid:`` positions,
+    :func:`place_sections` lays each component out in its own local column
+    grid and stacks the components vertically.  Stacking is only correct if
+    the components occupy disjoint vertical bands; an off-by-one in the
+    stacking cursor would let one component's bbox overlap another's,
+    producing tangled, ambiguous output.  This guard fails loudly if the
+    stacked bands ever overlap.
+
+    No-op for single-component graphs and for explicit-grid graphs (which
+    deliberately keep the shared grid and may interleave components).
+    """
+    from nf_metro.layout.section_placement import (
+        _component_extent,
+        _weakly_connected_components,
+    )
+
+    if not graph.sections or graph.section_dag is None or graph._explicit_grid:
+        return
+
+    components = _weakly_connected_components(graph, graph.section_dag.section_edges)
+    if len(components) <= 1:
+        return
+
+    def band(comp: set[str]) -> tuple[float, float]:
+        _, top, bottom = _component_extent([graph.sections[s] for s in comp])
+        return top, bottom
+
+    bands = sorted((band(c), c) for c in components)
+    for (lo_band, lo_comp), (hi_band, hi_comp) in zip(bands, bands[1:]):
+        # Bands are sorted by top edge; overlap if the lower band's bottom
+        # protrudes past the next band's top.
+        if lo_band[1] > hi_band[0] + COMPONENT_BAND_OVERLAP_TOLERANCE:
+            raise PhaseInvariantError(
+                f"{phase}: independently-stacked components overlap vertically: "
+                f"{sorted(lo_comp)} (band {lo_band[0]:.1f}..{lo_band[1]:.1f}) "
+                f"vs {sorted(hi_comp)} (band {hi_band[0]:.1f}..{hi_band[1]:.1f})"
+            )
 
 
 def _guard_explicit_grid_directions(graph: MetroGraph, phase: str) -> None:

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -41,13 +41,23 @@ def _assign_grid_layout(
     """Assign grid columns and rows to each section.
 
     Returns (col_assign, row_assign) dicts mapping section IDs to positions.
+    Only sections in ``graph.sections`` participate; callers laying out a
+    single weakly-connected component scope ``graph.sections`` to it (via
+    ``_scoped_sections``) so its grid is computed in isolation.
     """
     section_ids = list(graph.sections.keys())
 
-    # Topological layering (columns)
+    # Topological layering (columns).  ``section_edges`` is a set, so iterate
+    # it in a stable (sorted) order: the adjacency lists it builds drive the
+    # BFS queue and the column-group ordering below, and a hash-randomised
+    # traversal order would otherwise make row assignment depend on
+    # PYTHONHASHSEED.
+    section_set = set(section_ids)
     in_degree: dict[str, int] = {sid: 0 for sid in section_ids}
     adj: dict[str, list[str]] = {sid: [] for sid in section_ids}
-    for src, tgt in section_edges:
+    for src, tgt in sorted(section_edges):
+        if src not in section_set or tgt not in section_set:
+            continue
         adj[src].append(tgt)
         in_degree[tgt] += 1
 
@@ -76,6 +86,8 @@ def _assign_grid_layout(
 
     # Apply grid overrides
     for sid, (col, row, rowspan, colspan) in graph.grid_overrides.items():
+        if sid not in section_ids:
+            continue
         if sid in graph.sections:
             graph.sections[sid].grid_col = col
             graph.sections[sid].grid_row = row
@@ -90,15 +102,19 @@ def _assign_grid_layout(
 
     # Assign rows within each column (order by section number, then by id)
     row_assign: dict[str, int] = {}
-    for col, sids in sorted(col_groups.items()):
+    for col, col_sids in sorted(col_groups.items()):
         explicit = [
             (sid, graph.sections[sid].grid_row)
-            for sid in sids
+            for sid in col_sids
             if graph.sections[sid].grid_row >= 0
         ]
-        auto = [sid for sid in sids if graph.sections[sid].grid_row < 0]
+        auto = [sid for sid in col_sids if graph.sections[sid].grid_row < 0]
 
-        auto.sort(key=lambda s: graph.sections[s].number)
+        # Pack auto-row sections by definition number, with the section id as
+        # a deterministic tie-break.  ``col_sids`` derives from a set-built
+        # adjacency, so sorting on number alone would leave equal-numbered
+        # sections in hash-randomised order and flip their rows run-to-run.
+        auto.sort(key=lambda s: (graph.sections[s].number, s))
 
         used_rows: set[int] = set()
         for sid, row in explicit:
@@ -128,11 +144,18 @@ def _compute_section_offsets(
     """Compute pixel offsets for each section from grid assignments.
 
     Returns (min_col, max_col) for use by downstream gap enforcement.
+
+    The set of sections handled is exactly ``col_assign``'s keys.  In the
+    single-grid path that is every section; in the per-component path it is
+    one weakly-connected component, so other components' sections are left
+    untouched and never inflate this component's column widths.
     """
+    scoped = {sid: graph.sections[sid] for sid in col_assign if sid in graph.sections}
+
     min_col = min(col_assign.values()) if col_assign else 0
     max_col = max(col_assign.values()) if col_assign else 0
-    for sid in graph.sections:
-        cspan = graph.sections[sid].grid_col_span
+    for sid in scoped:
+        cspan = scoped[sid].grid_col_span
         col = col_assign.get(sid, 0)
         min_col = min(min_col, col)
         max_col = max(max_col, col + cspan - 1)
@@ -145,7 +168,7 @@ def _compute_section_offsets(
         return section.bbox_x + section.bbox_w + SECTION_X_PADDING
 
     col_widths: dict[int, float] = defaultdict(float)
-    for sid, section in graph.sections.items():
+    for sid, section in scoped.items():
         if section.grid_col_span == 1:
             col = col_assign.get(sid, 0)
             col_widths[col] = max(col_widths[col], _effective_width(section))
@@ -155,7 +178,7 @@ def _compute_section_offsets(
             col_widths[c] = 0.0
 
     # Expand columns if a spanning section exceeds spanned column widths
-    for sid, section in graph.sections.items():
+    for sid, section in scoped.items():
         cspan = section.grid_col_span
         if cspan <= 1:
             continue
@@ -176,13 +199,13 @@ def _compute_section_offsets(
 
     # Global row heights (only single-row non-TB sections)
     max_row = max(row_assign.values()) if row_assign else 0
-    for sid in graph.sections:
-        span = graph.sections[sid].grid_row_span
+    for sid in scoped:
+        span = scoped[sid].grid_row_span
         row = row_assign.get(sid, 0)
         max_row = max(max_row, row + span - 1)
 
     row_heights: dict[int, float] = defaultdict(float)
-    for sid, section in graph.sections.items():
+    for sid, section in scoped.items():
         if section.grid_row_span == 1 and section.direction != "TB":
             row = row_assign.get(sid, 0)
             row_heights[row] = max(row_heights[row], section.bbox_h)
@@ -192,7 +215,7 @@ def _compute_section_offsets(
             row_heights[r] = 0.0
 
     # Expand rows if a spanning section exceeds spanned row heights
-    for sid, section in graph.sections.items():
+    for sid, section in scoped.items():
         rspan = section.grid_row_span
         if rspan <= 1:
             continue
@@ -214,7 +237,7 @@ def _compute_section_offsets(
     tb_sections = sorted(
         [
             (sid, section)
-            for sid, section in graph.sections.items()
+            for sid, section in scoped.items()
             if section.direction == "TB" and section.grid_row_span == 1
         ],
         key=lambda x: row_assign.get(x[0], 0),
@@ -237,12 +260,12 @@ def _compute_section_offsets(
 
     # Right-align columns containing RL or TB sections
     right_align_cols: set[int] = set()
-    for sid, section in graph.sections.items():
+    for sid, section in scoped.items():
         if section.direction in ("RL", "TB") and section.grid_col_span == 1:
             right_align_cols.add(col_assign.get(sid, 0))
 
     # Set section offsets and adjust for spanning
-    for sid, section in graph.sections.items():
+    for sid, section in scoped.items():
         section.grid_col = col_assign.get(sid, 0)
         section.grid_row = row_assign.get(sid, 0)
         section.offset_x = col_offsets.get(section.grid_col, 0)
@@ -259,16 +282,14 @@ def _compute_section_offsets(
     # A section that spans multiple columns may have a different local
     # bbox_x from internal layout, causing its left edge to be offset
     # from single-span sections in the same starting column.
-    for section in graph.sections.values():
+    for section in scoped.values():
         if section.grid_col_span <= 1:
             continue
         col = section.grid_col
         # Find the representative left edge from single-span sections
         # in the same column.
         peers = [
-            s
-            for s in graph.sections.values()
-            if s.grid_col == col and s.grid_col_span == 1
+            s for s in scoped.values() if s.grid_col == col and s.grid_col_span == 1
         ]
         if not peers:
             continue
@@ -298,6 +319,80 @@ def _compute_section_offsets(
     return min_col, max_col
 
 
+def _weakly_connected_components(
+    graph: MetroGraph,
+    section_edges: set[tuple[str, str]],
+) -> list[set[str]]:
+    """Partition sections into weakly-connected components.
+
+    Treats inter-section edges as undirected.  Each returned set is one
+    group of sections with no inter-section edge to any other group.
+    """
+    import networkx as nx
+
+    meta: nx.Graph[str] = nx.Graph()
+    meta.add_nodes_from(graph.sections)
+    for src, tgt in sorted(section_edges):
+        if src in graph.sections and tgt in graph.sections:
+            meta.add_edge(src, tgt)
+    # ``nx.connected_components`` yields ``set`` objects in a traversal order
+    # that depends on hash iteration; return them in a stable order (by
+    # smallest member id) so any downstream iteration that does not re-sort
+    # is still deterministic.  Callers that need a particular stacking order
+    # re-sort on their own key.
+    return sorted(
+        (set(c) for c in nx.connected_components(meta)),
+        key=lambda c: min(c),
+    )
+
+
+def _component_extent(sections: list[Section]) -> tuple[float, float, float]:
+    """Global ``(left, top, bottom)`` bounding extent of placed sections.
+
+    Coordinates are in canvas space (``offset`` + local ``bbox``), so the
+    extent is comparable across components placed in separate local grids.
+    """
+    left = min(s.offset_x + s.bbox_x for s in sections)
+    top = min(s.offset_y + s.bbox_y for s in sections)
+    bottom = max(s.offset_y + s.bbox_y + s.bbox_h for s in sections)
+    return left, top, bottom
+
+
+def _place_section_group(
+    graph: MetroGraph,
+    section_edges: set[tuple[str, str]],
+    section_x_gap: float,
+    section_y_gap: float,
+    sids: set[str] | None,
+) -> None:
+    """Run column-grid placement for one section group (or all sections).
+
+    With ``sids`` set, ``graph.sections`` is temporarily restricted to that
+    weakly-connected component so its column widths and row heights are
+    computed in isolation from the other components.  ``None`` places every
+    section in one shared grid.
+    """
+    from contextlib import nullcontext
+
+    from nf_metro.layout.phases._common import _scoped_sections
+
+    scope = _scoped_sections(graph, sorted(sids)) if sids is not None else nullcontext()
+    with scope:
+        col_assign, row_assign = _assign_grid_layout(graph, section_edges)
+        min_col, max_col = _compute_section_offsets(
+            graph, col_assign, row_assign, section_x_gap, section_y_gap
+        )
+        _enforce_min_column_gaps(
+            graph, col_assign, min_col, max_col, requested_gap=section_x_gap
+        )
+        _enforce_min_row_gaps(
+            graph,
+            row_assign,
+            requested_gap=section_y_gap,
+            wrap_min_by_pair=_wrap_bundle_row_minimums(graph),
+        )
+
+
 def place_sections(
     graph: MetroGraph,
     section_x_gap: float = PLACEMENT_X_GAP,
@@ -308,6 +403,18 @@ def place_sections(
     Builds a meta-graph of section dependencies, assigns columns
     via topological layering, assigns rows within columns, then
     computes pixel offsets for each section.
+
+    Disconnected graphs (two or more weakly-connected components in the
+    section meta-graph) are placed one component at a time, each in its own
+    local column grid, then stacked vertically so a wide component never
+    inflates another component's column widths.  Components are stacked in
+    a deterministic order -- ascending minimum original grid row, then
+    descending section count, then the lexicographically smallest section
+    id as a final tie-break -- left-aligned and separated by
+    ``section_y_gap``.  A single-component graph, or any graph carrying an
+    explicit ``%%metro grid:`` override (where the author may have
+    deliberately interleaved components in one shared grid), falls back to
+    the legacy single-grid placement and is unaffected.
     """
     if not graph.sections:
         return
@@ -315,19 +422,43 @@ def place_sections(
     # auto_layout always populates section_dag before placement runs.
     assert graph.section_dag is not None
     section_edges = graph.section_dag.section_edges
-    col_assign, row_assign = _assign_grid_layout(graph, section_edges)
-    min_col, max_col = _compute_section_offsets(
-        graph, col_assign, row_assign, section_x_gap, section_y_gap
+
+    components = _weakly_connected_components(graph, section_edges)
+    if len(components) <= 1 or graph._explicit_grid:
+        _place_section_group(graph, section_edges, section_x_gap, section_y_gap, None)
+        return
+
+    # Deterministic stacking order: top-most original row first, then the
+    # larger components, then a stable id tie-break.  ``grid_row`` is the
+    # row auto_layout assigns before placement runs; it is valid here even
+    # though per-component placement has not yet recomputed offsets.
+    def _min_row(comp: set[str]) -> int:
+        return min(graph.sections[sid].grid_row for sid in comp)
+
+    ordered = sorted(
+        components,
+        key=lambda comp: (_min_row(comp), -len(comp), min(comp)),
     )
-    _enforce_min_column_gaps(
-        graph, col_assign, min_col, max_col, requested_gap=section_x_gap
-    )
-    _enforce_min_row_gaps(
-        graph,
-        row_assign,
-        requested_gap=section_y_gap,
-        wrap_min_by_pair=_wrap_bundle_row_minimums(graph),
-    )
+
+    # Anchor the stack to the first (top) component's natural top-left, so it
+    # keeps the origin a single-grid layout would give it; later components are
+    # left-aligned to that edge and stacked below.
+    origin_left = 0.0
+    stack_y = 0.0
+    for idx, comp in enumerate(ordered):
+        _place_section_group(graph, section_edges, section_x_gap, section_y_gap, comp)
+        # Sort members so the translation never depends on set hash order.
+        comp_secs = [graph.sections[sid] for sid in sorted(comp)]
+        left, top, bottom = _component_extent(comp_secs)
+        if idx == 0:
+            origin_left = left
+            stack_y = top
+        dx = origin_left - left
+        dy = stack_y - top
+        for s in comp_secs:
+            s.offset_y += dy
+            s.offset_x += dx
+        stack_y += (bottom - top) + section_y_gap
 
 
 def _rows_overlap(a: Section, b: Section) -> bool:

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1479,13 +1479,19 @@ def _compute_row_boundary_segments(
 
 def _compute_col_boundary_xs(
     col_bounds: dict[int, tuple[float, float]],
+    sections: list[Section] | None = None,
 ) -> list[tuple[int, int, float]]:
     """Return ``(col_a, col_b, mid_x)`` triples for consecutive grid columns
     whose bbox X ranges don't overlap.
 
-    Columns don't overlap like rows do (there's no column-axis analogue
-    of a fold), so a single canvas-spanning line per pair suffices; the
-    overlap guard is defensive.
+    Columns don't overlap like rows do within a single shared grid (there's
+    no column-axis analogue of a fold), so a single canvas-spanning line per
+    pair normally suffices.  When the section graph splits into independent
+    components, each component is placed in its own local column grid and the
+    components reuse the same ``grid_col`` indices in different X bands; a
+    midpoint computed from the merged per-column X bounds can then land
+    inside another component's section.  Any such boundary is dropped so the
+    overlay never cuts a section bbox.
     """
     result: list[tuple[int, int, float]] = []
     sorted_cols = sorted(col_bounds)
@@ -1495,7 +1501,13 @@ def _compute_col_boundary_xs(
         left = col_bounds[cb][0]
         if right >= left:
             continue
-        result.append((ca, cb, (right + left) / 2))
+        mid_x = (right + left) / 2
+        if sections is not None and any(
+            sec.grid_col_span == 1 and sec.bbox_x < mid_x < sec.bbox_x + sec.bbox_w
+            for sec in sections
+        ):
+            continue
+        result.append((ca, cb, mid_x))
     return result
 
 
@@ -1569,7 +1581,7 @@ def _render_debug_overlay(
             all_y1 = max(b[1] for b in row_bounds.values()) + 20
         grid_color = "rgba(255, 255, 0, 0.5)"
 
-        for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds):
+        for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds, sections):
             d.append(
                 draw.Line(
                     mid_x,

--- a/tests/test_independent_components.py
+++ b/tests/test_independent_components.py
@@ -1,0 +1,364 @@
+"""Independent placement of disconnected section components.
+
+When the section meta-graph splits into two or more weakly-connected
+components, each is placed in its own local column grid and the components
+are stacked vertically.  A wide disconnected component must NOT inflate the
+columns an unrelated connected trunk sits in.  A single-component graph (or
+any graph carrying an explicit ``%%metro grid:`` override) is unchanged.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.section_placement import _weakly_connected_components
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+
+# Geometry that must match the connected-only layout is compared with sub-pixel
+# slack to absorb rounding, not to tolerate real drift.
+_EQ_EPS = 0.5
+
+
+def _layout(text: str):
+    g = parse_metro_mermaid(text)
+    compute_layout(g)
+    return g
+
+
+def _right(section) -> float:
+    return section.offset_x + section.bbox_x + section.bbox_w
+
+
+def _left(section) -> float:
+    return section.offset_x + section.bbox_x
+
+
+# A connected 3-section trunk (A -> B -> C) plus a separate, very wide
+# disconnected section D.  In the old shared-grid placement D's width
+# inflated column 0 and flung B and C far to the right.
+_TRUNK_PLUS_WIDE = """%%metro title: Trunk Plus Wide
+%%metro line: main | Main | #e63946
+%%metro line: aux | Aux | #0570b0
+
+graph LR
+    subgraph a [A]
+        a1[A1]
+        a2[A2]
+        a1 -->|main| a2
+    end
+    subgraph b [B]
+        b1[B1]
+        b2[B2]
+        b1 -->|main| b2
+    end
+    subgraph c [C]
+        c1[C1]
+        c2[C2]
+        c1 -->|main| c2
+    end
+    subgraph d [D]
+        d1[D1]
+        d2[D2]
+        d3[D3]
+        d4[D4]
+        d5[D5]
+        d6[D6]
+        d1 -->|aux| d2
+        d2 -->|aux| d3
+        d3 -->|aux| d4
+        d4 -->|aux| d5
+        d5 -->|aux| d6
+    end
+    a2 -->|main| b1
+    b2 -->|main| c1
+"""
+
+# The same connected trunk WITHOUT the wide disconnected section.
+_TRUNK_ONLY = """%%metro title: Trunk Only
+%%metro line: main | Main | #e63946
+
+graph LR
+    subgraph a [A]
+        a1[A1]
+        a2[A2]
+        a1 -->|main| a2
+    end
+    subgraph b [B]
+        b1[B1]
+        b2[B2]
+        b1 -->|main| b2
+    end
+    subgraph c [C]
+        c1[C1]
+        c2[C2]
+        c1 -->|main| c2
+    end
+    a2 -->|main| b1
+    b2 -->|main| c1
+"""
+
+
+def test_wide_disconnected_section_does_not_push_trunk_right() -> None:
+    """The wide component must not widen the trunk's columns.
+
+    Each trunk section must start no further right than the previous
+    trunk section's right edge plus the disconnected component's width --
+    i.e. the trunk's own span, not the wide panel's span, bounds it.  We
+    assert the strong form: every trunk section stays left of where it
+    would land if the wide section's width leaked into the shared grid.
+    """
+    g = _layout(_TRUNK_PLUS_WIDE)
+
+    a, b, c, d = (g.sections[s] for s in ("a", "b", "c", "d"))
+
+    # The wide section D is genuinely much wider than any trunk section.
+    trunk_max_w = max(s.bbox_w for s in (a, b, c))
+    assert d.bbox_w > trunk_max_w * 2
+
+    # The trunk packs against its own widths: each later section begins
+    # within a couple of column gaps of its predecessor's right edge, far
+    # less than the wide section's width.
+    assert _left(b) - _right(a) < d.bbox_w
+    assert _left(c) - _right(b) < d.bbox_w
+
+    # The trunk's internal geometry does not depend on D's width: its
+    # inter-section gaps and total span are identical whether or not the
+    # wide panel is present.  (Only the global left/top canvas margin may
+    # differ, since the panel changes the overall canvas extent.)
+    g_no_d = _layout(_TRUNK_ONLY)
+    na, nb, nc = (g_no_d.sections[s] for s in ("a", "b", "c"))
+
+    span_with = _right(c) - _left(a)
+    span_without = _right(nc) - _left(na)
+    assert abs(span_with - span_without) < _EQ_EPS
+
+    gap_ab_with = _left(b) - _right(a)
+    gap_ab_without = _left(nb) - _right(na)
+    assert abs(gap_ab_with - gap_ab_without) < _EQ_EPS
+
+    gap_bc_with = _left(c) - _right(b)
+    gap_bc_without = _left(nc) - _right(nb)
+    assert abs(gap_bc_with - gap_bc_without) < _EQ_EPS
+
+
+def test_disconnected_components_are_separated_vertically() -> None:
+    """Stacked components do not overlap vertically."""
+    g = _layout(_TRUNK_PLUS_WIDE)
+    a = g.sections["a"]  # trunk top
+    d = g.sections["d"]  # wide panel, stacked below
+    trunk_bottom = max(
+        s.offset_y + s.bbox_y + s.bbox_h
+        for s in (g.sections["a"], g.sections["b"], g.sections["c"])
+    )
+    assert d.offset_y + d.bbox_y >= trunk_bottom - _EQ_EPS
+    assert a.offset_y + a.bbox_y < d.offset_y + d.bbox_y
+
+
+def test_top_component_keeps_single_grid_origin() -> None:
+    """The top stacked component must not gain a gratuitous down/right shift.
+
+    Disconnected placement anchors the whole stack to the first (top)
+    component's natural top-left, so that component lands at exactly the
+    same origin it would in a single connected layout.  Here the top
+    component is the A->B->C trunk; laid out on its own it must sit at the
+    same left/top as it does in the full disconnected graph.
+    """
+    g = _layout(_TRUNK_PLUS_WIDE)
+    g_trunk = _layout(_TRUNK_ONLY)
+
+    a, na = g.sections["a"], g_trunk.sections["a"]
+    assert abs(_left(a) - _left(na)) < _EQ_EPS
+    trunk_top = min(
+        s.offset_y + s.bbox_y
+        for s in (g.sections["a"], g.sections["b"], g.sections["c"])
+    )
+    trunk_only_top = min(
+        s.offset_y + s.bbox_y
+        for s in (g_trunk.sections["a"], g_trunk.sections["b"], g_trunk.sections["c"])
+    )
+    assert abs(trunk_top - trunk_only_top) < _EQ_EPS
+
+
+def test_single_component_placement_unchanged() -> None:
+    """A connected graph yields exactly one component and the legacy path."""
+    text = (EXAMPLES_DIR / "topologies" / "section_diamond.mmd").read_text()
+    g = parse_metro_mermaid(text)
+    comps = _weakly_connected_components(g, g.section_dag.section_edges)
+    assert len(comps) == 1
+    assert comps[0] == set(g.sections)
+
+
+def test_explicit_grid_keeps_shared_grid() -> None:
+    """An explicit %%metro grid: override disables independent stacking.
+
+    self_crossing_bridge deliberately interleaves two components in one
+    shared grid via explicit grid hints; that must be honoured.
+    """
+    text = (EXAMPLES_DIR / "topologies" / "self_crossing_bridge.mmd").read_text()
+    g = parse_metro_mermaid(text)
+    assert g._explicit_grid  # author pinned positions
+    comps = _weakly_connected_components(g, g.section_dag.section_edges)
+    assert len(comps) == 2
+    # Layout still succeeds and respects the explicit interleaving: the
+    # mid component (row 1) sits between top (row 0) and bus_sink (row 2).
+    compute_layout(g)
+    top_y = g.sections["top"].offset_y + g.sections["top"].bbox_y
+    mid_y = g.sections["mid_src"].offset_y + g.sections["mid_src"].bbox_y
+    sink_y = g.sections["bus_sink"].offset_y + g.sections["bus_sink"].bbox_y
+    assert top_y < mid_y < sink_y
+
+
+# A connected trunk wide enough to FOLD (its station-column count exceeds the
+# 15-column threshold, so auto-layout serpentines it across grid rows 0..2)
+# coexisting with a separate, disconnected section.  This is the topology the
+# component partition-and-stack path is most exposed to hash-order
+# nondeterminism on: ``networkx.weakly_connected_components`` yields ``set``
+# objects, and the set-built BFS adjacency that drives column grouping and row
+# packing must be traversed in a stable order or a trunk section's ``grid_row``
+# flips between runs (and the components stack in a different vertical order).
+_FOLDING_TRUNK_PLUS_DISC = """%%metro title: Folding Trunk Plus Disc
+%%metro line: main | Main | #e63946
+%%metro line: aux | Aux | #0570b0
+
+graph LR
+    subgraph disc [Disc]
+        da[a]
+        db[b]
+        dc[c]
+        dd[d]
+        de[e]
+        df[f]
+        da-->|aux|db
+        db-->|aux|dc
+        dc-->|aux|dd
+        dd-->|aux|de
+        de-->|aux|df
+    end
+    subgraph k1 [K1]
+        k1a[a]
+        k1b[b]
+        k1c[c]
+        k1d[d]
+        k1e[e]
+        k1a-->|main|k1b
+        k1b-->|main|k1c
+        k1c-->|main|k1d
+        k1d-->|main|k1e
+    end
+    subgraph k2 [K2]
+        k2a[a]
+        k2b[b]
+        k2c[c]
+        k2d[d]
+        k2e[e]
+        k2a-->|main|k2b
+        k2b-->|main|k2c
+        k2c-->|main|k2d
+        k2d-->|main|k2e
+    end
+    subgraph k3 [K3]
+        k3a[a]
+        k3b[b]
+        k3c[c]
+        k3d[d]
+        k3e[e]
+        k3a-->|main|k3b
+        k3b-->|main|k3c
+        k3c-->|main|k3d
+        k3d-->|main|k3e
+    end
+    subgraph k4 [K4]
+        k4a[a]
+        k4b[b]
+        k4c[c]
+        k4d[d]
+        k4e[e]
+        k4a-->|main|k4b
+        k4b-->|main|k4c
+        k4c-->|main|k4d
+        k4d-->|main|k4e
+    end
+    k1e -->|main| k2a
+    k2e -->|main| k3a
+    k3e -->|main| k4a
+"""
+
+
+def _placement_signature(g) -> tuple:
+    """A stable signature of every section's grid + canvas placement."""
+    return tuple(
+        (
+            sid,
+            g.sections[sid].grid_col,
+            g.sections[sid].grid_row,
+            round(g.sections[sid].offset_x + g.sections[sid].bbox_x, 3),
+            round(g.sections[sid].offset_y + g.sections[sid].bbox_y, 3),
+        )
+        for sid in sorted(g.sections)
+    )
+
+
+def test_component_placement_is_deterministic_in_process() -> None:
+    """Repeated layouts of the same graph yield identical placement.
+
+    Each ``compute_layout`` re-parses the source, so any reliance on a
+    set/dict iteration order seeded once per process would surface as a
+    drifting signature across repeats within a single interpreter.
+    """
+    sigs = {_placement_signature(_layout(_FOLDING_TRUNK_PLUS_DISC)) for _ in range(8)}
+    assert len(sigs) == 1
+
+
+def test_component_placement_is_deterministic_across_hash_seeds() -> None:
+    """Placement is identical under different ``PYTHONHASHSEED`` values.
+
+    Set iteration over section-id strings is hash-randomised, so a path that
+    leaks set order into grid assignment would place a trunk section in a
+    different ``grid_row`` (and stack the components differently) depending on
+    the seed.  Run the layout in fresh subprocesses under several explicit
+    seeds and assert the signature is identical every time.
+    """
+    import os
+
+    repo_root = Path(__file__).resolve().parent.parent
+    script = textwrap.dedent(
+        """
+        import sys
+        from nf_metro.parser.mermaid import parse_metro_mermaid
+        from nf_metro.layout.engine import compute_layout
+
+        text = sys.stdin.read()
+        g = parse_metro_mermaid(text)
+        compute_layout(g)
+        for sid in sorted(g.sections):
+            s = g.sections[sid]
+            print(
+                f"{sid} {s.grid_col} {s.grid_row} "
+                f"{round(s.offset_x + s.bbox_x, 3)} "
+                f"{round(s.offset_y + s.bbox_y, 3)}"
+            )
+        """
+    )
+
+    outputs = set()
+    for seed in ("0", "1", "2", "7", "42", "1234"):
+        env = dict(os.environ)
+        env["PYTHONHASHSEED"] = seed
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            input=_FOLDING_TRUNK_PLUS_DISC,
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            env=env,
+        )
+        assert proc.returncode == 0, proc.stderr
+        outputs.add(proc.stdout)
+
+    assert len(outputs) == 1, "section placement varied across PYTHONHASHSEED values"

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -4711,7 +4711,7 @@ def test_debug_grid_overlay_boundaries_outside_section_bboxes(fixture):
                     f"row {ra}|{rb} segment y={y:.1f} x={x_start:.0f}..{x_end:.0f} "
                     f"cuts {sec.id!r} (row={sec.grid_row}, y={y0:.1f}..{y1:.1f})"
                 )
-    for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds):
+    for ca, cb, mid_x in _compute_col_boundary_xs(col_bounds, sections):
         for sec in sections:
             if sec.grid_col_span != 1:
                 continue


### PR DESCRIPTION
## Problem

`section_placement.py` laid every section into a single shared column grid. When a graph has disconnected components (groups of sections with no inter-section edges between them), a wide component forces its column widths onto the others: a wide disconnected panel inflates the shared columns an unrelated connected trunk sits in, flinging that trunk's later sections far to the right.

## Fix

Each weakly-connected component of the section meta-graph is laid out **independently** in its own local column grid, then the components are **stacked vertically** (left-aligned, separated by `section_y_gap`). A wide component never affects another component's column widths or X positions. The stack is anchored to the top component's natural top-left, so it keeps the origin a single-grid layout would give it.

Stacking order is deterministic: ascending minimum original grid row, then descending component size, then the lexicographically smallest section id as a final tie-break.

This is the default for disconnected auto-laid graphs. A single-component graph, or any graph carrying an explicit `%%metro grid:` override (where the author may have deliberately interleaved components in one shared grid, e.g. `self_crossing_bridge`), falls back to the single shared-grid placement and is unaffected.

## What's included

- **Independent-component placement** in `section_placement.py`: component partition via `_weakly_connected_components`; each component laid out by scoping `graph.sections` to it (reusing the existing `_scoped_sections` context manager) so the column-grid phases compute its widths and heights in isolation; per-component vertical stacking anchored to the top component.
- **New demo fixture** `examples/disconnected_components.mmd`: a connected 3-section trunk (Ingest → Process → Results) plus a separate, wide disconnected QC panel. With independent placement the trunk spans ~1000px; under the old shared grid the 400px panel inflated column 0 and stretched the trunk to ~1480px. Registered in `scripts/build_gallery.py`.
- **Invariant tests** in `tests/test_independent_components.py`: the trunk's inter-section gaps and total span are identical with and without the wide disconnected section (fails on `main`, where they balloon by the panel's width); the top component keeps its single-grid origin; single-component and explicit-grid graphs keep the shared grid; placement is deterministic both in-process and across `PYTHONHASHSEED` values.
- **Runtime guard** `_guard_independent_components_disjoint` (under `validate=True`): stacked components must occupy disjoint vertical bands.
- **Debug-grid overlay** (`_compute_col_boundary_xs`): a column separator whose midpoint would cut a section living in another component's X band is dropped (independent components reuse the same `grid_col` indices in different X bands).
- **Shared helpers / reuse**: `_component_extent` (global bbox extent) backs both the stacking loop and the disjoint-band guard; the disconnected-component numbering in `_renumber_sections_by_grid` reuses `_weakly_connected_components`; the band-overlap tolerance is the named constant `COMPONENT_BAND_OVERLAP_TOLERANCE`.

## Visual deltas (gallery)

Compared byte-for-byte against `main`. The only delta is the new `disconnected_components` render; **every other gallery render is byte-identical**.

- **`disconnected_components`** — new fixture demonstrating the fix: the trunk packs tightly to the left instead of being stretched by the wide QC panel stacked below.
- **`parallel_independent`** (the pre-existing disconnected fixture, two equal-width pipelines) takes the independent-placement path but is **byte-identical to `main`**: with both components the same width, independent placement lands them at exactly the coordinates the shared grid produced, so there is nothing to change.

## Verification

- `pytest -q`: 6410 passed, 40 skipped, 5 xfailed.
- Full topology validation suite passes (`compute_layout(validate=True)` across the corpus).
- `ruff format --check`, `ruff check`, and `mypy` all clean.
- Every gallery render except the new `disconnected_components` is byte-identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
