### PR TITLE
feat(layout): unified line_spread axis (bundle / centered / rails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ These are automatically rewritten into port-to-port connections with junction st
 | `%%metro off_track: <station>[, <station>...]` | Global | Lift the listed stations (typically `file:`/`files:`/`dir:` inputs) above the section's main track, so they drop into their consumer instead of consuming a line-track slot |
 | `%%metro compact_offsets: true` | Global | Use compact per-station offsets instead of global line-priority slots (better for dense maps with few lines) |
 | `%%metro center_ports: true` | Global | Centre inter-section ports on the shorter of the two connected sections (overridden by the `--center-ports` / `--no-center-ports` CLI flag) |
+| `%%metro line_spread: <mode>[ \| <section>...]` | Global / Section | How lines sharing a station relate vertically: `bundle` (default) merges them onto one trunk that cascades downward, `centered` balances that bundle about the midline, `rails` draws each line as a parallel rail with shared stations as interchanges. Bare form sets the graph default; the `\| <section>, ...` form overrides named sections. Overridden by the `--line-spread` CLI flag |
 | `%%metro legend_min_height: <pixels>` | Global | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 | `%%metro entry: <side> \| <lines>` | Section | Entry port hint |
 | `%%metro exit: <side> \| <lines>` | Section | Exit port hint |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -520,6 +520,7 @@ These go at the top of the file, before `graph LR`.
 | `%%metro off_track: <station>[, <station>...]` | Lift the listed stations above the section's main track (see below) |
 | `%%metro compact_offsets: true` | Compact line offsets within stations (see below) |
 | `%%metro center_ports: true` | Centre inter-section ports on the shorter of the two connected sections, so lines enter/exit at the visual midpoint. Overridden by the `--center-ports` / `--no-center-ports` CLI flag. |
+| `%%metro line_spread: <mode>[ \| <id>...]` | How lines sharing a station relate vertically (see below). `<mode>` is `bundle` (default), `centered`, or `rails`. The bare form sets the graph default; `<mode> \| sectionA, sectionB` overrides those sections. Overridden by the `--line-spread` CLI flag. |
 | `%%metro legend_min_height: <pixels>` | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 
 **Compact offsets.** By default, each line reserves a fixed vertical slot across the whole map based on its declaration order. If you define three lines, every station that carries even one of them is sized to fit all three. This keeps bundles visually consistent but wastes space when most stations only carry one or two lines.
@@ -535,6 +536,27 @@ With `%%metro compact_offsets: true`, stations are only as wide as the lines act
 ```
 
 This pairs naturally with the `file:` / `files:` / `dir:` icon directives - the lifted stations are usually file terminals. The [`off_track_convergence`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/topologies/off_track_convergence.mmd) topology and the [differentialabundance](https://github.com/pinin4fjords/nf-metro/blob/main/examples/differentialabundance.mmd) example both use it.
+
+**Line spread.** `%%metro line_spread:` controls how lines that share a station relate to each other vertically. It has three modes:
+
+- **`bundle`** (the default) merges every line sharing a station onto a single trunk track; a line that detours to its own station dips off the trunk and back. Line base-tracks stack downward from the first line, so the shared trunk sits at the top and detours cascade below it.
+- **`centered`** also merges lines onto one trunk, but balances that bundle about the midline: the shared trunk sits on the vertical centre and each line's exclusive stations distribute symmetrically above and below it, instead of the top-anchored downward cascade.
+- **`rails`** does not merge at all. Each line gets a fixed, evenly-spaced horizontal rail and a multi-line station renders as the classic metro interchange: a white circle on each rail the station uses, joined by a straight connector segment - the rails never converge (the nf-core/sarek "Example analysis pathways" subway idiom). Station labels alternate above and below the rails so dense runs stay readable.
+
+The bare directive sets the graph-wide default:
+
+```text
+%%metro line_spread: rails
+```
+
+Append `| <section>, ...` to override individual sections, so one map can mix modes - a `bundle` trunk feeding a `rails` analysis panel, say:
+
+```text
+%%metro line_spread: centered
+%%metro line_spread: rails | pathways
+```
+
+Here every section defaults to `centered` while `pathways` is laid out as parallel rails; ordinary section placement positions both. The [`line_spread`](https://github.com/pinin4fjords/nf-metro/blob/main/examples/line_spread.mmd) example shows all three modes in one map via per-section overrides. For `rails`, inter-section edges into or out of a rail section are not yet supported - a rail section should be self-contained.
 
 ### Section directives
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -541,7 +541,7 @@ This pairs naturally with the `file:` / `files:` / `dir:` icon directives - the 
 
 - **`bundle`** (the default) merges every line sharing a station onto a single trunk track; a line that detours to its own station dips off the trunk and back. Line base-tracks stack downward from the first line, so the shared trunk sits at the top and detours cascade below it.
 - **`centered`** also merges lines onto one trunk, but balances that bundle about the midline: the shared trunk sits on the vertical centre and each line's exclusive stations distribute symmetrically above and below it, instead of the top-anchored downward cascade.
-- **`rails`** does not merge at all. Each line gets a fixed, evenly-spaced horizontal rail and a multi-line station renders as the classic metro interchange: a white circle on each rail the station uses, joined by a straight connector segment - the rails never converge (the nf-core/sarek "Example analysis pathways" subway idiom). Station labels alternate above and below the rails so dense runs stay readable.
+- **`rails`** keeps co-travelling lines on separate parallel rails rather than bundling them onto a trunk. Each line gets a fixed, evenly-spaced horizontal rail, and a station several lines *pass through* renders as the classic metro interchange: a white circle on each rail the station uses, joined by a straight connector segment (the nf-core/sarek "Example analysis pathways" subway idiom). Lines converge only at a genuine single-node fan-in/out - e.g. a file terminus all lines reach - where the rails ease together with 45-degree diagonals. Station labels alternate above and below the rails so dense runs stay readable.
 
 The bare directive sets the graph-wide default:
 

--- a/examples/centered_tracks.mmd
+++ b/examples/centered_tracks.mmd
@@ -1,0 +1,32 @@
+%%metro title: Centered Tracks Demo
+%%metro style: dark
+%%metro line_spread: centered
+%%metro line: dna | DNA samples | #4CAF50
+%%metro line: rna | RNA samples | #2196F3
+%%metro line: cfdna | cfDNA samples | #E91E63
+
+graph LR
+    fastqc[FastQC]
+    align[Alignment]
+    markdup[MarkDuplicates]
+    summary[Summary]
+
+    cnv[CNV call]
+    sv[SV call]
+    splice[Splice call]
+    fusion[Fusion call]
+    pileup[Pileup call]
+
+    fastqc -->|dna,rna,cfdna| align
+    align -->|dna,rna,cfdna| markdup
+
+    markdup -->|dna| cnv
+    cnv -->|dna| sv
+    sv -->|dna| summary
+
+    markdup -->|rna| splice
+    splice -->|rna| fusion
+    fusion -->|rna| summary
+
+    markdup -->|cfdna| pileup
+    pileup -->|cfdna| summary

--- a/examples/line_spread.mmd
+++ b/examples/line_spread.mmd
@@ -1,0 +1,67 @@
+%%metro title: Line spread modes
+%%metro style: dark
+%%metro line: dna | DNA | #4CAF50
+%%metro line: rna | RNA | #2196F3
+%%metro line: cfdna | cfDNA | #E91E63
+
+%%metro line_spread: bundle
+%%metro line_spread: centered | centered_sec
+%%metro line_spread: rails | rails_sec
+
+%% Rail panel input/output files: the rails fan out from the CRAM terminus and
+%% fan back in to the VCF terminus (a fan-in), each meeting a buffer-stop marker.
+%% rna skips Filter, so Filter is a partial interchange: the rna rail bridges
+%% straight over its connector rather than stopping there.
+%%metro file: r_in | CRAM
+%%metro file: r_out | VCF
+
+%%metro grid: bundle_sec | 0,0
+%%metro grid: centered_sec | 1,0
+%%metro grid: rails_sec | 2,0
+
+graph LR
+    subgraph bundle_sec [bundle]
+        b_in[Input]
+        b_dna[DNA]
+        b_rna[RNA]
+        b_cf[cfDNA]
+        b_out[QC]
+
+        b_in -->|dna| b_dna
+        b_in -->|rna| b_rna
+        b_in -->|cfdna| b_cf
+        b_dna -->|dna| b_out
+        b_rna -->|rna| b_out
+        b_cf -->|cfdna| b_out
+    end
+
+    subgraph centered_sec [centered]
+        c_in[Align]
+        c_dna[DNA]
+        c_rna[RNA]
+        c_cf[cfDNA]
+        c_out[Merge]
+
+        c_in -->|dna| c_dna
+        c_in -->|rna| c_rna
+        c_in -->|cfdna| c_cf
+        c_dna -->|dna| c_out
+        c_rna -->|rna| c_out
+        c_cf -->|cfdna| c_out
+    end
+
+    subgraph rails_sec [rails]
+        r_in[ ]
+        r_call[Call]
+        r_filter[Filter]
+        r_annotate[Annotate]
+        r_out[ ]
+
+        r_in -->|dna,rna,cfdna| r_call
+        r_call -->|dna,cfdna| r_filter
+        r_call -->|rna| r_annotate
+        r_filter -->|dna,cfdna| r_annotate
+        r_annotate -->|dna,rna,cfdna| r_out
+    end
+
+    b_out -->|dna,rna,cfdna| c_in

--- a/examples/rail_mode.mmd
+++ b/examples/rail_mode.mmd
@@ -1,0 +1,45 @@
+%%metro title: Rail mode: variant-calling sample routes
+%%metro style: dark
+%%metro line_spread: rails
+%%metro label_angle: 45
+%%metro line: germline | Germline | #2db572
+%%metro line: tumor_only | Tumour-only | #f4a300
+%%metro line: pair_n | Pair (normal) | #0570b0
+%%metro line: pair_t | Pair (tumour) | #e63946
+%%metro legend_combo: pair_n, pair_t | Tumour-normal pair
+%%metro legend: bl
+%%metro file: cram_in | CRAM
+%%metro file: samples_csv | CSV | Samples
+%%metro file: vcf_out | VCF
+%%metro off_track: samples_csv
+
+graph LR
+    subgraph calling [Variant calling]
+        cram_in[ ]
+        align[Alignment]
+        markdup[Mark duplicates]
+        bqsr[BQSR]
+        samples_csv[ ]
+        callvar[Call variants]
+        somatic[Somatic filter]
+        concord[Concordance]
+
+        cram_in -->|germline,tumor_only,pair_n,pair_t| align
+        align -->|germline,tumor_only,pair_n,pair_t| markdup
+        markdup -->|germline,tumor_only,pair_n,pair_t| bqsr
+        samples_csv -->|pair_n,pair_t| bqsr
+
+        bqsr -->|germline,tumor_only,pair_n,pair_t| callvar
+        callvar -->|tumor_only,pair_n,pair_t| somatic
+        callvar -->|germline| concord
+        somatic -->|pair_n,pair_t| concord
+    end
+
+    subgraph annotate [Annotation and output]
+        norm[Normalize]
+        vep[Annotate]
+        vcf_out[ ]
+
+        norm -->|germline,tumor_only,pair_n,pair_t| vep
+        vep -->|germline,tumor_only,pair_n,pair_t| vcf_out
+    end

--- a/examples/rail_section.mmd
+++ b/examples/rail_section.mmd
@@ -1,0 +1,61 @@
+%%metro title: Mixed mode: connected trunk + rail panel
+%%metro style: dark
+%%metro line: dna | DNA workflow | #0570b0
+%%metro line: rna | RNA workflow | #2db572
+%%metro line: deepvariant | DeepVariant | #2db572
+%%metro line: haplotypecaller | HaplotypeCaller | #0570b0
+%%metro line: strelka | Strelka2 | #e63946
+%%metro legend: bl
+%%metro file: reads_in | FASTQ
+%%metro file: report_out | Report
+
+%%metro line_spread: rails | pathways
+
+%%metro grid: preprocess | 0,0
+%%metro grid: calling | 1,0
+%%metro grid: annotate | 2,0
+%%metro grid: pathways | 0,1
+
+graph LR
+    subgraph preprocess [Pre-processing]
+        reads_in[ ]
+        trim[Trim adapters]
+        align[Align]
+
+        reads_in -->|dna,rna| trim
+        trim -->|dna,rna| align
+    end
+
+    subgraph calling [Variant calling]
+        markdup[Mark duplicates]
+        bqsr[BQSR]
+        callvar[Call variants]
+
+        markdup -->|dna,rna| bqsr
+        bqsr -->|dna,rna| callvar
+    end
+
+    subgraph annotate [Annotation]
+        norm[Normalize]
+        vep[Annotate]
+        report_out[ ]
+
+        norm -->|dna,rna| vep
+        vep -->|dna,rna| report_out
+    end
+
+    align -->|dna,rna| markdup
+    callvar -->|dna,rna| norm
+
+    subgraph pathways [Pathway analysis]
+        gene_in[Gene sets]
+        score[Score]
+        enrich[Enrichment]
+        summary[Summary]
+
+        gene_in -->|deepvariant,haplotypecaller,strelka| score
+        score -->|deepvariant,haplotypecaller,strelka| enrich
+        enrich -->|deepvariant| summary
+        enrich -->|haplotypecaller| summary
+        enrich -->|strelka| summary
+    end

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -43,6 +43,15 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "Minimal two-line pipeline with no sections.",
     ),
     (
+        "line_spread",
+        EXAMPLES_DIR,
+        "Demonstrates the `%%metro line_spread:` axis with one per-section "
+        "override per section: `bundle` (default) merges shared lines onto one "
+        "trunk that cascades downward, `centered` balances that bundle about "
+        "the midline, and `rails` draws each line as a parallel rail with "
+        "shared stations as interchanges.",
+    ),
+    (
         "rnaseq_auto",
         EXAMPLES_DIR,
         "Demonstrates fully auto-inferred layout: no `%%metro grid:` directives "

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -10,6 +10,7 @@ import click
 from nf_metro import __version__
 from nf_metro.layout import PhaseInvariantError, compute_layout
 from nf_metro.parser import parse_metro_mermaid
+from nf_metro.parser.model import LineSpread
 from nf_metro.render import render_svg
 from nf_metro.render.html import render_html
 from nf_metro.themes import THEMES
@@ -103,6 +104,15 @@ def cli() -> None:
     "the value of the %%metro center_ports: directive (if any) is used.",
 )
 @click.option(
+    "--line-spread",
+    type=click.Choice([m.value for m in LineSpread]),
+    default=None,
+    help="How lines sharing a station relate vertically: 'bundle' (default) "
+    "merges onto one trunk, 'centered' balances the bundle about the midline, "
+    "'rails' draws parallel rails with interchange stations. Overrides the "
+    "graph-wide %%metro line_spread: directive (per-section overrides stay).",
+)
+@click.option(
     "--section-x-gap",
     type=float,
     default=None,
@@ -142,6 +152,7 @@ def render(
     line_order: str | None,
     straight_diamonds: bool,
     center_ports: bool | None,
+    line_spread: str | None,
     section_x_gap: float | None,
     section_y_gap: float | None,
     from_nextflow: bool,
@@ -171,6 +182,9 @@ def render(
 
     if center_ports is not None:
         graph.center_ports = center_ports
+
+    if line_spread is not None:
+        graph.line_spread = LineSpread(line_spread)
 
     if logo is not None:
         graph.logo_path = str(logo)

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -155,6 +155,10 @@ MIN_STRAIGHT_PORT: float = 5.0
 MIN_STRAIGHT_EDGE: float = 10.0
 """Minimum straight track for non-port edges."""
 
+RAIL_TERMINUS_FAN_LEAD: float = 16.0
+"""Flat lead a rail-mode blank terminus's fan runs along its convergence Y
+before fanning out to the rails, so the bundle reads as entering/leaving it."""
+
 MIN_STATION_FLAT_LENGTH: float = 20.0
 """Minimum length of the visible horizontal flat segment THROUGH a station.
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -108,6 +108,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _ensure_routes,
     _guard_anchors_frozen_during_placement,
     _guard_bundle_order_preserved,
+    _guard_centered_line_spread_balanced,
     _guard_coordinates_finite,
     _guard_entry_approach_from_port_side,
     _guard_explicit_grid_directions,
@@ -232,7 +233,7 @@ from nf_metro.layout.phases.spacing import (  # noqa: F401
     _residual_label_overlaps,
     _spread_bump,
 )
-from nf_metro.parser.model import MetroGraph
+from nf_metro.parser.model import LineSpread, MetroGraph
 
 # ---------------------------------------------------------------------------
 # Stage-boundary guards
@@ -374,11 +375,33 @@ def compute_layout(
         graph.label_angle = 0.0
 
     # A diagonal label angle drives one graph-wide column pitch shared by every
-    # section, so spacing is a property of the whole render, not of any one
-    # section.  Used as the default x_spacing when the caller didn't pin one.
+    # section (rail and normal alike), so spacing is a property of the whole
+    # render, not of any one section.  Used as the default x_spacing when the
+    # caller didn't pin one.
     from nf_metro.layout.labels import diagonal_label_pitch
 
     default_x_spacing = diagonal_label_pitch(graph, X_SPACING)
+
+    # Opt-in rail mode runs a dedicated, self-contained layout pipeline and
+    # returns early so the normal phase pipeline below is never touched when
+    # rail mode is off (default).  See layout/rail_mode.py.
+    if graph.line_spread is LineSpread.RAILS:
+        from nf_metro.layout.rail_mode import compute_rail_layout
+
+        rail_y = y_spacing if y_spacing is not None else compute_min_y_spacing(graph)
+        rail_x = x_spacing if x_spacing is not None else default_x_spacing
+        compute_rail_layout(
+            graph,
+            x_spacing=rail_x,
+            y_spacing=rail_y,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+            section_y_gap=section_y_gap,
+        )
+        _guard_stations_within_bbox(graph, "final")
+        return
 
     auto_x = x_spacing is None
     auto_y = y_spacing is None
@@ -440,6 +463,32 @@ def compute_layout(
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y
 
+    # Per-section rail mode: the normal pipeline has positioned every
+    # section's bbox and inter-section ports.  Now overwrite the *internal*
+    # geometry of each rail-flagged section with the rail-mode layout (rails
+    # + spanning pills), anchored at the bbox the placement chose.  Non-rail
+    # sections and all inter-section placement keep the normal machinery.
+    rail_section_ids = [
+        sid
+        for sid, mode in graph.line_spread_overrides.items()
+        if mode is LineSpread.RAILS
+    ]
+    if rail_section_ids and graph.line_spread is not LineSpread.RAILS:
+        from nf_metro.layout.rail_mode import retrofit_section_rails
+
+        for sid in rail_section_ids:
+            section = graph.sections.get(sid)
+            if section is None:
+                continue
+            retrofit_section_rails(
+                graph,
+                section,
+                x_spacing=x_spacing,
+                y_spacing=y_spacing,
+                section_x_padding=section_x_padding,
+                section_y_padding=section_y_padding,
+            )
+
     # Always-on backstop (independent of ``validate``): the settled layout
     # must never leave a station outside its own section bbox.  Runs on the
     # render path so an unsupported directive combination fails loudly
@@ -450,6 +499,7 @@ def compute_layout(
     if validate:
         _guard_no_label_overlap(graph, "final")
         _guard_file_icon_no_name_label(graph, "final")
+        _guard_centered_line_spread_balanced(graph, "final")
 
 
 def _snap(graph: MetroGraph, phase_id: str) -> None:

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -86,7 +86,7 @@ def diagonal_label_pitch(graph: "MetroGraph", fallback: float) -> float:
     for st in graph.stations.values():
         if st.is_port or st.is_hidden or st.off_track:
             continue
-        if st.is_terminus and not st.label.strip():
+        if st.is_blank_terminus:
             continue
         if not st.label.strip():
             continue
@@ -110,6 +110,77 @@ class LabelPlacement:
     text_anchor: str = "middle"
     dominant_baseline: str = ""  # Empty means use above/below logic
     obstacle_bbox: tuple[float, float, float, float] | None = None
+
+
+def _rail_panel_extents(graph: "MetroGraph") -> dict[str, tuple[float, float]]:
+    """Per-rail-section (top_rail_y, bottom_rail_y) from the rail Y map.
+
+    Used to offset rail-mode station labels to the whole panel's outer edge
+    so a label always clears every rail rather than landing between two of
+    them.  Returns an empty map when the graph has no rail sections.
+    """
+    rail_y = graph._rail_y
+    extents: dict[str, tuple[float, float]] = {}
+    if not rail_y:
+        return extents
+    for sec_id, per_line in rail_y.items():
+        if not per_line:
+            continue
+        ys = list(per_line.values())
+        extents[sec_id] = (min(ys), max(ys))
+    return extents
+
+
+def _rail_label_side(
+    station: "Station",
+    panel_extents: dict[str, tuple[float, float]],
+) -> bool | None:
+    """Forced above/below side for a rail-mode single-rail station label.
+
+    A label beside a middle rail reads as noise in the bundle, so each
+    single-rail station's label is pushed *outward* to the panel edge (see
+    ``_rail_panel_label_offsets``): a station in the panel's top half labels
+    above (clearing the topmost rail), one in the bottom half labels below
+    (clearing the bottommost rail).  Splitting by half keeps a column of
+    single-rail stations from stacking every label on one panel edge.  Returns
+    True (above) / False (below), or None when the rule doesn't apply (non-rail
+    section, or a multi-rail spanning station which keeps layer alternation).
+    """
+    if not station.section_id:
+        return None
+    if station.rail_top_y is not None and station.rail_bottom_y is not None:
+        return None  # spanning pill: keeps layer alternation
+    extent = panel_extents.get(station.section_id)
+    if extent is None:
+        return None
+    top_y, bot_y = extent
+    mid = (top_y + bot_y) / 2
+    # Top-half rails label above (out the top of the panel), bottom-half below.
+    # The mid rail (== mid) defaults to below so it never collides with a
+    # top-half label dropping into the panel.
+    return station.y < mid - 0.5
+
+
+def _rail_panel_label_offsets(
+    station: "Station",
+    panel_extents: dict[str, tuple[float, float]],
+) -> tuple[float, float] | None:
+    """Label offsets (min_off, max_off) clearing the WHOLE rail panel.
+
+    A rail-mode label must never sit beside a middle rail: an above label has
+    to clear the panel's topmost rail and a below label its bottommost rail,
+    whatever rail(s) the station itself occupies.  Returns offsets measured
+    from ``station.y`` to the panel's top/bottom rail (so ``_try_place`` lands
+    the label outside the rail stack), or None when the station is not in a
+    known rail panel.
+    """
+    if not station.section_id:
+        return None
+    extent = panel_extents.get(station.section_id)
+    if extent is None:
+        return None
+    top_y, bot_y = extent
+    return (top_y - station.y, bot_y - station.y)
 
 
 def _label_bbox(
@@ -617,6 +688,7 @@ def _trial_cost(
     flip: bool,
     icon_obstacles: list[tuple[float, float, float, float]] | None = None,
     port_pref: dict[str, bool] | None = None,
+    panel_extents: dict[str, tuple[float, float]] | None = None,
 ) -> float:
     """Count label collision cost for a section using the given alternation.
 
@@ -648,10 +720,23 @@ def _trial_cost(
             max_off = max(line_offs) if line_offs else 0.0
         else:
             min_off = max_off = 0.0
+        rail_panel = (
+            _rail_panel_label_offsets(station, panel_extents)
+            if panel_extents is not None
+            else None
+        )
+        if rail_panel is not None:
+            min_off, max_off = rail_panel
 
         start_above = station.layer % 2 == 1
         if flip:
             start_above = not start_above
+
+        rail_side = (
+            _rail_label_side(station, panel_extents)
+            if panel_extents is not None
+            else None
+        )
 
         start_above = _apply_edge_override(
             station,
@@ -663,6 +748,9 @@ def _trial_cost(
 
         if port_pref and station.id in port_pref:
             start_above = port_pref[station.id]
+
+        if rail_side is not None:
+            start_above = rail_side
 
         candidate = _try_place(
             station, label_offset, start_above, placements, min_off, max_off
@@ -790,6 +878,10 @@ def place_labels(
     # off-Y ports, so labels avoid overlapping diagonal port routes.
     port_pref = _compute_port_label_preference(graph, max_dx=PORT_LABEL_MAX_DX)
 
+    # Rail-mode panels: offset labels to the whole panel's outer edge so they
+    # alternate above the top rail / below the bottom rail (never between rails).
+    panel_extents = _rail_panel_extents(graph)
+
     # Trial both alternation patterns per section, pick the better one.
     section_flip: dict[str, bool] = {}
     sec_groups: dict[str, list[Station]] = {}
@@ -808,10 +900,18 @@ def place_labels(
             sections_with_multiline,
         )
         cost_default = _trial_cost(
-            *args, flip=False, icon_obstacles=icon_obstacles, port_pref=port_pref
+            *args,
+            flip=False,
+            icon_obstacles=icon_obstacles,
+            port_pref=port_pref,
+            panel_extents=panel_extents,
         )
         cost_flipped = _trial_cost(
-            *args, flip=True, icon_obstacles=icon_obstacles, port_pref=port_pref
+            *args,
+            flip=True,
+            icon_obstacles=icon_obstacles,
+            port_pref=port_pref,
+            panel_extents=panel_extents,
         )
         if cost_flipped < cost_default:
             section_flip[sec_id] = True
@@ -836,6 +936,10 @@ def place_labels(
             max_off = max(line_offs) if line_offs else 0.0
         else:
             min_off = max_off = 0.0
+        rail_panel = _rail_panel_label_offsets(station, panel_extents)
+        if rail_panel is not None:
+            min_off, max_off = rail_panel
+        rail_side = _rail_label_side(station, panel_extents)
 
         # Check if this is a TB section station (horizontal pill)
         is_tb_vert = False
@@ -942,6 +1046,12 @@ def place_labels(
         # Override when a port route would clash with the label.
         if station.id in port_pref:
             start_above = port_pref[station.id]
+
+        # Rail mode: force single-rail labels outward (above their own rail in
+        # the top half, below in the bottom half) so they never sit between
+        # rails and a column of branch stations spreads its labels vertically.
+        if rail_side is not None:
+            start_above = rail_side
 
         safe_above, safe_below = safe_offsets.get(
             station.id, (label_offset, label_offset)
@@ -1061,7 +1171,57 @@ def place_labels(
         placements, graph, station_offsets, allow_hyphenation=allow_hyphenation
     )
 
+    if graph.label_angle:
+        _apply_rail_label_angle(
+            placements, graph, float(graph.label_angle), panel_extents
+        )
+
     return [p for p in placements if p.obstacle_bbox is None]
+
+
+_RAIL_LABEL_PANEL_CLEARANCE = 4.0
+
+
+def _apply_rail_label_angle(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+    label_angle: float,
+    panel_extents: dict[str, tuple[float, float]] | None = None,
+) -> None:
+    """Tilt rail-section station labels by *label_angle* degrees.
+
+    Only rail-mode panels are affected (the normal layout path has its own
+    diagonal-label machinery).  An angled label is anchored at the pill X and
+    its current vertical offset and rotated about that anchor with
+    ``text-anchor=start`` so the tilted text trails away from the station;
+    the rail column step is sized for the rotated label's horizontal
+    projection by ``_label_aware_x_spacing`` so the panel packs tighter.
+    """
+    for p in placements:
+        if p.obstacle_bbox is not None or not p.station_id:
+            continue
+        st = graph.stations.get(p.station_id)
+        if st is None or st.is_port:
+            continue
+        if not (st.section_id and graph.is_rail_section(st.section_id)):
+            continue
+        # Blank termini render as icons, not text; leave them alone.
+        if st.is_blank_terminus:
+            continue
+        p.angle = label_angle
+        p.text_anchor = "start"
+        p.x = st.x
+        # Tilting adds vertical extent; nudge the anchor so the rotated label
+        # still clears the whole rail panel (above its top rail / below its
+        # bottom rail) rather than dipping back beside a middle rail.
+        extent = panel_extents.get(st.section_id) if panel_extents else None
+        if extent is not None:
+            top_y, bot_y = extent
+            _, by0, _, by1 = _label_bbox(p)
+            if p.above and by1 > top_y - _RAIL_LABEL_PANEL_CLEARANCE:
+                p.y -= by1 - (top_y - _RAIL_LABEL_PANEL_CLEARANCE)
+            elif not p.above and by0 < bot_y + _RAIL_LABEL_PANEL_CLEARANCE:
+                p.y += (bot_y + _RAIL_LABEL_PANEL_CLEARANCE) - by0
 
 
 # Upper bound on wrapping rounds.  Each round narrows one offending label by

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -21,7 +21,7 @@ from nf_metro.layout.constants import (
     LINE_GAP,
     SIDE_BRANCH_NUDGE,
 )
-from nf_metro.parser.model import MetroGraph
+from nf_metro.parser.model import LineSpread, MetroGraph
 
 
 def assign_tracks(
@@ -66,10 +66,30 @@ def assign_tracks(
         else:
             node_primary[sid] = None
 
-    # Step 2: Fixed-gap base tracks per line
+    # Step 2: Fixed-gap base tracks per line.  In centred mode the bases
+    # are symmetric about zero so the weave balances around the midline;
+    # otherwise they stack downward from the top line.
+    centered = graph.line_spread is LineSpread.CENTERED
+    n_lines = len(line_order)
     line_base: dict[str, float] = {}
     for i, lid in enumerate(line_order):
-        line_base[lid] = i * line_gap
+        if centered:
+            line_base[lid] = (i - (n_lines - 1) / 2) * line_gap
+        else:
+            line_base[lid] = i * line_gap
+
+    # In centred mode a shared (multi-line) station should sit on the mean
+    # of its lines' base tracks (the bundle midline) rather than snap to
+    # its single highest-priority line's base, which would pull every trunk
+    # station up to the top line.  Single-line stations keep their own
+    # line's (now symmetric) base so exclusive callers fan above/below.
+    node_base: dict[str, float] = {}
+    if centered:
+        for sid in graph.stations:
+            node_lines = graph.station_lines(sid)
+            bases = [line_base[ln] for ln in node_lines if ln in line_base]
+            if bases:
+                node_base[sid] = sum(bases) / len(bases)
 
     # Step 3: Group nodes by (layer, primary_line).  Off-track stations
     # are excluded from grouping: their Y is overwritten by the Stage 5.2
@@ -99,9 +119,12 @@ def assign_tracks(
             base = line_base[lid]
 
             if len(nodes) == 1:
+                # Centred mode: a shared (multi-line) station anchors on the
+                # mean of its lines' bases so the trunk stays on the midline.
+                single_base = node_base.get(nodes[0], base) if centered else base
                 tracks[nodes[0]] = _place_single_node(
                     nodes[0],
-                    base,
+                    single_base,
                     line_gap,
                     G,
                     tracks,
@@ -135,7 +158,14 @@ def assign_tracks(
         # Equalize cross-line fork groups at this layer so downstream
         # placement sees corrected positions.
         _equalize_fork_groups(
-            layer_idx, layers, tracks, G, graph, node_primary, line_gap
+            layer_idx,
+            layers,
+            tracks,
+            G,
+            graph,
+            node_primary,
+            line_gap,
+            line_base=line_base if centered else None,
         )
 
     return tracks
@@ -560,6 +590,8 @@ def _equalize_fork_groups(
     graph: MetroGraph,
     node_primary: dict[str, str | None],
     line_gap: float,
+    *,
+    line_base: dict[str, float] | None = None,
 ) -> None:
     """Redistribute cross-line fork siblings to equidistant spacing.
 
@@ -573,6 +605,14 @@ def _equalize_fork_groups(
     positions (one *line_gap* apart), preserving their track ordering.
     Groups where all members share the same primary line (diamonds /
     fan-outs already handled by ``_place_fan_out``) are skipped.
+
+    In centred mode (*line_base* supplied), a fork group whose members are
+    all single-line exclusive stations is instead pinned to each member's
+    own line's symmetric base track.  Consecutive repacking would collapse
+    those exclusive runs toward the trunk midline (e.g. the bottom line's
+    run snapping up onto the centre), defeating the balanced weave; pinning
+    to the line base keeps each exclusive run on its own rail above/below
+    the shared trunk.
     """
     layer_nodes = [sid for sid, lyr in layers.items() if lyr == layer and sid in tracks]
     if len(layer_nodes) < 2:
@@ -608,6 +648,19 @@ def _equalize_fork_groups(
         primaries = {node_primary.get(sid) for sid in group}
         primaries.discard(None)
         if len(primaries) < 2:
+            continue
+
+        # Centred mode: when every member is a single-line exclusive
+        # station, pin each to its own line's symmetric base rail rather
+        # than repacking them consecutively (which would drag exclusive
+        # runs toward the trunk midline and unbalance the weave).
+        if line_base is not None and all(
+            len(graph.station_lines(sid)) == 1 for sid in group
+        ):
+            for sid in group:
+                primary = node_primary.get(sid)
+                if primary is not None and primary in line_base:
+                    tracks[sid] = line_base[primary]
             continue
 
         # Sort by primary line order first, then by current track position

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -570,6 +570,7 @@ def _build_section_subgraph(graph: MetroGraph, section: Section) -> MetroGraph:
     sub = MetroGraph()
     sub.lines = graph.lines  # Share line definitions
     sub.diamond_style = graph.diamond_style
+    sub.line_spread = graph.section_line_spread(section.id)
 
     # Collect port IDs for this section
     port_ids = section.port_ids

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -38,7 +38,7 @@ from nf_metro.layout.phases.spacing import (
     _placed_name_label_station_ids,
     _residual_label_overlaps,
 )
-from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
+from nf_metro.parser.model import LineSpread, MetroGraph, PortSide, Section, Station
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -232,6 +232,105 @@ def _guard_stations_within_bbox(graph: MetroGraph, phase: str) -> None:
                 f"its '%%metro direction:'."
             )
         raise PhaseInvariantError(detail)
+
+
+def _guard_centered_line_spread_balanced(graph: MetroGraph, phase: str) -> None:
+    """Each ``centered`` section's weave must balance about its trunk.
+
+    Two invariants are enforced for every section resolving to ``centered``
+    (the graph-wide ``line_spread`` default or a per-section override):
+
+    1. The line base tracks are placed symmetrically at
+       ``(i - (N-1)/2) * line_gap``, whose mean is exactly zero, so the
+       shared trunk sits on the vertical midline.
+    2. Each line's *exclusive run* (stations carrying only that one line)
+       lands on the correct side of its section's shared trunk: a line
+       above the centre keeps its exclusive stations at-or-above the trunk
+       and a line below the centre keeps them at-or-below it.  This catches
+       a regression where the fork-equalize pass collapses an exclusive run
+       back onto the trunk midline, leaving the panel top/centre-heavy
+       instead of symmetric.
+
+    No-op when no section is centered, fewer than two lines exist, or there
+    are no lines at all (nothing to balance).
+    """
+    centered_anywhere = graph.line_spread is LineSpread.CENTERED or any(
+        mode is LineSpread.CENTERED for mode in graph.line_spread_overrides.values()
+    )
+    if not centered_anywhere:
+        return
+    n = len(graph.lines)
+    if n < 2:
+        return
+    from nf_metro.layout.constants import LINE_GAP
+
+    bases = [(i - (n - 1) / 2) * LINE_GAP for i in range(n)]
+    mean = sum(bases) / n
+    if abs(mean) > GUARD_TOLERANCE:
+        raise PhaseInvariantError(
+            f"{phase}: centered line_spread base tracks not symmetric about zero "
+            f"(mean={mean:.3f}, bases={bases})"
+        )
+
+    # Sign of each line's symmetric base: <0 above the trunk, >0 below it,
+    # 0 on the centre.  Y increases downward, so an above-centre line wants
+    # its exclusive stations at smaller Y than the trunk.
+    line_index = {lid: i for i, lid in enumerate(graph.lines)}
+    line_sign = {lid: (i - (n - 1) / 2) for lid, i in line_index.items()}
+
+    # Real (visible, on-track, non-port) stations grouped by section.
+    by_section: dict[str | None, list[str]] = {}
+    for sid, st in graph.stations.items():
+        if st.is_port or st.is_hidden or st.off_track:
+            continue
+        by_section.setdefault(st.section_id, []).append(sid)
+
+    # A non-centre line's exclusive station must be displaced to its side
+    # of the trunk; a zero/negative displacement means the run has
+    # collapsed onto (or crossed) the trunk midline.  Any genuine offset is
+    # a whole track unit (one section y-spacing of pixels), far larger than
+    # the guard tolerance, so a tolerance floor cleanly separates "offset"
+    # from "collapsed" independent of the absolute y-spacing in use.
+    min_offset = GUARD_TOLERANCE
+    for sec_id, members in by_section.items():
+        # Only centered sections must straddle; a bundle or rails section in
+        # the same graph legitimately cascades or runs as parallel rails.
+        if graph.section_line_spread(sec_id) is not LineSpread.CENTERED:
+            continue
+        # Skip sections with no vertical spread: an un-laid-out graph (all
+        # Y == 0) or a genuinely flat single-track section has no weave to
+        # balance, and the side check is only meaningful once coordinates
+        # have been assigned.
+        member_ys = [graph.stations[s].y for s in members]
+        if max(member_ys) - min(member_ys) <= GUARD_TOLERANCE:
+            continue
+        # The trunk is the set of multi-line stations; use their mean Y.
+        trunk_ys = [
+            graph.stations[s].y for s in members if len(graph.station_lines(s)) >= 2
+        ]
+        if not trunk_ys:
+            continue
+        trunk_y = sum(trunk_ys) / len(trunk_ys)
+        for s in members:
+            lines = graph.station_lines(s)
+            if len(lines) != 1:
+                continue
+            sign = line_sign.get(lines[0], 0.0)
+            if abs(sign) < 1e-9:
+                continue  # centre line: exclusive stations belong on trunk
+            # signed_offset > 0 means "on this line's side"; Y grows
+            # downward, so an above-centre line (sign<0) wants smaller Y.
+            dy = graph.stations[s].y - trunk_y
+            signed_offset = -dy if sign < 0 else dy
+            if signed_offset <= min_offset:
+                side = "above" if sign < 0 else "below"
+                raise PhaseInvariantError(
+                    f"{phase}: centered line_spread exclusive station '{s}' on "
+                    f"{side}-centre line '{lines[0]}' is not offset to its "
+                    f"side of the trunk (y={graph.stations[s].y:.1f}, "
+                    f"trunk_y={trunk_y:.1f}, signed_offset={signed_offset:.1f}, "
+                    f"required>={min_offset:.1f})"
+                )
 
 
 def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -454,9 +454,7 @@ def _mirror_rl(sub: MetroGraph) -> None:
     Anchors on non-terminus stations so adding terminus layers
     extends leftward without shifting the entry point.
     """
-    non_term = [
-        s for s in sub.stations.values() if not (s.is_terminus and not s.label.strip())
-    ]
+    non_term = [s for s in sub.stations.values() if not (s.is_blank_terminus)]
     anchor_stations = non_term if non_term else list(sub.stations.values())
     max_x_val = max(s.x for s in anchor_stations)
     for s in sub.stations.values():

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -1,0 +1,576 @@
+"""Opt-in "rail mode" layout (the nf-core/sarek subway idiom).
+
+In normal layout a station shared by several metro lines is a single point
+and the lines converge (bundle) to that one Y.  Rail mode instead lays each
+line out as a fixed, evenly-spaced horizontal *rail* across the section and
+renders a multi-line station as the classic metro *interchange*: a circle on
+each rail the station uses, joined by a straight connector segment.  The
+rails do not converge: a line runs straight along its rail and only the
+interchange connector bridges across rails.
+
+This module is a self-contained pipeline, run by ``compute_layout`` only for
+sections whose ``line_spread`` resolves to ``rails`` (``graph.is_rail_section``),
+so the normal layout path is untouched for every other section.
+
+Scope (MVP): LR sections.  Each section's lines get rails centred about the
+section trunk Y; stations are placed by longest-path layer (X) and anchored to
+span their lines' rail range (Y).  Sections are stacked vertically in grid-row
+order.  Ports/junctions are positioned at their connecting rail Y so that the
+dedicated rail-mode router (see ``routing/rail.py``) can draw straight rails.
+"""
+
+from __future__ import annotations
+
+__all__ = ["compute_rail_layout"]
+
+from nf_metro.layout.constants import (
+    DIAGONAL_RUN,
+    MIN_STRAIGHT_EDGE,
+    OFFSET_STEP,
+    SECTION_HEADER_PROTRUSION,
+    SECTION_X_PADDING,
+    SECTION_Y_GAP,
+    SECTION_Y_PADDING,
+    X_OFFSET,
+    X_SPACING,
+    Y_OFFSET,
+)
+from nf_metro.parser.model import MetroGraph, PortSide, Section
+
+# Horizontal room a blank terminus's fan-out/fan-in needs to ease between the
+# convergence point and the rails without compressing: a flat lead plus the
+# 45-degree diagonal plus a straight stub each side.  Reserved as the gap
+# between a fanning terminus and its neighbour column so the S-curves keep
+# their shape no matter how tight the shared (diagonal-label) column pitch is.
+_TERMINUS_FAN_ROOM = DIAGONAL_RUN + 3.0 * MIN_STRAIGHT_EDGE
+
+
+def _section_lines_in_order(graph: MetroGraph, section: Section) -> list[str]:
+    """Lines present in *section*, ordered by line-definition priority.
+
+    A line is "present" if any of the section's stations carry it.  Ports
+    and junctions don't define which lines belong to the section's rail
+    set on their own, so they're excluded here.
+    """
+    present: set[str] = set()
+    for sid in section.station_ids:
+        st = graph.stations.get(sid)
+        if st is None or st.is_port:
+            continue
+        present.update(graph.station_lines(sid))
+    return [lid for lid in graph.lines if lid in present]
+
+
+def compute_rail_layout(
+    graph: MetroGraph,
+    *,
+    x_spacing: float = X_SPACING,
+    y_spacing: float,
+    x_offset: float = X_OFFSET,
+    y_offset: float = Y_OFFSET,
+    section_x_padding: float = SECTION_X_PADDING,
+    section_y_padding: float = SECTION_Y_PADDING,
+    section_y_gap: float = SECTION_Y_GAP,
+) -> None:
+    """Lay the whole graph out in rail mode.
+
+    Writes ``x``/``y`` onto every station, ``rail_top_y``/``rail_bottom_y``
+    onto multi-line stations, port/junction Ys onto their connecting rail,
+    and section bboxes.  Sections stack top-to-bottom in grid-row order
+    (then by grid-col, then by section number) so the result is a vertically
+    stacked set of parallel-rail panels.
+    """
+    # Sort sections into a stable top-to-bottom reading order.  When the
+    # auto-layout / explicit grid set grid_row, honour it; otherwise fall
+    # back to declaration order via the section number.
+    sections = [
+        s for s in graph.sections.values() if not s.is_implicit or s.station_ids
+    ]
+    ordered = sorted(
+        sections,
+        key=lambda s: (
+            s.grid_row if s.grid_row >= 0 else 0,
+            s.grid_col if s.grid_col >= 0 else 0,
+            s.number,
+        ),
+    )
+
+    # Per-section rail Y maps, keyed by section id then line id.
+    rail_y: dict[str, dict[str, float]] = {}
+
+    cursor_top = y_offset
+    for section in ordered:
+        bottom = _layout_section_rails(
+            graph,
+            section,
+            rail_y,
+            x_spacing=x_spacing,
+            x_offset=x_offset,
+            section_top=cursor_top,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+            y_spacing=y_spacing,
+        )
+        cursor_top = bottom + section_y_gap
+
+    # Stash the per-section rail map so the dedicated router can resolve a
+    # port's Y to its line's rail (rather than the port's stored average Y),
+    # keeping inter-section legs on the right rail per line.
+    graph._rail_y = rail_y
+
+    _position_ports_and_junctions(graph, rail_y)
+
+
+def retrofit_section_rails(
+    graph: MetroGraph,
+    section: Section,
+    *,
+    x_spacing: float = X_SPACING,
+    y_spacing: float,
+    section_x_padding: float = SECTION_X_PADDING,
+    section_y_padding: float = SECTION_Y_PADDING,
+) -> None:
+    """Re-lay one already-placed section as parallel rails (per-section mode).
+
+    The normal layout pipeline has already positioned this section's bbox via
+    section placement.  This function overwrites the section's *internal*
+    geometry (station X/Y, rail spans, used-Ys) and its internal edge routing
+    with the rail-mode layout, anchored at the section's existing bbox
+    top-left, and resizes the bbox to hug the resulting rails.  Inter-section
+    placement, ports, and routing are left to the normal machinery.
+
+    Used by ``compute_layout`` for a section that resolves to ``rails`` while
+    the graph-wide default is some other mode (the per-section override case).
+    """
+    # ``_layout_section_rails`` anchors the box top at
+    # ``section_top + SECTION_HEADER_PROTRUSION`` and positions stations from
+    # ``x_offset``; feeding it the placement-chosen bbox top-left (offsetting
+    # the header protrusion back out) keeps the box where placement put it
+    # while the rails fill it.
+    box_left = section.bbox_x
+    box_top = section.bbox_y
+    rail_y = graph._rail_y
+    _layout_section_rails(
+        graph,
+        section,
+        rail_y,
+        x_spacing=x_spacing,
+        x_offset=box_left,
+        section_top=box_top - SECTION_HEADER_PROTRUSION,
+        section_x_padding=section_x_padding,
+        section_y_padding=section_y_padding,
+        y_spacing=y_spacing,
+    )
+
+    # Re-position this section's own ports onto their line rails so the normal
+    # router still draws sensible inter-section legs (no-op when the rail
+    # section is disconnected, which is the supported case).
+    _position_section_ports(graph, section, rail_y.get(section.id, {}))
+
+
+def _position_section_ports(
+    graph: MetroGraph,
+    section: Section,
+    per_line: dict[str, float],
+) -> None:
+    """Snap one rail section's boundary ports onto their connecting line rail."""
+    for port_id in section.port_ids:
+        port = graph.ports.get(port_id)
+        st = graph.stations.get(port_id)
+        if port is None or st is None:
+            continue
+        lines = graph.station_lines_ordered(port_id)
+        ys = [per_line[lid] for lid in lines if lid in per_line]
+        if ys:
+            st.y = sum(ys) / len(ys)
+        if port.side is PortSide.LEFT:
+            st.x = section.bbox_x
+        elif port.side is PortSide.RIGHT:
+            st.x = section.bbox_x + section.bbox_w
+        else:
+            st.x = section.bbox_x + section.bbox_w / 2
+        port.x = st.x
+        port.y = st.y
+
+
+def _layout_section_rails(
+    graph: MetroGraph,
+    section: Section,
+    rail_y: dict[str, dict[str, float]],
+    *,
+    x_spacing: float,
+    x_offset: float,
+    section_top: float,
+    section_x_padding: float,
+    section_y_padding: float,
+    y_spacing: float,
+) -> float:
+    """Lay out one section's rails and stations; return its bbox bottom Y."""
+    lines = _section_lines_in_order(graph, section)
+    # Lines sharing a legend_combo collapse onto a single rail slot (a tight
+    # bundle), so the slot count - not the line count - drives rail spacing and
+    # the bbox height.  With no combos there is one slot per line.
+    slot_offset, _n_slots = _rail_slot_offsets(graph, lines, y_spacing)
+
+    # The section-number badge renders just above the bbox top edge (outside
+    # the box), so the box itself hugs content: the top rail sits exactly
+    # section_y_padding below the bbox top.  A header band above the box is
+    # reserved by advancing section_top by SECTION_HEADER_PROTRUSION before
+    # this section's bbox begins.
+    box_top = section_top + SECTION_HEADER_PROTRUSION
+    rails_top = box_top + section_y_padding
+    per_line_y = {lid: rails_top + slot_offset[lid] for lid in lines}
+    rail_y[section.id] = per_line_y
+
+    # X by longest-path layer over this section's internal stations, so a
+    # station's column reflects its in-section depth.
+    from nf_metro.layout.layers import assign_layers
+    from nf_metro.layout.phases._common import _build_section_subgraph
+
+    layers = assign_layers(_build_section_subgraph(graph, section))
+
+    # Place real stations.
+    real_ids = [
+        sid
+        for sid in section.station_ids
+        if (st := graph.stations.get(sid)) is not None and not st.is_port
+    ]
+
+    # Widen the column step so a column's widest label fits between its
+    # neighbours without wrapping.  Labels sit above/below the rails centred
+    # on the station X, so a column needs roughly half the widest label of it
+    # and of each neighbour to clear; using the per-column widest label as the
+    # step keeps the rails evenly spaced while giving long names room.
+    x_spacing = _label_aware_x_spacing(graph, real_ids, layers, x_spacing)
+    # Off-track input stations sit ABOVE the top rail and feed in with an
+    # S-curve (see routing/rail.py), so reserve a band above the rails for
+    # them.  rails_top is shifted down by that band; the off-track band Y is
+    # computed from the original box-content top.
+    off_track_ids = [sid for sid in real_ids if graph.stations[sid].off_track]
+    off_track_band = y_spacing if off_track_ids else 0.0
+    rails_top += off_track_band
+    if off_track_band:
+        per_line_y = {lid: rails_top + slot_offset[lid] for lid in lines}
+        rail_y[section.id] = per_line_y
+    off_track_y = box_top + section_y_padding
+
+    # A blank terminus that fans across rails needs its own horizontal room so
+    # the fan S-curves keep their shape regardless of the shared column pitch.
+    # Reserve it as extra gap AFTER the first column (a head/source terminus)
+    # and BEFORE the last column (a tail/sink terminus); the gap is the larger
+    # of the column pitch and the fan room, so it never shrinks the fan.
+    max_layer = max((layers.get(sid, 0) for sid in real_ids), default=0)
+
+    def _fans(sid: str) -> bool:
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.off_track:
+            return False
+        if not (st.is_blank_terminus):
+            return False
+        lns = graph.station_lines_ordered(sid)
+        return len({per_line_y[lid] for lid in lns if lid in per_line_y}) > 1
+
+    head_fan = any(_fans(sid) for sid in real_ids if layers.get(sid, 0) == 0)
+    tail_fan = any(_fans(sid) for sid in real_ids if layers.get(sid, 0) == max_layer)
+    head_extra = max(0.0, _TERMINUS_FAN_ROOM - x_spacing) if head_fan else 0.0
+    tail_extra = max(0.0, _TERMINUS_FAN_ROOM - x_spacing) if tail_fan else 0.0
+
+    def _layer_x(layer: float) -> float:
+        x = x_offset + section_x_padding + layer * x_spacing
+        if layer >= 1:
+            x += head_extra
+        if layer == max_layer:
+            x += tail_extra
+        return x
+
+    for sid in real_ids:
+        st = graph.stations[sid]
+        layer = layers.get(sid, 0)
+        st.layer = layer
+        st.x = _layer_x(layer)
+
+        if st.off_track:
+            # Park above the rails just to the left of the consumer column, so
+            # the router draws a short, clean S-curve down into the rail rather
+            # than a long diagonal traverse from layer 0.  The consumer's layer
+            # determines the X; the off-track input sits half a column before it.
+            consumer_layer = min(
+                (
+                    layers.get(e.target, layer)
+                    for e in graph.edges_from(sid)
+                    if e.target in layers
+                ),
+                default=layer + 1,
+            )
+            feed_layer = max(0.0, consumer_layer - 0.5)
+            st.x = _layer_x(feed_layer)
+            st.y = off_track_y
+            st.track = 0.0
+            st.rail_used_ys = []
+            st.rail_top_y = None
+            st.rail_bottom_y = None
+            continue
+
+        st_lines = graph.station_lines_ordered(sid)
+        ys = [per_line_y[lid] for lid in st_lines if lid in per_line_y]
+        if not ys:
+            # A station with no recognised line (shouldn't happen post-parse);
+            # park it on the first rail.
+            ys = [rails_top]
+        top_y = min(ys)
+        bot_y = max(ys)
+        st.y = (top_y + bot_y) / 2
+        st.track = 0.0
+        # A blank terminus (file/dir/report icon) converges its lines to a tight
+        # BUNDLE -- parallel lines a small offset apart, not all merged onto one
+        # Y -- so the fan to the rails leaves/enters a bundle (several distinct
+        # line widths) rather than a single line.  The slots are ordered by each
+        # line's rail Y so the fan never crosses; the terminus bar caps the
+        # bundle.  A single-line terminus stays a point.
+        is_blank_terminus = st.is_blank_terminus
+        if is_blank_terminus:
+            n = len(ys)
+            if n > 1:
+                rank = {
+                    i: r for r, i in enumerate(sorted(range(n), key=lambda i: ys[i]))
+                }
+                slots = [
+                    st.y + (rank[i] - (n - 1) / 2.0) * OFFSET_STEP for i in range(n)
+                ]
+                st.rail_used_ys = slots
+                st.rail_top_y = min(slots)
+                st.rail_bottom_y = max(slots)
+            else:
+                st.rail_used_ys = [st.y]
+                st.rail_top_y = None
+                st.rail_bottom_y = None
+        else:
+            # Record the rails this station actually uses (in line order) so
+            # the renderer can draw a knob on each; rails that merely pass
+            # behind the pill get no knob.
+            st.rail_used_ys = list(ys)
+            if len(set(ys)) > 1:
+                st.rail_top_y = top_y
+                st.rail_bottom_y = bot_y
+            else:
+                st.rail_top_y = None
+                st.rail_bottom_y = None
+
+    # Section bbox: span columns and rails with symmetric padding.  rails_top
+    # already includes the off-track band, so the box top stays at box_top and
+    # the box height covers padding + band + rails + padding.  The terminus fan
+    # room widens the column span, so include it.
+    bbox_x = x_offset
+    bbox_w = section_x_padding * 2 + max_layer * x_spacing + head_extra + tail_extra
+    # The lowest rail Y is the largest per-line offset below rails_top (which
+    # is a bundle sub-rail when the bottom slot is a combo), not simply the
+    # last slot centre.
+    rails_bottom = rails_top + (max(slot_offset.values()) if slot_offset else 0.0)
+    bbox_y = box_top
+    # Below-rail station labels hang under the bottom rail; the bbox must
+    # contain them so a section stacked below this one clears them (the
+    # stacking gap is measured bbox-to-bbox).  Reserve max(section_y_padding,
+    # below-rail label band) so the box always wraps its labels.  With the
+    # default 50px padding this is a no-op for short/level labels, but it grows
+    # the box for a long or steeply-angled label whose footprint exceeds the
+    # padding.
+    bottom_pad = max(section_y_padding, _below_rail_label_band(graph, real_ids))
+    bbox_h = (rails_bottom - box_top) + bottom_pad
+    section.bbox_x = bbox_x
+    section.bbox_y = bbox_y
+    section.bbox_w = bbox_w
+    section.bbox_h = bbox_h
+    section.direction = "LR"
+
+    return bbox_y + bbox_h
+
+
+def _below_rail_label_band(
+    graph: MetroGraph,
+    real_ids: list[str],
+) -> float:
+    """Vertical room a section's below-rail labels need under the bottom rail.
+
+    A rail label is offset ``LABEL_OFFSET`` from the rail then occupies its own
+    text footprint.  For an angled (diagonal) label the footprint that hangs
+    downward is ``height*cos(angle) + width*sin(angle)``.  Returns the worst
+    such band over the section's labelled stations (0 if none), so the caller
+    can keep the section bbox tall enough to contain every hanging label.
+    """
+    import math
+
+    from nf_metro.layout.constants import LABEL_OFFSET
+    from nf_metro.layout.labels import _label_text_height, label_text_width
+
+    angle = abs(graph.label_angle or 0.0)
+    cos_a = abs(math.cos(math.radians(angle)))
+    sin_a = abs(math.sin(math.radians(angle)))
+
+    band = 0.0
+    for sid in real_ids:
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.off_track:
+            continue
+        if st.is_blank_terminus:
+            continue
+        h = _label_text_height(st.label)
+        w = label_text_width(st.label)
+        footprint = h * cos_a + w * sin_a if angle else h
+        band = max(band, LABEL_OFFSET + footprint)
+    return band
+
+
+def _label_aware_x_spacing(
+    graph: MetroGraph,
+    real_ids: list[str],
+    layers: dict[str, int],
+    x_spacing: float,
+) -> float:
+    """Return a column step wide enough that no column's label wraps.
+
+    Labels render centred on a station's X, so two adjacent columns' labels
+    each consume half their own width either side of the column line.  Taking
+    the widest label across the section and requiring the step to seat half of
+    it plus half its neighbour (i.e. the full widest label, plus a small gap)
+    keeps every label on one line while the rails stay evenly spaced.
+    """
+    import math
+
+    from nf_metro.layout.constants import LABEL_MARGIN
+    from nf_metro.layout.labels import label_text_width
+
+    # A diagonal (angled) label's HORIZONTAL footprint is its width times
+    # cos(angle), so an angled-label panel only needs to seat that projection
+    # between columns and can pack noticeably tighter than horizontal text.
+    # Gated on angle != 0 so non-angled panels are unchanged.
+    angle = graph.label_angle or 0.0
+    h_factor = abs(math.cos(math.radians(angle))) if angle else 1.0
+
+    widest = 0.0
+    for sid in real_ids:
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.off_track:
+            continue
+        # Blank termini render as icons, not text labels, so don't size to them.
+        if st.is_blank_terminus:
+            continue
+        widest = max(widest, label_text_width(st.label) * h_factor)
+    if widest <= 0.0:
+        return x_spacing
+    return max(x_spacing, widest + LABEL_MARGIN * 2)
+
+
+def _rail_slot_offsets(
+    graph: MetroGraph,
+    lines: list[str],
+    y_spacing: float,
+) -> tuple[dict[str, float], int]:
+    """Map each line to a Y offset (from the top rail) and return the slot count.
+
+    Each line normally occupies its own evenly-spaced rail slot.  Lines that
+    are members of the same ``legend_combo`` instead share a SINGLE slot,
+    drawn as a tight adjacent bundle: the slot's lines hug each other with a
+    small sub-offset about the slot centre rather than spreading across full
+    rail pitches.  With no combos this is exactly ``i * y_spacing`` per line in
+    order, identical to the un-bundled layout.
+
+    Returns ``(per_line_offset, n_slots)`` where ``n_slots`` is the number of
+    distinct rail slots (non-combo lines + one per combo with members present).
+    """
+    # Build line -> combo-key, keeping only combos whose members appear here.
+    line_combo: dict[str, int] = {}
+    for ci, (combo_ids, _label) in enumerate(graph.legend_combos):
+        members = [lid for lid in combo_ids if lid in lines]
+        if len(members) >= 2:
+            for lid in members:
+                line_combo[lid] = ci
+
+    # Walk the lines in order, allocating one slot per non-combo line and one
+    # slot per combo (at the position of its first-encountered member).
+    slot_of_combo: dict[int, int] = {}
+    slot_index: dict[str, int] = {}
+    n_slots = 0
+    for lid in lines:
+        combo_key = line_combo.get(lid)
+        if combo_key is None:
+            slot_index[lid] = n_slots
+            n_slots += 1
+        elif combo_key in slot_of_combo:
+            slot_index[lid] = slot_of_combo[combo_key]
+        else:
+            slot_of_combo[combo_key] = n_slots
+            slot_index[lid] = n_slots
+            n_slots += 1
+
+    # A combo's members hug within their shared slot: spread them symmetrically
+    # about the slot centre, one OFFSET_STEP apart (the same pitch the normal
+    # router uses for parallel lines in a bundle), so the sub-lines abut and the
+    # bundle reads as a single track rather than separate rails.
+    from nf_metro.layout.constants import OFFSET_STEP
+
+    bundle_gap = OFFSET_STEP
+    members_in_slot: dict[int, list[str]] = {}
+    for lid in lines:
+        members_in_slot.setdefault(slot_index[lid], []).append(lid)
+
+    per_line_offset: dict[str, float] = {}
+    for lid in lines:
+        slot = slot_index[lid]
+        members = members_in_slot[slot]
+        base = slot * y_spacing
+        if len(members) == 1:
+            per_line_offset[lid] = base
+        else:
+            k = members.index(lid)
+            per_line_offset[lid] = base + (k - (len(members) - 1) / 2.0) * bundle_gap
+    return per_line_offset, max(1, n_slots)
+
+
+def _position_ports_and_junctions(
+    graph: MetroGraph,
+    rail_y: dict[str, dict[str, float]],
+) -> None:
+    """Place ports and junctions at the rail Y of the line(s) they carry.
+
+    Ports sit on their section's boundary edge (X from the bbox) at the Y of
+    their connecting line's rail.  Junctions sit in the inter-section gap at
+    the Y of one of their lines.  This keeps the dedicated rail router's
+    inter-section legs horizontal where possible.
+    """
+    for port_id, port in graph.ports.items():
+        st = graph.stations.get(port_id)
+        if st is None:
+            continue
+        section = graph.sections.get(port.section_id)
+        per_line = rail_y.get(port.section_id, {})
+        lines = graph.station_lines_ordered(port_id)
+        ys = [per_line[lid] for lid in lines if lid in per_line]
+        st.y = sum(ys) / len(ys) if ys else (section.bbox_y if section else 0.0)
+        if section is not None:
+            if port.side in (PortSide.LEFT,):
+                st.x = section.bbox_x
+            elif port.side in (PortSide.RIGHT,):
+                st.x = section.bbox_x + section.bbox_w
+            else:
+                st.x = section.bbox_x + section.bbox_w / 2
+        port.x = st.x
+        port.y = st.y
+
+    for jid in graph.junctions:
+        st = graph.stations.get(jid)
+        if st is None:
+            continue
+        # Place the junction midway between its predecessors and successors
+        # in X, at the average rail Y of the lines passing through it.
+        neighbours = [graph.stations.get(e.source) for e in graph.edges_to(jid)] + [
+            graph.stations.get(e.target) for e in graph.edges_from(jid)
+        ]
+        xs = [n.x for n in neighbours if n is not None]
+        st.x = sum(xs) / len(xs) if xs else 0.0
+        # Junction Y: average of its lines' rails across whichever section
+        # rail map contains them (use the target section's map if present).
+        line_ids = graph.station_lines_ordered(jid)
+        jys: list[float] = []
+        for per_line in rail_y.values():
+            jys.extend(per_line[lid] for lid in line_ids if lid in per_line)
+        st.y = sum(jys) / len(jys) if jys else 0.0

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -3,10 +3,12 @@
 In normal layout a station shared by several metro lines is a single point
 and the lines converge (bundle) to that one Y.  Rail mode instead lays each
 line out as a fixed, evenly-spaced horizontal *rail* across the section and
-renders a multi-line station as the classic metro *interchange*: a circle on
-each rail the station uses, joined by a straight connector segment.  The
-rails do not converge: a line runs straight along its rail and only the
-interchange connector bridges across rails.
+renders a station several lines *pass through* as the classic metro
+*interchange*: a circle on each rail the station uses, joined by a straight
+connector segment.  Co-travelling lines stay on their own rails rather than
+bundling to one Y; they converge only at a genuine fan-in/out to a single
+node (e.g. a file terminus all lines reach), eased in with 45-degree
+diagonals.
 
 This module is a self-contained pipeline, run by ``compute_layout`` only for
 sections whose ``line_spread`` resolves to ``rails`` (``graph.is_rail_section``),

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -70,7 +70,7 @@ from nf_metro.layout.routing.corners import (
     tb_entry_corner,
     tb_exit_corner,
 )
-from nf_metro.parser.model import Edge, MetroGraph, Port, PortSide, Station
+from nf_metro.parser.model import Edge, LineSpread, MetroGraph, Port, PortSide, Station
 
 # ---------------------------------------------------------------------------
 # Routing context: pre-computed state shared by all handlers
@@ -157,11 +157,42 @@ def route_edges(
     Detects cross-row edges (large Y gap relative to X gap) and routes
     them through a vertical connector at the fold edge.
     """
+    if graph.line_spread is LineSpread.RAILS:
+        from nf_metro.layout.routing.rail import route_rail_edges
+
+        return route_rail_edges(graph)
+
+    # Per-section rail mode: route each rail section's internal edges with the
+    # dedicated rail router (straight rails, no bundling) and let the normal
+    # router handle every other edge.  An edge is "internal" to a rail section
+    # when both endpoints are non-port stations of that section.
+    rail_routes: list[RoutedPath] = []
+    rail_internal: set[tuple[str, str, str]] = set()
+    if graph.has_rail_sections:
+        from nf_metro.layout.routing.rail import route_rail_edges
+
+        rail_edges = []
+        for edge in graph.edges:
+            src = graph.stations.get(edge.source)
+            tgt = graph.stations.get(edge.target)
+            if src is None or tgt is None or src.is_port or tgt.is_port:
+                continue
+            if (
+                src.section_id == tgt.section_id
+                and src.section_id is not None
+                and graph.is_rail_section(src.section_id)
+            ):
+                rail_edges.append(edge)
+                rail_internal.add((edge.source, edge.target, edge.line_id))
+        rail_routes = route_rail_edges(graph, rail_edges)
+
     ctx = _build_routing_context(graph, diagonal_run, curve_radius, station_offsets)
-    routes: list[RoutedPath] = []
+    routes: list[RoutedPath] = list(rail_routes)
 
     for edge in graph.edges:
         if (edge.source, edge.target, edge.line_id) in ctx.skip_edges:
+            continue
+        if (edge.source, edge.target, edge.line_id) in rail_internal:
             continue
 
         src = graph.stations.get(edge.source)

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -37,7 +37,7 @@ from nf_metro.layout.routing.common import (
     horizontal_direction,
     vertical_direction,
 )
-from nf_metro.parser.model import MetroGraph, PortSide
+from nf_metro.parser.model import Edge, MetroGraph, PortSide
 
 # Segments shorter than this are sub-pixel artefacts of per-line
 # offsets and carry no meaningful direction of travel.
@@ -769,8 +769,27 @@ def check_intra_section_collinear_distinct_lines(
     is excused, so genuine reconvergences are not flagged.
     """
     station_xy = {sid: (st.x, st.y) for sid, st in graph.stations.items()}
+    # Edges internal to a rail-mode section legitimately run several
+    # co-travelling lines on parallel rails; the rail router (not this
+    # normal-pass geometry) renders them, so they are not an overlay defect.
+    # Drop them before the overlay scan.
+    if getattr(graph, "has_rail_sections", False):
+        routes = [r for r in routes if not _edge_in_rail_section(graph, r.edge)]
     return _collinear_overlay_violations(
         routes, offsets, station_xy, inter_section=False
+    )
+
+
+def _edge_in_rail_section(graph: MetroGraph, edge: Edge) -> bool:
+    """True when both endpoints of *edge* are real stations of one rail section."""
+    src = graph.stations.get(edge.source)
+    tgt = graph.stations.get(edge.target)
+    if src is None or tgt is None or src.is_port or tgt.is_port:
+        return False
+    return (
+        src.section_id is not None
+        and src.section_id == tgt.section_id
+        and graph.is_rail_section(src.section_id)
     )
 
 

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -16,7 +16,7 @@ from nf_metro.layout.routing.invariants import (
     distinct_offset_levels,
 )
 from nf_metro.layout.routing.reversal import detect_reversed_sections
-from nf_metro.parser.model import MetroGraph, PortSide
+from nf_metro.parser.model import LineSpread, MetroGraph, PortSide
 
 # Tolerances used across offset phases
 _SAME_Y_TOLERANCE: float = SAME_Y_TOLERANCE
@@ -1307,6 +1307,11 @@ def compute_station_offsets(
 
     Returns dict mapping (station_id, line_id) -> y_offset.
     """
+    # Rail mode bakes absolute rail Ys into the route points and the pill
+    # span, so per-line offsets are not used; return an empty map.
+    if graph.line_spread is LineSpread.RAILS:
+        return {}
+
     ctx = _build_offset_ctx(graph, offset_step)
     _compute_base_offsets(ctx)
     _reindex_section_local(ctx)

--- a/src/nf_metro/layout/routing/rail.py
+++ b/src/nf_metro/layout/routing/rail.py
@@ -1,0 +1,234 @@
+"""Dedicated edge router for opt-in rail mode.
+
+In rail mode each metro line runs along a single fixed horizontal rail Y
+(see ``layout/rail_mode.py``).  An edge therefore connects two points that
+both sit on *this line's* rail, so the route is a straight horizontal run at
+that rail Y from the source X to the target X.  The station pills (drawn by
+the renderer) bridge across rails; the rails themselves never converge.
+
+A line that uses a station meets that station's pill at its own rail Y.  A
+line that does not use a station simply passes straight along its rail; if
+that rail falls between two rails the station spans, the rail visually
+crosses the pill (acceptable for v1 - see the feature notes).
+"""
+
+from __future__ import annotations
+
+__all__ = ["route_rail_edges"]
+
+from nf_metro.layout.constants import (
+    DIAGONAL_RUN,
+    MIN_STRAIGHT_EDGE,
+    RAIL_TERMINUS_FAN_LEAD,
+)
+from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.parser.model import Edge, MetroGraph, Station
+
+
+def _line_rail_y(graph: MetroGraph, station_id: str, line_id: str) -> float:
+    """Return the Y at which *line_id* meets *station_id* in rail mode.
+
+    A single-rail station sits at its ``y``.  A multi-rail (spanning) station
+    stores its rail range on ``rail_top_y``/``rail_bottom_y``; the line meets
+    the pill at the rail Y for that line, which is recoverable from the
+    station's served lines and the even rail spacing.  When the rail span is
+    unknown the station's own ``y`` is used (single-rail fallback).
+    """
+    st = graph.stations.get(station_id)
+    if st is None:
+        return 0.0
+
+    # Ports carry an averaged Y; resolve to the line's own rail in the port's
+    # section so inter-section legs stay on the correct rail per line.
+    port = graph.ports.get(station_id)
+    if port is not None:
+        section_rails = graph._rail_y.get(port.section_id, {})
+        if line_id in section_rails:
+            return section_rails[line_id]
+
+    if st.rail_top_y is None or st.rail_bottom_y is None:
+        return st.y
+
+    # Each served line's rail Y is recorded directly in rail_used_ys, parallel
+    # to the station's served-line order, so look it up rather than assuming
+    # the used rails evenly fill the span (a station may span a rail it does
+    # not use, which would break an interpolated estimate).
+    served = graph.station_lines_ordered(station_id)
+    if line_id in served and len(st.rail_used_ys) == len(served):
+        return st.rail_used_ys[served.index(line_id)]
+    return st.y
+
+
+def _off_track_drop_stagger(
+    graph: MetroGraph,
+    feeder: Station,
+    edge: Edge,
+) -> float:
+    """Horizontal offset for an off-track feeder line's vertical drop.
+
+    Several lines feeding the same consumer from one off-track input would
+    otherwise drop on the same X and overlap in the vertical leg (merging into
+    one fat line).  Each feeding line instead drops on its own X, ordered by
+    its target rail Y (top rail leftmost), one OFFSET_STEP apart and centred on
+    the feeder, so the bundle stays as parallel lines and the elbows form a
+    tidy staircase into the rails.
+    """
+    from nf_metro.layout.constants import OFFSET_STEP
+
+    feeder_id = feeder.id
+    consumer_id = edge.target if edge.source == feeder_id else edge.source
+    # Sibling feeder lines: every line carried by an edge between this feeder
+    # and the same consumer, ordered by their target rail Y.
+    sib_rails: list[tuple[float, str]] = []
+    for e in graph.edges:
+        if {e.source, e.target} != {feeder_id, consumer_id}:
+            continue
+        on_rail_id = e.target if e.source == feeder_id else e.source
+        sib_rails.append((_line_rail_y(graph, on_rail_id, e.line_id), e.line_id))
+    # Order the drop Xs so the bundle does NOT twist through the drop->rail
+    # elbow: the line landing on the LOWER rail (larger Y) drops on the LEFT
+    # (smaller X), matching the left/right ordering the rightward outgoing run
+    # expects (a D->R corner maps the down run's left side to the run's bottom).
+    sib_rails.sort(reverse=True)
+    order = [lid for _y, lid in sib_rails]
+    if edge.line_id not in order or len(order) <= 1:
+        return 0.0
+    k = order.index(edge.line_id)
+    return (k - (len(order) - 1) / 2.0) * OFFSET_STEP
+
+
+def _diagonal_placement(
+    sx: float,
+    tx: float,
+    sy: float,
+    ty: float,
+    is_fork: bool,
+    is_join: bool,
+) -> tuple[float, float]:
+    """X coordinates of a 45-degree diagonal joining two rails along an X run.
+
+    The diagonal climbs/falls between rail Ys at 45 degrees, so its horizontal
+    span equals the vertical rail separation ``|ty - sy|`` (clamped to the
+    available run so it never inverts).  The flat lead-in/out keeps a minimum
+    straight stub at each end; the diagonal is biased toward the fan's shared
+    convergence point (the fork source or the join target) so a rail eases off
+    the fan early and runs flat the rest of the column.
+    """
+    from nf_metro.layout.routing.core import _compute_diagonal_placement
+
+    # The diagonal's horizontal span equals the vertical rail separation (a true
+    # 45 degrees), clamped to DIAGONAL_RUN.  A station that both forks and joins
+    # has no single convergence point to bias toward, so it centres.
+    diag = min(abs(ty - sy), DIAGONAL_RUN)
+    return _compute_diagonal_placement(
+        sx,
+        tx,
+        diagonal_run=diag,
+        src_min_straight=MIN_STRAIGHT_EDGE,
+        tgt_min_straight=MIN_STRAIGHT_EDGE,
+        is_fork=is_fork and not is_join,
+        is_join=is_join and not is_fork,
+    )
+
+
+def route_rail_edges(
+    graph: MetroGraph,
+    edges: list[Edge] | None = None,
+) -> list[RoutedPath]:
+    """Route edges as straight horizontal runs along their line's rail.
+
+    The two endpoints of an edge are on the same line, hence the same rail,
+    so each route is two points at a common Y.  When the endpoints' resolved
+    rail Ys differ slightly (e.g. a port at a section's mid rail vs. a pill's
+    own rail), a short vertical jog at the source X joins them so the run
+    stays axis-aligned rather than diagonal.
+
+    When *edges* is None every edge in the graph is routed (whole-graph rail
+    mode).  In per-section rail mode the caller passes just that section's
+    internal edges so the normal router handles the rest.
+    """
+    routes: list[RoutedPath] = []
+    for edge in edges if edges is not None else graph.edges:
+        src = graph.stations.get(edge.source)
+        tgt = graph.stations.get(edge.target)
+        if src is None or tgt is None:
+            continue
+
+        # Off-track input: the source sits above the rails and feeds into the
+        # target's rail.  Drop straight down (a clean perpendicular crossing of
+        # any rails above the target reads far better than a steep diagonal
+        # merge), then turn onto the rail with a rounded elbow and run flat into
+        # the consumer.  Sibling feeder lines (a bundle feeding the same
+        # consumer) drop on staggered Xs - one per rail, lower rails turning
+        # later - so the bundle stays two parallel lines and never merges.
+        off_src = src.off_track and not tgt.off_track
+        off_tgt = tgt.off_track and not src.off_track
+        if off_src or off_tgt:
+            feeder = src if off_src else tgt
+            on_rail = tgt if off_src else src
+            rail_y = _line_rail_y(graph, on_rail.id, edge.line_id)
+            drop_x = feeder.x + _off_track_drop_stagger(graph, feeder, edge)
+            l_points = [
+                (drop_x, feeder.y),
+                (drop_x, rail_y),
+                (on_rail.x, rail_y),
+            ]
+            if off_tgt:
+                l_points.reverse()
+            routes.append(
+                RoutedPath(
+                    edge=edge,
+                    line_id=edge.line_id,
+                    points=l_points,
+                    offsets_applied=True,
+                )
+            )
+            continue
+
+        y_src = _line_rail_y(graph, edge.source, edge.line_id)
+        y_tgt = _line_rail_y(graph, edge.target, edge.line_id)
+
+        if abs(y_src - y_tgt) < 0.5:
+            points = [(src.x, y_src), (tgt.x, y_src)]
+        else:
+            # The endpoints sit on different rails: this is a fan-out (the
+            # source is a shared convergence point, e.g. the CRAM input) or a
+            # fan-in (the target is a shared collector, e.g. the VCF output).
+            # Ease between the two rails with a 45-degree diagonal transition -
+            # the metro-map convention used by the normal router - rather than
+            # a square right-angle jog.  Bias the diagonal toward whichever
+            # endpoint is the shared convergence point so the rail leaves/joins
+            # the fan on a diagonal and runs flat the rest of the way.
+            is_fork = len(graph.edges_from(edge.source)) > 1
+            is_join = len(graph.edges_to(edge.target)) > 1
+            # A blank terminus converges its lines to a point; give the fan a
+            # short flat lead-in at the source (or lead-out at the target) along
+            # the convergence Y so the bundle reads as entering/leaving the
+            # terminus level (next to its marker) before fanning to the rails.
+            dx = tgt.x - src.x
+            sign = 1.0 if dx >= 0 else -1.0
+            lead_src = RAIL_TERMINUS_FAN_LEAD if (src.is_blank_terminus) else 0.0
+            lead_tgt = RAIL_TERMINUS_FAN_LEAD if (tgt.is_blank_terminus) else 0.0
+            fan_sx = src.x + sign * lead_src
+            fan_tx = tgt.x - sign * lead_tgt
+            diag_start_x, diag_end_x = _diagonal_placement(
+                fan_sx, fan_tx, y_src, y_tgt, is_fork, is_join
+            )
+            points = [(src.x, y_src)]
+            if lead_src:
+                points.append((fan_sx, y_src))
+            points.append((diag_start_x, y_src))
+            points.append((diag_end_x, y_tgt))
+            if lead_tgt:
+                points.append((fan_tx, y_tgt))
+            points.append((tgt.x, y_tgt))
+
+        routes.append(
+            RoutedPath(
+                edge=edge,
+                line_id=edge.line_id,
+                points=points,
+                offsets_applied=True,
+            )
+        )
+    return routes

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -19,6 +19,7 @@ from nf_metro.parser.model import (
     VALID_LINE_STYLES,
     VALID_MARKER_SHAPES,
     Edge,
+    LineSpread,
     MarkerLegendEntry,
     MarkerStyle,
     MetroGraph,
@@ -303,6 +304,8 @@ def _parse_directive(
     elif content.startswith("center_ports:"):
         val = content[len("center_ports:") :].strip().lower()
         graph.center_ports = val in ("true", "yes", "1")
+    elif content.startswith("line_spread:"):
+        _parse_line_spread_directive(content[len("line_spread:") :].strip(), graph)
     elif content.startswith("label_angle:"):
         try:
             graph.label_angle = float(content[len("label_angle:") :].strip())
@@ -480,6 +483,48 @@ def _parse_legend_directive(value: str, graph: MetroGraph) -> None:
         )
 
 
+def _parse_legend_combo_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro legend_combo: lineA, lineB[, ...] | Display Label.
+
+    Stores a (line_ids, label) entry on ``graph.legend_combos``. The named
+    lines are rendered as a single combined legend row and (in rail mode)
+    share a single rail slot. A combo referencing unknown lines is warned
+    about and ignored; unknown members of an otherwise-valid combo are
+    dropped (with a warning) and the remaining members kept.
+    """
+    parts = value.split("|", 1)
+    if len(parts) != 2:
+        warnings.warn(
+            f"Invalid legend_combo {value!r}; expected 'lineA, lineB | Display Label'.",
+            stacklevel=2,
+        )
+        return
+    ids_raw, label = parts[0], parts[1].strip()
+    line_ids = [s.strip() for s in ids_raw.split(",") if s.strip()]
+    if len(line_ids) < 2 or not label:
+        warnings.warn(
+            f"Invalid legend_combo {value!r}; expected at least two line IDs "
+            "and a non-empty label.",
+            stacklevel=2,
+        )
+        return
+    known = [lid for lid in line_ids if lid in graph.lines]
+    unknown = [lid for lid in line_ids if lid not in graph.lines]
+    if unknown:
+        warnings.warn(
+            f"legend_combo {label!r} references unknown line(s) "
+            f"{', '.join(unknown)}; ignoring those.",
+            stacklevel=2,
+        )
+    if len(known) < 2:
+        warnings.warn(
+            f"legend_combo {label!r} has fewer than two known lines; ignoring.",
+            stacklevel=2,
+        )
+        return
+    graph.legend_combos.append((tuple(known), label))
+
+
 def _parse_logo_scale_directive(value: str, graph: MetroGraph) -> None:
     """Parse %%metro logo_scale: <factor> (1.0 = default auto-size)."""
     try:
@@ -549,46 +594,31 @@ def _parse_marker_legend_directive(value: str, graph: MetroGraph) -> None:
         graph.marker_legend.append(MarkerLegendEntry(style=style, caption=caption))
 
 
-def _parse_legend_combo_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro legend_combo: lineA, lineB[, ...] | Display Label.
+def _parse_line_spread_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro line_spread: <mode>[ | section[, section...]].
 
-    Stores a (line_ids, label) entry on ``graph.legend_combos``. The named
-    lines are rendered as a single combined legend row and suppressed from
-    their own individual rows. A combo referencing unknown lines is warned
-    about and ignored; unknown members of an otherwise-valid combo are
-    dropped (with a warning) and the remaining members kept.
+    Bare ``line_spread: <mode>`` sets the graph-wide default; the piped form
+    ``line_spread: <mode> | sectionA, sectionB`` records a per-section override
+    that wins over the default for those sections. ``<mode>`` is one of
+    ``bundle`` / ``centered`` / ``rails``; an unrecognised mode is warned about
+    and ignored.
     """
-    parts = value.split("|", 1)
-    if len(parts) != 2:
+    mode_raw, _, sids_raw = value.partition("|")
+    try:
+        mode = LineSpread(mode_raw.strip().lower())
+    except ValueError:
+        valid = ", ".join(m.value for m in LineSpread)
         warnings.warn(
-            f"Invalid legend_combo {value!r}; expected 'lineA, lineB | Display Label'.",
+            f"Invalid line_spread mode {mode_raw.strip()!r}; expected one of {valid}.",
             stacklevel=2,
         )
         return
-    ids_raw, label = parts[0], parts[1].strip()
-    line_ids = [s.strip() for s in ids_raw.split(",") if s.strip()]
-    if len(line_ids) < 2 or not label:
-        warnings.warn(
-            f"Invalid legend_combo {value!r}; expected at least two line IDs "
-            "and a non-empty label.",
-            stacklevel=2,
-        )
-        return
-    known = [lid for lid in line_ids if lid in graph.lines]
-    unknown = [lid for lid in line_ids if lid not in graph.lines]
-    if unknown:
-        warnings.warn(
-            f"legend_combo {label!r} references unknown line(s) "
-            f"{', '.join(unknown)}; ignoring those.",
-            stacklevel=2,
-        )
-    if len(known) < 2:
-        warnings.warn(
-            f"legend_combo {label!r} has fewer than two known lines; ignoring.",
-            stacklevel=2,
-        )
-        return
-    graph.legend_combos.append((tuple(known), label))
+    section_ids = [s.strip() for s in sids_raw.split(",") if s.strip()]
+    if section_ids:
+        for sid in section_ids:
+            graph.line_spread_overrides[sid] = mode
+    else:
+        graph.line_spread = mode
 
 
 # Regex patterns for node shapes

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -44,6 +44,24 @@ class PortSide(Enum):
     BOTTOM = "bottom"
 
 
+class LineSpread(str, Enum):
+    """How lines sharing a station relate to each other vertically.
+
+    A single axis the user controls per graph and per section:
+
+    - ``BUNDLE`` merges shared lines onto one trunk track; detours cascade
+      downward from the top line (the default).
+    - ``CENTERED`` also merges, but balances the bundle about the midline so
+      the shared trunk sits centred and exclusive callers fan above and below.
+    - ``RAILS`` does not merge: each line keeps its own parallel rail and a
+      shared station renders as an interchange spanning the rails it uses.
+    """
+
+    BUNDLE = "bundle"
+    CENTERED = "centered"
+    RAILS = "rails"
+
+
 VALID_LINE_STYLES = ("solid", "dashed", "dotted")
 
 MARKER_SHAPE_CIRCLE = "circle"
@@ -129,11 +147,34 @@ class Station:
     y: float = 0.0
     layer: int = 0
     track: float = 0.0
+    # Rail-mode span (set by the rail-mode layout for a section whose
+    # ``line_spread`` resolves to ``rails``).  ``rail_top_y``/``rail_bottom_y``
+    # are the Y of the topmost and bottommost rails this station's lines
+    # occupy; when they differ the renderer draws one vertical pill spanning
+    # that range.  None means the station was not laid out in rail mode
+    # (normal pill rules apply).
+    rail_top_y: float | None = None
+    rail_bottom_y: float | None = None
+    # Rail Ys this station actually *uses* (one per line it carries), set
+    # alongside rail_top_y/rail_bottom_y in rail mode.  A spanning pill draws
+    # a knob at each of these Ys; a rail that falls within the pill's span but
+    # is absent here belongs to a line the station does not use and passes
+    # behind the pill with no knob.  Empty when not laid out in rail mode.
+    rail_used_ys: list[float] = field(default_factory=list)
 
     @property
     def is_terminus(self) -> bool:
         """Station has one or more file icons."""
         return len(self.terminus_labels) > 0
+
+    @property
+    def is_blank_terminus(self) -> bool:
+        """A file-icon station with no text label of its own.
+
+        Rendered as its icon (and an unrounded nub) at the line convergence
+        rather than a labelled pill, so layout and routing treat it specially.
+        """
+        return self.is_terminus and not self.label.strip()
 
 
 @dataclass
@@ -239,6 +280,12 @@ class MetroGraph:
     diamond_style: str = "straight"  # "straight" or "symmetric"
     compact_offsets: bool = False
     center_ports: bool = False
+    # Vertical relationship between lines sharing a station (see LineSpread).
+    # ``line_spread`` is the graph-wide default; ``line_spread_overrides`` maps
+    # a section id to a mode that wins over the default for that section.
+    # Query via ``section_line_spread`` / ``is_rail_section`` / ``station_is_rail``.
+    line_spread: LineSpread = LineSpread.BUNDLE
+    line_spread_overrides: dict[str, LineSpread] = field(default_factory=dict)
     legend_position: str = "bottom"
     legend_min_height: float = 0.0
     # Opt-in diagonal station labels (#527). None means "use the theme
@@ -306,6 +353,10 @@ class MetroGraph:
     # compute_layout from the NF_METRO_PHASE_SNAPSHOTS env var; read by the
     # _snap hook after each phase.  Off by default (pure observation).
     _phase_snapshots_enabled: bool = field(default=False, repr=False)
+    # Per-section rail-Y map (section_id -> {line_id: rail_y}), set by the
+    # rail-mode layout so the dedicated router can resolve a port's per-line
+    # rail Y.  Empty when rail mode is off.
+    _rail_y: dict[str, dict[str, float]] = field(default_factory=dict, repr=False)
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""
@@ -384,6 +435,16 @@ class MetroGraph:
             self._station_lines_cache = {sid: sorted(lids) for sid, lids in idx.items()}
         return self._station_lines_cache.get(station_id, [])
 
+    def station_lines_ordered(self, station_id: str) -> list[str]:
+        """Line IDs on a station in line-definition priority order.
+
+        ``station_lines`` returns them alphabetically; rail-mode rendering and
+        routing need definition order so a multi-line station's knobs and slots
+        line up with the legend and the parallel rails.
+        """
+        lines = set(self.station_lines(station_id))
+        return [lid for lid in self.lines if lid in lines]
+
     def edges_from(self, station_id: str) -> list[Edge]:
         """Return edges whose ``source`` is *station_id* (lazy adjacency cache)."""
         if self._edges_from_cache is None:
@@ -415,6 +476,29 @@ class MetroGraph:
                     stations.append(edge.target)
                     seen.add(edge.target)
         return stations
+
+    def section_line_spread(self, section_id: str | None) -> LineSpread:
+        """Resolved line-spread mode for a section (override beats the default)."""
+        if section_id is not None and section_id in self.line_spread_overrides:
+            return self.line_spread_overrides[section_id]
+        return self.line_spread
+
+    @property
+    def has_rail_sections(self) -> bool:
+        """True if any section is laid out in rail mode (global default or override)."""
+        return self.line_spread is LineSpread.RAILS or any(
+            mode is LineSpread.RAILS for mode in self.line_spread_overrides.values()
+        )
+
+    def is_rail_section(self, section_id: str | None) -> bool:
+        """True if *section_id* resolves to rail mode."""
+        return self.section_line_spread(section_id) is LineSpread.RAILS
+
+    def station_is_rail(self, station_id: str) -> bool:
+        """True if a station belongs to a rail-mode section."""
+        st = self.stations.get(station_id)
+        section_id = st.section_id if st is not None else None
+        return self.is_rail_section(section_id)
 
     def section_for_station(self, station_id: str) -> str | None:
         """Return the section ID containing a station, or None."""

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -68,6 +68,12 @@ LEGEND_MARKER_PILL_RATIO: float = 1.7
 MARKER_PILL_LENGTH_RATIO: float = 4.0
 """Length of a ``pill`` marker along the line, as a multiple of the station radius."""
 
+RAIL_KNOB_RADIUS_RATIO: float = 1.35
+"""Rail-interchange knob circle radius, as a multiple of the station radius."""
+
+RAIL_LINK_HALF_WIDTH_RATIO: float = 0.7
+"""Rail-interchange connector bar half-width, as a multiple of the station radius."""
+
 # ---------------------------------------------------------------------------
 # SVG drawing
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -55,6 +55,8 @@ from nf_metro.render.constants import (
     LEGEND_ROUTE_CLEARANCE,
     LOGO_Y_STANDALONE,
     MARKER_PILL_LENGTH_RATIO,
+    RAIL_KNOB_RADIUS_RATIO,
+    RAIL_LINK_HALF_WIDTH_RATIO,
     SECTION_BOX_RADIUS,
     SECTION_LABEL_REGION_RATIO,
     SECTION_LABEL_TEXT_OFFSET,
@@ -980,6 +982,154 @@ def _render_marker_station(
     )
 
 
+def _station_data_attrs(graph: MetroGraph, station: Station) -> dict[str, str]:
+    """SVG data-attributes shared by every station marker.
+
+    Values that flow from user content (label, section name) are HTML-escaped
+    because drawsvg does not escape unknown kwargs.
+    """
+    data = {
+        "class_": "nf-metro-station",
+        "data-station-id": station.id,
+        "data-station-lines": ",".join(graph.station_lines(station.id)),
+        "data-station-label": html.escape(station.label or station.id),
+    }
+    if station.section_id:
+        data["data-section-id"] = station.section_id
+        sec_obj = graph.sections.get(station.section_id)
+        if sec_obj:
+            data["data-section-name"] = html.escape(sec_obj.name)
+    return data
+
+
+def _render_rail_pill(
+    d: draw.Drawing,
+    graph: MetroGraph,
+    station: Station,
+    theme: Theme,
+    r: float,
+) -> None:
+    """Render a rail-mode multi-rail station as the metro interchange idiom.
+
+    The station draws as a *white circle on each rail it uses* joined by a
+    *white link* running between the topmost and bottommost used rails - a
+    continuous outlined white interchange (the classic metro / nf-core-sarek
+    idiom).  The link is the station fill colour (not a dark stroke), so it
+    reads as connecting the circles; the dark station stroke forms the OUTER
+    boundary of the whole circles+link glyph rather than cutting across it.
+
+    The glyph is built in two stacked layers so the dark outline is continuous
+    and never gaps where the link meets a circle: first a dark layer (the link
+    bar plus a disc at each used rail, each grown by the stroke width) paints
+    the union's outer boundary, then a white layer of the same shapes (at the
+    true radii) paints the interior on top.  A rail that falls within the span
+    but is NOT used by the station gets no circle; the link passes behind it.
+    """
+    used_ys = [y for y in station.rail_used_ys] or [station.y]
+    top_y = min(used_ys)
+    bot_y = max(used_ys)
+    station_data = _station_data_attrs(graph, station)
+
+    sw = theme.station_stroke_width
+    # Circles are slightly larger than the bare marker so each used rail reads
+    # as a distinct knob along the white link; the link bar is a touch narrower
+    # than the circles so the knobs bulge out of it like a real interchange.
+    knob_r = r * RAIL_KNOB_RADIUS_RATIO
+    bar_half = r * RAIL_LINK_HALF_WIDTH_RATIO
+    # rail_used_ys is recorded parallel to the line-definition order (see
+    # rail_mode._layout_section_rails), so zip the knobs against that same
+    # order rather than the alphabetical order of graph.station_lines.
+    served = graph.station_lines_ordered(station.id)
+
+    def _link_bar(width: float, stroke: str, **extra: object) -> None:
+        # A round-capped line of the given width is a capsule; used here only
+        # for its straight body between top and bottom used rails (the caps are
+        # covered by the circles), so it joins the knobs with no seam.
+        if bot_y - top_y <= 0.5:
+            return
+        d.append(
+            draw.Line(
+                station.x,
+                top_y,
+                station.x,
+                bot_y,
+                stroke=stroke,
+                stroke_width=width,
+                stroke_linecap="round",
+                **extra,
+            )
+        )
+
+    def _knobs(radius: float, fill: str, stroke: str, **extra: object) -> None:
+        # Only rails the station USES get a knob; a rail that falls within the
+        # connector's span but belongs to a line this station does not use
+        # passes behind the bar (no knob), so the interchange reads as not
+        # stopping there.
+        for lid, y in zip(served, station.rail_used_ys):
+            d.append(
+                draw.Circle(
+                    station.x,
+                    y,
+                    radius,
+                    fill=fill,
+                    stroke=stroke,
+                    stroke_width=0,
+                    **{**extra, "data-line-id": lid},
+                )
+            )
+
+    # Dark outer-boundary layer: the link bar and the knob discs grown by the
+    # stroke width, all painted in the station stroke colour.  Their union is
+    # the continuous dark outline of the finished glyph.
+    _link_bar(
+        (bar_half + sw) * 2,
+        theme.station_stroke,
+        **{**station_data, "class_": "nf-metro-rail-connector"},
+    )
+    _knobs(
+        knob_r + sw,
+        theme.station_stroke,
+        theme.station_stroke,
+        **{"class_": "nf-metro-rail-knob-outline", "data-station-id": station.id},
+    )
+
+    # White interior layer: the same shapes at their true radii, filling the
+    # interior of the outlined union with the station fill.
+    _link_bar(bar_half * 2, theme.station_fill)
+    _knobs(
+        knob_r,
+        theme.station_fill,
+        theme.station_fill,
+        **{"class_": "nf-metro-rail-knob", "data-station-id": station.id},
+    )
+
+
+def _draw_blank_terminus_nub(
+    d: draw.Drawing,
+    station: Station,
+    r: float,
+    min_off: float,
+    max_off: float,
+    station_data: dict[str, str],
+    theme: Theme,
+    is_tb_vert: bool = False,
+) -> None:
+    """Draw a blank terminus's unrounded nub (a sharp-cornered station rect)."""
+    bx, by, bw, bh = _pill_box(station, r, min_off, max_off, is_tb_vert)
+    d.append(
+        draw.Rectangle(
+            bx,
+            by,
+            bw,
+            bh,
+            fill=theme.station_fill,
+            stroke=theme.station_stroke,
+            stroke_width=theme.station_stroke_width,
+            **station_data,
+        )
+    )
+
+
 def _render_stations(
     d: draw.Drawing,
     graph: MetroGraph,
@@ -999,6 +1149,42 @@ def _render_stations(
             continue
 
         r = theme.station_radius
+
+        # Rail mode: a blank terminus terminates its converged bundle exactly
+        # like any other render -- the standard unrounded nub (via _pill_box)
+        # spanning the bundle, plus the file icon -- rather than a rail-specific
+        # glyph.  The only difference is the span comes from the rail bundle
+        # (rail mode does not use station_offsets).  An off-track input drops in
+        # vertically (no horizontal fan), so it gets the icon only.
+        if graph.station_is_rail(station.id) and station.is_blank_terminus:
+            if station.off_track:
+                _append_terminus_icons(d, station, graph, theme, r, 0.0, 0.0)
+                continue
+            used = station.rail_used_ys or [station.y]
+            t_min = min(used) - station.y
+            t_max = max(used) - station.y
+            _draw_blank_terminus_nub(
+                d, station, r, t_min, t_max, _station_data_attrs(graph, station), theme
+            )
+            _append_terminus_icons(d, station, graph, theme, r, t_min, t_max)
+            continue
+
+        # Rail mode: a multi-rail station draws as a spanning interchange; a
+        # single-rail station draws as one knob centred on its rail.  Both go
+        # through _render_rail_pill (its link bar self-suppresses with no span),
+        # so a single stop sits exactly on the rail rather than being shifted by
+        # the normal-mode parallel-line station_offsets, which don't apply once
+        # a line is pinned to a fixed rail.  Marked stations keep their glyph.
+        if (
+            graph.station_is_rail(station.id)
+            and station.marker is None
+            and not station.is_terminus
+        ):
+            _render_rail_pill(d, graph, station, theme, r)
+            continue
+        if station.rail_top_y is not None and station.rail_bottom_y is not None:
+            _render_rail_pill(d, graph, station, theme, r)
+            continue
 
         # Determine if this is a TB vertical station (rotated pill)
         is_tb_vert = False
@@ -1020,20 +1206,7 @@ def _render_stations(
         else:
             min_off = max_off = 0.0
 
-        # Hand-escape values that flow from user content into XML attributes.
-        # drawsvg does not escape unknown kwargs, so an unescaped "&" or "<"
-        # in a section name or station label breaks XML well-formedness.
-        station_data = {
-            "class_": "nf-metro-station",
-            "data-station-id": station.id,
-            "data-station-lines": ",".join(graph.station_lines(station.id)),
-            "data-station-label": html.escape(station.label or station.id),
-        }
-        if station.section_id:
-            station_data["data-section-id"] = station.section_id
-            sec_obj = graph.sections.get(station.section_id)
-            if sec_obj:
-                station_data["data-section-name"] = html.escape(sec_obj.name)
+        station_data = _station_data_attrs(graph, station)
 
         if station.marker is not None:
             _render_marker_station(
@@ -1054,19 +1227,9 @@ def _render_stations(
         x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb_vert)
 
         # Blank terminus stations get an unrounded nub; everything else a pill.
-        is_blank_terminus = station.is_terminus and not station.label.strip()
-        if is_blank_terminus:
-            d.append(
-                draw.Rectangle(
-                    x,
-                    y,
-                    w,
-                    h,
-                    fill=theme.station_fill,
-                    stroke=theme.station_stroke,
-                    stroke_width=theme.station_stroke_width,
-                    **station_data,
-                )
+        if station.is_blank_terminus:
+            _draw_blank_terminus_nub(
+                d, station, r, min_off, max_off, station_data, theme, is_tb_vert
             )
         else:
             d.append(
@@ -1125,6 +1288,7 @@ def _terminus_icon_centers(
     first_offset: float,
     step: float,
     bundle_center: float,
+    is_rail: bool = False,
 ) -> list[tuple[float, float]]:
     """Centre coordinates for a terminus station's file icons.
 
@@ -1135,6 +1299,13 @@ def _terminus_icon_centers(
     the outside of the diagram.
     """
     is_tb = section_dir in ("TB", "BT")
+    # A rail-mode off-track input parks above the rails and feeds straight down
+    # into its consumer's rail (see routing/rail.py), so its icon sits directly
+    # on the station coordinate (centred on the drop X) rather than marching
+    # sideways.  Gated on the rail flag so normal-mode off-track feeders (which
+    # the standard router handles) are untouched.
+    if station.off_track and is_rail:
+        return [(station.x, station.y - (first_offset + i * step)) for i in range(n)]
     # Sinks sit at the end of the flow and extend forwards; sources sit at
     # the start and extend backwards.  RL/BT reverse the forward direction.
     extends_forward = is_source if section_dir in ("RL", "BT") else not is_source
@@ -1205,6 +1376,7 @@ def _render_terminus_icons(
         icon_gap + icon_half_flow,
         icon_step,
         bundle_center,
+        is_rail=graph.station_is_rail(station.id),
     )
 
     # Captions sitting at the same Y overlap when their estimated

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,16 @@ def content_corpus() -> list[tuple[str, Path, bool]]:
 
     Shared by the declarative-property tests (idempotence and purity) so they
     exercise the same fixtures.
+
+    Fixtures with a ``rails`` line-spread section are excluded: a rail section's
+    internal geometry is produced by the self-contained rail pipeline (which
+    overwrites the normal content-placement phases), so the per-phase
+    idempotence/purity contract those tests assert does not apply to it.
     """
+
+    def _uses_rails(path: Path) -> bool:
+        return "line_spread: rails" in path.read_text()
+
     items: list[tuple[str, Path, bool]] = []
     for d, tag in [
         (_EXAMPLES, "examples"),
@@ -95,6 +104,8 @@ def content_corpus() -> list[tuple[str, Path, bool]]:
         (_ROOT / "tests" / "fixtures", "tests"),
     ]:
         for p in sorted(d.glob("*.mmd")):
+            if _uses_rails(p):
+                continue
             items.append((f"{tag}/{p.stem}", p, False))
     for p in sorted(_NEXTFLOW.glob("*.mmd")):
         items.append((f"nextflow/{p.stem}", p, True))

--- a/tests/test_centered_tracks.py
+++ b/tests/test_centered_tracks.py
@@ -1,0 +1,355 @@
+"""Tests for the ``centered`` line_spread mode.
+
+When ``%%metro line_spread: centered`` is set, line base tracks become
+symmetric about zero and shared (multi-line) stations are centred on the
+mean of their lines' base tracks, so a section's weave balances above and
+below the shared trunk instead of cascading downward.
+"""
+
+from __future__ import annotations
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.layers import assign_layers
+from nf_metro.layout.ordering import assign_tracks
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import LineSpread
+
+# A compact 3-line weave: a shared trunk (in -> mid -> out carried by all
+# three lines) plus a pair of line-exclusive callers per line.
+_WEAVE_SRC = """\
+%%metro line: a | A | #4CAF50
+%%metro line: b | B | #2196F3
+%%metro line: c | C | #E91E63
+
+graph LR
+    in[In]
+    mid[Mid]
+    out[Out]
+    a1[A1]
+    a2[A2]
+    b1[B1]
+    b2[B2]
+    c1[C1]
+    c2[C2]
+
+    in -->|a,b,c| mid
+
+    mid -->|a| a1
+    mid -->|a| a2
+    a1 -->|a| out
+    a2 -->|a| out
+
+    mid -->|b| b1
+    mid -->|b| b2
+    b1 -->|b| out
+    b2 -->|b| out
+
+    mid -->|c| c1
+    mid -->|c| c2
+    c1 -->|c| out
+    c2 -->|c| out
+"""
+
+
+def _weave_graph(centered: bool):
+    src = _WEAVE_SRC
+    if centered:
+        src = "%%metro line_spread: centered\n" + src
+    return parse_metro_mermaid(src)
+
+
+def _trunk_ids() -> set[str]:
+    return {"in", "mid", "out"}
+
+
+# A fork weave where the middle line runs straight through the shared
+# trunk while the top and bottom lines each split off a short exclusive run
+# at the same layer, then rejoin.  The two exclusive runs are on distinct
+# lines, so they form a 2-member cross-line fork group -- the case the
+# fork-equalize pass repacks into consecutive tracks, collapsing the bottom
+# run onto the trunk instead of leaving it on the bottom rail.  Each
+# exclusive run carries two stations so we assert the whole run (not just
+# the leaf) rides its line's symmetric rail.
+_FORK_WEAVE_SRC = """\
+%%metro line: top | Top | #4CAF50
+%%metro line: mid | Mid | #2196F3
+%%metro line: bot | Bot | #E91E63
+
+graph LR
+    cram[Cram]
+    fb[Freebayes]
+    st[Strelka]
+    out[Out]
+
+    tA[TopA]
+    tB[TopB]
+    bA[BotA]
+    bB[BotB]
+
+    cram -->|top,mid,bot| fb
+    fb -->|top,mid,bot| st
+
+    st -->|mid| out
+
+    st -->|top| tA
+    tA -->|top| tB
+    tB -->|top| out
+
+    st -->|bot| bA
+    bA -->|bot| bB
+    bB -->|bot| out
+"""
+
+
+def _fork_weave_graph(centered: bool):
+    src = _FORK_WEAVE_SRC
+    if centered:
+        src = "%%metro line_spread: centered\n" + src
+    return parse_metro_mermaid(src)
+
+
+def test_flag_off_default():
+    """Absent the directive the graph defaults to uncentered tracks."""
+    graph = _weave_graph(centered=False)
+    assert graph.line_spread is LineSpread.BUNDLE
+
+
+def test_flag_on_parsed():
+    graph = _weave_graph(centered=True)
+    assert graph.line_spread is LineSpread.CENTERED
+
+
+def test_flag_off_tracks_unchanged():
+    """With the flag OFF, tracks match the legacy top-anchored assignment.
+
+    The trunk stations sit on the top line's base track (0.0) and every
+    exclusive caller is at or below it -- no station goes above the trunk.
+    """
+    graph = _weave_graph(centered=False)
+    layers = assign_layers(graph)
+    tracks = assign_tracks(graph, layers)
+
+    trunk_tracks = {tracks[t] for t in _trunk_ids()}
+    assert trunk_tracks == {0.0}, trunk_tracks
+    # Legacy: everything stacks downward from the trunk, nothing above it.
+    assert min(tracks.values()) >= 0.0
+
+
+def test_flag_on_trunk_centred_and_exclusives_straddle():
+    """With the flag ON, the shared trunk is centred and exclusive callers
+    distribute both above AND below it."""
+    graph = _weave_graph(centered=True)
+    layers = assign_layers(graph)
+    tracks = assign_tracks(graph, layers)
+
+    trunk_tracks = {tracks[t] for t in _trunk_ids()}
+    # The whole shared trunk shares a single (central) track.
+    assert len(trunk_tracks) == 1, trunk_tracks
+    trunk = next(iter(trunk_tracks))
+
+    all_tracks = list(tracks.values())
+    # Exclusive callers must straddle the trunk: at least one strictly
+    # above and at least one strictly below.
+    assert min(all_tracks) < trunk, (min(all_tracks), trunk)
+    assert max(all_tracks) > trunk, (max(all_tracks), trunk)
+
+    # The trunk sits near the centre of the vertical spread (within one
+    # line gap of the midpoint of min/max).
+    midpoint = (min(all_tracks) + max(all_tracks)) / 2
+    assert abs(trunk - midpoint) < 1.0, (trunk, midpoint)
+
+
+def test_flag_on_layout_validates_and_centres_y():
+    """End-to-end: centred layout passes validation and the trunk's final
+    Y straddles the exclusive callers."""
+    graph = _weave_graph(centered=True)
+    compute_layout(graph, validate=True)
+
+    real = {
+        sid: s.y
+        for sid, s in graph.stations.items()
+        if not s.is_port and not s.is_hidden
+    }
+    trunk_y = {real[t] for t in _trunk_ids()}
+    # Trunk shares one Y row.
+    assert len(trunk_y) == 1, trunk_y
+    ty = next(iter(trunk_y))
+
+    ys = list(real.values())
+    assert min(ys) < ty, (min(ys), ty)
+    assert max(ys) > ty, (max(ys), ty)
+
+
+def test_guard_balanced_runs_and_no_ops():
+    """The centred-tracks balance guard runs without error when on and is a
+    no-op when off or under-determined."""
+    from nf_metro.layout.engine import _guard_centered_line_spread_balanced
+
+    on = _weave_graph(centered=True)
+    _guard_centered_line_spread_balanced(on, "test")  # symmetric bases -> passes
+
+    off = _weave_graph(centered=False)
+    _guard_centered_line_spread_balanced(off, "test")  # flag off -> no-op
+
+    single = parse_metro_mermaid(
+        "%%metro line_spread: centered\n"
+        "%%metro line: a | A | #fff\n"
+        "graph LR\n x[X]\n y[Y]\n x -->|a| y\n"
+    )
+    _guard_centered_line_spread_balanced(single, "test")  # <2 lines -> no-op
+
+
+def _line_base_sign(graph, lid: str) -> float:
+    """Sign of line ``lid``'s symmetric base track (above/centre/below)."""
+    order = list(graph.lines.keys())
+    n = len(order)
+    base = order.index(lid) - (n - 1) / 2
+    return 0.0 if abs(base) < 1e-9 else (1.0 if base > 0 else -1.0)
+
+
+def test_fork_weave_exclusive_runs_ride_their_line_rail():
+    """A line's exclusive run must sit on its line's symmetric base rail.
+
+    The cross-line fork (top/mid/bot exclusive runs all diverging from the
+    same trunk station) used to be repacked into consecutive tracks by the
+    fork-equalize pass, collapsing the bottom line's run onto the trunk.
+    Each exclusive station must instead match its own line's base track, so
+    the top run rides above the trunk, the bottom run below, and the middle
+    run on the centre.
+    """
+    graph = _fork_weave_graph(centered=True)
+    layers = assign_layers(graph)
+    tracks = assign_tracks(graph, layers)
+
+    line_base = {
+        lid: (i - (len(graph.lines) - 1) / 2)
+        for i, lid in enumerate(graph.lines.keys())
+    }
+    exclusive = {
+        "tA": "top",
+        "tB": "top",
+        "bA": "bot",
+        "bB": "bot",
+    }
+    for sid, lid in exclusive.items():
+        assert tracks[sid] == line_base[lid], (
+            sid,
+            lid,
+            tracks[sid],
+            line_base[lid],
+        )
+
+
+def test_fork_weave_layout_each_line_run_on_correct_side():
+    """End-to-end: each exclusive run's final Y sits on the correct side of
+    the trunk (top above, bottom below, middle on the centre)."""
+    graph = _fork_weave_graph(centered=True)
+    compute_layout(graph, validate=True)
+
+    trunk_y = {graph.stations[t].y for t in ("cram", "fb", "st", "out")}
+    assert len(trunk_y) == 1, trunk_y
+    ty = next(iter(trunk_y))
+
+    runs = {"top": ("tA", "tB"), "bot": ("bA", "bB")}
+    for lid, members in runs.items():
+        sign = _line_base_sign(graph, lid)
+        for sid in members:
+            dy = graph.stations[sid].y - ty
+            if sign < 0:
+                assert dy < -1.0, (sid, lid, graph.stations[sid].y, ty)
+            elif sign > 0:
+                assert dy > 1.0, (sid, lid, graph.stations[sid].y, ty)
+            else:
+                assert abs(dy) < 1.0, (sid, lid, graph.stations[sid].y, ty)
+
+
+def test_guard_flags_collapsed_exclusive_run():
+    """The balance guard must fire when an exclusive run has collapsed onto
+    the trunk midline instead of riding its line's rail."""
+    import pytest
+
+    from nf_metro.layout.engine import _guard_centered_line_spread_balanced
+    from nf_metro.layout.phases.guards import PhaseInvariantError
+
+    graph = _fork_weave_graph(centered=True)
+    compute_layout(graph, validate=False)
+
+    # Force the bottom exclusive run onto the trunk Y (the regression).
+    trunk_y = graph.stations["st"].y
+    for sid in ("bA", "bB"):
+        graph.stations[sid].y = trunk_y
+
+    with pytest.raises(PhaseInvariantError, match="not offset to its side"):
+        _guard_centered_line_spread_balanced(graph, "test")
+
+
+def test_demo_fixture_balanced_and_valid():
+    """The shipped demo fixture renders, validates, and shows a centred trunk
+    with callers both above and below."""
+    from pathlib import Path
+
+    src = Path(__file__).parent.parent / "examples" / "centered_tracks.mmd"
+    graph = parse_metro_mermaid(src.read_text())
+    assert graph.line_spread is LineSpread.CENTERED
+    compute_layout(graph, validate=True)
+
+    trunk = {"fastqc", "align", "markdup", "summary"}
+    trunk_y = {graph.stations[t].y for t in trunk}
+    assert len(trunk_y) == 1, trunk_y
+    ty = next(iter(trunk_y))
+
+    real_ys = [
+        s.y for s in graph.stations.values() if not s.is_port and not s.is_hidden
+    ]
+    assert min(real_ys) < ty
+    assert max(real_ys) > ty
+
+
+_SECTION_OVERRIDE_SRC = """\
+%%metro line: a | A | #4CAF50
+%%metro line: b | B | #2196F3
+%%metro line: c | C | #E91E63
+%%metro line_spread: centered | weave
+
+graph LR
+    subgraph weave [Weave]
+        win[In]
+        wmid[Mid]
+        wout[Out]
+        wa[A1]
+        wb[B1]
+        wc[C1]
+
+        win -->|a,b,c| wmid
+        wmid -->|a| wa
+        wmid -->|b| wb
+        wmid -->|c| wc
+        wa -->|a| wout
+        wb -->|b| wout
+        wc -->|c| wout
+    end
+"""
+
+
+def test_per_section_centered_override_parses():
+    """A piped directive records a per-section override, not the graph default."""
+    graph = parse_metro_mermaid(_SECTION_OVERRIDE_SRC)
+    assert graph.line_spread is LineSpread.BUNDLE
+    assert graph.line_spread_overrides == {"weave": LineSpread.CENTERED}
+    assert graph.section_line_spread("weave") is LineSpread.CENTERED
+    assert graph.section_line_spread("other") is LineSpread.BUNDLE
+
+
+def test_per_section_centered_override_balances_and_validates():
+    """A section with a centered override balances about its trunk and passes
+    the (now per-section-aware) balance guard under validate=True."""
+    graph = parse_metro_mermaid(_SECTION_OVERRIDE_SRC)
+    compute_layout(graph, validate=True)
+
+    trunk_y = {graph.stations[t].y for t in ("win", "wmid", "wout")}
+    assert len(trunk_y) == 1, trunk_y
+    ty = next(iter(trunk_y))
+
+    caller_ys = [graph.stations[s].y for s in ("wa", "wb", "wc")]
+    assert min(caller_ys) < ty, (min(caller_ys), ty)
+    assert max(caller_ys) > ty, (max(caller_ys), ty)

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -130,8 +130,14 @@ def _discover_fixtures() -> list[str]:
     examples, addressable via :func:`_resolve_fixture`.
 
     Excludes Nextflow-format flowcharts under ``tests/fixtures/nextflow/``
-    (those are parser inputs, not layout inputs) and any file lacking a
-    ``%%metro`` directive.
+    (those are parser inputs, not layout inputs), any file lacking a
+    ``%%metro`` directive, and any fixture using ``line_spread: rails`` (which
+    runs a dedicated layout pipeline with its own geometry contract; see
+    ``tests/test_rail_mode.py``).  The substring match catches both the
+    graph-wide ``line_spread: rails`` and the per-section
+    ``line_spread: rails | <id>`` form: a mixed fixture's rail sections carry
+    spanning-pill geometry the corpus invariants don't model, so the whole
+    fixture is routed to the dedicated rail tests instead.
     """
     roots = [
         (FIXTURES, ""),
@@ -148,6 +154,8 @@ def _discover_fixtures() -> list[str]:
         for p in sorted(root.glob("*.mmd")):
             text = p.read_text(errors="ignore")
             if "%%metro" not in text:
+                continue
+            if "line_spread: rails" in text:
                 continue
             # Address all examples paths through the ``examples`` resolver
             # without the leading ``examples/`` so tests can pick up either

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1,0 +1,1014 @@
+"""Invariant tests for opt-in rail mode (parallel rails + spanning pills)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nf_metro.layout import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import LineSpread
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+RAIL_MMD = EXAMPLES / "rail_mode.mmd"
+
+
+def _rail_graph():
+    graph = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert graph.line_spread is LineSpread.RAILS
+    compute_layout(graph, validate=True)
+    return graph
+
+
+def _section_line_rails(graph):
+    """Map each section id -> {line_id: rail_y} derived from station Ys.
+
+    A line's rail Y is the common Y at which every station carrying ONLY that
+    line sits.  We reconstruct it from single-line stations plus the spanning
+    pills' top/bottom rails.
+    """
+    rails: dict[str, dict[str, float]] = {}
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden:
+            continue
+        if st.off_track or (st.is_terminus and not st.label.strip()):
+            # Converge to a point; contribute no rail evidence.
+            continue
+        # rail_used_ys is parallel to the line-definition order, so reconstruct
+        # rails with that ordering (not edge-discovery order).
+        lines = graph.station_lines_ordered(st.id)
+        if len(lines) == 1:
+            rails.setdefault(st.section_id, {})[lines[0]] = st.y
+        elif st.rail_used_ys and len(st.rail_used_ys) == len(lines):
+            # A spanning pill records each used line's rail Y directly, which
+            # lets us reconstruct rails even in sections with no single-line
+            # stations.
+            for lid, y in zip(lines, st.rail_used_ys):
+                rails.setdefault(st.section_id, {})[lid] = y
+    return rails
+
+
+def test_rail_mode_parses_directive():
+    graph = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert graph.line_spread is LineSpread.RAILS
+
+
+def test_each_line_runs_on_a_single_fixed_rail():
+    """Every station carrying a given line meets it at that line's fixed
+    rail Y, so the line is a straight horizontal run across the section."""
+    graph = _rail_graph()
+
+    # Per-section, per-line, collect the Y at which each station meets the
+    # line: single-rail stations contribute their y; spanning pills
+    # contribute the interpolated rail Y for the line within their span.
+    from nf_metro.layout.routing.rail import _line_rail_y
+
+    by_section_line: dict[tuple[str, str], set[float]] = {}
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden:
+            continue
+        # Off-track inputs sit above the rails and blank termini converge the
+        # rails to their icon; both legitimately meet lines off the rail Y.
+        if st.off_track or (st.is_terminus and not st.label.strip()):
+            continue
+        for lid in graph.station_lines(st.id):
+            y = _line_rail_y(graph, st.id, lid)
+            by_section_line.setdefault((st.section_id, lid), set()).add(round(y, 2))
+
+    offenders = [
+        f"{sec}/{lid}: rails at {sorted(ys)}"
+        for (sec, lid), ys in by_section_line.items()
+        if len(ys) > 1
+    ]
+    assert not offenders, (
+        "each line must meet every station on a single fixed rail Y: "
+        + "; ".join(offenders)
+    )
+
+
+def _combo_member_ids(graph) -> set[str]:
+    members: set[str] = set()
+    for line_ids, _label in graph.legend_combos:
+        if len([lid for lid in line_ids if lid in graph.lines]) >= 2:
+            members.update(line_ids)
+    return members
+
+
+def test_rails_are_evenly_spaced_and_distinct():
+    """A section's rail SLOTS are distinct and evenly spaced.
+
+    Each non-combo line occupies its own slot; combo members share one slot
+    (a tight bundle), so even spacing is asserted over the slot CENTRES (one
+    Y per non-combo line plus the bundle centre), not over every line's rail.
+    """
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    members = _combo_member_ids(graph)
+    assert rails, "expected at least one section with single-line stations"
+    for sec_id, line_rails in rails.items():
+        # Collapse combo members in this section to their bundle centre.
+        bundle_ys = [y for lid, y in line_rails.items() if lid in members]
+        slot_ys = [y for lid, y in line_rails.items() if lid not in members]
+        if bundle_ys:
+            slot_ys.append(sum(bundle_ys) / len(bundle_ys))
+        ys = sorted(slot_ys)
+        assert len(set(round(y, 2) for y in ys)) == len(ys), (
+            f"{sec_id}: rail slots not distinct: {ys}"
+        )
+        if len(ys) >= 3:
+            gaps = [round(b - a, 2) for a, b in zip(ys, ys[1:])]
+            assert max(gaps) - min(gaps) < 1.0, (
+                f"{sec_id}: rail slots not evenly spaced: {gaps}"
+            )
+
+
+def test_multi_line_station_span_covers_exactly_its_lines_rails():
+    """A spanning pill's drawn span (rail_top_y..rail_bottom_y) equals the
+    Y range of the rails its lines occupy -- no more, no less."""
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden:
+            continue
+        # Off-track inputs feed in from above the rails (an S-curve), so they
+        # converge to a point, not a spanning pill.
+        if st.off_track:
+            assert st.rail_top_y is None and st.rail_bottom_y is None, (
+                f"{st.id}: off-track input must not be a spanning pill"
+            )
+            continue
+        # A blank terminus converges to a tight bundle (capped by a terminus
+        # bar), whose span is the bundle width, not the rails' full Y range, so
+        # the exact-rail-span assertion below does not apply to it.
+        if st.is_terminus and not st.label.strip():
+            continue
+        lines = graph.station_lines(st.id)
+        line_rails = rails.get(st.section_id, {})
+        used_ys = [line_rails[lid] for lid in lines if lid in line_rails]
+        if len(used_ys) < 2:
+            # Single-rail station: must not be a spanning pill.
+            assert st.rail_top_y is None and st.rail_bottom_y is None, (
+                f"{st.id}: single-rail station marked as spanning"
+            )
+            continue
+        assert st.rail_top_y is not None and st.rail_bottom_y is not None, (
+            f"{st.id}: multi-line station not marked spanning"
+        )
+        assert abs(st.rail_top_y - min(used_ys)) < 1.0, (
+            f"{st.id}: top rail {st.rail_top_y} != min used rail {min(used_ys)}"
+        )
+        assert abs(st.rail_bottom_y - max(used_ys)) < 1.0, (
+            f"{st.id}: bottom rail {st.rail_bottom_y} != max used rail {max(used_ys)}"
+        )
+
+
+def test_lines_do_not_converge_to_a_point():
+    """In rail mode no two distinct rails collapse to a shared Y at any
+    station -- the hallmark of the parallel-rails (non-converging) look."""
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    for sec_id, line_rails in rails.items():
+        ys = list(line_rails.values())
+        assert len(set(round(y, 2) for y in ys)) == len(ys), (
+            f"{sec_id}: rails converged to shared Ys: {sorted(ys)}"
+        )
+
+
+def test_rail_routes_are_straight_horizontal_at_rail_y():
+    """Every routed edge in rail mode is a straight horizontal run at its
+    line's rail Y (all waypoints share one Y)."""
+    graph = _rail_graph()
+    from nf_metro.layout.routing import route_edges
+    from nf_metro.layout.routing.rail import _line_rail_y
+
+    routes = route_edges(graph)
+    assert routes
+    for route in routes:
+        src = graph.stations.get(route.edge.source)
+        tgt = graph.stations.get(route.edge.target)
+        # Off-track feeders deliberately leave the rail with an S-curve;
+        # exempt them from the straight-horizontal invariant.
+        if (src and src.off_track) or (tgt and tgt.off_track):
+            assert len(route.points) >= 3, (
+                f"off_track feeder {route.edge.source}->{route.edge.target} "
+                "should be a multi-point S-curve"
+            )
+            continue
+        ys = {round(y, 2) for _, y in route.points}
+        src_y = _line_rail_y(graph, route.edge.source, route.line_id)
+        tgt_y = _line_rail_y(graph, route.edge.target, route.line_id)
+        if abs(src_y - tgt_y) < 0.5:
+            assert len(ys) == 1, (
+                f"{route.edge.source}->{route.edge.target} ({route.line_id}) "
+                f"not horizontal: Ys {ys}"
+            )
+        else:
+            # endpoints on different rails: jog uses exactly the two rail Ys
+            assert ys <= {round(src_y, 2), round(tgt_y, 2)}, (
+                f"jog uses unexpected Ys {ys}"
+            )
+
+
+def test_rail_mode_stations_within_bbox():
+    """All stations (incl. spanning pill extents) stay within their section
+    bbox -- the always-on containment guard passes under validate=True (run
+    in _rail_graph) and pills don't overflow."""
+    graph = _rail_graph()
+    for st in graph.stations.values():
+        if st.is_port or st.is_hidden or not st.section_id:
+            continue
+        sec = graph.sections.get(st.section_id)
+        if sec is None or sec.bbox_w <= 0:
+            continue
+        top = st.rail_top_y if st.rail_top_y is not None else st.y
+        bot = st.rail_bottom_y if st.rail_bottom_y is not None else st.y
+        assert sec.bbox_y - 1.0 <= top, f"{st.id} top {top} above bbox {sec.bbox_y}"
+        assert bot <= sec.bbox_y + sec.bbox_h + 1.0, (
+            f"{st.id} bottom {bot} below bbox {sec.bbox_y + sec.bbox_h}"
+        )
+
+
+def test_spanning_station_draws_one_circle_per_used_rail_plus_connector():
+    """A multi-rail station renders as the interchange idiom: one white
+    circle on each rail it uses, joined by a single straight connector
+    segment -- not as one filled capsule (pill)."""
+    import re
+
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = _rail_graph()
+    svg = render_svg(graph, THEMES["nfcore"])
+
+    spanning = [
+        st
+        for st in graph.stations.values()
+        if st.rail_top_y is not None
+        and st.rail_bottom_y is not None
+        # Blank termini also span (a tight bundle) but render as a terminus bar
+        # rather than knobs+connector; they are covered by the terminus test.
+        and not (st.is_terminus and not st.label.strip())
+    ]
+    assert spanning, "demo must contain at least one multi-rail station"
+    for st in spanning:
+        used = graph.station_lines(st.id)
+        assert len(st.rail_used_ys) == len(used), (
+            f"{st.id}: rail_used_ys {st.rail_used_ys} not parallel to lines {used}"
+        )
+        # One circle (knob) per used rail.
+        knob_count = svg.count(f'class="nf-metro-rail-knob" data-station-id="{st.id}"')
+        assert knob_count == len(used), (
+            f"{st.id}: expected {len(used)} rail circles, found {knob_count}"
+        )
+        # Exactly one straight connector segment for the multi-rail station.
+        connectors = svg.count(
+            f'class="nf-metro-rail-connector" data-station-id="{st.id}"'
+        )
+        assert connectors == 1, (
+            f"{st.id}: expected one interchange connector, found {connectors}"
+        )
+
+    # The multi-rail marker must NOT be a filled capsule: no rounded rect
+    # (rx/ry) carries a rail station id.  (Single-rail circles use <circle>.)
+    for st in spanning:
+        rect_pat = re.compile(
+            rf'<rect[^>]*rx="[^"]+"[^>]*data-station-id="{re.escape(st.id)}"'
+        )
+        assert not rect_pat.search(svg), (
+            f"{st.id}: multi-rail station still renders as a capsule rect"
+        )
+
+
+def test_knob_absent_on_a_rail_the_span_crosses_but_does_not_use():
+    """A pill that spans a rail belonging to a line it does NOT use draws no
+    knob on that rail -- the rail reads as passing behind the pill."""
+    graph = _rail_graph()
+
+    rails = _section_line_rails(graph)
+    found = False
+    for st in graph.stations.values():
+        if st.rail_top_y is None or st.rail_bottom_y is None:
+            continue
+        used = set(graph.station_lines(st.id))
+        line_rails = rails.get(st.section_id, {})
+        # Lines whose rail falls strictly inside this pill's span.
+        crossing = {
+            lid
+            for lid, y in line_rails.items()
+            if st.rail_top_y - 0.5 < y < st.rail_bottom_y + 0.5
+        }
+        passing_behind = crossing - used
+        if not passing_behind:
+            continue
+        found = True
+        # None of the passing-behind lines may have a used-rail Y on this
+        # station (no knob), while every used line must.
+        for lid in passing_behind:
+            assert line_rails[lid] not in [
+                round(y, 2) for y in (round(v, 2) for v in st.rail_used_ys)
+            ], f"{st.id}: knob drawn on non-used rail for {lid}"
+    assert found, "demo must contain a pill that spans a rail of a line it does not use"
+
+
+def test_blank_terminus_renders_bar_and_icon_not_interchange():
+    """A blank file-terminus serving several lines converges its rails to a
+    tight bundle capped by a rectangular buffer-stop bar plus its file icon --
+    not a knobbed interchange and not a rounded capsule pill."""
+    import re
+
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = _rail_graph()
+    svg = render_svg(graph, THEMES["nfcore"])
+
+    blank_termini = [
+        st
+        for st in graph.stations.values()
+        if st.is_terminus and not st.label.strip() and not st.is_port
+    ]
+    assert blank_termini, "demo must contain a blank file-terminus"
+    for st in blank_termini:
+        # A terminus draws no interchange knobs (those carry its station id).
+        knob_count = svg.count(f'class="nf-metro-rail-knob" data-station-id="{st.id}"')
+        assert knob_count == 0, (
+            f"{st.id}: terminus must not draw interchange knobs (found {knob_count})"
+        )
+        # Nor a rounded capsule rect carrying its station id.
+        rect_pat = re.compile(
+            rf'<rect[^>]*rx="[^"]+"[^>]*data-station-id="{re.escape(st.id)}"'
+        )
+        assert not rect_pat.search(svg), f"{st.id}: terminus still renders as a pill"
+    # The CRAM/CSV/VCF icon chip labels must appear as rendered text.
+    for chip in ("CRAM", "CSV", "VCF"):
+        assert chip in svg, f"expected file-icon chip {chip!r} in rail-mode SVG"
+
+
+def test_stacked_sections_do_not_overlap():
+    """Two or more stacked rail-mode sections occupy disjoint vertical bands
+    (bbox-wise), so neither section's content reaches into the other."""
+    graph = _rail_graph()
+    boxes = sorted(
+        (
+            (s.bbox_y, s.bbox_y + s.bbox_h, s.id)
+            for s in graph.sections.values()
+            if s.bbox_h > 0 and (not s.is_implicit or s.station_ids)
+        ),
+        key=lambda b: b[0],
+    )
+    assert len(boxes) >= 2, "demo must contain at least two stacked sections"
+    for (top_a, bot_a, id_a), (top_b, bot_b, id_b) in zip(boxes, boxes[1:]):
+        assert bot_a <= top_b + 0.5, (
+            f"sections {id_a} and {id_b} overlap: {bot_a} > {top_b}"
+        )
+
+
+def test_off_track_input_sits_above_the_rails():
+    """An off_track input station is parked above every rail in its section
+    (it feeds in with an S-curve rather than sitting on a rail)."""
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    off_tracks = [st for st in graph.stations.values() if st.off_track]
+    assert off_tracks, "demo must contain an off_track input"
+    for st in off_tracks:
+        section_rails = rails.get(st.section_id, {})
+        if not section_rails:
+            continue
+        assert st.y < min(section_rails.values()) - 0.5, (
+            f"{st.id}: off_track station at {st.y} not above rails "
+            f"{sorted(section_rails.values())}"
+        )
+
+
+def test_rail_mode_labels_alternate_above_and_below():
+    """Rail-mode station labels alternate above/below the rails so dense
+    label runs don't pile on one edge: a section with several labelled
+    stations must use BOTH sides, and no label sits between two rails."""
+    from nf_metro.layout.labels import place_labels
+
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    placements = place_labels(graph)
+
+    by_section: dict[str, list] = {}
+    for lp in placements:
+        st = graph.stations.get(lp.station_id)
+        if st is None or st.is_port or st.is_terminus or not st.label.strip():
+            continue
+        by_section.setdefault(st.section_id, []).append(lp)
+
+    saw_multi = False
+    for sec_id, lps in by_section.items():
+        if len(lps) < 2:
+            continue
+        saw_multi = True
+        sides = {lp.above for lp in lps}
+        assert sides == {True, False}, (
+            f"{sec_id}: labels all on one side ({sides}); expected alternation"
+        )
+        # Each label stays close to its own station's rail span (it does not
+        # drift off into the middle of the inter-rail bundle): the baseline is
+        # within ~2 row-gaps of the nearest rail the station sits on.
+        section_rails = rails.get(sec_id, {})
+        for lp in lps:
+            st = graph.stations[lp.station_id]
+            own_top = st.rail_top_y if st.rail_top_y is not None else st.y
+            own_bot = st.rail_bottom_y if st.rail_bottom_y is not None else st.y
+            ys = sorted(section_rails.values())
+            gap = (ys[1] - ys[0]) if len(ys) >= 2 else 40.0
+            assert own_top - 2 * gap <= lp.y <= own_bot + 2 * gap, (
+                f"{sec_id}/{lp.station_id}: label at {lp.y} drifts far from its "
+                f"own rail span [{own_top}, {own_bot}]"
+            )
+    assert saw_multi, "demo must contain a section with several station labels"
+
+
+def test_off_track_input_feeds_in_with_clean_drop_and_elbow():
+    """An off-track input drops straight down from its icon then turns onto the
+    consumer's rail with a single elbow: a clean L (vertical leg + horizontal
+    leg), near its consumer, not a long diagonal traverse from the left edge."""
+    from nf_metro.layout.routing import route_edges
+
+    graph = _rail_graph()
+    routes = route_edges(graph)
+    off_tracks = {st.id for st in graph.stations.values() if st.off_track}
+    assert off_tracks, "demo must contain an off_track input"
+
+    checked = 0
+    for rp in routes:
+        src = graph.stations.get(rp.edge.source)
+        tgt = graph.stations.get(rp.edge.target)
+        if src is None or tgt is None:
+            continue
+        if rp.edge.source not in off_tracks and rp.edge.target not in off_tracks:
+            continue
+        consumer = tgt if rp.edge.source in off_tracks else src
+        checked += 1
+        # An off-track feed is exactly drop + elbow + horizontal: three points,
+        # a vertical first leg (shared X) and a horizontal last leg (shared Y).
+        pts = rp.points if rp.edge.source in off_tracks else list(reversed(rp.points))
+        assert len(pts) == 3, f"off-track feed not a 3-point L: {pts}"
+        assert abs(pts[0][0] - pts[1][0]) < 0.5, f"first leg not vertical: {pts}"
+        assert abs(pts[1][1] - pts[2][1]) < 0.5, f"last leg not horizontal: {pts}"
+        # The horizontal reach stays within the section (feeder near consumer).
+        xs = [x for x, _ in pts]
+        sec = graph.sections.get(consumer.section_id)
+        if sec and sec.bbox_w > 0:
+            assert (max(xs) - min(xs)) < sec.bbox_w, (
+                f"off-track feeder spans {max(xs) - min(xs)}px across a "
+                f"{sec.bbox_w}px section -- too long a traverse"
+            )
+    assert checked, "expected at least one off-track feeder edge"
+
+
+def test_off_track_bundle_feeders_do_not_merge():
+    """Several lines feeding from one off-track input each drop on their own X
+    (one per target rail), so the bundle stays distinct parallel lines in the
+    vertical leg rather than collapsing into one fat merged line."""
+    from nf_metro.layout.routing import route_edges
+
+    graph = _rail_graph()
+    routes = route_edges(graph)
+    off_tracks = {st.id for st in graph.stations.values() if st.off_track}
+
+    # Group off-track feeds by (feeder, consumer); the demo's samples_csv feeds
+    # bqsr on two lines (pair_n, pair_t) -- a 2-line bundle.
+    drops: dict[tuple[str, str], list[float]] = {}
+    for rp in routes:
+        if rp.edge.source not in off_tracks and rp.edge.target not in off_tracks:
+            continue
+        feeder = rp.edge.source if rp.edge.source in off_tracks else rp.edge.target
+        consumer = rp.edge.target if rp.edge.source in off_tracks else rp.edge.source
+        pts = rp.points if rp.edge.source in off_tracks else list(reversed(rp.points))
+        drops.setdefault((feeder, consumer), []).append(round(pts[0][0], 2))
+
+    multi = {k: v for k, v in drops.items() if len(v) >= 2}
+    assert multi, "demo must contain a multi-line off-track bundle feed"
+    for key, drop_xs in multi.items():
+        assert len(set(drop_xs)) == len(drop_xs), (
+            f"{key}: bundle feeder lines share a drop X {drop_xs} -- they merge"
+        )
+
+
+def test_rail_labels_clear_the_whole_panel_never_beside_a_middle_rail():
+    """Every rail-mode station label sits ABOVE the panel's topmost rail or
+    BELOW its bottommost rail - never beside a middle rail (which would have
+    the label collide with the lines).  This holds even for a station that
+    only occupies middle rails (its label still clears the outer rails)."""
+    from nf_metro.layout.labels import _label_bbox, place_labels
+
+    graph = _rail_graph()
+    rails = _section_line_rails(graph)
+    placements = place_labels(graph)
+
+    checked = 0
+    for lp in placements:
+        st = graph.stations.get(lp.station_id)
+        if st is None or st.is_port or not st.label.strip():
+            continue
+        if st.is_terminus and not st.label.strip():
+            continue
+        section_rails = rails.get(st.section_id)
+        if not section_rails or len(section_rails) < 2:
+            continue
+        top_rail = min(section_rails.values())
+        bot_rail = max(section_rails.values())
+        x0, y0, x1, y1 = _label_bbox(lp)
+        # The label's nearest edge to the rail band must be outside it: an
+        # above label's bottom edge is at/above the top rail; a below label's
+        # top edge is at/below the bottom rail.  A small tolerance covers the
+        # descender clearance baked into placement.
+        tol = 6.0
+        clears_top = y1 <= top_rail + tol
+        clears_bottom = y0 >= bot_rail - tol
+        assert clears_top or clears_bottom, (
+            f"{st.section_id}/{st.id}: label y[{y0:.1f},{y1:.1f}] sits beside a "
+            f"middle rail (rail band [{top_rail:.1f},{bot_rail:.1f}])"
+        )
+        checked += 1
+    assert checked, "expected at least one labelled rail station"
+
+
+def test_stacked_rail_section_bbox_contains_hanging_labels():
+    """A rail section's bbox reserves room for its below-rail labels so a
+    section stacked beneath it clears them.  A long, steeply-angled label whose
+    footprint exceeds the default padding grows the box; a section below then
+    keeps a positive header gap (no clash)."""
+    from nf_metro.layout import compute_layout
+    from nf_metro.layout.constants import SECTION_HEADER_PROTRUSION
+
+    src = (
+        "%%metro title: t\n"
+        "%%metro style: dark\n"
+        "%%metro line_spread: rails\n"
+        "%%metro label_angle: 45\n"
+        "%%metro line: a | A | #2db572\n"
+        "%%metro line: b | B | #0570b0\n"
+        "%%metro grid: top | 0,0\n"
+        "%%metro grid: bot | 0,1\n"
+        "graph LR\n"
+        "    subgraph top [Top]\n"
+        "        t1[Start]\n"
+        "        t2[An extremely long station label name to overflow the pad]\n"
+        "        t1 -->|a,b| t2\n"
+        "    end\n"
+        "    subgraph bot [Bottom]\n"
+        "        u1[Go]\n"
+        "        u2[End]\n"
+        "        u1 -->|a,b| u2\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(src)
+    compute_layout(graph, validate=True)
+    top = graph.sections["top"]
+    bot = graph.sections["bot"]
+    # The long-label section's bbox grew well past a bare two-rail panel.
+    assert top.bbox_h > 200, f"top bbox did not reserve label band: {top.bbox_h}"
+    # The lower section's header (badge top) clears the upper section's box.
+    gap = (bot.bbox_y - SECTION_HEADER_PROTRUSION) - (top.bbox_y + top.bbox_h)
+    assert gap >= 0, f"lower header overlaps the section above: gap {gap:.1f}px"
+
+
+def test_rail_mode_off_by_default_leaves_graph_unchanged():
+    """A representative graph laid out with rail mode OFF is byte-for-byte
+    the same as today: no rail spans are set, and the same SVG is produced
+    whether or not the default ``line_spread`` is touched."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
+
+    g1 = parse_metro_mermaid(src)
+    assert g1.line_spread is LineSpread.BUNDLE
+    compute_layout(g1)
+    svg1 = render_svg(g1, THEMES["nfcore"])
+
+    # No station should carry a rail span when rail mode is off.
+    assert all(
+        s.rail_top_y is None and s.rail_bottom_y is None for s in g1.stations.values()
+    )
+
+    g2 = parse_metro_mermaid(src)
+    g2.line_spread = LineSpread.BUNDLE  # explicit no-op
+    compute_layout(g2)
+    svg2 = render_svg(g2, THEMES["nfcore"])
+
+    assert svg1 == svg2
+
+
+# ---------------------------------------------------------------------------
+# Per-section rail mode (%%metro line_spread: rails | <id>)
+# ---------------------------------------------------------------------------
+
+RAIL_SECTION_MMD = EXAMPLES / "rail_section.mmd"
+
+
+def _rail_section_graph():
+    graph = parse_metro_mermaid(RAIL_SECTION_MMD.read_text())
+    compute_layout(graph, validate=True)
+    return graph
+
+
+def test_rail_section_directive_parses():
+    graph = parse_metro_mermaid(RAIL_SECTION_MMD.read_text())
+    assert graph.line_spread is LineSpread.BUNDLE
+    assert graph.line_spread_overrides == {"pathways": LineSpread.RAILS}
+    assert graph.has_rail_sections is True
+    assert graph.is_rail_section("pathways") is True
+    assert graph.is_rail_section("calling") is False
+
+
+def test_global_rail_mode_treats_all_sections_as_rail():
+    """The legacy global flag means every section is a rail section."""
+    graph = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert graph.line_spread is LineSpread.RAILS
+    # Every declared section reports as a rail section under the global flag.
+    for sid in graph.sections:
+        assert graph.is_rail_section(sid) is True
+    # ...even though rail_sections was never populated explicitly.
+    assert graph.line_spread_overrides == {}
+
+
+def test_flagged_section_gets_rail_spans():
+    """Stations in the flagged section span multiple rails (pills)."""
+    graph = _rail_section_graph()
+    pathways = graph.sections["pathways"]
+    spanning = [
+        graph.stations[sid]
+        for sid in pathways.station_ids
+        if not graph.stations[sid].is_port
+    ]
+    # The multi-line pathway stations all carry 3 lines, so each spans rails.
+    assert spanning, "pathways section should have real stations"
+    assert all(
+        st.rail_top_y is not None and st.rail_bottom_y is not None
+        for st in spanning
+        if len(graph.station_lines(st.id)) > 1
+    )
+    # Used rails recorded per station match the lines they carry.
+    for st in spanning:
+        lines = graph.station_lines(st.id)
+        if len(lines) > 1:
+            assert len(st.rail_used_ys) == len(lines)
+
+
+def test_normal_section_keeps_per_line_tracks_not_rail_spans():
+    """A non-flagged connected section keeps normal layout: no rail spans."""
+    graph = _rail_section_graph()
+    for sid in ("preprocess", "calling", "annotate"):
+        section = graph.sections[sid]
+        for st_id in section.station_ids:
+            st = graph.stations[st_id]
+            assert st.rail_top_y is None, f"{st_id} unexpectedly has a rail span"
+            assert st.rail_bottom_y is None
+            assert st.rail_used_ys == []
+
+
+def test_normal_section_lines_share_a_trunk():
+    """The connected trunk's co-travelling lines bundle (converge), unlike
+    rail mode where they stay on separate fixed rails."""
+    graph = _rail_section_graph()
+    # In the calling section, markdup carries both dna and rna; in normal
+    # (non-rail) layout that station sits at a single Y (the trunk), not a
+    # multi-rail pill.
+    markdup = graph.stations["markdup"]
+    assert markdup.rail_top_y is None
+    # Rail-section pathway stations DO span; assert the contrast holds.
+    score = graph.stations["score"]
+    assert score.rail_top_y is not None
+
+
+def test_rail_section_internal_edges_routed_as_straight_rails():
+    """Internal edges of the rail section render as flat horizontal runs."""
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    graph = _rail_section_graph()
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    pathway_ids = set(graph.sections["pathways"].station_ids)
+    seen_internal = 0
+    for rp in routes:
+        if rp.edge.source in pathway_ids and rp.edge.target in pathway_ids:
+            ys = {round(y, 2) for _, y in rp.points}
+            assert len(ys) == 1, (
+                f"rail edge {rp.edge.source}->{rp.edge.target} is not a "
+                f"flat horizontal run: Ys {ys}"
+            )
+            seen_internal += 1
+    assert seen_internal > 0, "expected some routed internal rail edges"
+
+
+def test_per_section_rail_validates_and_contains():
+    """validate=True passes and rail stations stay within their bbox."""
+    graph = _rail_section_graph()  # compute_layout(validate=True) inside
+    pathways = graph.sections["pathways"]
+    for st_id in pathways.station_ids:
+        st = graph.stations[st_id]
+        if st.is_port:
+            continue
+        top = st.rail_top_y if st.rail_top_y is not None else st.y
+        bot = st.rail_bottom_y if st.rail_bottom_y is not None else st.y
+        assert top >= pathways.bbox_y - 1e-6
+        assert bot <= pathways.bbox_y + pathways.bbox_h + 1e-6
+
+
+def test_no_rail_directive_default_off_byte_identical():
+    """Adding per-section rail support must not change a normal render."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
+    g = parse_metro_mermaid(src)
+    assert g.has_rail_sections is False
+    compute_layout(g)
+    svg = render_svg(g, THEMES["nfcore"])
+    # No rail span leaks into a normal graph.
+    assert all(
+        s.rail_top_y is None and s.rail_bottom_y is None for s in g.stations.values()
+    )
+    assert "nf-metro-rail-knob" not in svg
+
+
+# ---------------------------------------------------------------------------
+# Convergence corners: 45-degree diagonals, not square right-angle bends
+# ---------------------------------------------------------------------------
+
+
+def _is_axis_aligned(p0, p1) -> bool:
+    """True when the segment p0->p1 is purely horizontal or purely vertical."""
+    return abs(p0[0] - p1[0]) < 0.5 or abs(p0[1] - p1[1]) < 0.5
+
+
+def test_rail_convergence_segments_are_diagonal_not_square():
+    """Where rails fan out from a single input or fan in to a single output,
+    the rail eases between rail Ys on a 45-degree diagonal segment (a segment
+    that changes BOTH x and y), not a square right-angle vertical jog."""
+    graph = _rail_graph()
+    from nf_metro.layout.routing import route_edges
+
+    routes = route_edges(graph)
+    diagonals = 0
+    for route in routes:
+        src = graph.stations.get(route.edge.source)
+        tgt = graph.stations.get(route.edge.target)
+        # Off-track feeders deliberately use an S-curve; not a convergence.
+        if (src and src.off_track) or (tgt and tgt.off_track):
+            continue
+        pts = route.points
+        # A convergence route changes rail Y between its endpoints.
+        if abs(pts[0][1] - pts[-1][1]) < 0.5:
+            continue
+        # Some interior segment must be a true diagonal (changes both x and y);
+        # a square jog would have only axis-aligned segments.
+        has_diag = any(not _is_axis_aligned(a, b) for a, b in zip(pts, pts[1:]))
+        assert has_diag, (
+            f"convergence {route.edge.source}->{route.edge.target} "
+            f"({route.line_id}) uses square bends, not a diagonal: {pts}"
+        )
+        # And no purely-vertical interior jog between the rails (the old
+        # square-bend signature).
+        interior = list(zip(pts, pts[1:]))[1:-1]
+        for a, b in interior:
+            assert not (abs(a[0] - b[0]) < 0.5 and abs(a[1] - b[1]) >= 0.5), (
+                f"convergence {route.edge.source}->{route.edge.target} "
+                f"has a square vertical jog {a}->{b}"
+            )
+        diagonals += 1
+    assert diagonals > 0, "expected at least one diagonal convergence route"
+
+
+def test_rail_fan_out_diagonal_eases_off_the_shared_input():
+    """The CRAM fan-out rails (germline up, pair_t down) leave the shared
+    input point on a diagonal then run flat -- the diagonal is biased early
+    (toward the fork) so most of the column is a straight rail."""
+    graph = _rail_graph()
+    from nf_metro.layout.routing import route_edges
+
+    routes = {(r.edge.source, r.edge.target, r.line_id): r for r in route_edges(graph)}
+    # cram_in -> align carries germline (top) and pair_t (bottom): both
+    # change rail Y and must contain a diagonal.
+    for line in ("germline", "pair_t"):
+        rp = routes.get(("cram_in", "align", line))
+        assert rp is not None, f"missing cram_in->align route for {line}"
+        pts = rp.points
+        assert abs(pts[0][1] - pts[-1][1]) > 0.5, "expected a rail-Y change"
+        assert any(not _is_axis_aligned(a, b) for a, b in zip(pts, pts[1:])), (
+            f"cram_in->align ({line}) is not diagonal: {pts}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Angled labels: tighter column spacing via the rotated horizontal projection
+# ---------------------------------------------------------------------------
+
+
+def _calling_column_step(angle: float) -> float:
+    g = parse_metro_mermaid(RAIL_MMD.read_text())
+    g.label_angle = angle
+    compute_layout(g)
+    xs = sorted(
+        {
+            round(s.x, 2)
+            for s in g.stations.values()
+            if s.section_id == "calling" and not s.is_port and not s.off_track
+        }
+    )
+    steps = [b - a for a, b in zip(xs, xs[1:])]
+    assert steps, "expected multiple columns in the calling section"
+    return steps[0]
+
+
+def test_angled_label_column_pitch_is_tighter_than_horizontal():
+    """An angled-label rail panel packs columns tighter than the same panel
+    with horizontal labels, because a diagonal label's horizontal footprint
+    is width*cos(angle)."""
+    horizontal = _calling_column_step(0.0)
+    angled = _calling_column_step(45.0)
+    assert angled < horizontal - 1.0, (
+        f"angled pitch {angled:.1f} not tighter than horizontal {horizontal:.1f}"
+    )
+
+
+def test_label_angle_directive_parses():
+    g = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert g.label_angle == 45.0
+
+
+def test_angled_rail_labels_render_rotated():
+    """With label_angle set, rail-section station labels render with a
+    rotate() transform (so the tilted text is actually drawn)."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    g = _rail_graph()
+    assert g.label_angle == 45.0
+    svg = render_svg(g, THEMES["nfcore"])
+    assert "rotate(45" in svg, "expected rotated label transforms in the SVG"
+
+
+def test_label_angle_default_off_byte_identical():
+    """label_angle support must not change a render with no directive: a graph
+    without label_angle produces an identical SVG before and after this change
+    (label_angle is None -> no rotation, no spacing change)."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
+    g = parse_metro_mermaid(src)
+    assert g.label_angle is None
+    compute_layout(g)
+    svg = render_svg(g, THEMES["nfcore"])
+    assert "rotate(45" not in svg
+    assert "rotate(" not in svg
+
+
+# ---------------------------------------------------------------------------
+# legend_combo bundling: combo lines share ONE rail slot (a tight bundle)
+# ---------------------------------------------------------------------------
+
+
+def test_legend_combo_directive_parses():
+    g = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert g.legend_combos == [(("pair_n", "pair_t"), "Tumour-normal pair")]
+
+
+def test_combo_lines_share_one_rail_slot():
+    """Lines that are members of a legend_combo occupy a single rail slot
+    drawn as a tight adjacent bundle, so the rail-slot count equals the
+    distinct non-combo lines plus one slot per combo -- not one per line."""
+    from nf_metro.layout.rail_mode import _rail_slot_offsets, _section_lines_in_order
+
+    graph = _rail_graph()
+    y_spacing = 40.0
+    section = graph.sections["calling"]
+    lines = _section_lines_in_order(graph, section)
+    members = _combo_member_ids(graph)
+    assert members, "demo must contain a legend_combo"
+
+    slot_offset, n_slots = _rail_slot_offsets(graph, lines, y_spacing)
+
+    expected = len([lid for lid in lines if lid not in members]) + 1
+    assert n_slots == expected, (
+        f"expected {expected} rail slots (non-combo lines + 1 per combo), got {n_slots}"
+    )
+    # All combo members in the section land on the SAME slot centre: their
+    # offsets differ by less than a full rail pitch (they hug as a bundle).
+    member_offsets = [slot_offset[lid] for lid in members if lid in slot_offset]
+    assert len(member_offsets) >= 2
+    assert max(member_offsets) - min(member_offsets) < y_spacing, (
+        f"combo members did not bundle onto one slot: {member_offsets}"
+    )
+    # ...and they are NOT coincident (a visible two-line bundle, not one rail).
+    assert max(member_offsets) - min(member_offsets) > 0.5, (
+        "combo members collapsed to a single coincident rail"
+    )
+    # A non-combo line is a full rail pitch away from the bundle centre.
+    bundle_centre = sum(member_offsets) / len(member_offsets)
+    non_combo = [
+        slot_offset[lid] for lid in lines if lid not in members and lid in slot_offset
+    ]
+    assert all(abs(o - bundle_centre) >= y_spacing - 1.0 for o in non_combo), (
+        "a non-combo rail is closer than a full pitch to the bundle"
+    )
+
+
+def test_combo_bundle_sublines_hug_at_one_offset_step():
+    """A legend_combo bundle's sub-lines sit exactly one OFFSET_STEP apart -
+    the same tight pitch the normal router uses for parallel lines in a bundle -
+    so the bundle reads as a single track, not two spaced-apart rails."""
+    from nf_metro.layout.constants import OFFSET_STEP
+    from nf_metro.layout.rail_mode import _rail_slot_offsets, _section_lines_in_order
+
+    graph = _rail_graph()
+    section = graph.sections["calling"]
+    lines = _section_lines_in_order(graph, section)
+    members = _combo_member_ids(graph)
+    slot_offset, _ = _rail_slot_offsets(graph, lines, 40.0)
+
+    member_offsets = sorted(slot_offset[lid] for lid in members if lid in slot_offset)
+    assert len(member_offsets) == 2, "demo's combo bundle has two members"
+    gap = member_offsets[1] - member_offsets[0]
+    assert abs(gap - OFFSET_STEP) < 1e-6, (
+        f"combo sub-lines {gap}px apart; expected one OFFSET_STEP ({OFFSET_STEP}px)"
+    )
+
+
+def test_cross_track_station_knob_spans_the_bundle():
+    """A cross-track (spanning) station that uses the bundle draws a knob on
+    each of the bundle's hugging sub-rails -- its span reaches the bundle
+    slot."""
+    graph = _rail_graph()
+    members = _combo_member_ids(graph)
+    # `align` carries every line, so it must place a knob on each bundle sub-rail.
+    st = graph.stations["align"]
+    served = graph.station_lines_ordered(st.id)
+    member_ys = [y for lid, y in zip(served, st.rail_used_ys) if lid in members]
+    assert len(member_ys) == len(members), (
+        f"spanning station missing a bundle knob: {member_ys}"
+    )
+    # The bundle knobs are adjacent (within a pitch) and distinct.
+    assert 0.5 < max(member_ys) - min(member_ys) < 40.0
+
+
+def test_interchange_link_uses_station_fill_not_dark_stroke():
+    """The cross-track interchange link renders WHITE (the station fill), not
+    the dark station stroke -- the dark stroke is only the outer boundary.
+
+    The white link bar fills the interior; a separate dark layer paints the
+    outline.  Assert the white interior bar is present (station fill stroke)
+    and that the connector is no longer a lone dark line cutting across."""
+    import re
+
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = _rail_graph()
+    theme = THEMES["nfcore"]
+    svg = render_svg(graph, theme)
+
+    spanning = [
+        st
+        for st in graph.stations.values()
+        if st.rail_top_y is not None and st.rail_bottom_y is not None
+    ]
+    assert spanning, "demo must contain a multi-rail (cross-track) station"
+
+    # The link bars render as round-capped <path> elements (drawsvg emits Line
+    # as a path).  A white (station-fill) interior bar must be drawn for the
+    # glyph, joining the circles in white rather than dark.
+    fill = re.escape(theme.station_fill)
+    white_vbar = re.compile(rf'<path[^>]*stroke="{fill}"[^>]*stroke-linecap="round"')
+    assert white_vbar.search(svg), (
+        f"expected a white ({theme.station_fill}) interchange link bar; "
+        "the connector must render with the station fill, not the dark stroke"
+    )
+
+    # The dark outline layer carries the connector class so the glyph keeps a
+    # continuous dark outer boundary behind the white interior.
+    stroke = re.escape(theme.station_stroke)
+    dark_connector = re.compile(
+        rf'stroke="{stroke}"[^>]*stroke-linecap="round"[^>]*nf-metro-rail-connector'
+    )
+    assert dark_connector.search(svg), (
+        "expected a dark outline layer (connector class) behind the white link"
+    )
+
+
+def test_legend_combo_default_off_byte_identical():
+    """Adding legend_combo parsing/render must not change a render that has no
+    legend_combo directive: byte-for-byte identical SVG, no combo state."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
+    g = parse_metro_mermaid(src)
+    assert g.legend_combos == []
+    compute_layout(g)
+    svg1 = render_svg(g, THEMES["nfcore"])
+
+    g2 = parse_metro_mermaid(src)
+    g2.legend_combos = []  # explicit no-op
+    compute_layout(g2)
+    svg2 = render_svg(g2, THEMES["nfcore"])
+    assert svg1 == svg2


### PR DESCRIPTION
Introduces a single `%%metro line_spread:` directive controlling how lines that share a station relate vertically, with three modes, plus per-section overrides and a CLI flag. This unifies and supersedes the two separate controls previously proposed in #541 (centered tracks) and #542 (rail mode), which sat on the same conceptual axis.

## The `line_spread` axis

How lines sharing a station relate vertically:

- **`bundle`** (default) merges shared lines onto one trunk track; detours cascade downward. Byte-identical to today's layout.
- **`centered`** also merges, but balances the bundle about the midline so the shared trunk sits centred and exclusive callers fan symmetrically above and below.
- **`rails`** keeps co-travelling lines on separate parallel rails instead of bundling them onto a trunk; a station several lines pass through renders as a metro interchange (a circle on each rail it uses, joined by a connector, with unused rails passing behind). Lines converge only at a genuine single-node fan-in/out, e.g. a file terminus all lines reach, eased in with 45-degree diagonals.

```text
%%metro line_spread: centered          # graph-wide default
%%metro line_spread: rails | pathways  # per-section override
```

A bare directive sets the graph default; the `| section, ...` form overrides named sections, so one map can mix modes. The new `--line-spread` CLI flag overrides the graph-wide default (per-section overrides stay), matching the `--center-ports` precedent.

`diamond_style` is a separate axis (how a single line's fork-join branches arrange) and is unchanged.

## What's in the diff

- **Parser / model**: `LineSpread` enum + `line_spread` / `line_spread_overrides` on `MetroGraph`, resolved via `section_line_spread()`; `is_rail_section` / `has_rail_sections` / `station_is_rail` query helpers.
- **Layout**: `centered` track balancing in `ordering.assign_tracks` (with a validate-gated balance guard); a self-contained rail-mode layout pipeline (`layout/rail_mode.py`, `routing/rail.py`) for `rails`, dispatched globally or retrofitted per-section, reusing the normal `assign_layers` / `_compute_diagonal_placement` primitives.
- **Render**: interchange spanning-pills and straight rails for rail sections; shared blank-terminus nub, legend, label and icon handling.
- **CLI**: `--line-spread {bundle,centered,rails}`.
- **Gallery**: one mixed-mode showcase `examples/line_spread.mmd` demonstrating all three modes in a single map via per-section overrides.
- **Docs**: a single `line_spread` table row and prose section in `README.md` and `docs/guide.md`.

## Default-off is byte-identical

With no directive, `line_spread` is `bundle` and every existing gallery render is byte-identical to `main`. `centered` and `rails` are opt-in, and each carries its own invariant tests.

## Known limitation

A `rails` section must be self-contained: inter-section edges into or out of a rail section are not yet supported (mix a rails panel with a normal trunk by keeping the rail section disconnected, as the showcase does).

Supersedes #541 and #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)