### PR TITLE
feat(layout): pack diagonal-labelled rail sections to the graph column pitch

### DIFF
--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -82,6 +82,11 @@ def _residual_label_overlaps(
     overlaps surface (to be cleared by widening spacing rather than by
     hard-breaking words); the final guard calls it with True to validate the
     settled, fully wrapped state the renderer will draw.
+
+    Overlaps involving a rail-section station are dropped: rail sections run a
+    dedicated layout with their own column pitch, so widening the normal global
+    X spacing cannot fix them and would only needlessly bloat the normal
+    sections.
     """
     from nf_metro.layout.labels import find_label_overlaps
 
@@ -89,7 +94,15 @@ def _residual_label_overlaps(
     if probe is None:
         return []
     offsets, placements = probe
-    return find_label_overlaps(graph, placements, offsets)
+    overlaps = find_label_overlaps(graph, placements, offsets)
+    if not graph.has_rail_sections:
+        return overlaps
+
+    def _in_rail(station_id: str) -> bool:
+        st = graph.stations.get(station_id)
+        return bool(st and st.section_id and graph.is_rail_section(st.section_id))
+
+    return [o for o in overlaps if not (_in_rail(o.a) or _in_rail(o.b))]
 
 
 def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -436,18 +436,20 @@ def _label_aware_x_spacing(
     it plus half its neighbour (i.e. the full widest label, plus a small gap)
     keeps every label on one line while the rails stay evenly spaced.
     """
-    import math
-
     from nf_metro.layout.constants import LABEL_MARGIN
     from nf_metro.layout.labels import label_text_width
 
-    # A diagonal (angled) label's HORIZONTAL footprint is its width times
-    # cos(angle), so an angled-label panel only needs to seat that projection
-    # between columns and can pack noticeably tighter than horizontal text.
-    # Gated on angle != 0 so non-angled panels are unchanged.
-    angle = graph.label_angle or 0.0
-    h_factor = abs(math.cos(math.radians(angle))) if angle else 1.0
+    # Diagonal labels are all drawn at the same angle, so adjacent columns'
+    # labels are parallel and collide only by their perpendicular separation,
+    # not along their length.  They therefore share the one graph-wide pitch
+    # compute_layout already resolved (labels.diagonal_label_pitch, passed in as
+    # x_spacing), so every section -- rail and normal -- packs to the same tight
+    # column step instead of each rail widening to seat its label's full width.
+    if graph.label_angle:
+        return x_spacing
 
+    # Horizontal labels render centred on the station X, so the step must seat
+    # the full widest label (plus a small gap) to keep every label on one line.
     widest = 0.0
     for sid in real_ids:
         st = graph.stations.get(sid)
@@ -456,7 +458,7 @@ def _label_aware_x_spacing(
         # Blank termini render as icons, not text labels, so don't size to them.
         if st.is_blank_terminus:
             continue
-        widest = max(widest, label_text_width(st.label) * h_factor)
+        widest = max(widest, label_text_width(st.label))
     if widest <= 0.0:
         return x_spacing
     return max(x_spacing, widest + LABEL_MARGIN * 2)

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -122,6 +122,92 @@ def test_rails_are_evenly_spaced_and_distinct():
             )
 
 
+def test_diagonal_rail_section_packs_to_graph_pitch_not_label_width():
+    """Diagonal-labelled rail sections share the one tight graph column pitch.
+
+    Adjacent diagonal labels are parallel, so a rail panel need not widen each
+    column to seat its label's full width (which it must for horizontal text).
+    The angled path returns the passed-in graph pitch untouched; clearing the
+    angle restores the label-width widening, proving the gate has teeth.
+    """
+    from nf_metro.layout.labels import label_text_width
+    from nf_metro.layout.rail_mode import _label_aware_x_spacing
+
+    graph = parse_metro_mermaid(RAIL_MMD.read_text())
+    assert graph.label_angle, "rail_mode.mmd opts into 45-degree labels"
+    sec = next(s for s in graph.sections.values() if graph.is_rail_section(s.id))
+    real_ids = [
+        sid
+        for sid in sec.station_ids
+        if (st := graph.stations.get(sid)) is not None and not st.is_port
+    ]
+    widest = max(
+        label_text_width(graph.stations[sid].label)
+        for sid in real_ids
+        if not graph.stations[sid].is_blank_terminus
+    )
+    pitch = 39.6
+    assert widest > pitch, "fixture must carry a label wider than the pitch"
+
+    # Angled: the graph pitch passes straight through, however wide the labels.
+    assert _label_aware_x_spacing(graph, real_ids, {}, pitch) == pitch
+    # Horizontal: the same panel widens to seat the full widest label.
+    graph.label_angle = None
+    assert _label_aware_x_spacing(graph, real_ids, {}, pitch) > pitch
+
+
+def test_spread_residual_drops_rail_section_overlaps(monkeypatch):
+    """The spread loop's residual-overlap report excludes any overlap touching
+    a rail-section station.
+
+    Rail crowding is resolved by the rail layout's own column pitch, not by
+    widening the global X spacing; counting it would needlessly bloat the
+    normal sections.  The added filter drops overlaps whose either endpoint is
+    a rail-section station and keeps the rest.
+    """
+    import nf_metro.layout.labels as labels_mod
+    from nf_metro.layout.labels import LabelOverlap
+    from nf_metro.layout.phases.spacing import _residual_label_overlaps
+
+    mmd = (
+        "%%metro title: mixed\n"
+        "%%metro label_angle: 45\n"
+        "%%metro line: a | A | #ff0000\n"
+        "%%metro line: b | B | #0000ff\n"
+        "%%metro line_spread: rails | rails_sec\n"
+        "graph LR\n"
+        "    subgraph normal [Normal]\n"
+        "        n1[Trim]\n"
+        "        n2[Align]\n"
+        "        n3[Sort]\n"
+        "        n1 -->|a| n2\n"
+        "        n2 -->|a| n3\n"
+        "    end\n"
+        "    subgraph rails_sec [Rails]\n"
+        "        r1[CallerOne]\n"
+        "        r2[CallerTwo]\n"
+        "        r1 -->|a,b| r2\n"
+        "    end\n"
+        "    n3 -->|a| r1\n"
+    )
+    graph = parse_metro_mermaid(mmd)
+    compute_layout(graph)
+    assert graph.has_rail_sections and graph.is_rail_section("rails_sec")
+
+    # Inject synthetic overlaps: one touching a rail station (must be dropped),
+    # one purely between normal stations (must survive).
+    rail_norm = LabelOverlap("label", "r1", "n1", 20.0, 0.0)
+    norm_norm = LabelOverlap("label", "n1", "n2", 15.0, 0.0)
+    monkeypatch.setattr(
+        labels_mod, "find_label_overlaps", lambda *a, **k: [rail_norm, norm_norm]
+    )
+
+    residual = _residual_label_overlaps(graph, allow_hyphenation=False)
+    pairs = {(o.a, o.b) for o in residual}
+    assert ("n1", "n2") in pairs, "normal-only overlap must be kept"
+    assert ("r1", "n1") not in pairs, "rail-touching overlap must be dropped"
+
+
 def test_multi_line_station_span_covers_exactly_its_lines_rails():
     """A spanning pill's drawn span (rail_top_y..rail_bottom_y) equals the
     Y range of the rails its lines occupy -- no more, no less."""


### PR DESCRIPTION
## What

A `%%metro line_spread: rails` section combined with diagonal (`%%metro label_angle:`) labels was laid out far too wide. Two compounding causes:

1. The rail layout sized each column to seat its label's **full horizontal width**, ignoring that diagonal labels only need their perpendicular separation.
2. The global spread loop then widened X spacing further to clear the rail panel's label crowding, **bloating the normal sections too**.

## Fix

Diagonal labels are all drawn at the same angle, so adjacent columns' labels are parallel and collide only by their perpendicular separation, never along their length. They can share the one tight graph-wide pitch (`diagonal_label_pitch`) that `compute_layout` already resolves:

- `_label_aware_x_spacing` returns the passed-in pitch unchanged when `label_angle` is set (the full-width seating rule is kept for horizontal labels).
- `_residual_label_overlaps` drops overlaps touching a rail-section station, so rail crowding (handled by the rail layout's own pitch) no longer drives the global spread loop.

## Render impact

Byte-identical for **every gallery fixture except `rail_mode`**, whose panel tightens from **870px to 531px** wide (the exact over-wide spacing this fixes), with topology unchanged. Please eyeball the `rail_mode` before/after in the PR render preview.

## Tests

- `test_diagonal_rail_section_packs_to_graph_pitch_not_label_width` - the angled gate returns the graph pitch untouched; clearing the angle restores width-seating (proves the gate).
- `test_spread_residual_drops_rail_section_overlaps` - the residual filter drops rail-touching overlaps and keeps normal ones (fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)