### PR TITLE
fix(layout): snapshot structural extent after the off-track lift

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -972,12 +972,6 @@ def _place_pass_c_content(
     """Stage 5.1 through Stage 6.12: position junctions, lift off-track
     inputs, settle vertical content, and recenter fans / loop-side
     stations within each section."""
-    # Capture each section's structural content-bottom (as a height below
-    # its bbox top) before the opportunistic content-compaction phases run,
-    # so the inter-row cascade (Stage 6.13 phase 2) stacks lower rows from a
-    # structural prediction rather than the post-compaction settled extent.
-    _snapshot_struct_heights_below_top(graph, section_y_padding)
-
     # ---- Stage 5 - Pass C: Junctions & off-track lift ------------------
     # All port positions are now final; Stage 5.1 positions junctions
     # once.  Stage 5.2 lifts off-track stations; Stages 5.3 to 5.5
@@ -998,6 +992,16 @@ def _place_pass_c_content(
     _snap(graph, "5.2")
     if validate:
         _run_pass_c_guards(graph, "after Stage 5.2")
+
+    # Capture each section's structural content-bottom (as a height below its
+    # bbox top) before the opportunistic content-compaction phases run, so the
+    # inter-row cascade (Stage 6.13 phase 2) stacks lower rows from a structural
+    # prediction rather than the post-compaction settled extent.  Runs *after*
+    # the off-track lift (Stage 5.2): lifting an input above the trunk raises
+    # the section's bbox top, and capturing before that would understate the
+    # content height below the (then lower) top, making the cascade stack the
+    # row below too high.
+    _snapshot_struct_heights_below_top(graph, section_y_padding)
 
     # Stage 5.3: Re-align bbox tops within each grid row after off-track
     # lifting expanded some sections upward.  Unlike Stages 3.5 / 4.7 which

--- a/tests/test_struct_extent_predictor.py
+++ b/tests/test_struct_extent_predictor.py
@@ -38,7 +38,6 @@ DEFAULT_TOLERANCE = 1.0
 # loosens the inter-row gap, never overlaps.
 KNOWN_DIVERGENT: dict[str, float] = {
     "differentialabundance.mmd": 150.0,
-    "differentialabundance_default.mmd": 120.0,
     "variantbenchmarking.mmd": 20.0,
     "variantbenchmarking_auto.mmd": 20.0,
     "genomic_pipeline.mmd": 5.0,
@@ -110,6 +109,53 @@ def test_known_divergent_fixtures_actually_diverge(name: str) -> None:
     assert worst > DEFAULT_TOLERANCE, (
         f"{name}: divergence {worst:.2f}px no longer exceeds the default "
         f"tolerance; remove it from KNOWN_DIVERGENT"
+    )
+
+
+def test_off_track_lift_not_under_predicted() -> None:
+    """A section with a lifted off-track input must not under-predict its
+    content height below the bbox top.
+
+    The off-track lift (Stage 5.2) raises a section's bbox top to seat the
+    lifted input above the trunk.  The structural snapshot is taken after that
+    lift, so the stored height-below-top reflects the raised top.  Were it
+    captured before, the row-ending section here (``top``) would store a height
+    ~40px short of settled (the unsafe direction), and the inter-row cascade
+    would stack the row below it that much too high.
+    """
+    mmd = (
+        "%%metro title: off-track two-row\n"
+        "%%metro line: a | A | #ff0000\n"
+        "%%metro file: in_csv | CSV\n"
+        "%%metro off_track: in_csv\n"
+        "%%metro grid: top | 0,0\n"
+        "%%metro grid: bot | 0,1\n"
+        "graph LR\n"
+        "    subgraph top [Top]\n"
+        "        in_csv[ ]\n"
+        "        t1[Step One]\n"
+        "        t2[Step Two]\n"
+        "        in_csv -->|a| t1\n"
+        "        t1 -->|a| t2\n"
+        "    end\n"
+        "    subgraph bot [Bottom]\n"
+        "        b1[Bee One]\n"
+        "        b2[Bee Two]\n"
+        "        b1 -->|a| b2\n"
+        "    end\n"
+        "    t2 -->|a| b1\n"
+    )
+    graph = parse_metro_mermaid(mmd)
+    compute_layout(graph)
+    top = graph.sections["top"]
+    struct_h = graph._struct_height_below_top.get("top")
+    settled_h = _settled_height_below_top(graph, top)
+    assert struct_h is not None and settled_h is not None
+    # Safe direction only: structural must not fall short of settled (a shortfall
+    # makes the cascade stack the row below too high and risk overlap).
+    assert struct_h >= settled_h - DEFAULT_TOLERANCE, (
+        f"off-track section under-predicted: struct {struct_h:.1f} < settled "
+        f"{settled_h:.1f}; snapshot must run after the off-track lift"
     )
 
 


### PR DESCRIPTION
## What

The inter-row cascade (Stage 6.13 phase 2) stacks lower grid rows from a **structural snapshot** of each section's content height below its bbox top, captured before the opportunistic Pass C compaction phases. That snapshot ran *before* the off-track lift (Stage 5.2).

The off-track lift raises a section's bbox top to seat a lifted input (e.g. a FASTQ/CSV file node) above the trunk. Capturing the height-below-top *before* that lift stored a value **short of the settled extent** for any section with an off-track input. That is the unsafe direction (structural < settled): the cascade would then stack the row below it that much too high, risking overlap.

## Fix

Move the snapshot to just after the off-track lift and canvas re-shift, before the compaction phases begin. Sections without off-track inputs are unaffected (the lift is a no-op for them).

## Render impact

**Byte-identical** for every gallery fixture (the cascade is row-max dominated, so the per-section correction never shifts a binding constraint in the current corpus). The move also makes `differentialabundance_default`'s row-ending extent exact, so its now-stale `KNOWN_DIVERGENT` entry is removed.

## Tests

- `test_off_track_lift_not_under_predicted` - a two-row graph whose top section has an off-track input must not store a structural height short of settled (fails on main: struct 100 < settled 140; passes after the move).
- Existing parametrised tolerance/divergence tests still pass with the trimmed registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)