### PR TITLE
fix(labels): scope diagonal-label column pitch per component (#581)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -478,7 +478,7 @@ def compute_layout(
         from nf_metro.layout.labels import diagonal_label_pitch_by_section
         from nf_metro.layout.rail_mode import retrofit_section_rails
 
-        section_x_spacing = diagonal_label_pitch_by_section(graph, x_spacing)
+        section_pitch_map = diagonal_label_pitch_by_section(graph, x_spacing)
         for sid in rail_section_ids:
             section = graph.sections.get(sid)
             if section is None:
@@ -486,7 +486,7 @@ def compute_layout(
             retrofit_section_rails(
                 graph,
                 section,
-                x_spacing=section_x_spacing.get(sid, x_spacing),
+                x_spacing=section_pitch_map.get(sid, x_spacing),
                 y_spacing=y_spacing,
                 section_x_padding=section_x_padding,
                 section_y_padding=section_y_padding,
@@ -706,13 +706,13 @@ def _compute_section_layout(
     # Stage 1.1: Lay out each section independently (real stations only, no ports)
     from nf_metro.layout.labels import diagonal_label_pitch_by_section
 
-    section_x_spacing = diagonal_label_pitch_by_section(graph, x_spacing)
+    section_pitch_map = diagonal_label_pitch_by_section(graph, x_spacing)
     section_subgraphs: dict[str, MetroGraph] = {}
     for sec_id, section in graph.sections.items():
         sub = _layout_single_section(
             graph,
             section,
-            section_x_spacing.get(sec_id, x_spacing),
+            section_pitch_map.get(sec_id, x_spacing),
             y_spacing,
             section_x_padding,
             section_y_padding,

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -475,8 +475,10 @@ def compute_layout(
         if mode is LineSpread.RAILS
     ]
     if rail_section_ids and graph.line_spread is not LineSpread.RAILS:
+        from nf_metro.layout.labels import diagonal_label_pitch_by_section
         from nf_metro.layout.rail_mode import retrofit_section_rails
 
+        section_x_spacing = diagonal_label_pitch_by_section(graph, x_spacing)
         for sid in rail_section_ids:
             section = graph.sections.get(sid)
             if section is None:
@@ -484,7 +486,7 @@ def compute_layout(
             retrofit_section_rails(
                 graph,
                 section,
-                x_spacing=x_spacing,
+                x_spacing=section_x_spacing.get(sid, x_spacing),
                 y_spacing=y_spacing,
                 section_x_padding=section_x_padding,
                 section_y_padding=section_y_padding,
@@ -702,10 +704,18 @@ def _compute_section_layout(
     # overshoot.  All work in section-local coordinates.
 
     # Stage 1.1: Lay out each section independently (real stations only, no ports)
+    from nf_metro.layout.labels import diagonal_label_pitch_by_section
+
+    section_x_spacing = diagonal_label_pitch_by_section(graph, x_spacing)
     section_subgraphs: dict[str, MetroGraph] = {}
     for sec_id, section in graph.sections.items():
         sub = _layout_single_section(
-            graph, section, x_spacing, y_spacing, section_x_padding, section_y_padding
+            graph,
+            section,
+            section_x_spacing.get(sec_id, x_spacing),
+            y_spacing,
+            section_x_padding,
+            section_y_padding,
         )
         if sub is not None:
             section_subgraphs[sec_id] = sub

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -60,8 +60,12 @@ def _label_text_height(label: str) -> float:
     return FONT_HEIGHT + (n - 1) * FONT_HEIGHT * LABEL_LINE_HEIGHT
 
 
-def diagonal_label_pitch(graph: "MetroGraph", fallback: float) -> float:
-    """Graph-wide column pitch for diagonal (angled) station labels.
+def diagonal_label_pitch(
+    graph: "MetroGraph",
+    fallback: float,
+    section_ids: "set[str] | None" = None,
+) -> float:
+    """Column pitch for diagonal (angled) station labels.
 
     All diagonal labels are drawn at the same angle, so adjacent columns'
     labels are PARALLEL and collide only by their PERPENDICULAR separation, not
@@ -70,9 +74,12 @@ def diagonal_label_pitch(graph: "MetroGraph", fallback: float) -> float:
     row itself plus an equal gap); the column pitch that yields that is
     ``2 * height / sin(angle)``, floored at a marker-collision minimum.
 
-    This is computed once over the whole graph (the tallest label drives it) so
-    every section shares one consistent pitch rather than each section sizing
-    its own.  Returns *fallback* when no label angle is set or no labels exist.
+    The tallest qualifying label drives the pitch so every column in scope
+    shares one consistent pitch rather than each column sizing its own.  With
+    *section_ids* the scope is restricted to stations in those sections, so a
+    disconnected component's tall labels do not inflate another component's
+    pitch (issue #581); ``None`` scopes the whole graph.  Returns *fallback*
+    when no label angle is set or no qualifying label exists in scope.
     """
     from nf_metro.layout.constants import STATION_RADIUS_APPROX
 
@@ -84,6 +91,8 @@ def diagonal_label_pitch(graph: "MetroGraph", fallback: float) -> float:
         return fallback
     tallest = 0.0
     for st in graph.stations.values():
+        if section_ids is not None and st.section_id not in section_ids:
+            continue
         if st.is_port or st.is_hidden or st.off_track:
             continue
         if st.is_blank_terminus:
@@ -95,6 +104,36 @@ def diagonal_label_pitch(graph: "MetroGraph", fallback: float) -> float:
         return fallback
     marker_floor = STATION_RADIUS_APPROX * 3.0
     return max(marker_floor, (tallest * 2.0) / sin_a)
+
+
+def diagonal_label_pitch_by_section(
+    graph: "MetroGraph", fallback: float
+) -> dict[str, float]:
+    """Per-section diagonal-label column pitch, scoped per component.
+
+    A diagonal label angle drives the column pitch off the tallest label in
+    scope.  Scoping that to each weakly-connected component of the section
+    meta-graph stops one component's tall labels (e.g. a disconnected rail
+    panel) inflating another component's columns (issue #581).  Each section
+    maps to its component's pitch.
+
+    Returns an empty map -- a signal to keep the single graph-wide pitch and
+    stay byte-identical -- unless the graph both carries a label angle and
+    splits into two or more components.
+    """
+    if not graph.label_angle or graph.section_dag is None:
+        return {}
+    from nf_metro.layout.section_placement import _weakly_connected_components
+
+    components = _weakly_connected_components(graph, graph.section_dag.section_edges)
+    if len(components) <= 1:
+        return {}
+    per_section: dict[str, float] = {}
+    for comp in components:
+        pitch = diagonal_label_pitch(graph, fallback, section_ids=comp)
+        for sid in comp:
+            per_section[sid] = pitch
+    return per_section
 
 
 @dataclass

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -78,8 +78,8 @@ def diagonal_label_pitch(
     shares one consistent pitch rather than each column sizing its own.  With
     *section_ids* the scope is restricted to stations in those sections, so a
     disconnected component's tall labels do not inflate another component's
-    pitch (issue #581); ``None`` scopes the whole graph.  Returns *fallback*
-    when no label angle is set or no qualifying label exists in scope.
+    pitch; ``None`` scopes the whole graph.  Returns *fallback* when no label
+    angle is set or no qualifying label exists in scope.
     """
     from nf_metro.layout.constants import STATION_RADIUS_APPROX
 
@@ -114,12 +114,12 @@ def diagonal_label_pitch_by_section(
     A diagonal label angle drives the column pitch off the tallest label in
     scope.  Scoping that to each weakly-connected component of the section
     meta-graph stops one component's tall labels (e.g. a disconnected rail
-    panel) inflating another component's columns (issue #581).  Each section
-    maps to its component's pitch.
+    panel) inflating another component's columns.  Each section maps to its
+    component's pitch.
 
-    Returns an empty map -- a signal to keep the single graph-wide pitch and
-    stay byte-identical -- unless the graph both carries a label angle and
-    splits into two or more components.
+    Returns an empty map -- the signal for callers to keep the single
+    graph-wide pitch -- unless the graph both carries a label angle and splits
+    into two or more components.
     """
     if not graph.label_angle or graph.section_dag is None:
         return {}

--- a/tests/test_diagonal_labels.py
+++ b/tests/test_diagonal_labels.py
@@ -309,3 +309,77 @@ def test_angled_trunk_pitch_at_marker_floor():
         graph, station_offsets=offsets, routes=routes, label_angle=45.0
     )
     assert not find_label_overlaps(graph, placements, offsets)
+
+
+_COMPONENT_PITCH_TRUNK_BLOCK = """\
+    subgraph trunk [Trunk]
+        a[Trim]
+        b[Align]
+        c[Call]
+        a -->|dna| b
+        b -->|dna| c
+    end
+"""
+
+_COMPONENT_PITCH_RAIL_BLOCK = """\
+    subgraph panel [Panel]
+        x[Gene sets\\nreference\\ndatabase]
+        y[Score\\nenrichment\\nper set]
+        z[Enrichment\\nstatistical\\ntesting]
+        x -->|rna| y
+        y -->|rna| z
+    end
+"""
+
+
+def _component_graph(with_panel: bool) -> str:
+    """Diagonal-label graph: a normal trunk, optionally plus a tall rail panel.
+
+    Both components are grid-pinned to separate rows so the disconnected panel
+    stacks below the trunk rather than auto-placing into its band.
+    """
+    directives = [
+        "%%metro label_angle: 45",
+        "%%metro line: dna | DNA | #0570b0",
+        "%%metro grid: trunk | 0,0",
+    ]
+    body = _COMPONENT_PITCH_TRUNK_BLOCK
+    if with_panel:
+        directives += [
+            "%%metro line: rna | RNA | #2db572",
+            "%%metro line_spread: rails | panel",
+            "%%metro grid: panel | 0,1",
+        ]
+        body += _COMPONENT_PITCH_RAIL_BLOCK
+    return "\n".join(directives) + "\ngraph LR\n" + body
+
+
+def _component_trunk_pitch(text: str) -> float:
+    """Mean adjacent-station X pitch of the ``trunk`` section."""
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=True)
+    xs = sorted(
+        s.x
+        for s in graph.stations.values()
+        if s.section_id == "trunk" and not s.is_port and not s.is_hidden
+    )
+    deltas = [xs[i + 1] - xs[i] for i in range(len(xs) - 1)]
+    return sum(deltas) / len(deltas)
+
+
+def test_disconnected_rail_panel_does_not_inflate_trunk_pitch():
+    """A disconnected rail panel's tall labels must not widen the trunk (#581).
+
+    With diagonal labels the column pitch derives from the tallest label in
+    scope.  When a normal multi-station trunk and a ``rails`` panel with much
+    taller (multi-line) labels form two disconnected components, the panel's
+    pitch must stay local to the panel: the trunk's column pitch must equal
+    what it would be with the panel absent, not be inflated by the panel.
+    """
+    trunk_alone = _component_trunk_pitch(_component_graph(with_panel=False))
+    trunk_with_panel = _component_trunk_pitch(_component_graph(with_panel=True))
+
+    assert trunk_with_panel == pytest.approx(trunk_alone, abs=0.5), (
+        f"trunk pitch {trunk_with_panel:.1f} with disconnected rail panel "
+        f"differs from {trunk_alone:.1f} without it (panel inflated the trunk)"
+    )

--- a/tests/test_diagonal_labels.py
+++ b/tests/test_diagonal_labels.py
@@ -368,7 +368,7 @@ def _component_trunk_pitch(text: str) -> float:
 
 
 def test_disconnected_rail_panel_does_not_inflate_trunk_pitch():
-    """A disconnected rail panel's tall labels must not widen the trunk (#581).
+    """A disconnected rail panel's tall labels must not widen the trunk.
 
     With diagonal labels the column pitch derives from the tallest label in
     scope.  When a normal multi-station trunk and a ``rails`` panel with much


### PR DESCRIPTION
Fixes #581

## Problem

The diagonal-label column pitch (`diagonal_label_pitch`) derives from the tallest label in scope and was computed once over the whole graph. When a graph has two disconnected (weakly-connected) section components - e.g. the sarek showcase's core trunk (normal mode) plus a disconnected `line_spread: rails` panel - one component's tall labels inflate the other's column spacing. The rail panel's multi-line labels widened the non-rail trunk's columns (and vice-versa).

## Fix

Scope the diagonal-label pitch per weakly-connected component of the section meta-graph. `diagonal_label_pitch` gains an optional `section_ids` scope, and a new `diagonal_label_pitch_by_section` returns a per-section pitch map where each section uses its own component's pitch. The map is applied at the two places the pitch sets a section's internal column step: Stage 1.1 (`_layout_single_section`) and the per-section rail retrofit (`retrofit_section_rails`).

### Gate (byte-identical for everything else)

`diagonal_label_pitch_by_section` returns an empty map - the signal to keep the single graph-wide pitch unchanged - unless the graph **both** carries a `label_angle` **and** splits into 2+ components. Single-component graphs and graphs without diagonal labels are completely unaffected.

## Invariant test

`tests/test_diagonal_labels.py::test_disconnected_rail_panel_does_not_inflate_trunk_pitch` - builds a diagonal-label graph with a normal trunk and a disconnected `rails` panel with tall multi-line labels, grid-pinned to separate rows. Asserts the trunk's column pitch with the panel present equals the trunk-alone pitch. Fails on main (134.6 vs 39.6), passes after the fix.

## Gallery classification

Built the full gallery (`scripts/build_gallery.py`) on `main` -> `/tmp/base_581` and on this branch -> `/tmp/pr_581`. **All 77 rendered SVGs are byte-identical.** No gallery example combines `label_angle` with multiple disconnected components, so the gate keeps the fix dormant across the entire gallery:

- `diagonal_labels.mmd`: has `label_angle`, single component -> empty map -> unchanged.
- `rail_section.mmd`, `line_spread.mmd`: no `label_angle` -> empty map -> unchanged.
- `rail_mode.mmd`: graph-wide `rails` mode returns early before this path, single component -> unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)