### PR TITLE
fix(off-track): single-trunk sections lift by base pitch, not diagonal-widened (#580)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -521,11 +521,15 @@ in pipeline order.
 - **Helper**: `_lift_off_track_stations`.
 - **Precondition**: Stage 5.1 complete; all on-track Ys final.
 - **Postcondition**: Each off-track station sits at
-  `anchor.y - n*y_spacing` (n = stack rank). Section bbox extends
-  upward to fit.  May leave the topmost section above the canvas
-  margin -- ``_shift_graph_into_canvas`` runs immediately afterwards
-  to restore the margin (called explicitly by the caller, not by
-  the helper).
+  `anchor.y - n*step` (n = stack rank). The lift `step` is `y_spacing`
+  for multi-track sections; a single-trunk LR/RL section (one distinct
+  on-track Y) uses the base content pitch `graph._base_y_spacing`
+  instead, so the diagonal-label widening of `y_spacing` doesn't strand
+  the icon far above the trunk (issue #580, helper
+  `_off_track_lift_step`). Section bbox extends upward to fit.  May leave
+  the topmost section above the canvas margin --
+  ``_shift_graph_into_canvas`` runs immediately afterwards to restore the
+  margin (called explicitly by the caller, not by the helper).
 - **Invariants preserved**: On-track station Y. Other sections' Ys
   (only the canvas Y-offset may shift the world uniformly).
 - **Related tests**: `test_off_track_inputs_above_consumer`,

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -142,6 +142,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_section_bboxes_positive,
     _guard_section_top_padding,
     _guard_serpentine_no_backtrack,
+    _guard_single_trunk_off_track_step,
     _guard_station_x_column_drift,
     _guard_stations_in_sections,
     _guard_stations_within_bbox,
@@ -407,7 +408,13 @@ def compute_layout(
     auto_x = x_spacing is None
     auto_y = y_spacing is None
     if y_spacing is None:
+        # The base content pitch before the spread loop widens it for
+        # diagonal labels.  A single-trunk section's off-track lift step
+        # stays at this base so a widened pitch doesn't strand the icon far
+        # above the trunk (issue #580).  Only recorded when y_spacing is
+        # auto-resolved; an explicit pin is honoured verbatim.
         y_spacing = compute_min_y_spacing(graph)
+        graph._base_y_spacing = y_spacing
     else:
         min_required = compute_min_y_spacing(graph)
         if y_spacing < min_required - 1e-6:
@@ -502,6 +509,7 @@ def compute_layout(
         _guard_file_icon_no_name_label(graph, "final")
         _guard_centered_line_spread_balanced(graph, "final")
         _guard_rail_above_label_band(graph, "final")
+        _guard_single_trunk_off_track_step(graph, "final")
 
 
 def _snap(graph: MetroGraph, phase_id: str) -> None:

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -34,8 +34,8 @@ from nf_metro.layout.phases._common import (
 )
 from nf_metro.layout.phases.bbox import _section_fit_top
 from nf_metro.layout.phases.off_track import (
+    _is_single_trunk_lr_section,
     _off_track_anchor_of,
-    _section_distinct_trunk_ys,
 )
 from nf_metro.layout.phases.single_section import _terminus_y_overhang
 from nf_metro.layout.phases.spacing import (
@@ -612,10 +612,10 @@ def _guard_single_trunk_off_track_step(graph: MetroGraph, phase: str) -> None:
     A section that is a single horizontal trunk has no parallel tracks, so
     its off-track lift step stays at the base content pitch
     (``graph._base_y_spacing``) rather than the spread-widened ``y_spacing``
-    (issue #580).  When the base pitch was recorded (auto ``y_spacing``) and
-    is below the widened pitch, each off-track station in such a section must
-    sit an integer number of base steps above its anchor, never at the wider
-    pitch that would strand the icon far above the trunk.
+    (issue #580).  When the base pitch is recorded (auto ``y_spacing``), each
+    off-track station in such a section must sit an integer number of base
+    steps above its anchor, never at a wider pitch that would strand the icon
+    far above the trunk.
     """
     base = graph._base_y_spacing
     if base is None or base <= 0:
@@ -629,15 +629,13 @@ def _guard_single_trunk_off_track_step(graph: MetroGraph, phase: str) -> None:
         if off_st is None or anchor is None:
             continue
         section = graph.sections.get(off_st.section_id or "")
-        if section is None or section.direction not in ("LR", "RL"):
-            continue
-        if len(_section_distinct_trunk_ys(graph, section, junction_ids)) > 1:
+        if not _is_single_trunk_lr_section(graph, section, junction_ids):
             continue
         gap = anchor.y - off_st.y
         if gap <= tol:
             continue
-        steps = gap / base
-        if abs(steps - round(steps)) > tol / base:
+        nearest_multiple = round(gap / base) * base
+        if abs(gap - nearest_multiple) > tol:
             raise PhaseInvariantError(
                 f"{phase}: off-track {off_id!r} sits {gap:.1f}px above anchor "
                 f"{anchor_id!r} on single-trunk section {section.id!r}, not an "

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -629,7 +629,9 @@ def _guard_single_trunk_off_track_step(graph: MetroGraph, phase: str) -> None:
         if off_st is None or anchor is None:
             continue
         section = graph.sections.get(off_st.section_id or "")
-        if not _is_single_trunk_lr_section(graph, section, junction_ids):
+        if section is None or not _is_single_trunk_lr_section(
+            graph, section, junction_ids
+        ):
             continue
         gap = anchor.y - off_st.y
         if gap <= tol:

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -33,7 +33,10 @@ from nf_metro.layout.phases._common import (
     routes_through_unrelated_sections,
 )
 from nf_metro.layout.phases.bbox import _section_fit_top
-from nf_metro.layout.phases.off_track import _off_track_anchor_of
+from nf_metro.layout.phases.off_track import (
+    _off_track_anchor_of,
+    _section_distinct_trunk_ys,
+)
 from nf_metro.layout.phases.single_section import _terminus_y_overhang
 from nf_metro.layout.phases.spacing import (
     _placed_name_label_station_ids,
@@ -601,6 +604,46 @@ def _guard_terminus_icons_within_bbox(graph: MetroGraph, phase: str) -> None:
                     f"{st.y - above:.1f}, above section {section.id!r} bbox "
                     f"top {top:.1f}"
                 )
+
+
+def _guard_single_trunk_off_track_step(graph: MetroGraph, phase: str) -> None:
+    """Single-trunk sections lift off-track stations by the base pitch.
+
+    A section that is a single horizontal trunk has no parallel tracks, so
+    its off-track lift step stays at the base content pitch
+    (``graph._base_y_spacing``) rather than the spread-widened ``y_spacing``
+    (issue #580).  When the base pitch was recorded (auto ``y_spacing``) and
+    is below the widened pitch, each off-track station in such a section must
+    sit an integer number of base steps above its anchor, never at the wider
+    pitch that would strand the icon far above the trunk.
+    """
+    base = graph._base_y_spacing
+    if base is None or base <= 0:
+        return
+    anchor_of = _off_track_anchor_of(graph)
+    junction_ids = graph.junction_ids
+    tol = 1.0
+    for off_id, anchor_id in anchor_of.items():
+        off_st = graph.stations.get(off_id)
+        anchor = graph.stations.get(anchor_id)
+        if off_st is None or anchor is None:
+            continue
+        section = graph.sections.get(off_st.section_id or "")
+        if section is None or section.direction not in ("LR", "RL"):
+            continue
+        if len(_section_distinct_trunk_ys(graph, section, junction_ids)) > 1:
+            continue
+        gap = anchor.y - off_st.y
+        if gap <= tol:
+            continue
+        steps = gap / base
+        if abs(steps - round(steps)) > tol / base:
+            raise PhaseInvariantError(
+                f"{phase}: off-track {off_id!r} sits {gap:.1f}px above anchor "
+                f"{anchor_id!r} on single-trunk section {section.id!r}, not an "
+                f"integer multiple of the base step {base:.1f} -- the widened "
+                f"diagonal-label pitch leaked into the lift"
+            )
 
 
 def _guard_no_station_overlap(

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -458,6 +458,56 @@ def _off_track_groups(
     return result
 
 
+def _section_distinct_trunk_ys(
+    graph: MetroGraph,
+    section: Section,
+    junction_ids: set[str],
+) -> set[float]:
+    """Distinct Y values of a section's on-track (trunk) stations.
+
+    On-track means a real, visible station: not a port, hidden phantom,
+    junction, or off-track artefact.  Used to detect single-trunk sections
+    (one distinct Y), which carry no parallel tracks.
+    """
+    return {
+        round(st.y, 1)
+        for sid in section.station_ids
+        if (st := graph.stations.get(sid)) is not None
+        and not st.is_port
+        and not st.is_hidden
+        and not st.off_track
+        and sid not in junction_ids
+    }
+
+
+def _off_track_lift_step(
+    graph: MetroGraph,
+    section: Section | None,
+    junction_ids: set[str],
+    y_spacing: float,
+) -> float:
+    """Per-section vertical step for lifting off-track stations.
+
+    A section that is a single horizontal trunk (one distinct on-track Y)
+    has no parallel tracks, so the diagonal-label band that widened the
+    graph-wide ``y_spacing`` is wasted vertical room here: it would strand
+    the off-track icon far above the trunk (issue #580).  Such a section
+    lifts by the base content pitch (``graph._base_y_spacing``) instead.
+
+    Multi-track sections, and any section with no recorded base pitch, keep
+    the passed-in ``y_spacing``.  The base is clamped to ``y_spacing`` so an
+    explicit ``y_spacing`` below the base is never widened by this path.
+    """
+    if section is None or section.direction not in ("LR", "RL"):
+        return y_spacing
+    base = graph._base_y_spacing
+    if base is None or base >= y_spacing:
+        return y_spacing
+    if len(_section_distinct_trunk_ys(graph, section, junction_ids)) > 1:
+        return y_spacing
+    return base
+
+
 def _place_off_track_above_consumers(
     graph: MetroGraph,
     y_spacing: float,
@@ -482,6 +532,8 @@ def _place_off_track_above_consumers(
     section = graph.sections.get(section_id)
     sec_dir = section.direction if section is not None else "LR"
     junction_ids = graph.junction_ids
+
+    step = _off_track_lift_step(graph, section, junction_ids, y_spacing)
 
     # Track already-placed off-track Ys per column so a bumped icon
     # doesn't crash into a sibling off-track already at the desired Y.
@@ -515,13 +567,13 @@ def _place_off_track_above_consumers(
         n = len(stations)
         for i, st in enumerate(stations):
             base_step = n - i
-            candidate_y = consumer_y - base_step * y_spacing
+            candidate_y = consumer_y - base_step * step
             if section is not None and sec_dir in ("LR", "RL"):
                 candidate_y = _bump_off_track_clear_of_trunks(
                     graph,
                     st,
                     candidate_y,
-                    y_spacing,
+                    step,
                     section,
                     junction_ids,
                     sibling_ys=used_ys_per_col[round(st.x, 1)],

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -480,6 +480,19 @@ def _section_distinct_trunk_ys(
     }
 
 
+def _is_single_trunk_lr_section(
+    graph: MetroGraph,
+    section: Section | None,
+    junction_ids: set[str],
+) -> bool:
+    """An LR/RL section laid out as one horizontal trunk (no parallel tracks)."""
+    return (
+        section is not None
+        and section.direction in ("LR", "RL")
+        and len(_section_distinct_trunk_ys(graph, section, junction_ids)) == 1
+    )
+
+
 def _off_track_lift_step(
     graph: MetroGraph,
     section: Section | None,
@@ -488,22 +501,20 @@ def _off_track_lift_step(
 ) -> float:
     """Per-section vertical step for lifting off-track stations.
 
-    A section that is a single horizontal trunk (one distinct on-track Y)
-    has no parallel tracks, so the diagonal-label band that widened the
-    graph-wide ``y_spacing`` is wasted vertical room here: it would strand
-    the off-track icon far above the trunk (issue #580).  Such a section
-    lifts by the base content pitch (``graph._base_y_spacing``) instead.
+    A section that is a single horizontal trunk has no parallel tracks, so the
+    diagonal-label band that widened the graph-wide ``y_spacing`` is wasted
+    vertical room here: it would strand the off-track icon far above the trunk
+    (issue #580).  Such a section lifts by the base content pitch
+    (``graph._base_y_spacing``) instead.
 
-    Multi-track sections, and any section with no recorded base pitch, keep
-    the passed-in ``y_spacing``.  The base is clamped to ``y_spacing`` so an
+    Multi-track sections, and any section with no recorded base pitch, keep the
+    passed-in ``y_spacing``.  The base only applies when strictly smaller, so an
     explicit ``y_spacing`` below the base is never widened by this path.
     """
-    if section is None or section.direction not in ("LR", "RL"):
-        return y_spacing
     base = graph._base_y_spacing
     if base is None or base >= y_spacing:
         return y_spacing
-    if len(_section_distinct_trunk_ys(graph, section, junction_ids)) > 1:
+    if not _is_single_trunk_lr_section(graph, section, junction_ids):
         return y_spacing
     return base
 
@@ -589,7 +600,7 @@ def _bump_off_track_clear_of_trunks(
     graph: MetroGraph,
     off_st: Station,
     candidate_y: float,
-    y_spacing: float,
+    step: float,
     section: Section,
     junction_ids: set[str],
     sibling_ys: list[float] | None = None,
@@ -603,16 +614,16 @@ def _bump_off_track_clear_of_trunks(
     trunk station downstream of the icon (LR: higher X; RL: lower X)
     has tracks at Y values inside ``[candidate_y - icon_half,
     candidate_y + icon_half]``, the segment from the section's entry
-    port to that trunk crosses the icon.  Bump up by ``y_spacing``
-    steps until the band clears.
+    port to that trunk crosses the icon.  Bump up by ``step``
+    increments until the band clears.
 
     ``sibling_ys`` is a list of Ys already taken by other off-track
     inputs in the same column - the bump must also clear those (within
-    one ``y_spacing`` slot) so two icons don't end up in the same row.
+    one ``step`` slot) so two icons don't end up in the same row.
 
     Capped at six steps to avoid runaway lifts.
     """
-    if y_spacing <= 0:
+    if step <= 0:
         return candidate_y
 
     # Match the renderer's terminus icon height and add a small margin
@@ -676,7 +687,7 @@ def _bump_off_track_clear_of_trunks(
     y = candidate_y
     steps = 0
     while _overlaps(y) and steps < MAX_STEPS:
-        y -= y_spacing
+        y -= step
         steps += 1
     return y
 

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -377,6 +377,11 @@ class MetroGraph:
     # rail-mode layout so the dedicated router can resolve a port's per-line
     # rail Y.  Empty when rail mode is off.
     _rail_y: dict[str, dict[str, float]] = field(default_factory=dict, repr=False)
+    # Content pitch from compute_min_y_spacing, before the spread loop widens
+    # y_spacing for diagonal labels.  A single-trunk section's off-track lift
+    # step uses this base pitch so a widened pitch doesn't strand the icon far
+    # above the trunk.  None until compute_layout records it.
+    _base_y_spacing: float | None = field(default=None, repr=False)
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""

--- a/tests/fixtures/diagonal_single_trunk_off_track.mmd
+++ b/tests/fixtures/diagonal_single_trunk_off_track.mmd
@@ -1,0 +1,65 @@
+%%metro title: Diagonal Labels (dense trunk)
+%%metro style: dark
+%%metro label_angle: 45
+%%metro line: germline | Germline | #0570b0
+%%metro line: tumor_only | Tumor only | #d62728
+%%metro line: somatic | Tumor-normal pair | #756bb1
+%%metro file: fastq_in | FASTQ
+%%metro file: vcf_out | VCF
+%%metro off_track: bam_out
+%%metro file: bam_out | BAM
+%%metro grid: preprocessing | 0,0
+%%metro grid: variant_calling | 0,1
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        %%metro exit: right | germline, tumor_only, somatic
+        fastq_in[ ]
+        fastqc[FastQC]
+        fastp[FastP]
+        umi[UMI consensus]
+        bwa[BWA-MEM]
+        merge_index[samtools merge/index]
+        markdup[MarkDuplicates]
+        bqsr[BaseRecalibrator]
+        applybqsr[ApplyBQSR]
+        mosdepth[mosdepth]
+        ngscheckmate[NGSCheckmate]
+
+        fastq_in -->|germline,tumor_only,somatic| fastqc
+        fastqc -->|germline,tumor_only,somatic| fastp
+        fastp -->|germline,tumor_only,somatic| umi
+        umi -->|germline,tumor_only,somatic| bwa
+        bwa -->|germline,tumor_only,somatic| merge_index
+        bwa -->|germline| bam_out
+        bam_out[ ]
+        merge_index -->|germline,tumor_only,somatic| markdup
+        markdup -->|germline,tumor_only,somatic| bqsr
+        bqsr -->|germline,tumor_only,somatic| applybqsr
+        applybqsr -->|germline,tumor_only,somatic| mosdepth
+        mosdepth -->|germline,tumor_only,somatic| ngscheckmate
+    end
+
+    subgraph variant_calling [Variant calling]
+        %%metro entry: left | germline, tumor_only, somatic
+        split[split by analysis]
+        deepvariant[GATK]
+        mutect[Mutect2]
+        strelka[Strelka2]
+        merge_vcf[merge VCFs]
+        vcf_out[ ]
+
+        split -->|germline| deepvariant
+        split -->|tumor_only| mutect
+        split -->|somatic| strelka
+        deepvariant -->|germline| merge_vcf
+        mutect -->|tumor_only| merge_vcf
+        strelka -->|somatic| merge_vcf
+        merge_vcf -->|germline,tumor_only,somatic| vcf_out
+    end
+
+    %% The dense angled-label trunk feeds the variant-calling section in the
+    %% row below, which fans out to three callers (one per line) and fans
+    %% back in at merge VCFs -- exercising the vertical room the hanging
+    %% angled labels need above the row below.
+    ngscheckmate -->|germline,tumor_only,somatic| split

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1035,6 +1035,50 @@ def test_off_track_outputs_above_and_adjacent_to_producer(fixture):
         )
 
 
+def test_single_trunk_off_track_step_not_inflated_by_diagonal_band():
+    """On a single-trunk diagonal-label section, an off-track output hangs
+    one plain off-track step above its producer, not the diagonal-inflated
+    pitch (issue #580).
+
+    ``label_angle`` makes the spread loop widen the graph-wide ``y_spacing``
+    so hanging angled labels clear the row below.  A section that is a single
+    horizontal trunk has no parallel tracks, so that widened pitch is wasted
+    vertical room when used as the off-track lift step: it detaches the icon
+    far above the trunk.  The lift step for such a section must stay at the
+    base content pitch (``compute_min_y_spacing``).
+    """
+    fixture = "diagonal_single_trunk_off_track.mmd"
+    graph = _layout(fixture)
+    base_step = compute_min_y_spacing(graph)
+    producer_of = _off_track_output_sinks(graph)
+    assert producer_of, f"{fixture}: no off-track output sinks found"
+
+    junction_ids = set(graph.junctions)
+    for off_id, prod_id in producer_of.items():
+        off_st = graph.stations[off_id]
+        prod_st = graph.stations[prod_id]
+        section = graph.sections[off_st.section_id]
+        distinct_trunk_ys = {
+            round(graph.stations[sid].y, 1)
+            for sid in section.station_ids
+            if (st := graph.stations.get(sid)) is not None
+            and not st.is_port
+            and not st.is_hidden
+            and not st.off_track
+            and sid not in junction_ids
+        }
+        assert len(distinct_trunk_ys) == 1, (
+            f"{fixture}: section {section.id} is not single-trunk "
+            f"(trunk Ys {sorted(distinct_trunk_ys)})"
+        )
+        gap = prod_st.y - off_st.y
+        assert gap == pytest.approx(base_step, abs=_Y_TOL), (
+            f"{fixture}: off-track output {off_id} sits {gap:.0f}px above its "
+            f"producer {prod_id} on a single-trunk section, inflated past the "
+            f"base off-track step of {base_step:.0f}px by the diagonal-label band"
+        )
+
+
 @pytest.mark.parametrize("fixture", _FIXTURES_WITH_OFF_TRACK_OUTPUT)
 def test_off_track_output_owns_its_column(fixture):
     """An off-track output must occupy its own column, clear of every

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -47,6 +47,7 @@ from nf_metro.layout.phases.off_track import (
     _off_track_fit_top,
     _off_track_groups,
     _reanchor_off_track_to_consumer,
+    _section_distinct_trunk_ys,
 )
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.layout.routing.common import resolve_section
@@ -1058,15 +1059,7 @@ def test_single_trunk_off_track_step_not_inflated_by_diagonal_band():
         off_st = graph.stations[off_id]
         prod_st = graph.stations[prod_id]
         section = graph.sections[off_st.section_id]
-        distinct_trunk_ys = {
-            round(graph.stations[sid].y, 1)
-            for sid in section.station_ids
-            if (st := graph.stations.get(sid)) is not None
-            and not st.is_port
-            and not st.is_hidden
-            and not st.off_track
-            and sid not in junction_ids
-        }
+        distinct_trunk_ys = _section_distinct_trunk_ys(graph, section, junction_ids)
         assert len(distinct_trunk_ys) == 1, (
             f"{fixture}: section {section.id} is not single-trunk "
             f"(trunk Ys {sorted(distinct_trunk_ys)})"


### PR DESCRIPTION
Fixes #580.

## Problem

With `label_angle: 45`, the spread loop widens the graph-wide `y_spacing` so the hanging angled labels clear the row below. The off-track lift places each file output/input at `anchor.y - n*y_spacing`, so it inherited that widened pitch. On a section that is a single horizontal trunk (no parallel tracks), the widened pitch is wasted vertical room and detaches the off-track icon far above the trunk.

Minimal repro: a 3-line single-trunk LR section with `label_angle: 45` feeding a downstream fan-out (which drives the spread loop to widen `y_spacing` 40 -> 68). The off-track output `bam_out` landed 68px above its producer instead of the plain 40px off-track step.

## Fix

Gate the off-track lift step per section (`_off_track_lift_step` in `phases/off_track.py`):

- A single-trunk LR/RL section (one distinct on-track Y, via `_section_distinct_trunk_ys`) lifts by the base content pitch `graph._base_y_spacing`.
- `graph._base_y_spacing` is recorded in `compute_layout` from `compute_min_y_spacing` **only when `y_spacing` is auto-resolved** - an explicit `--y-spacing` pin is honoured verbatim, and the base is below or equal to the widened pitch so this path never widens.
- Multi-track sections keep the passed-in `y_spacing`, so their geometry is unchanged.

Both the Stage 5.2 lift and the Stage 6.6/6.8 reanchor funnel through `_place_off_track_above_consumers`, so the reduced step applies consistently.

A runtime validator `_guard_single_trunk_off_track_step` (run under `compute_layout(validate=True)`) asserts that off-track stations on single-trunk sections sit an integer number of base steps above their anchor, never at the widened pitch.

## Invariant test

`test_single_trunk_off_track_step_not_inflated_by_diagonal_band` in `tests/test_layout_invariants.py` (new fixture `tests/fixtures/diagonal_single_trunk_off_track.mmd`). Fails on `main` (gap 68 vs base 40), passes after the fix.

## Gallery render-diff

`build_render_diff.py` over the full gallery (base vs PR): **No render changes detected** - the existing gallery is byte-identical. No shipped example combines a spread-widened diagonal trunk with off-track stations, so the conditional fix touches nothing else. Two pre-existing unit tests in `test_layout.py` that pin an explicit `y_spacing=55` continue to pass (the auto-only gate keeps explicit pins verbatim).

Full test suite (6906 passed) and `ruff check` / `ruff format --check` are clean.