### PR TITLE
fix(rail): tint spanning interchange with marker fill (#586)

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -21,6 +21,8 @@ from nf_metro.parser.model import (
     ICON_TYPE_DIR,
     ICON_TYPE_FILE,
     ICON_TYPE_FILES,
+    MARKER_FILL_OPEN,
+    MARKER_FILL_SOLID,
     MARKER_SHAPE_PILL,
     MarkerStyle,
     MetroGraph,
@@ -1040,12 +1042,25 @@ def _station_data_attrs(graph: MetroGraph, station: Station) -> dict[str, str]:
     return data
 
 
+def _rail_marker_fill(marker: MarkerStyle | None, theme: Theme) -> str | None:
+    """Interior tint for a spanning rail interchange carrying a marker.
+
+    Only a marker with a literal colour fill (not the ``open`` / ``solid``
+    keywords) tints the interchange; keyword fills and unmarked stations keep
+    the default interior so their glyph is unchanged.
+    """
+    if marker is None or marker.fill in (MARKER_FILL_OPEN, MARKER_FILL_SOLID):
+        return None
+    return marker_fill_color(marker.fill, theme)
+
+
 def _render_rail_pill(
     d: draw.Drawing,
     graph: MetroGraph,
     station: Station,
     theme: Theme,
     r: float,
+    fill_override: str | None = None,
 ) -> None:
     """Render a rail-mode multi-rail station as the metro interchange idiom.
 
@@ -1062,7 +1077,12 @@ def _render_rail_pill(
     the union's outer boundary, then a white layer of the same shapes (at the
     true radii) paints the interior on top.  A rail that falls within the span
     but is NOT used by the station gets no circle; the link passes behind it.
+
+    ``fill_override`` tints the interior layer (link bar + knobs) with a marker
+    fill colour while keeping the interchange shape and dark outline, so a
+    spanning rail station can carry its ``%%metro marker:`` colour.
     """
+    interior_fill = fill_override if fill_override is not None else theme.station_fill
     used_ys = [y for y in station.rail_used_ys] or [station.y]
     top_y = min(used_ys)
     bot_y = max(used_ys)
@@ -1132,12 +1152,12 @@ def _render_rail_pill(
     )
 
     # White interior layer: the same shapes at their true radii, filling the
-    # interior of the outlined union with the station fill.
-    _link_bar(bar_half * 2, theme.station_fill)
+    # interior of the outlined union with the interior fill.
+    _link_bar(bar_half * 2, interior_fill)
     _knobs(
         knob_r,
-        theme.station_fill,
-        theme.station_fill,
+        interior_fill,
+        interior_fill,
         **{"class_": "nf-metro-rail-knob", "data-station-id": station.id},
     )
 
@@ -1221,7 +1241,9 @@ def _render_stations(
             _render_rail_pill(d, graph, station, theme, r)
             continue
         if station.rail_top_y is not None and station.rail_bottom_y is not None:
-            _render_rail_pill(d, graph, station, theme, r)
+            _render_rail_pill(
+                d, graph, station, theme, r, _rail_marker_fill(station.marker, theme)
+            )
             continue
 
         # Determine if this is a TB vertical station (rotated pill)

--- a/tests/fixtures/rail_marker_fill.mmd
+++ b/tests/fixtures/rail_marker_fill.mmd
@@ -1,0 +1,16 @@
+%%metro title: Rail interchange with coloured marker
+%%metro style: dark
+%%metro line_spread: rails
+%%metro line: line_a | Line A | #2db572
+%%metro line: line_b | Line B | #f4a300
+%%metro marker: interchange | circle, #1f4e79
+
+graph LR
+    subgraph proc [Process]
+        src[Source]
+        interchange[Interchange]
+        sink[Sink]
+
+        src -->|line_a,line_b| interchange
+        interchange -->|line_a,line_b| sink
+    end

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1180,3 +1180,57 @@ def test_rail_above_labels_do_not_overlap_section_above():
     render_svg(graph, THEMES["nfcore"])
     overlaps = check_section_overlap(graph)
     assert not overlaps, f"section boxes overlap after label growth: {overlaps}"
+
+
+# ---------------------------------------------------------------------------
+# Coloured-marker fill on a spanning rail interchange (#586)
+# ---------------------------------------------------------------------------
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+RAIL_MARKER_FILL_MMD = FIXTURES / "rail_marker_fill.mmd"
+
+
+def _knob_fills_for_station(svg: str, station_id: str) -> list[str]:
+    """The interior-knob fill colours drawn for ``station_id`` in ``svg``."""
+    import xml.etree.ElementTree as ET
+
+    root = ET.fromstring(svg)
+    fills: list[str] = []
+    for el in root.iter():
+        if el.attrib.get("class") != "nf-metro-rail-knob":
+            continue
+        if el.attrib.get("data-station-id") != station_id:
+            continue
+        fills.append(el.attrib.get("fill", ""))
+    return fills
+
+
+def test_spanning_rail_station_marker_tints_interchange():
+    """A spanning rail station carrying a coloured marker tints its
+    interchange knobs (and link bar) with the marker fill, while keeping the
+    interchange shape; unmarked spanning stations keep the default fill."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = parse_metro_mermaid(RAIL_MARKER_FILL_MMD.read_text())
+    compute_layout(graph)
+
+    interchange = graph.stations["interchange"]
+    assert interchange.rail_top_y is not None
+    assert interchange.rail_bottom_y is not None
+    assert interchange.marker is not None
+    assert interchange.marker.fill == "#1f4e79"
+
+    svg = render_svg(graph, THEMES["nfcore"])
+
+    marked = _knob_fills_for_station(svg, "interchange")
+    assert marked, "interchange must draw rail knobs"
+    assert all(fill == "#1f4e79" for fill in marked), (
+        f"coloured marker must tint the interchange knobs, got {marked}"
+    )
+
+    default_fill = THEMES["nfcore"].station_fill
+    unmarked = _knob_fills_for_station(svg, "src")
+    assert unmarked and all(fill == default_fill for fill in unmarked), (
+        f"unmarked spanning station must keep the default fill, got {unmarked}"
+    )


### PR DESCRIPTION
Fixes #586

## Problem

In `line_spread: rails` mode, a station spanning more than one rail renders as the metro interchange bar via `_render_rail_pill`. That branch in the station render loop runs *before* the marker branch, so a `%%metro marker:` colour on a spanning rail station was silently dropped. Single-rail rail stations honour their marker (they fall through to `_render_marker_station`), producing the inconsistency the issue describes: a two-rail Sentieon caller (e.g. tnscope = tumour + combined) could not show its navy colour while single-rail callers (haplotyper, dnascope) could.

## Change

The marker's literal-colour fill is threaded into `_render_rail_pill` as a new `fill_override` parameter. When set, the white interior layer (the link bar plus the per-rail knobs) is painted with that colour instead of `theme.station_fill`. The interchange shape and the dark outer outline are unchanged - only the fill follows the marker.

A small helper `_rail_marker_fill(marker, theme)` resolves the override and gates it: only a marker carrying a literal colour fill tints the bar. Markers with the `open` / `solid` keyword fills, and unmarked stations, return `None` and keep the default interior, so every existing rail render is byte-identical.

`rail_top_y` / `rail_bottom_y` are only set for genuinely spanning (multi-rail) stations, so single-rail marked stations are untouched and continue through the marker branch.

## Tests

- `tests/test_rail_mode.py::test_spanning_rail_station_marker_tints_interchange` - new invariant test (fails on `main`, passes here): a spanning rail station carrying `%%metro marker: interchange | circle, #1f4e79` draws its interchange knobs with that fill, while an unmarked spanning station on the same diagram keeps the default fill.
- Fixture: `tests/fixtures/rail_marker_fill.mmd` (a two-rail interchange with a coloured marker).

## Gallery classification

`build_gallery` on `main` -> `/tmp/base_586`, on this branch -> `/tmp/pr_586`, compared with `scripts/build_render_diff.py`: **No render changes detected** - all 77 gallery renders byte-identical. No shipped example has a coloured marker on a spanning rail station, so the tint is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)