### PR TITLE
fix(layout): fan uneven reconverging diamonds downward, short branch on trunk

### DIFF
--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -418,6 +418,94 @@ def _is_diamond_fanout(nodes: list[str], G: nx.DiGraph[str]) -> bool:
     return len(common_succs) > 0
 
 
+def _uneven_reconverging_branches(
+    nodes: list[str], G: nx.DiGraph[str], graph: MetroGraph | None
+) -> dict[str, int] | None:
+    """Return per-branch chain lengths when *nodes* form an uneven reconverging diamond.
+
+    A reconverging diamond rejoins at a shared node, but (unlike a classic
+    ``_is_diamond_fanout``) that node need not be an immediate successor: each
+    branch may run as a simple chain through several stations before merging.
+    When the branches reach that single shared reconvergence point in differing
+    numbers of hops, the fork is *uneven*: the short branch should hold the
+    trunk while the longer branch drops below it.
+
+    Detection requires that every branch is a linear chain converging on one
+    common merge node, and that the branch nodes, their shared predecessors,
+    and the merge's feeders are all real (visible, non-port) stations.  Forks
+    whose branches fan out further, or whose members are synthetic port/
+    junction/phantom nodes, keep their existing placement.
+
+    Returns a mapping ``branch -> chain length`` when the fork qualifies,
+    otherwise ``None``.
+    """
+    if graph is None or len(nodes) < 2:
+        return None
+
+    def _is_real(sid: str) -> bool:
+        st = graph.stations.get(sid)
+        return st is not None and not st.is_port and not st.is_hidden
+
+    if not all(_is_real(n) for n in nodes):
+        return None
+
+    shared_preds = set(G.predecessors(nodes[0]))
+    for node in nodes[1:]:
+        shared_preds &= set(G.predecessors(node))
+    if not shared_preds or not all(_is_real(p) for p in shared_preds):
+        return None
+
+    immediate_common = set(G.successors(nodes[0]))
+    for node in nodes[1:]:
+        immediate_common &= set(G.successors(node))
+    if immediate_common:
+        return None
+
+    chains = {node: _linear_chain_to_merge(node, G) for node in nodes}
+    if any(chain is None for chain in chains.values()):
+        return None
+
+    merges = {chain[-1] for chain in chains.values() if chain}
+    if len(merges) != 1:
+        return None
+    merge = merges.pop()
+    if not all(_is_real(p) for p in G.predecessors(merge)):
+        return None
+
+    hops = {node: len(chain) for node, chain in chains.items() if chain}
+    if len(set(hops.values())) < 2:
+        return None
+    return hops
+
+
+def _linear_chain_to_merge(branch: str, G: nx.DiGraph[str]) -> list[str] | None:
+    """Return the linear chain from *branch* up to its reconvergence node.
+
+    A branch qualifies when it runs as a simple chain -- one successor per
+    step and (past the fork) one predecessor per step -- until it reaches a
+    node with more than one predecessor (the reconvergence point).  The
+    returned list runs from *branch* through to that reconvergence node.
+
+    Returns ``None`` when the branch forks, dead-ends, or loops before
+    reconverging.
+    """
+    chain = [branch]
+    node = branch
+    seen = {branch}
+    while True:
+        succs = list(G.successors(node))
+        if len(succs) != 1:
+            return None
+        nxt = succs[0]
+        if nxt in seen:
+            return None
+        chain.append(nxt)
+        if len(list(G.predecessors(nxt))) > 1:
+            return chain
+        seen.add(nxt)
+        node = nxt
+
+
 def _trunk_fanout_node(nodes: list[str], graph: MetroGraph | None) -> str | None:
     """Return the unique fan-out node carrying a strict superset of all siblings.
 
@@ -558,6 +646,22 @@ def _place_fan_out(
         others = [n for n in nodes if n != phantom_trunk]
         for i, node in enumerate(others, 1):
             tracks[node] = anchor - i * fan_spacing
+        return
+
+    # Uneven reconverging diamond: branches rejoin at a shared descendant
+    # after differing numbers of hops.  Keep the shortest branch on the
+    # trunk and drop the longer branches below, so the short branch reads
+    # as the through-line rather than floating on a symmetric loop.
+    uneven_hops = (
+        _uneven_reconverging_branches(nodes, G, graph) if straight_diamonds else None
+    )
+    if uneven_hops is not None:
+        ordered = sorted(
+            nodes, key=lambda node: (uneven_hops[node], bary.get(node, base))
+        )
+        tracks[ordered[0]] = anchor
+        for i, node in enumerate(ordered[1:], 1):
+            tracks[node] = anchor + i * fan_spacing
         return
 
     # Trunk-anchored placement: when one node carries a strict superset

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -461,18 +461,22 @@ def _uneven_reconverging_branches(
     if immediate_common:
         return None
 
-    chains = {node: _linear_chain_to_merge(node, G) for node in nodes}
-    if any(chain is None for chain in chains.values()):
+    chains = {
+        node: chain
+        for node in nodes
+        if (chain := _linear_chain_to_merge(node, G)) is not None
+    }
+    if len(chains) != len(nodes):
         return None
 
-    merges = {chain[-1] for chain in chains.values() if chain}
+    merges = {chain[-1] for chain in chains.values()}
     if len(merges) != 1:
         return None
     merge = merges.pop()
     if not all(_is_real(p) for p in G.predecessors(merge)):
         return None
 
-    hops = {node: len(chain) for node, chain in chains.items() if chain}
+    hops = {node: len(chain) for node, chain in chains.items()}
     if len(set(hops.values())) < 2:
         return None
     return hops
@@ -500,7 +504,7 @@ def _linear_chain_to_merge(branch: str, G: nx.DiGraph[str]) -> list[str] | None:
         if nxt in seen:
             return None
         chain.append(nxt)
-        if len(list(G.predecessors(nxt))) > 1:
+        if G.in_degree(nxt) > 1:
             return chain
         seen.add(nxt)
         node = nxt

--- a/tests/fixtures/uneven_diamond.mmd
+++ b/tests/fixtures/uneven_diamond.mmd
@@ -1,0 +1,18 @@
+%%metro title: Uneven Diamond
+%%metro style: dark
+%%metro line: vc | Variant Calling | #ff0000
+
+graph LR
+    samtools_vc[Samtools]
+    varlociraptor[Varlociraptor]
+    finalise[Finalise]
+    normalise[Normalise]
+    consensus[Consensus]
+    merge[Merge]
+
+    samtools_vc -->|vc| varlociraptor
+    samtools_vc -->|vc| finalise
+    varlociraptor -->|vc| merge
+    finalise -->|vc| normalise
+    normalise -->|vc| consensus
+    consensus -->|vc| merge

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1073,6 +1073,28 @@ def test_straight_diamond_merge_returns_to_trunk():
     assert graph.stations["d"].y == graph.stations["a"].y
 
 
+def test_uneven_reconverging_diamond_short_branch_on_trunk():
+    """An uneven reconverging diamond keeps its short branch on the trunk.
+
+    samtools_vc forks into a one-hop branch (varlociraptor) and a three-hop
+    branch (finalise -> normalise -> consensus) that both rejoin at merge.
+    The short branch shares the trunk Y with the fork and join nodes, and
+    the long branch sits exactly one y-spacing below the trunk.
+    """
+    text = (
+        Path(__file__).resolve().parent / "fixtures" / "uneven_diamond.mmd"
+    ).read_text()
+    graph = parse_metro_mermaid(text)
+    y_spacing = 40.0
+    compute_layout(graph, y_spacing=y_spacing)
+
+    trunk_y = graph.stations["samtools_vc"].y
+    assert graph.stations["varlociraptor"].y == trunk_y
+    assert graph.stations["merge"].y == trunk_y
+    for long_branch in ("finalise", "normalise", "consensus"):
+        assert graph.stations[long_branch].y == trunk_y + y_spacing
+
+
 def _terminal_full_bundle_text():
     """Two full-bundle terminal stations fed from upstream methods.
 


### PR DESCRIPTION
## What this does

In a fork-join "diamond" where the two branches reach a common merge point after **different** numbers of hops, the engine placed them symmetrically (one branch above the trunk, one below). That wasted a vertical grid unit and left the short branch floating on a long horizontal loop.

This change makes uneven reconverging diamonds **fan downward**: the short branch stays on the trunk, and the longer branch(es) drop one row below. The fork and merge stations stay on the trunk, so the short branch reads as the through-line.

Concrete topology (the new `tests/fixtures/uneven_diamond.mmd`):

- `samtools_vc` forks to `varlociraptor` (1 hop to `merge`) and `finalise -> normalise -> consensus -> merge` (3 hops)
- both reconverge at `merge`

`varlociraptor` now shares the trunk Y with `samtools_vc` and `merge`; the `finalise` chain sits exactly one y-spacing below.

## Precondition

Detection is deliberately narrow so balanced diamonds and synthetic fan-ins are untouched. A fan-out group qualifies as an uneven reconverging diamond only when **all** of these hold:

1. It is not already a classic immediate-common diamond (those keep their existing handling).
2. Every branch is a **simple linear chain** (one successor per step, one predecessor per interior step) that converges on a **single** shared merge node.
3. The branch chains reach that merge in **differing** hop counts (the fork is genuinely uneven; equal-length branches stay symmetric).
4. The branch nodes, their shared predecessors, and the merge's feeders are all **real** (visible, non-port, non-hidden) stations.

Conditions 2 and 4 are what isolate the fix. An earlier "all real + uneven" rule alone was too broad: it also caught `variantbenchmarking`'s Output Processing fork (`results_hub -> {merge_res[3], sum_stats[1], bench_summaries[1]} -> multiqc`), where the branches fan out further rather than running as clean chains to a single reconvergence. Requiring linear chains to one merge node excludes that fork while still catching the repro.

## Verification

- **Invariant test** `test_uneven_reconverging_diamond_short_branch_on_trunk` (in `tests/test_layout.py`): fails on `main` (short branch lands at 120 vs trunk 160), passes after the fix (short branch and merge share trunk Y; long branch exactly one y-spacing below). Confirmed by reverting `ordering.py` to `main` with the test present.
- **Gallery byte-identical**: `PYTHONHASHSEED=0 python scripts/build_gallery.py` produces zero changes under `docs/assets/renders/` vs the committed `origin/main` renders. A sweep of the detector across every gallery fixture's fan-out groups returns zero triggers, so the change manifests only on the new fixture (which is not a gallery entry).
- **Suite/lint/types**: `pytest` (6961 passed), `ruff check`, `ruff format --check`, `mypy src/` all clean.

## Runtime guard

No runtime `_guard_*` is added. A post-layout guard would have to re-detect the topology against final geometry, where downstream phases (off-track lifts, grid snap, fold rows) can legitimately shift branch Y. With no qualifying instance anywhere in the gallery to anchor against, a strict final-geometry assertion risks false-positives on real pipelines that embed such a fork alongside other layout forces. The invariant test locks the behavior on the repro fixture instead.