### PR TITLE
fix(render): wrap over-wide file-icon captions across lines

### DIFF
--- a/examples/file_icons.mmd
+++ b/examples/file_icons.mmd
@@ -5,7 +5,7 @@
 %%metro file: ref_in | FASTA | Reference
 %%metro files: reads_in | FASTQ | Reads
 %%metro files: aln_out | BAM | Alignments | banner
-%%metro file: report_out | HTML | Report
+%%metro file: report_out | HTML/PDF | Report
 %%metro dir: results_out | Results
 
 graph LR

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -233,6 +233,10 @@ ICON_LABEL_CLEARANCE: float = 2.5
 """Minimum horizontal clearance (px per side) between the icon label and the
 icon's left/right edges; the label font shrinks to honour it."""
 
+ICON_LABEL_LINE_HEIGHT_RATIO: float = 1.1
+"""Baseline-to-baseline spacing of wrapped icon-label lines, as a multiple of
+the font size."""
+
 FILES_ICON_OFFSET_RATIO: float = 0.15
 """Offset of the back page as a fraction of icon width/height (stacked files icon)."""
 

--- a/src/nf_metro/render/icons.py
+++ b/src/nf_metro/render/icons.py
@@ -44,11 +44,14 @@ def _fit_label_font(label: str, font_size: float, width: float) -> float:
 
 
 def _split_icon_label_tokens(label: str) -> list[str]:
-    """Split ``label`` at ``/`` (kept as a trailing separator) and whitespace.
+    """Split ``label`` at ``/`` and whitespace, keeping the separator on the token.
 
-    A label with no such break point yields a single token, signalling the
-    caller to keep the label on one shrink-to-fit line rather than break a word
-    mid-character."""
+    A ``/`` stays as a trailing character and a whitespace break becomes a
+    trailing space, so concatenating the tokens of a line reconstructs the
+    original spacing (``BAM/`` + ``CRAM`` -> ``BAM/CRAM``; ``FASTQ `` + ``BAM``
+    -> ``FASTQ BAM``). A label with no break point yields a single token,
+    signalling the caller to keep it on one shrink-to-fit line rather than
+    break a word mid-character."""
     tokens: list[str] = []
     buf = ""
     for ch in label:
@@ -58,7 +61,7 @@ def _split_icon_label_tokens(label: str) -> list[str]:
             buf = ""
         elif ch.isspace():
             if buf.strip():
-                tokens.append(buf.strip())
+                tokens.append(buf.strip() + " ")
             buf = ""
     if buf.strip():
         tokens.append(buf.strip())
@@ -90,7 +93,7 @@ def _wrap_icon_label(label: str, font_size: float, width: float) -> list[str]:
             current += token
     if current:
         lines.append(current)
-    return [line for line in lines if line] or [label]
+    return [stripped for line in lines if (stripped := line.rstrip())] or [label]
 
 
 def _append_icon_label(
@@ -106,28 +109,12 @@ def _append_icon_label(
     """Render the format label as bold coloured text centred at ``text_y``.
 
     A label that fits the icon's usable width renders as a single line. A wider
-    label wraps onto stacked lines (splitting on ``/`` or whitespace, then
-    characters) centred vertically around ``text_y``, so the font stays legible
-    instead of shrinking to a sliver."""
+    label wraps onto stacked lines split on ``/`` or whitespace, centred
+    vertically around ``text_y``; a label with no break point shrinks to fit so
+    the font stays legible instead of breaking a word mid-character."""
     if not label:
         return
     lines = _wrap_icon_label(label, font_size, width)
-    if len(lines) == 1:
-        d.append(
-            draw.Text(
-                label,
-                _fit_label_font(label, font_size, width),
-                cx,
-                text_y,
-                fill=font_color,
-                font_family=font_family,
-                font_weight="bold",
-                text_anchor="middle",
-                dy=TEXT_VCENTER_DY,
-            )
-        )
-        return
-
     line_height = font_size * ICON_LABEL_LINE_HEIGHT_RATIO
     top_y = text_y - line_height * (len(lines) - 1) / 2
     for i, line in enumerate(lines):

--- a/src/nf_metro/render/icons.py
+++ b/src/nf_metro/render/icons.py
@@ -22,19 +22,75 @@ from nf_metro.render.constants import (
     ICON_FOLD_OVERLAY_OPACITY,
     ICON_LABEL_CHAR_WIDTH_RATIO,
     ICON_LABEL_CLEARANCE,
+    ICON_LABEL_LINE_HEIGHT_RATIO,
     ICON_TEXT_OFFSET_RATIO,
     TEXT_VCENTER_DY,
 )
+
+
+def _label_text_width(label: str, font_size: float) -> float:
+    """Estimated rendered width of ``label`` at ``font_size``."""
+    return len(label) * font_size * ICON_LABEL_CHAR_WIDTH_RATIO
 
 
 def _fit_label_font(label: str, font_size: float, width: float) -> float:
     """Shrink ``font_size`` so ``label`` keeps ``ICON_LABEL_CLEARANCE`` clear of
     the icon's left/right edges; returns ``font_size`` unchanged when it fits."""
     max_width = width - 2 * ICON_LABEL_CLEARANCE
-    text_width = len(label) * font_size * ICON_LABEL_CHAR_WIDTH_RATIO
+    text_width = _label_text_width(label, font_size)
     if max_width > 0 and text_width > max_width:
         return font_size * max_width / text_width
     return font_size
+
+
+def _split_icon_label_tokens(label: str) -> list[str]:
+    """Split ``label`` at ``/`` (kept as a trailing separator) and whitespace.
+
+    A label with no such break point yields a single token, signalling the
+    caller to keep the label on one shrink-to-fit line rather than break a word
+    mid-character."""
+    tokens: list[str] = []
+    buf = ""
+    for ch in label:
+        buf += ch
+        if ch == "/":
+            tokens.append(buf)
+            buf = ""
+        elif ch.isspace():
+            if buf.strip():
+                tokens.append(buf.strip())
+            buf = ""
+    if buf.strip():
+        tokens.append(buf.strip())
+    return tokens
+
+
+def _wrap_icon_label(label: str, font_size: float, width: float) -> list[str]:
+    """Break ``label`` into stacked lines each fitting the icon's usable width.
+
+    Splits are made on ``/`` then whitespace so format names like ``BAM/CRAM``
+    break at the slash. A label that fits, or that has no break point (a single
+    word), stays on one line so it shrinks to fit instead of breaking mid-word.
+    """
+    max_width = width - 2 * ICON_LABEL_CLEARANCE
+    if max_width <= 0 or _label_text_width(label, font_size) <= max_width:
+        return [label]
+
+    tokens = _split_icon_label_tokens(label)
+    if len(tokens) <= 1:
+        return [label]
+
+    lines: list[str] = []
+    current = ""
+    for token in tokens:
+        if current and _label_text_width(current + token, font_size) > max_width:
+            lines.append(current)
+            current = token
+        else:
+            current += token
+    if current:
+        lines.append(current)
+    return [line for line in lines if line] or [label]
 
 
 def _append_icon_label(
@@ -47,23 +103,47 @@ def _append_icon_label(
     font_color: str,
     font_family: str,
 ) -> None:
-    """Render the format label as bold coloured text centred at ``text_y``,
-    shrinking the font to stay clear of the icon's left/right edges."""
+    """Render the format label as bold coloured text centred at ``text_y``.
+
+    A label that fits the icon's usable width renders as a single line. A wider
+    label wraps onto stacked lines (splitting on ``/`` or whitespace, then
+    characters) centred vertically around ``text_y``, so the font stays legible
+    instead of shrinking to a sliver."""
     if not label:
         return
-    d.append(
-        draw.Text(
-            label,
-            _fit_label_font(label, font_size, width),
-            cx,
-            text_y,
-            fill=font_color,
-            font_family=font_family,
-            font_weight="bold",
-            text_anchor="middle",
-            dy=TEXT_VCENTER_DY,
+    lines = _wrap_icon_label(label, font_size, width)
+    if len(lines) == 1:
+        d.append(
+            draw.Text(
+                label,
+                _fit_label_font(label, font_size, width),
+                cx,
+                text_y,
+                fill=font_color,
+                font_family=font_family,
+                font_weight="bold",
+                text_anchor="middle",
+                dy=TEXT_VCENTER_DY,
+            )
         )
-    )
+        return
+
+    line_height = font_size * ICON_LABEL_LINE_HEIGHT_RATIO
+    top_y = text_y - line_height * (len(lines) - 1) / 2
+    for i, line in enumerate(lines):
+        d.append(
+            draw.Text(
+                line,
+                _fit_label_font(line, font_size, width),
+                cx,
+                top_y + i * line_height,
+                fill=font_color,
+                font_family=font_family,
+                font_weight="bold",
+                text_anchor="middle",
+                dy=TEXT_VCENTER_DY,
+            )
+        )
 
 
 def _append_icon_banner_band(

--- a/tests/fixtures/icon_caption_wrap.mmd
+++ b/tests/fixtures/icon_caption_wrap.mmd
@@ -1,0 +1,9 @@
+%%metro title: icon wrap
+graph LR
+  subgraph s [S]
+    a[Start]
+    out[ ]
+    a -->|main| out
+  end
+%%metro line: main | Main | #3b82f6
+%%metro files: out | BAM/CRAM

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -457,6 +457,18 @@ def test_wide_file_icon_label_wraps_within_icon_width():
         )
 
 
+def test_icon_label_wrap_keeps_separators():
+    """Wrapping keeps a ``/`` joined to its left token and restores the space
+    between whitespace-separated words; labels that fit or have no break point
+    stay on one line."""
+    from nf_metro.render.icons import _wrap_icon_label
+
+    assert _wrap_icon_label("BAM/CRAM", 12.0, 40.0) == ["BAM/", "CRAM"]
+    assert _wrap_icon_label("FASTQ to BAM", 12.0, 70.0) == ["FASTQ to", "BAM"]
+    assert _wrap_icon_label("BAM/CRAM", 12.0, 999.0) == ["BAM/CRAM"]
+    assert _wrap_icon_label("Results", 12.0, 40.0) == ["Results"]
+
+
 def test_render_multi_icon_fixture():
     """The 05b_multi_icons.mmd example renders without errors."""
     from pathlib import Path

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -426,6 +426,37 @@ def test_render_file_icon_no_name_no_caption():
     assert "FASTQ" in svg
 
 
+def test_wide_file_icon_label_wraps_within_icon_width():
+    """A file-icon label wider than the glyph wraps onto stacked lines, each
+    of which fits the icon width rather than overflowing it."""
+    from pathlib import Path
+
+    from nf_metro.render.constants import (
+        ICON_LABEL_CHAR_WIDTH_RATIO,
+        ICON_LABEL_CLEARANCE,
+    )
+
+    fixture = Path(__file__).parent / "fixtures" / "icon_caption_wrap.mmd"
+    graph = parse_metro_mermaid(fixture.read_text())
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+
+    pieces = re.findall(r'font-size="([0-9.]+)"[^>]*>([^<]*BAM[^<]*|CRAM)</text>', svg)
+    assert pieces, "wrapped BAM/CRAM label pieces not found in SVG"
+    assert all("BAM/CRAM" not in text for _, text in pieces), (
+        "label must wrap rather than render as a single over-wide line"
+    )
+
+    max_width = NFCORE_THEME.terminus_width - 2 * ICON_LABEL_CLEARANCE
+    tolerance = 1.0
+    for font_size, text in pieces:
+        line_width = len(text) * float(font_size) * ICON_LABEL_CHAR_WIDTH_RATIO
+        assert line_width <= max_width + tolerance, (
+            f"wrapped line {text!r} width {line_width:.1f} exceeds "
+            f"icon usable width {max_width:.1f}"
+        )
+
+
 def test_render_multi_icon_fixture():
     """The 05b_multi_icons.mmd example renders without errors."""
     from pathlib import Path


### PR DESCRIPTION
## Problem

A file/terminus icon's format label that is wider than the icon glyph (for example `BAM/CRAM` from a `%%metro files: <node> | BAM/CRAM` directive) was shrunk to a tiny single line so it would fit horizontally. The result was an illegible sliver of text rather than a readable caption.

## Fix

`render/icons.py` now wraps an over-wide icon label onto multiple stacked lines:

- Wrap is attempted only when the label does not fit the icon's usable width at the nominal font size.
- Splits are made on `/` (kept as a trailing separator) then whitespace (the inter-word space is preserved), so `BAM/CRAM` breaks into `BAM/` and `CRAM` and `FASTQ to BAM` keeps its spaces.
- A label that already fits, or a single word with no break point, stays on one line and follows the existing shrink-to-fit path, so its output is unchanged. This avoids ugly mid-word character breaks.
- Stacked lines are centred vertically on the existing caption baseline; per-line font shrink still applies as a safety net.

A new `ICON_LABEL_LINE_HEIGHT_RATIO` constant controls the baseline-to-baseline spacing of wrapped lines.

## Tests

- New fixture `tests/fixtures/icon_caption_wrap.mmd` with a wide `BAM/CRAM` file-icon label.
- `test_wide_file_icon_label_wraps_within_icon_width` asserts the label wraps (no single over-wide line) and that each wrapped line's estimated width fits the icon's usable width. It fails on `main` and passes with this change.
- `test_icon_label_wrap_keeps_separators` locks the `/` and whitespace separator handling.

## Gallery

The `file_icons` showcase now carries a wide `HTML/PDF` caption on its `report_out` file icon, so the rendered gallery visibly demonstrates the wrap (the single-line `HTML` caption on `main` becomes a stacked `HTML/` + `PDF`). The banner `BAM` strip on `aln_out` keeps its single-line coverage. All other gallery renders are byte-identical to a fresh `origin/main` build; single-word icon captions keep their existing shrink-to-fit single line.
