### PR TITLE
fix(rail): seat markers on their rail and align diagonal labels above the bundle

### DIFF
--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -1045,14 +1045,16 @@ def place_labels(
         # which lets densely-spaced stations share a compact horizontal
         # line without their long names colliding.
         if label_angle:
-            # In a rail panel the side is dictated by the station's rail (top
-            # rail above, every other single-rail station below) so top-line
-            # names sit outside the bundle; elsewhere a tilted label flips above
+            # In a rail panel every tilted label hangs ABOVE the topmost rail:
+            # the above anchor resolves to ``top_rail - label_offset -
+            # DIAGONAL_LABEL_OFFSET`` (``min_off`` reaches the panel's top rail),
+            # so all the panel's labels share one bottom-edge baseline and read
+            # as a tidy row of angled names above the rail bundle.  Outside a
+            # rail panel a tilted label hangs below the trunk and flips above
             # only to clear a fork sibling sitting directly below it.
+            in_rail_panel = station.section_id in panel_extents
             diag_above = (
-                rail_side
-                if rail_side is not None
-                else _diagonal_prefer_above(graph, station)
+                True if in_rail_panel else _diagonal_prefer_above(graph, station)
             )
             if diag_above:
                 # Mirror the tilt across the trunk: anchor at the pill top and

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -1045,17 +1045,14 @@ def place_labels(
         # which lets densely-spaced stations share a compact horizontal
         # line without their long names colliding.
         if label_angle:
-            # In a rail panel every tilted label hangs ABOVE the topmost rail:
-            # the above anchor resolves to ``top_rail - label_offset -
-            # DIAGONAL_LABEL_OFFSET`` (``min_off`` reaches the panel's top rail),
-            # so all the panel's labels share one bottom-edge baseline and read
-            # as a tidy row of angled names above the rail bundle.  Outside a
-            # rail panel a tilted label hangs below the trunk and flips above
-            # only to clear a fork sibling sitting directly below it.
+            # In a rail panel every tilted label hangs ABOVE the topmost rail
+            # on a shared baseline (the above anchor measures from ``min_off``,
+            # the panel's top rail), so the panel's labels read as a tidy row of
+            # angled names above the bundle.  Outside a rail panel a tilted label
+            # hangs below the trunk and flips above only to clear a fork sibling
+            # sitting directly below it.
             in_rail_panel = station.section_id in panel_extents
-            diag_above = (
-                True if in_rail_panel else _diagonal_prefer_above(graph, station)
-            )
+            diag_above = in_rail_panel or _diagonal_prefer_above(graph, station)
             if diag_above:
                 # Mirror the tilt across the trunk: anchor at the pill top and
                 # read up-and-to-the-right, clearing a fork sibling below.

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -455,14 +455,12 @@ def _rail_above_label_stations(
 
     def _labelled(sid: str) -> bool:
         st = graph.stations.get(sid)
-        return not (st is None or st.is_port or st.off_track or st.is_blank_terminus)
+        if st is None or st.is_port or st.off_track or st.is_blank_terminus:
+            return False
+        return bool(st.label.strip())
 
     if graph.label_angle:
-        return {
-            sid
-            for sid in real_ids
-            if _labelled(sid) and graph.stations[sid].label.strip()
-        }
+        return {sid for sid in real_ids if _labelled(sid)}
 
     threshold = _rail_above_threshold(per_line_y)
     if threshold is None:

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -441,22 +441,35 @@ def _rail_above_label_stations(
     real_ids: list[str],
     per_line_y: dict[str, float],
 ) -> set[str]:
-    """Single-rail stations whose labels hang above (those on the top rail).
+    """Stations whose labels hang above the top rail (so the box reserves room).
 
-    Mirrors ``labels._rail_label_side``: a station sitting on the topmost rail
-    labels above; a spanning (multi-rail) station keeps layer alternation and is
-    excluded.  Uses each station's line rail Y (station ``y`` is not yet
-    assigned when this runs) against the top-rail threshold.
+    With a diagonal label angle every rail-panel label is forced above the
+    topmost rail on a shared baseline (see ``labels.place_labels``), so the band
+    above the rails must clear *every* label-bearing station, not just those on
+    the top rail.  Without an angle the rule mirrors ``labels._rail_label_side``:
+    only a station sitting on the topmost rail labels above; a spanning
+    (multi-rail) station keeps layer alternation and is excluded.  Uses each
+    station's line rail Y (station ``y`` is not yet assigned when this runs).
     """
     from nf_metro.layout.labels import _rail_above_threshold
+
+    def _labelled(sid: str) -> bool:
+        st = graph.stations.get(sid)
+        return not (st is None or st.is_port or st.off_track or st.is_blank_terminus)
+
+    if graph.label_angle:
+        return {
+            sid
+            for sid in real_ids
+            if _labelled(sid) and graph.stations[sid].label.strip()
+        }
 
     threshold = _rail_above_threshold(per_line_y)
     if threshold is None:
         return set()
     above: set[str] = set()
     for sid in real_ids:
-        st = graph.stations.get(sid)
-        if st is None or st.is_port or st.off_track or st.is_blank_terminus:
+        if not _labelled(sid):
             continue
         station_ys = {
             per_line_y[lid]

--- a/tests/fixtures/rail_diagonal_labels.mmd
+++ b/tests/fixtures/rail_diagonal_labels.mmd
@@ -1,0 +1,19 @@
+%%metro title: Rail diagonal labels
+%%metro style: dark
+%%metro line_spread: rails
+%%metro label_angle: 45
+%%metro line: germline | Germline | #2db572
+%%metro line: tumor | Tumour | #f4a300
+%%metro line: pair | Pair | #0570b0
+
+graph LR
+    subgraph calling [Variant calling]
+        bqsr[BQSR]
+        callvar[Call variants]
+        somatic[Somatic filter]
+        concord[Concordance]
+
+        bqsr -->|germline,tumor,pair| callvar
+        callvar -->|germline,tumor,pair| somatic
+        somatic -->|germline,tumor,pair| concord
+    end

--- a/tests/fixtures/rail_single_line_callers.mmd
+++ b/tests/fixtures/rail_single_line_callers.mmd
@@ -1,0 +1,23 @@
+%%metro title: Rail single-line callers
+%%metro style: dark
+%%metro line_spread: rails
+%%metro label_angle: 45
+%%metro line: germline | Germline | #2db572
+%%metro line: tumor | Tumour | #f4a300
+%%metro line: pair | Pair | #0570b0
+
+graph LR
+    subgraph calling [Variant calling]
+        bqsr[BQSR]
+        haplo[HaplotypeCaller]
+        mutect[Mutect2]
+        strelka[Strelka]
+        merge[Merge]
+
+        bqsr -->|germline| haplo
+        bqsr -->|tumor| mutect
+        bqsr -->|pair| strelka
+        haplo -->|germline| merge
+        mutect -->|tumor| merge
+        strelka -->|pair| merge
+    end

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1136,10 +1136,10 @@ _STACKED_RAIL_MMD = (
 )
 
 
-def test_rail_top_rail_label_above_lower_rail_below():
-    """In a rail panel a single-rail station on the top rail labels above and a
-    lower-rail single-rail station labels below, regardless of whether a fork
-    sibling happens to sit in the same column."""
+def test_diagonal_rail_labels_all_hang_above_the_bundle():
+    """In a rail panel with a label angle every station label hangs above the
+    topmost rail (top- and bottom-rail stations alike), so they read as a tidy
+    row of angled names above the bundle rather than splitting either side."""
     from nf_metro.layout.labels import place_labels
     from nf_metro.layout.routing import compute_station_offsets, route_edges
 
@@ -1157,11 +1157,9 @@ def test_rail_top_rail_label_above_lower_rail_below():
         )
         if p.station_id
     }
-    # g2/g3 sit alone in their columns, so the only thing pushing them above is
-    # the top-rail rule (a fork-sibling heuristic would leave them below).
     assert placements["g2"].above, "top-rail station g2 must label above"
     assert placements["g3"].above, "top-rail station g3 must label above"
-    assert not placements["t1"].above, "bottom-rail station t1 must label below"
+    assert placements["t1"].above, "bottom-rail station t1 must label above"
 
 
 def test_rail_above_labels_do_not_overlap_section_above():
@@ -1234,3 +1232,110 @@ def test_spanning_rail_station_marker_tints_interchange():
     assert unmarked and all(fill == default_fill for fill in unmarked), (
         f"unmarked spanning station must keep the default fill, got {unmarked}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Diagonal rail labels: tidy row above the rail bundle; markers seat on rails
+# ---------------------------------------------------------------------------
+
+RAIL_DIAGONAL_LABELS_MMD = FIXTURES / "rail_diagonal_labels.mmd"
+RAIL_SINGLE_LINE_CALLERS_MMD = FIXTURES / "rail_single_line_callers.mmd"
+
+
+def _diagonal_label_placements(graph):
+    """Lay out *graph* and return its non-terminus rail-station label boxes.
+
+    Returns a list of ``(station_id, section_id, bbox_top, bbox_bottom)``,
+    where the bbox is the angled label's enclosing box (so the bottom edge is
+    the visible baseline of the tilted text).
+    """
+    from nf_metro.layout.labels import _label_corners, place_labels
+    from nf_metro.layout.routing.rail import route_rail_edges
+
+    compute_layout(graph, validate=True)
+    routes = route_rail_edges(graph)
+    placements = place_labels(
+        graph, routes=routes, label_angle=graph.label_angle or 0.0
+    )
+    out: list[tuple[str, str, float, float]] = []
+    for lp in placements:
+        st = graph.stations.get(lp.station_id)
+        if st is None or st.is_port or st.is_terminus or not st.label.strip():
+            continue
+        ys = [c[1] for c in _label_corners(lp)]
+        out.append((st.id, st.section_id, min(ys), max(ys)))
+    return out
+
+
+def test_diagonal_rail_labels_sit_above_the_bundle_on_a_common_baseline():
+    """With a label angle, every rail-section station label hangs ABOVE the
+    section's topmost rail and the labels share one bottom-edge baseline, so
+    they read as a tidy row of angled names above the rail bundle."""
+    graph = parse_metro_mermaid(RAIL_DIAGONAL_LABELS_MMD.read_text())
+    assert graph.line_spread is LineSpread.RAILS
+    assert graph.label_angle
+
+    by_section: dict[str, list[tuple[str, float, float]]] = {}
+    for sid, sec_id, top, bot in _diagonal_label_placements(graph):
+        by_section.setdefault(sec_id, []).append((sid, top, bot))
+
+    rails = _section_line_rails(graph)
+    checked = 0
+    for sec_id, labels in by_section.items():
+        if len(labels) < 2:
+            continue
+        section_rails = rails.get(sec_id)
+        assert section_rails, f"{sec_id}: no reconstructable rails"
+        top_rail = min(section_rails.values())
+
+        baselines = [bot for _sid, _top, bot in labels]
+        spread = max(baselines) - min(baselines)
+        assert spread <= 2.0, (
+            f"{sec_id}: diagonal label baselines not aligned (spread {spread:.1f}px)"
+        )
+        for sid, _top, bot in labels:
+            assert bot <= top_rail + 1.0, (
+                f"{sec_id}/{sid}: label baseline {bot:.1f} not above top rail "
+                f"{top_rail:.1f}"
+            )
+        checked += 1
+    assert checked, "fixture must have a section with several diagonal labels"
+
+
+def test_rail_station_markers_seat_on_their_rails():
+    """Every rail-station marker knob sits on one of the rails the station
+    carries: the rendered knob centre matches a line's fixed rail Y.  This
+    holds for spanning interchanges and for single-line callers parked on a
+    non-top rail alike."""
+    import xml.etree.ElementTree as ET
+
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = parse_metro_mermaid(RAIL_SINGLE_LINE_CALLERS_MMD.read_text())
+    compute_layout(graph, validate=True)
+    rails = _section_line_rails(graph)
+
+    svg = render_svg(graph, THEMES["nfcore"])
+    root = ET.fromstring(svg)
+
+    tol = 1.0
+    checked = 0
+    for el in root.iter():
+        if el.attrib.get("class") != "nf-metro-rail-knob":
+            continue
+        sid = el.attrib.get("data-station-id")
+        st = graph.stations.get(sid) if sid else None
+        if st is None or st.is_terminus:
+            continue
+        section_rails = rails.get(st.section_id)
+        if not section_rails:
+            continue
+        cy = float(el.attrib["cy"])
+        nearest = min(section_rails.values(), key=lambda r: abs(r - cy))
+        assert abs(nearest - cy) <= tol, (
+            f"{sid}: marker knob at cy={cy:.2f} is off every rail "
+            f"(nearest {nearest:.2f})"
+        )
+        checked += 1
+    assert checked, "fixture must render rail-station knobs"


### PR DESCRIPTION
## What

Rail mode (`%%metro line_spread: rails`) with diagonal station labels (`%%metro label_angle: 45`) placed each station's angled label on an inconsistent side: a station on the topmost rail labelled above, every other station below. The result split the angled names either side of the rail bundle with no shared baseline, making it hard to associate each label with its station.

This PR forces every diagonal label in a rail panel **above the topmost rail** on a **common bottom-edge baseline**, so they read as a tidy row of angled names above the bundle. The above-label band the section reserves now clears every label-bearing station (not just the top-rail ones), so the section box never grows upward at render time into the section stacked above it.

## Marker-on-rail

The companion symptom (markers sitting off their rail) was investigated exhaustively and does **not** reproduce on the current engine: a rail station's knobs are always drawn at its `rail_used_ys`, which are computed from the same per-section rail map the router uses, so every knob already seats on its line's rail (spanning interchanges, single-line callers on a non-top rail, combo-bundle members, and coloured-marker stations alike). A regression test (`test_rail_station_markers_seat_on_their_rails`) is added to pin this invariant; it passes on `main` and after this change.

## Tests

- `tests/fixtures/rail_diagonal_labels.mmd`, `tests/fixtures/rail_single_line_callers.mmd`.
- `test_diagonal_rail_labels_sit_above_the_bundle_on_a_common_baseline` and `test_diagonal_rail_labels_all_hang_above_the_bundle` fail on `main` (baseline spread ~64px, labels below the rails) and pass after the fix.
- `test_rail_station_markers_seat_on_their_rails` passes on `main` and after the fix.
- The layout-time band reservation is enforced by the existing `_guard_rail_above_label_band`, which now covers all forced-above labels.

## Gallery

`rail_mode.mmd`/`rail_section.mmd` are not committed gallery entries, so the rendered gallery is unaffected: all 77 gallery SVGs are byte-identical to a fresh `origin/main` build (`PYTHONHASHSEED=0 python scripts/build_gallery.py`). The rail improvement was verified by rendering `examples/rail_mode.mmd` and the new fixtures.

Full pytest green; `ruff check`, `ruff format --check`, `mypy src` all clean.