### PR TITLE
fix(rail): seat coloured interchange markers on their rail with a white stroke

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -137,6 +137,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_partial_branch_offset_gaps,
     _guard_ports_on_boundaries,
     _guard_rail_above_label_band,
+    _guard_rail_stations_seat_on_rails,
     _guard_routes_enter_sections_at_ports,
     _guard_row_gaps,
     _guard_row_trunk_cy_consistent,
@@ -513,6 +514,7 @@ def compute_layout(
         _guard_file_icon_no_name_label(graph, "final")
         _guard_centered_line_spread_balanced(graph, "final")
         _guard_rail_above_label_band(graph, "final")
+        _guard_rail_stations_seat_on_rails(graph, "final")
         _guard_single_trunk_off_track_step(graph, "final")
 
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -575,6 +575,42 @@ def _guard_rail_above_label_band(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _guard_rail_stations_seat_on_rails(graph: MetroGraph, phase: str) -> None:
+    """Every rail station's used-rail Ys must land on its lines' fixed rails.
+
+    A rail station records ``rail_used_ys`` parallel to its line order
+    (``rail_mode._layout_section_rails``); the renderer draws a knob at each so
+    the glyph seats on every line it carries.  If a used-rail Y drifts off its
+    line's rail (``graph._rail_y``), the knob, and a coloured-marker
+    interchange's fill, would float off the rail.  Verify the seating directly.
+    """
+    if not graph.has_rail_sections:
+        return
+    tol = 1.0
+    for section in graph.sections.values():
+        if not graph.is_rail_section(section.id):
+            continue
+        per_line = graph._rail_y.get(section.id) or {}
+        if not per_line:
+            continue
+        for sid in section.station_ids:
+            st = graph.stations.get(sid)
+            if st is None or st.is_port or st.off_track or st.is_blank_terminus:
+                continue
+            lines = graph.station_lines_ordered(sid)
+            if len(st.rail_used_ys) != len(lines):
+                continue
+            for lid, y in zip(lines, st.rail_used_ys):
+                rail_y = per_line.get(lid)
+                if rail_y is None:
+                    continue
+                if abs(y - rail_y) > tol:
+                    raise PhaseInvariantError(
+                        f"{phase}: rail station {sid!r} seats line {lid!r} at "
+                        f"y={y:.1f}, off its rail {rail_y:.1f}"
+                    )
+
+
 def _guard_terminus_icons_within_bbox(graph: MetroGraph, phase: str) -> None:
     """Final phase: TB/BT terminus file icons must fit inside the section bbox.
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1071,18 +1071,26 @@ def _render_rail_pill(
     reads as connecting the circles; the dark station stroke forms the OUTER
     boundary of the whole circles+link glyph rather than cutting across it.
 
-    The glyph is built in two stacked layers so the dark outline is continuous
-    and never gaps where the link meets a circle: first a dark layer (the link
+    The glyph is built in two stacked layers so the outline is continuous and
+    never gaps where the link meets a circle: first an outline layer (the link
     bar plus a disc at each used rail, each grown by the stroke width) paints
-    the union's outer boundary, then a white layer of the same shapes (at the
-    true radii) paints the interior on top.  A rail that falls within the span
-    but is NOT used by the station gets no circle; the link passes behind it.
+    the union's outer boundary, then an interior layer of the same shapes (at
+    the true radii) paints the interior on top.  A rail that falls within the
+    span but is NOT used by the station gets no circle; the link passes behind
+    it.
 
     ``fill_override`` tints the interior layer (link bar + knobs) with a marker
-    fill colour while keeping the interchange shape and dark outline, so a
-    spanning rail station can carry its ``%%metro marker:`` colour.
+    fill colour while keeping the interchange shape, so a spanning rail station
+    can carry its ``%%metro marker:`` colour.  A tinted interchange takes the
+    light marker outline (``marker_stroke``) so the fill reads against the dark
+    background, matching every other coloured marker glyph.
     """
     interior_fill = fill_override if fill_override is not None else theme.station_fill
+    outline = (
+        marker_stroke_color(theme)
+        if fill_override is not None
+        else theme.station_stroke
+    )
     used_ys = [y for y in station.rail_used_ys] or [station.y]
     top_y = min(used_ys)
     bot_y = max(used_ys)
@@ -1136,18 +1144,18 @@ def _render_rail_pill(
                 )
             )
 
-    # Dark outer-boundary layer: the link bar and the knob discs grown by the
-    # stroke width, all painted in the station stroke colour.  Their union is
-    # the continuous dark outline of the finished glyph.
+    # Outer-boundary layer: the link bar and the knob discs grown by the stroke
+    # width, all painted in the outline colour.  Their union is the continuous
+    # outline of the finished glyph.
     _link_bar(
         (bar_half + sw) * 2,
-        theme.station_stroke,
+        outline,
         **{**station_data, "class_": "nf-metro-rail-connector"},
     )
     _knobs(
         knob_r + sw,
-        theme.station_stroke,
-        theme.station_stroke,
+        outline,
+        outline,
         **{"class_": "nf-metro-rail-knob-outline", "data-station-id": station.id},
     )
 

--- a/tests/fixtures/rail_marker_subset_interchange.mmd
+++ b/tests/fixtures/rail_marker_subset_interchange.mmd
@@ -1,0 +1,24 @@
+%%metro title: Coloured subset interchange on rails
+%%metro style: dark
+%%metro line_spread: rails
+%%metro line: line_a | Line A | #2db572
+%%metro line: line_b | Line B | #f4a300
+%%metro line: line_c | Line C | #e4509a
+%%metro marker: hub | circle, #1f4e79
+
+graph LR
+    subgraph proc [Process]
+        src_a[SrcA]
+        src_b[SrcB]
+        src_c[SrcC]
+        hub[Hub]
+        sink_a[SinkA]
+        sink_b[SinkB]
+        sink_c[SinkC]
+
+        src_a -->|line_a| hub
+        src_c -->|line_c| hub
+        hub -->|line_a| sink_a
+        hub -->|line_c| sink_c
+        src_b -->|line_b| sink_b
+    end

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1339,3 +1339,87 @@ def test_rail_station_markers_seat_on_their_rails():
         )
         checked += 1
     assert checked, "fixture must render rail-station knobs"
+
+
+# ---------------------------------------------------------------------------
+# Coloured subset interchange: seats on its spanned rails with a light outline
+# ---------------------------------------------------------------------------
+
+RAIL_MARKER_SUBSET_MMD = FIXTURES / "rail_marker_subset_interchange.mmd"
+
+
+def _rail_elements_for_station(svg: str, station_id: str, css_class: str):
+    """The ``css_class`` rail SVG elements drawn for ``station_id``."""
+    import xml.etree.ElementTree as ET
+
+    root = ET.fromstring(svg)
+    return [
+        el
+        for el in root.iter()
+        if el.attrib.get("class") == css_class
+        and el.attrib.get("data-station-id") == station_id
+    ]
+
+
+def test_coloured_subset_interchange_knobs_seat_on_spanned_rails():
+    """A coloured marker on a station that uses a strict subset of the rails
+    draws its interchange knobs centred on exactly the rails it carries, not
+    on the rail bundle's geometric centre."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    graph = parse_metro_mermaid(RAIL_MARKER_SUBSET_MMD.read_text())
+    compute_layout(graph)
+
+    hub = graph.stations["hub"]
+    assert hub.marker is not None and hub.marker.fill == "#1f4e79"
+    spanned = sorted([graph.stations["src_a"].y, graph.stations["src_c"].y])
+
+    svg = render_svg(graph, THEMES["nfcore"])
+    knob_cys = sorted(
+        float(el.attrib["cy"])
+        for el in _rail_elements_for_station(svg, "hub", "nf-metro-rail-knob")
+    )
+    assert len(knob_cys) == len(spanned), (
+        f"hub must draw one knob per carried rail, got {knob_cys}"
+    )
+    for got, want in zip(knob_cys, spanned):
+        assert abs(got - want) <= 1.0, (
+            f"hub interchange knob at cy={got:.2f} is off its rail {want:.2f}"
+        )
+
+
+def test_coloured_spanning_interchange_has_light_outline():
+    """A coloured-marker interchange takes the theme's light marker outline so
+    the fill reads against the dark background, instead of the dark station
+    stroke that an untinted interchange uses."""
+    from nf_metro.render import render_svg
+    from nf_metro.themes import THEMES
+
+    theme = THEMES["nfcore"]
+    graph = parse_metro_mermaid(RAIL_MARKER_SUBSET_MMD.read_text())
+    compute_layout(graph)
+
+    svg = render_svg(graph, theme)
+
+    outline_strokes = {
+        el.attrib.get("stroke")
+        for el in _rail_elements_for_station(svg, "hub", "nf-metro-rail-knob-outline")
+    }
+    assert outline_strokes == {theme.marker_stroke}, (
+        f"coloured interchange outline must use the light marker stroke "
+        f"{theme.marker_stroke!r}, got {outline_strokes}"
+    )
+
+    connectors = _rail_elements_for_station(svg, "hub", "nf-metro-rail-connector")
+    assert connectors and all(
+        el.attrib.get("stroke") == theme.marker_stroke for el in connectors
+    ), "coloured interchange link-bar outline must use the light marker stroke"
+
+    unmarked = {
+        el.attrib.get("stroke")
+        for el in _rail_elements_for_station(svg, "src_a", "nf-metro-rail-knob-outline")
+    }
+    assert unmarked == {theme.station_stroke}, (
+        f"an untinted interchange must keep the dark station stroke, got {unmarked}"
+    )


### PR DESCRIPTION
## What

In rail mode (`%%metro line_spread: rails`), a station consumed by more than one line draws as a cross-track interchange glyph (`_render_rail_pill`). A `%%metro marker:` colour on such a station tints the interchange interior. On the dark theme the tinted interchange drew its outer boundary in the dark station stroke (`#333333`), which is invisible against the dark background, so the coloured fill had no edge and read as floating off its rails.

A coloured-marker interchange now takes the theme's light marker outline (`marker_stroke`, e.g. `#f0f0f0`), the same contrast outline every other coloured marker glyph already uses via `_render_marker_station`. An untinted (white) interchange keeps the dark station stroke, so its appearance is unchanged.

## Seating invariant

The companion symptom (a coloured interchange "off its rail") is a seating question: every interchange knob is drawn at the station's `rail_used_ys`, which are computed from the same per-section rail map (`graph._rail_y`) the router uses, so the knobs already seat on each line's rail. This PR adds a validate-time guard (`_guard_rail_stations_seat_on_rails`) and a regression test pinning that invariant for a coloured subset interchange. The seating test passes on `main` and after this change; the off-rail *appearance* was the missing-contrast outline that the stroke fix resolves.

## Tests

- `tests/fixtures/rail_marker_subset_interchange.mmd`: three rails, a coloured marker on a station that carries a strict subset (lines A and C, not B).
- `test_coloured_spanning_interchange_has_light_outline` fails on `main` (outline `#333333`) and passes after the fix (`#f0f0f0`); an untinted interchange keeps the dark stroke.
- `test_coloured_subset_interchange_knobs_seat_on_spanned_rails` pins that the knobs sit on exactly the rails the station carries.
- `_guard_rail_stations_seat_on_rails` enforces the seating invariant under `compute_layout(validate=True)`.

## Gallery

`rail_mode.mmd` / `rail_section.mmd` are not committed gallery entries and no committed example uses a coloured rail interchange, so the rendered gallery is unaffected: all 77 tracked gallery SVGs are byte-identical to a fresh `origin/main` build (`PYTHONHASHSEED=0 python scripts/build_gallery.py`). The improvement was verified by rendering the new fixture and a coloured-marker variant of the rail demonstrator.

Full pytest green; `ruff check`, `ruff format --check`, `mypy src` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)