### PR TITLE
fix(off-track): keep metro lines out of file icons and stop output overlaps

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -129,6 +129,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_no_collinear_distinct_lines,
     _guard_no_intra_section_collinear_distinct_lines,
     _guard_no_label_overlap,
+    _guard_no_line_crosses_file_icon,
     _guard_no_line_crosses_non_consumer,
     _guard_no_negative_grid_columns,
     _guard_no_route_through_section,
@@ -170,6 +171,7 @@ from nf_metro.layout.phases.off_track import (  # noqa: F401
     _compute_fork_join_gaps,
     _insert_phantom_pass_throughs,
     _lift_off_track_stations,
+    _line_crossed_file_icon_sinks,
     _off_track_groups,
     _off_track_output_below,
     _place_off_track_relative_to_anchors,
@@ -473,6 +475,28 @@ def compute_layout(
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y
 
+    # Assure file-icon leaf sinks off the trunk by construction: a leaf icon
+    # the laid-out routes rake a line across is taken off-track and the layout
+    # re-run once, so the off-track machinery lifts it clear of the passing
+    # line.  Keyed on an observed crossing (not on icon presence), so an
+    # end-of-chain terminus that already sits clear is never disturbed.
+    crossed_sinks = _line_crossed_file_icon_sinks(graph)
+    if crossed_sinks:
+        for sid in crossed_sinks:
+            graph.stations[sid].off_track = True
+        _layout_once(
+            graph,
+            x_spacing=x_spacing,
+            y_spacing=y_spacing,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+            section_x_gap=section_x_gap,
+            section_y_gap=section_y_gap,
+            validate=validate,
+        )
+
     # Per-section rail mode: the normal pipeline has positioned every
     # section's bbox and inter-section ports.  Now overwrite the *internal*
     # geometry of each rail-flagged section with the rail-mode layout (rails
@@ -511,6 +535,7 @@ def compute_layout(
     if validate:
         _guard_no_label_overlap(graph, "final")
         _guard_file_icon_no_name_label(graph, "final")
+        _guard_no_line_crosses_file_icon(graph, "final")
         _guard_centered_line_spread_balanced(graph, "final")
         _guard_rail_above_label_band(graph, "final")
         _guard_single_trunk_off_track_step(graph, "final")

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -753,6 +753,69 @@ def _guard_no_line_crosses_non_consumer(
                     )
 
 
+def _guard_no_line_crosses_file_icon(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: no rendered line segment may pass through a file /
+    terminus icon's drawn bbox, except the one segment that legitimately
+    terminates at (or originates from) that icon's station.
+
+    A metro line raking across a file icon reads as the route running
+    through the artefact.  Only the segment that arrives at (or leaves
+    from) the icon's own station is exempt -- that line is meant to touch
+    it.  Every other segment crossing the icon box is a violation, even
+    one belonging to a line the icon's station also carries, since a
+    different edge of that line is still raking the artefact.
+    """
+    from nf_metro.render.svg import _icon_obstacles_by_station, apply_route_offsets
+    from nf_metro.themes import THEMES
+
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
+
+        offsets = compute_station_offsets(graph)
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        # route_edges' diagonal-centring pass mutates Station.x in place;
+        # a guard must stay observational, so snapshot and restore X
+        # around the call (mirrors _run_pass_c_guards).
+        saved_x = {sid: s.x for sid, s in graph.stations.items()}
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+            return
+        finally:
+            for sid, x in saved_x.items():
+                graph.stations[sid].x = x
+
+    icon_boxes = _icon_obstacles_by_station(graph, THEMES["nfcore"], offsets)
+    if not icon_boxes:
+        return
+    index = BBoxXIndex(list(icon_boxes.items()))
+
+    for r in routes:
+        pts = apply_route_offsets(r, offsets)
+        src, tgt, line_id = r.edge.source, r.edge.target, r.line_id
+        for k in range(len(pts) - 1):
+            p1, p2 = pts[k], pts[k + 1]
+            for sid, bbox in index.query_x_range(min(p1[0], p2[0]), max(p1[0], p2[0])):
+                if src == sid or tgt == sid:
+                    continue
+                if segment_intersects_bbox(p1[0], p1[1], p2[0], p2[1], bbox):
+                    raise PhaseInvariantError(
+                        f"{phase}: line {line_id!r} on edge {src!r} -> {tgt!r} "
+                        f"crosses file icon of {sid!r} "
+                        f"bbox ({bbox[0]:.1f},{bbox[1]:.1f})-"
+                        f"({bbox[2]:.1f},{bbox[3]:.1f}); segment "
+                        f"({p1[0]:.1f},{p1[1]:.1f})->({p2[0]:.1f},{p2[1]:.1f})"
+                    )
+
+
 def _guard_row_trunk_cy_consistent(
     graph: MetroGraph,
     phase: str,

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -432,17 +432,6 @@ def _line_crossed_file_icon_sinks(graph: MetroGraph) -> set[str]:
     from nf_metro.themes import THEMES
 
     offsets = compute_station_offsets(graph)
-    # route_edges' diagonal-centring pass mutates Station.x in place; this is
-    # a read-only probe, so snapshot and restore X around the call.
-    saved_x = {sid: s.x for sid, s in graph.stations.items()}
-    try:
-        routes = route_edges(graph, station_offsets=offsets)
-    except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
-        return set()
-    finally:
-        for sid, x in saved_x.items():
-            graph.stations[sid].x = x
-
     icon_boxes = _icon_obstacles_by_station(graph, THEMES["nfcore"], offsets)
     leaf_sinks = {
         sid
@@ -454,6 +443,17 @@ def _line_crossed_file_icon_sinks(graph: MetroGraph) -> set[str]:
     }
     if not leaf_sinks:
         return set()
+
+    # route_edges' diagonal-centring pass mutates Station.x in place; this is
+    # a read-only probe, so snapshot and restore X around the call.
+    saved_x = {sid: s.x for sid, s in graph.stations.items()}
+    try:
+        routes = route_edges(graph, station_offsets=offsets)
+    except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+        return set()
+    finally:
+        for sid, x in saved_x.items():
+            graph.stations[sid].x = x
 
     crossed: set[str] = set()
     for r in routes:

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -8,6 +8,8 @@ from collections import defaultdict
 from nf_metro.layout.constants import (
     DIAGONAL_RUN,
     EXIT_GAP_MULTIPLIER,
+    ICON_CAPTION_FONT_HEIGHT,
+    ICON_CAPTION_GAP,
     ICON_HALF_HEIGHT,
     LABEL_BBOX_MARGIN,
     MIN_STRAIGHT_EDGE,
@@ -410,6 +412,65 @@ def _compute_fork_join_gaps(
     return layer_extra
 
 
+def _line_crossed_file_icon_sinks(graph: MetroGraph) -> set[str]:
+    """Leaf file-icon sinks whose icon a non-terminating line rakes across.
+
+    Runs against a laid-out graph: routes the edges, builds each terminus
+    icon's drawn bbox, and returns the id of every leaf file-icon sink
+    (``is_terminus`` with an in-edge and no out-edge) whose box is crossed
+    by a line segment that neither starts nor ends at that station and is
+    not one of the station's own lines.
+
+    These are the sinks an auto-lift must take off the trunk: leaving them
+    on a line-track row puts the icon under a passing line.  A sink whose
+    icon no line crosses is left alone, so an end-of-chain terminus that
+    already sits clear is never lifted.
+    """
+    from nf_metro.layout.geometry import segment_intersects_bbox
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.render.svg import _icon_obstacles_by_station, apply_route_offsets
+    from nf_metro.themes import THEMES
+
+    offsets = compute_station_offsets(graph)
+    # route_edges' diagonal-centring pass mutates Station.x in place; this is
+    # a read-only probe, so snapshot and restore X around the call.
+    saved_x = {sid: s.x for sid, s in graph.stations.items()}
+    try:
+        routes = route_edges(graph, station_offsets=offsets)
+    except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+        return set()
+    finally:
+        for sid, x in saved_x.items():
+            graph.stations[sid].x = x
+
+    icon_boxes = _icon_obstacles_by_station(graph, THEMES["nfcore"], offsets)
+    leaf_sinks = {
+        sid
+        for sid in icon_boxes
+        if (st := graph.stations.get(sid)) is not None
+        and not st.off_track
+        and graph.edges_to(sid)
+        and not graph.edges_from(sid)
+    }
+    if not leaf_sinks:
+        return set()
+
+    crossed: set[str] = set()
+    for r in routes:
+        pts = apply_route_offsets(r, offsets)
+        src, tgt = r.edge.source, r.edge.target
+        for sid in leaf_sinks - crossed:
+            if src == sid or tgt == sid:
+                continue
+            bbox = icon_boxes[sid]
+            for k in range(len(pts) - 1):
+                p1, p2 = pts[k], pts[k + 1]
+                if segment_intersects_bbox(p1[0], p1[1], p2[0], p2[1], bbox):
+                    crossed.add(sid)
+                    break
+    return crossed
+
+
 def _off_track_anchor_of(graph: MetroGraph) -> dict[str, str]:
     """Map each off-track station to the on-track same-section station it
     hangs next to.
@@ -799,17 +860,25 @@ def _bump_off_track_clear_of_trunks(
     if not trunk_offsets_at_x and not sib_ys:
         return candidate_y
 
+    # A captioned icon's drawn box reaches below its centre by the caption
+    # gap plus a caption line; a same-column sibling must clear that reach,
+    # not just the bare icon half-heights, or the upper icon's caption
+    # crashes into the lower icon.
+    caption_reach = (
+        ICON_CAPTION_GAP + ICON_CAPTION_FONT_HEIGHT
+        if (off_st.terminus_names and any(off_st.terminus_names))
+        else 0.0
+    )
+    sibling_clearance = 2 * ICON_HALF_HEIGHT + caption_reach + MARGIN
+
     def _overlaps(y: float) -> bool:
         top = y - ICON_HALF_HEIGHT - MARGIN
         bot = y + ICON_HALF_HEIGHT + MARGIN
         for tl_y_lo, tl_y_hi in zip(trunk_offsets_at_x[::2], trunk_offsets_at_x[1::2]):
             if not (bot < tl_y_lo or tl_y_hi < top):
                 return True
-        # Sibling clearance: keep at least 2 * ICON_HALF_HEIGHT + MARGIN between
-        # icon centres in the same column so the icon bboxes don't
-        # touch.
         for sy in sib_ys:
-            if abs(sy - y) < 2 * ICON_HALF_HEIGHT + MARGIN:
+            if abs(sy - y) < sibling_clearance:
                 return True
         return False
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -276,17 +276,20 @@ def _position_legend(
     return legend_x, legend_y, legend_w, legend_h, show_legend
 
 
-def _compute_icon_obstacles(
+def _icon_obstacles_by_station(
     graph: MetroGraph,
     theme: Theme,
     station_offsets: dict[tuple[str, str], float],
-) -> list[tuple[float, float, float, float]]:
-    """Compute bounding boxes for terminus file icons.
+) -> dict[str, tuple[float, float, float, float]]:
+    """Compute each terminus file icon's bounding box, keyed by station id.
 
-    These are passed to the label placer as obstacles so labels maintain
-    clearance from adjacent icons.
+    The box covers the icon row(s) and any caption text beneath, with a
+    clearance margin -- the same geometry the label placer treats as an
+    obstacle.  Keyed by station so a caller can attribute a box to the
+    station whose icon it is (e.g. to exempt that station's own terminating
+    segment from a line-crosses-icon check).
     """
-    obstacles: list[tuple[float, float, float, float]] = []
+    obstacles: dict[str, tuple[float, float, float, float]] = {}
     margin = ICON_CLEARANCE_MARGIN
 
     for station in graph.stations.values():
@@ -339,16 +342,23 @@ def _compute_icon_obstacles(
         if any(station.terminus_names or []):
             y_max += ICON_NAME_GAP + theme.label_font_size * ICON_NAME_FONT_SCALE
 
-        obstacles.append(
-            (
-                x_min - margin,
-                y_min - margin,
-                x_max + margin,
-                y_max + margin,
-            )
+        obstacles[station.id] = (
+            x_min - margin,
+            y_min - margin,
+            x_max + margin,
+            y_max + margin,
         )
 
     return obstacles
+
+
+def _compute_icon_obstacles(
+    graph: MetroGraph,
+    theme: Theme,
+    station_offsets: dict[tuple[str, str], float],
+) -> list[tuple[float, float, float, float]]:
+    """Bounding boxes for terminus file icons, as label-placement obstacles."""
+    return list(_icon_obstacles_by_station(graph, theme, station_offsets).values())
 
 
 def render_svg(

--- a/tests/fixtures/bubble_output_above.mmd
+++ b/tests/fixtures/bubble_output_above.mmd
@@ -1,0 +1,21 @@
+%%metro title: Output above a fork/join bubble
+%%metro line: main | Main | #3b82f6
+%%metro off_track: bam_out
+
+%%metro file: bam_out | BAM
+
+graph LR
+    subgraph proc [Processing]
+        mapping[Mapping]
+        convert[Convert]
+        markdups[MarkDuplicates]
+        mosdepth[Mosdepth]
+        bam_out[ ]
+
+        mapping -->|main| convert
+        mapping -->|main| markdups
+        convert -->|main| mosdepth
+        markdups -->|main| mosdepth
+
+        convert -->|main| bam_out
+    end

--- a/tests/fixtures/captioned_sibling_outputs.mmd
+++ b/tests/fixtures/captioned_sibling_outputs.mmd
@@ -1,0 +1,20 @@
+%%metro title: Captioned sibling outputs
+%%metro line: main | Main | #3b82f6
+%%metro off_track: cram_normal, cram_tumor
+%%metro file: cram_normal | CRAM | normal
+%%metro file: cram_tumor | CRAM | tumor
+
+graph LR
+    subgraph proc [Processing]
+        align[Align]
+        markdup[MarkDup]
+        ready[Ready]
+        cram_normal[ ]
+        cram_tumor[ ]
+
+        align -->|main| markdup
+        markdup -->|main| ready
+
+        markdup -->|main| cram_normal
+        markdup -->|main| cram_tumor
+    end

--- a/tests/fixtures/leaf_file_icon_on_trunk.mmd
+++ b/tests/fixtures/leaf_file_icon_on_trunk.mmd
@@ -1,0 +1,16 @@
+%%metro title: Leaf file icon on a continuing trunk
+%%metro line: main | Main | #3b82f6
+%%metro line: index | Index | #e63946
+%%metro file: bam_out | BAM
+
+graph LR
+    subgraph proc [Processing]
+        align[Align]
+        bam_out[ ]
+        sort[Sort]
+        markdup[MarkDup]
+
+        align -->|index| bam_out
+        align -->|main| sort
+        sort -->|index| markdup
+    end

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -56,7 +56,11 @@ from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.layout.routing.common import resolve_section
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
-from nf_metro.render.svg import _compute_icon_obstacles
+from nf_metro.render.svg import (
+    _compute_icon_obstacles,
+    _icon_obstacles_by_station,
+    apply_route_offsets,
+)
 from nf_metro.themes import THEMES
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -1335,6 +1339,190 @@ def test_off_track_output_routes_share_flat_tail(fixture):
             f"{spread:.1f}px (>{_Y_TOL}); tails {[(o, round(t, 1)) for o, t in tails]} "
             f"are not consistent"
         )
+
+
+# ---------------------------------------------------------------------------
+# A metro line must never pass through a file / terminus icon
+# ---------------------------------------------------------------------------
+
+
+def _segments_crossing_icons(
+    graph: MetroGraph,
+) -> list[tuple[str, str, str, str]]:
+    """Return ``(line, src, tgt, icon_station)`` for every routed segment
+    that crosses a file icon's drawn bbox other than the segment that
+    starts or ends at that icon's own station.
+    """
+    from nf_metro.layout.geometry import segment_intersects_bbox
+
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    boxes = _icon_obstacles_by_station(graph, THEMES["nfcore"], offsets)
+    hits: list[tuple[str, str, str, str]] = []
+    for r in routes:
+        pts = apply_route_offsets(r, offsets)
+        src, tgt = r.edge.source, r.edge.target
+        for sid, bbox in boxes.items():
+            if src == sid or tgt == sid:
+                continue
+            for k in range(len(pts) - 1):
+                p1, p2 = pts[k], pts[k + 1]
+                if segment_intersects_bbox(p1[0], p1[1], p2[0], p2[1], bbox):
+                    hits.append((r.line_id, src, tgt, sid))
+                    break
+    return hits
+
+
+def test_leaf_file_icon_crossing_fixture_crosses_without_auto_lift(monkeypatch):
+    """The problem-1 fixture genuinely puts a line across the icon when the
+    auto-off-track corrective re-run is suppressed.
+
+    Guards against the fixture silently ceasing to exercise the fix: with the
+    crossing-sink detector neutralised, the unmarked leaf icon must still be
+    raked by a non-terminating line.
+    """
+    import nf_metro.layout.engine as engine_module
+
+    monkeypatch.setattr(
+        engine_module, "_line_crossed_file_icon_sinks", lambda graph: set()
+    )
+    graph = _layout("leaf_file_icon_on_trunk.mmd")
+    assert not graph.stations["bam_out"].off_track
+    assert _segments_crossing_icons(graph), (
+        "fixture no longer crosses its icon without auto-lift; it can't "
+        "exercise the keep-lines-out-of-icons fix"
+    )
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_no_line_crosses_file_icon(fixture):
+    """No routed line segment may pass through a file / terminus icon's drawn
+    bbox, except the segment that terminates at (or originates from) that
+    icon's own station.
+
+    A leaf file-icon sink the layout would otherwise rake a line across is
+    auto-lifted off the trunk, so the settled layout is clear by
+    construction.
+    """
+    graph = _layout(fixture)
+    hits = _segments_crossing_icons(graph)
+    assert not hits, f"{fixture}: line(s) cross a file icon: " + "; ".join(
+        f"{ln} on {s}->{t} crosses {icon}" for ln, s, t, icon in hits
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sibling off-track output icons must not overlap each other
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_WITH_OFF_TRACK)
+def test_off_track_output_icons_do_not_overlap(fixture):
+    """Two off-track output icon bboxes in one section never overlap.
+
+    Outputs hanging off nearby producers stack so their drawn boxes -- icon
+    plus any under-icon caption -- stay clear of each other.
+    """
+    graph = _layout(fixture)
+    sinks = set(_off_track_output_sinks(graph))
+    if len(sinks) < 2:
+        pytest.skip(f"{fixture}: fewer than two off-track output sinks")
+    offsets = compute_station_offsets(graph)
+    boxes = {
+        sid: b
+        for sid, b in _icon_obstacles_by_station(
+            graph, THEMES["nfcore"], offsets
+        ).items()
+        if sid in sinks
+    }
+    items = list(boxes.items())
+    tol = 0.5
+    for i, (s1, (x1, y1, X1, Y1)) in enumerate(items):
+        for s2, (x2, y2, X2, Y2) in items[i + 1 :]:
+            overlap = (
+                x1 < X2 - tol and x2 < X1 - tol and y1 < Y2 - tol and y2 < Y1 - tol
+            )
+            assert not overlap, (
+                f"{fixture}: off-track output icons {s1!r} and {s2!r} overlap: "
+                f"({x1:.1f},{y1:.1f},{X1:.1f},{Y1:.1f}) vs "
+                f"({x2:.1f},{y2:.1f},{X2:.1f},{Y2:.1f})"
+            )
+
+
+def test_captioned_sibling_outputs_clear_caption_band():
+    """Same-column captioned off-track outputs reserve their caption band.
+
+    Two captioned outputs stacked in one column must keep their full drawn
+    boxes -- icon plus the under-icon caption that reaches below each icon --
+    apart, not merely the bare icon half-heights.
+    """
+    graph = _layout("captioned_sibling_outputs.mmd")
+    sinks = set(_off_track_output_sinks(graph))
+    assert len(sinks) >= 2
+    offsets = compute_station_offsets(graph)
+    boxes = {
+        sid: b
+        for sid, b in _icon_obstacles_by_station(
+            graph, THEMES["nfcore"], offsets
+        ).items()
+        if sid in sinks
+    }
+    items = list(boxes.items())
+    for i, (s1, (x1, y1, X1, Y1)) in enumerate(items):
+        for s2, (x2, y2, X2, Y2) in items[i + 1 :]:
+            overlap = x1 < X2 and x2 < X1 and y1 < Y2 and y2 < Y1
+            assert not overlap, (
+                f"captioned outputs {s1!r}/{s2!r} overlap: "
+                f"({x1:.1f},{y1:.1f},{X1:.1f},{Y1:.1f}) vs "
+                f"({x2:.1f},{y2:.1f},{X2:.1f},{Y2:.1f})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# A producer's label clears an off-track output icon above its fork/join bubble
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_WITH_OFF_TRACK)
+def test_off_track_output_clears_station_labels(fixture):
+    """No on-track station label overlaps an off-track output icon.
+
+    A fork/join bubble carrying an output above it must leave its stations'
+    labels clear of the output icon; the column gap widens to fit them.
+    """
+    graph = _layout(fixture)
+    sinks = set(_off_track_output_sinks(graph))
+    if not sinks:
+        pytest.skip(f"{fixture}: no off-track output sinks")
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    icon_boxes = _icon_obstacles_by_station(graph, THEMES["nfcore"], offsets)
+    labels = place_labels(
+        graph,
+        station_offsets=offsets,
+        icon_obstacles=list(icon_boxes.values()),
+        routes=routes,
+        label_angle=graph.label_angle or 0.0,
+    )
+    sink_boxes = {sid: b for sid, b in icon_boxes.items() if sid in sinks}
+    tol = 0.5
+    for p in labels:
+        if not p.station_id or p.station_id in sinks:
+            continue
+        lx0, ly0, lx1, ly1 = _label_bbox(p)
+        for oid, (bx0, by0, bx1, by1) in sink_boxes.items():
+            overlap = (
+                lx0 < bx1 - tol
+                and bx0 < lx1 - tol
+                and ly0 < by1 - tol
+                and by0 < ly1 - tol
+            )
+            assert not overlap, (
+                f"{fixture}: label of {p.station_id!r} overlaps off-track "
+                f"output icon {oid!r}: label "
+                f"({lx0:.1f},{ly0:.1f},{lx1:.1f},{ly1:.1f}) vs icon "
+                f"({bx0:.1f},{by0:.1f},{bx1:.1f},{by1:.1f})"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three off-track-output quality fixes in the off-track placement subsystem.

### Keep metro lines out of file icons (headline)
A leaf file-icon sink (`%%metro file:` terminus, producer-fed, no onward consumer) that a metro line would otherwise rake across is now taken off the trunk **by construction**, without the author having to mark it `off_track`.

Approach: **auto-off-track via a post-layout corrective re-run, keyed on an observed crossing.** After the layout settles, the engine routes the edges, builds each terminus icon's drawn bbox, and finds any leaf file-icon sink whose box a non-terminating line crosses. Those sinks are marked `off_track` and the layout re-runs once so the existing off-track machinery lifts them clear.

This precondition is exact ("a line would otherwise cross the icon") rather than structural, so an end-of-chain terminus that already sits clear is never disturbed. The whole gallery has zero such crossings today, so it stays byte-identical.

A runtime guard `_guard_no_line_crosses_file_icon` backs this: wired into `compute_layout`'s `validate` block, it raises `PhaseInvariantError` if any routed segment intersects a file/terminus icon's bbox other than the segment that terminates at (or originates from) that icon's own station. The guard snapshots/restores `Station.x` around its `route_edges` call so it stays observational under `validate=True`.

### Sibling off-track output icons must not overlap
The same-column sibling clearance in `_bump_off_track_clear_of_trunks` is now caption-aware: a captioned icon's under-icon text band is reserved against the icon below it, not just the bare icon half-heights.

### Producer label clears an output above a fork/join bubble
A corpus invariant now asserts no on-track station label overlaps an off-track output icon, locking the bubble/label-clearance behaviour.

## Tests
- `_icon_obstacles_by_station` exposed so layout-side code and guards can attribute an icon box to its station; `_compute_icon_obstacles` wraps it.
- New fixtures: `leaf_file_icon_on_trunk.mmd` (a line crosses the icon on main), `captioned_sibling_outputs.mmd`, `bubble_output_above.mmd`.
- New corpus invariant tests: no routed segment crosses a file-icon bbox except its own terminus; no two off-track output icon bboxes overlap; no station label overlaps an off-track output icon. The crossing invariant fails on main for `leaf_file_icon_on_trunk.mmd` and passes after.

## Verification
- Full `pytest` green (7252 passed); `ruff check`, `ruff format --check`, `mypy src` all clean.
- Gallery byte-identical to main (`PYTHONHASHSEED=0 python scripts/build_gallery.py` produces no diff): the auto-off-track re-run fires on zero gallery examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)