### PR TITLE
fix(rail): space rails at the base grid pitch, not the label-widened one

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -513,6 +513,12 @@ def compute_layout(
         from nf_metro.layout.rail_mode import retrofit_section_rails
 
         section_pitch_map = diagonal_label_pitch_by_section(graph, x_spacing)
+        # Rails sit one base grid pitch apart and their labels hang above or
+        # below the bundle, so the diagonal-label widening of the global
+        # y_spacing (the spread loop, for between-station label clearance) must
+        # not also push the rails apart.  Column X still uses the label-aware
+        # pitch, where horizontal label room genuinely matters.
+        rail_pitch = getattr(graph, "_base_y_spacing", y_spacing)
         for sid in rail_section_ids:
             section = graph.sections.get(sid)
             if section is None:
@@ -521,7 +527,7 @@ def compute_layout(
                 graph,
                 section,
                 x_spacing=section_pitch_map.get(sid, x_spacing),
-                y_spacing=y_spacing,
+                y_spacing=rail_pitch,
                 section_x_padding=section_x_padding,
                 section_y_padding=section_y_padding,
             )

--- a/tests/fixtures/rail_pitch_vs_labels.mmd
+++ b/tests/fixtures/rail_pitch_vs_labels.mmd
@@ -1,0 +1,39 @@
+%%metro title: rail pitch vs labels
+%%metro label_angle: 45
+%%metro line_spread: rails | calling
+%%metro grid: intro | 0,0
+%%metro grid: calling | 0,1
+%%metro line: core | Core | #2db572
+%%metro line: g | Germline | #0570b0
+%%metro line: t | Tumour | #d62728
+
+%%metro files: bam_out | BAM/CRAM
+%%metro off_track: bam_out
+%%metro marker: bx | square, solid
+%%metro marker: by | square, solid
+
+graph LR
+    subgraph intro [Intro]
+        a[Map]
+        bx[Convert]
+        by[MarkDup]
+        z[Merge]
+        bam_out[ ]
+        a -->|core| bx
+        a -->|core| by
+        bx -->|core| z
+        by -->|core| z
+        a -->|core| bam_out
+    end
+    subgraph calling [Calling]
+        c0[ ]
+        gc[Germline Caller]
+        tc[Tumour Caller]
+        sh[Shared]
+        sink[ ]
+        c0 -->|g| gc
+        gc -->|g| sh
+        c0 -->|t| tc
+        tc -->|t| sh
+        sh -->|g,t| sink
+    end

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1239,6 +1239,30 @@ def test_spanning_rail_station_marker_tints_interchange():
 # ---------------------------------------------------------------------------
 
 RAIL_SINGLE_LINE_CALLERS_MMD = FIXTURES / "rail_single_line_callers.mmd"
+RAIL_PITCH_VS_LABELS_MMD = FIXTURES / "rail_pitch_vs_labels.mmd"
+
+
+def test_rail_pitch_stays_at_base_when_labels_widen_y_spacing():
+    """Rails sit one base grid pitch apart regardless of label-driven spacing.
+
+    A marker collision elsewhere makes the spread loop widen the global
+    ``y_spacing`` for between-station label clearance.  Rail labels hang above
+    or below the bundle, not between the rails, so that widening must not push
+    the rails apart: the rail-to-rail gap stays at the base pitch.
+    """
+    from nf_metro.layout.engine import compute_min_y_spacing
+
+    graph = parse_metro_mermaid(RAIL_PITCH_VS_LABELS_MMD.read_text())
+    base = compute_min_y_spacing(graph)
+    compute_layout(graph)
+    rail_ys = sorted(graph._rail_y.get("calling", {}).values())
+    assert len(rail_ys) >= 2, "fixture must lay out at least two rails"
+    gaps = [rail_ys[i + 1] - rail_ys[i] for i in range(len(rail_ys) - 1)]
+    assert max(gaps) <= base + 1.0, (
+        f"rails spaced {max(gaps):.1f}px apart, beyond the base pitch "
+        f"{base:.1f}px; a label-driven y_spacing widening leaked into the "
+        f"rail gap"
+    )
 
 
 def _diagonal_label_placements(graph):


### PR DESCRIPTION
## What

A per-section rail panel was spaced using the global `y_spacing`, which the spread loop widens to clear between-station label overlaps. Rail labels hang **above or below** the bundle, not between the rails, so that widening should not push the rails apart. Space the rails at the **base grid pitch** instead (column X still uses the label-aware pitch, where horizontal label room genuinely matters).

## Effect

A rail panel whose global `y_spacing` was widened (e.g. by a marker collision elsewhere) had its rails spread to the widened pitch (~68px). They now sit one base grid unit apart (40px), independent of label size.

## Verification

- New fixture + invariant test (`test_rail_pitch_stays_at_base_when_labels_widen_y_spacing`): fails on main (68px), passes after (40px).
- Gallery byte-identical to main.
- Full suite + `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)