### PR TITLE
chore(github): add issue templates and subsystem labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: A render, layout, or parse result that is wrong. Bring a minimized repro.
+title: "[bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. This project lives on a "dense bug -> isolated fixture" loop:
+        the fastest path to a fix is a **minimized `.mmd`** that reproduces the problem with as
+        few lines, lines/stations, and directives as possible. A 200-line pipeline `.mmd` that
+        "looks wrong somewhere" is much harder to act on than a 10-line fixture that isolates it.
+  - type: textarea
+    id: minimized-mmd
+    attributes:
+      label: Minimized .mmd repro
+      description: >
+        The smallest `.mmd` that still shows the bug. Strip unrelated sections, lines, and
+        `%%metro` directives until removing anything more makes the bug disappear.
+      render: text
+      placeholder: |
+        %%metro title: Repro
+        %%metro line: l1 | Line 1 | #ff0000 | solid
+
+        graph LR
+            a[A] -->|l1| b[B]
+            b -->|l1| c[C]
+    validations:
+      required: true
+  - type: input
+    id: render-command
+    attributes:
+      label: Render command used
+      description: The exact `nf-metro` (or `python -m nf_metro`) invocation, including any flags.
+      placeholder: "nf-metro render repro.mmd -o out.svg --x-spacing 60 --y-spacing 40"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: What the render or layout should produce. Describe the geometry/visual you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: >
+        What actually happened. Attach the rendered SVG/PNG if you can, and quote any
+        error or warning text verbatim.
+    validations:
+      required: true
+  - type: dropdown
+    id: subsystem
+    attributes:
+      label: Suspected subsystem
+      description: Best guess at where the bug lives. Leave as "Not sure" if unknown.
+      options:
+        - Not sure
+        - parser (Mermaid + %%metro parsing)
+        - layout (engine, phases, ordering)
+        - routing (edge routing)
+        - render (SVG, themes, legend, icons)
+        - cli (command-line interface)
+        - convert (Nextflow DAG / external-format conversion)
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: nf-metro version / commit
+      description: Output of `nf-metro --version`, or the git commit you ran against.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/pinin4fjords/nf-metro/discussions
+    about: Ask how to author a .mmd, use a directive, or render a pipeline. Open a discussion rather than an issue.
+  - name: Mermaid + %%metro input format
+    url: https://github.com/pinin4fjords/nf-metro/blob/main/CLAUDE.md
+    about: Reference for the supported Mermaid subset and %%metro directives before filing a bug.

--- a/.github/ISSUE_TEMPLATE/new_directive_design.yml
+++ b/.github/ISSUE_TEMPLATE/new_directive_design.yml
@@ -1,0 +1,76 @@
+name: New directive design
+description: Propose a new %%metro directive or CLI control, with its stability tier and intent classification.
+title: "[directive]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to propose a new `%%metro` directive (or a CLI flag with a directive twin).
+        Before adding a control surface, we classify two things: which **stability tier** it
+        belongs to (see #561), and whether it expresses **authored meaning** about the pipeline
+        or merely a **render preference** (see #549 and #553). Getting these right up front keeps
+        the control surface from proliferating and keeps committed `.mmd` files reproducible.
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed directive / control
+      description: Name, grammar, and what it does. Show the syntax you would write in a `.mmd`.
+      placeholder: "%%metro <name>: <args>"
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivating case
+      description: >
+        What render or pipeline can you not currently express well? Include a `.mmd` snippet
+        and, ideally, the suboptimal render you get today.
+    validations:
+      required: true
+  - type: dropdown
+    id: stability-tier
+    attributes:
+      label: Proposed stability tier
+      description: "Which tier should this ship in? See the feature-tiers issue (#561)."
+      options:
+        - core (stable, broadly useful, supported long-term)
+        - advanced (stable but niche / power-user)
+        - experimental (may change or be removed)
+    validations:
+      required: true
+  - type: dropdown
+    id: intent-classification
+    attributes:
+      label: Authored meaning vs render preference
+      description: >
+        Does this directive state something true about the pipeline (authored meaning, e.g. "these
+        two steps are alternatives"), or does it only tune how the diagram looks (render preference,
+        e.g. spacing/offset)? See #549 and #553. Render preferences ideally have both a directive and
+        a CLI flag so committed `.mmd` files stay reproducible.
+      options:
+        - Authored meaning (a fact about the pipeline/workflow)
+        - Render preference (a visual/layout tuning knob)
+        - Mixed / unsure (explain below)
+    validations:
+      required: true
+  - type: textarea
+    id: classification-rationale
+    attributes:
+      label: Classification rationale
+      description: >
+        Justify the tier and the meaning-vs-preference choice. If it is a render preference, say
+        whether it needs a matching CLI flag (and vice versa) so renders stay reproducible from the
+        committed `.mmd`.
+    validations:
+      required: true
+  - type: textarea
+    id: interactions
+    attributes:
+      label: Interactions and alternatives
+      description: >
+        How does this interact with existing directives / auto-layout? Could auto-layout infer it
+        instead of asking the author to spell it out? Any simpler alternative considered?
+    validations:
+      required: false


### PR DESCRIPTION
Closes #568.

Adds contributor-onboarding scaffolding: GitHub issue form templates and subsystem labels. Process/docs only, no source-code or render changes.

## Issue templates (`.github/ISSUE_TEMPLATE/`)

GitHub YAML form schema (the modern standard):

- **`bug_report.yml`** - requires a minimized `.mmd` repro, the exact render command, and expected vs actual results, codifying the project's "dense bug -> isolated fixture" loop. Includes an optional suspected-subsystem dropdown and version field. Labelled `bug`.
- **`new_directive_design.yml`** - for proposing a new `%%metro` directive or CLI control. Requires the proposed stability tier (core / advanced / experimental, per #561) and the authored-meaning-vs-render-preference classification (per #549 / #553), with a rationale field. Labelled `enhancement`.
- **`config.yml`** - sets `blank_issues_enabled: false` and adds contact links to Discussions (usage questions) and the input-format reference.

## Subsystem labels

Created directly on the repo (a settings change, not part of this PR's diff): `parser`, `layout`, `routing`, `render`, `cli`, `convert`. These add a subsystem dimension that complements the existing type labels (`bug`, `enhancement`, etc.).

## Validation

All three YAML files parse cleanly and conform to the GitHub issue-form schema (top-level `name`/`description`/`body`; every non-markdown body element has `id`, `type`, and `attributes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)