### PR TITLE
refactor(parser): replace the regex Mermaid front-end with a lark grammar

### DIFF
--- a/docs/dev/parser.md
+++ b/docs/dev/parser.md
@@ -1,11 +1,40 @@
 # Parser
 
-The parser reads a Mermaid `graph LR` definition plus `%%metro`
-directives and produces a `MetroGraph`.  The entry point is
-`parse_metro_mermaid` in
+A walkthrough of how nf-metro turns `.mmd` text into a `MetroGraph`. If
+you're adding a node shape, a `%%metro` directive, or a new statement
+form - or just trying to understand the grammar - start here.
+
+The entry point is `parse_metro_mermaid` in
 [`src/nf_metro/parser/mermaid.py`](https://github.com/pinin4fjords/nf-metro/blob/main/src/nf_metro/parser/mermaid.py);
-the data model is in
+the data model it builds is in
 [`src/nf_metro/parser/model.py`](https://github.com/pinin4fjords/nf-metro/blob/main/src/nf_metro/parser/model.py).
+The parser package is split by job: `grammar.py` (grammar, statement types,
+transformer), `directives.py` (directive parsing and dispatch), `resolve.py`
+(the post-parse graph rewrites), and `mermaid.py` (the public entry point and
+statement-application driver).
+Parsing is the first of the three stages (**Parse -> Layout -> Render**);
+the [layout pipeline](layout_pipeline.md) takes over from the `MetroGraph`
+this stage produces.
+
+## What "parsing" means here
+
+The input is a subset of Mermaid `graph LR` syntax plus `%%metro`
+directives. Parsing reads that text and produces a `MetroGraph` of
+sections, stations, edges, lines, and ports - with no coordinates yet
+(those are the layout stage's job).
+
+The work splits in two:
+
+1. **Front-end** - recognise each line's shape (a node? an edge? a
+   directive?) and pull out its pieces. The grammar recognises statement
+   *shapes and boundaries*; directive *payloads* and graph *semantics* are
+   handled by Python (see [Directives](#directives) and
+   [Parse-then-resolve flow](#parse-then-resolve-flow)).
+2. **Post-parse** - rewrite the raw graph into the form layout expects:
+   resolve inter-section edges into ports and junctions, insert bypass
+   and convergence stations, create the implicit section for loose
+   nodes. These are plain functions operating on the model, covered in
+   [Parse-then-resolve flow](#parse-then-resolve-flow) below.
 
 ## Input format
 
@@ -29,17 +58,117 @@ graph LR
 - A Mermaid `subgraph` becomes a `Section`.
 - A node (`node_id[Label]`) becomes a `Station`.
 - An edge (`a -->|line1,line2| b`) becomes one `Edge` per line id; the
-  pipe-delimited label lists the lines the edge carries.
-- Lines must be declared with `%%metro line:` before use; an undeclared
-  line id on an edge raises a parse error.
+  pipe-delimited label lists the lines the edge carries. An endpoint may
+  also be written with an inline shape (`a[A] -->|line1| b[B]`), which
+  declares that node's label as well as the edge.
+- Lines must be declared with `%%metro line:` before use; an edge with no
+  line annotation, or one naming an undeclared line, is rejected as a
+  semantic error (see [Leniency and error policy](#leniency-and-error-policy)).
 - A primary graph direction other than `LR` is warned about
   (`_warn_if_non_lr_primary`); per-section flow is controlled by
   `%%metro direction:` and is independent of the header.
 
-## Directive model
+## What a grammar is, and why we use one
 
-Every `%%metro` line is dispatched by `_parse_directive`.  The directives
-it recognises:
+The naive way to read a line-oriented format is to write the
+*instructions* for recognising each line: "does this line start with
+`graph`? else is it a `subgraph`? else does it contain an arrow? else
+try these six node-shape patterns in this exact order...". That works,
+but the order of the checks becomes load-bearing, and every new shape or
+directive means finding the right slot in the chain.
+
+A **grammar** flips this around: instead of writing the recognising
+instructions, you write down *the rules of what a valid line is* and let
+a library do the recognising. nf-metro uses [`lark`](https://lark-parser.readthedocs.io/)
+for this. The grammar lives as a string in `grammar.py` (`_GRAMMAR`),
+and reads roughly:
+
+```lark
+node:  NAME SHAPE?
+edge:  NAME SHAPE? ARROW EDGELABEL? NAME SHAPE?
+
+SHAPE: /\(\[...\]\)|\[\[...\]\]|\(\(...\)\)|\[...\]|\(...\)|\{...\}/
+ARROW: /-->|---|==>/
+NAME:  /[a-zA-Z_][a-zA-Z0-9_]*/
+```
+
+An edge endpoint may carry an inline shape: `x[X] -->|a| y[Y]` declares
+node `x` with label "X", node `y` with label "Y", and the edge between
+them, all in one line. The `SHAPE` terminal's inner pattern
+(`_SHAPE_INNER`) excludes the arrow sequences so a source shape like
+`[X]` stops at the arrow rather than greedily swallowing it.
+
+You describe the shapes; lark works out how to match them. Adding a node
+shape is one more alternative in the `SHAPE` rule, not a new regex
+slotted into a hand-ordered chain, and the order of the rules stops
+mattering for correctness.
+
+It helps to think of it like describing the structure of a sentence
+("a sentence is a subject, a verb, then an object") rather than writing
+out, character by character, how to scan one.
+
+## From text to `MetroGraph`
+
+Three steps:
+
+1. **Parse.** `_PARSER.parse(text)` turns the whole document into a
+   parse tree using the grammar.
+2. **Transform.** `_StatementTransformer` walks that tree and flattens
+   it into an ordered list of **typed statements** - one small dataclass
+   per source line, from a fixed union: `_GraphHeader`, `_Subgraph`,
+   `_Directive`, `_Node`, `_Edge`, `_End`, `_Comment`, and `_Junk`. The
+   transformer does the normalisation here, so each statement carries
+   structured fields rather than raw tokens: `_Subgraph` already splits
+   the section id from its display name, `_Directive` splits the body on
+   the first colon into `key`/`value`, and `_Edge` carries its line ids
+   as a list plus any inline endpoint labels.
+3. **Drive.** `parse_metro_mermaid` iterates those statements *in source
+   order* and dispatches each by `isinstance`, applying it to the graph
+   while tracking which `subgraph` it's currently inside
+   (`current_section_id`). A `_Subgraph` opens a section, an `_End`
+   closes it, and the nodes/edges/directives in between are attached to
+   it.
+
+Because the appliers receive structured fields, the driver stays a thin
+dispatch: a `_Node` registers a station, an `_Edge` registers one edge
+per line id (declaring any inline-shaped endpoints), a `_Directive` is
+routed to a handler, and so on.
+
+Keeping the driver a simple in-order loop is deliberate: source order
+matters (e.g. dictionary insertion order of stations affects downstream
+layout), so the grammar handles *recognising* lines while the driver
+handles *applying* them in sequence.
+
+### One simplification worth knowing
+
+The model records only a node's **id and label** - never which shape it
+was drawn as. So all six Mermaid shapes collapse to a single `SHAPE`
+terminal plus a tiny "strip the delimiters" helper (`_shape_label`),
+instead of six separate regexes that each had to be tried in the right
+order.
+
+## Directives
+
+The `%%metro` directive *bodies* are not described by the grammar - they
+keep their own handler functions, because a grammar can't express
+behaviour like "warn about this and ignore it", which several directives
+need. What the grammar gives us is the directive line as a unit; the
+transformer splits its body once on the first colon into a **key** and a
+**value** (a `%%metro` line with no colon becomes a `_Comment` and is
+ignored).
+
+Dispatch on the key happens in `_apply_directive`. Most directives are
+graph-wide and live in the `_GLOBAL_DIRECTIVE_HANDLERS` dict, keyed by **exact
+name** and mapping to a `(value, graph) -> None` handler. Exact-key
+lookup means handler order is irrelevant and a key that is a prefix of
+another (`legend` vs `legend_combo`, `logo` vs `logo_scale`) cannot
+shadow it. Three families are dispatched separately because they need
+more than the value alone: `entry` / `exit` / `direction` need the
+enclosing section, and the icon keys `file` / `files` / `dir` need the
+key itself to choose the icon type. A key matching none of these is
+ignored with a `UserWarning`.
+
+The directives `_apply_directive` recognises:
 
 | Directive | Effect |
 | --- | --- |
@@ -62,14 +191,55 @@ it recognises:
 | `file:` / `files:` / `dir:` | terminus file-icon designation |
 
 Note that `entry:` / `exit:` do **not** create `Port` objects at parse
-time.  `_parse_port_hint` records them as `entry_hints` / `exit_hints`
+time. `_parse_port_hint` records them as `entry_hints` / `exit_hints`
 (a `(side, [line_ids])` list) on the `Section`; the actual ports are
 created later, driven by real inter-section edges.
 
+## Leniency and error policy
+
+The split is deliberate: the **grammar/parse layer is lenient** about
+syntax it doesn't recognise (it warns rather than crashing), while
+**semantic validity is a separate, stricter phase**. A typo in a node
+line should not abort a render of an otherwise-fine diagram, but an edge
+that names no metro line is a real modelling error.
+
+| Input | Outcome |
+| --- | --- |
+| Blank line, `%%` comment, or `%%metro` line with no colon | ignored silently |
+| Unrecognised non-blank line (the grammar `junk` rule) | dropped, with a `UserWarning` ("Ignored unrecognised line: ...") |
+| Unknown `%%metro` directive key | ignored, with a `UserWarning` ("Ignored unknown %%metro directive: ...") |
+| Malformed directive *payload* (too few `\|` fields, an unusable enum/number/bool, a section-scoped directive outside a subgraph) | warned about and ignored, uniformly across handlers (`_warn_directive`) |
+| Foreign/unsupported syntax (Mermaid `flowchart`) | raises `ValueError` with guidance, via `_check_unsupported_input`, before the grammar runs |
+| Edge with no line annotation, or an undeclared line id | raised by `_validate_edge_annotations` after parsing |
+
+Broader graph-semantic checks (beyond edge annotations) live in the
+separate `validate` phase, `nf_metro.parser.validate.validate_graph`.
+
+The unrecognised-line case is handled in the grammar by a low-priority
+catch-all:
+
+```lark
+JUNK.-10: /[^\n]+/
+```
+
+`JUNK` matches any line, but its negative priority means it only wins
+when nothing more specific does. The transformer turns the match into a
+`_Junk` statement, and the driver warns when it applies one.
+
+This `junk` fallback is why the parser is configured as
+`Lark(..., parser="earley", lexer="dynamic")` rather than the faster
+`lalr`. A line that *begins* like a valid statement but then hits an
+unexpected token must be able to fall back to `junk` and be dropped. An
+earley parser can explore that fallback; a committing `lalr` parser
+cannot backtrack a partly-matched line, so it would turn such a line
+into a fatal error instead. **Do not switch the parser to `lalr`**
+without accepting that behaviour change. The parse runs once per render,
+so earley's extra cost over `lalr` is not worth optimising away.
+
 ## Parse-then-resolve flow
 
-`parse_metro_mermaid` scans the input line by line, then runs a
-post-parse sequence (only when the graph has sections):
+After the grammar parse and statement application, `parse_metro_mermaid`
+runs a post-parse sequence (only when the graph has sections):
 
 1. `_validate_edge_annotations` - reject malformed edges.
 2. `_remove_empty_sections` and `_create_implicit_section` - drop empty
@@ -82,16 +252,16 @@ post-parse sequence (only when the graph has sections):
 5. `_resolve_sections` - the core rewrite (below).
 6. `_insert_bypass_stations`.
 
-Finally the parser applies pending terminus icons and `off_track` marks
-that were buffered during the line scan.
+Finally the parser applies pending terminus icons, `off_track` marks,
+and per-station markers that were buffered during the statement scan.
 
 ### `_resolve_sections`
 
 `_resolve_sections` rewrites inter-section edges into port/junction
-chains.  It is split into three helpers:
+chains. It is split into three helpers:
 
 - `_build_entry_side_mapping` - per-line entry-side lookup from the
-  `entry_hints`.  A section gets **one** entry side: if all hints agree,
+  `entry_hints`. A section gets **one** entry side: if all hints agree,
   that side is used; otherwise they collapse to the natural entry for the
   section direction (LEFT for LR, RIGHT for RL, TOP for TB).
 - `_classify_edges` - split edges into internal (both endpoints in one
@@ -99,13 +269,40 @@ chains.  It is split into three helpers:
   `internal_edges`.
 - `_create_ports_and_junctions` - create `Port` objects and rewrite each
   inter-section edge into a chain: `source -> exit_port -> entry_port ->
-  target`.  The design rule is **one exit port per source section**
-  (all lines leave together for consistent ordering) and **one entry
-  port per target section per side**; junction stations handle fan-out
-  to multiple target sections.
+  target`. The design rule is **one exit port per source section** (all
+  lines leave together for consistent ordering) and **one entry port per
+  target section per side**; junction stations handle fan-out to multiple
+  target sections.
 
 After ports and junctions exist, `_insert_merge_junctions` adds merge
 junctions and `_assign_section_numbers` numbers any unnumbered sections.
 
 The result is a `MetroGraph` whose edges all live within a section or
 run port-to-port, ready for the layout stage.
+
+## Adding things
+
+- **A node shape** - add one alternative to the `SHAPE` terminal in
+  `_GRAMMAR`; if its delimiters are two characters per side, add the
+  opener to `two_char_opens` in `_shape_label`.
+- **A `%%metro` directive** - write a `(value, graph) -> None` handler
+  and add an entry to the `_GLOBAL_DIRECTIVE_HANDLERS` dict keyed by the exact
+  directive name. No ordering concerns. (A directive that needs the
+  enclosing section or the key itself is dispatched in `_apply_directive`
+  instead of the dict.) On an unusable payload, call `_warn_malformed`
+  (or `_warn_directive` for a more specific message) and return, rather
+  than failing silently - that is the leniency policy above.
+- **A new statement form** - add a rule and its terminal to `_GRAMMAR`,
+  a typed statement dataclass (added to the `_Statement` union), a method
+  to `_StatementTransformer` returning that dataclass, and an `isinstance`
+  branch to the driver loop in `parse_metro_mermaid`.
+
+## How equivalence is verified
+
+The grammar must produce exactly the same `MetroGraph` as the input
+implies, so changes here are checked by **comparing parsed model objects**
+(not rendered SVGs): parse every fixture in `tests/fixtures/`,
+`examples/`, and `examples/topologies/` and assert the model matches.
+Because identical models render identically, this keeps the gallery
+byte-identical without chasing sub-pixel render drift. The grammar's
+coverage and behaviour are pinned by `tests/test_parser_grammar.py`.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -40,6 +40,9 @@ A few things to notice:
 - **Stations** use Mermaid node syntax: `node_id[Label]`.
 - **Edges** carry a line ID: `source -->|line_id| target`. An edge can carry multiple lines at once: `a -->|line1,line2| b`.
 
+!!! tip "Declare each station on its own line"
+    Give every station one labelled line of its own (`fastqc[FastQC]`) and use **bare ids** in edges (`fastqc -->|qc| multiqc`). Because most stations are shared by several edges, this keeps each label in exactly one place, and it gives `%%metro` directives (`file:`, `marker:`, `off_track:`, ...) a clear node to anchor to. nf-metro also accepts inline-shaped endpoints (`fastqc[FastQC] -->|qc| multiqc[MultiQC]`) for Mermaid compatibility, but avoid them in committed maps: a station can only carry its inline label on one of its edges, so mixing the two styles fragments where a label lives.
+
 Without sections, all stations sit on a single track. That works for simple pipelines, but real workflows have logical groupings.
 
 ## 2. Grouping stations into sections

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
     "click>=8.0",
     "drawsvg>=2.0",
+    "lark>=1.1",
     "networkx>=3.0",
     "pillow>=9.0",
 ]

--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -1,0 +1,574 @@
+"""Parsing and dispatch of ``%%metro`` directives.
+
+Each directive maps a ``key: value`` line onto the :class:`MetroGraph` (or the
+enclosing section). Graph-wide directives are routed through a registry; the
+section-scoped (entry/exit/direction) and file/files/dir icon directives need
+extra context and are handled by :func:`_apply_directive`.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable
+from typing import Literal, TypeVar
+
+from nf_metro.parser.grammar import _split_csv, _unquote
+from nf_metro.parser.model import (
+    MARKER_FILL_OPEN,
+    MARKER_FILL_SOLID,
+    MARKER_SHAPE_CIRCLE,
+    VALID_ICON_TYPES,
+    VALID_LINE_STYLES,
+    VALID_MARKER_SHAPES,
+    LineSpread,
+    MarkerLegendEntry,
+    MarkerStyle,
+    MetroGraph,
+    MetroLine,
+    PortSide,
+    StationGroup,
+)
+
+_Number = TypeVar("_Number", int, float)
+
+
+def _warn_directive(key: str, message: str) -> None:
+    """Warn about a %%metro directive; every directive warning uses this."""
+    warnings.warn(f"%%metro {key}: {message}", stacklevel=2)
+
+
+def _warn_malformed(key: str, value: str, expected: str) -> None:
+    """Warn that a directive's payload is unusable and is being ignored."""
+    _warn_directive(key, f"ignoring {value!r}; expected {expected}")
+
+
+def _parse_bool(value: str) -> bool | None:
+    """Parse a boolean directive flag; ``None`` for an unrecognised value."""
+    token = value.strip().lower()
+    if token in ("true", "yes", "1"):
+        return True
+    if token in ("false", "no", "0", ""):
+        return False
+    return None
+
+
+def _parse_number(
+    key: str, value: str, cast: Callable[[str], _Number]
+) -> _Number | None:
+    """Parse a numeric directive value; warn and return ``None`` if not a number."""
+    try:
+        return cast(value)
+    except ValueError:
+        _warn_malformed(key, value, "a number")
+        return None
+
+
+def _split_fields(value: str) -> list[str]:
+    """Split a ``|``-delimited directive body into stripped fields.
+
+    Empty fields are kept (so positional access by index stays valid); only the
+    surrounding whitespace of each field is removed.
+    """
+    return [field.strip() for field in value.split("|")]
+
+
+def _dir_title(value: str, graph: MetroGraph) -> None:
+    graph.title = value
+
+
+def _dir_style(value: str, graph: MetroGraph) -> None:
+    graph.style = value
+
+
+def _dir_logo(value: str, graph: MetroGraph) -> None:
+    graph.logo_path = value
+
+
+def _dir_line_order(value: str, graph: MetroGraph) -> None:
+    order = value.lower()
+    if order in ("definition", "span"):
+        graph.line_order = order
+    else:
+        _warn_malformed("line_order", value, "'definition' or 'span'")
+
+
+def _dir_compact_offsets(value: str, graph: MetroGraph) -> None:
+    flag = _parse_bool(value)
+    if flag is None:
+        _warn_malformed("compact_offsets", value, "a boolean (true/false)")
+    else:
+        graph.compact_offsets = flag
+
+
+def _dir_center_ports(value: str, graph: MetroGraph) -> None:
+    flag = _parse_bool(value)
+    if flag is None:
+        _warn_malformed("center_ports", value, "a boolean (true/false)")
+    else:
+        graph.center_ports = flag
+
+
+def _dir_fold_threshold(value: str, graph: MetroGraph) -> None:
+    threshold = _parse_number("fold_threshold", value, int)
+    if threshold is not None:
+        graph.fold_threshold = threshold
+
+
+def _dir_label_angle(value: str, graph: MetroGraph) -> None:
+    angle = _parse_number("label_angle", value, float)
+    if angle is not None:
+        graph.label_angle = angle
+
+
+def _dir_legend_min_height(value: str, graph: MetroGraph) -> None:
+    height = _parse_number("legend_min_height", value, float)
+    if height is not None:
+        graph.legend_min_height = height
+
+
+def _dir_off_track(value: str, graph: MetroGraph) -> None:
+    graph._pending_off_track.extend(_split_csv(value))
+
+
+def _dir_line(value: str, graph: MetroGraph) -> None:
+    parts = _split_fields(value)
+    if len(parts) < 3:
+        _warn_malformed("line", value, "'id | name | #color' [| style]")
+        return
+    style = "solid"
+    if len(parts) >= 4 and parts[3]:
+        raw_style = parts[3].lower()
+        if raw_style in VALID_LINE_STYLES:
+            style = raw_style
+        else:
+            _warn_malformed("line style", parts[3], "/".join(VALID_LINE_STYLES))
+    graph.add_line(
+        MetroLine(
+            id=parts[0],
+            display_name=parts[1],
+            color=parts[2],
+            style=style,
+        )
+    )
+
+
+def _parse_icon_directive(icon_type: str, value: str, graph: MetroGraph) -> None:
+    """Parse %%metro file:/files:/dir: station_id | labels [| name [| options]].
+
+    Records a pending terminus designation; each comma-separated label becomes
+    one icon, optionally captioned by the third field and bannered when the
+    fourth field's options include ``banner``.
+    """
+    parts = _split_fields(value)
+    if len(parts) < 2:
+        _warn_malformed(icon_type, value, "'station_id | labels [| name [| options]]'")
+        return
+    station_id = parts[0]
+    labels = _split_csv(parts[1])
+    name = parts[2] if len(parts) >= 3 else ""
+    options = {o.lower() for o in _split_csv(parts[3])} if len(parts) >= 4 else set()
+    banner = "banner" in options
+    graph._pending_terminus.setdefault(station_id, []).extend(
+        (label, icon_type, name, banner) for label in labels
+    )
+
+
+def _parse_port_hint(
+    value: str,
+    graph: MetroGraph,
+    section_id: str,
+    is_entry: bool,
+) -> None:
+    """Parse %%metro entry:/exit: and store as a hint on the Section.
+
+    Does NOT create Port objects - those are created later in _resolve_sections
+    based on actual inter-section edges.
+    """
+    key = "entry" if is_entry else "exit"
+    parts = _split_fields(value)
+    if len(parts) < 2:
+        _warn_malformed(key, value, "'side | line1, line2'")
+        return
+
+    side_str = parts[0].lower()
+    side_map = {
+        "left": PortSide.LEFT,
+        "right": PortSide.RIGHT,
+        "top": PortSide.TOP,
+        "bottom": PortSide.BOTTOM,
+    }
+    side = side_map.get(side_str)
+    if side is None:
+        _warn_malformed(key, side_str, "a side (left/right/top/bottom)")
+        return
+
+    line_ids = _split_csv(parts[1])
+
+    section = graph.sections.get(section_id)
+    if section:
+        if is_entry:
+            section.entry_hints.append((side, line_ids))
+        else:
+            section.exit_hints.append((side, line_ids))
+
+
+def _parse_grid_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro grid: section_id | col,row[,rowspan[,colspan]] directive."""
+    parts = _split_fields(value)
+    coords = parts[1].split(",") if len(parts) >= 2 else []
+    if len(parts) < 2 or len(coords) < 2:
+        _warn_malformed("grid", value, "'section_id | col,row[,rowspan[,colspan]]'")
+        return
+
+    section_id = parts[0]
+    try:
+        col = int(coords[0].strip())
+        row = int(coords[1].strip())
+        rowspan = int(coords[2].strip()) if len(coords) >= 3 else 1
+        colspan = int(coords[3].strip()) if len(coords) >= 4 else 1
+    except ValueError:
+        _warn_malformed("grid", value, "integer col,row[,rowspan[,colspan]]")
+        return
+    graph.grid_overrides[section_id] = (col, row, rowspan, colspan)
+    graph._explicit_grid.add(section_id)
+
+
+_LEGEND_KEYWORDS = ("bl", "br", "tl", "tr", "bottom", "right", "none")
+
+
+def _parse_xy(text: str) -> tuple[float, float] | None:
+    """Parse a ``x,y`` pair into floats, or None if it is not a number pair."""
+    if "," not in text:
+        return None
+    x_str, _, y_str = text.partition(",")
+    try:
+        return (float(x_str.strip()), float(y_str.strip()))
+    except ValueError:
+        return None
+
+
+def _parse_legend_directive(value: str, graph: MetroGraph) -> None:
+    """Parse the %%metro legend: directive positioning the legend+logo block.
+
+    Grammar (the keyword forms stay content-anchored with the content-overlap
+    fallback; the qualifier and absolute forms pin the block exactly):
+
+        legend: <keyword>              keyword (bl/br/tl/tr/bottom/right/none)
+        legend: <keyword> | canvas     anchor the keyword to the canvas frame
+        legend: <keyword> | <dx>,<dy>  nudge the keyword anchor by an offset
+        legend: <x>,<y>                absolute top-left coordinates
+    """
+    # Reset modifiers so a re-declared directive starts clean.
+    graph.legend_anchor = "content"
+    graph.legend_offset = None
+    graph.legend_at = None
+
+    head, sep, qualifier = value.partition("|")
+    head = head.strip().lower()
+    qualifier = qualifier.strip().lower()
+
+    coords = _parse_xy(head)
+    if coords is not None:
+        graph.legend_at = coords
+        graph.legend_position = "free"
+        if sep:
+            _warn_directive(
+                "legend",
+                f"qualifier {qualifier!r} ignored with absolute coordinates",
+            )
+        return
+
+    if head not in _LEGEND_KEYWORDS:
+        _warn_directive(
+            "legend",
+            f"unknown position {head!r}; expected one of "
+            f"{'/'.join(_LEGEND_KEYWORDS)} or 'x,y'. Ignoring",
+        )
+        return
+    graph.legend_position = head
+
+    if not qualifier:
+        return
+    if qualifier == "canvas":
+        graph.legend_anchor = "canvas"
+        return
+    offset = _parse_xy(qualifier)
+    if offset is not None:
+        graph.legend_offset = offset
+    else:
+        _warn_directive(
+            "legend",
+            f"unknown qualifier {qualifier!r}; expected 'canvas' or 'dx,dy'. Ignoring",
+        )
+
+
+def _parse_group_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro group: Label | station1, station2[, ...] [| above|below].
+
+    Stores an annotative caption spanning the listed stations.  The optional
+    third field selects whether the caption renders ``below`` (default) or
+    ``above`` the spanned stations.  Purely decorative; does not affect layout.
+    """
+    parts = _split_fields(value)
+    if len(parts) < 2:
+        _warn_directive(
+            "group",
+            f"{value!r} needs 'Label | station1, station2'. Ignoring",
+        )
+        return
+    label = _unquote(parts[0])
+    station_ids = _split_csv(parts[1])
+    if not label or not station_ids:
+        _warn_directive(
+            "group",
+            f"{value!r} needs a label and at least one station. Ignoring",
+        )
+        return
+    position: Literal["above", "below"] = "below"
+    if len(parts) >= 3:
+        raw_pos = parts[2].lower()
+        if raw_pos == "above":
+            position = "above"
+        elif raw_pos == "below":
+            position = "below"
+        elif raw_pos:
+            _warn_directive(
+                "group",
+                f"position {raw_pos!r} not recognised; expected "
+                "'above' or 'below'. Using 'below'",
+            )
+    graph.groups.append(
+        StationGroup(label=label, station_ids=station_ids, position=position)
+    )
+
+
+def _parse_legend_combo_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro legend_combo: lineA, lineB[, ...] | Display Label.
+
+    Stores a (line_ids, label) entry on ``graph.legend_combos``. The named
+    lines are rendered as a single combined legend row and (in rail mode)
+    share a single rail slot. A combo referencing unknown lines is warned
+    about and ignored; unknown members of an otherwise-valid combo are
+    dropped (with a warning) and the remaining members kept.
+    """
+    parts = value.split("|", 1)
+    if len(parts) != 2:
+        _warn_directive(
+            "legend_combo",
+            f"invalid {value!r}; expected 'lineA, lineB | Display Label'",
+        )
+        return
+    ids_raw, label = parts[0], parts[1].strip()
+    line_ids = _split_csv(ids_raw)
+    if len(line_ids) < 2 or not label:
+        _warn_directive(
+            "legend_combo",
+            f"invalid {value!r}; expected at least two line IDs and a non-empty label",
+        )
+        return
+    known = [lid for lid in line_ids if lid in graph.lines]
+    unknown = [lid for lid in line_ids if lid not in graph.lines]
+    if unknown:
+        _warn_directive(
+            "legend_combo",
+            f"{label!r} references unknown line(s) "
+            f"{', '.join(unknown)}; ignoring those",
+        )
+    if len(known) < 2:
+        _warn_directive(
+            "legend_combo",
+            f"{label!r} has fewer than two known lines; ignoring",
+        )
+        return
+    graph.legend_combos.append((tuple(known), label))
+
+
+def _parse_nonneg_number(value: str, name: str, *, allow_zero: bool) -> float | None:
+    """Parse a numeric %%metro directive value, warning and returning None if invalid.
+
+    ``allow_zero`` admits 0 (a gap may legitimately be zero); otherwise the value
+    must be strictly positive (a scale factor cannot be zero).
+    """
+    try:
+        num = float(value)
+    except ValueError:
+        _warn_directive(name, f"invalid {value!r}; expected a number")
+        return None
+    if num < 0 or (num == 0 and not allow_zero):
+        constraint = "non-negative" if allow_zero else "positive"
+        _warn_directive(name, f"must be {constraint}, got {value!r}; ignoring")
+        return None
+    return num
+
+
+def _parse_logo_scale_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro logo_scale: <factor> (1.0 = default auto-size)."""
+    scale = _parse_nonneg_number(value, "logo_scale", allow_zero=False)
+    if scale is not None:
+        graph.logo_scale = scale
+
+
+def _parse_legend_logo_gap_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro legend_logo_gap: <px> (horizontal gap logo->legend entries)."""
+    gap = _parse_nonneg_number(value, "legend_logo_gap", allow_zero=True)
+    if gap is not None:
+        graph.legend_logo_gap = gap
+
+
+def _parse_font_scale_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro font_scale: <factor> (1.0 = default text sizes)."""
+    scale = _parse_nonneg_number(value, "font_scale", allow_zero=False)
+    if scale is not None:
+        graph.font_scale = scale
+
+
+def _parse_marker_style(key: str, spec: str) -> MarkerStyle | None:
+    """Parse a ``shape, fill`` marker spec into a MarkerStyle.
+
+    ``shape`` defaults to ``circle`` and ``fill`` to ``solid`` when omitted.
+    An unknown shape is rejected (returns None with a warning); any fill
+    string other than ``open``/``solid`` is taken as a literal colour.
+    """
+    parts = [p.strip() for p in spec.split(",")]
+    shape = parts[0].lower() if parts and parts[0] else MARKER_SHAPE_CIRCLE
+    fill = parts[1] if len(parts) >= 2 and parts[1] else MARKER_FILL_SOLID
+    if shape not in VALID_MARKER_SHAPES:
+        _warn_directive(
+            key,
+            f"unknown shape {shape!r}; expected one of "
+            f"{'/'.join(VALID_MARKER_SHAPES)}. Ignoring",
+        )
+        return None
+    # Normalise the fill keywords to lowercase; leave literal colours as-is.
+    if fill.lower() in (MARKER_FILL_OPEN, MARKER_FILL_SOLID):
+        fill = fill.lower()
+    return MarkerStyle(shape=shape, fill=fill)
+
+
+def _parse_marker_directive(value: str, graph: MetroGraph) -> None:
+    """Parse ``%%metro marker: node_id | shape, fill``."""
+    node_part, sep, style_part = value.partition("|")
+    node_id = node_part.strip()
+    if not node_id:
+        return
+    style = _parse_marker_style("marker", style_part.strip() if sep else "")
+    if style is not None:
+        graph._pending_markers[node_id] = style
+
+
+def _parse_marker_legend_directive(value: str, graph: MetroGraph) -> None:
+    """Parse ``%%metro marker_legend: shape, fill | Caption``."""
+    style_part, sep, caption = value.partition("|")
+    if not sep:
+        _warn_directive(
+            "marker_legend",
+            "needs a caption: 'shape, fill | Caption'. Ignoring",
+        )
+        return
+    style = _parse_marker_style("marker_legend", style_part.strip())
+    caption = caption.strip()
+    if style is not None and caption:
+        graph.marker_legend.append(MarkerLegendEntry(style=style, caption=caption))
+
+
+def _parse_line_spread_directive(value: str, graph: MetroGraph) -> None:
+    """Parse %%metro line_spread: <mode>[ | section[, section...]].
+
+    Bare ``line_spread: <mode>`` sets the graph-wide default; the piped form
+    ``line_spread: <mode> | sectionA, sectionB`` records a per-section override
+    that wins over the default for those sections. ``<mode>`` is one of
+    ``bundle`` / ``centered`` / ``rails``; an unrecognised mode is warned about
+    and ignored.
+    """
+    mode_raw, _, sids_raw = value.partition("|")
+    try:
+        mode = LineSpread(mode_raw.strip().lower())
+    except ValueError:
+        valid = ", ".join(m.value for m in LineSpread)
+        _warn_directive(
+            "line_spread",
+            f"invalid mode {mode_raw.strip()!r}; expected one of {valid}",
+        )
+        return
+    section_ids = _split_csv(sids_raw)
+    if section_ids:
+        for sid in section_ids:
+            graph.line_spread_overrides[sid] = mode
+    else:
+        graph.line_spread = mode
+
+
+# Graph-wide directives: keyed by exact name, each a (value, graph) handler.
+# Order is irrelevant - a key that is a prefix of another (``legend`` vs
+# ``legend_combo``) cannot shadow it. The section-scoped keys
+# (entry/exit/direction) and the file/files/dir icon keys are NOT here: they
+# need the enclosing section or the key itself, and are handled in
+# _apply_directive / _apply_scoped_directive.
+_GLOBAL_DIRECTIVE_HANDLERS: dict[str, Callable[[str, MetroGraph], None]] = {
+    "title": _dir_title,
+    "style": _dir_style,
+    "logo": _dir_logo,
+    "line_order": _dir_line_order,
+    "line": _dir_line,
+    "compact_offsets": _dir_compact_offsets,
+    "center_ports": _dir_center_ports,
+    "fold_threshold": _dir_fold_threshold,
+    "label_angle": _dir_label_angle,
+    "legend_min_height": _dir_legend_min_height,
+    "off_track": _dir_off_track,
+    "grid": _parse_grid_directive,
+    "logo_scale": _parse_logo_scale_directive,
+    "font_scale": _parse_font_scale_directive,
+    "legend_logo_gap": _parse_legend_logo_gap_directive,
+    "line_spread": _parse_line_spread_directive,
+    "legend_combo": _parse_legend_combo_directive,
+    "legend": _parse_legend_directive,
+    "group": _parse_group_directive,
+    "marker_legend": _parse_marker_legend_directive,
+    "marker": _parse_marker_directive,
+}
+
+# Directives that act on the enclosing subgraph rather than the whole graph.
+_SCOPED_DIRECTIVES = ("entry", "exit", "direction")
+
+
+def _apply_scoped_directive(
+    key: str, value: str, graph: MetroGraph, section_id: str | None
+) -> None:
+    """Apply a section-scoped directive (entry/exit/direction).
+
+    These only mean anything inside a subgraph; outside one they are warned
+    about and ignored.
+    """
+    if section_id is None or section_id not in graph.sections:
+        _warn_directive(key, "must appear inside a subgraph; ignoring")
+    elif key == "direction":
+        direction = value.upper()
+        if direction in ("LR", "RL", "TB"):
+            graph.sections[section_id].direction = direction
+            graph._explicit_directions.add(section_id)
+        else:
+            _warn_malformed("direction", value, "LR/RL/TB")
+    else:
+        _parse_port_hint(value, graph, section_id, is_entry=key == "entry")
+
+
+def _apply_directive(
+    key: str,
+    value: str,
+    graph: MetroGraph,
+    current_section_id: str | None,
+) -> None:
+    """Apply one ``%%metro`` directive by its exact key.
+
+    Routes to the section-scoped handler, the file/files/dir icon directive, or
+    the graph-wide registry. An unknown key is warned about and ignored.
+    """
+    if key in _SCOPED_DIRECTIVES:
+        _apply_scoped_directive(key, value, graph, current_section_id)
+    elif key in VALID_ICON_TYPES:
+        _parse_icon_directive(key, value, graph)
+    elif handler := _GLOBAL_DIRECTIVE_HANDLERS.get(key):
+        handler(value, graph)
+    else:
+        _warn_directive(key, "unknown directive; ignoring")

--- a/src/nf_metro/parser/grammar.py
+++ b/src/nf_metro/parser/grammar.py
@@ -1,0 +1,262 @@
+"""Lark front-end for the Mermaid subset nf-metro accepts.
+
+The line shapes (graph header, subgraph, node declarations across all
+Mermaid shapes, edges, %%metro directives, comments) are described by a
+small ``lark`` grammar; a transformer turns the parse tree into an ordered
+list of typed statements which the driver in :mod:`nf_metro.parser.mermaid`
+applies to build the :class:`MetroGraph`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from lark import Lark, Token, Transformer, UnexpectedInput
+
+# A node label's inner text. It excludes the edge arrows so a shaped edge
+# endpoint (``x[X] --> y[Y]``) doesn't greedily swallow the arrow into one
+# label; the shape stops at the arrow and the line parses as an edge with
+# shaped endpoints.
+_SHAPE_INNER = r"(?:(?!-->|---|==>).)+"
+
+# Grammar for the Mermaid subset nf-metro accepts. The document is a sequence
+# of newline-separated statements; inline whitespace (indentation, spacing
+# around arrows) is ignored, but whitespace inside the whole-line terminals
+# (labels, directive bodies) is part of the match. Whole-line terminals carry
+# an explicit priority so they win the tie against NAME on their keyword.
+# ``_I_`` in the SHAPE terminal is substituted with ``_SHAPE_INNER`` below.
+_GRAMMAR = r"""
+start: (_statement? _NL)* _statement?
+
+_statement: graph_header
+          | subgraph_header
+          | end_stmt
+          | directive
+          | comment
+          | edge
+          | node
+          | junk
+
+graph_header: GRAPH_HEADER
+subgraph_header: SUBGRAPH_HEADER
+end_stmt: END
+directive: DIRECTIVE
+comment: COMMENT
+edge: NAME SHAPE? ARROW EDGELABEL? NAME SHAPE?
+node: NAME SHAPE?
+junk: JUNK
+
+GRAPH_HEADER.5: /graph[ \t][^\n]*/
+SUBGRAPH_HEADER.5: /subgraph\b[^\n]*/
+END.5: /end(?=[ \t]*(?:\n|$))/
+DIRECTIVE.5: /%%metro[^\n]*/
+COMMENT.3: /%%[^\n]*/
+ARROW.4: /-->|---|==>/
+EDGELABEL.4: /\|[^|\n]*\|/
+SHAPE.4: /\(\[_I_\]\)|\[\[_I_\]\]|\(\(_I_\)\)|\[_I_\]|\(_I_\)|\{_I_\}/
+NAME: /[a-zA-Z_][a-zA-Z0-9_]*/
+JUNK.-10: /[^\n]+/
+
+_NL: /\r?\n/
+%ignore /[ \t]+/
+"""
+
+
+@dataclass
+class _GraphHeader:
+    """A ``graph <DIR>`` header line."""
+
+    line: str
+
+
+@dataclass
+class _Subgraph:
+    """A ``subgraph id [Name]`` header, opening a section."""
+
+    section_id: str
+    name: str
+
+
+@dataclass
+class _End:
+    """An ``end`` line, closing the current section."""
+
+
+@dataclass
+class _Directive:
+    """A ``%%metro key: value`` directive, split into key and stripped value."""
+
+    key: str
+    value: str
+
+
+@dataclass
+class _Comment:
+    """A ``%%`` comment (or a directive with no colon); ignored silently."""
+
+
+@dataclass
+class _Junk:
+    """A non-blank line matching no statement; ignored with a warning."""
+
+    text: str
+
+
+@dataclass
+class _Node:
+    """A node declaration with its id and (shape-stripped) label."""
+
+    node_id: str
+    label: str
+
+
+@dataclass
+class _Edge:
+    """An edge with its endpoints, line ids, and any inline endpoint labels.
+
+    ``line_ids`` is one or more line ids (``["default"]`` when the source
+    carried no ``|...|`` annotation). ``source_label`` / ``target_label`` are
+    set only when an endpoint was written with an inline shape, in which case
+    that endpoint also declares the node.
+    """
+
+    source: str
+    target: str
+    line_ids: list[str]
+    source_label: str | None = None
+    target_label: str | None = None
+
+
+_Statement = (
+    _GraphHeader | _Subgraph | _End | _Directive | _Comment | _Junk | _Node | _Edge
+)
+
+
+# Subgraph pattern: subgraph id [Display Name]
+_SUBGRAPH_PATTERN = re.compile(r"^subgraph\s+(\w+)\s*(?:\[(.+?)\])?\s*$")
+
+
+def _unquote(text: str) -> str:
+    """Strip one pair of surrounding double quotes from a title or label.
+
+    Mermaid requires special characters such as parentheses to be wrapped in
+    double quotes (e.g. ``["Liftover (Picard)"]``) so the diagram parses on
+    GitHub. The quotes are escaping syntax, not part of the displayed text, so
+    they are removed here, leaving the inner text untouched.
+    """
+    if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+        return text[1:-1]
+    return text
+
+
+def _shape_label(shape: str) -> str:
+    """Return the inner text of a shaped node label, delimiters stripped.
+
+    The Mermaid shape delimiters are one or two characters per side; the model
+    records only id + label (never which shape was used), so distinguishing
+    them beyond delimiter width is unnecessary.
+    """
+    two_char_opens = ("([", "[[", "((")
+    width = 2 if shape[:2] in two_char_opens else 1
+    return shape[width:-width]
+
+
+def _split_csv(value: str) -> list[str]:
+    """Split a comma-separated value into stripped, non-empty parts."""
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _edge_line_ids(edge_label: str) -> list[str]:
+    """Split a ``|a, b|`` token into line ids; ``["default"]`` when absent/empty."""
+    inner = edge_label[1:-1].strip() if edge_label else ""
+    return _split_csv(inner) if inner else ["default"]
+
+
+class _StatementTransformer(Transformer[Token, list[_Statement]]):
+    """Turn the parse tree into a flat, ordered list of typed statements."""
+
+    def graph_header(self, items: list[Token]) -> _Statement:
+        return _GraphHeader(str(items[0]))
+
+    def subgraph_header(self, items: list[Token]) -> _Statement:
+        m = _SUBGRAPH_PATTERN.match(str(items[0]))
+        if not m:
+            return _Junk(str(items[0]))
+        return _Subgraph(m.group(1), _unquote((m.group(2) or m.group(1)).strip()))
+
+    def end_stmt(self, items: list[Token]) -> _Statement:
+        return _End()
+
+    def directive(self, items: list[Token]) -> _Statement:
+        content = str(items[0])[len("%%metro") :].strip()
+        key, sep, rest = content.partition(":")
+        if not sep:
+            return _Comment()
+        return _Directive(key, rest.strip())
+
+    def comment(self, items: list[Token]) -> _Statement:
+        return _Comment()
+
+    def junk(self, items: list[Token]) -> _Statement:
+        return _Junk(str(items[0]))
+
+    def node(self, items: list[Token]) -> _Statement:
+        name = str(items[0])
+        label = _shape_label(str(items[1])) if len(items) > 1 else name
+        return _Node(name, label)
+
+    def edge(self, items: list[Token]) -> _Statement:
+        # items: NAME [SHAPE] ARROW [EDGELABEL] NAME [SHAPE]
+        source = str(items[0])
+        rest = items[1:]
+        source_label = None
+        if rest and rest[0].type == "SHAPE":
+            source_label = _shape_label(str(rest[0]))
+            rest = rest[1:]
+        rest = rest[1:]  # drop ARROW
+        edge_label = ""
+        if rest and rest[0].type == "EDGELABEL":
+            edge_label = str(rest[0])
+            rest = rest[1:]
+        target = str(rest[0])
+        target_label = (
+            _shape_label(str(rest[1]))
+            if len(rest) > 1 and rest[1].type == "SHAPE"
+            else None
+        )
+        return _Edge(
+            source, target, _edge_line_ids(edge_label), source_label, target_label
+        )
+
+    def start(self, items: list[_Statement]) -> list[_Statement]:
+        return [it for it in items if not isinstance(it, Token)]
+
+
+# earley + the dynamic lexer are required, not a default: a line that begins
+# like a statement but then hits an unexpected token must fall back to the
+# low-priority junk rule and be dropped. A lalr/contextual parser commits
+# token-by-token and cannot backtrack such a line to junk, so it would turn a
+# dropped line (e.g. an inline-shaped edge endpoint) into a fatal error.
+_PARSER = Lark(_GRAMMAR.replace("_I_", _SHAPE_INNER), parser="earley", lexer="dynamic")
+_TRANSFORMER = _StatementTransformer()
+
+
+def parse_statements(text: str) -> list[_Statement]:
+    """Parse Mermaid source into an ordered list of typed statements.
+
+    Raises ``ValueError`` with a helpful, located message when the grammar
+    rejects the input.
+    """
+    try:
+        tree = _PARSER.parse(text)
+    except UnexpectedInput as e:
+        context = e.get_context(text).rstrip("\n")
+        raise ValueError(
+            f"Could not parse the diagram at line {e.line}, column {e.column}.\n\n"
+            f"{context}\n\n"
+            "Expected a node (fastqc[FastQC]), an edge (fastqc -->|qc| falco), a "
+            "subgraph header, an 'end', or a %%metro directive. A stray "
+            "character here is the usual cause."
+        ) from e
+    return _TRANSFORMER.transform(tree)

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -1,7 +1,13 @@
-"""Parser for Mermaid graph definitions with %%metro directives.
+"""Public entry point for parsing Mermaid graph definitions with %%metro directives.
 
-Uses a simple line-by-line approach rather than a full grammar parser,
-since the Mermaid subset we need is straightforward.
+This module is the driver: it turns source text into a list of typed statements
+(via :mod:`nf_metro.parser.grammar`) and applies them in source order to build a
+:class:`MetroGraph`, maintaining the enclosing-subgraph context exactly as the
+source order implies, then runs the post-parse resolution.
+
+The grammar lives in :mod:`nf_metro.parser.grammar`, directive parsing and
+dispatch in :mod:`nf_metro.parser.directives`, and the post-parse graph rewrites
+in :mod:`nf_metro.parser.resolve`.
 
 Sections are defined as Mermaid subgraphs with %%metro entry/exit directives.
 """
@@ -10,26 +16,28 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import Literal
 
-from nf_metro.parser.model import (
-    MARKER_FILL_OPEN,
-    MARKER_FILL_SOLID,
-    MARKER_SHAPE_CIRCLE,
-    VALID_ICON_TYPES,
-    VALID_LINE_STYLES,
-    VALID_MARKER_SHAPES,
-    Edge,
-    LineSpread,
-    MarkerLegendEntry,
-    MarkerStyle,
-    MetroGraph,
-    MetroLine,
-    Port,
-    PortSide,
-    Section,
-    Station,
-    StationGroup,
+from nf_metro.parser.directives import _apply_directive
+from nf_metro.parser.grammar import (
+    _Comment,
+    _Directive,
+    _Edge,
+    _End,
+    _GraphHeader,
+    _Junk,
+    _Node,
+    _Statement,
+    _Subgraph,
+    _unquote,
+    parse_statements,
+)
+from nf_metro.parser.model import Edge, MetroGraph, Section, Station
+from nf_metro.parser.resolve import (
+    _create_implicit_section,
+    _insert_bypass_stations,
+    _insert_terminus_convergence_stations,
+    _remove_empty_sections,
+    _resolve_sections,
 )
 
 
@@ -142,59 +150,42 @@ def parse_metro_mermaid(
     fold_threshold`` directive supplies the width, falling back to 15.
     """
     _check_unsupported_input(text)
-
     graph = MetroGraph()
-    lines = text.strip().split("\n")
+    _apply_statements(parse_statements(text), graph)
+    _finalize_graph(graph, max_station_columns)
+    return graph
 
+
+def _apply_statements(statements: list[_Statement], graph: MetroGraph) -> None:
+    """Apply parsed statements in source order, tracking the enclosing section."""
     current_section_id: str | None = None
 
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            continue
-
-        # Subgraph end
-        if stripped == "end":
+    for stmt in statements:
+        if isinstance(stmt, _End):
             current_section_id = None
+        elif isinstance(stmt, _Subgraph):
+            graph.add_section(Section(id=stmt.section_id, name=stmt.name))
+            current_section_id = stmt.section_id
+        elif isinstance(stmt, _Directive):
+            _apply_directive(stmt.key, stmt.value, graph, current_section_id)
+        elif isinstance(stmt, _GraphHeader):
+            _warn_if_non_lr_primary(stmt.line)
+        elif isinstance(stmt, _Comment):
             continue
+        elif isinstance(stmt, _Junk):
+            warnings.warn(f"Ignored unrecognised line: {stmt.text!r}", stacklevel=2)
+        elif isinstance(stmt, _Edge):
+            _apply_edge(stmt, graph, current_section_id)
+        elif isinstance(stmt, _Node):
+            _apply_node(stmt.node_id, stmt.label, graph, current_section_id)
 
-        # Subgraph start
-        subgraph_m = _SUBGRAPH_PATTERN.match(stripped)
-        if subgraph_m:
-            section_id = subgraph_m.group(1)
-            display_name = subgraph_m.group(2) or section_id
-            section = Section(id=section_id, name=_unquote(display_name.strip()))
-            graph.add_section(section)
-            current_section_id = section_id
-            continue
 
-        # Metro directives
-        if stripped.startswith("%%metro"):
-            _parse_directive(stripped, graph, current_section_id)
-            continue
-
-        # Graph declaration
-        if stripped.startswith("graph "):
-            _warn_if_non_lr_primary(stripped)
-            continue
-
-        # Skip regular comments
-        if stripped.startswith("%%"):
-            continue
-
-        # Try edge first (contains arrow)
-        if "-->" in stripped or "---" in stripped or "==>" in stripped:
-            _parse_edge(stripped, graph, current_section_id)
-            continue
-
-        # Try node definition
-        _parse_node(stripped, graph, current_section_id)
-
-    # Validate edges before layout
+def _finalize_graph(graph: MetroGraph, max_station_columns: int | None) -> None:
+    """Validate, run the post-parse resolution, and apply buffered metadata."""
     _validate_edge_annotations(graph)
 
-    # Post-parse: remove empty sections, create implicit section for loose
-    # stations, auto-infer layout parameters, then resolve sections
+    # Remove empty sections, create implicit section for loose stations,
+    # auto-infer layout parameters, then resolve sections.
     if graph.sections:
         _remove_empty_sections(graph)
 
@@ -218,12 +209,17 @@ def parse_metro_mermaid(
         _resolve_sections(graph)
         _insert_bypass_stations(graph)
 
-    # Apply pending terminus designations.  Skip mid-pipeline hub
-    # stations: stations the .mmd author tagged as a file/dir input but
-    # which actually receive AND forward data (predecessors + successors).
-    # The file icon implies "this is where the path starts" or "this is
-    # where it ends", which is misleading on a routing hub.  Pure sources
-    # (no predecessors) and pure sinks (no successors) keep their icon.
+    _apply_pending_metadata(graph)
+
+
+def _apply_pending_metadata(graph: MetroGraph) -> None:
+    """Apply terminus icons, off-track marks, and markers buffered during parse.
+
+    Terminus icons skip mid-pipeline hub stations: a station the author tagged
+    as a file/dir input but which both receives and forwards data. The file
+    icon implies a path start or end, which is misleading on a routing hub, so
+    only pure sources (no predecessors) and pure sinks (no successors) keep it.
+    """
     for station_id, entries in graph._pending_terminus.items():
         station = graph.stations.get(station_id)
         if not station:
@@ -235,1290 +231,78 @@ def parse_metro_mermaid(
         station.terminus_names = [name for _, _, name, _ in entries]
         station.terminus_icon_banners = [banner for _, _, _, banner in entries]
 
-    # Apply pending off-track marks
     for station_id in graph._pending_off_track:
         station = graph.stations.get(station_id)
         if station:
             station.off_track = True
 
-    # Apply pending per-station marker styles
     for station_id, marker in graph._pending_markers.items():
         station = graph.stations.get(station_id)
         if station:
             station.marker = marker
 
-    return graph
 
-
-# Subgraph pattern: subgraph id [Display Name]
-_SUBGRAPH_PATTERN = re.compile(r"^subgraph\s+(\w+)\s*(?:\[(.+?)\])?\s*$")
-
-
-def _unquote(text: str) -> str:
-    """Strip one pair of surrounding double quotes from a title or label.
-
-    Mermaid requires special characters such as parentheses to be wrapped in
-    double quotes (e.g. ``["Liftover (Picard)"]``) so the diagram parses on
-    GitHub. The quotes are escaping syntax, not part of the displayed text, so
-    they are removed here, leaving the inner text untouched.
-    """
-    if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
-        return text[1:-1]
-    return text
-
-
-def _parse_directive(
-    line: str,
-    graph: MetroGraph,
-    current_section_id: str | None = None,
-) -> None:
-    """Parse a %%metro directive line."""
-    content = line[len("%%metro") :].strip()
-
-    if content.startswith("title:"):
-        graph.title = content[len("title:") :].strip()
-    elif content.startswith("style:"):
-        graph.style = content[len("style:") :].strip()
-    elif content.startswith("line_order:"):
-        order = content[len("line_order:") :].strip().lower()
-        if order in ("definition", "span"):
-            graph.line_order = order
-    elif content.startswith("line:"):
-        parts = content[len("line:") :].strip().split("|")
-        if len(parts) >= 3:
-            style = "solid"
-            if len(parts) >= 4:
-                raw_style = parts[3].strip().lower()
-                if raw_style in VALID_LINE_STYLES:
-                    style = raw_style
-            graph.add_line(
-                MetroLine(
-                    id=parts[0].strip(),
-                    display_name=parts[1].strip(),
-                    color=parts[2].strip(),
-                    style=style,
-                )
-            )
-    elif content.startswith("entry:"):
-        if current_section_id:
-            _parse_port_hint(content, graph, current_section_id, is_entry=True)
-    elif content.startswith("exit:"):
-        if current_section_id:
-            _parse_port_hint(content, graph, current_section_id, is_entry=False)
-    elif content.startswith("direction:"):
-        if current_section_id and current_section_id in graph.sections:
-            direction = content[len("direction:") :].strip().upper()
-            if direction in ("LR", "RL", "TB"):
-                graph.sections[current_section_id].direction = direction
-                graph._explicit_directions.add(current_section_id)
-    elif content.startswith("grid:"):
-        _parse_grid_directive(content, graph)
-    elif content.startswith("logo_scale:"):
-        _parse_logo_scale_directive(content[len("logo_scale:") :].strip(), graph)
-    elif content.startswith("font_scale:"):
-        _parse_font_scale_directive(content[len("font_scale:") :].strip(), graph)
-    elif content.startswith("legend_logo_gap:"):
-        _parse_legend_logo_gap_directive(
-            content[len("legend_logo_gap:") :].strip(), graph
-        )
-    elif content.startswith("logo:"):
-        graph.logo_path = content[len("logo:") :].strip()
-    elif content.startswith("compact_offsets:"):
-        val = content[len("compact_offsets:") :].strip().lower()
-        graph.compact_offsets = val in ("true", "yes", "1")
-    elif content.startswith("center_ports:"):
-        val = content[len("center_ports:") :].strip().lower()
-        graph.center_ports = val in ("true", "yes", "1")
-    elif content.startswith("line_spread:"):
-        _parse_line_spread_directive(content[len("line_spread:") :].strip(), graph)
-    elif content.startswith("fold_threshold:"):
-        try:
-            graph.fold_threshold = int(content[len("fold_threshold:") :].strip())
-        except ValueError:
-            pass
-    elif content.startswith("label_angle:"):
-        try:
-            graph.label_angle = float(content[len("label_angle:") :].strip())
-        except ValueError:
-            pass
-    elif content.startswith("legend_min_height:"):
-        try:
-            graph.legend_min_height = float(
-                content[len("legend_min_height:") :].strip()
-            )
-        except ValueError:
-            pass
-    elif content.startswith("legend_combo:"):
-        _parse_legend_combo_directive(content[len("legend_combo:") :].strip(), graph)
-    elif content.startswith("legend:"):
-        _parse_legend_directive(content[len("legend:") :].strip(), graph)
-    elif content.startswith("off_track:"):
-        ids = [s.strip() for s in content[len("off_track:") :].split(",")]
-        graph._pending_off_track.extend(sid for sid in ids if sid)
-    elif content.startswith("group:"):
-        _parse_group_directive(content[len("group:") :].strip(), graph)
-    elif content.startswith("marker_legend:"):
-        _parse_marker_legend_directive(content[len("marker_legend:") :].strip(), graph)
-    elif content.startswith("marker:"):
-        _parse_marker_directive(content[len("marker:") :].strip(), graph)
-    elif ":" in content and content.split(":", 1)[0] in VALID_ICON_TYPES:
-        icon_type, rest = content.split(":", 1)
-        parts = rest.strip().split("|")
-        if len(parts) >= 2:
-            station_id = parts[0].strip()
-            raw_labels = parts[1].strip()
-            labels = [s.strip() for s in raw_labels.split(",") if s.strip()]
-            # Optional third field: human-readable caption rendered below the
-            # icon. A single name applies to all labels from this directive.
-            name = parts[2].strip() if len(parts) >= 3 else ""
-            # Optional fourth field: comma-separated icon options. "banner"
-            # renders the format label as bold white text on a dark banner.
-            options = (
-                {o.strip().lower() for o in parts[3].split(",")}
-                if len(parts) >= 4
-                else set()
-            )
-            banner = "banner" in options
-            graph._pending_terminus.setdefault(station_id, []).extend(
-                (label, icon_type, name, banner) for label in labels
-            )
-
-
-def _parse_port_hint(
-    content: str,
-    graph: MetroGraph,
-    section_id: str,
-    is_entry: bool,
-) -> None:
-    """Parse %%metro entry:/exit: and store as a hint on the Section.
-
-    Does NOT create Port objects - those are created later in _resolve_sections
-    based on actual inter-section edges.
-    """
-    prefix = "entry:" if is_entry else "exit:"
-    rest = content[len(prefix) :].strip()
-    parts = rest.split("|")
-    if len(parts) < 2:
-        return
-
-    side_str = parts[0].strip().lower()
-    side_map = {
-        "left": PortSide.LEFT,
-        "right": PortSide.RIGHT,
-        "top": PortSide.TOP,
-        "bottom": PortSide.BOTTOM,
-    }
-    side = side_map.get(side_str)
-    if side is None:
-        return
-
-    line_ids = [lid.strip() for lid in parts[1].strip().split(",") if lid.strip()]
-
-    section = graph.sections.get(section_id)
-    if section:
-        if is_entry:
-            section.entry_hints.append((side, line_ids))
-        else:
-            section.exit_hints.append((side, line_ids))
-
-
-def _parse_grid_directive(content: str, graph: MetroGraph) -> None:
-    """Parse %%metro grid: section_id | col,row[,rowspan[,colspan]] directive."""
-    rest = content[len("grid:") :].strip()
-    parts = rest.split("|")
-    if len(parts) < 2:
-        return
-
-    section_id = parts[0].strip()
-    coords = parts[1].strip().split(",")
-    if len(coords) < 2:
-        return
-
-    try:
-        col = int(coords[0].strip())
-        row = int(coords[1].strip())
-        rowspan = int(coords[2].strip()) if len(coords) >= 3 else 1
-        colspan = int(coords[3].strip()) if len(coords) >= 4 else 1
-    except ValueError:
-        return
-    graph.grid_overrides[section_id] = (col, row, rowspan, colspan)
-    graph._explicit_grid.add(section_id)
-
-
-_LEGEND_KEYWORDS = ("bl", "br", "tl", "tr", "bottom", "right", "none")
-
-
-def _parse_xy(text: str) -> tuple[float, float] | None:
-    """Parse a ``x,y`` pair into floats, or None if it is not a number pair."""
-    if "," not in text:
-        return None
-    x_str, _, y_str = text.partition(",")
-    try:
-        return (float(x_str.strip()), float(y_str.strip()))
-    except ValueError:
-        return None
-
-
-def _parse_legend_directive(value: str, graph: MetroGraph) -> None:
-    """Parse the %%metro legend: directive positioning the legend+logo block.
-
-    Grammar (the keyword forms stay content-anchored with the historical
-    overlap fallback; the qualifier and absolute forms pin the block exactly):
-
-        legend: <keyword>              keyword (bl/br/tl/tr/bottom/right/none)
-        legend: <keyword> | canvas     anchor the keyword to the canvas frame
-        legend: <keyword> | <dx>,<dy>  nudge the keyword anchor by an offset
-        legend: <x>,<y>                absolute top-left coordinates
-    """
-    # Reset modifiers so a re-declared directive starts clean.
-    graph.legend_anchor = "content"
-    graph.legend_offset = None
-    graph.legend_at = None
-
-    head, sep, qualifier = value.partition("|")
-    head = head.strip().lower()
-    qualifier = qualifier.strip().lower()
-
-    coords = _parse_xy(head)
-    if coords is not None:
-        graph.legend_at = coords
-        graph.legend_position = "free"
-        if sep:
-            warnings.warn(
-                f"legend qualifier {qualifier!r} ignored with absolute coordinates.",
-                stacklevel=2,
-            )
-        return
-
-    if head not in _LEGEND_KEYWORDS:
-        warnings.warn(
-            f"Unknown legend position {head!r}; expected one of "
-            f"{'/'.join(_LEGEND_KEYWORDS)} or 'x,y'. Ignoring.",
-            stacklevel=2,
-        )
-        return
-    graph.legend_position = head
-
-    if not qualifier:
-        return
-    if qualifier == "canvas":
-        graph.legend_anchor = "canvas"
-        return
-    offset = _parse_xy(qualifier)
-    if offset is not None:
-        graph.legend_offset = offset
-    else:
-        warnings.warn(
-            f"Unknown legend qualifier {qualifier!r}; expected 'canvas' or "
-            "'dx,dy'. Ignoring.",
-            stacklevel=2,
-        )
-
-
-def _parse_group_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro group: Label | station1, station2[, ...] [| above|below].
-
-    Stores an annotative caption spanning the listed stations.  The optional
-    third field selects whether the caption renders ``below`` (default) or
-    ``above`` the spanned stations.  Purely decorative; does not affect layout.
-    """
-    parts = value.split("|")
-    if len(parts) < 2:
-        warnings.warn(
-            f"group directive {value!r} needs 'Label | station1, station2'. Ignoring.",
-            stacklevel=2,
-        )
-        return
-    label = _unquote(parts[0].strip())
-    station_ids = [s.strip() for s in parts[1].split(",") if s.strip()]
-    if not label or not station_ids:
-        warnings.warn(
-            f"group directive {value!r} needs a label and at least one station. "
-            "Ignoring.",
-            stacklevel=2,
-        )
-        return
-    position: Literal["above", "below"] = "below"
-    if len(parts) >= 3:
-        raw_pos = parts[2].strip().lower()
-        if raw_pos == "above":
-            position = "above"
-        elif raw_pos == "below":
-            position = "below"
-        elif raw_pos:
-            warnings.warn(
-                f"group position {raw_pos!r} not recognised; expected "
-                "'above' or 'below'. Using 'below'.",
-                stacklevel=2,
-            )
-    graph.groups.append(
-        StationGroup(label=label, station_ids=station_ids, position=position)
-    )
-
-
-def _parse_legend_combo_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro legend_combo: lineA, lineB[, ...] | Display Label.
-
-    Stores a (line_ids, label) entry on ``graph.legend_combos``. The named
-    lines are rendered as a single combined legend row and (in rail mode)
-    share a single rail slot. A combo referencing unknown lines is warned
-    about and ignored; unknown members of an otherwise-valid combo are
-    dropped (with a warning) and the remaining members kept.
-    """
-    parts = value.split("|", 1)
-    if len(parts) != 2:
-        warnings.warn(
-            f"Invalid legend_combo {value!r}; expected 'lineA, lineB | Display Label'.",
-            stacklevel=2,
-        )
-        return
-    ids_raw, label = parts[0], parts[1].strip()
-    line_ids = [s.strip() for s in ids_raw.split(",") if s.strip()]
-    if len(line_ids) < 2 or not label:
-        warnings.warn(
-            f"Invalid legend_combo {value!r}; expected at least two line IDs "
-            "and a non-empty label.",
-            stacklevel=2,
-        )
-        return
-    known = [lid for lid in line_ids if lid in graph.lines]
-    unknown = [lid for lid in line_ids if lid not in graph.lines]
-    if unknown:
-        warnings.warn(
-            f"legend_combo {label!r} references unknown line(s) "
-            f"{', '.join(unknown)}; ignoring those.",
-            stacklevel=2,
-        )
-    if len(known) < 2:
-        warnings.warn(
-            f"legend_combo {label!r} has fewer than two known lines; ignoring.",
-            stacklevel=2,
-        )
-        return
-    graph.legend_combos.append((tuple(known), label))
-
-
-def _parse_numeric_directive(
-    value: str, name: str, *, allow_zero: bool
-) -> float | None:
-    """Parse a numeric %%metro directive value, warning and returning None if invalid.
-
-    ``allow_zero`` admits 0 (a gap may legitimately be zero); otherwise the value
-    must be strictly positive (a scale factor cannot be zero).
-    """
-    try:
-        num = float(value)
-    except ValueError:
-        warnings.warn(f"Invalid {name} {value!r}; expected a number.", stacklevel=3)
-        return None
-    if num < 0 or (num == 0 and not allow_zero):
-        constraint = "non-negative" if allow_zero else "positive"
-        warnings.warn(
-            f"{name} must be {constraint}, got {value!r}; ignoring.", stacklevel=3
-        )
-        return None
-    return num
-
-
-def _parse_logo_scale_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro logo_scale: <factor> (1.0 = default auto-size)."""
-    scale = _parse_numeric_directive(value, "logo_scale", allow_zero=False)
-    if scale is not None:
-        graph.logo_scale = scale
-
-
-def _parse_legend_logo_gap_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro legend_logo_gap: <px> (horizontal gap logo->legend entries)."""
-    gap = _parse_numeric_directive(value, "legend_logo_gap", allow_zero=True)
-    if gap is not None:
-        graph.legend_logo_gap = gap
-
-
-def _parse_font_scale_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro font_scale: <factor> (1.0 = default text sizes)."""
-    scale = _parse_numeric_directive(value, "font_scale", allow_zero=False)
-    if scale is not None:
-        graph.font_scale = scale
-
-
-def _parse_marker_style(spec: str) -> MarkerStyle | None:
-    """Parse a ``shape, fill`` marker spec into a MarkerStyle.
-
-    ``shape`` defaults to ``circle`` and ``fill`` to ``solid`` when omitted.
-    An unknown shape is rejected (returns None with a warning); any fill
-    string other than ``open``/``solid`` is taken as a literal colour.
-    """
-    parts = [p.strip() for p in spec.split(",")]
-    shape = parts[0].lower() if parts and parts[0] else MARKER_SHAPE_CIRCLE
-    fill = parts[1] if len(parts) >= 2 and parts[1] else MARKER_FILL_SOLID
-    if shape not in VALID_MARKER_SHAPES:
-        warnings.warn(
-            f"Unknown marker shape {shape!r}; expected one of "
-            f"{'/'.join(VALID_MARKER_SHAPES)}. Ignoring.",
-            stacklevel=2,
-        )
-        return None
-    # Normalise the fill keywords to lowercase; leave literal colours as-is.
-    if fill.lower() in (MARKER_FILL_OPEN, MARKER_FILL_SOLID):
-        fill = fill.lower()
-    return MarkerStyle(shape=shape, fill=fill)
-
-
-def _parse_marker_directive(value: str, graph: MetroGraph) -> None:
-    """Parse ``%%metro marker: node_id | shape, fill``."""
-    node_part, sep, style_part = value.partition("|")
-    node_id = node_part.strip()
-    if not node_id:
-        return
-    style = _parse_marker_style(style_part.strip() if sep else "")
-    if style is not None:
-        graph._pending_markers[node_id] = style
-
-
-def _parse_marker_legend_directive(value: str, graph: MetroGraph) -> None:
-    """Parse ``%%metro marker_legend: shape, fill | Caption``."""
-    style_part, sep, caption = value.partition("|")
-    if not sep:
-        warnings.warn(
-            "marker_legend directive needs a caption: "
-            "'shape, fill | Caption'. Ignoring.",
-            stacklevel=2,
-        )
-        return
-    style = _parse_marker_style(style_part.strip())
-    caption = caption.strip()
-    if style is not None and caption:
-        graph.marker_legend.append(MarkerLegendEntry(style=style, caption=caption))
-
-
-def _parse_line_spread_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro line_spread: <mode>[ | section[, section...]].
-
-    Bare ``line_spread: <mode>`` sets the graph-wide default; the piped form
-    ``line_spread: <mode> | sectionA, sectionB`` records a per-section override
-    that wins over the default for those sections. ``<mode>`` is one of
-    ``bundle`` / ``centered`` / ``rails``; an unrecognised mode is warned about
-    and ignored.
-    """
-    mode_raw, _, sids_raw = value.partition("|")
-    try:
-        mode = LineSpread(mode_raw.strip().lower())
-    except ValueError:
-        valid = ", ".join(m.value for m in LineSpread)
-        warnings.warn(
-            f"Invalid line_spread mode {mode_raw.strip()!r}; expected one of {valid}.",
-            stacklevel=2,
-        )
-        return
-    section_ids = [s.strip() for s in sids_raw.split(",") if s.strip()]
-    if section_ids:
-        for sid in section_ids:
-            graph.line_spread_overrides[sid] = mode
-    else:
-        graph.line_spread = mode
-
-
-# Regex patterns for node shapes
-_NODE_PATTERNS = [
-    # stadium: node_id([label])
-    re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\(\[(.+?)\]\)$"),
-    # subroutine: node_id[[label]]
-    re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\[\[(.+?)\]\]$"),
-    # circle: node_id((label))
-    re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\(\((.+?)\)\)$"),
-    # square bracket: node_id[label]
-    re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\[(.+?)\]$"),
-    # round bracket: node_id(label)
-    re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\((.+?)\)$"),
-    # rhombus: node_id{label}
-    re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\{(.+?)\}$"),
-    # bare id
-    re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)$"),
-]
-
-# Edge pattern: source -->|label| target  or  source --> target
-_EDGE_PATTERN = re.compile(
-    r"^([a-zA-Z_][a-zA-Z0-9_]*)\s*"  # source
-    r"(-->|---|==>)"  # arrow
-    r"(?:\|([^|]*)\|)?\s*"  # optional |label|
-    r"([a-zA-Z_][a-zA-Z0-9_]*)$"  # target
-)
-
-
-def _parse_node(
-    line: str,
+def _apply_node(
+    node_id: str,
+    label: str,
     graph: MetroGraph,
     section_id: str | None = None,
 ) -> None:
-    """Parse a node definition line."""
-    for pattern in _NODE_PATTERNS:
-        m = pattern.match(line)
-        if m:
-            node_id = m.group(1)
-            label = (
-                m.group(2).strip()
-                if m.lastindex is not None and m.lastindex >= 2
-                else node_id
-            )
-            label = _unquote(label)
-            # Convert literal \n sequences to real newlines (multi-line labels)
-            if "\\n" in label:
-                label = "\n".join(part.strip() for part in label.split("\\n"))
-            if node_id not in graph.stations:
-                graph.register_station(
-                    Station(
-                        id=node_id,
-                        label=label,
-                        section_id=section_id,
-                        is_hidden=node_id.startswith("_"),
-                    )
-                )
-            else:
-                # Update label if station was auto-created from an edge
-                graph.stations[node_id].label = label
-                graph.stations[node_id].is_hidden = node_id.startswith("_")
-                # Also set section if not yet set
-                if section_id and graph.stations[node_id].section_id is None:
-                    graph.stations[node_id].section_id = section_id
-                    if section_id in graph.sections:
-                        graph.sections[section_id].station_ids.append(node_id)
-            return
-
-
-def _parse_edge(
-    line: str,
-    graph: MetroGraph,
-    section_id: str | None = None,
-) -> None:
-    """Parse an edge definition line.
-
-    Supports comma-separated line IDs: a -->|line1,line2,line3| b
-    Creates a separate Edge for each line ID.
-    """
-    m = _EDGE_PATTERN.match(line)
-    if not m:
-        return
-
-    source = m.group(1)
-    label = m.group(3).strip() if m.group(3) else "default"
-    target = m.group(4)
-
-    # Ensure stations exist
-    if source not in graph.stations:
+    """Declare a node: register it (or set the label on a station an edge
+    auto-created) from its id and (shape-stripped) label text."""
+    label = _unquote(label.strip())
+    # Convert literal \n sequences to real newlines (multi-line labels)
+    if "\\n" in label:
+        label = "\n".join(part.strip() for part in label.split("\\n"))
+    if node_id not in graph.stations:
         graph.register_station(
             Station(
-                id=source,
-                label=source,
+                id=node_id,
+                label=label,
                 section_id=section_id,
-                is_hidden=source.startswith("_"),
+                is_hidden=node_id.startswith("_"),
             )
         )
-    if target not in graph.stations:
+    else:
+        graph.stations[node_id].label = label
+        graph.stations[node_id].is_hidden = node_id.startswith("_")
+        if section_id and graph.stations[node_id].section_id is None:
+            graph.stations[node_id].section_id = section_id
+            if section_id in graph.sections:
+                graph.sections[section_id].station_ids.append(node_id)
+
+
+def _ensure_station(graph: MetroGraph, node_id: str, section_id: str | None) -> None:
+    """Register a bare edge endpoint as a station if it doesn't exist yet.
+
+    Unlike a node declaration, a bare endpoint provides no label, so an existing
+    station's label is left untouched and a new one takes its id as its label.
+    """
+    if node_id not in graph.stations:
         graph.register_station(
             Station(
-                id=target,
-                label=target,
+                id=node_id,
+                label=node_id,
                 section_id=section_id,
-                is_hidden=target.startswith("_"),
+                is_hidden=node_id.startswith("_"),
             )
         )
 
-    # Split comma-separated line IDs
-    line_ids = [lid.strip() for lid in label.split(",")]
-    for line_id in line_ids:
-        graph.add_edge(Edge(source=source, target=target, line_id=line_id))
 
+def _apply_edge(edge: _Edge, graph: MetroGraph, section_id: str | None) -> None:
+    """Register an edge and its endpoints (one ``Edge`` per line id).
 
-def _remove_empty_sections(graph: MetroGraph) -> None:
-    """Remove sections that have no stations.
-
-    Sections can end up empty when a subgraph contains only edges referencing
-    nodes defined elsewhere. Empty sections cause layout failures.
+    An endpoint written with an inline shape also declares that node with its
+    label; a bare endpoint just ensures the station exists.
     """
-    empty_ids = [sid for sid, sec in graph.sections.items() if not sec.station_ids]
-    for sid in empty_ids:
-        del graph.sections[sid]
-        warnings.warn(
-            f"Section '{sid}' has no node definitions and was ignored. "
-            f"Nodes must be defined inside a subgraph (not just referenced "
-            f"in edges) to become members of that section.",
-            stacklevel=2,
-        )
-
-
-def _create_implicit_section(graph: MetroGraph) -> None:
-    """Create an implicit section for stations not in any explicit section.
-
-    When some stations are in sections and others are not, the layout engine
-    only positions sectioned stations. This creates an invisible section for
-    the remaining 'loose' stations so they participate in layout.
-    """
-    loose = [
-        s for s in graph.stations.values() if s.section_id is None and not s.is_port
-    ]
-    if not loose:
-        return
-
-    implicit = Section(id="__implicit__", name="", is_implicit=True)
-    for s in loose:
-        s.section_id = "__implicit__"
-        implicit.station_ids.append(s.id)
-    graph.add_section(implicit)
-
-
-def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
-    """Insert virtual convergence stations before multi-source termini.
-
-    When a terminus station (a file/files/dir output) has 2+ direct
-    inbound edges from distinct sources, the layout typically places
-    the sources at different Ys and routes diagonals into the terminus
-    marker, producing a Y-shaped converge AT the icon.  Inserting a
-    hidden convergence station between the sources and the terminus
-    forces the layout to allocate a column for the converge, so the
-    diagonals meet there and the final segment to the terminus marker
-    is a clean horizontal/vertical line.
-
-    The convergence station inherits the terminus's section.  It is
-    marked ``is_hidden`` so the renderer skips its label and marker.
-    For each inbound edge ``source -> terminus`` carrying line ``L``,
-    the edge is replaced with ``source -> converge`` followed by a
-    single ``converge -> terminus`` edge per distinct line.
-    """
-    pending_terminus = graph._pending_terminus
-    if not pending_terminus:
-        return
-
-    new_stations: list[Station] = []
-    new_edges: list[Edge] = []
-    edges_to_remove: set[int] = set()
-    converge_count = 0
-
-    for terminus_id in list(pending_terminus.keys()):
-        # Find direct inbound edges and their sources.
-        inbound: list[tuple[int, Edge]] = []
-        for i, edge in enumerate(graph.edges):
-            if edge.target == terminus_id:
-                inbound.append((i, edge))
-        if not inbound:
-            continue
-        sources = {e.source for _, e in inbound}
-        if len(sources) < 2:
-            continue
-
-        terminus = graph.stations.get(terminus_id)
-        if terminus is None:
-            continue
-
-        converge_count += 1
-        converge_id = f"__converge_{terminus_id}_{converge_count}"
-        new_stations.append(
-            Station(
-                id=converge_id,
-                label="",
-                section_id=terminus.section_id,
-                is_hidden=True,
-            )
-        )
-
-        # Replace each ``src -> terminus (line)`` with
-        # ``src -> converge (line)`` and add ``converge -> terminus (line)``.
-        seen_lines: set[str] = set()
-        for idx, edge in inbound:
-            edges_to_remove.add(idx)
-            new_edges.append(
-                Edge(source=edge.source, target=converge_id, line_id=edge.line_id)
-            )
-            if edge.line_id not in seen_lines:
-                seen_lines.add(edge.line_id)
-                new_edges.append(
-                    Edge(source=converge_id, target=terminus_id, line_id=edge.line_id)
-                )
-
-    if not new_stations:
-        return
-
-    for st in new_stations:
-        graph.register_station(st)
-
-    if edges_to_remove:
-        graph.replace_edges(
-            [e for i, e in enumerate(graph.edges) if i not in edges_to_remove]
-        )
-    for edge in new_edges:
-        graph.add_edge(edge)
-
-
-def _insert_bypass_stations(graph: MetroGraph) -> None:
-    """Insert virtual stations so non-consumed lines bypass intermediate stops.
-
-    When a station S sits in the layer-path between an in-section
-    source P and an exit port, lines flowing ``P -> exit_port`` that S
-    neither consumes nor produces would otherwise route through S's
-    column and crash into the marker.  Inserting a hidden virtual
-    station ``V`` between P and the exit port gives the routing engine
-    a column-mate to fan the bypassing lines around S, using the same
-    parallel-branch primitives the rest of the section uses.
-
-    The trigger only fires when the routing engine genuinely needs the
-    helper - otherwise V's add tracks that inflate section height
-    without visual benefit.  The three discriminants are:
-
-    1. *Section topology*.  Single-trunk sections (one head station at
-       the lowest non-port layer, e.g. the 05/06 guide family) funnel
-       every line through a shared trunk and can't escape S's marker
-       without help.  Multi-trunk sections (rnaseq_auto's
-       ``genome_align``, epitopeprediction's ``input_processing``,
-       etc.) already place each inbound line on its own parallel track
-       from the entry, so the routing engine clears the marker via
-       track consolidation - bypass would only over-detour the line.
-       In multi-trunk sections we still allow bypass at fan-in
-       convergence points (S with >=2 in-section predecessors, e.g.
-       differentialabundance's ``annotate``) where the line bundle
-       genuinely loses its parallel-track headroom past S.
-
-    2. *Trunk consumption*.  S must consume at least one line that
-       also flows through some other in-section edge.  A station whose
-       only consumed line is a local spur (e.g. nf_with_subworkflows's
-       ``samtools_index`` taking a single ``spur`` line straight from
-       ``samtools_sort``) sits off-trunk; bypass would snap it back to
-       the trunk Y and open a vertical gap.
-
-    3. *Candidate predecessors*.  In single-trunk sections we scan all
-       lower-layer in-section stations P (siblings and direct preds
-       alike) because the bypass line may originate from either side of
-       the trunk.  In multi-trunk fan-in sections we restrict to S's
-       direct predecessors P -> S, since unrelated lines have their own
-       track already.
-
-    Rewrite (per bypassing ``(P, S)`` group):
-
-    * Add ``V`` (``id=f"__bypass_{S}_{P}_{n}"``, ``is_hidden=True``,
-      same section as S).
-    * For each bypassed edge ``P -> exit_port (L)`` (L not in S's
-      consumed-or-produced line set, ``layer(P) < layer(S) <
-      layer(exit)``), replace with ``P -> V (L)`` + ``V -> exit_port
-      (L)``.
-    """
-    if not graph.sections:
-        return
-
-    import networkx as nx
-
-    pending_terminus_ids: set[str] = set(graph._pending_terminus.keys())
-
-    edges_by_source: dict[str, list[tuple[int, Edge]]] = {}
-    for i, edge in enumerate(graph.edges):
-        edges_by_source.setdefault(edge.source, []).append((i, edge))
-
-    new_stations: list[Station] = []
-    new_edges: list[Edge] = []
-    edges_to_remove: set[int] = set()
-    bypass_count = 0
-
-    def _section_layers(section_ids: set[str]) -> dict[str, int]:
-        sub: nx.DiGraph[str] = nx.DiGraph()
-        for sid in section_ids:
-            sub.add_node(sid)
-        for edge in graph.edges:
-            if edge.source in section_ids and edge.target in section_ids:
-                sub.add_edge(edge.source, edge.target)
-        try:
-            topo = list(nx.topological_sort(sub))
-        except nx.NetworkXUnfeasible:
-            return {}
-        layers: dict[str, int] = {}
-        for node in topo:
-            preds = list(sub.predecessors(node))
-            layers[node] = (
-                max((layers[p] for p in preds), default=-1) + 1 if preds else 0
-            )
-        return layers
-
-    for section in graph.sections.values():
-        station_ids = set(section.station_ids)
-        if not station_ids:
-            continue
-
-        sec_layers = _section_layers(station_ids)
-        exit_port_ids = set(section.exit_ports)
-        # Pin exit ports past every internal station so longest-path layering
-        # doesn't tie an exit port with an internal station sharing its
-        # predecessor (which would suppress the bypass trigger).
-        if exit_port_ids and sec_layers:
-            internal_max = max(
-                v for k, v in sec_layers.items() if k not in exit_port_ids
-            )
-            for pid in exit_port_ids:
-                if sec_layers.get(pid, 0) <= internal_max:
-                    sec_layers[pid] = internal_max + 1
-
-        in_section_edges = [
-            e
-            for e in graph.edges
-            if e.source in station_ids and e.target in station_ids
-        ]
-        in_preds_by_target: dict[str, set[str]] = {}
-        consumed_lines_by_target: dict[str, set[str]] = {}
-        for e in in_section_edges:
-            in_preds_by_target.setdefault(e.target, set()).add(e.source)
-            consumed_lines_by_target.setdefault(e.target, set()).add(e.line_id)
-
-        entry_port_ids = set(section.entry_ports)
-        internal_ids = [
-            sid
-            for sid in station_ids
-            if sid not in exit_port_ids
-            and sid not in entry_port_ids
-            and sid in sec_layers
-        ]
-        if not internal_ids:
-            continue
-        min_internal_layer = min(sec_layers[sid] for sid in internal_ids)
-        head_count = sum(
-            1 for sid in internal_ids if sec_layers[sid] == min_internal_layer
-        )
-        single_trunk_section = head_count <= 1
-
-        for sid in section.station_ids:
-            station = graph.stations.get(sid)
-            if station is None or station.is_port or station.is_hidden:
-                continue
-            if station.is_terminus or sid in pending_terminus_ids:
-                continue
-
-            s_layer = sec_layers.get(sid)
-            if s_layer is None:
-                continue
-            s_lines = set(graph.station_lines(sid))
-
-            in_section_preds = in_preds_by_target.get(sid, set())
-            # In multi-trunk sections, only fan-in convergence points
-            # (S has >=2 in-section predecessors) need bypass help, and
-            # only from a direct predecessor of S - other lines already
-            # have their own parallel tracks.
-            if not single_trunk_section and len(in_section_preds) < 2:
-                continue
-
-            # Skip stations that only consume a spur line - the bypass
-            # would snap S's spur track to the section trunk Y, opening
-            # an unnecessary vertical gap to S.  A consumed line is
-            # "trunk" when it has at least one in-section edge that
-            # doesn't touch S.
-            consumed_lines = consumed_lines_by_target.get(sid, set())
-            trunk_lines = {
-                e.line_id
-                for e in in_section_edges
-                if e.source != sid and e.target != sid
-            }
-            if consumed_lines and not (consumed_lines & trunk_lines):
-                continue
-
-            candidate_preds = sorted(
-                station_ids if single_trunk_section else in_section_preds
-            )
-
-            bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
-            for pred_id in candidate_preds:
-                if pred_id == sid:
-                    continue
-                pred_layer = sec_layers.get(pred_id)
-                if pred_layer is None or pred_layer >= s_layer:
-                    continue
-                for i, edge in edges_by_source.get(pred_id, []):
-                    if edge.target not in exit_port_ids:
-                        continue
-                    if edge.line_id in s_lines:
-                        continue
-                    t_layer = sec_layers.get(edge.target)
-                    if t_layer is None or t_layer <= s_layer:
-                        continue
-                    bypass_by_pred.setdefault(pred_id, []).append((i, edge))
-
-            for pred_id, bypass_edges in bypass_by_pred.items():
-                bypass_count += 1
-                v_id = f"__bypass_{sid}_{pred_id}_{bypass_count}"
-                new_stations.append(
-                    Station(
-                        id=v_id,
-                        label="",
-                        section_id=section.id,
-                        is_hidden=True,
-                    )
-                )
-
-                for idx, edge in bypass_edges:
-                    edges_to_remove.add(idx)
-                    new_edges.append(
-                        Edge(source=edge.source, target=v_id, line_id=edge.line_id)
-                    )
-                    new_edges.append(
-                        Edge(source=v_id, target=edge.target, line_id=edge.line_id)
-                    )
-
-    if not new_stations:
-        return
-
-    for st in new_stations:
-        graph.register_station(st)
-
-    if edges_to_remove:
-        graph.replace_edges(
-            [e for i, e in enumerate(graph.edges) if i not in edges_to_remove]
-        )
-    for edge in new_edges:
-        graph.add_edge(edge)
-
-
-def _resolve_sections(graph: MetroGraph) -> None:
-    """Post-parse: classify edges, create ports, rewrite inter-section edges.
-
-    Key design: ONE exit port per source section. All lines leaving a section
-    exit together, ensuring consistent ordering. Junctions handle fan-out
-    to multiple target sections. ONE entry port per target section per side
-    (side from hints or LEFT default).
-    """
-    entry_side_for_line = _build_entry_side_mapping(graph)
-    internal_edges, inter_section_edges = _classify_edges(graph)
-
-    if inter_section_edges:
-        _create_ports_and_junctions(
-            graph, internal_edges, inter_section_edges, entry_side_for_line
-        )
-        _insert_merge_junctions(graph)
-
-    _assign_section_numbers(graph)
-
-
-def _assign_section_numbers(graph: MetroGraph) -> None:
-    """Assign sequential numbers to sections that don't already have one."""
-    for i, section in enumerate(graph.sections.values()):
-        if section.number == 0:
-            section.number = i + 1
-
-
-def _natural_entry_side(direction: str) -> PortSide:
-    """Return the natural entry side for a section's flow direction."""
-    if direction == "RL":
-        return PortSide.RIGHT
-    if direction == "TB":
-        return PortSide.TOP
-    return PortSide.LEFT  # LR default
-
-
-def _build_entry_side_mapping(
-    graph: MetroGraph,
-) -> dict[tuple[str, str], PortSide]:
-    """Build per-line entry side lookup from explicit entry hints.
-
-    Each section gets a single entry side.  When all hints agree on one
-    side, that side is used.  When hints specify multiple sides, they
-    are collapsed to the natural entry for the section's flow direction
-    (LEFT for LR, RIGHT for RL, TOP for TB) so all lines share one
-    entry port.
-
-    Returns dict mapping (section_id, line_id) -> PortSide.
-    """
-    entry_side_for_line: dict[tuple[str, str], PortSide] = {}
-    for sec_id, section in graph.sections.items():
-        if not section.entry_hints:
-            continue
-        unique_sides = {s for s, _ in section.entry_hints}
-        if len(unique_sides) == 1:
-            side = unique_sides.pop()
+    for node_id, node_label in (
+        (edge.source, edge.source_label),
+        (edge.target, edge.target_label),
+    ):
+        if node_label is not None:
+            _apply_node(node_id, node_label, graph, section_id)
         else:
-            side = _natural_entry_side(section.direction)
-        all_lines: set[str] = set()
-        for _hint_side, line_ids in section.entry_hints:
-            all_lines.update(line_ids)
-        for lid in all_lines:
-            entry_side_for_line[(sec_id, lid)] = side
-    return entry_side_for_line
+            _ensure_station(graph, node_id, section_id)
 
-
-def _classify_edges(
-    graph: MetroGraph,
-) -> tuple[list[Edge], list[Edge]]:
-    """Separate edges into internal and inter-section categories.
-
-    Internal edges stay within a single section. Inter-section edges
-    cross section boundaries and need port/junction rewriting.
-    Also populates section.internal_edges for each section.
-
-    Returns (internal_edges, inter_section_edges).
-    """
-    internal_edges: list[Edge] = []
-    inter_section_edges: list[Edge] = []
-
-    for edge in graph.edges:
-        src_sec = graph.section_for_station(edge.source)
-        tgt_sec = graph.section_for_station(edge.target)
-
-        if src_sec and tgt_sec and src_sec != tgt_sec:
-            inter_section_edges.append(edge)
-        else:
-            internal_edges.append(edge)
-            sec_id = src_sec or tgt_sec
-            if sec_id and sec_id in graph.sections:
-                graph.sections[sec_id].internal_edges.append(edge)
-
-    return internal_edges, inter_section_edges
-
-
-def _determine_exit_sides(
-    graph: MetroGraph,
-) -> dict[str, PortSide]:
-    """Map each section to its exit side based on exit hints."""
-    section_exit_side: dict[str, PortSide] = {}
-    for sec_id, section in graph.sections.items():
-        unique_sides = {side for side, _line_ids in section.exit_hints}
-        if len(unique_sides) == 1:
-            section_exit_side[sec_id] = unique_sides.pop()
-        else:
-            section_exit_side[sec_id] = PortSide.RIGHT
-    return section_exit_side
-
-
-def _group_inter_section_edges(
-    graph: MetroGraph,
-    inter_section_edges: list[Edge],
-    entry_side_for_line: dict[tuple[str, str], PortSide],
-) -> tuple[dict[str, list[Edge]], dict[tuple[str, PortSide], list[Edge]]]:
-    """Group inter-section edges by exit section and (entry section, side)."""
-    exit_group_edges: dict[str, list[Edge]] = {}
-    entry_group_edges: dict[tuple[str, PortSide], list[Edge]] = {}
-
-    for edge in inter_section_edges:
-        src_sec = graph.section_for_station(edge.source)
-        tgt_sec = graph.section_for_station(edge.target)
-        # _classify_edges only files an edge as inter-section when both
-        # endpoints resolve to a section, so neither lookup is None here.
-        assert src_sec is not None and tgt_sec is not None
-        entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
-
-        exit_group_edges.setdefault(src_sec, []).append(edge)
-        entry_group_edges.setdefault((tgt_sec, entry_side), []).append(edge)
-
-    return exit_group_edges, entry_group_edges
-
-
-def _create_port_stations(
-    graph: MetroGraph,
-    exit_group_edges: dict[str, list[Edge]],
-    entry_group_edges: dict[tuple[str, PortSide], list[Edge]],
-    section_exit_side: dict[str, PortSide],
-) -> tuple[dict[str, str], dict[tuple[str, PortSide], str], int]:
-    """Create exit and entry port stations on the graph.
-
-    Returns (exit_port_map, entry_port_map, next_port_counter).
-    """
-    port_counter = 0
-    exit_port_map: dict[str, str] = {}
-
-    for sec_id in exit_group_edges:
-        side = section_exit_side.get(sec_id, PortSide.RIGHT)
-        port_id = f"{sec_id}__exit_{side.value}_{port_counter}"
-        port = Port(
-            id=port_id,
-            section_id=sec_id,
-            side=side,
-            is_entry=False,
-        )
-        graph.add_port(port)
-        exit_port_map[sec_id] = port_id
-        port_counter += 1
-
-    entry_port_map: dict[tuple[str, PortSide], str] = {}
-
-    for sec_id, side in entry_group_edges:
-        port_id = f"{sec_id}__entry_{side.value}_{port_counter}"
-        port = Port(
-            id=port_id,
-            section_id=sec_id,
-            side=side,
-            is_entry=True,
-        )
-        graph.add_port(port)
-        entry_port_map[(sec_id, side)] = port_id
-        port_counter += 1
-
-    return exit_port_map, entry_port_map, port_counter
-
-
-def _rewrite_edges_with_junctions(
-    graph: MetroGraph,
-    internal_edges: list[Edge],
-    inter_section_edges: list[Edge],
-    entry_side_for_line: dict[tuple[str, str], PortSide],
-    exit_port_map: dict[str, str],
-    entry_port_map: dict[tuple[str, PortSide], str],
-    port_counter: int,
-) -> None:
-    """Rewrite inter-section edges into 3-part chains with junctions."""
-    new_edges: list[Edge] = list(internal_edges)
-
-    # Group by exit port to detect fan-outs
-    exit_fan: dict[str, dict[str, list[Edge]]] = {}
-
-    for edge in inter_section_edges:
-        src_sec = graph.section_for_station(edge.source)
-        tgt_sec = graph.section_for_station(edge.target)
-        assert src_sec is not None and tgt_sec is not None
-        entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
-
-        exit_port_id = exit_port_map[src_sec]
-        entry_port_id = entry_port_map[(tgt_sec, entry_side)]
-
-        new_edges.append(
-            Edge(source=edge.source, target=exit_port_id, line_id=edge.line_id)
-        )
-        new_edges.append(
-            Edge(source=entry_port_id, target=edge.target, line_id=edge.line_id)
-        )
-
-        exit_fan.setdefault(exit_port_id, {}).setdefault(entry_port_id, []).append(edge)
-
-    for exit_port_id, entry_targets in exit_fan.items():
-        if len(entry_targets) <= 1:
-            for entry_port_id, edges in entry_targets.items():
-                for edge in edges:
-                    new_edges.append(
-                        Edge(
-                            source=exit_port_id,
-                            target=entry_port_id,
-                            line_id=edge.line_id,
-                        )
-                    )
-        else:
-            junction_id = f"__junction_{port_counter}"
-            port_counter += 1
-            junction = Station(id=junction_id, label="", is_port=True, section_id=None)
-            graph.add_station(junction)
-            graph.add_junction(junction_id)
-
-            all_line_ids_set: set[str] = set()
-            for edges in entry_targets.values():
-                for edge in edges:
-                    all_line_ids_set.add(edge.line_id)
-            for lid in sorted(all_line_ids_set):
-                new_edges.append(
-                    Edge(source=exit_port_id, target=junction_id, line_id=lid)
-                )
-
-            for entry_port_id, edges in entry_targets.items():
-                for edge in edges:
-                    new_edges.append(
-                        Edge(
-                            source=junction_id,
-                            target=entry_port_id,
-                            line_id=edge.line_id,
-                        )
-                    )
-
-    # Deduplicate edges by (source, target, line_id) - multiple original
-    # inter-section edges targeting different stations in the same section
-    # can produce identical port-to-port or junction-to-port edges.
-    seen: set[tuple[str, str, str]] = set()
-    deduped: list[Edge] = []
-    for edge in new_edges:
-        key = (edge.source, edge.target, edge.line_id)
-        if key not in seen:
-            seen.add(key)
-            deduped.append(edge)
-    graph.replace_edges(deduped)
-
-
-def _create_ports_and_junctions(
-    graph: MetroGraph,
-    internal_edges: list[Edge],
-    inter_section_edges: list[Edge],
-    entry_side_for_line: dict[tuple[str, str], PortSide],
-) -> None:
-    """Create exit/entry ports and junctions, rewrite inter-section edges.
-
-    Creates one exit port per source section, one entry port per
-    (target_section, entry_side), and inserts junction stations where
-    an exit port fans out to multiple entry ports.
-    """
-    section_exit_side = _determine_exit_sides(graph)
-    exit_groups, entry_groups = _group_inter_section_edges(
-        graph, inter_section_edges, entry_side_for_line
-    )
-    exit_port_map, entry_port_map, port_counter = _create_port_stations(
-        graph, exit_groups, entry_groups, section_exit_side
-    )
-    _rewrite_edges_with_junctions(
-        graph,
-        internal_edges,
-        inter_section_edges,
-        entry_side_for_line,
-        exit_port_map,
-        entry_port_map,
-        port_counter,
-    )
-
-
-def _insert_merge_junctions(graph: MetroGraph) -> None:
-    """Insert merge junctions where multiple same-line edges converge on one entry port.
-
-    After _create_ports_and_junctions, multiple inter-section edges of the same
-    line can target the same entry port from different sources (e.g. raw_asm,
-    purging, polishing all sending 'assemblies' to scaffolding's entry port).
-
-    For each such group (N>1 same-line edges to one entry port), this inserts a
-    merge junction and rewrites edges: all N sources -> merge junction, then one
-    edge merge junction -> entry port.
-
-    The merge junction's section_id is set to the TARGET section so that
-    _resolve_section_col() in routing correctly resolves its column for bypass
-    detection.
-    """
-    # Find edges from fan-out junctions targeting entry ports, grouped
-    # by (entry_port_id, line_id).  Only junction sources are counted -
-    # exit port sources route fine as normal L-shapes and shouldn't be
-    # merged (merging disrupts exit port positioning).
-    convergent: dict[tuple[str, str], list[Edge]] = {}
-    for edge in graph.edges:
-        tgt_port = graph.ports.get(edge.target)
-        if not tgt_port or not tgt_port.is_entry:
-            continue
-        if edge.source not in graph.junctions:
-            continue
-        key = (edge.target, edge.line_id)
-        convergent.setdefault(key, []).append(edge)
-
-    # Only process groups with N>1 convergent edges
-    merge_groups = {k: v for k, v in convergent.items() if len(v) > 1}
-    if not merge_groups:
-        return
-
-    counter = len(graph.junctions)
-    edges_to_remove: set[tuple[str, str, str]] = set()
-    new_edges: list[Edge] = []
-
-    for (entry_port_id, line_id), edges in merge_groups.items():
-        entry_port = graph.ports[entry_port_id]
-        merge_id = f"__merge_{counter}"
-        counter += 1
-
-        merge_station = Station(
-            id=merge_id,
-            label="",
-            is_port=True,
-            section_id=entry_port.section_id,
-        )
-        graph.add_station(merge_station)
-        graph.add_junction(merge_id)
-
-        # Rewrite: each source -> merge junction
-        for edge in edges:
-            edges_to_remove.add((edge.source, edge.target, edge.line_id))
-            new_edges.append(Edge(source=edge.source, target=merge_id, line_id=line_id))
-
-        # One edge: merge junction -> entry port
-        new_edges.append(Edge(source=merge_id, target=entry_port_id, line_id=line_id))
-
-    # Apply edge rewrites
-    kept = [
-        e for e in graph.edges if (e.source, e.target, e.line_id) not in edges_to_remove
-    ]
-    graph.replace_edges(kept + new_edges)
+    for line_id in edge.line_ids:
+        graph.add_edge(Edge(source=edge.source, target=edge.target, line_id=line_id))

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -1,0 +1,715 @@
+"""Post-parse graph rewrites.
+
+After the driver in :mod:`nf_metro.parser.mermaid` has applied every statement,
+these helpers reshape the :class:`MetroGraph`: dropping empty sections, wrapping
+loose stations in an implicit section, inserting convergence/bypass/merge
+junctions, and resolving inter-section edges into port-to-port chains.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import networkx as nx
+
+from nf_metro.parser.model import (
+    Edge,
+    MetroGraph,
+    Port,
+    PortSide,
+    Section,
+    Station,
+)
+
+
+def _remove_empty_sections(graph: MetroGraph) -> None:
+    """Remove sections that have no stations.
+
+    Sections can end up empty when a subgraph contains only edges referencing
+    nodes defined elsewhere. Empty sections cause layout failures.
+    """
+    empty_ids = [sid for sid, sec in graph.sections.items() if not sec.station_ids]
+    for sid in empty_ids:
+        del graph.sections[sid]
+        warnings.warn(
+            f"Section '{sid}' has no node definitions and was ignored. "
+            f"Nodes must be defined inside a subgraph (not just referenced "
+            f"in edges) to become members of that section.",
+            stacklevel=2,
+        )
+
+
+def _create_implicit_section(graph: MetroGraph) -> None:
+    """Create an implicit section for stations not in any explicit section.
+
+    When some stations are in sections and others are not, the layout engine
+    only positions sectioned stations. This creates an invisible section for
+    the remaining 'loose' stations so they participate in layout.
+    """
+    loose = [
+        s for s in graph.stations.values() if s.section_id is None and not s.is_port
+    ]
+    if not loose:
+        return
+
+    implicit = Section(id="__implicit__", name="", is_implicit=True)
+    for s in loose:
+        s.section_id = "__implicit__"
+        implicit.station_ids.append(s.id)
+    graph.add_section(implicit)
+
+
+def _insert_terminus_convergence_stations(graph: MetroGraph) -> None:
+    """Insert virtual convergence stations before multi-source termini.
+
+    When a terminus station (a file/files/dir output) has 2+ direct
+    inbound edges from distinct sources, the layout typically places
+    the sources at different Ys and routes diagonals into the terminus
+    marker, producing a Y-shaped converge AT the icon.  Inserting a
+    hidden convergence station between the sources and the terminus
+    forces the layout to allocate a column for the converge, so the
+    diagonals meet there and the final segment to the terminus marker
+    is a clean horizontal/vertical line.
+
+    The convergence station inherits the terminus's section.  It is
+    marked ``is_hidden`` so the renderer skips its label and marker.
+    For each inbound edge ``source -> terminus`` carrying line ``L``,
+    the edge is replaced with ``source -> converge`` followed by a
+    single ``converge -> terminus`` edge per distinct line.
+    """
+    pending_terminus = graph._pending_terminus
+    if not pending_terminus:
+        return
+
+    new_stations: list[Station] = []
+    new_edges: list[Edge] = []
+    edges_to_remove: set[int] = set()
+    converge_count = 0
+
+    for terminus_id in list(pending_terminus.keys()):
+        # Find direct inbound edges and their sources.
+        inbound: list[tuple[int, Edge]] = []
+        for i, edge in enumerate(graph.edges):
+            if edge.target == terminus_id:
+                inbound.append((i, edge))
+        if not inbound:
+            continue
+        sources = {e.source for _, e in inbound}
+        if len(sources) < 2:
+            continue
+
+        terminus = graph.stations.get(terminus_id)
+        if terminus is None:
+            continue
+
+        converge_count += 1
+        converge_id = f"__converge_{terminus_id}_{converge_count}"
+        new_stations.append(
+            Station(
+                id=converge_id,
+                label="",
+                section_id=terminus.section_id,
+                is_hidden=True,
+            )
+        )
+
+        # Replace each ``src -> terminus (line)`` with
+        # ``src -> converge (line)`` and add ``converge -> terminus (line)``.
+        seen_lines: set[str] = set()
+        for idx, edge in inbound:
+            edges_to_remove.add(idx)
+            new_edges.append(
+                Edge(source=edge.source, target=converge_id, line_id=edge.line_id)
+            )
+            if edge.line_id not in seen_lines:
+                seen_lines.add(edge.line_id)
+                new_edges.append(
+                    Edge(source=converge_id, target=terminus_id, line_id=edge.line_id)
+                )
+
+    if not new_stations:
+        return
+
+    for st in new_stations:
+        graph.register_station(st)
+
+    if edges_to_remove:
+        graph.replace_edges(
+            [e for i, e in enumerate(graph.edges) if i not in edges_to_remove]
+        )
+    for edge in new_edges:
+        graph.add_edge(edge)
+
+
+def _insert_bypass_stations(graph: MetroGraph) -> None:
+    """Insert virtual stations so non-consumed lines bypass intermediate stops.
+
+    When a station S sits in the layer-path between an in-section
+    source P and an exit port, lines flowing ``P -> exit_port`` that S
+    neither consumes nor produces would otherwise route through S's
+    column and crash into the marker.  Inserting a hidden virtual
+    station ``V`` between P and the exit port gives the routing engine
+    a column-mate to fan the bypassing lines around S, using the same
+    parallel-branch primitives the rest of the section uses.
+
+    The trigger only fires when the routing engine genuinely needs the
+    helper - otherwise V's add tracks that inflate section height
+    without visual benefit.  The three discriminants are:
+
+    1. *Section topology*.  Single-trunk sections (one head station at
+       the lowest non-port layer, e.g. the 05/06 guide family) funnel
+       every line through a shared trunk and can't escape S's marker
+       without help.  Multi-trunk sections (rnaseq_auto's
+       ``genome_align``, epitopeprediction's ``input_processing``,
+       etc.) already place each inbound line on its own parallel track
+       from the entry, so the routing engine clears the marker via
+       track consolidation - bypass would only over-detour the line.
+       In multi-trunk sections we still allow bypass at fan-in
+       convergence points (S with >=2 in-section predecessors, e.g.
+       differentialabundance's ``annotate``) where the line bundle
+       genuinely loses its parallel-track headroom past S.
+
+    2. *Trunk consumption*.  S must consume at least one line that
+       also flows through some other in-section edge.  A station whose
+       only consumed line is a local spur (e.g. nf_with_subworkflows's
+       ``samtools_index`` taking a single ``spur`` line straight from
+       ``samtools_sort``) sits off-trunk; bypass would snap it back to
+       the trunk Y and open a vertical gap.
+
+    3. *Candidate predecessors*.  In single-trunk sections we scan all
+       lower-layer in-section stations P (siblings and direct preds
+       alike) because the bypass line may originate from either side of
+       the trunk.  In multi-trunk fan-in sections we restrict to S's
+       direct predecessors P -> S, since unrelated lines have their own
+       track already.
+
+    Rewrite (per bypassing ``(P, S)`` group):
+
+    * Add ``V`` (``id=f"__bypass_{S}_{P}_{n}"``, ``is_hidden=True``,
+      same section as S).
+    * For each bypassed edge ``P -> exit_port (L)`` (L not in S's
+      consumed-or-produced line set, ``layer(P) < layer(S) <
+      layer(exit)``), replace with ``P -> V (L)`` + ``V -> exit_port
+      (L)``.
+    """
+    if not graph.sections:
+        return
+
+    pending_terminus_ids: set[str] = set(graph._pending_terminus.keys())
+
+    edges_by_source: dict[str, list[tuple[int, Edge]]] = {}
+    for i, edge in enumerate(graph.edges):
+        edges_by_source.setdefault(edge.source, []).append((i, edge))
+
+    new_stations: list[Station] = []
+    new_edges: list[Edge] = []
+    edges_to_remove: set[int] = set()
+    bypass_count = 0
+
+    def _section_layers(section_ids: set[str]) -> dict[str, int]:
+        sub: nx.DiGraph[str] = nx.DiGraph()
+        for sid in section_ids:
+            sub.add_node(sid)
+        for edge in graph.edges:
+            if edge.source in section_ids and edge.target in section_ids:
+                sub.add_edge(edge.source, edge.target)
+        try:
+            topo = list(nx.topological_sort(sub))
+        except nx.NetworkXUnfeasible:
+            return {}
+        layers: dict[str, int] = {}
+        for node in topo:
+            preds = list(sub.predecessors(node))
+            layers[node] = (
+                max((layers[p] for p in preds), default=-1) + 1 if preds else 0
+            )
+        return layers
+
+    for section in graph.sections.values():
+        station_ids = set(section.station_ids)
+        if not station_ids:
+            continue
+
+        sec_layers = _section_layers(station_ids)
+        exit_port_ids = set(section.exit_ports)
+        # Pin exit ports past every internal station so longest-path layering
+        # doesn't tie an exit port with an internal station sharing its
+        # predecessor (which would suppress the bypass trigger).
+        if exit_port_ids and sec_layers:
+            internal_max = max(
+                v for k, v in sec_layers.items() if k not in exit_port_ids
+            )
+            for pid in exit_port_ids:
+                if sec_layers.get(pid, 0) <= internal_max:
+                    sec_layers[pid] = internal_max + 1
+
+        in_section_edges = [
+            e
+            for e in graph.edges
+            if e.source in station_ids and e.target in station_ids
+        ]
+        in_preds_by_target: dict[str, set[str]] = {}
+        consumed_lines_by_target: dict[str, set[str]] = {}
+        for e in in_section_edges:
+            in_preds_by_target.setdefault(e.target, set()).add(e.source)
+            consumed_lines_by_target.setdefault(e.target, set()).add(e.line_id)
+
+        entry_port_ids = set(section.entry_ports)
+        internal_ids = [
+            sid
+            for sid in station_ids
+            if sid not in exit_port_ids
+            and sid not in entry_port_ids
+            and sid in sec_layers
+        ]
+        if not internal_ids:
+            continue
+        min_internal_layer = min(sec_layers[sid] for sid in internal_ids)
+        head_count = sum(
+            1 for sid in internal_ids if sec_layers[sid] == min_internal_layer
+        )
+        single_trunk_section = head_count <= 1
+
+        for sid in section.station_ids:
+            station = graph.stations.get(sid)
+            if station is None or station.is_port or station.is_hidden:
+                continue
+            if station.is_terminus or sid in pending_terminus_ids:
+                continue
+
+            s_layer = sec_layers.get(sid)
+            if s_layer is None:
+                continue
+            s_lines = set(graph.station_lines(sid))
+
+            in_section_preds = in_preds_by_target.get(sid, set())
+            # In multi-trunk sections, only fan-in convergence points
+            # (S has >=2 in-section predecessors) need bypass help, and
+            # only from a direct predecessor of S - other lines already
+            # have their own parallel tracks.
+            if not single_trunk_section and len(in_section_preds) < 2:
+                continue
+
+            # Skip stations that only consume a spur line - the bypass
+            # would snap S's spur track to the section trunk Y, opening
+            # an unnecessary vertical gap to S.  A consumed line is
+            # "trunk" when it has at least one in-section edge that
+            # doesn't touch S.
+            consumed_lines = consumed_lines_by_target.get(sid, set())
+            trunk_lines = {
+                e.line_id
+                for e in in_section_edges
+                if e.source != sid and e.target != sid
+            }
+            if consumed_lines and not (consumed_lines & trunk_lines):
+                continue
+
+            candidate_preds = sorted(
+                station_ids if single_trunk_section else in_section_preds
+            )
+
+            bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
+            for pred_id in candidate_preds:
+                if pred_id == sid:
+                    continue
+                pred_layer = sec_layers.get(pred_id)
+                if pred_layer is None or pred_layer >= s_layer:
+                    continue
+                for i, edge in edges_by_source.get(pred_id, []):
+                    if edge.target not in exit_port_ids:
+                        continue
+                    if edge.line_id in s_lines:
+                        continue
+                    t_layer = sec_layers.get(edge.target)
+                    if t_layer is None or t_layer <= s_layer:
+                        continue
+                    bypass_by_pred.setdefault(pred_id, []).append((i, edge))
+
+            for pred_id, bypass_edges in bypass_by_pred.items():
+                bypass_count += 1
+                v_id = f"__bypass_{sid}_{pred_id}_{bypass_count}"
+                new_stations.append(
+                    Station(
+                        id=v_id,
+                        label="",
+                        section_id=section.id,
+                        is_hidden=True,
+                    )
+                )
+
+                for idx, edge in bypass_edges:
+                    edges_to_remove.add(idx)
+                    new_edges.append(
+                        Edge(source=edge.source, target=v_id, line_id=edge.line_id)
+                    )
+                    new_edges.append(
+                        Edge(source=v_id, target=edge.target, line_id=edge.line_id)
+                    )
+
+    if not new_stations:
+        return
+
+    for st in new_stations:
+        graph.register_station(st)
+
+    if edges_to_remove:
+        graph.replace_edges(
+            [e for i, e in enumerate(graph.edges) if i not in edges_to_remove]
+        )
+    for edge in new_edges:
+        graph.add_edge(edge)
+
+
+def _resolve_sections(graph: MetroGraph) -> None:
+    """Post-parse: classify edges, create ports, rewrite inter-section edges.
+
+    Key design: ONE exit port per source section. All lines leaving a section
+    exit together, ensuring consistent ordering. Junctions handle fan-out
+    to multiple target sections. ONE entry port per target section per side
+    (side from hints or LEFT default).
+    """
+    entry_side_for_line = _build_entry_side_mapping(graph)
+    internal_edges, inter_section_edges = _classify_edges(graph)
+
+    if inter_section_edges:
+        _create_ports_and_junctions(
+            graph, internal_edges, inter_section_edges, entry_side_for_line
+        )
+        _insert_merge_junctions(graph)
+
+    _assign_section_numbers(graph)
+
+
+def _assign_section_numbers(graph: MetroGraph) -> None:
+    """Assign sequential numbers to sections that don't already have one."""
+    for i, section in enumerate(graph.sections.values()):
+        if section.number == 0:
+            section.number = i + 1
+
+
+def _natural_entry_side(direction: str) -> PortSide:
+    """Return the natural entry side for a section's flow direction."""
+    if direction == "RL":
+        return PortSide.RIGHT
+    if direction == "TB":
+        return PortSide.TOP
+    return PortSide.LEFT  # LR default
+
+
+def _build_entry_side_mapping(
+    graph: MetroGraph,
+) -> dict[tuple[str, str], PortSide]:
+    """Build per-line entry side lookup from explicit entry hints.
+
+    Each section gets a single entry side.  When all hints agree on one
+    side, that side is used.  When hints specify multiple sides, they
+    are collapsed to the natural entry for the section's flow direction
+    (LEFT for LR, RIGHT for RL, TOP for TB) so all lines share one
+    entry port.
+
+    Returns dict mapping (section_id, line_id) -> PortSide.
+    """
+    entry_side_for_line: dict[tuple[str, str], PortSide] = {}
+    for sec_id, section in graph.sections.items():
+        if not section.entry_hints:
+            continue
+        unique_sides = {s for s, _ in section.entry_hints}
+        if len(unique_sides) == 1:
+            side = unique_sides.pop()
+        else:
+            side = _natural_entry_side(section.direction)
+        all_lines: set[str] = set()
+        for _hint_side, line_ids in section.entry_hints:
+            all_lines.update(line_ids)
+        for lid in all_lines:
+            entry_side_for_line[(sec_id, lid)] = side
+    return entry_side_for_line
+
+
+def _classify_edges(
+    graph: MetroGraph,
+) -> tuple[list[Edge], list[Edge]]:
+    """Separate edges into internal and inter-section categories.
+
+    Internal edges stay within a single section. Inter-section edges
+    cross section boundaries and need port/junction rewriting.
+    Also populates section.internal_edges for each section.
+
+    Returns (internal_edges, inter_section_edges).
+    """
+    internal_edges: list[Edge] = []
+    inter_section_edges: list[Edge] = []
+
+    for edge in graph.edges:
+        src_sec = graph.section_for_station(edge.source)
+        tgt_sec = graph.section_for_station(edge.target)
+
+        if src_sec and tgt_sec and src_sec != tgt_sec:
+            inter_section_edges.append(edge)
+        else:
+            internal_edges.append(edge)
+            sec_id = src_sec or tgt_sec
+            if sec_id and sec_id in graph.sections:
+                graph.sections[sec_id].internal_edges.append(edge)
+
+    return internal_edges, inter_section_edges
+
+
+def _determine_exit_sides(
+    graph: MetroGraph,
+) -> dict[str, PortSide]:
+    """Map each section to its exit side based on exit hints."""
+    section_exit_side: dict[str, PortSide] = {}
+    for sec_id, section in graph.sections.items():
+        unique_sides = {side for side, _line_ids in section.exit_hints}
+        if len(unique_sides) == 1:
+            section_exit_side[sec_id] = unique_sides.pop()
+        else:
+            section_exit_side[sec_id] = PortSide.RIGHT
+    return section_exit_side
+
+
+def _group_inter_section_edges(
+    graph: MetroGraph,
+    inter_section_edges: list[Edge],
+    entry_side_for_line: dict[tuple[str, str], PortSide],
+) -> tuple[dict[str, list[Edge]], dict[tuple[str, PortSide], list[Edge]]]:
+    """Group inter-section edges by exit section and (entry section, side)."""
+    exit_group_edges: dict[str, list[Edge]] = {}
+    entry_group_edges: dict[tuple[str, PortSide], list[Edge]] = {}
+
+    for edge in inter_section_edges:
+        src_sec = graph.section_for_station(edge.source)
+        tgt_sec = graph.section_for_station(edge.target)
+        # _classify_edges only files an edge as inter-section when both
+        # endpoints resolve to a section, so neither lookup is None here.
+        assert src_sec is not None and tgt_sec is not None
+        entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
+
+        exit_group_edges.setdefault(src_sec, []).append(edge)
+        entry_group_edges.setdefault((tgt_sec, entry_side), []).append(edge)
+
+    return exit_group_edges, entry_group_edges
+
+
+def _create_port_stations(
+    graph: MetroGraph,
+    exit_group_edges: dict[str, list[Edge]],
+    entry_group_edges: dict[tuple[str, PortSide], list[Edge]],
+    section_exit_side: dict[str, PortSide],
+) -> tuple[dict[str, str], dict[tuple[str, PortSide], str], int]:
+    """Create exit and entry port stations on the graph.
+
+    Returns (exit_port_map, entry_port_map, next_port_counter).
+    """
+    port_counter = 0
+    exit_port_map: dict[str, str] = {}
+
+    for sec_id in exit_group_edges:
+        side = section_exit_side.get(sec_id, PortSide.RIGHT)
+        port_id = f"{sec_id}__exit_{side.value}_{port_counter}"
+        port = Port(
+            id=port_id,
+            section_id=sec_id,
+            side=side,
+            is_entry=False,
+        )
+        graph.add_port(port)
+        exit_port_map[sec_id] = port_id
+        port_counter += 1
+
+    entry_port_map: dict[tuple[str, PortSide], str] = {}
+
+    for sec_id, side in entry_group_edges:
+        port_id = f"{sec_id}__entry_{side.value}_{port_counter}"
+        port = Port(
+            id=port_id,
+            section_id=sec_id,
+            side=side,
+            is_entry=True,
+        )
+        graph.add_port(port)
+        entry_port_map[(sec_id, side)] = port_id
+        port_counter += 1
+
+    return exit_port_map, entry_port_map, port_counter
+
+
+def _rewrite_edges_with_junctions(
+    graph: MetroGraph,
+    internal_edges: list[Edge],
+    inter_section_edges: list[Edge],
+    entry_side_for_line: dict[tuple[str, str], PortSide],
+    exit_port_map: dict[str, str],
+    entry_port_map: dict[tuple[str, PortSide], str],
+    port_counter: int,
+) -> None:
+    """Rewrite inter-section edges into 3-part chains with junctions."""
+    new_edges: list[Edge] = list(internal_edges)
+
+    # Group by exit port to detect fan-outs
+    exit_fan: dict[str, dict[str, list[Edge]]] = {}
+
+    for edge in inter_section_edges:
+        src_sec = graph.section_for_station(edge.source)
+        tgt_sec = graph.section_for_station(edge.target)
+        assert src_sec is not None and tgt_sec is not None
+        entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
+
+        exit_port_id = exit_port_map[src_sec]
+        entry_port_id = entry_port_map[(tgt_sec, entry_side)]
+
+        new_edges.append(
+            Edge(source=edge.source, target=exit_port_id, line_id=edge.line_id)
+        )
+        new_edges.append(
+            Edge(source=entry_port_id, target=edge.target, line_id=edge.line_id)
+        )
+
+        exit_fan.setdefault(exit_port_id, {}).setdefault(entry_port_id, []).append(edge)
+
+    for exit_port_id, entry_targets in exit_fan.items():
+        if len(entry_targets) <= 1:
+            for entry_port_id, edges in entry_targets.items():
+                for edge in edges:
+                    new_edges.append(
+                        Edge(
+                            source=exit_port_id,
+                            target=entry_port_id,
+                            line_id=edge.line_id,
+                        )
+                    )
+        else:
+            junction_id = f"__junction_{port_counter}"
+            port_counter += 1
+            junction = Station(id=junction_id, label="", is_port=True, section_id=None)
+            graph.add_station(junction)
+            graph.add_junction(junction_id)
+
+            all_line_ids_set: set[str] = set()
+            for edges in entry_targets.values():
+                for edge in edges:
+                    all_line_ids_set.add(edge.line_id)
+            for lid in sorted(all_line_ids_set):
+                new_edges.append(
+                    Edge(source=exit_port_id, target=junction_id, line_id=lid)
+                )
+
+            for entry_port_id, edges in entry_targets.items():
+                for edge in edges:
+                    new_edges.append(
+                        Edge(
+                            source=junction_id,
+                            target=entry_port_id,
+                            line_id=edge.line_id,
+                        )
+                    )
+
+    # Deduplicate edges by (source, target, line_id) - multiple original
+    # inter-section edges targeting different stations in the same section
+    # can produce identical port-to-port or junction-to-port edges.
+    seen: set[tuple[str, str, str]] = set()
+    deduped: list[Edge] = []
+    for edge in new_edges:
+        key = (edge.source, edge.target, edge.line_id)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(edge)
+    graph.replace_edges(deduped)
+
+
+def _create_ports_and_junctions(
+    graph: MetroGraph,
+    internal_edges: list[Edge],
+    inter_section_edges: list[Edge],
+    entry_side_for_line: dict[tuple[str, str], PortSide],
+) -> None:
+    """Create exit/entry ports and junctions, rewrite inter-section edges.
+
+    Creates one exit port per source section, one entry port per
+    (target_section, entry_side), and inserts junction stations where
+    an exit port fans out to multiple entry ports.
+    """
+    section_exit_side = _determine_exit_sides(graph)
+    exit_groups, entry_groups = _group_inter_section_edges(
+        graph, inter_section_edges, entry_side_for_line
+    )
+    exit_port_map, entry_port_map, port_counter = _create_port_stations(
+        graph, exit_groups, entry_groups, section_exit_side
+    )
+    _rewrite_edges_with_junctions(
+        graph,
+        internal_edges,
+        inter_section_edges,
+        entry_side_for_line,
+        exit_port_map,
+        entry_port_map,
+        port_counter,
+    )
+
+
+def _insert_merge_junctions(graph: MetroGraph) -> None:
+    """Insert merge junctions where multiple same-line edges converge on one entry port.
+
+    After _create_ports_and_junctions, multiple inter-section edges of the same
+    line can target the same entry port from different sources (e.g. raw_asm,
+    purging, polishing all sending 'assemblies' to scaffolding's entry port).
+
+    For each such group (N>1 same-line edges to one entry port), this inserts a
+    merge junction and rewrites edges: all N sources -> merge junction, then one
+    edge merge junction -> entry port.
+
+    The merge junction's section_id is set to the TARGET section so that
+    _resolve_section_col() in routing correctly resolves its column for bypass
+    detection.
+    """
+    # Find edges from fan-out junctions targeting entry ports, grouped
+    # by (entry_port_id, line_id).  Only junction sources are counted -
+    # exit port sources route fine as normal L-shapes and shouldn't be
+    # merged (merging disrupts exit port positioning).
+    convergent: dict[tuple[str, str], list[Edge]] = {}
+    for edge in graph.edges:
+        tgt_port = graph.ports.get(edge.target)
+        if not tgt_port or not tgt_port.is_entry:
+            continue
+        if edge.source not in graph.junctions:
+            continue
+        key = (edge.target, edge.line_id)
+        convergent.setdefault(key, []).append(edge)
+
+    # Only process groups with N>1 convergent edges
+    merge_groups = {k: v for k, v in convergent.items() if len(v) > 1}
+    if not merge_groups:
+        return
+
+    counter = len(graph.junctions)
+    edges_to_remove: set[tuple[str, str, str]] = set()
+    new_edges: list[Edge] = []
+
+    for (entry_port_id, line_id), edges in merge_groups.items():
+        entry_port = graph.ports[entry_port_id]
+        merge_id = f"__merge_{counter}"
+        counter += 1
+
+        merge_station = Station(
+            id=merge_id,
+            label="",
+            is_port=True,
+            section_id=entry_port.section_id,
+        )
+        graph.add_station(merge_station)
+        graph.add_junction(merge_id)
+
+        # Rewrite: each source -> merge junction
+        for edge in edges:
+            edges_to_remove.add((edge.source, edge.target, edge.line_id))
+            new_edges.append(Edge(source=edge.source, target=merge_id, line_id=line_id))
+
+        # One edge: merge junction -> entry port
+        new_edges.append(Edge(source=merge_id, target=entry_port_id, line_id=line_id))
+
+    # Apply edge rewrites
+    kept = [
+        e for e in graph.edges if (e.source, e.target, e.line_id) not in edges_to_remove
+    ]
+    graph.replace_edges(kept + new_edges)

--- a/tests/test_parser_grammar.py
+++ b/tests/test_parser_grammar.py
@@ -1,0 +1,276 @@
+"""Grammar-parser coverage and behaviour tests.
+
+The Mermaid front-end is a ``lark`` grammar plus a statement-applying driver.
+These tests lock the contract the grammar must honour: every committed corpus
+file parses (and the Nextflow-flowchart fixtures raise), every node shape and
+arrow form is recognised, directive dispatch is key-exact rather than
+order-sensitive, and an unrecognised line is dropped rather than aborting the
+parse.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+REPO = Path(__file__).parent.parent
+CORPUS = sorted(
+    p
+    for p in REPO.glob("**/*.mmd")
+    if ".claude" not in p.parts and "site" not in p.parts
+)
+# The Nextflow-flowchart fixtures are intentionally rejected up front.
+FLOWCHART = sorted((REPO / "tests/fixtures/nextflow").glob("*.mmd"))
+
+
+@pytest.mark.parametrize("path", CORPUS, ids=lambda p: p.name)
+def test_every_corpus_file_parses(path):
+    """The grammar covers every committed ``.mmd``; none falls through to error."""
+    if path in FLOWCHART:
+        with pytest.raises(ValueError):
+            parse_metro_mermaid(path.read_text())
+        return
+    graph = parse_metro_mermaid(path.read_text())
+    assert graph.stations, f"{path.name} parsed to an empty graph"
+
+
+SHAPE_CASES = {
+    "square": "x[Label]",
+    "stadium": "x([Label])",
+    "subroutine": "x[[Label]]",
+    "circle": "x((Label))",
+    "round": "x(Label)",
+    "rhombus": "x{Label}",
+}
+
+
+@pytest.mark.parametrize("decl", SHAPE_CASES.values(), ids=list(SHAPE_CASES))
+def test_node_shapes_extract_label(decl):
+    """Every Mermaid shape yields the same id + inner label."""
+    text = f"graph LR\n%%metro line: a | A | #fff\n{decl}\ny[Y]\nx -->|a| y\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["x"].label == "Label"
+
+
+def test_bare_node_label_is_its_id():
+    graph = parse_metro_mermaid("graph LR\n%%metro line: a | A | #fff\nx\nx -->|a| y\n")
+    assert graph.stations["x"].label == "x"
+
+
+@pytest.mark.parametrize("arrow", ["-->", "---", "==>"])
+def test_arrow_variants_form_edges(arrow):
+    text = f"graph LR\n%%metro line: a | A | #fff\nx[X]\ny[Y]\nx {arrow}|a| y\n"
+    graph = parse_metro_mermaid(text)
+    assert any(e.source == "x" and e.target == "y" for e in graph.edges)
+
+
+def test_comma_separated_line_ids_split_into_edges():
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\n%%metro line: b | B | #000\n"
+        "x[X]\ny[Y]\nx -->|a, b| y\n"
+    )
+    graph = parse_metro_mermaid(text)
+    lines = {e.line_id for e in graph.edges if e.source == "x"}
+    assert lines == {"a", "b"}
+
+
+def test_multiline_label_converts_backslash_n():
+    text = 'graph LR\n%%metro line: a | A | #fff\nx["Foo\\nBar"]\ny[Y]\nx -->|a| y\n'
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["x"].label == "Foo\nBar"
+
+
+def test_quoted_label_with_parens_is_unquoted():
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\n"
+        'x["Liftover (Picard, UCSC)"]\ny[Y]\nx -->|a| y\n'
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["x"].label == "Liftover (Picard, UCSC)"
+
+
+def test_underscore_node_is_hidden():
+    text = "graph LR\n%%metro line: a | A | #fff\n_h[Hidden]\ny[Y]\n_h -->|a| y\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["_h"].is_hidden is True
+
+
+def test_directive_dispatch_is_key_exact_not_prefix():
+    """legend_combo / logo_scale are not shadowed by legend / logo.
+
+    Key-exact dispatch must route each directive to its own handler regardless
+    of declaration order, so a key that is a prefix of another does not win.
+    """
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\n%%metro line: b | B | #000\n"
+        "%%metro legend_combo: a, b | Combined\n"
+        "%%metro logo: /p/logo.png\n%%metro logo_scale: 2.0\n"
+        "x[X]\ny[Y]\nx -->|a| y\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.legend_combos == [(("a", "b"), "Combined")]
+    assert graph.logo_path == "/p/logo.png"
+    assert graph.logo_scale == 2.0
+
+
+def test_icon_directive_keys_recognised():
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\n"
+        "%%metro file: y | results.csv | Samples\nx[X]\ny[Y]\nx -->|a| y\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["y"].terminus_labels == ["results.csv"]
+
+
+def test_plain_comment_is_ignored():
+    text = (
+        "graph LR\n%% just a note\n%%metro line: a | A | #fff\nx[X]\ny[Y]\nx -->|a| y\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert "x" in graph.stations
+
+
+def test_unrecognised_line_is_dropped_with_warning():
+    """A line matching no statement is skipped, with a warning (not silently)."""
+    with pytest.warns(UserWarning, match="unrecognised line"):
+        graph = parse_metro_mermaid("not a valid mermaid file")
+    assert graph.stations == {}
+
+
+def test_inline_shaped_edge_endpoints_declare_their_nodes():
+    """An edge endpoint written with an inline shape also declares that node."""
+    graph = parse_metro_mermaid(
+        "graph LR\n%%metro line: a | A | #fff\nx[X] -->|a| y[Y]\n"
+    )
+    assert graph.stations["x"].label == "X"
+    assert graph.stations["y"].label == "Y"
+    assert any(
+        e.source == "x" and e.target == "y" and e.line_id == "a" for e in graph.edges
+    )
+
+
+def test_inline_shaped_edge_mixed_with_bare_endpoint():
+    """Only the shaped endpoint declares a label; the bare one keeps its id."""
+    graph = parse_metro_mermaid("graph LR\n%%metro line: a | A | #fff\nx -->|a| y[Y]\n")
+    assert graph.stations["x"].label == "x"
+    assert graph.stations["y"].label == "Y"
+
+
+def test_unknown_directive_warns():
+    """An unrecognised %%metro key is ignored, with a warning."""
+    text = (
+        "graph LR\n%%metro frobnicate: nonsense\n%%metro line: a | A | #fff\n"
+        "x[X]\ny[Y]\nx -->|a| y\n"
+    )
+    with pytest.warns(UserWarning, match="unknown directive"):
+        graph = parse_metro_mermaid(text)
+    assert "x" in graph.stations
+
+
+MALFORMED_DIRECTIVES = [
+    "%%metro line: onlyone",
+    "%%metro line: b | B | #000 | wiggly",
+    "%%metro grid: sec | notints",
+    "%%metro grid: sec",
+    "%%metro fold_threshold: abc",
+    "%%metro label_angle: abc",
+    "%%metro legend_min_height: abc",
+    "%%metro line_order: sideways",
+    "%%metro compact_offsets: maybe",
+    "%%metro file: nolabels",
+]
+
+
+@pytest.mark.parametrize("directive", MALFORMED_DIRECTIVES)
+def test_malformed_directive_payload_warns(directive):
+    """Every directive warns (rather than silently ignoring) unusable payload."""
+    text = (
+        f"graph LR\n{directive}\n%%metro line: a | A | #fff\nx[X]\ny[Y]\nx -->|a| y\n"
+    )
+    with pytest.warns(UserWarning, match="ignoring"):
+        graph = parse_metro_mermaid(text)
+    # The rest of the diagram still parses.
+    assert "x" in graph.stations
+
+
+def test_section_scoped_directive_outside_subgraph_warns():
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\n%%metro entry: left | a\n"
+        "x[X]\ny[Y]\nx -->|a| y\n"
+    )
+    with pytest.warns(UserWarning, match="inside a subgraph"):
+        parse_metro_mermaid(text)
+
+
+def test_invalid_section_direction_warns():
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\n"
+        "subgraph s [S]\n%%metro direction: sideways\nx[X]\nend\n"
+        "y[Y]\nx -->|a| y\n"
+    )
+    with pytest.warns(UserWarning, match="LR/RL/TB"):
+        parse_metro_mermaid(text)
+
+
+def test_non_lr_primary_direction_warns():
+    text = "graph TB\n%%metro line: a | A | #fff\nx[X]\ny[Y]\nx -->|a| y\n"
+    with pytest.warns(UserWarning, match="left-to-right"):
+        parse_metro_mermaid(text)
+
+
+def test_bare_graph_header_does_not_warn():
+    import warnings
+
+    text = "graph\n%%metro line: a | A | #fff\nx[X]\ny[Y]\nx -->|a| y\n"
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        parse_metro_mermaid(text)
+
+
+def test_marker_legend_without_caption_warns():
+    """A marker_legend with no '| Caption' warns and adds no legend entry."""
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\n%%metro marker_legend: circle, solid\n"
+        "x[X]\ny[Y]\nx -->|a| y\n"
+    )
+    with pytest.warns(UserWarning, match="marker_legend"):
+        graph = parse_metro_mermaid(text)
+    assert graph.marker_legend == []
+
+
+def test_legend_combo_single_id_warns():
+    """A legend_combo with a single id, no '| Label', and < 2 line ids warns."""
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\n%%metro line: b | B | #000\n"
+        "%%metro legend_combo: a\nx[X]\ny[Y]\nx -->|a| y\n"
+    )
+    with pytest.warns(UserWarning, match="legend_combo"):
+        graph = parse_metro_mermaid(text)
+    assert graph.legend_combos == []
+
+
+def test_edge_before_node_declaration_sets_label_later():
+    """An edge auto-creates a station; a later node declaration sets its label."""
+    text = "graph LR\n%%metro line: m | M | #fff\na[A]\na -->|m| b\nb[Real Label]\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["b"].label == "Real Label"
+    assert graph.stations["b"].is_hidden is False
+
+
+def test_later_separate_declaration_overrides_inline_label():
+    """A later explicit node declaration overrides an inline edge-endpoint label."""
+    text = "graph LR\n%%metro line: a | A | #fff\nx[X] -->|a| y[Y]\ny[Y Final]\n"
+    graph = parse_metro_mermaid(text)
+    assert graph.stations["y"].label == "Y Final"
+    assert graph.stations["x"].label == "X"
+
+
+def test_bare_subgraph_header_warns_and_makes_no_section():
+    """A 'subgraph' line with no id is unrecognised and creates no section."""
+    text = (
+        "graph LR\n%%metro line: a | A | #fff\nsubgraph\nx[X]\nend\ny[Y]\nx -->|a| y\n"
+    )
+    with pytest.warns(UserWarning, match="unrecognised line"):
+        graph = parse_metro_mermaid(text)
+    assert graph.sections == {}


### PR DESCRIPTION
## Summary

Replaces the hand-rolled regex front-end of the Mermaid parser with a `lark` grammar (per #557), then carries that structure through the rest of the parse layer and splits the package by job.

**Grammar front-end.** A grammar describes the document shape (graph header, subgraph, node across all Mermaid shapes, edge, `%%metro` directive, comment); a transformer flattens it into ordered, **typed statement** dataclasses with normalization done in the transformer; the driver is a plain `isinstance` dispatch. Removes the six order-sensitive node-shape regexes (the model stores only id + label, so all shapes collapse to one `SHAPE` terminal) and the load-bearing statement-dispatch ordering.

**Directive dispatch.** The order-sensitive `startswith()` chain and its per-directive slicing become a key/value split plus a `_GLOBAL_DIRECTIVE_HANDLERS` registry keyed by exact name; the section-scoped `entry`/`exit`/`direction` go through `_apply_scoped_directive`, and `file`/`files`/`dir` icons alongside. Shared `_split_csv` / `_split_fields` / `_parse_bool` / `_parse_number` helpers replace the repeated field-shaping, and every directive warning flows through a single `_warn_directive` mechanism.

**Module split.** `mermaid.py` is split into `grammar.py` (grammar + statement types + transformer), `directives.py` (directive parsing + dispatch), `resolve.py` (post-parse section/port/junction rewrites), and `mermaid.py` (the public `parse_metro_mermaid` driver, itself split into `_apply_statements` / `_finalize_graph` / `_apply_pending_metadata`). `parse_metro_mermaid` stays importable from `nf_metro.parser.mermaid`.

**Docs.** New Internals page `docs/dev/parser.md`; a one-station-per-line authoring-convention note in the guide.

## Intentional behaviour changes

These are deliberate (the parser was silently dropping things; silent ignores hide user mistakes). All are leniency/UX changes, not model changes for valid input, so the **gallery is unaffected** (no fixture exercises them):

1. **Warnings instead of silent drops.** An unrecognised non-blank line, an unknown `%%metro` key, and a malformed directive payload (too few fields, an unusable number/enum/bool, a section-scoped directive outside a subgraph) now emit a `UserWarning` and are ignored, rather than vanishing silently. Policy: lenient about *syntax* (warn, don't crash); strict about *semantics* (the `validate` phase still raises).
2. **Inline-shaped edge endpoints are now accepted** (a small syntax expansion): `x[X] -->|a| y[Y]` declares both nodes and the edge, instead of the line being dropped. The authoring convention remains one-station-per-line (documented in the guide); this is for Mermaid compatibility and to stop silent data loss.

## Verification

- **Byte-identical parsed `MetroGraph`** across all 108 corpus files (`tests/fixtures`, `examples`, `examples/topologies`), compared as serialized model objects. The 5 `tests/fixtures/nextflow/*` flowchart fixtures still raise. CI render-diff: no visual changes.
- Full suite green (7661 passed); `mypy` and `ruff` clean repo-wide. New/changed behaviour covered by `tests/test_parser_grammar.py` (corpus coverage, shapes/arrows, directive dispatch, malformed-payload warnings, inline edges, edge-before-node, malformed subgraph header, leniency).

## Notes for review

- Adds a runtime dependency (`lark`).
- Net result is structural, not fewer lines: the win is a declarative grammar, typed statements, exact-key directive dispatch, a uniform warn-and-ignore leniency policy, and a parser package split by job.

Fixes #557

## Test plan
- [x] pytest passes (7661 passed)
- [x] ruff check + ruff format clean on whole repo
- [x] mypy clean repo-wide
- [x] Byte-identical parsed model across all 108 corpus files
- [x] Render-preview verdict: no visual changes detected
