### PR TITLE
feat(options): unify CLI flags and %%metro directives via a shared registry

### DIFF
--- a/docs/dev/parser.md
+++ b/docs/dev/parser.md
@@ -168,6 +168,17 @@ enclosing section, and the icon keys `file` / `files` / `dir` need the
 key itself to choose the icon type. A key matching none of these is
 ignored with a `UserWarning`.
 
+The simple scalar / bool / enum knobs that also have a CLI flag (spacing,
+gaps, `diamond_style`, scales, `width` / `height` / `animate`, ...) are not
+hand-written handlers. They are declared once in `nf_metro.options`
+(`LayoutOption` / `LAYOUT_OPTIONS`); `_make_layout_option_handler` generates a
+directive handler from each entry (parsing via `coerce`, writing the named
+`MetroGraph` field), and `nf_metro.cli` generates the matching `click` flag
+from the same registry. Adding such an option means one registry entry, not a
+handler plus a flag plus a docs row. `tests/test_options_parity.py` guards that
+every registry option exists in both planes. The bespoke handlers below carry
+grammar (fields, sections, coordinates) the generic registry can't express.
+
 The directives `_apply_directive` recognises:
 
 | Directive | Effect |
@@ -179,8 +190,11 @@ The directives `_apply_directive` recognises:
 | `direction:` | section flow `LR` / `RL` / `TB` |
 | `grid:` | manual section grid placement |
 | `compact_offsets:` / `center_ports:` | bundle layout toggles |
+| `diamond_style:` | fork-join layout `straight` / `symmetric` |
 | `line_spread:` | how shared lines relate vertically (`bundle` / `centered` / `rails`), graph-wide or per-section |
 | `fold_threshold:` | station count at which long chains wrap into serpentine rows |
+| `x_spacing:` / `y_spacing:` / `section_x_gap:` / `section_y_gap:` | layout spacing and section gaps |
+| `width:` / `height:` / `animate:` | render output size and animation toggle |
 | `off_track:` | mark stations to lift above the section's top track |
 | `label_angle:` | diagonal station-label angle |
 | `legend:` / `legend_min_height:` / `legend_combo:` / `legend_logo_gap:` | legend block |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -510,21 +510,32 @@ These go at the top of the file, before `graph LR`.
 | Directive | Description |
 |-----------|-------------|
 | `%%metro title: <text>` | Map title |
-| `%%metro logo: <path>` | Logo image, bundled into the legend (or top-left if there is no legend). Use `--logo` CLI flag to override per-render. |
+| `%%metro logo: <path>` | Logo image, bundled into the legend (or top-left if there is no legend). |
 | `%%metro logo_scale: <factor>` | Scale the logo within the legend block (`1.0` = default auto-size). Values above 1 grow the legend box to contain the logo. |
-| `%%metro style: <name>` | Theme: `dark` (default) or `light` |
+| `%%metro style: <name>` | Theme: `dark` (default, the nfcore theme) or `light`. Selects the render theme unless `--theme` is passed. |
 | `%%metro line: <id> \| <name> \| <color> [\| <style>]` | Define a metro line. Optional style: `solid` (default), `dashed`, or `dotted` |
 | `%%metro grid: <section> \| <col>,<row>[,<rowspan>[,<colspan>]]` | Pin a section to a grid position |
 | `%%metro legend: <position>` | Position the legend (and its embedded logo). Keyword: `tl`, `tr`, `bl`, `br`, `bottom`, `right`, or `none` (a bare keyword auto-relocates if it would overlap a section or route). Add `\| canvas` to anchor the keyword to the canvas margin, or `\| <dx>,<dy>` to nudge it; both pin the block exactly (warning on overlap rather than relocating). Use `<x>,<y>` for absolute top-left coordinates. |
 | `%%metro line_order: <strategy>` | Line ordering for track assignment: `definition` (default, preserves `.mmd` order) or `span` (longest-spanning lines get inner tracks) |
-| `%%metro fold_threshold: <columns>` | Max station-columns a section row may reach before the auto-layout wraps it onto the next row (default 15). Raise it to keep a long horizontal trunk of sections on a single row. Overridden by the `--max-layers-per-row` CLI flag. |
+| `%%metro diamond_style: <mode>` | Fork-join (diamond) layout: `straight` (default) keeps the top branch on the main track; `symmetric` fans the branches evenly |
+| `%%metro fold_threshold: <columns>` | Max station-columns a section row may reach before the auto-layout wraps it onto the next row (default 15). Raise it to keep a long horizontal trunk of sections on a single row. |
+| `%%metro x_spacing: <pixels>` | Horizontal spacing between layers (default: auto - widened from 60 only when wide labels would collide) |
+| `%%metro y_spacing: <pixels>` | Vertical spacing between tracks (default: auto - derived from the map's content) |
+| `%%metro section_x_gap: <pixels>` | Horizontal gap between sections (default: 50) |
+| `%%metro section_y_gap: <pixels>` | Vertical gap between sections (default: 50) |
+| `%%metro label_angle: <degrees>` | Station-label angle (0 = horizontal). Overrides the theme default |
+| `%%metro font_scale: <factor>` | Scale every text size and the label-width metrics that drive layout spacing (`1.0` = default) |
+| `%%metro legend_logo_gap: <pixels>` | Horizontal gap between the logo and the legend entries |
+| `%%metro width: <pixels>` | Output width in pixels (default: auto from content) |
+| `%%metro height: <pixels>` | Output height in pixels (default: auto from content) |
+| `%%metro animate: true` | Add animated balls traveling along the metro lines |
 | `%%metro file: <station> \| <label> [\| <name>] [\| banner]` | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon; optional `banner` draws the label on a dark strip across the icon. |
 | `%%metro files: <station> \| <label> [\| <name>] [\| banner]` | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption; optional `banner` strip. |
 | `%%metro dir: <station> \| <label> [\| <name>]` | Mark a station with a folder icon (e.g. output directory). Optional `name` caption. |
 | `%%metro off_track: <station>[, <station>...]` | Lift the listed stations above the section's main track, anchored to their consumer (inputs) or producer (output artefacts) (see below) |
 | `%%metro compact_offsets: true` | Compact line offsets within stations (see below) |
-| `%%metro center_ports: true` | Centre inter-section ports on the shorter of the two connected sections, so lines enter/exit at the visual midpoint. Overridden by the `--center-ports` / `--no-center-ports` CLI flag. |
-| `%%metro line_spread: <mode>[ \| <id>...]` | How lines sharing a station relate vertically (see below). `<mode>` is `bundle` (default), `centered`, or `rails`. The bare form sets the graph default; `<mode> \| sectionA, sectionB` overrides those sections. Overridden by the `--line-spread` CLI flag. |
+| `%%metro center_ports: true` | Centre inter-section ports on the shorter of the two connected sections, so lines enter/exit at the visual midpoint. |
+| `%%metro line_spread: <mode>[ \| <id>...]` | How lines sharing a station relate vertically (see below). `<mode>` is `bundle` (default), `centered`, or `rails`. The bare form sets the graph default; `<mode> \| sectionA, sectionB` overrides those sections. |
 | `%%metro legend_min_height: <pixels>` | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 
 **Compact offsets.** By default, each line reserves a fixed vertical slot across the whole map based on its declaration order. If you define three lines, every station that carries even one of them is sized to fit all three. This keeps bundles visually consistent but wastes space when most stations only carry one or two lines.
@@ -582,6 +593,41 @@ These go inside `subgraph` blocks.
 | `%%metro direction: <dir>` | Internal flow direction: `LR`, `RL`, or `TB` |
 
 Entry/exit hints tell the layout engine which side of the section box lines should enter or leave from. Most of the time you can **omit these entirely** and let the auto-layout engine figure it out. They are useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others).
+
+## CLI flags and directive precedence
+
+Every layout and render option can be set two ways: a `%%metro` directive in the file, or the matching `nf-metro render` CLI flag. They share one precedence rule:
+
+> **CLI flag (when passed) → `%%metro` directive → built-in default.**
+
+Set the directive in your committed `.mmd` so the map reproduces from the file alone, and reach for the flag only to tweak a single render without editing the file. The two planes always use the same name (the flag is the kebab-cased directive); a directive and its flag are defined from one registry, so they cannot drift apart.
+
+| Directive | CLI flag | Default |
+|-----------|----------|---------|
+| `title:` | `--title` | (none) |
+| `style:` | `--theme` | `nfcore` |
+| `logo:` | `--logo` | (none) |
+| `x_spacing:` | `--x-spacing` | auto |
+| `y_spacing:` | `--y-spacing` | auto |
+| `section_x_gap:` | `--section-x-gap` | 50 |
+| `section_y_gap:` | `--section-y-gap` | 50 |
+| `fold_threshold:` | `--fold-threshold` | auto (15) |
+| `diamond_style:` | `--diamond-style` | `straight` |
+| `line_order:` | `--line-order` | `definition` |
+| `center_ports:` | `--center-ports` / `--no-center-ports` | false |
+| `compact_offsets:` | `--compact-offsets` / `--no-compact-offsets` | false |
+| `line_spread:` | `--line-spread` | `bundle` |
+| `label_angle:` | `--label-angle` | theme default (0) |
+| `font_scale:` | `--font-scale` | 1.0 |
+| `logo_scale:` | `--logo-scale` | 1.0 |
+| `legend:` | `--legend` | auto |
+| `legend_min_height:` | `--legend-min-height` | 0 |
+| `legend_logo_gap:` | `--legend-logo-gap` | auto |
+| `width:` | `--width` | auto |
+| `height:` | `--height` | auto |
+| `animate:` | `--animate` / `--no-animate` | off |
+
+`--output`, `--format`, `--from-nextflow`, and `--debug` have no directive: they select the output target or a diagnostic overlay rather than describing the diagram.
 
 ## Tips
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,22 +58,36 @@ Render a Mermaid metro map definition to SVG or interactive HTML.
 nf-metro render [OPTIONS] INPUT_FILE
 ```
 
+Every layout/render option below also has a `%%metro` directive twin; an explicitly-passed flag overrides the directive (see the [precedence table](guide.md#cli-flags-and-directive-precedence) in the guide).
+
 | Option | Default | Description |
 |--------|---------|-------------|
 | `-o`, `--output PATH` | `<input>.<format>` | Output file path |
 | `--format [svg\|html]` | `svg` | Output format: `svg` or interactive `html` |
-| `--theme [nfcore\|light]` | `nfcore` | Visual theme |
-| `--width INTEGER` | auto | SVG width in pixels |
-| `--height INTEGER` | auto | SVG height in pixels |
+| `--theme [nfcore\|light]` | from `style:`, else `nfcore` | Visual theme |
+| `--debug / --no-debug` | off | Show debug overlay |
+| `--from-nextflow` | off | Convert Nextflow `-with-dag` input before rendering |
+| `--logo PATH` | none | Logo image path |
+| `--title TEXT` | none | Pipeline title |
+| `--legend TEXT` | auto | Legend+logo position (keyword, `keyword \| canvas`, `keyword \| dx,dy`, or `x,y`) |
+| `--line-spread [bundle\|centered\|rails]` | `bundle` | How shared lines relate vertically |
 | `--x-spacing FLOAT` | auto | Horizontal spacing between layers |
 | `--y-spacing FLOAT` | auto | Vertical spacing between tracks |
-| `--max-layers-per-row INTEGER` | auto | Max layers before folding to next row |
+| `--section-x-gap FLOAT` | 50 | Horizontal gap between sections |
+| `--section-y-gap FLOAT` | 50 | Vertical gap between sections |
+| `--fold-threshold INTEGER` | auto (15) | Max station-columns per row before folding |
+| `--diamond-style [straight\|symmetric]` | `straight` | Fork-join layout |
+| `--line-order [definition\|span]` | `definition` | Line ordering for track assignment |
+| `--center-ports / --no-center-ports` | off | Centre inter-section ports on the shorter section |
+| `--compact-offsets / --no-compact-offsets` | off | Size stations only for the lines passing through |
+| `--label-angle FLOAT` | theme default | Station-label angle in degrees |
+| `--font-scale FLOAT` | 1.0 | Scale text and label-driven layout spacing |
+| `--logo-scale FLOAT` | 1.0 | Scale the logo within the legend |
+| `--legend-min-height FLOAT` | 0 | Minimum legend content height in pixels |
+| `--legend-logo-gap FLOAT` | auto | Gap between logo and legend entries |
+| `--width INTEGER` | auto | Output width in pixels |
+| `--height INTEGER` | auto | Output height in pixels |
 | `--animate / --no-animate` | off | Add animated balls traveling along lines |
-| `--debug / --no-debug` | off | Show debug overlay |
-| `--logo PATH` | none | Logo image path (overrides `%%metro logo:` directive) |
-| `--center-ports / --no-center-ports` | off | Centre inter-section ports on the shorter of the two connected sections |
-| `--from-nextflow` | off | Convert Nextflow `-with-dag` input before rendering |
-| `--title TEXT` | none | Pipeline title (used with `--from-nextflow`) |
 
 #### Interactive HTML output
 

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 import click
 
 from nf_metro import __version__
 from nf_metro.layout import PhaseInvariantError, compute_layout
+from nf_metro.options import LAYOUT_OPTIONS, LayoutOption
 from nf_metro.parser import ERROR, parse_metro_mermaid, validate_graph
-from nf_metro.parser.model import LineSpread
+from nf_metro.parser.directives import apply_legend_directive
+from nf_metro.parser.model import LineSpread, MetroGraph
 from nf_metro.render import render_svg
 from nf_metro.render.html import render_html
+from nf_metro.render.style import Theme
 from nf_metro.themes import THEMES
 
 
@@ -20,6 +24,66 @@ from nf_metro.themes import THEMES
 @click.version_option(version=__version__)
 def cli() -> None:
     """nf-metro: Generate metro-map-style SVG diagrams from Mermaid definitions."""
+
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _layout_cli_option(opt: LayoutOption) -> Callable[..., Any]:
+    """Build the ``click.option`` decorator for a registry option.
+
+    All default to ``None`` so an omitted flag leaves the directive value in
+    place; a set flag overrides it (the CLI half of the cascade in
+    :mod:`nf_metro.options`).
+    """
+    if opt.kind == "bool":
+        no_flag = "--no-" + opt.name.replace("_", "-")
+        return click.option(
+            f"{opt.cli_flag}/{no_flag}", opt.name, default=None, help=opt.help
+        )
+    ctype: Any = (
+        click.Choice(opt.choices)
+        if opt.kind == "choice"
+        else {
+            "int": int,
+            "float": float,
+            "str": str,
+        }[opt.kind]
+    )
+    return click.option(opt.cli_flag, opt.name, type=ctype, default=None, help=opt.help)
+
+
+def layout_cli_options(f: _F) -> _F:
+    """Attach a CLI flag for every registry option, in declaration order."""
+    for opt in reversed(LAYOUT_OPTIONS):
+        f = _layout_cli_option(opt)(f)
+    return f
+
+
+def _apply_layout_overrides(graph: MetroGraph, opts: dict[str, object]) -> None:
+    """Write each explicitly-set CLI option onto its graph field.
+
+    Parse-time options (``fold_threshold``) are skipped: their value reaches
+    the graph through ``parse_metro_mermaid`` instead.
+    """
+    for opt in LAYOUT_OPTIONS:
+        if opt.parse_time:
+            continue
+        value = opts.get(opt.name)
+        if value is not None:
+            setattr(graph, opt.target_attr, value)
+
+
+# Maps legacy `style:` values onto theme keys (the nfcore theme is the dark one).
+_STYLE_THEME_ALIASES = {"dark": "nfcore"}
+
+
+def _resolve_theme(theme: str | None, graph: MetroGraph) -> Theme:
+    """Pick the theme: an explicit ``--theme`` wins over the ``style:`` directive."""
+    if theme is not None:
+        return THEMES[theme]
+    name = graph.style.strip().lower()
+    return THEMES.get(_STYLE_THEME_ALIASES.get(name, name), THEMES["nfcore"])
 
 
 @cli.command()
@@ -42,36 +106,8 @@ def cli() -> None:
 @click.option(
     "--theme",
     type=click.Choice(list(THEMES.keys())),
-    default="nfcore",
-    help="Visual theme (default: nfcore)",
-)
-@click.option("--width", type=int, default=None, help="SVG width in pixels")
-@click.option("--height", type=int, default=None, help="SVG height in pixels")
-@click.option(
-    "--x-spacing",
-    type=float,
     default=None,
-    help="Horizontal spacing between layers (default: auto - widened from "
-    "60 only when wide labels would otherwise collide)",
-)
-@click.option(
-    "--y-spacing",
-    type=float,
-    default=None,
-    help="Vertical spacing between tracks (default: auto - derived from "
-    "the map's content so captioned icons and dense labels don't collide)",
-)
-@click.option(
-    "--max-layers-per-row",
-    type=int,
-    default=None,
-    help="Max layers before folding to next row (default: auto). Overrides "
-    "the %%metro fold_threshold: directive.",
-)
-@click.option(
-    "--animate/--no-animate",
-    default=False,
-    help="Add animated balls traveling along lines",
+    help="Visual theme (default: from the %%metro style: directive, else nfcore).",
 )
 @click.option(
     "--debug/--no-debug",
@@ -82,27 +118,7 @@ def cli() -> None:
     "--logo",
     type=click.Path(exists=True, path_type=Path),
     default=None,
-    help="Logo image path (overrides %%metro logo: directive)",
-)
-@click.option(
-    "--line-order",
-    type=click.Choice(["definition", "span"]),
-    default=None,
-    help="Line ordering strategy: 'definition' (default) preserves .mmd order, "
-    "'span' sorts by section span (longest first)",
-)
-@click.option(
-    "--straight-diamonds/--no-straight-diamonds",
-    default=True,
-    help="Keep top branch of diamond fork-joins on the main track (default: on). "
-    "Use --no-straight-diamonds for symmetric fan-out.",
-)
-@click.option(
-    "--center-ports/--no-center-ports",
-    default=None,
-    help="Centre inter-section ports on the shorter of the two connected "
-    "sections, so lines enter/exit at the visual midpoint. When unset, "
-    "the value of the %%metro center_ports: directive (if any) is used.",
+    help="Logo image path (overrides the %%metro logo: directive).",
 )
 @click.option(
     "--line-spread",
@@ -114,16 +130,11 @@ def cli() -> None:
     "graph-wide %%metro line_spread: directive (per-section overrides stay).",
 )
 @click.option(
-    "--section-x-gap",
-    type=float,
+    "--legend",
     default=None,
-    help="Horizontal gap between sections (default: 50)",
-)
-@click.option(
-    "--section-y-gap",
-    type=float,
-    default=None,
-    help="Vertical gap between sections (default: 40)",
+    help="Position the legend+logo block (overrides the %%metro legend: "
+    "directive). Keyword (bl/br/tl/tr/bottom/right/none), '<keyword> | canvas', "
+    "'<keyword> | dx,dy', or absolute 'x,y'.",
 )
 @click.option(
     "--from-nextflow",
@@ -135,29 +146,21 @@ def cli() -> None:
     "--title",
     type=str,
     default=None,
-    help="Pipeline title (used with --from-nextflow)",
+    help="Pipeline title (overrides the %%metro title: directive).",
 )
+@layout_cli_options
 def render(
     input_file: Path,
     output: Path | None,
     format_: str,
-    theme: str,
-    width: int | None,
-    height: int | None,
-    x_spacing: float | None,
-    y_spacing: float | None,
-    max_layers_per_row: int | None,
-    animate: bool,
+    theme: str | None,
     debug: bool,
     logo: Path | None,
-    line_order: str | None,
-    straight_diamonds: bool,
-    center_ports: bool | None,
     line_spread: str | None,
-    section_x_gap: float | None,
-    section_y_gap: float | None,
+    legend: str | None,
     from_nextflow: bool,
     title: str | None,
+    **layout_opts: object,
 ) -> None:
     """Render a Mermaid metro map definition to SVG or interactive HTML."""
     text = input_file.read_text()
@@ -167,61 +170,40 @@ def render(
 
         text = convert_nextflow_dag(text, title=title or "")
 
+    fold = layout_opts.get("fold_threshold")
     try:
         graph = parse_metro_mermaid(
             text,
-            max_station_columns=max_layers_per_row,
+            max_station_columns=fold if isinstance(fold, int) else None,
         )
     except ValueError as e:
         raise click.ClickException(str(e))
 
-    if line_order is not None:
-        graph.line_order = line_order
-
-    if not straight_diamonds:
-        graph.diamond_style = "symmetric"
-
-    if center_ports is not None:
-        graph.center_ports = center_ports
+    _apply_layout_overrides(graph, layout_opts)
 
     if line_spread is not None:
         graph.line_spread = LineSpread(line_spread)
-
     if logo is not None:
         graph.logo_path = str(logo)
+    if legend is not None:
+        apply_legend_directive(legend, graph)
+    if title is not None:
+        graph.title = title
 
-    layout_kwargs: dict[str, Any] = dict(
-        x_spacing=x_spacing,
-        y_spacing=y_spacing,
-    )
-    if section_x_gap is not None:
-        layout_kwargs["section_x_gap"] = section_x_gap
-    if section_y_gap is not None:
-        layout_kwargs["section_y_gap"] = section_y_gap
     try:
-        compute_layout(graph, **layout_kwargs)
+        compute_layout(graph)
     except PhaseInvariantError as e:
         raise click.ClickException(str(e))
 
-    theme_obj = THEMES[theme]
+    theme_obj = _resolve_theme(theme, graph)
 
     if output is None:
         output = input_file.with_suffix(f".{format_}")
 
     if format_ == "html":
-        content = render_html(
-            graph,
-            theme_obj,
-            width=width,
-            height=height,
-            animate=animate,
-            debug=debug,
-            embed_basename=output.name,
-        )
+        content = render_html(graph, theme_obj, debug=debug, embed_basename=output.name)
     else:
-        content = render_svg(
-            graph, theme_obj, width=width, height=height, animate=animate, debug=debug
-        )
+        content = render_svg(graph, theme_obj, debug=debug)
 
     output.write_text(content if content.endswith("\n") else content + "\n")
     click.echo(

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -342,18 +342,22 @@ def compute_layout(
     section_gap: float = SECTION_GAP,
     section_x_padding: float = SECTION_X_PADDING,
     section_y_padding: float = SECTION_Y_PADDING,
-    section_x_gap: float = SECTION_X_GAP,
-    section_y_gap: float = SECTION_Y_GAP,
+    section_x_gap: float | None = None,
+    section_y_gap: float | None = None,
     validate: bool = _VALIDATE_DEFAULT,
 ) -> None:
     """Compute layout positions for all stations in the graph.
 
-    When ``y_spacing`` is ``None`` (the default) it is derived from the
-    graph's content via ``compute_min_y_spacing`` so renders adapt to
-    captioned icons and labelled stations automatically.  Pass an
-    explicit numeric value to override.
+    The spacing and section-gap arguments default to ``None``, meaning "read
+    the graph's field" (``graph.x_spacing`` etc., set by a ``%%metro``
+    directive).  An explicit value passed here overrides that field, so the
+    cascade is CLI flag > directive > auto/default.
 
-    If the explicit value is below the minimum the content needs, a
+    When ``y_spacing`` resolves to ``None`` it is derived from the graph's
+    content via ``compute_min_y_spacing`` so renders adapt to captioned icons
+    and labelled stations automatically.
+
+    If an explicit value is below the minimum the content needs, a
     ``UserWarning`` is emitted: the render is honoured at the requested
     pitch, but labels and captioned file-icons may collide.  Omit
     ``y_spacing`` to let the engine pick a safe value.
@@ -362,6 +366,19 @@ def compute_layout(
     key phases.  Violations raise ``PhaseInvariantError`` instead of
     silently producing broken layouts.
     """
+    if x_spacing is None:
+        x_spacing = graph.x_spacing
+    if y_spacing is None:
+        y_spacing = graph.y_spacing
+    if section_x_gap is None:
+        section_x_gap = (
+            graph.section_x_gap if graph.section_x_gap is not None else SECTION_X_GAP
+        )
+    if section_y_gap is None:
+        section_y_gap = (
+            graph.section_y_gap if graph.section_y_gap is not None else SECTION_Y_GAP
+        )
+
     # Read the phase-snapshot enable flag once (issue #363) and stash it on
     # the graph so per-stage call sites can snapshot without signature churn.
     # Off by default: when unset, each _snap call is a single attribute read.

--- a/src/nf_metro/options.py
+++ b/src/nf_metro/options.py
@@ -1,0 +1,204 @@
+"""Single source of truth for layout/render options exposed in both planes.
+
+Every tunable that can be set both by a ``%%metro`` directive and by a CLI
+flag is declared once here as a :class:`LayoutOption`. The directive
+dispatcher (:mod:`nf_metro.parser.directives`) and the CLI
+(:mod:`nf_metro.cli`) each build their surface from this registry, so adding
+an option - its name, type, constraints, and help - wires up the directive
+handler and the CLI flag together rather than in two hand-kept places.
+
+Each option targets a field on :class:`~nf_metro.parser.model.MetroGraph` of
+the same name (or :attr:`LayoutOption.attr`): the directive writes that field
+during parsing, an explicitly-set CLI flag overwrites it afterwards, and the
+layout engine and renderer read it. Precedence is uniform: CLI flag (when set)
+> ``%%metro`` directive > built-in default.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+# Returned by :func:`coerce` in place of a value when the payload is unusable.
+INVALID = object()
+
+OptionKind = Literal["float", "int", "bool", "choice", "str"]
+NumberSign = Literal["any", "nonneg", "positive"]
+
+
+@dataclass(frozen=True)
+class LayoutOption:
+    """One tunable settable via ``%%metro`` and the equivalent CLI flag.
+
+    ``kind`` selects parsing and the CLI type: ``float``/``int`` numbers
+    (constrained by ``sign``), a ``bool`` flag, a ``choice`` from ``choices``,
+    or a free ``str``.
+    """
+
+    name: str
+    kind: OptionKind
+    help: str
+    attr: str = ""
+    choices: tuple[str, ...] = ()
+    sign: NumberSign = "any"
+    parse_time: bool = False  # consumed during parsing, not after
+
+    @property
+    def target_attr(self) -> str:
+        """Graph attribute this option writes (defaults to ``name``)."""
+        return self.attr or self.name
+
+    @property
+    def cli_flag(self) -> str:
+        """Long CLI flag for this option (kebab-cased ``name``)."""
+        return "--" + self.name.replace("_", "-")
+
+
+def coerce(opt: LayoutOption, raw: str) -> tuple[Any, str]:
+    """Parse a directive payload for *opt*.
+
+    Returns ``(value, "")`` on success or ``(INVALID, expected)`` on failure,
+    where *expected* describes the valid input for a warning message.
+    """
+    text = raw.strip()
+    if opt.kind == "bool":
+        token = text.lower()
+        if token in ("true", "yes", "1"):
+            return True, ""
+        if token in ("false", "no", "0", ""):
+            return False, ""
+        return INVALID, "a boolean (true/false)"
+    if opt.kind == "choice":
+        token = text.lower()
+        if token in opt.choices:
+            return token, ""
+        return INVALID, " or ".join(repr(c) for c in opt.choices)
+    if opt.kind in ("int", "float"):
+        caster = int if opt.kind == "int" else float
+        try:
+            num = caster(text)
+        except ValueError:
+            return INVALID, "a number"
+        if opt.sign == "nonneg" and num < 0:
+            return INVALID, "a non-negative number"
+        if opt.sign == "positive" and num <= 0:
+            return INVALID, "a positive number"
+        return num, ""
+    return text, ""
+
+
+# Declaration order is the order CLI flags appear in --help.
+LAYOUT_OPTIONS: tuple[LayoutOption, ...] = (
+    LayoutOption(
+        name="x_spacing",
+        kind="float",
+        sign="positive",
+        help="Horizontal spacing between layers (default: auto - widened from "
+        "60 only when wide labels would otherwise collide).",
+    ),
+    LayoutOption(
+        name="y_spacing",
+        kind="float",
+        sign="positive",
+        help="Vertical spacing between tracks (default: auto - derived from the "
+        "map's content so captioned icons and dense labels don't collide).",
+    ),
+    LayoutOption(
+        name="section_x_gap",
+        kind="float",
+        sign="nonneg",
+        help="Horizontal gap between sections (default: 50).",
+    ),
+    LayoutOption(
+        name="section_y_gap",
+        kind="float",
+        sign="nonneg",
+        help="Vertical gap between sections (default: 50).",
+    ),
+    LayoutOption(
+        name="fold_threshold",
+        kind="int",
+        sign="positive",
+        parse_time=True,
+        help="Max station-columns a section row may reach before the "
+        "auto-layout wraps it onto the next row (default 15). Raise it to keep "
+        "a long horizontal trunk of sections on a single row.",
+    ),
+    LayoutOption(
+        name="diamond_style",
+        kind="choice",
+        choices=("straight", "symmetric"),
+        help="Fork-join (diamond) layout: 'straight' keeps the top branch on "
+        "the main track (default); 'symmetric' fans the branches evenly.",
+    ),
+    LayoutOption(
+        name="line_order",
+        kind="choice",
+        choices=("definition", "span"),
+        help="Line ordering for track assignment: 'definition' (default) "
+        "preserves .mmd order, 'span' gives longest-spanning lines inner tracks.",
+    ),
+    LayoutOption(
+        name="center_ports",
+        kind="bool",
+        help="Centre inter-section ports on the shorter of the two connected "
+        "sections, so lines enter/exit at the visual midpoint.",
+    ),
+    LayoutOption(
+        name="compact_offsets",
+        kind="bool",
+        help="Size each station only for the lines actually passing through it, "
+        "rather than reserving a slot for every declared line.",
+    ),
+    LayoutOption(
+        name="label_angle",
+        kind="float",
+        sign="any",
+        help="Angle in degrees for station labels (0 = horizontal). Overrides "
+        "the theme default; useful for dense trunks where horizontal labels "
+        "collide.",
+    ),
+    LayoutOption(
+        name="font_scale",
+        kind="float",
+        sign="positive",
+        help="Scale every text size and the label-width metrics that drive "
+        "layout spacing (1.0 = default).",
+    ),
+    LayoutOption(
+        name="logo_scale",
+        kind="float",
+        sign="positive",
+        help="Scale the logo within the legend block (1.0 = default auto-size).",
+    ),
+    LayoutOption(
+        name="legend_min_height",
+        kind="float",
+        sign="nonneg",
+        help="Minimum legend content height in pixels (useful for single-line "
+        "maps where the logo would otherwise be tiny).",
+    ),
+    LayoutOption(
+        name="legend_logo_gap",
+        kind="float",
+        sign="nonneg",
+        help="Horizontal gap in pixels between the logo and the legend entries.",
+    ),
+    LayoutOption(
+        name="width",
+        kind="int",
+        sign="positive",
+        help="Output width in pixels (default: auto from content).",
+    ),
+    LayoutOption(
+        name="height",
+        kind="int",
+        sign="positive",
+        help="Output height in pixels (default: auto from content).",
+    ),
+    LayoutOption(
+        name="animate",
+        kind="bool",
+        help="Add animated balls traveling along the metro lines.",
+    ),
+)

--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
-from typing import Literal, TypeVar
+from typing import Literal
 
+from nf_metro.options import INVALID, LAYOUT_OPTIONS, LayoutOption, coerce
 from nf_metro.parser.grammar import _split_csv, _unquote
 from nf_metro.parser.model import (
     MARKER_FILL_OPEN,
@@ -29,8 +30,6 @@ from nf_metro.parser.model import (
     StationGroup,
 )
 
-_Number = TypeVar("_Number", int, float)
-
 
 def _warn_directive(key: str, message: str) -> None:
     """Warn about a %%metro directive; every directive warning uses this."""
@@ -40,27 +39,6 @@ def _warn_directive(key: str, message: str) -> None:
 def _warn_malformed(key: str, value: str, expected: str) -> None:
     """Warn that a directive's payload is unusable and is being ignored."""
     _warn_directive(key, f"ignoring {value!r}; expected {expected}")
-
-
-def _parse_bool(value: str) -> bool | None:
-    """Parse a boolean directive flag; ``None`` for an unrecognised value."""
-    token = value.strip().lower()
-    if token in ("true", "yes", "1"):
-        return True
-    if token in ("false", "no", "0", ""):
-        return False
-    return None
-
-
-def _parse_number(
-    key: str, value: str, cast: Callable[[str], _Number]
-) -> _Number | None:
-    """Parse a numeric directive value; warn and return ``None`` if not a number."""
-    try:
-        return cast(value)
-    except ValueError:
-        _warn_malformed(key, value, "a number")
-        return None
 
 
 def _split_fields(value: str) -> list[str]:
@@ -82,48 +60,6 @@ def _dir_style(value: str, graph: MetroGraph) -> None:
 
 def _dir_logo(value: str, graph: MetroGraph) -> None:
     graph.logo_path = value
-
-
-def _dir_line_order(value: str, graph: MetroGraph) -> None:
-    order = value.lower()
-    if order in ("definition", "span"):
-        graph.line_order = order
-    else:
-        _warn_malformed("line_order", value, "'definition' or 'span'")
-
-
-def _dir_compact_offsets(value: str, graph: MetroGraph) -> None:
-    flag = _parse_bool(value)
-    if flag is None:
-        _warn_malformed("compact_offsets", value, "a boolean (true/false)")
-    else:
-        graph.compact_offsets = flag
-
-
-def _dir_center_ports(value: str, graph: MetroGraph) -> None:
-    flag = _parse_bool(value)
-    if flag is None:
-        _warn_malformed("center_ports", value, "a boolean (true/false)")
-    else:
-        graph.center_ports = flag
-
-
-def _dir_fold_threshold(value: str, graph: MetroGraph) -> None:
-    threshold = _parse_number("fold_threshold", value, int)
-    if threshold is not None:
-        graph.fold_threshold = threshold
-
-
-def _dir_label_angle(value: str, graph: MetroGraph) -> None:
-    angle = _parse_number("label_angle", value, float)
-    if angle is not None:
-        graph.label_angle = angle
-
-
-def _dir_legend_min_height(value: str, graph: MetroGraph) -> None:
-    height = _parse_number("legend_min_height", value, float)
-    if height is not None:
-        graph.legend_min_height = height
 
 
 def _dir_off_track(value: str, graph: MetroGraph) -> None:
@@ -247,7 +183,7 @@ def _parse_xy(text: str) -> tuple[float, float] | None:
         return None
 
 
-def _parse_legend_directive(value: str, graph: MetroGraph) -> None:
+def apply_legend_directive(value: str, graph: MetroGraph) -> None:
     """Parse the %%metro legend: directive positioning the legend+logo block.
 
     Grammar (the keyword forms stay content-anchored with the content-overlap
@@ -383,45 +319,6 @@ def _parse_legend_combo_directive(value: str, graph: MetroGraph) -> None:
     graph.legend_combos.append((tuple(known), label))
 
 
-def _parse_nonneg_number(value: str, name: str, *, allow_zero: bool) -> float | None:
-    """Parse a numeric %%metro directive value, warning and returning None if invalid.
-
-    ``allow_zero`` admits 0 (a gap may legitimately be zero); otherwise the value
-    must be strictly positive (a scale factor cannot be zero).
-    """
-    try:
-        num = float(value)
-    except ValueError:
-        _warn_directive(name, f"invalid {value!r}; expected a number")
-        return None
-    if num < 0 or (num == 0 and not allow_zero):
-        constraint = "non-negative" if allow_zero else "positive"
-        _warn_directive(name, f"must be {constraint}, got {value!r}; ignoring")
-        return None
-    return num
-
-
-def _parse_logo_scale_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro logo_scale: <factor> (1.0 = default auto-size)."""
-    scale = _parse_nonneg_number(value, "logo_scale", allow_zero=False)
-    if scale is not None:
-        graph.logo_scale = scale
-
-
-def _parse_legend_logo_gap_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro legend_logo_gap: <px> (horizontal gap logo->legend entries)."""
-    gap = _parse_nonneg_number(value, "legend_logo_gap", allow_zero=True)
-    if gap is not None:
-        graph.legend_logo_gap = gap
-
-
-def _parse_font_scale_directive(value: str, graph: MetroGraph) -> None:
-    """Parse %%metro font_scale: <factor> (1.0 = default text sizes)."""
-    scale = _parse_nonneg_number(value, "font_scale", allow_zero=False)
-    if scale is not None:
-        graph.font_scale = scale
-
-
 def _parse_marker_style(key: str, spec: str) -> MarkerStyle | None:
     """Parse a ``shape, fill`` marker spec into a MarkerStyle.
 
@@ -498,35 +395,51 @@ def _parse_line_spread_directive(value: str, graph: MetroGraph) -> None:
         graph.line_spread = mode
 
 
-# Graph-wide directives: keyed by exact name, each a (value, graph) handler.
-# Order is irrelevant - a key that is a prefix of another (``legend`` vs
-# ``legend_combo``) cannot shadow it. The section-scoped keys
-# (entry/exit/direction) and the file/files/dir icon keys are NOT here: they
-# need the enclosing section or the key itself, and are handled in
-# _apply_directive / _apply_scoped_directive.
+def _make_layout_option_handler(
+    opt: LayoutOption,
+) -> Callable[[str, MetroGraph], None]:
+    """Build the directive handler for a registry option.
+
+    The handler parses the payload via :func:`coerce`, writing the option's
+    graph field on success or warning (and leaving the default) on a malformed
+    value.  This is the directive half of the single-definition cascade in
+    :mod:`nf_metro.options`; the CLI half lives in :mod:`nf_metro.cli`.
+    """
+
+    def handler(value: str, graph: MetroGraph) -> None:
+        result, expected = coerce(opt, value)
+        if result is INVALID:
+            _warn_malformed(opt.name, value, expected)
+        else:
+            setattr(graph, opt.target_attr, result)
+
+    return handler
+
+
+# Graph-wide directives, keyed by exact name. The simple scalar/bool/enum
+# knobs are generated from the LAYOUT_OPTIONS registry (shared with the CLI);
+# the bespoke handlers below carry grammar the generic registry can't express.
+# Section-scoped (entry/exit/direction) and icon (file/files/dir) keys are
+# dispatched separately in _apply_directive / _apply_scoped_directive.
 _GLOBAL_DIRECTIVE_HANDLERS: dict[str, Callable[[str, MetroGraph], None]] = {
-    "title": _dir_title,
-    "style": _dir_style,
-    "logo": _dir_logo,
-    "line_order": _dir_line_order,
-    "line": _dir_line,
-    "compact_offsets": _dir_compact_offsets,
-    "center_ports": _dir_center_ports,
-    "fold_threshold": _dir_fold_threshold,
-    "label_angle": _dir_label_angle,
-    "legend_min_height": _dir_legend_min_height,
-    "off_track": _dir_off_track,
-    "grid": _parse_grid_directive,
-    "logo_scale": _parse_logo_scale_directive,
-    "font_scale": _parse_font_scale_directive,
-    "legend_logo_gap": _parse_legend_logo_gap_directive,
-    "line_spread": _parse_line_spread_directive,
-    "legend_combo": _parse_legend_combo_directive,
-    "legend": _parse_legend_directive,
-    "group": _parse_group_directive,
-    "marker_legend": _parse_marker_legend_directive,
-    "marker": _parse_marker_directive,
+    opt.name: _make_layout_option_handler(opt) for opt in LAYOUT_OPTIONS
 }
+_GLOBAL_DIRECTIVE_HANDLERS.update(
+    {
+        "title": _dir_title,
+        "style": _dir_style,
+        "logo": _dir_logo,
+        "line": _dir_line,
+        "off_track": _dir_off_track,
+        "grid": _parse_grid_directive,
+        "line_spread": _parse_line_spread_directive,
+        "legend_combo": _parse_legend_combo_directive,
+        "legend": apply_legend_directive,
+        "group": _parse_group_directive,
+        "marker_legend": _parse_marker_legend_directive,
+        "marker": _parse_marker_directive,
+    }
+)
 
 # Directives that act on the enclosing subgraph rather than the whole graph.
 _SCOPED_DIRECTIVES = ("entry", "exit", "direction")

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -295,10 +295,19 @@ class MetroGraph:
     diamond_style: str = "straight"  # "straight" or "symmetric"
     compact_offsets: bool = False
     center_ports: bool = False
+    # None = auto; compute_layout resolves spacing and section gaps.
+    x_spacing: float | None = None
+    y_spacing: float | None = None
+    section_x_gap: float | None = None
+    section_y_gap: float | None = None
+    # None/False = auto/off; the renderer resolves these.
+    width: int | None = None
+    height: int | None = None
+    animate: bool = False
     # Max station-columns a section row may reach before the auto-layout wraps
     # it onto the next row. None falls back to 15; raise it to keep a long
     # horizontal trunk of sections on a single row. Overridden by the
-    # --max-layers-per-row CLI flag.
+    # --fold-threshold CLI flag.
     fold_threshold: int | None = None
     # Vertical relationship between lines sharing a station (see LineSpread).
     # ``line_spread`` is the graph-wide default; ``line_spread_overrides`` maps

--- a/src/nf_metro/render/html.py
+++ b/src/nf_metro/render/html.py
@@ -23,7 +23,7 @@ def render_html(
     theme: Theme,
     width: int | None = None,
     height: int | None = None,
-    animate: bool = False,
+    animate: bool | None = None,
     debug: bool = False,
     embed_basename: str = "metro_map.html",
 ) -> str:

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -373,17 +373,27 @@ def render_svg(
     width: int | None = None,
     height: int | None = None,
     padding: float = CANVAS_PADDING,
-    animate: bool = False,
+    animate: bool | None = None,
     debug: bool = False,
     legend_position: str | None = None,
 ) -> str:
     """Render a metro map graph to an SVG string.
+
+    ``width``, ``height``, and ``animate`` fall back to the graph's fields
+    (set by directive or CLI flag) when left unset.
 
     If ``legend_position`` is given it overrides ``graph.legend_position``
     for this render only, without mutating the graph.
     """
     if not graph.stations:
         return '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+
+    if width is None:
+        width = graph.width
+    if height is None:
+        height = graph.height
+    if animate is None:
+        animate = graph.animate
 
     scaled_theme = _scale_theme_fonts(theme, graph.font_scale)
     with font_scale_context(graph.font_scale):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1311,8 +1311,8 @@ def test_off_track_convergence_keeps_consumer_on_trunk():
         )
 
 
-def test_cli_straight_diamonds_default(tmp_path):
-    """--straight-diamonds is on by default."""
+def test_cli_diamond_style_default(tmp_path):
+    """diamond_style defaults to straight (no flag needed)."""
     from click.testing import CliRunner
 
     from nf_metro.cli import cli
@@ -1325,8 +1325,8 @@ def test_cli_straight_diamonds_default(tmp_path):
     assert result.exit_code == 0, result.output
 
 
-def test_cli_no_straight_diamonds(tmp_path):
-    """--no-straight-diamonds reverts to symmetric behaviour."""
+def test_cli_diamond_style_symmetric(tmp_path):
+    """--diamond-style symmetric reverts to symmetric behaviour."""
     from click.testing import CliRunner
 
     from nf_metro.cli import cli
@@ -1336,7 +1336,7 @@ def test_cli_no_straight_diamonds(tmp_path):
     out = tmp_path / "out.svg"
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["render", str(mmd), "-o", str(out), "--no-straight-diamonds"]
+        cli, ["render", str(mmd), "-o", str(out), "--diamond-style", "symmetric"]
     )
     assert result.exit_code == 0, result.output
 

--- a/tests/test_options_parity.py
+++ b/tests/test_options_parity.py
@@ -1,0 +1,158 @@
+"""CLI <-> %%metro directive parity for layout/render options (issue #553).
+
+Every tunable in the :data:`nf_metro.options.LAYOUT_OPTIONS` registry must be
+settable by a directive and overridable by the matching CLI flag, with a
+uniform precedence: CLI flag > directive > default. These tests pin the new
+directives, the cascade, and a completeness guard that fails if an option ever
+exists in only one plane.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from nf_metro.cli import _apply_layout_overrides, _resolve_theme, render
+from nf_metro.layout import compute_layout
+from nf_metro.options import LAYOUT_OPTIONS
+from nf_metro.parser.directives import _GLOBAL_DIRECTIVE_HANDLERS
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
+from nf_metro.themes import THEMES
+
+_LINE = "%%metro line: a | A | #f00\n"
+_FLAT = _LINE + "graph LR\n  n1[N1] -->|a| n2[N2]\n"
+
+
+def _two_sections(extra: str = "") -> str:
+    return (
+        _LINE
+        + extra
+        + "graph LR\n"
+        + "  subgraph s1 [S1]\n    n1[N1] -->|a| n2[N2]\n  end\n"
+        + "  subgraph s2 [S2]\n    n3[N3] -->|a| n4[N4]\n  end\n"
+        + "  n2 -->|a| n3\n"
+    )
+
+
+def test_every_option_is_in_both_planes():
+    """Each registry option has a directive handler, a CLI flag, and a real field."""
+    cli_params = {p.name for p in render.params}
+    fields = set(vars(MetroGraph()))
+    for opt in LAYOUT_OPTIONS:
+        assert opt.name in _GLOBAL_DIRECTIVE_HANDLERS, f"{opt.name}: no directive"
+        assert opt.name in cli_params, f"{opt.name}: no CLI flag"
+        assert opt.target_attr in fields, (
+            f"{opt.name}: no graph field {opt.target_attr}"
+        )
+
+
+def test_no_duplicate_or_shadowed_options():
+    """The two planes share one name each: no option is defined twice or shadowed."""
+    names = [opt.name for opt in LAYOUT_OPTIONS]
+    attrs = [opt.target_attr for opt in LAYOUT_OPTIONS]
+    assert len(names) == len(set(names)), "duplicate registry option name"
+    assert len(attrs) == len(set(attrs)), "two options write the same graph field"
+
+    # A bespoke handler must not shadow a generated one: the directive a
+    # registry option resolves to has to be the registry-generated handler,
+    # not a hand-written entry that silently diverges from the CLI.
+    for opt in LAYOUT_OPTIONS:
+        handler = _GLOBAL_DIRECTIVE_HANDLERS[opt.name]
+        assert handler.__qualname__.startswith("_make_layout_option_handler"), (
+            f"{opt.name}: directive shadowed by a bespoke handler"
+        )
+
+    # No registry flag collides with a hand-written click option on `render`.
+    counts = Counter(p.name for p in render.params)
+    assert all(c == 1 for c in counts.values()), "a CLI flag is declared twice"
+
+
+@pytest.mark.parametrize(
+    "directive, attr, expected",
+    [
+        ("x_spacing: 120", "x_spacing", 120.0),
+        ("y_spacing: 80", "y_spacing", 80.0),
+        ("section_x_gap: 90", "section_x_gap", 90.0),
+        ("section_y_gap: 70", "section_y_gap", 70.0),
+        ("diamond_style: symmetric", "diamond_style", "symmetric"),
+        ("width: 1400", "width", 1400),
+        ("height: 900", "height", 900),
+        ("animate: true", "animate", True),
+    ],
+)
+def test_new_directive_sets_field(directive, attr, expected):
+    graph = parse_metro_mermaid(f"%%metro {directive}\ngraph LR\n")
+    assert getattr(graph, attr) == expected
+
+
+@pytest.mark.parametrize(
+    "directive, attr, default",
+    [
+        ("x_spacing: huge", "x_spacing", None),
+        ("x_spacing: -5", "x_spacing", None),
+        ("section_x_gap: -1", "section_x_gap", None),
+        ("diamond_style: round", "diamond_style", "straight"),
+        ("width: tall", "width", None),
+    ],
+)
+def test_new_directive_malformed_ignored(directive, attr, default):
+    with pytest.warns(UserWarning):
+        graph = parse_metro_mermaid(f"%%metro {directive}\ngraph LR\n")
+    assert getattr(graph, attr) == default
+
+
+def test_cli_override_beats_directive():
+    graph = parse_metro_mermaid("%%metro x_spacing: 200\ngraph LR\n")
+    assert graph.x_spacing == 200.0
+    _apply_layout_overrides(graph, {"x_spacing": 60.0})
+    assert graph.x_spacing == 60.0
+    _apply_layout_overrides(graph, {"x_spacing": None})
+    assert graph.x_spacing == 60.0
+
+
+def test_cli_override_skips_parse_time_options():
+    """fold_threshold reaches the graph through the parser, not a post-parse setattr."""
+    graph = MetroGraph(fold_threshold=99)
+    _apply_layout_overrides(graph, {"fold_threshold": 5})
+    assert graph.fold_threshold == 99
+
+
+def test_x_spacing_directive_drives_layout():
+    base = parse_metro_mermaid(_FLAT)
+    compute_layout(base)
+    wide = parse_metro_mermaid("%%metro x_spacing: 200\n" + _FLAT)
+    compute_layout(wide)
+    dx_base = base.stations["n2"].x - base.stations["n1"].x
+    dx_wide = wide.stations["n2"].x - wide.stations["n1"].x
+    assert dx_wide > dx_base
+
+
+def test_section_x_gap_directive_drives_layout():
+    base = parse_metro_mermaid(_two_sections())
+    compute_layout(base)
+    wide = parse_metro_mermaid(_two_sections("%%metro section_x_gap: 200\n"))
+    compute_layout(wide)
+    assert wide.sections["s2"].offset_x > base.sections["s2"].offset_x
+
+
+def test_style_directive_selects_theme_and_cli_overrides():
+    assert _resolve_theme(None, MetroGraph(style="light")) is THEMES["light"]
+    assert _resolve_theme(None, MetroGraph(style="dark")) is THEMES["nfcore"]
+    assert _resolve_theme("nfcore", MetroGraph(style="light")) is THEMES["nfcore"]
+
+
+def test_html_output_honours_graph_width_and_animate():
+    """width/animate set by directive drive HTML identically to the explicit args."""
+    from nf_metro.render.html import render_html
+
+    via_directive = parse_metro_mermaid(
+        "%%metro width: 1234\n%%metro animate: true\n" + _FLAT
+    )
+    compute_layout(via_directive)
+    via_arg = parse_metro_mermaid(_FLAT)
+    compute_layout(via_arg)
+    assert render_html(via_directive, THEMES["nfcore"]) == render_html(
+        via_arg, THEMES["nfcore"], width=1234, animate=True
+    )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1146,7 +1146,7 @@ def test_fold_threshold_keeps_wide_chain_on_one_row():
 
 
 def test_max_station_columns_arg_overrides_fold_threshold():
-    """An explicit caller value (the --max-layers-per-row CLI flag) wins over a
+    """An explicit caller value (the --fold-threshold CLI flag) wins over a
     fold_threshold directive, matching the CLI-overrides-directive convention."""
     graph = parse_metro_mermaid(
         "%%metro fold_threshold: 100\n" + _wide_section_chain(),


### PR DESCRIPTION
## Summary

Layout/render options were split across two control planes that could drift: some were CLI-only (`--x-spacing`, `--y-spacing`, `--section-x-gap`, `--section-y-gap`), one CLI flag named its directive twin differently (`--max-layers-per-row` vs `fold_threshold:`), and `diamond_style` had a CLI flag but no directive. This makes a committed `.mmd` reproducible from itself and lets you do the same thing from config or the CLI using the same language.

Every dual-plane option is now declared **once** in a registry (`src/nf_metro/options.py`, `LAYOUT_OPTIONS`). The directive dispatcher generates a handler per entry and the CLI generates the matching `click` flag from the same list, so the two planes can't drift and adding an option is a single registry entry. Precedence is uniform:

> **CLI flag (when set) → `%%metro` directive → built-in default.**

### Parity changes

- New directives **and** matching flags: `x_spacing`, `y_spacing`, `section_x_gap`, `section_y_gap`, `diamond_style`, `width`, `height`, `animate`.
- New CLI flags for existing directives: `--diamond-style`, `--legend`, `--label-angle`, `--font-scale`, `--logo-scale`, `--legend-min-height`, `--legend-logo-gap`, `--compact-offsets`, `--fold-threshold`.
- **Breaking (pre-v1):** `--max-layers-per-row` renamed to `--fold-threshold`; the boolean `--straight-diamonds/--no-straight-diamonds` replaced by `--diamond-style straight|symmetric`.
- `--theme` now defers to the `style:` directive when unset (the directive previously had no effect on theming); `--title` now applies to any render, not only `--from-nextflow`.
- CLI-only by design (output target / diagnostics, not part of the diagram): `-o`, `--format`, `--from-nextflow`, `--debug`.

### Mechanics

- `compute_layout` reads `graph.x_spacing` / `y_spacing` / `section_x_gap` / `section_y_gap` when its matching kwarg is unset, so the engine is the single source of truth for any render path.
- `render_svg` honours `graph.width` / `height` / `animate`.
- `test_options_parity.py` is a completeness guard: every registry option must have a directive handler, a CLI flag, and a real graph field.

### Docs

- `docs/guide.md`: completed the directive table and added one authoritative directive ⇄ CLI-flag precedence table.
- `docs/index.md`: refreshed the CLI option table.
- `docs/dev/parser.md`: documented the shared registry.

Fixes #553

### Guards

`test_options_parity.py` machine-enforces the single-source contract: every registry option exists in both planes and writes a real graph field; no two options share a name or graph field; no bespoke directive handler shadows a generated one; no CLI flag is declared twice. An HTML-parity test proves directive-driven `width`/`animate` produce identical output to the explicit `render_html` arguments.

## Test plan
- [x] `pytest` passes (incl. parity/duplication/cascade/engine/HTML-parity tests)
- [x] `ruff check` + `ruff format --check` clean on whole repo
- [x] mypy clean
- [x] All 77 example renders byte-for-byte identical to `main` (local check)
- [x] Render-preview verdict: **no visual changes detected** (all renders match `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
