### PR TITLE
test(perf): one layout pass per fixture for content-placement property tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,10 +124,6 @@ def compute_corpus_layout(path: Path, is_nextflow: bool) -> MetroGraph:
 
 
 # --- Mutable-geometry snapshot/restore ---
-#
-# The declarative-property tests (purity #491, idempotence #488) probe a single
-# layout phase by mutating station/section geometry, measuring, then putting the
-# graph back so the rest of the pipeline runs unperturbed.
 
 Coords = dict[str, tuple[float, float]]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,35 @@ def compute_corpus_layout(path: Path, is_nextflow: bool) -> MetroGraph:
     return graph
 
 
+# --- Mutable-geometry snapshot/restore ---
+#
+# The declarative-property tests (purity #491, idempotence #488) probe a single
+# layout phase by mutating station/section geometry, measuring, then putting the
+# graph back so the rest of the pipeline runs unperturbed.
+
+Coords = dict[str, tuple[float, float]]
+
+
+def snapshot_graph_state(graph: MetroGraph) -> tuple[Coords, Coords]:
+    """Capture every station ``(x, y)`` and section ``(bbox_y, bbox_h)``."""
+    stations = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bboxes = {sec.id: (sec.bbox_y, sec.bbox_h) for sec in graph.sections.values()}
+    return stations, bboxes
+
+
+def restore_graph_state(graph: MetroGraph, snap: tuple[Coords, Coords]) -> None:
+    """Write a :func:`snapshot_graph_state` result back onto ``graph``."""
+    stations, bboxes = snap
+    for sid, (x, y) in stations.items():
+        st = graph.stations.get(sid)
+        if st is not None:
+            st.x, st.y = x, y
+    for sid, (y, h) in bboxes.items():
+        sec = graph.sections.get(sid)
+        if sec is not None:
+            sec.bbox_y, sec.bbox_h = y, h
+
+
 # --- Parse/layout helpers ---
 
 

--- a/tests/test_content_placement_idempotent.py
+++ b/tests/test_content_placement_idempotent.py
@@ -9,19 +9,19 @@ Idempotence is a fixed-point property and is strictly weaker than *purity*
 (output a function of frozen anchors + structure only); the stronger property
 is checked by ``test_content_placement_pure`` (#491).
 
-Mechanism: monkeypatch the engine's reference to one placement phase with a
-wrapper that invokes it twice, run the full layout (with the anchor guard
-active), and assert every station coordinate matches the single-application
-baseline.  A phase that reads its own prior output (e.g. selecting/sorting by
-current Y) diverges on the second call and fails here.
+Mechanism: monkeypatch every placement phase with a probe that applies it once,
+snapshots the result, applies it a second time on that result, records any
+station the second application moves, then restores the single-application
+snapshot so the rest of the pipeline runs unperturbed.  Because each probe is
+self-contained, all eight share one layout pass and a failure names the
+offending phase.  A phase that reads its own prior output (e.g. selecting or
+sorting by current Y) moves content on the second call and fails here.
 
 Covers the whole render corpus so any fixture that exercises a phase
 participates.  Refs #488, #465.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 from conftest import CONTENT_PLACEMENT_PHASES, compute_corpus_layout, content_corpus
@@ -31,46 +31,90 @@ from nf_metro.parser.model import MetroGraph
 
 CORPUS = content_corpus()
 
+TOL = 1e-6
 
-def _coords(graph: MetroGraph) -> dict[str, tuple[float, float]]:
-    return {sid: (round(s.x, 6), round(s.y, 6)) for sid, s in graph.stations.items()}
-
-
-# The single-pass baseline depends only on the fixture, so compute it once per
-# fixture rather than re-running it for each of the eight phases.
-_BASELINE: dict[str, dict[str, tuple[float, float]]] = {}
+_Coords = dict[str, tuple[float, float]]
 
 
-def _baseline(
-    fid: str, path: Path, is_nextflow: bool
-) -> dict[str, tuple[float, float]]:
-    if fid not in _BASELINE:
-        _BASELINE[fid] = _coords(compute_corpus_layout(path, is_nextflow))
-    return _BASELINE[fid]
+def _snapshot(graph: MetroGraph) -> tuple[_Coords, _Coords]:
+    stations = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bboxes = {sec.id: (sec.bbox_y, sec.bbox_h) for sec in graph.sections.values()}
+    return stations, bboxes
 
 
-@pytest.mark.parametrize("phase_name", CONTENT_PLACEMENT_PHASES)
-@pytest.mark.parametrize("fixture", CORPUS, ids=[fid for fid, _, _ in CORPUS])
-def test_placement_phase_is_idempotent(fixture, phase_name, monkeypatch):
-    fid, path, is_nextflow = fixture
+def _restore(graph: MetroGraph, snap: tuple[_Coords, _Coords]) -> None:
+    stations, bboxes = snap
+    for sid, (x, y) in stations.items():
+        st = graph.stations.get(sid)
+        if st is not None:
+            st.x, st.y = x, y
+    for sid, (y, h) in bboxes.items():
+        sec = graph.sections.get(sid)
+        if sec is not None:
+            sec.bbox_y, sec.bbox_h = y, h
 
-    baseline = _baseline(fid, path, is_nextflow)
 
-    original = getattr(engine, phase_name)
+def _make_idempotence_probe(original, diffs: list[tuple[str, tuple, tuple]]):
+    """Wrap ``original`` so each call checks ``P(P(x)) == P(x)`` locally and
+    then leaves the genuine single-application result for the pipeline.
 
-    def run_twice(graph, *args, **kwargs):
+    Apply the phase once and snapshot its output; apply it again on that output
+    and record any station whose coordinate moves on the second application;
+    then restore the single-application snapshot so the rest of the pipeline
+    runs exactly as it would unprobed.  Being self-contained, every phase's
+    probe coexists in one layout pass and isolates non-idempotence to the phase
+    that caused it.
+    """
+
+    def probe(graph: MetroGraph, *args, **kwargs):
         original(graph, *args, **kwargs)
+        snap1 = _snapshot(graph)
+        after1 = snap1[0]
+
         original(graph, *args, **kwargs)
+        after2 = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
 
-    monkeypatch.setattr(engine, phase_name, run_twice)
-    doubled = _coords(compute_corpus_layout(path, is_nextflow))
+        for sid, (x1, y1) in after1.items():
+            x2, y2 = after2.get(sid, (x1, y1))
+            if abs(x2 - x1) > TOL or abs(y2 - y1) > TOL:
+                diffs.append((sid, (x1, y1), (x2, y2)))
 
-    diff = {
-        k: (baseline[k], doubled.get(k))
-        for k in baseline
-        if baseline[k] != doubled.get(k)
-    }
-    assert doubled == baseline, (
-        f"{phase_name} is not idempotent on {fid}: applying it twice moved "
-        f"content. Differing stations: {diff}"
+        _restore(graph, snap1)
+
+    return probe
+
+
+@pytest.mark.parametrize(
+    "fid,path,is_nextflow", CORPUS, ids=[fid for fid, _, _ in CORPUS]
+)
+def test_placement_phase_is_idempotent(fid, path, is_nextflow, monkeypatch):
+    """Every content-placement phase is idempotent on ``fid``.
+
+    The probe checks ``P(P(x)) == P(x)`` directly at each phase and restores the
+    single-application result, so all eight probes share one layout pass and a
+    failure names the offending phase.  This is the literal property the file
+    asserts, checked in isolation at the phase rather than inferred from the
+    cascaded final layout, and covers the same (fixture, phase) pairs at
+    one-eighth the layout cost.
+    """
+    diffs_by_phase: dict[str, list[tuple[str, tuple, tuple]]] = {}
+    for phase_name in CONTENT_PLACEMENT_PHASES:
+        diffs_by_phase[phase_name] = []
+        original = getattr(engine, phase_name)
+        monkeypatch.setattr(
+            engine,
+            phase_name,
+            _make_idempotence_probe(original, diffs_by_phase[phase_name]),
+        )
+
+    compute_corpus_layout(path, is_nextflow)
+
+    non_idempotent = {name: diffs for name, diffs in diffs_by_phase.items() if diffs}
+    assert not non_idempotent, (
+        f"content-placement phase(s) not idempotent on {fid}: applying twice "
+        f"moved content. Stations per phase (station: first -> second): "
+        + "; ".join(
+            f"{name}: {[(s, a, b) for s, a, b in diffs[:8]]}"
+            for name, diffs in non_idempotent.items()
+        )
     )

--- a/tests/test_content_placement_idempotent.py
+++ b/tests/test_content_placement_idempotent.py
@@ -24,7 +24,13 @@ participates.  Refs #488, #465.
 from __future__ import annotations
 
 import pytest
-from conftest import CONTENT_PLACEMENT_PHASES, compute_corpus_layout, content_corpus
+from conftest import (
+    CONTENT_PLACEMENT_PHASES,
+    compute_corpus_layout,
+    content_corpus,
+    restore_graph_state,
+    snapshot_graph_state,
+)
 
 import nf_metro.layout.engine as engine
 from nf_metro.parser.model import MetroGraph
@@ -33,53 +39,31 @@ CORPUS = content_corpus()
 
 TOL = 1e-6
 
-_Coords = dict[str, tuple[float, float]]
+_Point = tuple[float, float]
+_Diff = tuple[str, _Point | None, _Point | None]
 
 
-def _snapshot(graph: MetroGraph) -> tuple[_Coords, _Coords]:
-    stations = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bboxes = {sec.id: (sec.bbox_y, sec.bbox_h) for sec in graph.sections.values()}
-    return stations, bboxes
-
-
-def _restore(graph: MetroGraph, snap: tuple[_Coords, _Coords]) -> None:
-    stations, bboxes = snap
-    for sid, (x, y) in stations.items():
-        st = graph.stations.get(sid)
-        if st is not None:
-            st.x, st.y = x, y
-    for sid, (y, h) in bboxes.items():
-        sec = graph.sections.get(sid)
-        if sec is not None:
-            sec.bbox_y, sec.bbox_h = y, h
-
-
-def _make_idempotence_probe(original, diffs: list[tuple[str, tuple, tuple]]):
-    """Wrap ``original`` so each call checks ``P(P(x)) == P(x)`` locally and
-    then leaves the genuine single-application result for the pipeline.
-
-    Apply the phase once and snapshot its output; apply it again on that output
-    and record any station whose coordinate moves on the second application;
-    then restore the single-application snapshot so the rest of the pipeline
-    runs exactly as it would unprobed.  Being self-contained, every phase's
-    probe coexists in one layout pass and isolates non-idempotence to the phase
-    that caused it.
-    """
+def _make_idempotence_probe(original, diffs: list[_Diff]):
+    """Wrap ``original`` to check ``P(P(x)) == P(x)`` locally, recording into
+    ``diffs`` any station added, removed or moved by the second application."""
 
     def probe(graph: MetroGraph, *args, **kwargs):
         original(graph, *args, **kwargs)
-        snap1 = _snapshot(graph)
+        snap1 = snapshot_graph_state(graph)
         after1 = snap1[0]
 
         original(graph, *args, **kwargs)
-        after2 = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+        after2 = snapshot_graph_state(graph)[0]
 
         for sid, (x1, y1) in after1.items():
-            x2, y2 = after2.get(sid, (x1, y1))
-            if abs(x2 - x1) > TOL or abs(y2 - y1) > TOL:
-                diffs.append((sid, (x1, y1), (x2, y2)))
+            if sid not in after2:
+                diffs.append((sid, (x1, y1), None))
+            elif abs(after2[sid][0] - x1) > TOL or abs(after2[sid][1] - y1) > TOL:
+                diffs.append((sid, (x1, y1), after2[sid]))
+        for sid in after2.keys() - after1.keys():
+            diffs.append((sid, None, after2[sid]))
 
-        _restore(graph, snap1)
+        restore_graph_state(graph, snap1)
 
     return probe
 
@@ -97,7 +81,7 @@ def test_placement_phase_is_idempotent(fid, path, is_nextflow, monkeypatch):
     cascaded final layout, and covers the same (fixture, phase) pairs at
     one-eighth the layout cost.
     """
-    diffs_by_phase: dict[str, list[tuple[str, tuple, tuple]]] = {}
+    diffs_by_phase: dict[str, list[_Diff]] = {}
     for phase_name in CONTENT_PLACEMENT_PHASES:
         diffs_by_phase[phase_name] = []
         original = getattr(engine, phase_name)

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -107,12 +107,6 @@ def _make_purity_probe(original, leaks: list[tuple[str, float, float]]):
     return probe
 
 
-def _cases():
-    for fid, path, is_nf in CORPUS:
-        for phase in CONTENT_PLACEMENT_PHASES:
-            yield pytest.param(fid, path, is_nf, phase, id=f"{fid}-{phase}")
-
-
 def test_content_placement_phases_complete():
     """Completeness guard (#503): the set of phases actually run through the
     ``_run_placement`` wrapper in ``_compute_section_layout`` must equal the
@@ -151,16 +145,33 @@ def test_content_placement_phases_complete():
     )
 
 
-@pytest.mark.parametrize("fid,path,is_nf,phase_name", list(_cases()))
-def test_placement_phase_is_pure(fid, path, is_nf, phase_name, monkeypatch):
-    leaks: list[tuple[str, float, float]] = []
-    original = getattr(engine, phase_name)
-    monkeypatch.setattr(engine, phase_name, _make_purity_probe(original, leaks))
+@pytest.mark.parametrize("fid,path,is_nf", CORPUS, ids=[fid for fid, _, _ in CORPUS])
+def test_placement_phase_is_pure(fid, path, is_nf, monkeypatch):
+    """Every content-placement phase is pure on ``fid``.
+
+    Each phase's purity probe is self-contained -- it snapshots, measures, and
+    restores the genuine single-application result around its own phase call --
+    so all eight coexist in one layout pass without perturbing the pipeline or
+    each other.  This checks the same (fixture, phase) coverage as eight
+    separate runs would, at one-eighth the layout cost.
+    """
+    leaks_by_phase: dict[str, list[tuple[str, float, float]]] = {}
+    for phase_name in CONTENT_PLACEMENT_PHASES:
+        leaks_by_phase[phase_name] = []
+        original = getattr(engine, phase_name)
+        monkeypatch.setattr(
+            engine, phase_name, _make_purity_probe(original, leaks_by_phase[phase_name])
+        )
+
     compute_corpus_layout(path, is_nf)
 
-    assert not leaks, (
-        f"{phase_name} is not pure on {fid}: perturbing non-anchor state "
-        f"(current Y + section bbox) changed where it placed content. "
-        f"Leaks (station: baseline_y -> perturbed_y): "
-        f"{[(s, round(a, 1), round(b, 1)) for s, a, b in leaks[:8]]}"
+    impure = {name: leaks for name, leaks in leaks_by_phase.items() if leaks}
+    assert not impure, (
+        f"content-placement phase(s) not pure on {fid}: perturbing non-anchor "
+        f"state (current Y + section bbox) changed where they placed content. "
+        f"Leaks per phase (station: baseline_y -> perturbed_y): "
+        + "; ".join(
+            f"{name}: {[(s, round(a, 1), round(b, 1)) for s, a, b in leaks[:8]]}"
+            for name, leaks in impure.items()
+        )
     )

--- a/tests/test_content_placement_pure.py
+++ b/tests/test_content_placement_pure.py
@@ -26,34 +26,20 @@ Refs #491, #488, #487, #485, #465.
 from __future__ import annotations
 
 import pytest
-from conftest import CONTENT_PLACEMENT_PHASES, compute_corpus_layout, content_corpus
+from conftest import (
+    CONTENT_PLACEMENT_PHASES,
+    compute_corpus_layout,
+    content_corpus,
+    restore_graph_state,
+    snapshot_graph_state,
+)
 
 import nf_metro.layout.engine as engine
 from nf_metro.parser.model import MetroGraph
 
 TOL = 1e-3
 
-_Coords = dict[str, tuple[float, float]]
-
 CORPUS = content_corpus()
-
-
-def _snapshot(graph: MetroGraph) -> tuple[_Coords, _Coords]:
-    stations = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bboxes = {sec.id: (sec.bbox_y, sec.bbox_h) for sec in graph.sections.values()}
-    return stations, bboxes
-
-
-def _restore(graph: MetroGraph, snap: tuple[_Coords, _Coords]) -> None:
-    stations, bboxes = snap
-    for sid, (x, y) in stations.items():
-        st = graph.stations.get(sid)
-        if st is not None:
-            st.x, st.y = x, y
-    for sid, (y, h) in bboxes.items():
-        sec = graph.sections.get(sid)
-        if sec is not None:
-            sec.bbox_y, sec.bbox_h = y, h
 
 
 def _perturb(graph: MetroGraph) -> None:
@@ -79,7 +65,7 @@ def _make_purity_probe(original, leaks: list[tuple[str, float, float]]):
     into ``leaks`` and then leaves the genuine single-application result."""
 
     def probe(graph: MetroGraph, *args, **kwargs):
-        pre = _snapshot(graph)
+        pre = snapshot_graph_state(graph)
         before_y = {sid: s.y for sid, s in graph.stations.items()}
 
         original(graph, *args, **kwargs)
@@ -88,7 +74,7 @@ def _make_purity_probe(original, leaks: list[tuple[str, float, float]]):
             sid for sid in base_after if abs(base_after[sid] - before_y[sid]) > TOL
         }
 
-        _restore(graph, pre)
+        restore_graph_state(graph, pre)
         _perturb(graph)
         pert_before = {sid: s.y for sid, s in graph.stations.items()}
         original(graph, *args, **kwargs)
@@ -101,7 +87,7 @@ def _make_purity_probe(original, leaks: list[tuple[str, float, float]]):
             if abs(base_after[sid] - pert_after[sid]) > TOL:
                 leaks.append((sid, base_after[sid], pert_after[sid]))
 
-        _restore(graph, pre)
+        restore_graph_state(graph, pre)
         original(graph, *args, **kwargs)
 
     return probe


### PR DESCRIPTION
## What

The content-placement **purity** (`test_content_placement_pure.py`, #491) and **idempotence** (`test_content_placement_idempotent.py`, #488) property tests each parametrized over `fixture × phase` (96 fixtures × 8 phases), running a full validated `compute_layout` for **every** `(fixture, phase)` pair. Each fixture's entire layout was recomputed eight times just to probe one phase per run.

This re-parametrizes both tests **per fixture** and installs all eight phase probes in a single layout pass.

## Why it's safe (no coverage loss)

- **Purity test:** the purity probe is already self-contained, snapshotting, measuring and restoring the genuine single-application result around its own phase call. So the eight probes coexist in one pass without perturbing the pipeline or each other. Every `(fixture, phase)` pair is still checked, and a failure still names the offending phase.
- **Idempotence test:** switched from the indirect cascade mechanism (double one phase, run the whole pipeline, compare the final layout to a single-application baseline) to a **direct local `P(P(x)) == P(x)` probe** at each phase that restores the single-application result. This is the literal property the file asserts, checked in isolation rather than inferred from the cascaded final layout, so it can no longer be masked by a downstream phase washing out a divergence. The same self-containment lets all eight share one pass. Since purity (verified by the still-green purity test) implies idempotence, the stronger local check stays green.

## Verification

- Injected a non-idempotent / non-pure mutation into a content phase: **both tests go red and name it**, confirming the consolidated tests still catch regressions (not vacuous).
- Full suite green (one unrelated failure, `test_independent_components.py::test_component_placement_is_deterministic_across_hash_seeds`, is a pre-existing local-env subprocess-import artifact that passes under CI's proper install).

## Impact

The two files drop from **~63s to ~10s** (1537 tests → 193) with no loss of `(fixture, phase)` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)