### PR TITLE
feat(layout): stack tall-anchor section chains vertically (#552)

### DIFF
--- a/examples/genomic_pipeline.mmd
+++ b/examples/genomic_pipeline.mmd
@@ -12,11 +12,6 @@
 %%metro line: germline | Germline | #0570b0
 %%metro line: tumor_only | Tumor only | #d62728
 %%metro line: somatic | Tumor-normal pair | #756bb1
-%%metro grid: preprocessing | 0,0,1,2
-%%metro grid: variant_calling | 0,1,3,1
-%%metro grid: post_vc | 1,1,1,1
-%%metro grid: annotation | 1,2,1,1
-%%metro grid: reporting | 1,3,1,1
 
 graph LR
     subgraph preprocessing [Pre-processing]

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -91,54 +91,13 @@ def _build_section_dag(
     return dict(successors), dict(predecessors), dict(edge_lines)
 
 
-def _estimate_section_layers(graph: MetroGraph, section_id: str) -> int:
-    """Estimate the number of station layers (horizontal span) for a section.
+def _internal_station_depths(
+    graph: MetroGraph, section_id: str
+) -> dict[str, int] | None:
+    """Longest-path depth of each station through a section's internal edges.
 
-    Computes the longest path through internal edges via topological DP.
-    Returns at least 1.
-    """
-    section = graph.sections[section_id]
-    station_ids = set(section.station_ids)
-
-    # Build adjacency for internal edges only
-    adj: dict[str, set[str]] = defaultdict(set)
-    has_pred: set[str] = set()
-    for edge in graph.edges:
-        if edge.source in station_ids and edge.target in station_ids:
-            adj[edge.source].add(edge.target)
-            has_pred.add(edge.target)
-
-    if not adj:
-        return max(len(station_ids), 1)
-
-    # BFS longest path from roots
-    roots = station_ids - has_pred
-    if not roots:
-        return len(station_ids)
-
-    longest: dict[str, int] = {sid: 0 for sid in station_ids}
-    queue: deque[str] = deque(roots)
-    visited: set[str] = set()
-
-    while queue:
-        node = queue.popleft()
-        if node in visited:
-            continue
-        visited.add(node)
-        for succ in adj.get(node, set()):
-            if longest[node] + 1 > longest[succ]:
-                longest[succ] = longest[node] + 1
-            queue.append(succ)
-
-    return max(longest.values()) + 1  # +1: convert 0-indexed depth to layer count
-
-
-def _estimate_section_height(graph: MetroGraph, section_id: str) -> int:
-    """Estimate a section's vertical extent as its widest internal layer.
-
-    Counts the stations sharing the busiest longest-path depth (the broadest
-    fan), the orthogonal counterpart to ``_estimate_section_layers``. Returns
-    at least 1.
+    Returns ``None`` when the section has no internal edges or contains a
+    cycle (no roots), so callers fall back to a station count.
     """
     section = graph.sections[section_id]
     station_ids = set(section.station_ids)
@@ -151,11 +110,10 @@ def _estimate_section_height(graph: MetroGraph, section_id: str) -> int:
             has_pred.add(edge.target)
 
     if not adj:
-        return max(len(station_ids), 1)
-
+        return None
     roots = station_ids - has_pred
     if not roots:
-        return len(station_ids)
+        return None
 
     depth: dict[str, int] = {sid: 0 for sid in station_ids}
     queue: deque[str] = deque(roots)
@@ -169,10 +127,34 @@ def _estimate_section_height(graph: MetroGraph, section_id: str) -> int:
             if depth[node] + 1 > depth[succ]:
                 depth[succ] = depth[node] + 1
             queue.append(succ)
+    return depth
 
+
+def _estimate_section_layers(graph: MetroGraph, section_id: str) -> int:
+    """Estimate the number of station layers (horizontal span) for a section.
+
+    Computes the longest path through internal edges via topological DP.
+    Returns at least 1.
+    """
+    depth = _internal_station_depths(graph, section_id)
+    if depth is None:
+        return max(len(graph.sections[section_id].station_ids), 1)
+    return max(depth.values()) + 1  # +1: convert 0-indexed depth to layer count
+
+
+def _estimate_section_height(graph: MetroGraph, section_id: str) -> int:
+    """Estimate a section's vertical extent as its widest internal layer.
+
+    Counts the stations sharing the busiest longest-path depth (the broadest
+    fan), the orthogonal counterpart to ``_estimate_section_layers``. Returns
+    at least 1.
+    """
+    depth = _internal_station_depths(graph, section_id)
+    if depth is None:
+        return max(len(graph.sections[section_id].station_ids), 1)
     per_layer: dict[int, int] = defaultdict(int)
-    for sid in station_ids:
-        per_layer[depth[sid]] += 1
+    for d in depth.values():
+        per_layer[d] += 1
     return max(per_layer.values())
 
 
@@ -217,9 +199,7 @@ def _detect_tall_anchor_chain(graph: MetroGraph) -> str | None:
         return None
     # A unique tall section: a second comparably tall fan would want its own
     # column, which the single-anchor stack cannot express.
-    if any(
-        s != anchor and heights[s] >= TALL_ANCHOR_MIN_HEIGHT for s in section_ids
-    ):
+    if any(s != anchor and heights[s] >= TALL_ANCHOR_MIN_HEIGHT for s in section_ids):
         return None
     # The anchor must sit mid-spine: a non-empty head (upstream) to form the
     # header row and a non-empty tail (downstream) to stack beside it.
@@ -233,7 +213,6 @@ def _place_with_tall_anchor(
     graph: MetroGraph,
     col_assign: dict[str, int],
     anchor: str,
-    successors: dict[str, set[str]],
 ) -> tuple[set[str], set[str], set[str]]:
     """Place a tall-anchor chain: header row, tall anchor, stacked tail.
 
@@ -370,13 +349,11 @@ def _assign_grid_positions(
         topo_col_width[col] = max(_estimate_section_layers(graph, sid) for sid in sids)
 
     # --- Tall-anchor vertical stack ---
-    # A single-source/single-sink chain dominated by one section that is much
-    # taller than wide (a large fan, e.g. a many-way caller block) packs more
-    # compactly by stacking the narrow downstream chain vertically beside the
-    # tall anchor than by giving every section its own topological column.
+    # Stack the narrow downstream chain in the shadow of one dominant tall-
+    # narrow fan instead of giving every section its own topological column.
     anchor = _detect_tall_anchor_chain(graph)
     if anchor is not None:
-        return _place_with_tall_anchor(graph, col_assign, anchor, successors)
+        return _place_with_tall_anchor(graph, col_assign, anchor)
 
     # --- Convergence-based row split ---
     # Detect sections with predecessors spanning 2+ non-adjacent topo columns.

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -133,6 +133,167 @@ def _estimate_section_layers(graph: MetroGraph, section_id: str) -> int:
     return max(longest.values()) + 1  # +1: convert 0-indexed depth to layer count
 
 
+def _estimate_section_height(graph: MetroGraph, section_id: str) -> int:
+    """Estimate a section's vertical extent as its widest internal layer.
+
+    Counts the stations sharing the busiest longest-path depth (the broadest
+    fan), the orthogonal counterpart to ``_estimate_section_layers``. Returns
+    at least 1.
+    """
+    section = graph.sections[section_id]
+    station_ids = set(section.station_ids)
+
+    adj: dict[str, set[str]] = defaultdict(set)
+    has_pred: set[str] = set()
+    for edge in graph.edges:
+        if edge.source in station_ids and edge.target in station_ids:
+            adj[edge.source].add(edge.target)
+            has_pred.add(edge.target)
+
+    if not adj:
+        return max(len(station_ids), 1)
+
+    roots = station_ids - has_pred
+    if not roots:
+        return len(station_ids)
+
+    depth: dict[str, int] = {sid: 0 for sid in station_ids}
+    queue: deque[str] = deque(roots)
+    visited: set[str] = set()
+    while queue:
+        node = queue.popleft()
+        if node in visited:
+            continue
+        visited.add(node)
+        for succ in adj.get(node, set()):
+            if depth[node] + 1 > depth[succ]:
+                depth[succ] = depth[node] + 1
+            queue.append(succ)
+
+    per_layer: dict[int, int] = defaultdict(int)
+    for sid in station_ids:
+        per_layer[depth[sid]] += 1
+    return max(per_layer.values())
+
+
+# A section qualifies as a tall anchor when its fan is at least this many
+# stations deep and at least this many times taller than it is wide. The fan
+# then has enough vertical room to host the downstream chain stacked beside it.
+TALL_ANCHOR_MIN_HEIGHT = 10
+TALL_ANCHOR_ASPECT_RATIO = 2.0
+
+
+def _detect_tall_anchor_chain(graph: MetroGraph) -> str | None:
+    """Return the section to anchor a vertical-stack layout, or ``None``.
+
+    Qualifies when the section meta-graph is a single-source/single-sink chain
+    whose unique tallest section is a dominant tall-narrow fan (a mid-spine
+    section with both upstream and downstream neighbours). The narrow tail
+    downstream of that anchor can then stack vertically in its shadow.
+    """
+    dag = graph.section_dag
+    if dag is None or len(graph.sections) < 3:
+        return None
+    # A single explicit pin is manual layout intent for the whole map; the
+    # vertical-stack packer owns every section's cell, so it must not run
+    # alongside hand-placed grids.
+    if graph._explicit_grid:
+        return None
+    successors, predecessors = dag.successors, dag.predecessors
+    section_ids = list(graph.sections)
+
+    sources = [s for s in section_ids if not predecessors.get(s)]
+    sinks = [s for s in section_ids if not successors.get(s)]
+    if len(sources) != 1 or len(sinks) != 1:
+        return None
+
+    heights = {s: _estimate_section_height(graph, s) for s in section_ids}
+    widths = {s: _estimate_section_layers(graph, s) for s in section_ids}
+    anchor = max(section_ids, key=lambda s: heights[s])
+
+    if heights[anchor] < TALL_ANCHOR_MIN_HEIGHT:
+        return None
+    if heights[anchor] < TALL_ANCHOR_ASPECT_RATIO * widths[anchor]:
+        return None
+    # A unique tall section: a second comparably tall fan would want its own
+    # column, which the single-anchor stack cannot express.
+    if any(
+        s != anchor and heights[s] >= TALL_ANCHOR_MIN_HEIGHT for s in section_ids
+    ):
+        return None
+    # The anchor must sit mid-spine: a non-empty head (upstream) to form the
+    # header row and a non-empty tail (downstream) to stack beside it.
+    if not predecessors.get(anchor) or not successors.get(anchor):
+        return None
+
+    return anchor
+
+
+def _place_with_tall_anchor(
+    graph: MetroGraph,
+    col_assign: dict[str, int],
+    anchor: str,
+    successors: dict[str, set[str]],
+) -> tuple[set[str], set[str], set[str]]:
+    """Place a tall-anchor chain: header row, tall anchor, stacked tail.
+
+    The sections upstream of the anchor occupy row 0 (a header that spans the
+    grid width); the anchor sits below in column 0 spanning the tail's rows;
+    the downstream sections stack vertically in column 1, ordered by topo
+    column. No TB bridge is created -- every section keeps horizontal flow and
+    the inter-section router carriage-returns each stacked connection.
+    """
+    anchor_col = col_assign[anchor]
+    head = sorted(
+        (s for s in col_assign if col_assign[s] < anchor_col),
+        key=lambda s: col_assign[s],
+    )
+    tail = sorted(
+        (s for s in col_assign if col_assign[s] > anchor_col),
+        key=lambda s: col_assign[s],
+    )
+
+    folded: dict[str, tuple[int, int, int, int]] = {}
+
+    # Header row: one section per upstream column, left to right.
+    for col, sid in enumerate(head):
+        folded[sid] = (col, 0, 1, 1)
+    grid_width = max(len(head), 2)
+
+    # Tail stacks in the last column on rows below the header.
+    tail_col = grid_width - 1
+    for row, sid in enumerate(tail, start=1):
+        folded[sid] = (tail_col, row, 1, 1)
+
+    # Anchor sits in column 0, spanning every tail row.
+    folded[anchor] = (0, 1, max(len(tail), 1), 1)
+
+    # A lone header section spans the full width so its column is not inflated
+    # by the wide upstream block (the narrow anchor/tail columns set the width).
+    if len(head) == 1:
+        col, row, _rspan, _cspan = folded[head[0]]
+        folded[head[0]] = (col, row, 1, grid_width)
+
+    for sid, (col, row, rspan, cspan) in folded.items():
+        graph.grid_overrides[sid] = (col, row, rspan, cspan)
+        section = graph.sections[sid]
+        section.grid_col = col
+        section.grid_row = row
+        section.grid_row_span = rspan
+        section.grid_col_span = cspan
+
+    # Pin the anchor and its stacked tail to horizontal flow: each connects to
+    # the section below via a carriage-return wrap, so direction inference must
+    # not reorient a single-successor-below section to TB (which would force a
+    # perpendicular TOP entry on the LR sink). Registering them as fixed
+    # directions makes _infer_directions leave them LR.
+    for sid in [anchor, *tail]:
+        graph.sections[sid].direction = "LR"
+        graph._explicit_directions.add(sid)
+
+    return set(), set(), set()
+
+
 def _assign_grid_positions(
     graph: MetroGraph,
     successors: dict[str, set[str]],
@@ -207,6 +368,15 @@ def _assign_grid_positions(
     topo_col_width: dict[int, int] = {}
     for col, sids in col_groups.items():
         topo_col_width[col] = max(_estimate_section_layers(graph, sid) for sid in sids)
+
+    # --- Tall-anchor vertical stack ---
+    # A single-source/single-sink chain dominated by one section that is much
+    # taller than wide (a large fan, e.g. a many-way caller block) packs more
+    # compactly by stacking the narrow downstream chain vertically beside the
+    # tall anchor than by giving every section its own topological column.
+    anchor = _detect_tall_anchor_chain(graph)
+    if anchor is not None:
+        return _place_with_tall_anchor(graph, col_assign, anchor, successors)
 
     # --- Convergence-based row split ---
     # Detect sections with predecessors spanning 2+ non-adjacent topo columns.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -150,6 +150,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_station_x_column_drift,
     _guard_stations_in_sections,
     _guard_stations_within_bbox,
+    _guard_tall_anchor_stack_well_formed,
     _guard_terminus_icons_within_bbox,
     _inter_section_backtrack_legs,
     _port_anchor_snapshot,
@@ -821,6 +822,7 @@ def _compute_section_layout(
         _guard_section_bboxes_positive(graph, "after Stage 1.1")
         _guard_no_negative_grid_columns(graph, "after Stage 1.1")
         _guard_explicit_grid_directions(graph, "after Stage 1.1")
+        _guard_tall_anchor_stack_well_formed(graph, "after Stage 1.1")
 
     # Stage 1.2: Align Y grids across same-row, same-direction sections
     _align_row_y_grids(graph, section_subgraphs, y_spacing, section_y_padding)

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -461,6 +461,66 @@ def _guard_explicit_grid_directions(graph: MetroGraph, phase: str) -> None:
         )
 
 
+def _guard_tall_anchor_stack_well_formed(graph: MetroGraph, phase: str) -> None:
+    """A tall-anchor vertical stack keeps its anchor's downstream chain
+    stacked in one column within the anchor's row span, all horizontal.
+
+    The vertical-stack packer relies on every stacked section flowing
+    horizontally so the inter-section router carriage-returns each drop; a
+    section that slipped out of the anchor's column, off its row span, or into
+    a vertical (TB/BT) direction would dangle beside empty space or force a
+    perpendicular port on an LR sink. No-op when the packer did not fire.
+    """
+    from nf_metro.layout.auto_layout import _detect_tall_anchor_chain
+
+    anchor = _detect_tall_anchor_chain(graph)
+    if anchor is None or graph.section_dag is None:
+        return
+
+    successors = graph.section_dag.successors
+    tail: set[str] = set()
+    queue = list(successors.get(anchor, set()))
+    while queue:
+        sid = queue.pop()
+        if sid in tail:
+            continue
+        tail.add(sid)
+        queue.extend(successors.get(sid, set()))
+
+    horizontal = {"LR", "RL"}
+    non_horizontal = {
+        sid: graph.sections[sid].direction
+        for sid in (anchor, *tail)
+        if graph.sections[sid].direction not in horizontal
+    }
+    if non_horizontal:
+        raise PhaseInvariantError(
+            f"{phase}: tall-anchor stack sections are not horizontal-flow: "
+            f"{non_horizontal}"
+        )
+
+    tail_cols = {graph.sections[sid].grid_col for sid in tail}
+    if len(tail_cols) != 1:
+        raise PhaseInvariantError(
+            f"{phase}: tall-anchor tail spans columns {sorted(tail_cols)}; "
+            f"expected a single stacked column"
+        )
+
+    anchor_sec = graph.sections[anchor]
+    span_top = anchor_sec.grid_row
+    span_bottom = anchor_sec.grid_row + anchor_sec.grid_row_span - 1
+    escaped = {
+        sid: graph.sections[sid].grid_row
+        for sid in tail
+        if not span_top <= graph.sections[sid].grid_row <= span_bottom
+    }
+    if escaped:
+        raise PhaseInvariantError(
+            f"{phase}: tall-anchor tail rows {escaped} fall outside the anchor "
+            f"{anchor!r} row span [{span_top}, {span_bottom}]"
+        )
+
+
 def _guard_row_gaps(graph: MetroGraph, phase: str, *, section_y_gap: float) -> None:
     """Final phase: column-overlapping adjacent-row section pairs must
     keep at least ``section_y_gap`` between the upper section's bbox

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -471,21 +471,16 @@ def _guard_tall_anchor_stack_well_formed(graph: MetroGraph, phase: str) -> None:
     a vertical (TB/BT) direction would dangle beside empty space or force a
     perpendicular port on an LR sink. No-op when the packer did not fire.
     """
-    from nf_metro.layout.auto_layout import _detect_tall_anchor_chain
+    from nf_metro.layout.auto_layout import (
+        _detect_tall_anchor_chain,
+        _transitive_successors,
+    )
 
     anchor = _detect_tall_anchor_chain(graph)
     if anchor is None or graph.section_dag is None:
         return
 
-    successors = graph.section_dag.successors
-    tail: set[str] = set()
-    queue = list(successors.get(anchor, set()))
-    while queue:
-        sid = queue.pop()
-        if sid in tail:
-            continue
-        tail.add(sid)
-        queue.extend(successors.get(sid, set()))
+    tail = _transitive_successors(anchor, graph.section_dag.successors)
 
     horizontal = {"LR", "RL"}
     non_horizontal = {

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -267,7 +267,7 @@ def test_explicit_grid_section_keeps_lr_against_auto_successor_below():
 @pytest.mark.parametrize(
     "fixture",
     [
-        "genomic_pipeline.mmd",
+        "sarek_metro.mmd",
         "genomeassembly_staggered.mmd",
         "topologies/stacked_lr_serpentine.mmd",
         "topologies/around_section_below.mmd",

--- a/tests/test_tall_anchor_stack.py
+++ b/tests/test_tall_anchor_stack.py
@@ -1,0 +1,126 @@
+"""Tall-anchor vertical-stack placement.
+
+A pipeline whose section meta-graph is a single-source/single-sink chain
+containing one section that is much taller than it is wide (a large fan,
+e.g. a 19-way variant-caller block) should be packed by stacking the narrow
+downstream chain vertically beside the tall anchor, rather than spreading
+every section into its own topological column. The latter sprawls the canvas
+horizontally; the former keeps it compact.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.auto_layout import _detect_tall_anchor_chain
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.phases.guards import (
+    PhaseInvariantError,
+    _guard_tall_anchor_stack_well_formed,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.svg import render_svg
+from nf_metro.themes import NFCORE_THEME
+
+EXAMPLES = Path(__file__).parent.parent / "examples"
+
+
+def _strip_grid_pins(path: Path) -> str:
+    """Return the example text with all explicit ``grid:`` pins removed."""
+    return "\n".join(
+        line
+        for line in path.read_text().splitlines()
+        if not line.startswith("%%metro grid:")
+    )
+
+
+def _section_columns(graph) -> set[int]:
+    """Grid columns occupied by any section (accounting for col spans)."""
+    cols: set[int] = set()
+    for section in graph.sections.values():
+        if section.grid_col < 0:
+            continue
+        for col in range(
+            section.grid_col, section.grid_col + section.grid_col_span
+        ):
+            cols.add(col)
+    return cols
+
+
+def _render_width(text: str) -> int:
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph)
+    svg = render_svg(graph, NFCORE_THEME)
+    match = re.search(r'width="(\d+)"', svg)
+    assert match is not None
+    return int(match.group(1))
+
+
+def test_tall_anchor_chain_stacks_into_two_columns():
+    """genomic_pipeline (grid pins stripped) packs into <= 2 section columns."""
+    graph = parse_metro_mermaid(_strip_grid_pins(EXAMPLES / "genomic_pipeline.mmd"))
+    cols = _section_columns(graph)
+    assert cols, "no sections placed"
+    assert max(cols) <= 1, (
+        f"expected the tall-anchor chain to stack into <= 2 columns, "
+        f"got columns {sorted(cols)}"
+    )
+
+
+def test_tall_anchor_auto_matches_or_beats_pinned_width():
+    """Auto layout is no wider than the hand-pinned grid (issue acceptance)."""
+    pinned = _render_width((EXAMPLES / "genomic_pipeline.mmd").read_text())
+    auto = _render_width(_strip_grid_pins(EXAMPLES / "genomic_pipeline.mmd"))
+    assert auto <= pinned * 1.05, (
+        f"auto width {auto}px should match or beat pinned width {pinned}px"
+    )
+
+
+def test_tall_anchor_detected_on_genomic_pipeline():
+    """The dominant tall-narrow caller fan is identified as the anchor."""
+    graph = parse_metro_mermaid(_strip_grid_pins(EXAMPLES / "genomic_pipeline.mmd"))
+    assert _detect_tall_anchor_chain(graph) == "variant_calling"
+
+
+# Multi-section auto examples lacking a dominant tall-narrow anchor: the packer
+# must not fire (each tallest section is short, wide, or the graph branches /
+# has multiple sinks), so the detector returns None and their layout is
+# governed by the ordinary topological packer.
+NON_FIRING = [
+    "epitopeprediction.mmd",
+    "hlatyping.mmd",
+    "variant_calling.mmd",
+    "variant_calling_tuned.mmd",
+    "genomeassembly.mmd",
+    "longread_variant_calling.mmd",
+    "differentialabundance.mmd",
+    "variantbenchmarking.mmd",
+    "rnaseq_auto.mmd",
+]
+
+
+@pytest.mark.parametrize("name", NON_FIRING)
+def test_tall_anchor_does_not_fire_on_ordinary_pipelines(name):
+    graph = parse_metro_mermaid(_strip_grid_pins(EXAMPLES / name))
+    assert _detect_tall_anchor_chain(graph) is None, (
+        f"{name}: tall-anchor packer fired but should not"
+    )
+
+
+def test_guard_rejects_reoriented_tail_section():
+    """A stacked tail section flipped to vertical flow trips the guard."""
+    graph = parse_metro_mermaid(_strip_grid_pins(EXAMPLES / "genomic_pipeline.mmd"))
+    graph.sections["annotation"].direction = "TB"
+    with pytest.raises(PhaseInvariantError, match="not horizontal-flow"):
+        _guard_tall_anchor_stack_well_formed(graph, "test")
+
+
+def test_guard_rejects_tail_section_off_anchor_span():
+    """A tail section dropped below the anchor's row span trips the guard."""
+    graph = parse_metro_mermaid(_strip_grid_pins(EXAMPLES / "genomic_pipeline.mmd"))
+    anchor = graph.sections["variant_calling"]
+    bottom = anchor.grid_row + anchor.grid_row_span - 1
+    graph.sections["reporting"].grid_row = bottom + 5
+    with pytest.raises(PhaseInvariantError, match="outside the anchor"):
+        _guard_tall_anchor_stack_well_formed(graph, "test")

--- a/tests/test_tall_anchor_stack.py
+++ b/tests/test_tall_anchor_stack.py
@@ -41,9 +41,7 @@ def _section_columns(graph) -> set[int]:
     for section in graph.sections.values():
         if section.grid_col < 0:
             continue
-        for col in range(
-            section.grid_col, section.grid_col + section.grid_col_span
-        ):
+        for col in range(section.grid_col, section.grid_col + section.grid_col_span):
             cols.add(col)
     return cols
 


### PR DESCRIPTION
## Summary

Auto-layout placed each section of a single-source/single-sink chain in its own topological column, sprawling the canvas horizontally when one section is a tall narrow fan (e.g. a many-way variant-caller block). `genomic_pipeline` therefore needed hand-pinned `grid:` directives to stay compact.

This adds an aspect-aware placement path: when the section meta-graph is a single-source/single-sink chain whose unique tallest section is a dominant tall-narrow fan, the narrow downstream chain is stacked vertically in the anchor's shadow:

- upstream sections form a header row spanning the grid width,
- the tall anchor occupies column 0, spanning the tail's rows,
- the downstream sections stack in a single adjacent column.

Every stacked section keeps horizontal flow, so the inter-section router carriage-returns each drop (no TB bridges, no perpendicular ports on the LR sink).

The trigger is a measurable topology property (height >= 10 stations and >= 2x the section's width, unique tallest, mid-spine, no user grid pins), not a per-pipeline special case. Across the gallery it currently fires only on `genomic_pipeline`, whose auto layout now reproduces the previous hand-pinned two-column grid **byte-for-byte**; its `grid:` pins are removed.

A validate-time guard (`_guard_tall_anchor_stack_well_formed`) fails loudly if a stacked tail ever leaves the anchor's column, drops out of its row span, or is reoriented to vertical flow.

Fixes #552

## Test plan
- [x] `pytest` passes (7696 passed, 60 skipped, 5 xfailed), including new `tests/test_tall_anchor_stack.py` (column-count, width-vs-pinned, detector fires/does-not-fire across 9 fixtures, guard rejects malformed stacks)
- [x] `ruff check` + `ruff format --check` clean on whole repo
- [x] Runtime validator added and wired into the validate block
- [x] Local gallery render diff vs `origin/main`: 0 changed SVGs (every example byte-identical; `genomic_pipeline` auto == its old pinned render)
- [x] Render-preview verdict (CI): no visual changes detected, all renders match main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
