### PR TITLE
fix: don't fold a linear section chain that fits one row (#551)

### DIFF
--- a/examples/genomeassembly.mmd
+++ b/examples/genomeassembly.mmd
@@ -7,11 +7,6 @@
 %%metro file: input_long_reads | FASTX
 %%metro file: input_hic_reads | CRAM
 %%metro file: input_10x_reads | FASTQ
-%%metro grid: raw_asm | 0, 0, 2
-%%metro grid: purging | 1, 0, 2
-%%metro grid: polishing | 2, 0, 2
-%%metro grid: scaffolding | 3, 0, 4
-%%metro grid: genome_statistics | 4, 0, 4
 %%metro line_order: span
 %%metro compact_offsets: true
 %%metro legend: bl

--- a/examples/topologies/cross_row_gap_wrap.mmd
+++ b/examples/topologies/cross_row_gap_wrap.mmd
@@ -2,6 +2,7 @@
 %%metro style: dark
 %%metro line: main | Main | #0570b0
 %%metro line: feed | Feed | #e63946
+%%metro fold_threshold: 8
 
 graph LR
     subgraph ingest [Ingest]

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -359,22 +359,30 @@ def _assign_grid_positions(
     # Detect sections with predecessors spanning 2+ non-adjacent topo columns.
     # These are natural "convergence points" that should drop to a return row
     # along with their downstream sections, instead of extending the top row.
-    convergence_result = _detect_convergence_split(
-        col_assign,
-        col_groups,
-        successors,
-        predecessors,
-    )
-    if convergence_result is not None:
-        return _place_with_convergence(
-            graph,
-            col_groups,
-            topo_col_width,
+    #
+    # A purely linear spine (one section per topo column) that fits the fold
+    # threshold stays unsplit: splitting it only bends the flow into a
+    # backward-reading serpentine for no readability gain.
+    single_row_width = sum(topo_col_width.values())
+    is_linear_spine = all(len(sids) == 1 for sids in col_groups.values())
+    chain_fits_one_row = is_linear_spine and single_row_width <= max_station_columns
+    if not chain_fits_one_row:
+        convergence_result = _detect_convergence_split(
             col_assign,
+            col_groups,
             successors,
             predecessors,
-            convergence_result,
         )
+        if convergence_result is not None:
+            return _place_with_convergence(
+                graph,
+                col_groups,
+                topo_col_width,
+                col_assign,
+                successors,
+                predecessors,
+                convergence_result,
+            )
 
     # Greedily pack topo columns into row bands.
     # When overflow is detected, the overflowing column becomes the fold
@@ -466,6 +474,18 @@ def _assign_grid_positions(
         min_col = min(col for col, _ in folded.values())
         if min_col < 0:
             folded = {sid: (col - min_col, row) for sid, (col, row) in folded.items()}
+
+    # A chain judged to fit one row must not have folded: the packer's
+    # overflow test uses the same threshold, so a multi-row result means the
+    # fit decision and the packer disagree.
+    if chain_fits_one_row and any(row != 0 for _, row in folded.values()):
+        from nf_metro.layout.phases.guards import PhaseInvariantError
+
+        rows = sorted({row for _, row in folded.values()})
+        raise PhaseInvariantError(
+            f"linear section spine fits one row (width {single_row_width} "
+            f"<= {max_station_columns}) but packed across rows {rows}"
+        )
 
     # Write results to grid_overrides and section fields
     for sid, (col, row) in folded.items():

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -5969,3 +5969,107 @@ def test_cross_row_top_entry_bundle_corners_are_concentric():
             f"corner C{k + 1} arc centres are {gap:.2f}px apart "
             f"(non-concentric): {a} vs {b}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Linear section spine should not fold when it fits one row
+# ---------------------------------------------------------------------------
+
+# A linear section spine threads one section per topo column; forward "skip"
+# edges over that spine create a convergence point. When the whole flow fits
+# comfortably in a single row, splitting it onto a return row only bends the
+# flow backward, so every section must land in grid row 0. These fixtures are
+# such chains.
+_LINEAR_SPINE_FITS_ONE_ROW = {
+    "single_skip": """%%metro title: Single Skip
+%%metro line: m | M | #0570b0
+graph LR
+    subgraph a [A]
+        a1[A1]
+    end
+    subgraph b [B]
+        b1[B1]
+    end
+    subgraph c [C]
+        c1[C1]
+    end
+    subgraph d [D]
+        d1[D1]
+    end
+    a1 -->|m| b1
+    b1 -->|m| c1
+    c1 -->|m| d1
+    a1 -->|m| c1
+    b1 -->|m| d1
+""",
+    "genomeassembly_shape": """%%metro title: Genomeassembly Shape
+%%metro line: m | M | #0570b0
+graph LR
+    subgraph raw [Raw]
+        r1[R1]
+        r2[R2]
+        r1 -->|m| r2
+    end
+    subgraph purge [Purge]
+        p1[P1]
+        p2[P2]
+        p1 -->|m| p2
+    end
+    subgraph polish [Polish]
+        o1[O1]
+        o2[O2]
+        o1 -->|m| o2
+    end
+    subgraph scaffold [Scaffold]
+        s1[S1]
+        s2[S2]
+        s1 -->|m| s2
+    end
+    subgraph qc [QC]
+        q1[Q1]
+    end
+    r2 -->|m| p1
+    p2 -->|m| o1
+    o2 -->|m| s1
+    s2 -->|m| q1
+    r2 -->|m| o1
+    r2 -->|m| s1
+    p2 -->|m| s1
+    r2 -->|m| q1
+    p2 -->|m| q1
+    o2 -->|m| q1
+""",
+}
+
+
+@pytest.mark.parametrize("name", sorted(_LINEAR_SPINE_FITS_ONE_ROW))
+def test_linear_spine_fitting_one_row_is_single_row(name):
+    """A linear section spine that fits the fold threshold stays in one row.
+
+    Forward skip edges over an already-linear chain of sections form a
+    convergence point, but splitting the chain onto a return row when it
+    fits a single row only bends the flow backward.  Each fixture here is a
+    one-section-per-column spine whose total width is well under the
+    threshold; every section must sit in grid row 0.
+    """
+    graph = parse_metro_mermaid(_LINEAR_SPINE_FITS_ONE_ROW[name])
+    rows = {sec.grid_row for sec in graph.sections.values()}
+    assert rows == {0}, (
+        f"{name}: linear spine fitting one row spread across rows "
+        f"{sorted(rows)}; expected all sections in row 0"
+    )
+
+
+def test_genomeassembly_auto_layout_is_single_row():
+    """The de-pinned genomeassembly example must auto-lay-out in one row.
+
+    Its sections form a single chain (Raw assembly -> Purging -> Polishing
+    -> Scaffolding -> Genome QC) that fits one row; auto-layout must
+    reproduce the single-row flow rather than fold it.
+    """
+    graph = parse_metro_mermaid((EXAMPLES / "genomeassembly.mmd").read_text())
+    rows = {sec.grid_row for sec in graph.sections.values()}
+    assert rows == {0}, (
+        f"genomeassembly sections spread across rows {sorted(rows)}; "
+        f"expected a single row"
+    )


### PR DESCRIPTION
## Summary

Auto-layout's convergence-based row split fired whenever a section had predecessors spanning 2+ non-adjacent topo columns. A linear section spine with forward "skip" edges (e.g. `genomeassembly`) creates exactly such a point, so a chain that fits one row was bent onto a backward-reading return row (genomeassembly grew 1443x451 -> 1260x706 with its second row in reversed flow order).

- Gate the convergence split in `_assign_grid_positions`: a purely linear spine (one section per topo column) that fits the fold threshold in a single row is left unsplit. Stacked topo columns (genuine parallel branches) still take the split.
- Add a postcondition guard that raises `PhaseInvariantError` if a chain judged to fit one row is folded by the packer anyway.
- Strip the now-redundant `%%metro grid:` pins from `examples/genomeassembly.mmd`; auto-layout reproduces the hand-pinned single-row layout byte-for-byte.
- Pin `examples/topologies/cross_row_gap_wrap.mmd` with `fold_threshold: 8` so it keeps exercising the cross-row wrap path (its 10-wide linear spine would otherwise fit one row under the default threshold); its render stays byte-identical.
- Add parametrized invariant tests for linear-spine-fits-one-row, plus a direct assertion on the de-pinned `genomeassembly` example.

The full gallery renders byte-identical to `main`.

Fixes #551

## Test plan
- [x] pytest passes (6355 passed, 5 pre-existing xfails); new invariant tests fail on `main`, pass here
- [x] ruff check + ruff format clean on whole repo
- [x] Runtime validator added (`PhaseInvariantError` postcondition guard)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/608/)
- [x] Local gallery render-diff: byte-identical across all 78 renders

Generated with Claude Code
