### PR TITLE
fix(routing): order inter-row trunk bands to minimise line crossovers (#547)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -152,6 +152,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_stations_within_bbox,
     _guard_tall_anchor_stack_well_formed,
     _guard_terminus_icons_within_bbox,
+    _guard_trunk_bands_crossing_optimal,
     _inter_section_backtrack_legs,
     _port_anchor_snapshot,
     _route_exit_side,
@@ -1450,6 +1451,9 @@ def _finalize_layout(
             _guard_serpentine_no_backtrack(graph, phase, routes=routes)
             _guard_no_artefactual_counter_flow(graph, phase, routes=routes)
             _guard_inter_row_run_clearance(graph, phase, routes=routes)
+            _guard_trunk_bands_crossing_optimal(
+                graph, phase, offsets=offsets, routes=routes
+            )
             _guard_inter_section_descent_edge_clearance(graph, phase, routes=routes)
             _guard_fan_bundles_coincide_or_separate(
                 graph, phase, offsets=offsets, routes=routes

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1852,6 +1852,38 @@ def _guard_inter_row_run_clearance(
                 )
 
 
+def _guard_trunk_bands_crossing_optimal(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """After routing: every same-direction inter-row trunk band carries the
+    line order that minimises crossings between its slots.
+
+    Sibling corridors sharing one inter-row gap stack in a Y order chosen by
+    :func:`_plan_trunk_band`.  When two slots are ordered so that one's
+    peel-off risers needlessly cross the other's trunk leg, swapping them would
+    strictly reduce crossings.  This guard fails loudly if a future change ever
+    leaves a band in such an avoidable-crossing order.
+    """
+    from nf_metro.layout.constants import CURVE_RADIUS, DIAGONAL_RUN
+    from nf_metro.layout.routing.context import _build_routing_context
+    from nf_metro.layout.routing.normalize import _suboptimal_trunk_bands
+
+    routes = _ensure_routes(graph, routes)
+    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
+    bad = _suboptimal_trunk_bands(routes, ctx)
+    if bad:
+        y, cur, best = bad[0]
+        raise PhaseInvariantError(
+            f"{phase}: inter-row trunk band near y={y:.1f} has {cur} crossings; "
+            f"reordering its slots reaches {best}. A sibling-corridor band is "
+            f"stacked in an avoidable-crossing order."
+        )
+
+
 def _guard_inter_section_descent_edge_clearance(
     graph: MetroGraph,
     phase: str,

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -75,6 +75,7 @@ from nf_metro.layout.routing.intra_handlers import (  # noqa: F401
 )
 from nf_metro.layout.routing.normalize import (  # noqa: F401
     _align_peeloff_riser_gaps,
+    _band_order_crossings,
     _build_gap_intervals,
     _clamp_inter_row_band_top,
     _clear_channel_x_in_band,
@@ -102,6 +103,7 @@ from nf_metro.layout.routing.normalize import (  # noqa: F401
     _restack_trunk_band,
     _set_port_approach_x,
     _set_riser_x_and_radii,
+    _suboptimal_trunk_bands,
     _VChannel,
 )
 from nf_metro.layout.routing.postprocess import (  # noqa: F401

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -916,16 +916,16 @@ def _plan_trunk_band(band: list[_HTrunk]) -> list[list[_HTrunk]]:
     h_rank = {id(sg): r for r, sg in enumerate(h_ttb)}
     feats = {id(sg): _trunk_slot_features(sg) for sg in slot_groups}
 
-    def _key(perm: tuple[list[_HTrunk], ...]) -> tuple[int, ...]:
+    def _key(perm: list[list[_HTrunk]]) -> tuple[int, ...]:
         # Tie-break by position in the heuristic order: the heuristic itself
         # scores (0, 1, .. m-1), the lexicographically smallest tuple, so an
         # already-optimal band reproduces the heuristic order exactly.
         return (
-            _band_order_crossings(list(perm), feats),
+            _band_order_crossings(perm, feats),
             *(h_rank[id(sg)] for sg in perm),
         )
 
-    best_ttb = list(min(itertools.permutations(h_ttb), key=_key))
+    best_ttb = min((list(p) for p in itertools.permutations(h_ttb)), key=_key)
     return list(reversed(best_ttb)) if dips else best_ttb
 
 

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -6,6 +6,7 @@ import functools
 import itertools
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from nf_metro.layout.constants import (
     BUNDLE_TO_BUNDLE_CLEARANCE,
@@ -802,16 +803,26 @@ def _normalize_bypass_trunks(routes: list[RoutedPath], ctx: _RoutingCtx) -> None
     _dogleg_off_exempt_trunks(routes, ctx, skip=bundled)
 
 
-def _trunk_slot_features(
-    slot: list[_HTrunk],
-) -> tuple[list[float], list[float], list[tuple[float, float]]]:
+class _SlotFeatures(NamedTuple):
+    """Riser leg xs and trunk x-spans for one slot.
+
+    ``below`` / ``above`` are the xs of risers whose far end drops below /
+    rises above the band; ``spans`` is each trunk's ``(x_lo, x_hi)``.
+    """
+
+    below: list[float]
+    above: list[float]
+    spans: list[tuple[float, float]]
+
+
+def _trunk_slot_features(slot: list[_HTrunk]) -> _SlotFeatures:
     """Riser xs (below / above the band) and x-spans for one line's trunk slot.
 
-    Each horizontal trunk is flanked by two vertical legs; a leg's far
-    endpoint sits either below the trunk (continuing toward the lower row or a
-    peel-off target) or above it (rising to the source row / junction).
-    Returns ``(below_xs, above_xs, spans)`` accumulated over every trunk on the
-    slot; the risers score against other slots' trunk legs to count crossings.
+    Each horizontal trunk is flanked by two vertical legs; a leg's far endpoint
+    sits either below the trunk (continuing toward the lower row or a peel-off
+    target) or above it (rising to the source row / junction).  The two legs
+    can split (one up, one down at a peel-off), so they are classified
+    individually rather than from the trunk's single ``dips_down`` flag.
     """
     below: list[float] = []
     above: list[float] = []
@@ -828,37 +839,42 @@ def _trunk_slot_features(
                 below.append(leg_x)
             elif far_y < t.y - COORD_TOLERANCE:
                 above.append(leg_x)
-    return below, above, spans
+    return _SlotFeatures(below, above, spans)
 
 
-def _trunk_pair_crossings(
-    upper: tuple[list[float], list[float], list[tuple[float, float]]],
-    lower: tuple[list[float], list[float], list[tuple[float, float]]],
-) -> int:
+def _trunk_pair_crossings(upper: _SlotFeatures, lower: _SlotFeatures) -> int:
     """Crossings between two trunk slots when *upper* sits above *lower*.
 
     *upper*'s downward risers cross *lower*'s trunk leg wherever they pass
     through its x-span; *lower*'s upward risers cross *upper*'s leg likewise.
     Risers grazing a span endpoint (a shared corner) are not crossings.
     """
-    below_u, _above_u, span_u = upper
-    _below_l, above_l, span_l = lower
 
     def _within(x: float, spans: list[tuple[float, float]]) -> bool:
         return any(lo + COORD_TOLERANCE < x < hi - COORD_TOLERANCE for lo, hi in spans)
 
-    return sum(_within(x, span_l) for x in below_u) + sum(
-        _within(x, span_u) for x in above_l
+    return sum(_within(x, lower.spans) for x in upper.below) + sum(
+        _within(x, upper.spans) for x in lower.above
     )
 
 
-def _band_order_crossings(order_top_to_bottom: list[list[_HTrunk]]) -> int:
-    """Total riser/leg crossings for a top-to-bottom ordering of trunk slots."""
-    feats = [_trunk_slot_features(sg) for sg in order_top_to_bottom]
+def _band_order_crossings(
+    order_top_to_bottom: list[list[_HTrunk]],
+    feats: dict[int, _SlotFeatures] | None = None,
+) -> int:
+    """Total riser/leg crossings for a top-to-bottom ordering of trunk slots.
+
+    *feats* optionally supplies each slot's features keyed by ``id(slot)`` so a
+    permutation search extracts them once instead of per candidate ordering.
+    """
+    if feats is None:
+        feats = {id(sg): _trunk_slot_features(sg) for sg in order_top_to_bottom}
     return sum(
-        _trunk_pair_crossings(feats[i], feats[j])
-        for i in range(len(feats))
-        for j in range(i + 1, len(feats))
+        _trunk_pair_crossings(
+            feats[id(order_top_to_bottom[i])], feats[id(order_top_to_bottom[j])]
+        )
+        for i in range(len(order_top_to_bottom))
+        for j in range(i + 1, len(order_top_to_bottom))
     )
 
 
@@ -898,12 +914,16 @@ def _plan_trunk_band(band: list[_HTrunk]) -> list[list[_HTrunk]]:
     dips = band[0].dips_down
     h_ttb = list(reversed(heuristic)) if dips else heuristic
     h_rank = {id(sg): r for r, sg in enumerate(h_ttb)}
+    feats = {id(sg): _trunk_slot_features(sg) for sg in slot_groups}
 
     def _key(perm: tuple[list[_HTrunk], ...]) -> tuple[int, ...]:
         # Tie-break by position in the heuristic order: the heuristic itself
         # scores (0, 1, .. m-1), the lexicographically smallest tuple, so an
         # already-optimal band reproduces the heuristic order exactly.
-        return (_band_order_crossings(list(perm)), *(h_rank[id(sg)] for sg in perm))
+        return (
+            _band_order_crossings(list(perm), feats),
+            *(h_rank[id(sg)] for sg in perm),
+        )
 
     best_ttb = list(min(itertools.permutations(h_ttb), key=_key))
     return list(reversed(best_ttb)) if dips else best_ttb
@@ -915,7 +935,7 @@ def _suboptimal_trunk_bands(
     """Same-direction inter-row trunk bands whose realized Y order leaves
     avoidable crossings: ``(band y, current crossings, best achievable)``.
 
-    Reconstructs the bands the way :func:`_normalize_bypass_trunks` does, then
+    Reconstructs the bands :func:`_normalize_bypass_trunks` reorders, then
     checks each realized top-to-bottom order against the crossing-minimal
     permutation.  An empty result means every band is crossing-optimal.
     """
@@ -927,15 +947,19 @@ def _suboptimal_trunk_bands(
     for grp in groups:
         if len({id(t.route) for t in grp}) < 2:
             continue
+        if not any(not t.route.normalize_exempt for t in grp):
+            continue  # handler-owned all-exempt groups: the planner leaves them
         for sign in (1, -1):
             band = [t for t in grp if t.sign_x == sign]
             slots = _coincident_trunk_slots(band)
             if len(slots) < 2 or len(slots) > _MAX_BAND_PERMUTE:
                 continue
+            feats = {id(sg): _trunk_slot_features(sg) for sg in slots}
             realized = sorted(slots, key=lambda sg: min(t.y for t in sg))
-            cur = _band_order_crossings(realized)
+            cur = _band_order_crossings(realized, feats)
             best = min(
-                _band_order_crossings(list(p)) for p in itertools.permutations(slots)
+                _band_order_crossings(list(p), feats)
+                for p in itertools.permutations(slots)
             )
             if best < cur:
                 out.append((min(t.y for t in band), cur, best))

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import itertools
 from collections import defaultdict
 from dataclasses import dataclass
 
@@ -801,18 +802,86 @@ def _normalize_bypass_trunks(routes: list[RoutedPath], ctx: _RoutingCtx) -> None
     _dogleg_off_exempt_trunks(routes, ctx, skip=bundled)
 
 
+def _trunk_slot_features(
+    slot: list[_HTrunk],
+) -> tuple[list[float], list[float], list[tuple[float, float]]]:
+    """Riser xs (below / above the band) and x-spans for one line's trunk slot.
+
+    Each horizontal trunk is flanked by two vertical legs; a leg's far
+    endpoint sits either below the trunk (continuing toward the lower row or a
+    peel-off target) or above it (rising to the source row / junction).
+    Returns ``(below_xs, above_xs, spans)`` accumulated over every trunk on the
+    slot; the risers score against other slots' trunk legs to count crossings.
+    """
+    below: list[float] = []
+    above: list[float] = []
+    spans: list[tuple[float, float]] = []
+    for t in slot:
+        pts = t.route.points
+        k = t.idx
+        spans.append((t.x_lo, t.x_hi))
+        for leg_x, far_y in (
+            (pts[k][0], pts[k - 1][1]),
+            (pts[k + 1][0], pts[k + 2][1]),
+        ):
+            if far_y > t.y + COORD_TOLERANCE:
+                below.append(leg_x)
+            elif far_y < t.y - COORD_TOLERANCE:
+                above.append(leg_x)
+    return below, above, spans
+
+
+def _trunk_pair_crossings(
+    upper: tuple[list[float], list[float], list[tuple[float, float]]],
+    lower: tuple[list[float], list[float], list[tuple[float, float]]],
+) -> int:
+    """Crossings between two trunk slots when *upper* sits above *lower*.
+
+    *upper*'s downward risers cross *lower*'s trunk leg wherever they pass
+    through its x-span; *lower*'s upward risers cross *upper*'s leg likewise.
+    Risers grazing a span endpoint (a shared corner) are not crossings.
+    """
+    below_u, _above_u, span_u = upper
+    _below_l, above_l, span_l = lower
+
+    def _within(x: float, spans: list[tuple[float, float]]) -> bool:
+        return any(lo + COORD_TOLERANCE < x < hi - COORD_TOLERANCE for lo, hi in spans)
+
+    return sum(_within(x, span_l) for x in below_u) + sum(
+        _within(x, span_u) for x in above_l
+    )
+
+
+def _band_order_crossings(order_top_to_bottom: list[list[_HTrunk]]) -> int:
+    """Total riser/leg crossings for a top-to-bottom ordering of trunk slots."""
+    feats = [_trunk_slot_features(sg) for sg in order_top_to_bottom]
+    return sum(
+        _trunk_pair_crossings(feats[i], feats[j])
+        for i in range(len(feats))
+        for j in range(i + 1, len(feats))
+    )
+
+
+_MAX_BAND_PERMUTE = 6
+
+
 def _plan_trunk_band(band: list[_HTrunk]) -> list[list[_HTrunk]]:
     """Order one same-direction band into concentric slots.
 
     Bundle slots are per distinct LINE, not per trunk: two trunks of the SAME
     line whose X-spans overlap are a fan-out/fan-in of one metro line and
     COINCIDE on one slot (issue #484); distinct lines (and disjoint same-line
-    trunks) keep their own concentric slots.  The widest-reaching slot sorts
-    OUTERMOST (deepest into the channel) so a slot's flanking verticals never
-    cross another slot's trunk leg; ties keep incoming order.
+    trunks) keep their own concentric slots.
+
+    Slots are ordered to minimise crossings between each slot's peel-off risers
+    and the others' trunk legs.  Among orderings tied on crossings the
+    widest-reaching slot sorts OUTERMOST (deepest into the channel) so a
+    slot's flanking verticals never needlessly cross another slot's leg; ties
+    beyond that keep incoming order.  The width key is also the tie-break that
+    keeps every already-optimal band byte-identical to the prior heuristic.
     """
     slot_groups = _coincident_trunk_slots(band)
-    return sorted(
+    heuristic = sorted(
         slot_groups,
         key=lambda sg: (
             -max(t.x_hi - t.x_lo for t in sg),
@@ -820,6 +889,57 @@ def _plan_trunk_band(band: list[_HTrunk]) -> list[list[_HTrunk]]:
             min(t.y for t in sg),
         ),
     )
+    if len(slot_groups) < 2 or len(slot_groups) > _MAX_BAND_PERMUTE:
+        return heuristic
+
+    # `_restack_trunk_band` lays slot 0 at the channel-interior extreme: the
+    # BOTTOM (largest y) for a downward dip, the TOP for an upward dip.  Score
+    # crossings in top-to-bottom space, then convert the winner back to slots.
+    dips = band[0].dips_down
+    h_ttb = list(reversed(heuristic)) if dips else heuristic
+    h_rank = {id(sg): r for r, sg in enumerate(h_ttb)}
+
+    def _key(perm: tuple[list[_HTrunk], ...]) -> tuple[int, ...]:
+        # Tie-break by position in the heuristic order: the heuristic itself
+        # scores (0, 1, .. m-1), the lexicographically smallest tuple, so an
+        # already-optimal band reproduces the heuristic order exactly.
+        return (_band_order_crossings(list(perm)), *(h_rank[id(sg)] for sg in perm))
+
+    best_ttb = list(min(itertools.permutations(h_ttb), key=_key))
+    return list(reversed(best_ttb)) if dips else best_ttb
+
+
+def _suboptimal_trunk_bands(
+    routes: list[RoutedPath], ctx: _RoutingCtx
+) -> list[tuple[float, int, int]]:
+    """Same-direction inter-row trunk bands whose realized Y order leaves
+    avoidable crossings: ``(band y, current crossings, best achievable)``.
+
+    Reconstructs the bands the way :func:`_normalize_bypass_trunks` does, then
+    checks each realized top-to-bottom order against the crossing-minimal
+    permutation.  An empty result means every band is crossing-optimal.
+    """
+    trunks = _collect_htrunks(routes, include_exempt=True)
+    if len(trunks) < 2:
+        return []
+    groups = _group_channel_trunks(trunks, ctx.offset_step, ctx)
+    out: list[tuple[float, int, int]] = []
+    for grp in groups:
+        if len({id(t.route) for t in grp}) < 2:
+            continue
+        for sign in (1, -1):
+            band = [t for t in grp if t.sign_x == sign]
+            slots = _coincident_trunk_slots(band)
+            if len(slots) < 2 or len(slots) > _MAX_BAND_PERMUTE:
+                continue
+            realized = sorted(slots, key=lambda sg: min(t.y for t in sg))
+            cur = _band_order_crossings(realized)
+            best = min(
+                _band_order_crossings(list(p)) for p in itertools.permutations(slots)
+            )
+            if best < cur:
+                out.append((min(t.y for t in band), cur, best))
+    return out
 
 
 def _clamp_inter_row_band_top(ctx: _RoutingCtx, top: float, total: float) -> float:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -954,6 +954,35 @@ def test_opposite_direction_trunks_on_separate_bands(fixture):
 
 
 @pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_inter_row_trunk_bands_crossing_optimal(fixture):
+    """Sibling corridors sharing one inter-row gap stack in the Y order that
+    minimises crossings between their peel-off risers and trunk legs.
+
+    Two corridors dipping into one gap (e.g. from different junction fans) are
+    ordered by ``_plan_trunk_band``.  When the realized order lets one slot's
+    risers needlessly cross another slot's leg, swapping the two strictly
+    reduces crossings; the planner must pick the crossing-minimal order so no
+    such avoidable swap remains in the routed output.
+    """
+    from nf_metro.layout.constants import CURVE_RADIUS, DIAGONAL_RUN
+    from nf_metro.layout.routing.core import (
+        _build_routing_context,
+        _suboptimal_trunk_bands,
+    )
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    ctx = _build_routing_context(graph, DIAGONAL_RUN, CURVE_RADIUS, offsets)
+
+    bad = _suboptimal_trunk_bands(routes, ctx)
+    assert not bad, (
+        f"{fixture}: inter-row trunk band(s) ordered with avoidable crossings "
+        + ", ".join(f"y={y:.1f} ({cur}->{best} crossings)" for y, cur, best in bad)
+    )
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
 def test_top_entry_lead_corner_concentric(fixture):
     """A multi-line TOP-entry L-shape must turn its lead-in corner
     concentrically: co-routed lines share one bend centre.


### PR DESCRIPTION
## Summary

Sibling corridors that share one inter-row gap were stacked in a Y order driven by a width heuristic ("widest-reaching outermost") in `_plan_trunk_band`. That heuristic is only a proxy for crossing avoidance, so where it disagreed with the crossing-minimal order, two corridors' peel-off risers needlessly crossed each other's trunk legs.

`_plan_trunk_band` now scores each candidate slot ordering by the actual crossings between every slot's risers and the others' trunk legs, picks the minimum, and tie-breaks toward the prior width heuristic so already-optimal bands stay byte-identical. A runtime guard (`_guard_trunk_bands_crossing_optimal`, validate-only) and a corpus-wide invariant test (`test_inter_row_trunk_bands_crossing_optimal`) fail loudly if any band is left in an avoidable-crossing order.

The whole gallery is byte-identical except `longread_variant_calling`, whose two reported crossovers are resolved:
- the orange/yellow bundle under section 2 (Small variant calling)
- the red/yellow run above sections 5/6

Fixes #547

## Test plan
- [x] `pytest` passes (6445 tests); new invariant test verified to fail on the pre-fix ordering and pass with the fix
- [x] `ruff check` + `ruff format --check` clean on the whole repo
- [x] Runtime validator added (`_guard_trunk_bands_crossing_optimal`)
- [ ] Visual review of render preview
- [x] Gallery byte-identical except `longread_variant_calling` (verified by rendering all examples with and without the reorder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)