### PR TITLE
fix(ordering): give each branch of an uneven diamond its own track

### DIFF
--- a/examples/topologies/README.md
+++ b/examples/topologies/README.md
@@ -24,6 +24,7 @@ Each fixture is tagged with the layout class(es) it primarily exercises. Use thi
 | `fan_in_merge.mmd` | same-line fan-in / merge-junction routing |
 | `multi_input_convergence.mmd` | single-line multi-source convergence |
 | `section_diamond.mmd` | section-level fork-join |
+| `uneven_diamond.mmd` | fork-join with unequal-length branches / distinct track per branch (issue #610) |
 | `shared_sink_parallel.mmd` | parallel multi-line branches with shared source and sink |
 | `asymmetric_tree.mmd` | unbalanced branching / variable branch depth |
 | `complex_multipath.mmd` | per-line route variation / bundle slot reservation |
@@ -95,6 +96,10 @@ Same-line convergence: one line fans out from the source to all downstream secti
 A section-level fork-join: one source fans out to two parallel sections, which then reconverge into a single sink. Tests both fan-out junction creation and fan-in routing in the same topology.
 
 ![Section Diamond](section_diamond.png)
+
+### Uneven Diamond
+
+A node-level fork-join where one branch (`b`) runs through an extra station before rejoining the shared sink while the other two branches (`a`, `c`) reach it directly. The branch length difference must not collapse the shorter branches onto a single track: each of the three branches gets a distinct track (issue #610).
 
 ---
 

--- a/examples/topologies/uneven_diamond.mmd
+++ b/examples/topologies/uneven_diamond.mmd
@@ -1,0 +1,12 @@
+%%metro title: Uneven fork-join diamond
+%%metro line: a | A | #f0a000 | solid
+%%metro line: b | B | #3a86ff | solid
+%%metro line: c | C | #2bb673 | solid
+graph LR
+    hub[Hub] -->|a| la[Leaf A]
+    hub -->|b| lb[Leaf B]
+    lb  -->|b| lb2[Leaf B2]
+    hub -->|c| lc[Leaf C]
+    la  -->|a| sink[Sink]
+    lb2 -->|b| sink
+    lc  -->|c| sink

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -217,6 +217,12 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "Section-level fork-join: fan-out then reconverge.",
     ),
     (
+        "uneven_diamond",
+        TOPOLOGIES_DIR,
+        "Node-level fork-join whose branches differ in length; each branch "
+        "holds its own track instead of collapsing the shorter ones together.",
+    ),
+    (
         "terminal_symmetric_fan",
         TOPOLOGIES_DIR,
         "A terminal section whose entry fans into equal-rank sinks; the "

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -126,6 +126,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_inter_section_routes_in_row_band,
     _guard_merge_port_approach_side,
     _guard_no_artefactual_counter_flow,
+    _guard_no_coincident_station_coords,
     _guard_no_collinear_distinct_lines,
     _guard_no_intra_section_collinear_distinct_lines,
     _guard_no_label_overlap,

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -740,12 +740,21 @@ def _equalize_fork_groups(
         if succs:
             succ_groups[succs].append(sid)
 
-    # Merge both groupings, deduplicating by sorted member tuple
+    # Merge both groupings, deduplicating by sorted member tuple.  A
+    # convergent (successor) group that is a proper subset of a common-
+    # predecessor fork is dropped: the larger fork already spaces all its
+    # branches, and repacking the subset consecutively would ignore the
+    # intervening siblings (longer branches that reach the shared sink via
+    # extra stations) and collapse the subset onto their tracks.
+    pred_member_sets = [set(g) for g in pred_groups.values() if len(g) >= 2]
     all_groups: dict[tuple[str, ...], list[str]] = {}
-    for group in list(pred_groups.values()) + list(succ_groups.values()):
-        key = tuple(sorted(group))
-        if key not in all_groups:
-            all_groups[key] = group
+    for group in pred_groups.values():
+        all_groups.setdefault(tuple(sorted(group)), group)
+    for group in succ_groups.values():
+        members = set(group)
+        if any(members < fork for fork in pred_member_sets):
+            continue
+        all_groups.setdefault(tuple(sorted(group)), group)
 
     for group in all_groups.values():
         if len(group) < 2:

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -776,6 +776,31 @@ def _guard_no_station_overlap(
                 )
 
 
+def _guard_no_coincident_station_coords(
+    graph: MetroGraph, phase: str, *, tolerance: float = 1.0
+) -> None:
+    """Final-phase: no two distinct visible stations may share a centre.
+
+    Offset-independent companion to ``_guard_no_station_overlap``: it reads
+    ``Station.x``/``.y`` directly, so it catches branches collapsed onto the
+    same track even where per-line routing offsets nudge the marker bboxes
+    just clear of each other.  Rail-mode stations are exempt -- their markers
+    render as per-rail knobs across the rail bundle, so a shared centre is
+    not a visual collision there.
+    """
+    placed: list[tuple[str, float, float]] = []
+    for sid, st in graph.stations.items():
+        if st.is_port or st.is_hidden or graph.station_is_rail(sid):
+            continue
+        for other, ox, oy in placed:
+            if abs(st.x - ox) <= tolerance and abs(st.y - oy) <= tolerance:
+                raise PhaseInvariantError(
+                    f"{phase}: {sid!r} and {other!r} share coordinate "
+                    f"({st.x:.1f}, {st.y:.1f})"
+                )
+        placed.append((sid, st.x, st.y))
+
+
 def _guard_no_line_crosses_non_consumer(
     graph: MetroGraph,
     phase: str,
@@ -2310,6 +2335,7 @@ checkpoint in ``_compute_section_layout``.
 _BISECTION_FIRST_VALID: dict[str, str] = {
     "_guard_stations_in_sections": "after Stage 5.3",
     "_guard_no_station_overlap": "after Stage 6.4",
+    "_guard_no_coincident_station_coords": "after Stage 6.4",
     "_guard_no_line_crosses_non_consumer": "after Stage 6.14",
 }
 
@@ -2436,6 +2462,8 @@ def _run_pass_c_guards(
     _guard_ports_on_boundaries(graph, phase)
     if _bisection_should_run("_guard_no_station_overlap", phase):
         _guard_no_station_overlap(graph, phase, offsets=offsets)
+    if _bisection_should_run("_guard_no_coincident_station_coords", phase):
+        _guard_no_coincident_station_coords(graph, phase)
     if routes is not None and _bisection_should_run(
         "_guard_no_line_crosses_non_consumer", phase
     ):

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -788,17 +788,21 @@ def _guard_no_coincident_station_coords(
     render as per-rail knobs across the rail bundle, so a shared centre is
     not a visual collision there.
     """
+    exempt_rail = graph.has_rail_sections
     placed: list[tuple[str, float, float]] = []
     for sid, st in graph.stations.items():
-        if st.is_port or st.is_hidden or graph.station_is_rail(sid):
+        if st.is_port or st.is_hidden or (exempt_rail and graph.station_is_rail(sid)):
             continue
-        for other, ox, oy in placed:
-            if abs(st.x - ox) <= tolerance and abs(st.y - oy) <= tolerance:
-                raise PhaseInvariantError(
-                    f"{phase}: {sid!r} and {other!r} share coordinate "
-                    f"({st.x:.1f}, {st.y:.1f})"
-                )
         placed.append((sid, st.x, st.y))
+    placed.sort(key=lambda p: p[1])
+    for i, (sid, x, y) in enumerate(placed):
+        for oid, ox, oy in placed[i + 1 :]:
+            if ox - x > tolerance:
+                break  # Sorted by x; no further coincidence possible.
+            if abs(y - oy) <= tolerance:
+                raise PhaseInvariantError(
+                    f"{phase}: {sid!r} and {oid!r} share coordinate ({x:.1f}, {y:.1f})"
+                )
 
 
 def _guard_no_line_crosses_non_consumer(

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -48,6 +48,7 @@ def validate_layout(graph: MetroGraph) -> list[Violation]:
     violations.extend(check_station_containment(graph))
     violations.extend(check_port_boundary(graph))
     violations.extend(check_coordinate_sanity(graph))
+    violations.extend(check_coincident_stations(graph))
     violations.extend(check_minimum_section_spacing(graph))
 
     # Compute offsets + routes once for all routing-dependent checks.
@@ -246,6 +247,44 @@ def check_coordinate_sanity(
                         context={"station": sid, "coordinate": coord_name},
                     )
                 )
+
+    return violations
+
+
+def check_coincident_stations(
+    graph: MetroGraph, tolerance: float = 1.0
+) -> list[Violation]:
+    """Check that no two distinct visible stations share a coordinate.
+
+    Two real (non-port, non-hidden) stations placed within *tolerance* of
+    the same ``(x, y)`` render their pill markers on top of each other.
+    Rail-mode stations are exempt: their markers render as per-rail knobs
+    distributed across the rail bundle, so a shared station centre is not a
+    visual collision there.
+    """
+    violations: list[Violation] = []
+
+    placed: list[tuple[str, float, float]] = []
+    for sid, station in graph.stations.items():
+        if station.is_port or station.is_hidden:
+            continue
+        if graph.station_is_rail(sid):
+            continue
+        for other, ox, oy in placed:
+            if abs(station.x - ox) <= tolerance and abs(station.y - oy) <= tolerance:
+                violations.append(
+                    Violation(
+                        check="coincident_stations",
+                        severity=Severity.ERROR,
+                        message=(
+                            f"Stations '{other}' and '{sid}' share coordinate "
+                            f"({station.x:.1f}, {station.y:.1f})"
+                        ),
+                        context={"stations": [other, sid]},
+                    )
+                )
+                break
+        placed.append((sid, station.x, station.y))
 
     return violations
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -2005,6 +2005,7 @@ class TestPassCBisection:
         [
             ("_guard_stations_in_sections", "after Stage 5.3"),
             ("_guard_no_station_overlap", "after Stage 6.4"),
+            ("_guard_no_coincident_station_coords", "after Stage 6.4"),
             ("_guard_no_line_crosses_non_consumer", "after Stage 6.14"),
         ],
     )

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -12,6 +12,7 @@ import pytest
 from layout_validator import (
     Severity,
     check_almost_horizontal_edges,
+    check_coincident_stations,
     check_coordinate_sanity,
     check_edge_section_crossing,
     check_edge_waypoints,
@@ -89,6 +90,11 @@ class TestTopologyValidation:
 
     def test_coordinate_sanity(self, topology_graph):
         violations = check_coordinate_sanity(topology_graph)
+        errors = [v for v in violations if v.severity == Severity.ERROR]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    def test_no_coincident_stations(self, topology_graph):
+        violations = check_coincident_stations(topology_graph)
         errors = [v for v in violations if v.severity == Severity.ERROR]
         assert not errors, "\n".join(v.message for v in errors)
 


### PR DESCRIPTION
## Summary

In a fork-join diamond where one branch reaches the shared sink through extra stations while the others reach it directly, the shorter branches collapsed onto the same `(x, y)` and rendered on top of each other. A *balanced* diamond (all branches equal length) was unaffected.

Root cause: `_equalize_fork_groups` built a convergent successor group from only the branches feeding the sink directly, repacked that subset to consecutive tracks, and ignored the intervening longer branch sitting between them. The fix drops a successor group that is a proper subset of a common-predecessor fork, since the fork already spaces all of its branches.

Each branch now gets a distinct track (e.g. `120 / 160 / 200`), matching balanced-diamond behaviour.

## Changes
- `ordering.py`: skip a convergent successor group that is a proper subset of a common-predecessor fork.
- `guards.py`: new `_guard_no_coincident_station_coords` runtime guard (offset-independent, raw-coordinate check; rail-mode stations exempt because they render as per-rail knobs). Wired into the Pass C validate block from the Stage 6.4 boundary.
- `tests/layout_validator.py`: new `check_coincident_stations` check, added to `validate_layout`.
- `tests/test_topology_validation.py`: parametrized `test_no_coincident_stations` over the whole topology corpus.
- `examples/topologies/uneven_diamond.mmd` + README entry: regression fixture.

Fixes #610

## Test plan
- [x] pytest passes (6536 passed; new `test_no_coincident_stations` fails on `main`, passes here)
- [x] ruff check + ruff format clean on whole repo
- [x] Runtime validator added (`_guard_no_coincident_station_coords`)
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/613/)
- [x] Render-preview verdict: No visual changes detected (all renders match main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

