### PR TITLE
fix(labels): clear angled rail labels off lower-rail markers (#577)

### DIFF
--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -1268,7 +1268,7 @@ def place_labels(
 
     if graph.label_angle:
         _apply_rail_label_angle(
-            placements, graph, float(graph.label_angle), panel_extents
+            placements, graph, float(graph.label_angle), station_offsets
         )
 
     return [p for p in placements if p.obstacle_bbox is None]
@@ -1277,11 +1277,44 @@ def place_labels(
 _RAIL_LABEL_PANEL_CLEARANCE = 4.0
 
 
+def _rail_panel_marker_extents(
+    graph: MetroGraph,
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> dict[str, tuple[float, float]]:
+    """Per-rail-section (top_marker_y, bottom_marker_y) from rendered pills.
+
+    Reports the topmost pill top and bottommost pill bottom across every
+    visible station in the panel (rather than the rail-centre Ys of
+    :func:`_rail_panel_extents`).  A diagonal label cleared only to the rail
+    centre rakes the markers of lone lower-rail stations whose pills extend
+    past that centre; clearing to the pill edge keeps the angled text off
+    those markers.  Returns an empty map when the graph has no rail sections.
+    """
+    from nf_metro.layout.engine import _station_marker_bbox
+
+    extents: dict[str, tuple[float, float]] = {}
+    if not graph._rail_y:
+        return extents
+    for sid, st in graph.stations.items():
+        if not st.section_id or not graph.is_rail_section(st.section_id):
+            continue
+        mb = _station_marker_bbox(graph, sid, station_offsets)
+        if mb is None:
+            continue
+        _, m_top, _, m_bot = mb
+        cur = extents.get(st.section_id)
+        if cur is None:
+            extents[st.section_id] = (m_top, m_bot)
+        else:
+            extents[st.section_id] = (min(cur[0], m_top), max(cur[1], m_bot))
+    return extents
+
+
 def _apply_rail_label_angle(
     placements: list[LabelPlacement],
     graph: MetroGraph,
     label_angle: float,
-    panel_extents: dict[str, tuple[float, float]] | None = None,
+    station_offsets: dict[tuple[str, str], float] | None = None,
 ) -> None:
     """Tilt rail-section station labels by *label_angle* degrees.
 
@@ -1292,7 +1325,12 @@ def _apply_rail_label_angle(
     name leads directly into its station marker.  The rail column step is sized
     for the rotated label's horizontal projection by ``_label_aware_x_spacing``
     so the panel packs tighter.
+
+    The clearance is measured to the panel's outer *pill* edges, not its rail
+    centres, so a down-right label never rakes the marker of a lone lower-rail
+    station sitting one rail down and a column over.
     """
+    panel_extents = _rail_panel_marker_extents(graph, station_offsets)
     for p in placements:
         if p.obstacle_bbox is not None or not p.station_id:
             continue
@@ -1311,9 +1349,10 @@ def _apply_rail_label_angle(
         # from the pill.
         p.text_anchor = "end" if p.above else "start"
         # Tilting adds vertical extent; nudge the anchor so the rotated label
-        # clears the whole rail panel (above its top rail / below its bottom
-        # rail) rather than dipping back beside a middle rail.
-        extent = panel_extents.get(st.section_id) if panel_extents else None
+        # clears the whole rail panel (above its top pill / below its bottom
+        # pill) rather than dipping back over a middle rail or a lower-rail
+        # marker.
+        extent = panel_extents.get(st.section_id)
         if extent is not None:
             top_y, bot_y = extent
             _, by0, _, by1 = _label_bbox(p)

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -616,6 +616,41 @@ def test_rail_labels_clear_the_whole_panel_never_beside_a_middle_rail():
     assert checked, "expected at least one labelled rail station"
 
 
+def test_angled_rail_labels_do_not_rake_lower_rail_markers():
+    """A 45-degree below-bundle rail label must clear the pills of the panel's
+    lower rails, not just their centre lines.
+
+    A lone lower-rail station sits one rail down and a column over from an
+    upper-rail station whose down-right label, cleared only to the rail centre,
+    would rake the lower station's marker.  Clearing to the pill edge keeps
+    every angled label off every marker."""
+    from nf_metro.layout.labels import find_label_overlaps, place_labels
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    graph = parse_metro_mermaid((EXAMPLES / "sarek_metro.mmd").read_text())
+    assert graph.is_rail_section("calling"), "sarek_metro flags 'calling' as rails"
+    assert graph.label_angle, "sarek_metro opts into 45-degree labels"
+    compute_layout(graph)
+
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    placements = place_labels(
+        graph,
+        station_offsets=offsets,
+        routes=routes,
+        label_angle=graph.label_angle,
+    )
+    marker_overlaps = [
+        ov
+        for ov in find_label_overlaps(graph, placements, offsets)
+        if ov.kind == "marker"
+    ]
+    assert not marker_overlaps, "\n".join(
+        f"label {ov.a!r} rakes marker {ov.b!r} by ({ov.ox:.1f}, {ov.oy:.1f})px"
+        for ov in marker_overlaps
+    )
+
+
 def test_stacked_rail_section_bbox_contains_hanging_labels():
     """A rail section's bbox reserves room for its below-rail labels so a
     section stacked beneath it clears them.  A long, steeply-angled label whose


### PR DESCRIPTION
Closes #577

## Problem

In a `line_spread: rails` panel with `label_angle: 45`, a below-bundle station label trails down-and-right from its pill. The clearance only pushed the label below the bottom **rail centre line**, not below the lower-rail stations' marker pills. A lone lower-rail station (e.g. `muse`, `msisensorpro` in `examples/sarek_metro.mmd`), whose pill extends ~15px past the rail centre, had its marker raked by the down-right diagonal of an upper-rail sibling's label in the same/adjacent column.

`check_label_overlap` reported label-vs-marker overlaps on `sarek_metro` of 4-10px.

## Fix

`_apply_rail_label_angle` now measures the panel clearance against the panel's outer **pill edges** rather than its rail centres, via a new `_rail_panel_marker_extents` helper. It reuses the engine's canonical `_station_marker_bbox` pill geometry, so the topmost pill top and bottommost pill bottom define the band each angled label must clear. A below label seats below the bottommost pill, an above label above the topmost pill, never over a marker.

The change is scoped to the rail-mode angled-label path only. The non-angled rail placement path (`_rail_panel_label_offsets` / `_rail_panel_extents`) is untouched.

## Tests

New invariant `test_angled_rail_labels_do_not_rake_lower_rail_markers` asserts zero label-vs-marker overlaps on `examples/sarek_metro.mmd`. It fails on `main` (3 marker rakes) and passes with the fix.

Full suite: 6537 passed, 61 skipped, 5 xfailed (pre-existing). ruff check, ruff format --check, and mypy all clean.

## Render deltas

Gallery render-diff vs `main`: only `sarek_metro.svg` changed (improvement: the `calling` panel's angled labels now sit below the lower-rail pills, clearing `muse` / `msisensorpro` markers; the panel grows ~26px to host them). Every other gallery fixture is byte-identical.

Manual checks on non-gallery rail fixtures:
- `examples/rail_mode.mmd`: byte-identical.
- `tests/fixtures/rail_marked_single_line.mmd`, `rail_pitch_vs_labels.mmd`: labels shifted down to clear lower-rail markers (improvement / neutral; readability preserved).
- Other rail fixtures: byte-identical.

Pre-existing same-column label/label overlaps in the sarek `calling` panel (e.g. `lofreq`/`muse`) are out of scope here (related to #513 / #555) and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)