### PR TITLE
Glyph-ink label-strike guard and foreign-horizontal label flip (#513)

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -375,6 +375,16 @@ Wrapping narrows a label to clear a collision; this stops it shrinking past
 a legible width.  A single word longer than the budget is hard-broken with a
 hyphen (the last-resort split), but never below this many characters."""
 
+LABEL_GLYPH_INK_RATIO: float = 0.75
+"""Fraction of the reserved label width occupied by drawn glyph ink.
+
+``label_text_width`` reserves ``CHAR_WIDTH`` (9px) per character so labels
+get generous collision room, but the rendered text at ``label_font_size``
+covers appreciably less than that.  Routing-vs-label crossing checks model
+the glyph ink as the centred sub-box ``center +/- half_width * this`` so a
+line clipping only the empty reserved margin is not mistaken for one striking
+through the text."""
+
 # ---------------------------------------------------------------------------
 # Ordering
 # ---------------------------------------------------------------------------

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -12,6 +12,7 @@ __all__ = [
     "active_font_scale",
     "find_label_overlaps",
     "font_scale_context",
+    "label_glyph_ink_bbox",
     "label_text_width",
     "place_labels",
 ]
@@ -28,6 +29,7 @@ from nf_metro.layout.constants import (
     DIAGONAL_LABEL_OFFSET,
     FONT_HEIGHT,
     LABEL_BBOX_MARGIN,
+    LABEL_GLYPH_INK_RATIO,
     LABEL_LINE_HEIGHT,
     LABEL_MARGIN,
     LABEL_NUDGE_MAX,
@@ -299,6 +301,25 @@ def _label_bbox(
         y_max = placement.y + text_h
 
     return (x_min, y_min, x_max, y_max)
+
+
+def label_glyph_ink_bbox(
+    placement: LabelPlacement,
+) -> tuple[float, float, float, float]:
+    """Return the label's drawn-glyph box, horizontally tightened to the ink.
+
+    The reserved box from :func:`_label_bbox` budgets ``CHAR_WIDTH`` per
+    character so labels claim ample collision room, but the rendered text is
+    narrower than that.  This shrinks the horizontal span to
+    ``LABEL_GLYPH_INK_RATIO`` of the reserved width about the box centre,
+    approximating where the glyphs are actually inked.  A route grazing only
+    the empty reserved margin clears this box; a route striking through the
+    text intersects it.  Vertical bounds match the reserved box.
+    """
+    x0, y0, x1, y1 = _label_bbox(placement)
+    center = (x0 + x1) / 2
+    ink_half = (x1 - x0) / 2 * LABEL_GLYPH_INK_RATIO
+    return (center - ink_half, y0, center + ink_half, y1)
 
 
 def _rotated_label_bbox(
@@ -1261,6 +1282,7 @@ def place_labels(
 
     if routes:
         _avoid_diagonal_routes(placements, graph, routes, station_offsets)
+        _avoid_horizontal_strikethrough(placements, graph, routes, station_offsets)
 
     _wrap_overlapping_labels(
         placements, graph, station_offsets, allow_hyphenation=allow_hyphenation
@@ -1533,6 +1555,87 @@ def _avoid_diagonal_routes(
             )
         siblings = [p for p in placements if p is not placement]
         if _has_collision(trial, siblings) or hits(_label_bbox(trial)):
+            continue
+        placement.x, placement.y, placement.above = trial.x, trial.y, trial.above
+
+
+def _avoid_horizontal_strikethrough(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+    routes: list["RoutedPath"],
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> None:
+    """Flip a label off a foreign horizontal trunk that strikes its glyph ink.
+
+    A label hanging on the side of its station where another line's horizontal
+    run passes reads as struck through.  ``_avoid_diagonal_routes`` ignores
+    horizontal segments because labels normally clear the trunk they sit on;
+    this catches the case a *foreign* trunk (a line the station does not carry,
+    not an edge endpoint) crosses the label's glyph ink, and flips the label to
+    the opposite side when that side is free of label and ink collisions.
+    """
+    foreign: list[tuple[str, tuple[float, float, float, float]]] = []
+    for route in routes:
+        pts = list(route.points)
+        if station_offsets and not route.offsets_applied and pts:
+            so = station_offsets.get((route.edge.source, route.line_id), 0.0)
+            to = station_offsets.get((route.edge.target, route.line_id), 0.0)
+            pts[0] = (pts[0][0], pts[0][1] + so)
+            pts[-1] = (pts[-1][0], pts[-1][1] + to)
+        for (x1, y1), (x2, y2) in zip(pts, pts[1:]):
+            if abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * 0.05:
+                continue
+            foreign.append((route.line_id, (min(x1, x2), y1, max(x1, x2), y2)))
+    if not foreign:
+        return
+
+    for placement in [p for p in placements if p.obstacle_bbox is None]:
+        if placement.dominant_baseline or placement.angle:
+            continue
+        station = graph.stations.get(placement.station_id)
+        if station is None:
+            continue
+        carried = set(graph.station_lines(station.id))
+        ink = label_glyph_ink_bbox(placement)
+
+        def strikes(box: tuple[float, float, float, float]) -> bool:
+            for line_id, (sx1, sy1, sx2, sy2) in foreign:
+                if line_id in carried:
+                    continue
+                if segment_intersects_bbox(sx1, sy1, sx2, sy2, box):
+                    return True
+            return False
+
+        if not strikes(ink):
+            continue
+        if station_offsets:
+            offs = [
+                station_offsets.get((station.id, lid), 0.0)
+                for lid in graph.station_lines(station.id)
+            ]
+            min_off, max_off = (min(offs), max(offs)) if offs else (0.0, 0.0)
+        else:
+            min_off = max_off = 0.0
+        if placement.above:
+            gap = max((station.y + min_off) - placement.y, LABEL_OFFSET)
+            trial = LabelPlacement(
+                station_id=placement.station_id,
+                text=placement.text,
+                x=placement.x,
+                y=station.y + max_off + gap,
+                above=False,
+            )
+        else:
+            gap = max(placement.y - (station.y + max_off), LABEL_OFFSET)
+            trial = LabelPlacement(
+                station_id=placement.station_id,
+                text=placement.text,
+                x=placement.x,
+                y=station.y + min_off - gap,
+                above=True,
+            )
+        siblings = [p for p in placements if p is not placement]
+        if _has_collision(trial, siblings) or strikes(label_glyph_ink_bbox(trial)):
             continue
         placement.x, placement.y, placement.above = trial.x, trial.y, trial.above
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -936,6 +936,106 @@ def _guard_no_line_crosses_file_icon(
                     )
 
 
+def _guard_no_line_strikes_label(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: no rendered line segment may strike through a station label.
+
+    A line dipping, fanning, or running across a station's name label reads as
+    a strike-through.  The label glyph-ink box (the reserved label width
+    tightened to where the text is actually inked, see
+    ``label_glyph_ink_bbox``) is used rather than the full reserved box, so a
+    line clipping only the empty reserved margin does not trip this -- only one
+    crossing the glyphs does.  A segment is exempt when it belongs to a line
+    the label's station carries, or when the label's station is an endpoint of
+    the segment's edge (that line legitimately touches the station).
+    """
+    from nf_metro.layout.labels import (
+        label_glyph_ink_bbox,
+        place_labels,
+    )
+    from nf_metro.render.svg import _compute_icon_obstacles, apply_route_offsets
+    from nf_metro.themes import THEMES
+
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
+
+        offsets = compute_station_offsets(graph)
+
+    # route_edges' diagonal-centring nudges Station.x and place_labels expands
+    # section bboxes to fit labels; the renderer draws labels on exactly that
+    # mutated geometry, so the guard must too.  Snapshot station coords and
+    # section bboxes, run the crossing check, then restore -- the guard stays
+    # observational (validate=True must not perturb the settled layout).
+    pos_snapshot = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bbox_snapshot = {
+        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
+        for sid, s in graph.sections.items()
+    }
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+            return
+    try:
+        placements = place_labels(
+            graph,
+            station_offsets=offsets,
+            icon_obstacles=_compute_icon_obstacles(graph, THEMES["nfcore"], offsets),
+            routes=routes,
+            label_angle=graph.label_angle or 0.0,
+        )
+        boxes: list[tuple[str, tuple[float, float, float, float]]] = []
+        for p in placements:
+            station = graph.stations.get(p.station_id)
+            if station is None or not station.label.strip():
+                continue
+            boxes.append((p.station_id, label_glyph_ink_bbox(p)))
+        if not boxes:
+            return
+        index = BBoxXIndex(boxes)
+        station_lines_cache: dict[str, set[str]] = {}
+
+        for r in routes:
+            pts = apply_route_offsets(r, offsets)
+            src, tgt, line_id = r.edge.source, r.edge.target, r.line_id
+            for k in range(len(pts) - 1):
+                p1, p2 = pts[k], pts[k + 1]
+                lo, hi = min(p1[0], p2[0]), max(p1[0], p2[0])
+                for sid, bbox in index.query_x_range(lo, hi):
+                    if src == sid or tgt == sid:
+                        continue
+                    lines = station_lines_cache.get(sid)
+                    if lines is None:
+                        lines = set(graph.station_lines(sid))
+                        station_lines_cache[sid] = lines
+                    if line_id in lines:
+                        continue
+                    if segment_intersects_bbox(p1[0], p1[1], p2[0], p2[1], bbox):
+                        raise PhaseInvariantError(
+                            f"{phase}: line {line_id!r} on edge {src!r} -> {tgt!r} "
+                            f"strikes through label of {sid!r} "
+                            f"glyph-ink bbox ({bbox[0]:.1f},{bbox[1]:.1f})-"
+                            f"({bbox[2]:.1f},{bbox[3]:.1f}); segment "
+                            f"({p1[0]:.1f},{p1[1]:.1f})->({p2[0]:.1f},{p2[1]:.1f})"
+                        )
+    finally:
+        for sid, (x, y) in pos_snapshot.items():
+            st = graph.stations.get(sid)
+            if st is not None:
+                st.x, st.y = x, y
+        for sid, (bx, by, bw, bh) in bbox_snapshot.items():
+            s = graph.sections.get(sid)
+            if s is not None:
+                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+
+
 def _guard_off_track_output_clears_non_producer(
     graph: MetroGraph,
     phase: str,

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -37,7 +37,7 @@ from nf_metro.layout.engine import (
     is_loop_side_branch_station,
 )
 from nf_metro.layout.geometry import segment_intersects_bbox
-from nf_metro.layout.labels import _label_bbox, place_labels
+from nf_metro.layout.labels import _label_bbox, label_glyph_ink_bbox, place_labels
 from nf_metro.layout.phases._common import _grow_section_bbox_upward
 from nf_metro.layout.phases.bbox import (
     _section_band_is_empty,
@@ -1269,6 +1269,102 @@ def test_off_track_outputs_below_downward_branch_producer(fixture):
             f"did not clear the section's top trunk row y={top_trunk_y}; it "
             f"crosses back over the trunk"
         )
+
+
+# Fixtures where a foreign fan/bypass diagonal rakes a wide label's glyph ink.
+# Clearing the diagonal needs the column widened so its corner seats clear of
+# the label, but the required amount depends on which side ``place_labels``
+# lands the label (a label flipped away from the diagonal is not struck), which
+# is only known after routing -- the column-sizing phase runs before that.  The
+# runtime guard ``_guard_no_line_strikes_label`` flags these; the widening
+# auto-fix is tracked as a follow-up.
+_LABEL_STRIKE_DIAGONAL_XFAIL = {
+    "topologies/funcprofiler_upstream.mmd": "fan diagonal rakes 'FMH FunProfiler'",
+    "guide/06a_without_hidden.mmd": "bypass diagonal rakes 'Quantification'",
+    "guide/06b_with_hidden.mmd": "bypass diagonal rakes 'Quantification'",
+    "da_pipeline.mmd": "bypass diagonal rakes 'annotate'",
+}
+
+_LABEL_STRIKE_FIXTURES = _params_with_xfails(ALL_FIXTURES, _LABEL_STRIKE_DIAGONAL_XFAIL)
+
+
+def _label_glyph_strikes(fixture: str) -> list[tuple[str, str]]:
+    """Return ``(station_id, line_id)`` pairs where a foreign line strikes a label.
+
+    Mirrors the renderer: ``route_edges`` mutates Station.x via diagonal
+    centring and the renderer places labels on that mutated geometry, so the
+    label glyph-ink boxes are built without restoring X.  A pair is reported
+    when a segment of a line the station does not carry (and which is not an
+    endpoint of the segment's edge) crosses the label's glyph-ink box.
+    """
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    theme = THEMES["nfcore"]
+    icon_obstacles = _compute_icon_obstacles(graph, theme, offsets)
+    placements = place_labels(
+        graph,
+        station_offsets=offsets,
+        icon_obstacles=icon_obstacles,
+        routes=routes,
+        label_angle=graph.label_angle or 0.0,
+    )
+    strikes: list[tuple[str, str]] = []
+    for p in placements:
+        station = graph.stations.get(p.station_id)
+        if station is None or not station.label.strip():
+            continue
+        ink = label_glyph_ink_bbox(p)
+        carried = set(graph.station_lines(p.station_id))
+        for r in routes:
+            if r.edge.source == p.station_id or r.edge.target == p.station_id:
+                continue
+            if r.line_id in carried:
+                continue
+            pts = apply_route_offsets(r, offsets)
+            if any(
+                segment_intersects_bbox(x1, y1, x2, y2, ink)
+                for (x1, y1), (x2, y2) in zip(pts, pts[1:])
+            ):
+                strikes.append((p.station_id, r.line_id))
+                break
+    return strikes
+
+
+@pytest.mark.parametrize("fixture", _LABEL_STRIKE_FIXTURES)
+def test_no_line_strikes_through_label(fixture):
+    """No foreign line crosses a station label's glyph ink.
+
+    A line a station does not carry dipping, fanning, or running across that
+    station's name label reads as a strike-through.  The check models the label
+    by its glyph ink rather than the full reserved box, so a line clipping only
+    the empty reserved margin (an acceptable graze) is not flagged.
+    """
+    strikes = _label_glyph_strikes(fixture)
+    assert not strikes, (
+        f"{fixture}: foreign lines strike label glyph ink: "
+        + ", ".join(f"{lid!r} over {sid!r}" for sid, lid in strikes)
+    )
+
+
+def test_label_strike_guard_catches_a_strike():
+    """The runtime guard fires on a genuine glyph strike and clears a graze.
+
+    Locks the guard's teeth and its glyph-ink discrimination: a fixture whose
+    fan diagonal rakes a wide label's glyphs must raise, while one where a line
+    only clips a label's empty reserved margin must pass.
+    """
+    from nf_metro.layout.phases.guards import (
+        PhaseInvariantError,
+        _guard_no_line_strikes_label,
+    )
+
+    struck = _layout("topologies/funcprofiler_upstream.mmd")
+    with pytest.raises(PhaseInvariantError, match="strikes through label"):
+        _guard_no_line_strikes_label(struck, "test")
+
+    grazed = _layout("variantbenchmarking.mmd")
+    _guard_no_line_strikes_label(grazed, "test")
 
 
 @pytest.mark.parametrize("fixture", _FIXTURES_WITH_DOWNWARD_OUTPUT)


### PR DESCRIPTION
## Summary

Adds a glyph-ink model for station labels and uses it to detect and avoid metro lines striking through label text (the "strike-through" read described in #513), while leaving acceptable empty-margin grazes alone.

- **`LABEL_GLYPH_INK_RATIO` + `label_glyph_ink_bbox()`** (`constants.py`, `labels.py`): the reserved label box budgets `CHAR_WIDTH` (9px) per character, appreciably wider than the rendered text. The glyph-ink box tightens that box about its centre to approximate where the glyphs are actually inked, so a line clipping only the empty reserved margin is not mistaken for one crossing the text. This is the tight width-measure #513 calls for to avoid the false positives.
- **`_avoid_horizontal_strikethrough`** (`labels.py`): a `place_labels` pass that flips a label off a *foreign* horizontal trunk (a line the station does not carry, not an edge endpoint) crossing its glyph ink, when the opposite side is free of label and ink collisions. Clears the `MERGE_RUNS` strike in `funcprofiler_upstream`.
- **`_guard_no_line_strikes_label`** (`guards.py`): an observational guard (snapshots/restores station coords and section bboxes, so it never perturbs the settled layout) that raises when a foreign segment crosses a label's glyph ink. Modelled on the legend-overlap / file-icon guards via `segment_intersects_bbox`.
- **`test_no_line_strikes_through_label`**: corpus-parametrized over every fixture, locking the invariant so a new strike anywhere reds CI. Includes `test_label_strike_guard_catches_a_strike` for the guard's teeth (raises on a genuine strike, passes on a margin graze).

## Render impact

Gallery is **byte-identical** to `main` (all 79 fixtures). The `MERGE_RUNS` fix lands in `funcprofiler_upstream`, which is a topology fixture not in the rendered gallery.

## Known-remaining (strict xfail)

Four fan/bypass *diagonal* strikes remain and are recorded as strict xfails: `funcprofiler_upstream` (rgi vs FMH FunProfiler), `guide/06a`+`06b` (prot vs Quantification), `da_pipeline` (maxquant vs annotate). Clearing a diagonal needs the column widened so its corner seats clear of the label, but the required amount depends on which side `place_labels` lands the label (a label flipped away from the diagonal is not struck), which is only known after routing while the column-sizing phase runs before that. A probe-driven re-layout to resolve these is left as a follow-up; the guard and corpus test flag them so they cannot silently regress. The triaged false positives (`variantbenchmarking`, `guide/05*`) correctly pass — they are empty-margin grazes under the glyph-ink model.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)