### PR TITLE
fix(rail): one station per column, in declaration order (#576)

### DIFF
--- a/examples/sarek_metro.mmd
+++ b/examples/sarek_metro.mmd
@@ -190,7 +190,6 @@ graph LR
         cnvkit[CNVkit]
         msisensor2[MSIsensor2]
         msisensorpro[MSIsensor-pro]
-        collect[ ]
         out[ ]
 
         %% Germline route (top rail): deepvariant, haplotypecaller, haplotyper,
@@ -207,7 +206,7 @@ graph LR
         indexcov -->|germline| manta
         manta -->|germline| tiddit
         tiddit -->|germline| cnvkit
-        cnvkit -->|germline| collect
+        cnvkit -->|germline| out
 
         %% Tumour-only route (middle rail): tnscope, lofreq, mutect2, msisensor2
         %% join here; mpileup/indexcov run tumour but not the combined pair.
@@ -222,7 +221,7 @@ graph LR
         tiddit -->|tumor_only| controlfreec
         controlfreec -->|tumor_only| cnvkit
         cnvkit -->|tumor_only| msisensor2
-        msisensor2 -->|tumor_only| collect
+        msisensor2 -->|tumor_only| out
 
         %% Tumour-normal pair route (bottom rail): muse, ascat, msisensorpro are
         %% combined-only; strelka2 runs germline + combined (not tumour-only).
@@ -237,9 +236,7 @@ graph LR
         ascat -->|pair_n,pair_t| controlfreec
         controlfreec -->|pair_n,pair_t| cnvkit
         cnvkit -->|pair_n,pair_t| msisensorpro
-        msisensorpro -->|pair_n,pair_t| collect
-
-        collect -->|germline,tumor_only,pair_n,pair_t| out
+        msisensorpro -->|pair_n,pair_t| out
     end
 
     %% Inter-section: core workflow flows through the top three sections.

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -140,6 +140,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_partial_branch_offset_gaps,
     _guard_ports_on_boundaries,
     _guard_rail_above_label_band,
+    _guard_rail_one_station_per_column,
     _guard_rail_stations_seat_on_rails,
     _guard_routes_enter_sections_at_ports,
     _guard_row_gaps,
@@ -602,6 +603,7 @@ def _compute_layout_scaled(
         _guard_centered_line_spread_balanced(graph, "final")
         _guard_rail_above_label_band(graph, "final")
         _guard_rail_stations_seat_on_rails(graph, "final")
+        _guard_rail_one_station_per_column(graph, "final")
         _guard_single_trunk_off_track_step(graph, "final")
 
 

--- a/src/nf_metro/layout/layers.py
+++ b/src/nf_metro/layout/layers.py
@@ -6,11 +6,26 @@ monotonicity: every edge goes from a lower layer to a higher layer.
 
 from __future__ import annotations
 
-__all__ = ["assign_layers"]
+__all__ = ["assign_layers", "build_station_digraph"]
 
 import networkx as nx
 
 from nf_metro.parser.model import MetroGraph
+
+
+def build_station_digraph(graph: MetroGraph) -> nx.DiGraph[str]:
+    """Build a station-id DiGraph from a MetroGraph's edges.
+
+    Every edge becomes a directed edge; stations carrying no edges are added
+    as isolated nodes so the graph covers all stations.
+    """
+    G: nx.DiGraph[str] = nx.DiGraph()
+    for edge in graph.edges:
+        G.add_edge(edge.source, edge.target)
+    for sid in graph.stations:
+        if sid not in G:
+            G.add_node(sid)
+    return G
 
 
 def assign_layers(graph: MetroGraph) -> dict[str, int]:
@@ -22,14 +37,7 @@ def assign_layers(graph: MetroGraph) -> dict[str, int]:
 
     Returns a dict mapping station_id -> layer number (0-based).
     """
-    G: nx.DiGraph[str] = nx.DiGraph()
-    for edge in graph.edges:
-        G.add_edge(edge.source, edge.target)
-
-    # Add isolated nodes
-    for sid in graph.stations:
-        if sid not in G:
-            G.add_node(sid)
+    G = build_station_digraph(graph)
 
     # Topological sort (will raise if cycles exist)
     topo_order = list(nx.topological_sort(G))

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -338,6 +338,40 @@ def _guard_centered_line_spread_balanced(graph: MetroGraph, phase: str) -> None:
                 )
 
 
+def _guard_rail_one_station_per_column(graph: MetroGraph, phase: str) -> None:
+    """Rails place one distinct station per column.
+
+    ``line_spread: rails`` is a one-station-per-X layout: each column holds a
+    single station.  A genuine interchange is one shared station, so it occupies
+    a single column legitimately; two *distinct* on-rail stations sharing a
+    column stack their markers and labels and read as a false interchange.
+    Flag any rails section where two visible on-rail stations share an X.
+    No-op when no section resolves to rails.
+    """
+    rails_anywhere = graph.line_spread is LineSpread.RAILS or any(
+        mode is LineSpread.RAILS for mode in graph.line_spread_overrides.values()
+    )
+    if not rails_anywhere:
+        return
+    by_section: dict[str | None, list[str]] = {}
+    for sid, st in graph.stations.items():
+        if st.is_port or st.is_hidden or st.off_track:
+            continue
+        by_section.setdefault(st.section_id, []).append(sid)
+    for sec_id, members in by_section.items():
+        if graph.section_line_spread(sec_id) is not LineSpread.RAILS:
+            continue
+        ordered = sorted(members, key=lambda m: graph.stations[m].x)
+        for a, b in zip(ordered, ordered[1:]):
+            xa, xb = graph.stations[a].x, graph.stations[b].x
+            if abs(xb - xa) <= GUARD_TOLERANCE:
+                raise PhaseInvariantError(
+                    f"{phase}: rails section '{sec_id}' places distinct stations "
+                    f"'{a}' and '{b}' in the same column (x={xa:.1f}); rails "
+                    f"require one station per column"
+                )
+
+
 def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:
     """After Stage 3.1+: ports must sit on their section's bounding box edge."""
     tolerance = GUARD_TOLERANCE

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -230,7 +230,7 @@ def _layout_section_rails(
     # head/tail terminus depth checks (column X is assigned separately).
     import networkx as nx
 
-    from nf_metro.layout.layers import assign_layers
+    from nf_metro.layout.layers import assign_layers, build_station_digraph
     from nf_metro.layout.phases._common import _build_section_subgraph
 
     section_dag = _build_section_subgraph(graph, section)
@@ -286,12 +286,7 @@ def _layout_section_rails(
     # and no two distinct stations share an X.
     decl_index = {sid: i for i, sid in enumerate(section.station_ids)}
     real_set = set(real_ids)
-    dag: nx.DiGraph[str] = nx.DiGraph()
-    for edge in section_dag.edges:
-        dag.add_edge(edge.source, edge.target)
-    for sid in section_dag.stations:
-        if sid not in dag:
-            dag.add_node(sid)
+    dag = build_station_digraph(section_dag)
     topo = nx.lexicographical_topological_sort(dag, key=lambda n: decl_index.get(n, 0))
     on_rail_ids = [
         sid for sid in topo if sid in real_set and not graph.stations[sid].off_track

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -15,8 +15,9 @@ sections whose ``line_spread`` resolves to ``rails`` (``graph.is_rail_section``)
 so the normal layout path is untouched for every other section.
 
 Scope (MVP): LR sections.  Each section's lines get rails centred about the
-section trunk Y; stations are placed by longest-path layer (X) and anchored to
-span their lines' rail range (Y).  Sections are stacked vertically in grid-row
+section trunk Y; stations are placed one per column in declaration-priority
+topological order (X) and anchored to span their lines' rail range (Y).
+Sections are stacked vertically in grid-row
 order.  Ports/junctions are positioned at their connecting rail Y so that the
 dedicated rail-mode router (see ``routing/rail.py``) can draw straight rails.
 """
@@ -225,12 +226,15 @@ def _layout_section_rails(
     per_line_y = {lid: rails_top + slot_offset[lid] for lid in lines}
     rail_y[section.id] = per_line_y
 
-    # X by longest-path layer over this section's internal stations, so a
-    # station's column reflects its in-section depth.
+    # Longest-path layer over this section's internal stations, used below for
+    # head/tail terminus depth checks (column X is assigned separately).
+    import networkx as nx
+
     from nf_metro.layout.layers import assign_layers
     from nf_metro.layout.phases._common import _build_section_subgraph
 
-    layers = assign_layers(_build_section_subgraph(graph, section))
+    section_dag = _build_section_subgraph(graph, section)
+    layers = assign_layers(section_dag)
 
     # Place real stations.
     real_ids = [
@@ -275,19 +279,29 @@ def _layout_section_rails(
         per_line_y = {lid: rails_top + slot_offset[lid] for lid in lines}
         rail_y[section.id] = per_line_y
 
-    # Rails are designed for one distinct station per column.  The longest-path
-    # layer orders stations by depth, but distinct stations on different rails
-    # can share a layer; taking X straight from the layer would stack them in a
-    # single column.  Rank the on-rail stations by (layer, declaration order) and
-    # give each its own column, so a rail's internal order and the authored
-    # cross-rail order are both preserved while no two distinct stations share X.
+    # Rails place one distinct station per column.  Order the columns by a
+    # topological sort that breaks ties on declaration order, so the columns
+    # follow the order stations are authored in (the intended reading) while
+    # always respecting edge direction; each on-rail station gets its own column
+    # and no two distinct stations share an X.
     decl_index = {sid: i for i, sid in enumerate(section.station_ids)}
-    on_rail_ids = [sid for sid in real_ids if not graph.stations[sid].off_track]
-    ordered_cols = sorted(
-        on_rail_ids, key=lambda sid: (layers.get(sid, 0), decl_index.get(sid, 0))
-    )
-    cols: dict[str, int] = {sid: i for i, sid in enumerate(ordered_cols)}
-    max_col = len(ordered_cols) - 1 if ordered_cols else 0
+    real_set = set(real_ids)
+    dag: nx.DiGraph[str] = nx.DiGraph()
+    for edge in section_dag.edges:
+        dag.add_edge(edge.source, edge.target)
+    for sid in section_dag.stations:
+        if sid not in dag:
+            dag.add_node(sid)
+    topo = nx.lexicographical_topological_sort(dag, key=lambda n: decl_index.get(n, 0))
+    on_rail_ids = [
+        sid for sid in topo if sid in real_set and not graph.stations[sid].off_track
+    ]
+    seen = set(on_rail_ids)
+    on_rail_ids += [
+        sid for sid in real_ids if sid not in seen and not graph.stations[sid].off_track
+    ]
+    cols: dict[str, int] = {sid: i for i, sid in enumerate(on_rail_ids)}
+    max_col = len(on_rail_ids) - 1 if on_rail_ids else 0
 
     # A blank terminus that fans across rails needs its own horizontal room so
     # the fan S-curves keep their shape regardless of the shared column pitch.

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -275,6 +275,20 @@ def _layout_section_rails(
         per_line_y = {lid: rails_top + slot_offset[lid] for lid in lines}
         rail_y[section.id] = per_line_y
 
+    # Rails are designed for one distinct station per column.  The longest-path
+    # layer orders stations by depth, but distinct stations on different rails
+    # can share a layer; taking X straight from the layer would stack them in a
+    # single column.  Rank the on-rail stations by (layer, declaration order) and
+    # give each its own column, so a rail's internal order and the authored
+    # cross-rail order are both preserved while no two distinct stations share X.
+    decl_index = {sid: i for i, sid in enumerate(section.station_ids)}
+    on_rail_ids = [sid for sid in real_ids if not graph.stations[sid].off_track]
+    ordered_cols = sorted(
+        on_rail_ids, key=lambda sid: (layers.get(sid, 0), decl_index.get(sid, 0))
+    )
+    cols: dict[str, int] = {sid: i for i, sid in enumerate(ordered_cols)}
+    max_col = len(ordered_cols) - 1 if ordered_cols else 0
+
     # A blank terminus that fans across rails needs its own horizontal room so
     # the fan S-curves keep their shape regardless of the shared column pitch.
     # Reserve it as extra gap AFTER the first column (a head/source terminus)
@@ -323,41 +337,40 @@ def _layout_section_rails(
         tail_icon_extra = max(tail_icon_extra, need - section_x_padding)
     tail_icon_extra = max(0.0, tail_icon_extra)
 
-    def _layer_x(layer: float) -> float:
-        x = x_offset + section_x_padding + layer * x_spacing
-        if layer >= 1:
+    def _col_x(col: float) -> float:
+        x = x_offset + section_x_padding + col * x_spacing
+        if col >= 1:
             x += head_extra
-        if layer == max_layer:
+        if col == max_col:
             x += tail_extra
         return x
 
     for sid in real_ids:
         st = graph.stations[sid]
-        layer = layers.get(sid, 0)
-        st.layer = layer
-        st.x = _layer_x(layer)
 
         if st.off_track:
             # Park above the rails just to the left of the consumer column, so
             # the router draws a short, clean S-curve down into the rail rather
-            # than a long diagonal traverse from layer 0.  The consumer's layer
-            # determines the X; the off-track input sits half a column before it.
-            consumer_layer = min(
-                (
-                    layers.get(e.target, layer)
-                    for e in graph.edges_from(sid)
-                    if e.target in layers
-                ),
-                default=layer + 1,
+            # than a long diagonal traverse from the section head.  The consumer's
+            # column determines the X; the off-track input sits half a column
+            # before it.
+            consumer_col = min(
+                (cols[e.target] for e in graph.edges_from(sid) if e.target in cols),
+                default=max_col + 1,
             )
-            feed_layer = max(0.0, consumer_layer - 0.5)
-            st.x = _layer_x(feed_layer)
+            feed_col = max(0.0, consumer_col - 0.5)
+            st.layer = consumer_col
+            st.x = _col_x(feed_col)
             st.y = off_track_y
             st.track = 0.0
             st.rail_used_ys = []
             st.rail_top_y = None
             st.rail_bottom_y = None
             continue
+
+        col = cols[sid]
+        st.layer = col
+        st.x = _col_x(col)
 
         st_lines = graph.station_lines_ordered(sid)
         ys = [per_line_y[lid] for lid in st_lines if lid in per_line_y]
@@ -411,7 +424,7 @@ def _layout_section_rails(
     bbox_x = x_offset
     bbox_w = (
         section_x_padding * 2
-        + max_layer * x_spacing
+        + max_col * x_spacing
         + head_extra
         + tail_extra
         + tail_icon_extra

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1515,3 +1515,53 @@ def test_coloured_spanning_interchange_has_light_outline():
     assert unmarked == {theme.station_stroke}, (
         f"an untinted interchange must keep the dark station stroke, got {unmarked}"
     )
+
+
+SAREK_MMD = EXAMPLES / "sarek_metro.mmd"
+
+
+def test_rails_place_one_station_per_column_on_sarek():
+    """Distinct stations on different rails never share a column (#576).
+
+    The sarek calling panel runs three routes whose rail-specific stations land
+    on shared topological layers; rails must give each its own column rather
+    than stacking them.  Fails on a layer-X layout where same-layer stations
+    collide.  Uses the render path: validate=True trips an unrelated Stage-6.14
+    rail transient that the content corpus excludes for rails.
+    """
+    graph = parse_metro_mermaid(SAREK_MMD.read_text())
+    compute_layout(graph)
+    section = graph.sections["calling"]
+    xs: dict[int, str] = {}
+    for sid in section.station_ids:
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.is_hidden or st.off_track:
+            continue
+        key = round(st.x)
+        clash = next((k for k in xs if abs(k - key) <= 1), None)
+        assert clash is None, f"{sid} shares column x={st.x:.1f} with {xs[clash]}"
+        xs[key] = sid
+
+
+def test_rail_one_per_column_guard_catches_a_collision():
+    """The guard rejects two distinct on-rail stations sharing a column."""
+    import pytest
+
+    from nf_metro.layout.phases.guards import (
+        PhaseInvariantError,
+        _guard_rail_one_station_per_column,
+    )
+    from nf_metro.parser.model import MetroGraph, Section, Station
+
+    graph = MetroGraph()
+    graph.line_spread = LineSpread.RAILS
+    graph.sections["s"] = Section(id="s", name="S", station_ids=["a", "b"])
+    for sid in ("a", "b"):
+        st = Station(id=sid, label=sid.upper())
+        st.x = 100.0
+        st.y = 10.0 if sid == "a" else 50.0
+        st.section_id = "s"
+        graph.stations[sid] = st
+
+    with pytest.raises(PhaseInvariantError, match="one station per column"):
+        _guard_rail_one_station_per_column(graph, "test")


### PR DESCRIPTION
## What

`line_spread: rails` is a one-station-per-X layout: each column holds a single station (a genuine interchange is one shared station, so it legitimately occupies one column). Previously rails assigned X from the longest-path layer, so distinct rail-specific stations sharing a layer collapsed onto the same column and read as a false interchange (stacked markers/labels).

This change:
- **One station per column** - each on-rail station gets its own column.
- **Declaration-order columns** - column order comes from a declaration-priority topological sort (`nx.lexicographical_topological_sort` keyed by declaration index), so columns follow the order stations are authored in (matching the intended reading) while always respecting edge direction. This keeps each rail's run contiguous (a layer-first order interleaved, e.g., germline `haplotyper`/`dnascope` across the tumour branch).
- **Guard** - validate-gated `_guard_rail_one_station_per_column` rejects two distinct on-rail stations sharing a column.
- **Sarek fixture cleanup** - drops the blank `collect` convergence node, which was a redundant interior merge rendering as a spurious un-named 4-line bar before the `out` output. The three branch tails feed `out` directly; the rails ease straight into the VCF/TXT output icons.

## Scope

Rails-only. In the gallery render-diff, **only `examples/sarek_metro.mmd` changes**; the other **78 renders are byte-identical**.

## Tests

- `test_rails_place_one_station_per_column_on_sarek` (fails on a layer-X layout)
- `test_rail_one_per_column_guard_catches_a_collision` (guard teeth)
- Full suite green (6626 passed), ruff + mypy clean.

Composes with #615 (PR for #577): #576 + #615 together give 0 label overlaps on the sarek calling panel.

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)