### PR TITLE
docs(pipelines): add nf-core/sarek to the pipelines page

### DIFF
--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -387,6 +387,14 @@ PIPELINE_ENTRIES: list[tuple[str, str, str, str]] = [
         "(STAR/RSEM, STAR/Salmon, HISAT2, Salmon pseudo-alignment, Kallisto).",
     ),
     (
+        "sarek_metro",
+        "nf-core/sarek",
+        "https://github.com/nf-core/sarek",
+        "Germline and somatic variant calling, covering germline, tumor-only, "
+        "and tumor-normal paired analysis through SNP/indel, SV/CNV, and MSI "
+        "callers with downstream variant annotation.",
+    ),
+    (
         "epitopeprediction",
         "nf-core/epitopeprediction",
         "https://github.com/nf-core/epitopeprediction",


### PR DESCRIPTION
Adds `nf-core/sarek` to `PIPELINE_ENTRIES` in `scripts/build_gallery.py`, so the existing `examples/sarek_metro.mmd` renders on the [nf-core Pipelines](https://pinin4fjords.github.io/nf-metro/pipelines/) page alongside rnaseq and the others.

The sarek render already appears in the main gallery framed as a feature integration showcase (diagonal labels, off-track input, file termini, marker styles, rails panel). This keeps that entry and additionally lists sarek as a real-world pipeline, matching how the other nf-core pipelines are presented.

Source-only change: the rendered `docs/pipelines/index.md` and SVGs are gitignored build artifacts regenerated by CI. The PR render-diff will show the new `pipeline_sarek_metro.svg`; all other renders stay byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)