### PR TITLE
feat(svg): embed a machine-readable data manifest in every render

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ GitHub READMEs strip `<script>` tags, so embed there as a static SVG (or link ou
 Every rendered SVG carries a machine-readable manifest so the committed file is a self-contained, durable artifact - a downstream tool can drive it (position overlays, restyle stations, look up which processes a station represents) without re-running the layout engine. The data is carried two redundant ways, both sanitization-safe (no `<script>`):
 
 - A JSON manifest in a `<metadata id="nf-metro-manifest">` element: schema `version`, map `title`, canvas `width`/`height`, `lines`, `sections`, and `stations` (each with `id`, `label`, absolute `x`/`y`/`r`, the `lines` and `section` it belongs to, and the `processes` regexes it represents).
-- `data-metro-*` attributes on each station's `<g>` element (`data-metro-station`, `data-metro-cx/cy/r`, `data-metro-lines`), so individual stations stay addressable directly in the DOM.
+- `data-metro-*` attributes on each station's `<g>` element (`data-metro-station`, `data-metro-cx/cy/r`, `data-metro-lines`, `data-metro-section`), so individual stations stay addressable directly in the DOM.
 
-The station `id` is the join key between the two: it equals `data-metro-station="<id>"` on the matching element. Coordinates are absolute SVG user units inside the `viewBox="0 0 width height"`, so an overlay sharing that viewBox lines up exactly. The manifest is always embedded and adds no external dependencies. See [Live progress](docs/live.md#the-embedded-data-manifest) for the full schema and matching semantics.
+The station `id` is the join key between the two: it equals `data-metro-station="<id>"` on the matching element. Coordinates are absolute SVG user units inside the `viewBox="0 0 width height"`, so an overlay sharing that viewBox lines up exactly. The manifest is embedded by default and adds no external dependencies; pass `--no-manifest` (or `%%metro manifest: false`) to emit the drawn map only. See [Live progress](docs/live.md#the-embedded-data-manifest) for the full schema and matching semantics.
 
 ### `nf-metro validate`
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Every rendered SVG carries a machine-readable manifest so the committed file is 
 - A JSON manifest in a `<metadata id="nf-metro-manifest">` element: schema `version`, map `title`, canvas `width`/`height`, `lines`, `sections`, and `stations` (each with `id`, `label`, absolute `x`/`y`/`r`, the `lines` and `section` it belongs to, and the `processes` regexes it represents).
 - `data-metro-*` attributes on each station's `<g>` element (`data-metro-station`, `data-metro-cx/cy/r`, `data-metro-lines`, `data-metro-section`), so individual stations stay addressable directly in the DOM.
 
-The station `id` is the join key between the two: it equals `data-metro-station="<id>"` on the matching element. Coordinates are absolute SVG user units inside the `viewBox="0 0 width height"`, so an overlay sharing that viewBox lines up exactly. The manifest is embedded by default and adds no external dependencies; pass `--no-manifest` (or `%%metro manifest: false`) to emit the drawn map only. See [Live progress](docs/live.md#the-embedded-data-manifest) for the full schema and matching semantics.
+The station `id` is the join key between the two: it equals `data-metro-station="<id>"` on the matching element. Coordinates are absolute SVG user units inside the `viewBox="0 0 width height"`, so an overlay sharing that viewBox lines up exactly. The manifest is embedded by default and adds no external dependencies; set `%%metro manifest: false` to emit the drawn map only. See [Live progress](docs/live.md#the-embedded-data-manifest) for the full schema and matching semantics.
 
 ### `nf-metro validate`
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ The page provides:
 
 GitHub READMEs strip `<script>` tags, so embed there as a static SVG (or link out to a hosted version). Most static-site generators and internal wikis run the inline-HTML snippet as-is.
 
+#### Embedded data manifest
+
+Every rendered SVG carries a machine-readable manifest so the committed file is a self-contained, durable artifact - a downstream tool can drive it (position overlays, restyle stations, look up which processes a station represents) without re-running the layout engine. The data is carried two redundant ways, both sanitization-safe (no `<script>`):
+
+- A JSON manifest in a `<metadata id="nf-metro-manifest">` element: schema `version`, map `title`, canvas `width`/`height`, `lines`, `sections`, and `stations` (each with `id`, `label`, absolute `x`/`y`/`r`, the `lines` and `section` it belongs to, and the `processes` regexes it represents).
+- `data-metro-*` attributes on each station's `<g>` element (`data-metro-station`, `data-metro-cx/cy/r`, `data-metro-lines`), so individual stations stay addressable directly in the DOM.
+
+The station `id` is the join key between the two: it equals `data-metro-station="<id>"` on the matching element. Coordinates are absolute SVG user units inside the `viewBox="0 0 width height"`, so an overlay sharing that viewBox lines up exactly. The manifest is always embedded and adds no external dependencies. See [Live progress](docs/live.md#the-embedded-data-manifest) for the full schema and matching semantics.
+
 ### `nf-metro validate`
 
 Check a `.mmd` file for errors without producing output.

--- a/docs/live.md
+++ b/docs/live.md
@@ -72,9 +72,9 @@ and carried two redundant, sanitization-safe ways (no `<script>`):
 1. A JSON manifest inside a `<metadata id="nf-metro-manifest">` element.
 2. `data-metro-*` attributes on each station's `<g>` element.
 
-Pass `--no-manifest` (or `%%metro manifest: false`) to emit the drawn map only,
-with no manifest, no `data-metro-*` attributes, and no station-group wrapper -
-byte-for-byte the same SVG as a build that predates the manifest.
+Set `%%metro manifest: false` to emit the drawn map only, with no manifest, no
+`data-metro-*` attributes, and no station-group wrapper - byte-for-byte the same
+SVG as a build that predates the manifest.
 
 ### Schema
 

--- a/docs/live.md
+++ b/docs/live.md
@@ -66,11 +66,15 @@ inside the file. Every rendered SVG therefore embeds a machine-readable manifest
 so it is a self-contained, durable contract: an overlay can be positioned,
 stations restyled, and process mappings looked up with no re-render.
 
-It is **always embedded** (it is small and adds no external dependencies), and
-carried two redundant, sanitization-safe ways (no `<script>`):
+It is **embedded by default** (it is small and adds no external dependencies),
+and carried two redundant, sanitization-safe ways (no `<script>`):
 
 1. A JSON manifest inside a `<metadata id="nf-metro-manifest">` element.
 2. `data-metro-*` attributes on each station's `<g>` element.
+
+Pass `--no-manifest` (or `%%metro manifest: false`) to emit the drawn map only,
+with no manifest, no `data-metro-*` attributes, and no station-group wrapper -
+byte-for-byte the same SVG as a build that predates the manifest.
 
 ### Schema
 

--- a/docs/live.md
+++ b/docs/live.md
@@ -57,6 +57,84 @@ matched against the **fully-qualified** process name:
   `NFCORE_RNASEQ:RNASEQ:ALIGN:...`, when a tool recurs).
 - The directive is pure metadata: it never affects the rendered map.
 
+## The embedded data manifest
+
+`nf-metro serve` lights up a map because it holds the in-memory graph - it knows
+each station's coordinates and the `process:` mapping. A tool that has only the
+**committed SVG file** (no Python, no graph) needs that information carried
+inside the file. Every rendered SVG therefore embeds a machine-readable manifest
+so it is a self-contained, durable contract: an overlay can be positioned,
+stations restyled, and process mappings looked up with no re-render.
+
+It is **always embedded** (it is small and adds no external dependencies), and
+carried two redundant, sanitization-safe ways (no `<script>`):
+
+1. A JSON manifest inside a `<metadata id="nf-metro-manifest">` element.
+2. `data-metro-*` attributes on each station's `<g>` element.
+
+### Schema
+
+```json
+{
+  "version": "1.0",
+  "match": { "target": "fqProcessName", "type": "regex", "flags": "i" },
+  "title": "nf-core/rnaseq",
+  "width": 1829,
+  "height": 724,
+  "lines":    [ { "id": "star_salmon", "label": "STAR + Salmon", "color": "#e64949" } ],
+  "sections": [ { "id": "preprocessing", "label": "Pre-processing" } ],
+  "stations": [
+    {
+      "id": "fastqc",
+      "label": "FastQC",
+      "x": 120.0, "y": 80.0, "r": 5.0,
+      "lines": ["star_salmon", "star_rsem"],
+      "section": "preprocessing",
+      "processes": ["FASTQC", "MULTIQC"]
+    }
+  ]
+}
+```
+
+- **`id` is the join key.** A station's `id` in the manifest equals
+  `data-metro-station="<id>"` on its `<g>` element, so a consumer can go
+  manifest→element and element→manifest without guessing.
+- **Coordinate space.** `x`/`y`/`r` are absolute SVG user units inside the
+  `viewBox="0 0 width height"` (the renderer emits no outer transform), so an
+  overlay sharing that viewBox lines up exactly. `r` is a single nominal marker
+  radius. Coordinates are rounded to one decimal place.
+- **Stations** are every non-port, non-hidden station - unmapped ones simply
+  carry an empty `processes` list, so the manifest is a complete inventory of
+  addressable stations, not only the subset that lights up.
+- **Forward compatibility.** Consumers must ignore unknown fields; additive
+  fields keep the same major `version`.
+
+### Process matching semantics
+
+`station.processes` are regular expressions matched **case-insensitively**
+against the **fully-qualified** Nextflow process name - exactly the rule the
+live server's `stations_for_process` uses (the `match` block states this
+explicitly so a non-Python consumer can reproduce it). To keep Python `re` and,
+say, JavaScript `RegExp` from diverging, keep patterns within a portable regex
+subset: character classes, anchors, `.`/`*`/`+`/`?`, bounded `{m,n}`,
+alternation, and groups. Avoid Python-only constructs (named groups `(?P<>)`,
+inline flags `(?i)`, possessive quantifiers, `\Z`).
+
+A process may legitimately match **more than one** station (the `check-mapping`
+"ambiguous" case below); how to resolve that is a consumer-side policy decision,
+not a schema error.
+
+### Reading it back
+
+`nf_metro.render` ships the canonical reader and matcher:
+
+```python
+from nf_metro.render import read_manifest, match_station_ids
+
+manifest = read_manifest(open("pipeline.svg").read())
+match_station_ids(manifest, "NFCORE_RNASEQ:RNASEQ:FASTQC")   # -> ["fastqc"]
+```
+
 ## 2. Serve the map
 
 `serve` hosts **one** map at a stable URL. Each run's `started` event resets it,

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -434,6 +434,17 @@ PIPELINE_ENTRIES: list[tuple[str, str, str, str]] = [
 _manifest: dict[str, str] = {}
 
 
+def render_drawn_svg(graph, theme, **kwargs) -> str:
+    """Render the drawn map only, with the embedded data manifest disabled.
+
+    The gallery is the visual-regression surface: the render diff compares
+    these SVGs byte-for-byte, and the data manifest carries no visual content.
+    Disabling it keeps the diff a true picture of what changed on screen.
+    """
+    graph.embed_manifest = False
+    return render_svg(graph, theme, **kwargs)
+
+
 def render_mmd(mmd_path: Path, svg_path: Path, *, debug: bool = DEBUG_RENDERS) -> None:
     """Parse, layout, and render a .mmd file to SVG."""
     text = mmd_path.read_text()
@@ -441,7 +452,7 @@ def render_mmd(mmd_path: Path, svg_path: Path, *, debug: bool = DEBUG_RENDERS) -
     compute_layout(graph)
     theme_name = graph.style if graph.style in THEMES else "nfcore"
     theme = THEMES[theme_name]
-    svg_str = render_svg(graph, theme, debug=debug)
+    svg_str = render_drawn_svg(graph, theme, debug=debug)
     svg_path.write_text(svg_str)
 
 
@@ -492,7 +503,7 @@ def render_guide_examples() -> None:
             compute_layout(graph)
             theme_name = graph.style if graph.style in THEMES else "nfcore"
             theme = THEMES[theme_name]
-            svg_str = render_svg(graph, theme, debug=True)
+            svg_str = render_drawn_svg(graph, theme, debug=True)
             debug_svg.write_text(svg_str)
             _manifest[debug_svg.name] = section
             print("  rnaseq_auto_debug: OK")
@@ -585,7 +596,7 @@ def render_nextflow_examples() -> None:
             graph = parse_metro_mermaid(converted)
             compute_layout(graph)
             theme = THEMES[graph.style if graph.style in THEMES else "nfcore"]
-            svg_str = render_svg(graph, theme, debug=DEBUG_RENDERS)
+            svg_str = render_drawn_svg(graph, theme, debug=DEBUG_RENDERS)
             svg_path.write_text(svg_str)
             _manifest[svg_path.name] = section
             print(f"  nf_{mmd_path.stem}: OK")

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -39,7 +39,11 @@ def _layout_cli_option(opt: LayoutOption) -> Callable[..., Any]:
     if opt.kind == "bool":
         no_flag = "--no-" + opt.name.replace("_", "-")
         return click.option(
-            f"{opt.cli_flag}/{no_flag}", opt.name, default=None, help=opt.help
+            f"{opt.cli_flag}/{no_flag}",
+            opt.name,
+            default=None,
+            help=opt.help,
+            hidden=opt.hidden,
         )
     ctype: Any = (
         click.Choice(opt.choices)
@@ -50,7 +54,14 @@ def _layout_cli_option(opt: LayoutOption) -> Callable[..., Any]:
             "str": str,
         }[opt.kind]
     )
-    return click.option(opt.cli_flag, opt.name, type=ctype, default=None, help=opt.help)
+    return click.option(
+        opt.cli_flag,
+        opt.name,
+        type=ctype,
+        default=None,
+        help=opt.help,
+        hidden=opt.hidden,
+    )
 
 
 def layout_cli_options(f: _F) -> _F:

--- a/src/nf_metro/options.py
+++ b/src/nf_metro/options.py
@@ -42,6 +42,7 @@ class LayoutOption:
     choices: tuple[str, ...] = ()
     sign: NumberSign = "any"
     parse_time: bool = False  # consumed during parsing, not after
+    hidden: bool = False  # omit the generated CLI flag from --help
 
     @property
     def target_attr(self) -> str:
@@ -205,6 +206,7 @@ LAYOUT_OPTIONS: tuple[LayoutOption, ...] = (
         name="manifest",
         attr="embed_manifest",
         kind="bool",
+        hidden=True,
         help="Embed the machine-readable data manifest (the <metadata> block "
         "and per-station data-metro-* attributes) in the SVG. On by default; "
         "--no-manifest emits the drawn map only.",

--- a/src/nf_metro/options.py
+++ b/src/nf_metro/options.py
@@ -201,4 +201,12 @@ LAYOUT_OPTIONS: tuple[LayoutOption, ...] = (
         kind="bool",
         help="Add animated balls traveling along the metro lines.",
     ),
+    LayoutOption(
+        name="manifest",
+        attr="embed_manifest",
+        kind="bool",
+        help="Embed the machine-readable data manifest (the <metadata> block "
+        "and per-station data-metro-* attributes) in the SVG. On by default; "
+        "--no-manifest emits the drawn map only.",
+    ),
 )

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -304,6 +304,7 @@ class MetroGraph:
     width: int | None = None
     height: int | None = None
     animate: bool = False
+    embed_manifest: bool = True
     # Max station-columns a section row may reach before the auto-layout wraps
     # it onto the next row. None falls back to 15; raise it to keep a long
     # horizontal trunk of sections on a single row. Overridden by the

--- a/src/nf_metro/render/__init__.py
+++ b/src/nf_metro/render/__init__.py
@@ -1,5 +1,17 @@
 """SVG rendering for metro maps."""
 
+from nf_metro.render.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    build_manifest,
+    match_station_ids,
+    read_manifest,
+)
 from nf_metro.render.svg import render_svg
 
-__all__ = ["render_svg"]
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "build_manifest",
+    "match_station_ids",
+    "read_manifest",
+    "render_svg",
+]

--- a/src/nf_metro/render/manifest.py
+++ b/src/nf_metro/render/manifest.py
@@ -1,0 +1,202 @@
+"""Self-describing JSON manifest embedded in every rendered SVG.
+
+The rendered SVG is meant to be a durable, machine-readable contract: a single
+committed file that downstream consumers can drive without re-running the
+layout engine or holding a :class:`~nf_metro.parser.model.MetroGraph` in
+memory.  Two redundant mechanisms carry the data, and this module owns the
+first:
+
+1. A JSON manifest embedded in a ``<metadata>`` element (built here).
+2. ``data-metro-*`` attributes on each station's ``<g>`` element (emitted by
+   :mod:`nf_metro.render.svg`).
+
+The contract between the two halves: a station's ``id`` in the manifest is the
+join key and **equals** ``data-metro-station="<id>"`` on its ``<g>`` element, so
+a consumer can go manifest->element and element->manifest without guessing.
+
+Coordinate space
+-----------------
+``x``/``y``/``r`` are absolute SVG user units inside the ``viewBox`` declared by
+the manifest's ``width``/``height`` (the renderer emits ``viewBox="0 0 width
+height"`` with no outer transform), so an overlay sharing that viewBox lines up
+exactly.  Coordinates are rounded to one decimal place, matching the live
+server's overlay geometry so the two never drift apart.
+
+Process matching
+----------------
+``station.processes`` are regular expressions matched **case-insensitively**
+against the **fully-qualified** Nextflow process name (the ``match`` block makes
+this explicit for non-Python consumers).  Patterns must stay within a portable
+regex subset common to Python ``re`` and JavaScript ``RegExp`` -- plain
+character classes, anchors, ``.``/``*``/``+``/``?``, bounded quantifiers
+``{m,n}``, alternation, and groups -- so the two implementations cannot diverge.
+Avoid Python-only constructs (named groups ``(?P<>)``, inline flags ``(?i)``,
+possessive quantifiers, ``\\Z``, etc.).  A process may legitimately match more
+than one station; resolving that is a consumer-side policy decision, not a
+schema error (``check-mapping`` flags it as ``ambiguous``).
+
+Forward compatibility
+----------------------
+Consumers MUST ignore unknown fields so the schema can grow within a major
+``version``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nf_metro.parser.model import MetroGraph
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "MANIFEST_ELEMENT_ID",
+    "build_manifest",
+    "manifest_json",
+    "manifest_metadata_svg",
+    "read_manifest",
+    "match_station_ids",
+]
+
+# Bump the major part for a breaking change; minor for additive fields (which
+# consumers tolerate via the "ignore unknown fields" rule).
+MANIFEST_SCHEMA_VERSION = "1.0"
+
+# The id of the <metadata> element carrying the manifest; the stable anchor a
+# consumer searches for in the SVG.
+MANIFEST_ELEMENT_ID = "nf-metro-manifest"
+
+# How station.processes are matched, made explicit for non-Python consumers.
+_MATCH_SPEC = {"target": "fqProcessName", "type": "regex", "flags": "i"}
+
+
+def _round1(value: float) -> float:
+    """Round a coordinate to one decimal place, matching the live overlay."""
+    return round(float(value), 1)
+
+
+def build_manifest(
+    graph: MetroGraph,
+    *,
+    width: int,
+    height: int,
+    station_radius: float,
+) -> dict[str, Any]:
+    """Build the manifest dict from the graph the renderer just laid out.
+
+    Coordinates and the process mapping are read from the same fields the live
+    server uses (``graph.stations[].x/.y`` and ``graph.process_mapping``), so
+    the embedded data cannot drift from the live behaviour.  ``width`` and
+    ``height`` are the final canvas dimensions; ``station_radius`` is the
+    single nominal marker radius (an overlay needs a point and a radius, not
+    the per-station pill geometry).
+
+    Ports and hidden nodes are excluded.  Every other station is included --
+    unmapped ones simply carry an empty ``processes`` list -- so the manifest
+    is a complete, future-proof inventory of addressable stations rather than
+    only the subset that lights up today.
+    """
+    real_sections = {
+        sid: sec for sid, sec in graph.sections.items() if not sec.is_implicit
+    }
+
+    lines = [
+        {"id": line.id, "label": line.display_name, "color": line.color}
+        for line in graph.lines.values()
+    ]
+
+    sections = [{"id": sid, "label": sec.name} for sid, sec in real_sections.items()]
+
+    stations: list[dict[str, Any]] = []
+    for station in graph.stations.values():
+        if station.is_port or station.is_hidden:
+            continue
+        entry: dict[str, Any] = {
+            "id": station.id,
+            "label": station.label or station.id,
+            "x": _round1(station.x),
+            "y": _round1(station.y),
+            "r": _round1(station_radius),
+            "lines": graph.station_lines(station.id),
+            "processes": list(graph.process_mapping.get(station.id, [])),
+        }
+        if station.section_id in real_sections:
+            entry["section"] = station.section_id
+        stations.append(entry)
+
+    return {
+        "version": MANIFEST_SCHEMA_VERSION,
+        "match": dict(_MATCH_SPEC),
+        "title": graph.title,
+        "width": int(width),
+        "height": int(height),
+        "lines": lines,
+        "sections": sections,
+        "stations": stations,
+    }
+
+
+def manifest_json(manifest: dict[str, Any]) -> str:
+    """Serialize a manifest deterministically (sorted keys, compact)."""
+    return json.dumps(
+        manifest, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def manifest_metadata_svg(manifest: dict[str, Any]) -> str:
+    """Return the ``<metadata>`` element carrying the manifest as CDATA JSON.
+
+    CDATA keeps the JSON pristine (no entity escaping of the many quote
+    characters).  The only sequence CDATA cannot contain is ``]]>``; on the
+    rare chance a regex includes it, split it with the standard idiom so the
+    document stays well-formed.  :func:`read_manifest` reverses the split.
+    """
+    payload = manifest_json(manifest).replace("]]>", "]]]]><![CDATA[>")
+    return (
+        f'<metadata id="{MANIFEST_ELEMENT_ID}" '
+        f'data-nf-metro-schema="{manifest.get("version", MANIFEST_SCHEMA_VERSION)}">'
+        f"<![CDATA[{payload}]]></metadata>"
+    )
+
+
+_METADATA_RE = re.compile(
+    rf'<metadata id="{re.escape(MANIFEST_ELEMENT_ID)}"[^>]*>(.*?)</metadata>',
+    re.DOTALL,
+)
+_CDATA_RE = re.compile(r"\s*<!\[CDATA\[(.*)\]\]>\s*\Z", re.DOTALL)
+
+
+def read_manifest(svg: str) -> dict[str, Any] | None:
+    """Parse the embedded manifest back out of a rendered SVG string.
+
+    The canonical reader for the contract: returns the manifest dict, or
+    ``None`` if the SVG carries no nf-metro manifest.  Parser-independent (a
+    plain regex extract) so a consumer needn't load an XML library.
+    """
+    m = _METADATA_RE.search(svg)
+    if m is None:
+        return None
+    inner = m.group(1)
+    cdata = _CDATA_RE.match(inner)
+    text = cdata.group(1) if cdata else inner
+    text = text.replace("]]]]><![CDATA[>", "]]>")
+    return json.loads(text)
+
+
+def match_station_ids(manifest: dict[str, Any], process_name: str) -> list[str]:
+    """Station ids whose patterns match ``process_name`` (case-insensitive).
+
+    The reference matcher for the manifest: it mirrors the live server's
+    ``stations_for_process`` against the embedded ``processes`` regexes, so a
+    consumer (in any language) can reproduce the documented semantics exactly.
+    """
+    return [
+        station["id"]
+        for station in manifest.get("stations", [])
+        if any(
+            re.search(pattern, process_name, re.IGNORECASE)
+            for pattern in station.get("processes", [])
+        )
+    ]

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -535,13 +535,14 @@ def _render_svg_scaled(
 
     # Embed the machine-readable manifest first, so the file is a durable,
     # self-describing contract regardless of what is drawn below it.
-    manifest = build_manifest(
-        graph,
-        width=svg_width,
-        height=svg_height,
-        station_radius=theme.station_radius,
-    )
-    d.append(draw.Raw(manifest_metadata_svg(manifest)))
+    if graph.embed_manifest:
+        manifest = build_manifest(
+            graph,
+            width=svg_width,
+            height=svg_height,
+            station_radius=theme.station_radius,
+        )
+        d.append(draw.Raw(manifest_metadata_svg(manifest)))
 
     # Dark-mode CSS for transparent-background themes so that elements
     # rendered directly on the canvas (section labels, number badges,
@@ -1316,27 +1317,35 @@ def _render_stations(
     section get horizontal pills (wide, short) since the lines run
     vertically through them.
 
-    Each station's glyph (pill/marker/rail interchange plus any terminus
-    icons) is wrapped in its own ``<g>`` carrying ``data-metro-*`` identity
-    and geometry, so the station is a single addressable element. Skips port
-    stations (is_port=True).
+    When the manifest is embedded, each station's glyph (pill/marker/rail
+    interchange plus any terminus icons) is wrapped in its own ``<g>`` carrying
+    ``data-metro-*`` identity and geometry, so the station is a single
+    addressable element; with ``--no-manifest`` the glyphs are drawn directly
+    with no wrapper. Skips port stations (is_port=True).
     """
     for station in graph.stations.values():
         if station.is_port or station.is_hidden:
             continue
-        g = draw.Group(**_station_group_attrs(graph, theme, station))
-        _render_station_into(g, graph, theme, station, station_offsets)
-        d.append(g)
+        if graph.embed_manifest:
+            g = draw.Group(**_station_group_attrs(graph, theme, station))
+            _render_station_into(g, graph, theme, station, station_offsets)
+            d.append(g)
+        else:
+            _render_station_into(d, graph, theme, station, station_offsets)
 
 
 def _render_station_into(
-    d: draw.Group,
+    d: draw.Group | draw.Drawing,
     graph: MetroGraph,
     theme: Theme,
     station: Station,
     station_offsets: dict[tuple[str, str], float] | None,
 ) -> None:
-    """Draw one station's glyph and terminus icons into its wrapping group."""
+    """Draw one station's glyph and terminus icons into a container.
+
+    The container is the station's wrapping ``<g>`` when the manifest is
+    embedded, or the drawing itself under ``--no-manifest``.
+    """
     r = theme.station_radius
 
     # Rail mode: a blank terminus terminates its converged bundle exactly

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1281,7 +1281,9 @@ def _draw_blank_terminus_nub(
     )
 
 
-def _station_group_attrs(graph: MetroGraph, theme: Theme, station: Station) -> dict:
+def _station_group_attrs(
+    graph: MetroGraph, theme: Theme, station: Station
+) -> dict[str, Any]:
     """Attributes for a station's wrapping ``<g>`` element.
 
     Makes each station one addressable DOM node carrying its identity and

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -101,6 +101,7 @@ from nf_metro.render.legend import (
     marker_stroke_color,
     render_legend,
 )
+from nf_metro.render.manifest import _round1, build_manifest, manifest_metadata_svg
 from nf_metro.render.style import Theme
 
 
@@ -531,6 +532,16 @@ def _render_svg_scaled(
     svg_height = height or int(auto_height)
 
     d = draw.Drawing(svg_width, svg_height)
+
+    # Embed the machine-readable manifest first, so the file is a durable,
+    # self-describing contract regardless of what is drawn below it.
+    manifest = build_manifest(
+        graph,
+        width=svg_width,
+        height=svg_height,
+        station_radius=theme.station_radius,
+    )
+    d.append(draw.Raw(manifest_metadata_svg(manifest)))
 
     # Dark-mode CSS for transparent-background themes so that elements
     # rendered directly on the canvas (section labels, number badges,
@@ -1269,6 +1280,30 @@ def _draw_blank_terminus_nub(
     )
 
 
+def _station_group_attrs(graph: MetroGraph, theme: Theme, station: Station) -> dict:
+    """Attributes for a station's wrapping ``<g>`` element.
+
+    Makes each station one addressable DOM node carrying its identity and
+    geometry, so a consumer can restyle or replace it without the manifest or
+    a re-render.  ``data-metro-station`` is the join key: it equals the
+    station's ``id`` in the embedded manifest.  The geometry attributes mirror
+    the manifest's ``x``/``y``/``r`` (absolute SVG user units, rounded to 1dp)
+    so an overlay can position against either half interchangeably.
+    """
+    attrs = {
+        "class_": "nf-metro-station-group",
+        "data-metro-station": station.id,
+        "data-metro-cx": _round1(station.x),
+        "data-metro-cy": _round1(station.y),
+        "data-metro-r": _round1(theme.station_radius),
+        "data-metro-lines": ",".join(graph.station_lines(station.id)),
+    }
+    section = graph.sections.get(station.section_id) if station.section_id else None
+    if section is not None and not section.is_implicit:
+        attrs["data-metro-section"] = station.section_id
+    return attrs
+
+
 def _render_stations(
     d: draw.Drawing,
     graph: MetroGraph,
@@ -1281,125 +1316,140 @@ def _render_stations(
     section get horizontal pills (wide, short) since the lines run
     vertically through them.
 
-    Skips port stations (is_port=True).
+    Each station's glyph (pill/marker/rail interchange plus any terminus
+    icons) is wrapped in its own ``<g>`` carrying ``data-metro-*`` identity
+    and geometry, so the station is a single addressable element. Skips port
+    stations (is_port=True).
     """
     for station in graph.stations.values():
         if station.is_port or station.is_hidden:
             continue
+        g = draw.Group(**_station_group_attrs(graph, theme, station))
+        _render_station_into(g, graph, theme, station, station_offsets)
+        d.append(g)
 
-        r = theme.station_radius
 
-        # Rail mode: a blank terminus terminates its converged bundle exactly
-        # like any other render -- the standard unrounded nub (via _pill_box)
-        # spanning the bundle, plus the file icon -- rather than a rail-specific
-        # glyph.  The only difference is the span comes from the rail bundle
-        # (rail mode does not use station_offsets).  An off-track input drops in
-        # vertically (no horizontal fan), so it gets the icon only.
-        if graph.station_is_rail(station.id) and station.is_blank_terminus:
-            if station.off_track:
-                _append_terminus_icons(d, station, graph, theme, r, 0.0, 0.0)
-                continue
-            used = station.rail_used_ys or [station.y]
-            t_min = min(used) - station.y
-            t_max = max(used) - station.y
-            _draw_blank_terminus_nub(
-                d, station, r, t_min, t_max, _station_data_attrs(graph, station), theme
-            )
-            _append_terminus_icons(d, station, graph, theme, r, t_min, t_max)
-            continue
+def _render_station_into(
+    d: draw.Group,
+    graph: MetroGraph,
+    theme: Theme,
+    station: Station,
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> None:
+    """Draw one station's glyph and terminus icons into its wrapping group."""
+    r = theme.station_radius
 
-        # Rail mode: a multi-rail station draws as a spanning interchange; a
-        # single-rail station draws as one knob centred on its rail.  Both go
-        # through _render_rail_pill (its link bar self-suppresses with no span),
-        # so a single stop sits exactly on the rail rather than being shifted by
-        # the normal-mode parallel-line station_offsets, which don't apply once
-        # a line is pinned to a fixed rail.  Marked stations keep their glyph.
-        if (
-            graph.station_is_rail(station.id)
-            and station.marker is None
-            and not station.is_terminus
-        ):
-            _render_rail_pill(d, graph, station, theme, r)
-            continue
-        if station.rail_top_y is not None and station.rail_bottom_y is not None:
-            _render_rail_pill(
-                d, graph, station, theme, r, _rail_marker_fill(station.marker, theme)
-            )
-            continue
+    # Rail mode: a blank terminus terminates its converged bundle exactly
+    # like any other render -- the standard unrounded nub (via _pill_box)
+    # spanning the bundle, plus the file icon -- rather than a rail-specific
+    # glyph.  The only difference is the span comes from the rail bundle
+    # (rail mode does not use station_offsets).  An off-track input drops in
+    # vertically (no horizontal fan), so it gets the icon only.
+    if graph.station_is_rail(station.id) and station.is_blank_terminus:
+        if station.off_track:
+            _append_terminus_icons(d, station, graph, theme, r, 0.0, 0.0)
+            return
+        used = station.rail_used_ys or [station.y]
+        t_min = min(used) - station.y
+        t_max = max(used) - station.y
+        _draw_blank_terminus_nub(
+            d, station, r, t_min, t_max, _station_data_attrs(graph, station), theme
+        )
+        _append_terminus_icons(d, station, graph, theme, r, t_min, t_max)
+        return
 
-        # Determine if this is a TB vertical station (rotated pill)
-        is_tb_vert = False
-        if station.section_id:
-            sec = graph.sections.get(station.section_id)
-            if sec and sec.direction == "TB":
-                is_tb_vert = True
+    # Rail mode: a multi-rail station draws as a spanning interchange; a
+    # single-rail station draws as one knob centred on its rail.  Both go
+    # through _render_rail_pill (its link bar self-suppresses with no span),
+    # so a single stop sits exactly on the rail rather than being shifted by
+    # the normal-mode parallel-line station_offsets, which don't apply once
+    # a line is pinned to a fixed rail.  Marked stations keep their glyph.
+    if (
+        graph.station_is_rail(station.id)
+        and station.marker is None
+        and not station.is_terminus
+    ):
+        _render_rail_pill(d, graph, station, theme, r)
+        return
+    if station.rail_top_y is not None and station.rail_bottom_y is not None:
+        _render_rail_pill(
+            d, graph, station, theme, r, _rail_marker_fill(station.marker, theme)
+        )
+        return
 
-        # A rail station is pinned to its rail Y; the parallel-line bundle
-        # offsets do not apply (the rail-pill path above ignores them too), so a
-        # marked single-rail station's glyph must seat on the rail rather than
-        # ride the bundle's mid-offset.
-        if station_offsets and not graph.station_is_rail(station.id):
-            line_offsets = [
-                station_offsets.get((station.id, lid), 0.0)
-                for lid in graph.station_lines(station.id)
-            ]
-            if line_offsets:
-                min_off = min(line_offsets)
-                max_off = max(line_offsets)
-            else:
-                min_off = max_off = 0.0
+    # Determine if this is a TB vertical station (rotated pill)
+    is_tb_vert = False
+    if station.section_id:
+        sec = graph.sections.get(station.section_id)
+        if sec and sec.direction == "TB":
+            is_tb_vert = True
+
+    # A rail station is pinned to its rail Y; the parallel-line bundle
+    # offsets do not apply (the rail-pill path above ignores them too), so a
+    # marked single-rail station's glyph must seat on the rail rather than
+    # ride the bundle's mid-offset.
+    if station_offsets and not graph.station_is_rail(station.id):
+        line_offsets = [
+            station_offsets.get((station.id, lid), 0.0)
+            for lid in graph.station_lines(station.id)
+        ]
+        if line_offsets:
+            min_off = min(line_offsets)
+            max_off = max(line_offsets)
         else:
             min_off = max_off = 0.0
+    else:
+        min_off = max_off = 0.0
 
-        station_data = _station_data_attrs(graph, station)
+    station_data = _station_data_attrs(graph, station)
 
-        if graph.station_is_rail(station.id) and (min_off, max_off) != (0.0, 0.0):
-            raise AssertionError(
-                f"rail station {station.id!r} marker glyph offset "
-                f"({min_off}, {max_off}) would lift it off its rail"
-            )
+    if graph.station_is_rail(station.id) and (min_off, max_off) != (0.0, 0.0):
+        raise AssertionError(
+            f"rail station {station.id!r} marker glyph offset "
+            f"({min_off}, {max_off}) would lift it off its rail"
+        )
 
-        if station.marker is not None:
-            _render_marker_station(
-                d,
-                station.marker,
-                theme,
-                station,
-                r,
-                min_off,
-                max_off,
-                is_tb_vert,
-                station_data,
-            )
-            if station.is_terminus:
-                _append_terminus_icons(d, station, graph, theme, r, min_off, max_off)
-            continue
-
-        x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb_vert)
-
-        # Blank terminus stations get an unrounded nub; everything else a pill.
-        if station.is_blank_terminus:
-            _draw_blank_terminus_nub(
-                d, station, r, min_off, max_off, station_data, theme, is_tb_vert
-            )
-        else:
-            d.append(
-                draw.Rectangle(
-                    x,
-                    y,
-                    w,
-                    h,
-                    rx=r,
-                    ry=r,
-                    fill=theme.station_fill,
-                    stroke=theme.station_stroke,
-                    stroke_width=theme.station_stroke_width,
-                    **station_data,
-                )
-            )
-
+    if station.marker is not None:
+        _render_marker_station(
+            d,
+            station.marker,
+            theme,
+            station,
+            r,
+            min_off,
+            max_off,
+            is_tb_vert,
+            station_data,
+        )
         if station.is_terminus:
             _append_terminus_icons(d, station, graph, theme, r, min_off, max_off)
+        return
+
+    x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb_vert)
+
+    # Blank terminus stations get an unrounded nub; everything else a pill.
+    if station.is_blank_terminus:
+        _draw_blank_terminus_nub(
+            d, station, r, min_off, max_off, station_data, theme, is_tb_vert
+        )
+    else:
+        d.append(
+            draw.Rectangle(
+                x,
+                y,
+                w,
+                h,
+                rx=r,
+                ry=r,
+                fill=theme.station_fill,
+                stroke=theme.station_stroke,
+                stroke_width=theme.station_stroke_width,
+                **station_data,
+            )
+        )
+
+    if station.is_terminus:
+        _append_terminus_icons(d, station, graph, theme, r, min_off, max_off)
 
 
 def caption_aware_icon_step(

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -68,6 +68,42 @@ def test_svg_without_manifest_returns_none() -> None:
     assert read_manifest("<svg xmlns='http://www.w3.org/2000/svg'></svg>") is None
 
 
+def test_no_manifest_opt_out_emits_drawn_map_only() -> None:
+    """``embed_manifest=False`` drops every data decoration from the SVG.
+
+    The drawn map carries no ``<metadata>`` manifest, no ``data-metro-*``
+    attributes, and no station-group wrapper, so it is the lean output the
+    gallery's render diff compares against the base branch.
+    """
+    graph = parse_and_layout(MAPPED_TEXT)
+    graph.embed_manifest = False
+    svg = render_svg(graph, NFCORE_THEME)
+
+    ET.fromstring(svg)  # well-formed XML
+    assert read_manifest(svg) is None
+    assert "nf-metro-manifest" not in svg
+    assert "data-metro-" not in svg
+    assert "nf-metro-station-group" not in svg
+
+
+def test_no_manifest_drops_only_data_not_glyphs() -> None:
+    """The manifest-off SVG draws the same glyphs, minus the identity data.
+
+    Both outputs draw one ``<rect>`` per station; the manifest-off SVG is
+    shorter only because it omits the non-visual ``<metadata>`` block and
+    ``data-metro-*`` attributes.
+    """
+    graph = parse_and_layout(MAPPED_TEXT)
+    on = render_svg(graph, NFCORE_THEME)
+    graph.embed_manifest = False
+    off = render_svg(graph, NFCORE_THEME)
+
+    rects_on = on.count("<rect")
+    rects_off = off.count("<rect")
+    assert rects_off == rects_on
+    assert len(off) < len(on)
+
+
 def test_match_block_documents_semantics(mapped_svg: str) -> None:
     """The match block makes the (non-Python) matching contract explicit."""
     manifest = read_manifest(mapped_svg)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -149,7 +149,12 @@ def test_id_is_join_key_to_dom(mapped_svg: str) -> None:
 
 
 def test_data_attrs_mirror_manifest_geometry(mapped_svg: str) -> None:
-    """The <g> data-metro-cx/cy/r equal the manifest x/y/r for each station."""
+    """The <g> data-metro-* values equal the manifest entry for each station.
+
+    The manifest and the per-station attributes derive the same geometry,
+    lines, and section independently, so this pins them together: a divergence
+    in either derivation fails here rather than shipping inconsistent halves.
+    """
     manifest = read_manifest(mapped_svg)
     root = ET.fromstring(mapped_svg)
     groups = {
@@ -164,6 +169,7 @@ def test_data_attrs_mirror_manifest_geometry(mapped_svg: str) -> None:
         assert float(g.get("data-metro-cy")) == station["y"]
         assert float(g.get("data-metro-r")) == station["r"]
         assert g.get("data-metro-lines") == ",".join(station["lines"])
+        assert g.get("data-metro-section") == station.get("section")
 
 
 def test_coordinate_space_is_viewbox(mapped_svg: str) -> None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,198 @@
+"""Tests for the embedded SVG manifest contract.
+
+The rendered SVG is a durable, machine-readable contract: a JSON manifest in a
+``<metadata>`` element plus ``data-metro-*`` attributes on each station ``<g>``.
+These tests assert the manifest round-trips, that its coordinates/processes
+match the graph it was built from, that the two halves agree on the station
+``id`` join key, and that the documented matching/coordinate semantics hold.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+
+import pytest
+from conftest import compute_corpus_layout, content_corpus, parse_and_layout
+
+from nf_metro.live.mapping import stations_for_process
+from nf_metro.render.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    match_station_ids,
+    read_manifest,
+)
+from nf_metro.render.svg import render_svg
+from nf_metro.themes import NFCORE_THEME
+
+# A small map with sections, multiple lines, and a process mapping so every
+# manifest field is exercised.
+MAPPED_TEXT = """\
+%%metro title: Demo Pipeline
+%%metro line: qc    | QC        | #f0a000
+%%metro line: align | Alignment | #3a86ff
+
+graph LR
+    subgraph prep [Preparation]
+        %%metro process: input | SAMPLESHEET
+        input[Samplesheet]
+        %%metro process: trim | TRIMGALORE
+        trim[Trim]
+        input -->|qc,align| trim
+    end
+    subgraph main [Analysis]
+        %%metro process: star | STAR_ALIGN
+        star[Align]
+        fastqc[FastQC]
+        trim -->|align| star
+        trim -->|qc| fastqc
+    end
+"""
+
+
+@pytest.fixture
+def mapped_svg() -> str:
+    graph = parse_and_layout(MAPPED_TEXT)
+    return render_svg(graph, NFCORE_THEME)
+
+
+def test_manifest_embedded_and_roundtrips(mapped_svg: str) -> None:
+    manifest = read_manifest(mapped_svg)
+    assert manifest is not None
+    assert manifest["version"] == MANIFEST_SCHEMA_VERSION
+    assert manifest["title"] == "Demo Pipeline"
+    assert {ln["id"] for ln in manifest["lines"]} == {"qc", "align"}
+    assert {s["id"] for s in manifest["sections"]} == {"prep", "main"}
+
+
+def test_svg_without_manifest_returns_none() -> None:
+    assert read_manifest("<svg xmlns='http://www.w3.org/2000/svg'></svg>") is None
+
+
+def test_match_block_documents_semantics(mapped_svg: str) -> None:
+    """The match block makes the (non-Python) matching contract explicit."""
+    manifest = read_manifest(mapped_svg)
+    assert manifest["match"] == {
+        "target": "fqProcessName",
+        "type": "regex",
+        "flags": "i",
+    }
+
+
+def test_stations_coords_and_processes_match_graph() -> None:
+    graph = parse_and_layout(MAPPED_TEXT)
+    svg = render_svg(graph, NFCORE_THEME)
+    manifest = read_manifest(svg)
+
+    by_id = {s["id"]: s for s in manifest["stations"]}
+    # Ports are excluded; every real (non-port, non-hidden) station is present.
+    expected = {
+        sid
+        for sid, st in graph.stations.items()
+        if not st.is_port and not st.is_hidden
+    }
+    assert set(by_id) == expected
+
+    for sid, entry in by_id.items():
+        st = graph.stations[sid]
+        assert entry["x"] == round(st.x, 1)
+        assert entry["y"] == round(st.y, 1)
+        assert entry["r"] == round(NFCORE_THEME.station_radius, 1)
+        assert entry["lines"] == graph.station_lines(sid)
+        assert entry["processes"] == graph.process_mapping.get(sid, [])
+
+
+def test_unmapped_station_has_empty_processes(mapped_svg: str) -> None:
+    manifest = read_manifest(mapped_svg)
+    fastqc = next(s for s in manifest["stations"] if s["id"] == "fastqc")
+    assert fastqc["processes"] == []
+
+
+def test_id_is_join_key_to_dom(mapped_svg: str) -> None:
+    """Every manifest station id is emitted as data-metro-station on a <g>."""
+    manifest = read_manifest(mapped_svg)
+    for station in manifest["stations"]:
+        assert f'data-metro-station="{station["id"]}"' in mapped_svg
+
+
+def test_data_attrs_mirror_manifest_geometry(mapped_svg: str) -> None:
+    """The <g> data-metro-cx/cy/r equal the manifest x/y/r for each station."""
+    manifest = read_manifest(mapped_svg)
+    root = ET.fromstring(mapped_svg)
+    groups = {
+        g.get("data-metro-station"): g
+        for g in root.iter("{http://www.w3.org/2000/svg}g")
+        if g.get("data-metro-station")
+    }
+    assert groups  # sanity: the namespaced iter found the station groups
+    for station in manifest["stations"]:
+        g = groups[station["id"]]
+        assert float(g.get("data-metro-cx")) == station["x"]
+        assert float(g.get("data-metro-cy")) == station["y"]
+        assert float(g.get("data-metro-r")) == station["r"]
+        assert g.get("data-metro-lines") == ",".join(station["lines"])
+
+
+def test_coordinate_space_is_viewbox(mapped_svg: str) -> None:
+    """x/y/r are absolute user units in viewBox '0 0 width height', no transform."""
+    manifest = read_manifest(mapped_svg)
+    vb = re.search(r'<svg[^>]*viewBox="([^"]+)"', mapped_svg).group(1)
+    assert vb == f"0 0 {manifest['width']} {manifest['height']}"
+    # No outer transform wrapping the content: the first child after <defs>
+    # carries raw coordinates, so manifest coords are post-transform absolute.
+    root = ET.fromstring(mapped_svg)
+    for child in root:
+        assert "transform" not in child.attrib
+
+
+def test_matcher_mirrors_live_server() -> None:
+    """match_station_ids reproduces stations_for_process exactly."""
+    graph = parse_and_layout(MAPPED_TEXT)
+    manifest = read_manifest(render_svg(graph, NFCORE_THEME))
+    process_names = [
+        "NFCORE:PIPE:SAMPLESHEET",
+        "TRIMGALORE",
+        "star_align",  # case-insensitive
+        "NFCORE:PIPE:STAR_ALIGN",
+        "UNMAPPED_PROCESS",
+    ]
+    for name in process_names:
+        assert sorted(match_station_ids(manifest, name)) == sorted(
+            stations_for_process(name, graph.process_mapping)
+        )
+
+
+def test_manifest_is_deterministic() -> None:
+    graph = parse_and_layout(MAPPED_TEXT)
+    a = render_svg(graph, NFCORE_THEME)
+    b = render_svg(graph, NFCORE_THEME)
+    assert read_manifest(a) == read_manifest(b)
+
+
+def test_cdata_survives_bracket_sequence() -> None:
+    """A pattern containing ']]>' stays well-formed and round-trips."""
+    graph = parse_and_layout(
+        "%%metro line: x | X | #fff\n"
+        "graph LR\n"
+        "    %%metro process: a | FOO]]>BAR\n"
+        "    a[A]\n"
+        "    b[B]\n"
+        "    a -->|x| b\n"
+    )
+    svg = render_svg(graph, NFCORE_THEME)
+    ET.fromstring(svg)  # must be well-formed XML
+    parsed = read_manifest(svg)
+    a = next(s for s in parsed["stations"] if s["id"] == "a")
+    assert a["processes"] == ["FOO]]>BAR"]
+
+
+@pytest.mark.parametrize("fixture_id,path,is_nextflow", content_corpus())
+def test_corpus_manifest_roundtrips(fixture_id, path, is_nextflow) -> None:
+    """Every gallery/topology fixture renders an SVG whose manifest reads back
+    and whose station ids all appear as data-metro-station handles."""
+    graph = compute_corpus_layout(path, is_nextflow)
+    svg = render_svg(graph, NFCORE_THEME)
+    manifest = read_manifest(svg)
+    assert manifest is not None
+    for station in manifest["stations"]:
+        assert f'data-metro-station="{station["id"]}"' in svg
+        assert station["processes"] == graph.process_mapping.get(station["id"], [])

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -86,9 +86,7 @@ def test_stations_coords_and_processes_match_graph() -> None:
     by_id = {s["id"]: s for s in manifest["stations"]}
     # Ports are excluded; every real (non-port, non-hidden) station is present.
     expected = {
-        sid
-        for sid, st in graph.stations.items()
-        if not st.is_port and not st.is_hidden
+        sid for sid, st in graph.stations.items() if not st.is_port and not st.is_hidden
     }
     assert set(by_id) == expected
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -172,6 +172,27 @@ def test_data_attrs_mirror_manifest_geometry(mapped_svg: str) -> None:
         assert g.get("data-metro-section") == station.get("section")
 
 
+def test_manifest_arrays_follow_graph_declaration_order() -> None:
+    """stations, lines, and sections keep the graph's declaration order.
+
+    Manifest equality alone would catch a render-to-render reorder but not
+    pin the order to anything meaningful; anchoring it to the graph makes an
+    ordering regression point straight at the offending derivation.
+    """
+    graph = parse_and_layout(MAPPED_TEXT)
+    manifest = read_manifest(render_svg(graph, NFCORE_THEME))
+
+    expected_stations = [
+        sid for sid, st in graph.stations.items() if not st.is_port and not st.is_hidden
+    ]
+    expected_sections = [
+        sid for sid, sec in graph.sections.items() if not sec.is_implicit
+    ]
+    assert [s["id"] for s in manifest["stations"]] == expected_stations
+    assert [ln["id"] for ln in manifest["lines"]] == list(graph.lines)
+    assert [s["id"] for s in manifest["sections"]] == expected_sections
+
+
 def test_coordinate_space_is_viewbox(mapped_svg: str) -> None:
     """x/y/r are absolute user units in viewBox '0 0 width height', no transform."""
     manifest = read_manifest(mapped_svg)

--- a/tests/test_process_directive.py
+++ b/tests/test_process_directive.py
@@ -20,6 +20,7 @@ def _visual_svg(svg: str) -> str:
     """The SVG with the embedded manifest stripped (the drawn output only)."""
     return _METADATA_BLOCK.sub("", svg)
 
+
 BASE = (
     "%%metro line: a | A | #ff0000 | solid\n"
     "graph LR\n"

--- a/tests/test_process_directive.py
+++ b/tests/test_process_directive.py
@@ -1,5 +1,6 @@
 """Tests for the ``%%metro process:`` directive (live-progress mapping)."""
 
+import re
 import warnings
 
 import pytest
@@ -7,7 +8,17 @@ import pytest
 from nf_metro.layout import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render import render_svg
+from nf_metro.render.manifest import MANIFEST_ELEMENT_ID, read_manifest
 from nf_metro.themes import THEMES
+
+_METADATA_BLOCK = re.compile(
+    rf'<metadata id="{re.escape(MANIFEST_ELEMENT_ID)}".*?</metadata>', re.S
+)
+
+
+def _visual_svg(svg: str) -> str:
+    """The SVG with the embedded manifest stripped (the drawn output only)."""
+    return _METADATA_BLOCK.sub("", svg)
 
 BASE = (
     "%%metro line: a | A | #ff0000 | solid\n"
@@ -55,8 +66,14 @@ def test_process_directive_malformed_warns():
     assert graph.process_mapping == {}
 
 
-def test_process_directive_does_not_change_render():
-    """Pure metadata: the directive must not perturb layout or SVG output."""
+def test_process_directive_does_not_change_visual_render():
+    """The directive must not perturb layout or the drawn SVG output.
+
+    It is no longer pure metadata at the byte level: the mapping is now
+    serialized into the embedded ``<metadata>`` manifest (so a committed SVG
+    carries it). But everything *drawn* must be byte-identical -- the directive
+    still never moves a station or changes a glyph.
+    """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         plain = parse_metro_mermaid(BASE)
@@ -64,4 +81,15 @@ def test_process_directive_does_not_change_render():
     compute_layout(plain)
     compute_layout(mapped)
     theme = THEMES["nfcore"]
-    assert render_svg(plain, theme) == render_svg(mapped, theme)
+    plain_svg = render_svg(plain, theme)
+    mapped_svg = render_svg(mapped, theme)
+
+    # Identical once the manifest is stripped (nothing drawn changed)...
+    assert _visual_svg(plain_svg) == _visual_svg(mapped_svg)
+    # ...but the manifest carries the mapping difference.
+    plain_proc = {s["id"]: s["processes"] for s in read_manifest(plain_svg)["stations"]}
+    mapped_proc = {
+        s["id"]: s["processes"] for s in read_manifest(mapped_svg)["stations"]
+    }
+    assert plain_proc["trim"] == []
+    assert mapped_proc["trim"] == ["TRIMGALORE"]


### PR DESCRIPTION
## What

Make the rendered SVG a self-contained, durable artifact so a downstream tool can drive it — position overlays, restyle station elements, look up which processes a station represents — from the **committed SVG file alone**, with no re-render and no access to the in-memory `MetroGraph`.

The data is carried two redundant, sanitization-safe ways (no `<script>`, so it survives inline-SVG sanitizers):

1. **A JSON manifest** in a `<metadata id="nf-metro-manifest">` element: schema `version`, `match` semantics block, `title`, canvas `width`/`height`, `lines`, `sections`, and `stations` — each with `id`, `label`, absolute `x`/`y`/`r`, the `lines`/`section` it belongs to, and the `processes` regexes it represents.
2. **`data-metro-*` attributes** on each station's wrapping `<g>` (`data-metro-station`, `-cx`/`-cy`/`-r`, `-lines`, `-section`), so individual stations stay addressable directly in the DOM.

## Contract guarantees

- **`id` is the join key**: a manifest station's `id` equals `data-metro-station="<id>"` on its `<g>`, so consumers can go manifest→element and element→manifest.
- **Coordinate space pinned**: `x`/`y`/`r` are absolute SVG user units inside `viewBox="0 0 width height"` (no outer transform), so an overlay sharing that viewBox lines up exactly. Rounded to 1dp.
- **No drift**: coords and process mappings are read from the same graph fields the live server uses (`graph.stations`, `graph.process_mapping`).
- **Process matching made explicit** for non-Python consumers: regex, case-insensitive, against the fully-qualified process name; portable-regex subset documented.
- **Embedded by default, with an opt-out** — `--no-manifest` (or `%%metro manifest: false`) emits the drawn map only, byte-for-byte identical to a pre-manifest build. Gallery renders use the opt-out so the render diff stays a true picture of visual changes. Output stays deterministic (sorted keys, rounded coords).

Ships `read_manifest()` and `match_station_ids()` (re-exported from `nf_metro.render`) as the canonical reader/matcher.

## Tests

New `tests/test_manifest.py` asserts round-trip, coord/process parity with the graph, the `id` join key, geometry mirrored on both halves, the viewBox contract, matcher parity with the live server's `stations_for_process`, determinism, and CDATA `]]>` safety — plus a sweep over the entire fixture corpus. `test_process_directive.py` updated: the directive still leaves the *drawn* SVG byte-identical (manifest carries the mapping). Full suite green; ruff clean.

## Docs

README gains an "Embedded data manifest" subsection; `docs/live.md` documents the full schema, matching semantics, and reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
