### PR TITLE
ci(render-preview): publish previews for fork PRs via workflow_run

### DIFF
--- a/.github/workflows/pr-render-publish.yml
+++ b/.github/workflows/pr-render-publish.yml
@@ -1,0 +1,65 @@
+name: Publish render preview
+
+on:
+  workflow_run:
+    workflows: ["PR render preview"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: render-preview
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read preview metadata
+        id: meta
+        run: |
+          echo "pr=$(cat artifact/preview_meta/pr_number.txt)" >> "$GITHUB_OUTPUT"
+          echo "has_changes=$(cat artifact/preview_meta/has_changes.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to GitHub Pages
+        if: steps.meta.outputs.has_changes == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: artifact/diff_site
+          destination_dir: _pr/${{ steps.meta.outputs.pr }}
+          keep_files: true
+
+      - name: Comment on PR (changes found)
+        if: steps.meta.outputs.has_changes == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: render-preview
+          number: ${{ steps.meta.outputs.pr }}
+          message: |
+            **Render preview** is ready for review:
+            :framed_picture: https://pinin4fjords.github.io/nf-metro/_pr/${{ steps.meta.outputs.pr }}/
+
+            This preview shows only the renders that changed compared to `main`.
+
+      - name: Comment on PR (no changes)
+        if: steps.meta.outputs.has_changes == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: render-preview
+          number: ${{ steps.meta.outputs.pr }}
+          message: |
+            **Render preview**: no visual changes detected. All renders match `main`.

--- a/.github/workflows/pr-render-publish.yml
+++ b/.github/workflows/pr-render-publish.yml
@@ -3,7 +3,7 @@ name: Publish render preview
 on:
   workflow_run:
     workflows: ["PR render preview"]
-    types: [completed]
+    types: [requested, completed]
 
 permissions:
   contents: write
@@ -14,10 +14,36 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  pending:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.action == 'requested'
+    steps:
+      - name: Resolve PR number from head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
+            --jq '.[0].number')
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Mark preview as rendering
+        if: steps.pr.outputs.number != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: render-preview
+          number: ${{ steps.pr.outputs.number }}
+          message: |
+            **Render preview**: :hourglass_flowing_sand: rendering in progress...
+
   publish:
     runs-on: ubuntu-latest
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
+      github.event.action == 'completed' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download preview artifact

--- a/.github/workflows/pr-renders.yml
+++ b/.github/workflows/pr-renders.yml
@@ -5,24 +5,12 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
-
-concurrency:
-  group: gh-pages
-  cancel-in-progress: false
+  contents: read
 
 jobs:
   render-diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Mark previous preview as stale
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: render-preview
-          message: |
-            **Render preview**: :hourglass_flowing_sand: rendering in progress...
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -86,31 +74,20 @@ jobs:
             exit $EXIT_CODE
           fi
 
-      # --- Deploy preview ---
-      - name: Deploy to GitHub Pages
-        if: steps.diff.outputs.has_changes == 'true'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: /tmp/diff_site
-          destination_dir: _pr/${{ github.event.number }}
-          keep_files: true
+      # A fork PR's GITHUB_TOKEN is read-only, so this job cannot deploy Pages or
+      # comment. Hand the site plus the publish decision to pr-render-publish.yml,
+      # which runs from the base repo with a write token via workflow_run.
+      - name: Stage preview metadata
+        run: |
+          mkdir -p /tmp/diff_site /tmp/preview_meta
+          echo "${{ github.event.number }}" > /tmp/preview_meta/pr_number.txt
+          echo "${{ steps.diff.outputs.has_changes }}" > /tmp/preview_meta/has_changes.txt
 
-      - name: Comment on PR (changes found)
-        if: steps.diff.outputs.has_changes == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
         with:
-          header: render-preview
-          message: |
-            **Render preview** is ready for review:
-            :framed_picture: https://pinin4fjords.github.io/nf-metro/_pr/${{ github.event.number }}/
-
-            This preview shows only the renders that changed compared to `main`.
-
-      - name: Comment on PR (no changes)
-        if: steps.diff.outputs.has_changes == 'false'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: render-preview
-          message: |
-            **Render preview**: no visual changes detected. All renders match `main`.
+          name: render-preview
+          path: |
+            /tmp/diff_site
+            /tmp/preview_meta
+          retention-days: 3


### PR DESCRIPTION
## What

Render previews failed on fork PRs (e.g. #623) with `Resource not accessible by integration`: GitHub forces a fork PR's `GITHUB_TOKEN` to read-only, so the `render-diff` job could neither deploy to Pages nor post the sticky comment.

This splits the preview into the standard secure two-workflow pattern so **any contributor's fork PR gets a preview**, with no need to add them as explicit collaborators.

## How

- **`pr-renders.yml`** (`pull_request`) now runs with `permissions: contents: read` only. It renders the PR-vs-base diff exactly as before, then uploads the diff site plus a small metadata file (`pr_number`, `has_changes`) as a `render-preview` artifact. No write token, no secrets, so it is safe to run untrusted fork code.
- **`pr-render-publish.yml`** (new, `workflow_run`) fires when the build completes, runs from the base repo with `contents: write` + `pull-requests: write`, downloads the artifact, deploys to Pages (`_pr/<n>/`) and posts the sticky comment. It targets the PR explicitly via the action's `number:` input. The privileged half never executes contributor code.

## Note on rollout

`workflow_run` triggers only fire for the workflow file as it exists on the **default branch**, so the publish job does not run on this PR itself. The build job will run here and exercise the artifact upload; the publish half goes live once this lands on `main`, and the first fork PR after merge is the real end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)