### PR TITLE
ci(render-preview): resolve fork PR number by head SHA

### DIFF
--- a/.github/workflows/pr-render-publish.yml
+++ b/.github/workflows/pr-render-publish.yml
@@ -25,9 +25,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR=$(gh api \
-            "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
-            --jq '.[0].number')
+          PR=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+            --jq ".[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\") | .number" \
+            | head -n1)
           echo "number=$PR" >> "$GITHUB_OUTPUT"
 
       - name: Mark preview as rendering


### PR DESCRIPTION
## What

The "⏳ rendering in progress…" placeholder added in #624 was silently skipped on **fork** PRs, so the render-preview comment never flipped back to pending on a new push (observed on #623).

## Cause

The `pending` job resolved the PR number via `GET /repos/{repo}/commits/{sha}/pulls`. That endpoint returns nothing for a commit that lives on a fork, even when the SHA is genuinely the head of an open fork PR, so the PR number came back empty and the placeholder step's `if:` guard skipped it.

## Fix

Resolve the PR by matching the build's `head_sha` against the open pull-request list (`GET /repos/{repo}/pulls?state=open`), whose `head.sha` does carry the fork commit. Verified this returns the right PR number for the fork PR head SHA where the commits-pulls endpoint returned empty.

Only the `pending` job's resolve step changes; the deploy/comment logic is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)