### PR TITLE
ci(cleanup): clean up fork-PR previews via pull_request_target

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,8 +1,17 @@
 name: Clean up PR render preview
 
 on:
-  pull_request:
+  # pull_request_target runs in the base-repo context with a write token even
+  # for fork PRs (a fork PR's pull_request token is read-only and cannot push
+  # to gh-pages). Safe here: no PR-head code is checked out or run; the job only
+  # removes a directory keyed by the integer PR number.
+  pull_request_target:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number whose preview directory to remove
+        required: true
 
 permissions:
   contents: write
@@ -21,13 +30,19 @@ jobs:
           fetch-depth: 1
 
       - name: Remove preview directory
+        env:
+          PR: ${{ github.event.inputs.pr_number || github.event.number }}
         run: |
-          if [ -d "_pr/${{ github.event.number }}" ]; then
+          if ! echo "$PR" | grep -qE '^[0-9]+$'; then
+            echo "Refusing to act on non-numeric PR number '$PR'." >&2
+            exit 1
+          fi
+          if [ -d "_pr/$PR" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git rm -rf "_pr/${{ github.event.number }}"
-            git commit -m "Clean up render preview for PR #${{ github.event.number }}"
+            git rm -rf "_pr/$PR"
+            git commit -m "Clean up render preview for PR #$PR"
             git push
           else
-            echo "No preview directory found for PR #${{ github.event.number }}, nothing to clean up."
+            echo "No preview directory found for PR #$PR, nothing to clean up."
           fi


### PR DESCRIPTION
## What

The PR render-preview cleanup job (`pr-cleanup.yml`) fails on every **fork** PR close with a 403:

```
remote: Permission to pinin4fjords/nf-metro.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

A fork PR's `pull_request` `GITHUB_TOKEN` is read-only regardless of the workflow's `permissions:` block, so the job cannot push the preview-directory removal to `gh-pages`. The build/publish split (#624) handled this for *rendering* but left cleanup on the old `pull_request` trigger.

## Change

- Trigger on **`pull_request_target`** instead of `pull_request`. It runs in the base-repo context with a write token even for fork PRs. Safe here: the job checks out the trusted `gh-pages` branch and runs no PR-head code, only `git rm`/`commit`/`push` keyed by the integer PR number. The PR number is passed via an `env:` var rather than interpolated into the script.
- Add a **`workflow_dispatch`** entry (`pr_number` input) to remove a preview directory by hand - useful for clearing orphaned dirs left behind while cleanup was broken.
- Guard the run step to act only on a numeric PR value, so a malformed input cannot `git rm -rf "_pr/"` and wipe every preview.

## Testing

- `actionlint` clean.
- Bash logic exercised against a local bare remote: existing dir removed + pushed, missing dir is a clean no-op, and empty / injection / path-traversal inputs are refused while other previews survive.
- The fork-token path itself is only verifiable once this is on `main` (like `workflow_run`, `pull_request_target` runs the default-branch workflow file), so it will be confirmed post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)