### PR TITLE
docs(live): separate plugin content from no-plugin sections

### DIFF
--- a/docs/live.md
+++ b/docs/live.md
@@ -225,18 +225,34 @@ watch every run light up on one page; the server stays up across runs.
 
 ## 2c. The Nextflow plugin (optional)
 
-!!! warning "Not yet released"
-    The nf-metro Nextflow plugin is not yet published to the Nextflow plugin
-    registry. The instructions below describe its intended interface; watch
-    the [plugin repository](https://github.com/pinin4fjords/nf-metro-plugin)
-    for release announcements.
-
 Everything in §2 and §2b works with **no plugin**: Nextflow's built-in
 `-with-weblog` posts events to a running server, and the persistent dashboard
 is driven by a `curl` to `/maps` plus a per-run `-with-weblog` URL. The
 [nf-metro Nextflow plugin](https://github.com/pinin4fjords/nf-metro-plugin) is a
 convenience layer on top - it emits the same events, but from config and with
 the plumbing handled for you. The Python tooling here never depends on it.
+
+### Installing the plugin
+
+!!! warning "Not yet on the Nextflow plugin registry"
+    The plugin is not yet published to the Nextflow plugin registry, so the
+    normal `plugins { id 'nf-metro@0.1.0' }` auto-download does not work yet.
+    Build and install it locally first:
+
+    ```bash
+    git clone https://github.com/pinin4fjords/nf-metro-plugin
+    cd nf-metro-plugin
+    make install        # installs to ~/.nextflow/plugins
+    ```
+
+    Requires Java 17+ and Nextflow 25.10.0+. Once installed, the `plugins {}`
+    block in the config examples below will find it.
+
+    Alternatively, run without installing by prefixing your `nextflow` command:
+
+    ```bash
+    NXF_PLUGINS_DEV=/path/to/nf-metro-plugin nextflow run my/pipeline
+    ```
 
 ### Plugin demo: shared dashboard
 

--- a/docs/live.md
+++ b/docs/live.md
@@ -248,10 +248,12 @@ the plumbing handled for you. The Python tooling here never depends on it.
     Requires Java 17+ and Nextflow 25.10.0+. Once installed, the `plugins {}`
     block in the config examples below will find it.
 
-    Alternatively, run without installing by prefixing your `nextflow` command:
+    Alternatively, run without installing by pointing Nextflow at the build tree
+    directly (still requires `-plugins` on the command line):
 
     ```bash
-    NXF_PLUGINS_DEV=/path/to/nf-metro-plugin nextflow run my/pipeline
+    NXF_PLUGINS_DEV=/path/to/nf-metro-plugin \
+      nextflow run my/pipeline -plugins nf-metro@0.1.0
     ```
 
 ### Plugin demo: shared dashboard

--- a/docs/live.md
+++ b/docs/live.md
@@ -200,9 +200,45 @@ map. Endpoints mirror the single-map server under a `/r/<id>/` prefix
 
 ### Demo: a shared dashboard
 
-The [Nextflow plugin](https://github.com/pinin4fjords/nf-metro-plugin)'s
-`metro.server` mode does the register-and-emit automatically, so a plain
-`nextflow run` shows up on the dashboard:
+Start one persistent server:
+
+```bash
+nf-metro serve-multi --port 8080            # dashboard at http://localhost:8080/
+```
+
+Register each pipeline's map, capture the run id, then point Nextflow at the
+run's own events endpoint:
+
+```bash
+# register the map (prints JSON with "id" and "events" fields)
+RUN=$(curl -s --data-binary @assets/metro_map.mmd \
+      "http://localhost:8080/maps?name=myrun")
+RUN_ID=$(echo "$RUN" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+# start the pipeline pointing at that run's events endpoint
+nextflow run my/pipeline \
+  -with-weblog "http://localhost:8080/r/${RUN_ID}/events"
+```
+
+Repeat for as many pipelines as you like. Open `http://localhost:8080/` to
+watch every run light up on one page; the server stays up across runs.
+
+## 2c. The Nextflow plugin (optional)
+
+!!! warning "Not yet released"
+    The nf-metro Nextflow plugin is not yet published to the Nextflow plugin
+    registry. The instructions below describe its intended interface; watch
+    the [plugin repository](https://github.com/pinin4fjords/nf-metro-plugin)
+    for release announcements.
+
+Everything in §2 and §2b works with **no plugin**: Nextflow's built-in
+`-with-weblog` posts events to a running server, and the persistent dashboard
+is driven by a `curl` to `/maps` plus a per-run `-with-weblog` URL. The
+[nf-metro Nextflow plugin](https://github.com/pinin4fjords/nf-metro-plugin) is a
+convenience layer on top - it emits the same events, but from config and with
+the plumbing handled for you. The Python tooling here never depends on it.
+
+### Plugin demo: shared dashboard
 
 Start one persistent server:
 
@@ -227,19 +263,7 @@ nextflow run my/pipeline      # repeat for as many pipelines as you like
 
 Each run prints `registered on ...; live map: http://localhost:8080/r/<id>/`.
 Open `http://localhost:8080/` to watch every run light up on one page; the
-server stays up across runs. Without the plugin you can register and drive a
-run with `curl` exactly as shown above.
-
-## 2c. The Nextflow plugin (optional)
-
-Everything above works with **no plugin**: Nextflow's built-in `-with-weblog`
-posts events to a running server, and the persistent dashboard is driven by a
-`curl` to `/maps` plus a per-run `-with-weblog` URL. The
-[nf-metro Nextflow plugin](https://github.com/pinin4fjords/nf-metro-plugin) is a
-convenience layer on top - it emits the same events, but from config and with
-the plumbing handled for you. The Python tooling here never depends on it.
-
-What the plugin adds over `-with-weblog`:
+server stays up across runs.
 
 | Task | Without the plugin | With the plugin |
 |------|--------------------|-----------------|

--- a/docs/live.md
+++ b/docs/live.md
@@ -258,6 +258,9 @@ the plumbing handled for you. The Python tooling here never depends on it.
 
 ### Plugin demo: shared dashboard
 
+The plugin's `metro.server` mode does the register-and-emit automatically, so a
+plain `nextflow run` shows up on the dashboard:
+
 Start one persistent server:
 
 ```bash

--- a/docs/live.md
+++ b/docs/live.md
@@ -248,10 +248,14 @@ the plumbing handled for you. The Python tooling here never depends on it.
     Requires Java 17+ and Nextflow 25.10.0+. Once installed, the `plugins {}`
     block in the config examples below will find it.
 
-    Alternatively, run without installing by pointing Nextflow at the build tree
-    directly (still requires `-plugins` on the command line):
+    Alternatively, run against the build tree without installing (build first,
+    then set `NXF_PLUGINS_DEV`; still requires `-plugins` on the command line):
 
     ```bash
+    git clone https://github.com/pinin4fjords/nf-metro-plugin
+    cd nf-metro-plugin
+    make assemble       # build but do not install
+    # then, from anywhere:
     NXF_PLUGINS_DEV=/path/to/nf-metro-plugin \
       nextflow run my/pipeline -plugins nf-metro@0.1.0
     ```
@@ -299,6 +303,13 @@ and stopped for you, or want runs to self-register on a shared dashboard (the
 register-then-emit step is awkward to do by hand). The plugin has three modes -
 attach, managed, central - documented in its
 [README](https://github.com/pinin4fjords/nf-metro-plugin#three-modes).
+
+!!! note "Managed mode requires `nf-metro` on PATH"
+    Managed mode spawns `nf-metro serve` as a subprocess, so the `nf-metro`
+    command must be on the PATH when Nextflow runs. If it is not found the
+    plugin logs a warning and the pipeline continues without the live map.
+    Use `metro.binary = '/absolute/path/to/nf-metro'` in the config to point
+    to a specific installation.
 
 ## 3. Keep the mapping honest
 


### PR DESCRIPTION
## Summary

- §2b's "Demo" section was showing plugin config (`plugins {}` + `metro {}` block), but §2c opened with "Everything above works with no plugin" — a false claim
- Rewrote §2b demo to show the pure-curl workflow (POST to `/maps`, capture run id, `-with-weblog` the run endpoint) — no plugin required
- Moved plugin config and demo to §2c under a `### Plugin demo: shared dashboard` subheading
- Added a "Not yet released" warning admonition in §2c since the plugin is not yet published to the Nextflow plugin registry
- Fixed the no-plugin claim to "Everything in §2 and §2b works with no plugin"

## Test plan

- [ ] Docs build renders cleanly (`mkdocs serve`)
- [ ] §2b demo curl commands are self-contained (no plugin dependency)
- [ ] §2c unreleased warning is visible
- [ ] Comparison table and plugin modes description still present in §2c

🤖 Generated with [Claude Code](https://claude.com/claude-code)