### PR TITLE
fix(labels): flip labels off foreign diagonal strikes by glyph ink (#513)

### DIFF
--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -250,6 +250,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "the metro line on the track above; the label is pulled back to its "
         "un-pushed anchor so the name clears the line.",
     ),
+    (
+        "funcprofiler_upstream",
+        TOPOLOGIES_DIR,
+        "A profiling section whose stacked tools share a fan-in/fan-out: a "
+        "line the 'FMH FunProfiler' station does not carry would rake its wide "
+        "below-station label, so the label flips to its clear side and the "
+        "diagonal no longer strikes the glyphs.",
+    ),
     # --- Branching and multipath ---
     (
         "asymmetric_tree",

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -8,10 +8,132 @@ section_placement.py, and ordering.py.
 # Font / text metrics
 # ---------------------------------------------------------------------------
 CHAR_WIDTH: float = 9.0
-"""Approximate pixel width of a single character at default font size."""
+"""Approximate pixel width of a single character at default font size.
+
+A generous fixed per-character budget used to *reserve* collision room
+(:func:`~nf_metro.layout.labels.label_text_width`).  Where the *rendered*
+glyph extent matters -- strike detection, fan-run sizing -- use
+:data:`GLYPH_ADVANCE_EM` via
+:func:`~nf_metro.layout.labels.label_glyph_advance_width` instead, which
+tracks the proportional font and so neither over-reserves narrow strings nor
+under-measures wide all-caps ones."""
 
 FONT_HEIGHT: float = 14.0
 """Approximate pixel height of default font."""
+
+LABEL_FONT_SIZE: float = 13.0
+"""Pixel font size the proportional glyph-advance model measures against.
+
+Matches the theme ``label_font_size`` the renderer draws station names at;
+kept here as a theme-agnostic layout proxy (like :data:`CHAR_WIDTH`), with the
+``font_scale`` directive applied on top at measurement time."""
+
+GLYPH_ADVANCE_EM: dict[str, float] = {
+    " ": 0.278,
+    "!": 0.333,
+    '"': 0.474,
+    "#": 0.556,
+    "$": 0.556,
+    "%": 0.889,
+    "&": 0.722,
+    "'": 0.238,
+    "(": 0.333,
+    ")": 0.333,
+    "*": 0.389,
+    "+": 0.584,
+    ",": 0.278,
+    "-": 0.333,
+    ".": 0.278,
+    "/": 0.278,
+    "0": 0.556,
+    "1": 0.556,
+    "2": 0.556,
+    "3": 0.556,
+    "4": 0.556,
+    "5": 0.556,
+    "6": 0.556,
+    "7": 0.556,
+    "8": 0.556,
+    "9": 0.556,
+    ":": 0.333,
+    ";": 0.333,
+    "<": 0.584,
+    "=": 0.584,
+    ">": 0.584,
+    "?": 0.611,
+    "@": 0.975,
+    "A": 0.722,
+    "B": 0.722,
+    "C": 0.722,
+    "D": 0.722,
+    "E": 0.667,
+    "F": 0.611,
+    "G": 0.778,
+    "H": 0.722,
+    "I": 0.278,
+    "J": 0.556,
+    "K": 0.722,
+    "L": 0.611,
+    "M": 0.833,
+    "N": 0.722,
+    "O": 0.778,
+    "P": 0.667,
+    "Q": 0.778,
+    "R": 0.722,
+    "S": 0.667,
+    "T": 0.611,
+    "U": 0.722,
+    "V": 0.667,
+    "W": 0.944,
+    "X": 0.667,
+    "Y": 0.667,
+    "Z": 0.611,
+    "[": 0.333,
+    "\\": 0.278,
+    "]": 0.333,
+    "^": 0.584,
+    "_": 0.556,
+    "`": 0.333,
+    "a": 0.556,
+    "b": 0.611,
+    "c": 0.556,
+    "d": 0.611,
+    "e": 0.556,
+    "f": 0.333,
+    "g": 0.611,
+    "h": 0.611,
+    "i": 0.278,
+    "j": 0.278,
+    "k": 0.556,
+    "l": 0.278,
+    "m": 0.889,
+    "n": 0.611,
+    "o": 0.611,
+    "p": 0.611,
+    "q": 0.611,
+    "r": 0.389,
+    "s": 0.556,
+    "t": 0.333,
+    "u": 0.611,
+    "v": 0.556,
+    "w": 0.778,
+    "x": 0.556,
+    "y": 0.556,
+    "z": 0.500,
+    "{": 0.389,
+    "|": 0.280,
+    "}": 0.389,
+    "~": 0.584,
+}
+"""Per-character advance width in em units for Helvetica-Bold (Adobe AFM).
+
+The themes draw station names in bold Helvetica/Arial; these advances scaled
+by :data:`LABEL_FONT_SIZE` reproduce the rendered glyph extent to within ~1px,
+so a wide all-caps name (``MERGE_RUNS``) is measured as wide as it draws and a
+narrow one (``lll``) is not over-claimed."""
+
+GLYPH_ADVANCE_DEFAULT_EM: float = 0.6
+"""Advance for a character absent from :data:`GLYPH_ADVANCE_EM`."""
 
 LABEL_LINE_HEIGHT: float = 1.2
 """Line-height multiplier for multi-line labels (em units)."""

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -243,7 +243,10 @@ from nf_metro.layout.phases.snapshots import (
 from nf_metro.layout.phases.spacing import (  # noqa: F401
     _MAX_SPREAD_ITERS,
     _SPREAD_SLACK,
+    _STRIKE_X_STEP,
+    _layout_has_collinear,
     _residual_label_overlaps,
+    _residual_label_strikes,
     _spread_bump,
 )
 from nf_metro.parser.model import LineSpread, MetroGraph
@@ -508,11 +511,10 @@ def _compute_layout_scaled(
     # so nothing is widened; only crowded wide-label graphs iterate.  When
     # the caller pins both spacings explicitly there is nothing to widen,
     # so a single pass runs.
-    max_iters = _MAX_SPREAD_ITERS if (auto_x or auto_y) else 1
-    for attempt in range(max_iters):
+    def _lay(xs: float) -> None:
         _layout_once(
             graph,
-            x_spacing=x_spacing,
+            x_spacing=xs,
             y_spacing=y_spacing,
             x_offset=x_offset,
             y_offset=y_offset,
@@ -522,14 +524,35 @@ def _compute_layout_scaled(
             section_y_gap=section_y_gap,
             validate=validate,
         )
+
+    max_iters = _MAX_SPREAD_ITERS if (auto_x or auto_y) else 1
+    pre_strike_x = x_spacing  # last pitch before a strike-widening step
+    widening_strike = False
+    for attempt in range(max_iters):
+        _lay(x_spacing)
+        # A strike-widening step that overshot into a collinear overlay is worse
+        # than the strike it cleared; step back to the last good pitch and stop.
+        if widening_strike and _layout_has_collinear(graph):
+            x_spacing = pre_strike_x
+            _lay(x_spacing)
+            break
         if attempt == max_iters - 1:
             break
         residual = _residual_label_overlaps(graph, allow_hyphenation=False)
-        if not residual:
+        # A horizontal label a diagonal route crosses needs a wider pitch so its
+        # station's flat run clears the transition.  Strikes a wider pitch can't
+        # fix (bypass-V, angled) are excluded from the count, so the step only
+        # fires where it helps.
+        strikes = _residual_label_strikes(graph) if auto_x else 0
+        if not residual and strikes == 0:
             break
         new_x, new_y = _spread_bump(
             graph, residual, x_spacing, y_spacing, auto_x, auto_y
         )
+        if strikes > 0 and auto_x:
+            pre_strike_x = x_spacing
+            widening_strike = True
+            new_x = max(new_x, x_spacing + _STRIKE_X_STEP)
         if new_x <= x_spacing + 1e-6 and new_y <= y_spacing + 1e-6:
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -511,11 +511,11 @@ def _compute_layout_scaled(
     # so nothing is widened; only crowded wide-label graphs iterate.  When
     # the caller pins both spacings explicitly there is nothing to widen,
     # so a single pass runs.
-    def _lay(xs: float) -> None:
+    def _lay(xs: float, ys: float) -> None:
         _layout_once(
             graph,
             x_spacing=xs,
-            y_spacing=y_spacing,
+            y_spacing=ys,
             x_offset=x_offset,
             y_offset=y_offset,
             section_x_padding=section_x_padding,
@@ -529,12 +529,12 @@ def _compute_layout_scaled(
     pre_strike_x = x_spacing
     strike_widened = False
     for attempt in range(max_iters):
-        _lay(x_spacing)
+        _lay(x_spacing, y_spacing)
         # A strike-widening step that overshot into a collinear overlay is worse
         # than the strike it cleared; step back to the last good pitch and stop.
         if strike_widened and _layout_has_collinear(graph):
             x_spacing = pre_strike_x
-            _lay(x_spacing)
+            _lay(x_spacing, y_spacing)
             break
         if attempt == max_iters - 1:
             break

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -526,13 +526,13 @@ def _compute_layout_scaled(
         )
 
     max_iters = _MAX_SPREAD_ITERS if (auto_x or auto_y) else 1
-    pre_strike_x = x_spacing  # last pitch before a strike-widening step
-    widening_strike = False
+    pre_strike_x = x_spacing
+    strike_widened = False
     for attempt in range(max_iters):
         _lay(x_spacing)
         # A strike-widening step that overshot into a collinear overlay is worse
         # than the strike it cleared; step back to the last good pitch and stop.
-        if widening_strike and _layout_has_collinear(graph):
+        if strike_widened and _layout_has_collinear(graph):
             x_spacing = pre_strike_x
             _lay(x_spacing)
             break
@@ -540,8 +540,8 @@ def _compute_layout_scaled(
             break
         residual = _residual_label_overlaps(graph, allow_hyphenation=False)
         # A horizontal label a diagonal route crosses needs a wider pitch so its
-        # station's flat run clears the transition.  Strikes a wider pitch can't
-        # fix (bypass-V, angled) are excluded from the count, so the step only
+        # station's flat run clears the transition; crossings a wider pitch can't
+        # fix (bypass-V, angled) are excluded by _strikes_from, so the step only
         # fires where it helps.
         strikes = _residual_label_strikes(graph) if auto_x else 0
         if not residual and strikes == 0:
@@ -549,9 +549,9 @@ def _compute_layout_scaled(
         new_x, new_y = _spread_bump(
             graph, residual, x_spacing, y_spacing, auto_x, auto_y
         )
-        if strikes > 0 and auto_x:
+        strike_widened = strikes > 0 and auto_x
+        if strike_widened:
             pre_strike_x = x_spacing
-            widening_strike = True
             new_x = max(new_x, x_spacing + _STRIKE_X_STEP)
         if new_x <= x_spacing + 1e-6 and new_y <= y_spacing + 1e-6:
             break  # can't widen the binding axis (e.g. pinned) -- give up

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -6,6 +6,54 @@ import bisect
 from collections.abc import Iterator
 
 
+def segment_intersects_quad(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    quad: list[tuple[float, float]],
+) -> bool:
+    """``True`` iff the segment touches or crosses the convex *quad*.
+
+    *quad* is four corners in order (winding either way).  Exact for a convex
+    polygon: the segment hits it when an endpoint lies inside or the segment
+    crosses any edge.  Used for rotated (angled) label footprints, where an
+    axis-aligned bbox would overstate the diagonal strip's extent.
+    """
+    n = len(quad)
+
+    def _inside(px: float, py: float) -> bool:
+        sign = 0
+        for i in range(n):
+            ax, ay = quad[i]
+            bx, by = quad[(i + 1) % n]
+            cross = (bx - ax) * (py - ay) - (by - ay) * (px - ax)
+            if cross > 1e-9:
+                if sign < 0:
+                    return False
+                sign = 1
+            elif cross < -1e-9:
+                if sign > 0:
+                    return False
+                sign = -1
+        return True
+
+    if _inside(x1, y1) or _inside(x2, y2):
+        return True
+
+    def _ccw(ax: float, ay: float, bx: float, by: float, cx: float, cy: float) -> bool:
+        return (cy - ay) * (bx - ax) > (by - ay) * (cx - ax)
+
+    for i in range(n):
+        cx, cy = quad[i]
+        dx, dy = quad[(i + 1) % n]
+        if _ccw(x1, y1, cx, cy, dx, dy) != _ccw(x2, y2, cx, cy, dx, dy) and _ccw(
+            x1, y1, x2, y2, cx, cy
+        ) != _ccw(x1, y1, x2, y2, dx, dy):
+            return True
+    return False
+
+
 def segment_intersects_bbox(
     x1: float,
     y1: float,

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -354,6 +354,46 @@ def _label_ink_y_band(placement: LabelPlacement) -> tuple[float, float]:
     return placement.y, placement.y + (n - 1) * line_spacing + font_height
 
 
+def _anchor_span(text_anchor: str, x: float, width: float) -> tuple[float, float]:
+    """``(left, right)`` x-extent of a ``width``-wide label at anchor ``x``.
+
+    ``end`` ends at ``x``, ``start`` begins at ``x``, anything else (the default
+    ``middle``) centres on ``x``.
+    """
+    if text_anchor == "end":
+        return x - width, x
+    if text_anchor == "start":
+        return x, x + width
+    return x - width / 2, x + width / 2
+
+
+def _rotated_text_corners(
+    placement: LabelPlacement, width: float
+) -> list[tuple[float, float]]:
+    """Corners of an upright ``width`` x text-height box rotated about the anchor.
+
+    Matches the renderer's ``rotate(angle, x, y)`` transform.
+    """
+    left, right = _anchor_span(placement.text_anchor, placement.x, width)
+    h = _label_text_height(placement.text)
+    upright = [
+        (left, placement.y - h),
+        (right, placement.y - h),
+        (right, placement.y),
+        (left, placement.y),
+    ]
+    rad = math.radians(placement.angle)
+    cos_a, sin_a = math.cos(rad), math.sin(rad)
+    ax, ay = placement.x, placement.y
+    return [
+        (
+            ax + (cx - ax) * cos_a - (cy - ay) * sin_a,
+            ay + (cx - ax) * sin_a + (cy - ay) * cos_a,
+        )
+        for cx, cy in upright
+    ]
+
+
 def label_glyph_ink_bbox(
     placement: LabelPlacement,
 ) -> tuple[float, float, float, float]:
@@ -376,13 +416,9 @@ def label_glyph_ink_bbox(
         ink_half = (x1 - x0) / 2 * LABEL_GLYPH_INK_RATIO
         return (center - ink_half, y0, center + ink_half, y1)
 
-    advance = label_glyph_advance_width(placement.text)
-    if placement.text_anchor == "end":
-        gx0, gx1 = placement.x - advance, placement.x
-    elif placement.text_anchor == "start":
-        gx0, gx1 = placement.x, placement.x + advance
-    else:
-        gx0, gx1 = placement.x - advance / 2, placement.x + advance / 2
+    gx0, gx1 = _anchor_span(
+        placement.text_anchor, placement.x, label_glyph_advance_width(placement.text)
+    )
     iy0, iy1 = _label_ink_y_band(placement)
     return (gx0, iy0, gx1, iy1)
 
@@ -397,30 +433,9 @@ def _label_ink_quad(placement: LabelPlacement) -> list[tuple[float, float]]:
     label it is the four corners of :func:`label_glyph_ink_bbox`.
     """
     if placement.angle and placement.obstacle_bbox is None:
-        w = label_glyph_advance_width(placement.text)
-        h = _label_text_height(placement.text)
-        if placement.text_anchor == "end":
-            left, right = placement.x - w, placement.x
-        elif placement.text_anchor == "start":
-            left, right = placement.x, placement.x + w
-        else:
-            left, right = placement.x - w / 2, placement.x + w / 2
-        upright = [
-            (left, placement.y - h),
-            (right, placement.y - h),
-            (right, placement.y),
-            (left, placement.y),
-        ]
-        rad = math.radians(placement.angle)
-        cos_a, sin_a = math.cos(rad), math.sin(rad)
-        ax, ay = placement.x, placement.y
-        return [
-            (
-                ax + (cx - ax) * cos_a - (cy - ay) * sin_a,
-                ay + (cx - ax) * sin_a + (cy - ay) * cos_a,
-            )
-            for cx, cy in upright
-        ]
+        return _rotated_text_corners(
+            placement, label_glyph_advance_width(placement.text)
+        )
     x0, y0, x1, y1 = label_glyph_ink_bbox(placement)
     return [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
 

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -1437,6 +1437,7 @@ def place_labels(
     if routes:
         _avoid_diagonal_routes(placements, graph, routes, station_offsets)
         _avoid_horizontal_strikethrough(placements, graph, routes, station_offsets)
+        _avoid_diagonal_strikethrough(placements, graph, routes, station_offsets)
 
     _wrap_overlapping_labels(
         placements, graph, station_offsets, allow_hyphenation=allow_hyphenation
@@ -1757,22 +1758,21 @@ def _avoid_diagonal_routes(
         placement.x, placement.y, placement.above = trial.x, trial.y, trial.above
 
 
-def _avoid_horizontal_strikethrough(
-    placements: list[LabelPlacement],
-    graph: MetroGraph,
+def _foreign_route_segments(
     routes: list["RoutedPath"],
     station_offsets: dict[tuple[str, str], float] | None,
-) -> None:
-    """Flip a label off a foreign horizontal trunk that strikes its glyph ink.
+    *,
+    diagonal: bool,
+) -> list[tuple[str, str, str, float, float, float, float]]:
+    """Route segments usable as label-strike obstacles, offsets applied.
 
-    A label hanging on the side of its station where another line's horizontal
-    run passes reads as struck through.  ``_avoid_diagonal_routes`` ignores
-    horizontal segments because labels normally clear the trunk they sit on;
-    this catches the case a *foreign* trunk (a line the station does not carry,
-    not an edge endpoint) crosses the label's glyph ink, and flips the label to
-    the opposite side when that side is free of label and ink collisions.
+    ``diagonal=True`` keeps non-horizontal runs (trunk-to-fan transitions,
+    off-track entries, bypass Vs); ``diagonal=False`` keeps horizontal runs
+    (trunks).  Each entry is ``(line_id, source, target, x1, y1, x2, y2)`` so a
+    caller can exclude segments whose edge the label's station carries or is an
+    endpoint of.
     """
-    foreign: list[tuple[str, tuple[float, float, float, float]]] = []
+    segs: list[tuple[str, str, str, float, float, float, float]] = []
     for route in routes:
         pts = list(route.points)
         if station_offsets and not route.offsets_applied and pts:
@@ -1781,10 +1781,30 @@ def _avoid_horizontal_strikethrough(
             pts[0] = (pts[0][0], pts[0][1] + so)
             pts[-1] = (pts[-1][0], pts[-1][1] + to)
         for (x1, y1), (x2, y2) in zip(pts, pts[1:]):
-            if abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * 0.05:
+            is_diagonal = abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * 0.05
+            if is_diagonal != diagonal:
                 continue
-            foreign.append((route.line_id, (min(x1, x2), y1, max(x1, x2), y2)))
-    if not foreign:
+            segs.append(
+                (route.line_id, route.edge.source, route.edge.target, x1, y1, x2, y2)
+            )
+    return segs
+
+
+def _flip_labels_off_foreign_strikes(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+    station_offsets: dict[tuple[str, str], float] | None,
+    segments: list[tuple[str, str, str, float, float, float, float]],
+) -> None:
+    """Flip each label whose glyph ink a foreign ``segments`` entry strikes.
+
+    A segment strikes a label only when its line is one the label's station
+    does not carry and the station is not an endpoint of the segment's edge
+    (the strike definition shared with ``_guard_no_line_strikes_label``).  A
+    struck label flips to its other side when that side is free of sibling
+    collisions and foreign strikes; one struck on both sides stays put.
+    """
+    if not segments:
         return
 
     for placement in [p for p in placements if p.obstacle_bbox is None]:
@@ -1794,26 +1814,18 @@ def _avoid_horizontal_strikethrough(
         if station is None:
             continue
         carried = set(graph.station_lines(station.id))
-        ink = label_glyph_ink_bbox(placement)
 
         def strikes(box: tuple[float, float, float, float]) -> bool:
-            for line_id, (sx1, sy1, sx2, sy2) in foreign:
-                if line_id in carried:
+            for line_id, src, tgt, sx1, sy1, sx2, sy2 in segments:
+                if line_id in carried or src == station.id or tgt == station.id:
                     continue
                 if segment_intersects_bbox(sx1, sy1, sx2, sy2, box):
                     return True
             return False
 
-        if not strikes(ink):
+        if not strikes(label_glyph_ink_bbox(placement)):
             continue
-        if station_offsets:
-            offs = [
-                station_offsets.get((station.id, lid), 0.0)
-                for lid in graph.station_lines(station.id)
-            ]
-            min_off, max_off = (min(offs), max(offs)) if offs else (0.0, 0.0)
-        else:
-            min_off = max_off = 0.0
+        min_off, max_off = _pill_offsets(graph, station, station_offsets)
         if placement.above:
             gap = max((station.y + min_off) - placement.y, LABEL_OFFSET)
             trial = LabelPlacement(
@@ -1836,6 +1848,53 @@ def _avoid_horizontal_strikethrough(
         if _has_collision(trial, siblings) or strikes(label_glyph_ink_bbox(trial)):
             continue
         placement.x, placement.y, placement.above = trial.x, trial.y, trial.above
+
+
+def _avoid_horizontal_strikethrough(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+    routes: list["RoutedPath"],
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> None:
+    """Flip a label off a foreign horizontal trunk that strikes its glyph ink.
+
+    A label hanging on the side of its station where another line's horizontal
+    run passes reads as struck through.  ``_avoid_diagonal_routes`` ignores
+    horizontal segments because labels normally clear the trunk they sit on;
+    this catches the case a *foreign* trunk (a line the station does not carry,
+    not an edge endpoint) crosses the label's glyph ink, and flips the label to
+    the opposite side when that side is free of label and ink collisions.
+    """
+    _flip_labels_off_foreign_strikes(
+        placements,
+        graph,
+        station_offsets,
+        _foreign_route_segments(routes, station_offsets, diagonal=False),
+    )
+
+
+def _avoid_diagonal_strikethrough(
+    placements: list[LabelPlacement],
+    graph: MetroGraph,
+    routes: list["RoutedPath"],
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> None:
+    """Flip a label off a foreign diagonal route that strikes its glyph ink.
+
+    The diagonal counterpart of ``_avoid_horizontal_strikethrough``.
+    ``_avoid_diagonal_routes`` already flips diagonally-overlapped labels but
+    judges the flip target by the full reserved box, so it declines when the
+    target's empty margin merely grazes a diagonal even though the glyph ink
+    clears.  Judging by glyph ink (the strike measure) and over foreign lines,
+    a label with a clean opposite side flips, while one a bypass V rakes on
+    both sides stays put.
+    """
+    _flip_labels_off_foreign_strikes(
+        placements,
+        graph,
+        station_offsets,
+        _foreign_route_segments(routes, station_offsets, diagonal=True),
+    )
 
 
 def _clamp_label_vertical(

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -12,9 +12,11 @@ __all__ = [
     "active_font_scale",
     "find_label_overlaps",
     "font_scale_context",
+    "label_glyph_advance_width",
     "label_glyph_ink_bbox",
     "label_text_width",
     "place_labels",
+    "segment_strikes_label",
 ]
 
 import math
@@ -28,7 +30,10 @@ from nf_metro.layout.constants import (
     DESCENDER_CLEARANCE,
     DIAGONAL_LABEL_OFFSET,
     FONT_HEIGHT,
+    GLYPH_ADVANCE_DEFAULT_EM,
+    GLYPH_ADVANCE_EM,
     LABEL_BBOX_MARGIN,
+    LABEL_FONT_SIZE,
     LABEL_GLYPH_INK_RATIO,
     LABEL_LINE_HEIGHT,
     LABEL_MARGIN,
@@ -42,7 +47,7 @@ from nf_metro.layout.constants import (
     TB_PILL_EDGE_OFFSET,
     X_SPACING,
 )
-from nf_metro.layout.geometry import segment_intersects_bbox
+from nf_metro.layout.geometry import segment_intersects_bbox, segment_intersects_quad
 from nf_metro.parser.model import MetroGraph
 
 if TYPE_CHECKING:
@@ -76,11 +81,31 @@ def font_scale_context(scale: float) -> Iterator[None]:
 
 
 def label_text_width(label: str) -> float:
-    """Pixel width of the widest line in a (possibly multi-line) label."""
+    """Reserved pixel width of the widest line in a (possibly multi-line) label.
+
+    A generous fixed-per-character budget for collision spacing; for the width
+    the text actually draws at, use :func:`label_glyph_advance_width`.
+    """
     char_width = CHAR_WIDTH * _ACTIVE_FONT_SCALE
     if "\n" not in label:
         return len(label) * char_width
     return max(len(line) for line in label.split("\n")) * char_width
+
+
+def label_glyph_advance_width(label: str) -> float:
+    """Rendered pixel width of the widest line in a (possibly multi-line) label.
+
+    Sums per-character advances (:data:`GLYPH_ADVANCE_EM`, Helvetica-Bold)
+    scaled by :data:`LABEL_FONT_SIZE` and the active font scale, so a wide
+    all-caps name measures as wide as it draws and a narrow one is not
+    over-claimed -- unlike the fixed-width :func:`label_text_width`.
+    """
+    size = LABEL_FONT_SIZE * _ACTIVE_FONT_SCALE
+    lines = label.split("\n") if "\n" in label else [label]
+    return size * max(
+        sum(GLYPH_ADVANCE_EM.get(c, GLYPH_ADVANCE_DEFAULT_EM) for c in line)
+        for line in lines
+    )
 
 
 def _label_text_height(label: str) -> float:
@@ -334,22 +359,84 @@ def label_glyph_ink_bbox(
 ) -> tuple[float, float, float, float]:
     """Return the label's drawn-glyph box, tightened to where text is inked.
 
-    The reserved box from :func:`_label_bbox` budgets ``CHAR_WIDTH`` per
-    character so labels claim ample collision room, but the rendered text is
-    narrower than that.  This shrinks the horizontal span to
-    ``LABEL_GLYPH_INK_RATIO`` of the reserved width about the box centre, and
-    (for a standard above/below label) replaces the vertical span with the
-    renderer's true ink band (:func:`_label_ink_y_band`), which stacks wrapped
-    lines downward rather than growing upward from the anchor.  A route grazing
-    only the empty reserved margin clears this box; a route striking through
-    the text intersects it.
+    For an axis-aligned label the horizontal span is the proportional glyph
+    advance (:func:`label_glyph_advance_width`) anchored to match the rendered
+    text, and the vertical span is the renderer's true ink band
+    (:func:`_label_ink_y_band`, which stacks wrapped lines downward rather than
+    growing upward from the anchor).  A route grazing only the empty reserved
+    margin clears this box; a route striking through the text intersects it.
+
+    Rotated or vertically-centred labels keep the reserved-box footprint
+    narrowed by ``LABEL_GLYPH_INK_RATIO``; the advance model is for horizontal
+    text.
     """
     x0, y0, x1, y1 = _label_bbox(placement)
-    center = (x0 + x1) / 2
-    ink_half = (x1 - x0) / 2 * LABEL_GLYPH_INK_RATIO
-    if not placement.angle and not placement.dominant_baseline:
-        y0, y1 = _label_ink_y_band(placement)
-    return (center - ink_half, y0, center + ink_half, y1)
+    if placement.angle or placement.dominant_baseline:
+        center = (x0 + x1) / 2
+        ink_half = (x1 - x0) / 2 * LABEL_GLYPH_INK_RATIO
+        return (center - ink_half, y0, center + ink_half, y1)
+
+    advance = label_glyph_advance_width(placement.text)
+    if placement.text_anchor == "end":
+        gx0, gx1 = placement.x - advance, placement.x
+    elif placement.text_anchor == "start":
+        gx0, gx1 = placement.x, placement.x + advance
+    else:
+        gx0, gx1 = placement.x - advance / 2, placement.x + advance / 2
+    iy0, iy1 = _label_ink_y_band(placement)
+    return (gx0, iy0, gx1, iy1)
+
+
+def _label_ink_quad(placement: LabelPlacement) -> list[tuple[float, float]]:
+    """Corners of the label's drawn-glyph footprint, rotated when angled.
+
+    For an angled label this is the proportional glyph strip
+    (:func:`label_glyph_advance_width` wide, one text-height tall) rotated about
+    the anchor like the renderer's ``rotate(angle, x, y)`` -- a thin diagonal
+    band, not the axis-aligned box that would overstate it.  For a horizontal
+    label it is the four corners of :func:`label_glyph_ink_bbox`.
+    """
+    if placement.angle and placement.obstacle_bbox is None:
+        w = label_glyph_advance_width(placement.text)
+        h = _label_text_height(placement.text)
+        if placement.text_anchor == "end":
+            left, right = placement.x - w, placement.x
+        elif placement.text_anchor == "start":
+            left, right = placement.x, placement.x + w
+        else:
+            left, right = placement.x - w / 2, placement.x + w / 2
+        upright = [
+            (left, placement.y - h),
+            (right, placement.y - h),
+            (right, placement.y),
+            (left, placement.y),
+        ]
+        rad = math.radians(placement.angle)
+        cos_a, sin_a = math.cos(rad), math.sin(rad)
+        ax, ay = placement.x, placement.y
+        return [
+            (
+                ax + (cx - ax) * cos_a - (cy - ay) * sin_a,
+                ay + (cx - ax) * sin_a + (cy - ay) * cos_a,
+            )
+            for cx, cy in upright
+        ]
+    x0, y0, x1, y1 = label_glyph_ink_bbox(placement)
+    return [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+
+
+def segment_strikes_label(
+    x1: float, y1: float, x2: float, y2: float, placement: LabelPlacement
+) -> bool:
+    """``True`` iff the segment crosses the label's drawn-glyph footprint.
+
+    Uses the rotated glyph strip for an angled label (so a route grazing only
+    the empty corner of its axis-aligned box is not a strike) and the
+    glyph-ink bbox otherwise.
+    """
+    if placement.angle and placement.obstacle_bbox is None:
+        return segment_intersects_quad(x1, y1, x2, y2, _label_ink_quad(placement))
+    return segment_intersects_bbox(x1, y1, x2, y2, label_glyph_ink_bbox(placement))
 
 
 def _rotated_label_bbox(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1017,6 +1017,7 @@ def _guard_no_line_strikes_label(
     the segment's edge (that line legitimately touches the station).
     """
     from nf_metro.layout.labels import (
+        LabelPlacement,
         label_glyph_ink_bbox,
         place_labels,
         segment_strikes_label,
@@ -1045,7 +1046,7 @@ def _guard_no_line_strikes_label(
             label_angle=graph.label_angle or 0.0,
         )
         boxes: list[tuple[str, tuple[float, float, float, float]]] = []
-        placement_by_sid: dict[str, object] = {}
+        placement_by_sid: dict[str, LabelPlacement] = {}
         for p in placements:
             station = graph.stations.get(p.station_id)
             if station is None or not station.label.strip():

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1019,6 +1019,7 @@ def _guard_no_line_strikes_label(
     from nf_metro.layout.labels import (
         label_glyph_ink_bbox,
         place_labels,
+        segment_strikes_label,
     )
     from nf_metro.render.svg import _compute_icon_obstacles, apply_route_offsets
     from nf_metro.themes import THEMES
@@ -1044,11 +1045,13 @@ def _guard_no_line_strikes_label(
             label_angle=graph.label_angle or 0.0,
         )
         boxes: list[tuple[str, tuple[float, float, float, float]]] = []
+        placement_by_sid: dict[str, object] = {}
         for p in placements:
             station = graph.stations.get(p.station_id)
             if station is None or not station.label.strip():
                 continue
             boxes.append((p.station_id, label_glyph_ink_bbox(p)))
+            placement_by_sid[p.station_id] = p
         if not boxes:
             return
         index = BBoxXIndex(boxes)
@@ -1069,7 +1072,9 @@ def _guard_no_line_strikes_label(
                         station_lines_cache[sid] = lines
                     if line_id in lines:
                         continue
-                    if segment_intersects_bbox(p1[0], p1[1], p2[0], p2[1], bbox):
+                    if segment_strikes_label(
+                        p1[0], p1[1], p2[0], p2[1], placement_by_sid[sid]
+                    ):
                         raise PhaseInvariantError(
                             f"{phase}: line {line_id!r} on edge {src!r} -> {tgt!r} "
                             f"strikes through label of {sid!r} "

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -17,6 +17,13 @@ _MAX_SPREAD_ITERS = 6
 # spacing, so the re-laid-out labels land with a small gap, not flush.
 _SPREAD_SLACK = 4.0
 
+# Column-pitch increment (px) a spread pass applies while a diagonal crosses a
+# station's name.  A wider pitch lengthens the flat run at each station so the
+# fan transition seats clear of the label.  Small enough to settle near the
+# minimum clearing pitch rather than overshoot into a wider layout's defects;
+# the loop re-probes and stops once the strikes clear.
+_STRIKE_X_STEP = 10.0
+
 
 def _probe_label_placements(
     graph: MetroGraph, *, allow_hyphenation: bool
@@ -109,6 +116,125 @@ def _residual_label_overlaps(
         return bool(st and st.section_id and graph.is_rail_section(st.section_id))
 
     return [o for o in overlaps if not (_in_rail(o.a) or _in_rail(o.b))]
+
+
+def _residual_label_strikes(graph: MetroGraph) -> int:
+    """Count stations whose horizontal label a diagonal route crosses.
+
+    The visual goal driving the spread loop's X widening: a fan-in/fan-out or
+    convergence diagonal (a line the station carries or not) that transitions
+    through a station's drawn name reads as a strike-through.  Widening the
+    column pitch lengthens the flat run at each station so the transition seats
+    outside the label.
+
+    Excluded because widening cannot move them:
+
+    - angled labels (a rotated strip is handled by its own footprint, not
+      column pitch),
+    - bypass-V crossings (the V sits a fixed track offset from the station, so
+      a wider pitch does not relocate its corners -- those need a different
+      fix).
+
+    Snapshots and restores geometry like :func:`_probe_label_placements`.
+    """
+    from nf_metro.layout.labels import (
+        place_labels,
+        segment_strikes_label,
+    )
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.render.svg import apply_route_offsets
+
+    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bbox = {
+        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
+        for sid, s in graph.sections.items()
+    }
+    try:
+        offsets = compute_station_offsets(graph)
+        routes = route_edges(graph, station_offsets=offsets)
+        placements = place_labels(
+            graph,
+            station_offsets=offsets,
+            routes=routes,
+            label_angle=graph.label_angle or 0.0,
+            lift_wrapped_off_trunks=False,
+        )
+        seg_lists = [
+            (
+                r,
+                apply_route_offsets(r, offsets),
+                r.edge.source.startswith("__bypass_")
+                or r.edge.target.startswith("__bypass_"),
+            )
+            for r in routes
+        ]
+        struck = 0
+        for p in placements:
+            station = graph.stations.get(p.station_id)
+            if station is None or not station.label.strip() or p.angle:
+                continue
+            for _r, pts, is_bypass in seg_lists:
+                if is_bypass:
+                    continue
+                if any(
+                    segment_strikes_label(x1, y1, x2, y2, p)
+                    and abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * 0.05
+                    for (x1, y1), (x2, y2) in zip(pts, pts[1:])
+                ):
+                    struck += 1
+                    break
+        return struck
+    except Exception:  # noqa: BLE001 - a transient probe failure never blocks layout
+        return 0
+    finally:
+        for sid, (x, y) in pos.items():
+            st = graph.stations.get(sid)
+            if st is not None:
+                st.x, st.y = x, y
+        for sid, (bx, by, bw, bh) in bbox.items():
+            s = graph.sections.get(sid)
+            if s is not None:
+                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+
+
+def _layout_has_collinear(graph: MetroGraph) -> bool:
+    """Whether the current layout draws two distinct lines on top of each other.
+
+    Probes the offset-applied routes and runs the inter- and intra-section
+    collinear-overlay checks (the same the final-phase guards enforce), so the
+    spread loop can step back a strike-clearing widening that would overshoot
+    into a collinear defect rather than ship it.  Restores geometry like
+    :func:`_probe_label_placements`; returns ``False`` on a probe failure.
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.routing.invariants import (
+        check_intra_section_collinear_distinct_lines,
+        check_no_collinear_distinct_lines,
+    )
+
+    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bbox = {
+        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
+        for sid, s in graph.sections.items()
+    }
+    try:
+        offsets = compute_station_offsets(graph)
+        routes = route_edges(graph, station_offsets=offsets)
+        return bool(
+            check_no_collinear_distinct_lines(graph, routes, offsets)
+            or check_intra_section_collinear_distinct_lines(graph, routes, offsets)
+        )
+    except Exception:  # noqa: BLE001 - a transient probe failure never blocks layout
+        return False
+    finally:
+        for sid, (x, y) in pos.items():
+            st = graph.stations.get(sid)
+            if st is not None:
+                st.x, st.y = x, y
+        for sid, (bx, by, bw, bh) in bbox.items():
+            s = graph.sections.get(sid)
+            if s is not None:
+                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
 
 
 def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from nf_metro.parser.model import MetroGraph
 
 if TYPE_CHECKING:
     from nf_metro.layout.labels import LabelOverlap, LabelPlacement
+    from nf_metro.layout.routing.common import RoutedPath
 
 # Cap on spread-loop passes.  Each pass strictly widens the binding axis,
 # so a handful suffices to clear any realistic crowding before giving up.
@@ -25,19 +28,52 @@ _SPREAD_SLACK = 4.0
 _STRIKE_X_STEP = 10.0
 
 
+_Probe = tuple[
+    dict[tuple[str, str], float],
+    "list[RoutedPath]",
+    "list[LabelPlacement]",
+]
+
+# Slope above which a route segment counts as a diagonal (not a flat trunk
+# run): |dy| >= |dx| * this.  A diagonal is what can rake a station label.
+_DIAGONAL_SLOPE_RATIO = 0.05
+
+
+@contextmanager
+def _restored_layout_geometry(graph: MetroGraph) -> Iterator[None]:
+    """Restore station coordinates and section bboxes on exit.
+
+    Routing and placement mutate the graph in place (route_edges nudges station
+    X for bundle separation; place_labels expands section bboxes to fit labels),
+    so a probe that runs them must undo the mutations before returning.
+    """
+    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bbox = {
+        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
+        for sid, s in graph.sections.items()
+    }
+    try:
+        yield
+    finally:
+        for sid, (x, y) in pos.items():
+            st = graph.stations.get(sid)
+            if st is not None:
+                st.x, st.y = x, y
+        for sid, (bx, by, bw, bh) in bbox.items():
+            s = graph.sections.get(sid)
+            if s is not None:
+                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+
+
 def _probe_label_placements(
     graph: MetroGraph, *, allow_hyphenation: bool
-) -> tuple[dict[tuple[str, str], float], list[LabelPlacement]] | None:
+) -> _Probe | None:
     """Run the renderer's offset/route/label pipeline at the current layout.
 
-    Returns the computed ``(station_offsets, placements)`` so callers can
-    inspect the settled labelling the renderer would draw, or ``None`` if
-    routing/placement raises (a transient failure never blocks layout).
-
-    Routing and placement mutate the graph (route_edges nudges station X for
-    bundle separation; place_labels expands section bboxes to fit labels).
-    This probe snapshots station coordinates and section bboxes and restores
-    them, so it never leaks those mutations into the positioned state.
+    Returns the computed ``(station_offsets, routes, placements)`` so callers
+    can inspect the settled geometry and labelling the renderer would draw, or
+    ``None`` if routing/placement raises (a transient failure never blocks
+    layout).  Snapshots and restores the in-place mutations route/place make.
 
     The render-time wrapped-label trunk lift is held off here so the spacing
     search and the label-overlap guard reason about the unlifted geometry; the
@@ -47,54 +83,29 @@ def _probe_label_placements(
     from nf_metro.layout.labels import place_labels
     from nf_metro.layout.routing import compute_station_offsets, route_edges
 
-    # Resolve the effective label angle so the spread search sizes column
-    # spacing for the same (possibly rotated, hence narrower) footprint the
-    # renderer will draw.  graph.label_angle is None when no directive set it;
-    # the theme default is horizontal (0), so None -> 0 here (#527).
-    label_angle = graph.label_angle or 0.0
-
-    pos_snapshot = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bbox_snapshot = {
-        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
-        for sid, s in graph.sections.items()
-    }
-    try:
-        offsets = compute_station_offsets(graph)
-        routes = route_edges(graph, station_offsets=offsets)
-        placements = place_labels(
-            graph,
-            station_offsets=offsets,
-            routes=routes,
-            allow_hyphenation=allow_hyphenation,
-            label_angle=label_angle,
-            lift_wrapped_off_trunks=False,
-        )
-        return offsets, placements
-    except Exception:
-        return None
-    finally:
-        for sid, (x, y) in pos_snapshot.items():
-            st = graph.stations.get(sid)
-            if st is not None:
-                st.x, st.y = x, y
-        for sid, (bx, by, bw, bh) in bbox_snapshot.items():
-            s = graph.sections.get(sid)
-            if s is not None:
-                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+    with _restored_layout_geometry(graph):
+        try:
+            offsets = compute_station_offsets(graph)
+            routes = route_edges(graph, station_offsets=offsets)
+            placements = place_labels(
+                graph,
+                station_offsets=offsets,
+                routes=routes,
+                allow_hyphenation=allow_hyphenation,
+                label_angle=graph.label_angle or 0.0,
+                lift_wrapped_off_trunks=False,
+            )
+            return offsets, routes, placements
+        except Exception:
+            return None
 
 
-def _residual_label_overlaps(
-    graph: MetroGraph, *, allow_hyphenation: bool
+def _overlaps_from(
+    graph: MetroGraph,
+    offsets: dict[tuple[str, str], float],
+    placements: list[LabelPlacement],
 ) -> list[LabelOverlap]:
-    """Place labels at the current layout and report leftover overlaps.
-
-    Returns the overlaps that wrapping could not resolve, or an empty list if
-    routing/placement raises.
-
-    The spread loop calls this with ``allow_hyphenation=False`` so residual
-    overlaps surface (to be cleared by widening spacing rather than by
-    hard-breaking words); the final guard calls it with True to validate the
-    settled, fully wrapped state the renderer will draw.
+    """Leftover label overlaps in a probed placement set.
 
     Overlaps involving a rail-section station are dropped: rail sections run a
     dedicated layout with their own column pitch, so widening the normal global
@@ -103,10 +114,6 @@ def _residual_label_overlaps(
     """
     from nf_metro.layout.labels import find_label_overlaps
 
-    probe = _probe_label_placements(graph, allow_hyphenation=allow_hyphenation)
-    if probe is None:
-        return []
-    offsets, placements = probe
     overlaps = find_label_overlaps(graph, placements, offsets)
     if not graph.has_rail_sections:
         return overlaps
@@ -118,7 +125,12 @@ def _residual_label_overlaps(
     return [o for o in overlaps if not (_in_rail(o.a) or _in_rail(o.b))]
 
 
-def _residual_label_strikes(graph: MetroGraph) -> int:
+def _strikes_from(
+    graph: MetroGraph,
+    offsets: dict[tuple[str, str], float],
+    routes: list[RoutedPath],
+    placements: list[LabelPlacement],
+) -> int:
     """Count stations whose horizontal label a diagonal route crosses.
 
     The visual goal driving the spread loop's X widening: a fan-in/fan-out or
@@ -134,107 +146,100 @@ def _residual_label_strikes(graph: MetroGraph) -> int:
     - bypass-V crossings (the V sits a fixed track offset from the station, so
       a wider pitch does not relocate its corners -- those need a different
       fix).
-
-    Snapshots and restores geometry like :func:`_probe_label_placements`.
     """
-    from nf_metro.layout.labels import (
-        place_labels,
-        segment_strikes_label,
-    )
-    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.labels import segment_strikes_label
     from nf_metro.render.svg import apply_route_offsets
 
-    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bbox = {
-        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
-        for sid, s in graph.sections.items()
-    }
-    try:
-        offsets = compute_station_offsets(graph)
-        routes = route_edges(graph, station_offsets=offsets)
-        placements = place_labels(
-            graph,
-            station_offsets=offsets,
-            routes=routes,
-            label_angle=graph.label_angle or 0.0,
-            lift_wrapped_off_trunks=False,
+    seg_lists = [
+        (
+            apply_route_offsets(r, offsets),
+            r.edge.source.startswith("__bypass_")
+            or r.edge.target.startswith("__bypass_"),
         )
-        seg_lists = [
-            (
-                r,
-                apply_route_offsets(r, offsets),
-                r.edge.source.startswith("__bypass_")
-                or r.edge.target.startswith("__bypass_"),
-            )
-            for r in routes
-        ]
-        struck = 0
-        for p in placements:
-            station = graph.stations.get(p.station_id)
-            if station is None or not station.label.strip() or p.angle:
+        for r in routes
+    ]
+    struck = 0
+    for p in placements:
+        station = graph.stations.get(p.station_id)
+        if station is None or not station.label.strip() or p.angle:
+            continue
+        for pts, is_bypass in seg_lists:
+            if is_bypass:
                 continue
-            for _r, pts, is_bypass in seg_lists:
-                if is_bypass:
-                    continue
-                if any(
-                    segment_strikes_label(x1, y1, x2, y2, p)
-                    and abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * 0.05
-                    for (x1, y1), (x2, y2) in zip(pts, pts[1:])
-                ):
-                    struck += 1
-                    break
-        return struck
-    except Exception:  # noqa: BLE001 - a transient probe failure never blocks layout
-        return 0
-    finally:
-        for sid, (x, y) in pos.items():
-            st = graph.stations.get(sid)
-            if st is not None:
-                st.x, st.y = x, y
-        for sid, (bx, by, bw, bh) in bbox.items():
-            s = graph.sections.get(sid)
-            if s is not None:
-                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+            if any(
+                segment_strikes_label(x1, y1, x2, y2, p)
+                and abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * _DIAGONAL_SLOPE_RATIO
+                for (x1, y1), (x2, y2) in zip(pts, pts[1:])
+            ):
+                struck += 1
+                break
+    return struck
 
 
-def _layout_has_collinear(graph: MetroGraph) -> bool:
-    """Whether the current layout draws two distinct lines on top of each other.
+def _collinear_from(
+    graph: MetroGraph,
+    offsets: dict[tuple[str, str], float],
+    routes: list[RoutedPath],
+) -> bool:
+    """Whether probed routes draw two distinct lines on top of each other.
 
-    Probes the offset-applied routes and runs the inter- and intra-section
-    collinear-overlay checks (the same the final-phase guards enforce), so the
-    spread loop can step back a strike-clearing widening that would overshoot
-    into a collinear defect rather than ship it.  Restores geometry like
-    :func:`_probe_label_placements`; returns ``False`` on a probe failure.
+    Runs the inter- and intra-section collinear-overlay checks the final-phase
+    guards enforce, so the spread loop can step back a strike-clearing widening
+    that would overshoot into a collinear defect rather than ship it.
     """
-    from nf_metro.layout.routing import compute_station_offsets, route_edges
     from nf_metro.layout.routing.invariants import (
         check_intra_section_collinear_distinct_lines,
         check_no_collinear_distinct_lines,
     )
 
-    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bbox = {
-        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
-        for sid, s in graph.sections.items()
-    }
-    try:
-        offsets = compute_station_offsets(graph)
-        routes = route_edges(graph, station_offsets=offsets)
-        return bool(
-            check_no_collinear_distinct_lines(graph, routes, offsets)
-            or check_intra_section_collinear_distinct_lines(graph, routes, offsets)
-        )
-    except Exception:  # noqa: BLE001 - a transient probe failure never blocks layout
+    return bool(
+        check_no_collinear_distinct_lines(graph, routes, offsets)
+        or check_intra_section_collinear_distinct_lines(graph, routes, offsets)
+    )
+
+
+def _residual_label_overlaps(
+    graph: MetroGraph, *, allow_hyphenation: bool
+) -> list[LabelOverlap]:
+    """Place labels at the current layout and report leftover overlaps.
+
+    The spread loop calls this with ``allow_hyphenation=False`` so residual
+    overlaps surface (to be cleared by widening spacing rather than by
+    hard-breaking words); the final guard calls it with True to validate the
+    settled, fully wrapped state the renderer will draw.  Returns an empty list
+    if routing/placement raises.
+    """
+    probe = _probe_label_placements(graph, allow_hyphenation=allow_hyphenation)
+    if probe is None:
+        return []
+    offsets, _routes, placements = probe
+    return _overlaps_from(graph, offsets, placements)
+
+
+def _residual_label_strikes(graph: MetroGraph) -> int:
+    """Stations whose horizontal label a diagonal route crosses (or 0 on probe
+    failure).  See :func:`_strikes_from`.
+
+    Probes with ``allow_hyphenation=True`` -- the renderer-faithful wrapping --
+    so a strike is judged against the label the renderer actually draws (unlike
+    the overlap probe, which suppresses hyphenation so residuals surface for the
+    spacing search).
+    """
+    probe = _probe_label_placements(graph, allow_hyphenation=True)
+    if probe is None:
+        return 0
+    offsets, routes, placements = probe
+    return _strikes_from(graph, offsets, routes, placements)
+
+
+def _layout_has_collinear(graph: MetroGraph) -> bool:
+    """Whether the current layout draws two distinct lines on top of each other
+    (or ``False`` on probe failure).  See :func:`_collinear_from`."""
+    probe = _probe_label_placements(graph, allow_hyphenation=False)
+    if probe is None:
         return False
-    finally:
-        for sid, (x, y) in pos.items():
-            st = graph.stations.get(sid)
-            if st is not None:
-                st.x, st.y = x, y
-        for sid, (bx, by, bw, bh) in bbox.items():
-            s = graph.sections.get(sid)
-            if s is not None:
-                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+    offsets, routes, _placements = probe
+    return _collinear_from(graph, offsets, routes)
 
 
 def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:
@@ -247,7 +252,7 @@ def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:
     probe = _probe_label_placements(graph, allow_hyphenation=True)
     if probe is None:
         return set()
-    _offsets, placements = probe
+    _offsets, _routes, placements = probe
     return {p.station_id for p in placements if p.station_id}
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1276,18 +1276,14 @@ def test_off_track_outputs_below_downward_branch_producer(fixture):
         )
 
 
-# Fixtures where a foreign fan/bypass diagonal rakes a wide label's glyph ink.
-# Clearing the diagonal needs the column widened so its corner seats clear of
-# the label, but the required amount depends on which side ``place_labels``
-# lands the label (a label flipped away from the diagonal is not struck), which
-# is only known after routing -- the column-sizing phase runs before that.  The
-# runtime guard ``_guard_no_line_strikes_label`` flags these; the widening
-# auto-fix is tracked as a follow-up.
+# Fixtures where a foreign bypass V rakes a wide label's glyph ink on BOTH
+# sides of its station, so flipping the label to its other side does not clear
+# it (``_avoid_diagonal_strikethrough`` leaves a label whose flip target is also
+# struck).  Clearing these needs the V's flat run widened past the label or the
+# label moved, not a side flip -- tracked as a follow-up.
 _LABEL_STRIKE_DIAGONAL_XFAIL = {
-    "topologies/funcprofiler_upstream.mmd": "fan diagonal rakes 'FMH FunProfiler'",
-    "guide/06a_without_hidden.mmd": "bypass diagonal rakes 'Quantification'",
-    "guide/06b_with_hidden.mmd": "bypass diagonal rakes 'Quantification'",
-    "da_pipeline.mmd": "bypass diagonal rakes 'annotate'",
+    "guide/06a_without_hidden.mmd": "bypass V rakes 'Quantification' both sides",
+    "guide/06b_with_hidden.mmd": "bypass V rakes 'Quantification' both sides",
 }
 
 _LABEL_STRIKE_FIXTURES = _params_with_xfails(ALL_FIXTURES, _LABEL_STRIKE_DIAGONAL_XFAIL)
@@ -1356,15 +1352,16 @@ def test_label_strike_guard_catches_a_strike():
     """The runtime guard fires on a genuine glyph strike and clears a graze.
 
     Locks the guard's teeth and its glyph-ink discrimination: a fixture whose
-    fan diagonal rakes a wide label's glyphs must raise, while one where a line
-    only clips a label's empty reserved margin must pass.
+    bypass V rakes a wide label's glyphs on both sides (no flip clears it) must
+    raise, while one where a line only clips a label's empty reserved margin
+    must pass.
     """
     from nf_metro.layout.phases.guards import (
         PhaseInvariantError,
         _guard_no_line_strikes_label,
     )
 
-    struck = _layout("topologies/funcprofiler_upstream.mmd")
+    struck = _layout("guide/06a_without_hidden.mmd")
     with pytest.raises(PhaseInvariantError, match="strikes through label"):
         _guard_no_line_strikes_label(struck, "test")
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -40,8 +40,8 @@ from nf_metro.layout.geometry import segment_intersects_bbox
 from nf_metro.layout.labels import (
     _label_bbox,
     find_wrapped_label_trunk_strikes,
-    label_glyph_ink_bbox,
     place_labels,
+    segment_strikes_label,
 )
 from nf_metro.layout.phases._common import _grow_section_bbox_upward
 from nf_metro.layout.phases.bbox import (
@@ -1315,7 +1315,6 @@ def _label_glyph_strikes(fixture: str) -> list[tuple[str, str]]:
         station = graph.stations.get(p.station_id)
         if station is None or not station.label.strip():
             continue
-        ink = label_glyph_ink_bbox(p)
         carried = set(graph.station_lines(p.station_id))
         for r in routes:
             if r.edge.source == p.station_id or r.edge.target == p.station_id:
@@ -1324,7 +1323,7 @@ def _label_glyph_strikes(fixture: str) -> list[tuple[str, str]]:
                 continue
             pts = apply_route_offsets(r, offsets)
             if any(
-                segment_intersects_bbox(x1, y1, x2, y2, ink)
+                segment_strikes_label(x1, y1, x2, y2, p)
                 for (x1, y1), (x2, y2) in zip(pts, pts[1:])
             ):
                 strikes.append((p.station_id, r.line_id))

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1279,11 +1279,12 @@ def test_off_track_outputs_below_downward_branch_producer(fixture):
 # Fixtures where a foreign bypass V rakes a wide label's glyph ink on BOTH
 # sides of its station, so flipping the label to its other side does not clear
 # it (``_avoid_diagonal_strikethrough`` leaves a label whose flip target is also
-# struck).  Clearing these needs the V's flat run widened past the label or the
-# label moved, not a side flip -- tracked as a follow-up.
+# struck) and widening the column pitch does not relocate the V's corners.
+# Clearing these needs the V's flat-bottom run widened past the bypassed
+# station's label.
 _LABEL_STRIKE_DIAGONAL_XFAIL = {
-    "guide/06a_without_hidden.mmd": "bypass V rakes 'Quantification' both sides",
-    "guide/06b_with_hidden.mmd": "bypass V rakes 'Quantification' both sides",
+    "guide/06a_without_hidden.mmd": "#632: bypass V rakes 'Quantification' both sides",
+    "guide/06b_with_hidden.mmd": "#632: bypass V rakes 'Quantification' both sides",
 }
 
 _LABEL_STRIKE_FIXTURES = _params_with_xfails(ALL_FIXTURES, _LABEL_STRIKE_DIAGONAL_XFAIL)


### PR DESCRIPTION
## Summary

Station name labels were being crossed by metro lines (reading as strike-throughs). Visual review on real renders showed this spans several distinct mechanisms; accurate measurement was the prerequisite to see them all. This PR fixes the measurement and three of the mechanisms.

### Accurate label-width measurement
`label_text_width` used a fixed `CHAR_WIDTH` per glyph, which under-measured wide all-caps names (`MERGE_RUNS`) and over-measured narrow ones. The glyph-ink box now uses a Helvetica-Bold advance-width table scaled by font size (a static baked constant - no runtime font dependency, layout stays deterministic). Reserve/collision spacing keeps the generous fixed budget.

### Orientation-aware strike detection
A strike is now tested against a label's drawn footprint: the rotated glyph strip for an angled (`label_angle`) label rather than its axis-aligned bounding box. This removes false positives where a route grazed only the empty corner of a 45-degree label's box (e.g. `sarek_metro`, `diagonal_labels`) - so those renders are untouched.

### Flip off a foreign diagonal (from the prior commit)
`_avoid_diagonal_strikethrough` flips a label off a foreign diagonal when its other side is clear (glyph-ink + foreign, matching the guard). Clears `da_pipeline` ("Annotate results").

### Widen the column pitch to clear fan/convergence diagonals
A fan-in/fan-out or convergence diagonal that transitions through a station's name is cleared by widening the column pitch so the station's flat run brackets the label. The spread loop detects these crossings (excluding bypass-V and angled cases a wider pitch can't fix) and steps the pitch up to the smallest value that clears them; a step that would overshoot into a collinear-distinct-lines overlay is stepped back. Clears `funcprofiler_upstream` (FMH FunProfiler, MERGE_RUNS), `rnaseq_sections` (Kraken2/Bracken) and `variant_calling` (DeepVariant).

`funcprofiler_upstream` is added to the gallery as the demonstrator.

## Still open (tracked)
- **Bypass-V both-sides rake** (`guide/06a`, `guide/06b` - "Quantification"): a `prot` bypass V dips below the station and its ascending corner rakes the wide label; no side flip or column widening relocates it (the V sits a fixed offset from the station). Needs the bypass V's flat-bottom made aware of the bypassed station's label - separable routing work. Remains strict `xfail`; tracked in #632.
- The strike guard is intentionally **not** wired into the validate pass yet, since that bypass-V clip would trip it; wiring is deferred to the follow-up that clears it.

## Test plan
- [x] Full suite green (6941 passed, 7 xfailed); ruff clean
- [x] Gallery: 78 renders byte-identical; only funcprofiler_upstream (new), rnaseq_sections(+manual), variant_calling change - all label-clip fixes, verified visually
- [x] Orientation-aware detection removes the angled false positives (sarek flagship unchanged)
- [ ] Render-preview verdict captured

Fixes #513 (bypass-V residual tracked in #632)

Generated with Claude Code
