### PR TITLE
fix(layout): clear fan-diagonal label strikes via grid-quantized runway growth (#513)

### DIFF
--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -250,6 +250,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "the metro line on the track above; the label is pulled back to its "
         "un-pushed anchor so the name clears the line.",
     ),
+    (
+        "funcprofiler_upstream",
+        TOPOLOGIES_DIR,
+        "A profiling section whose stacked tools share a fan-in/fan-out: a line "
+        "the 'FMH FunProfiler' station does not carry would rake its wide "
+        "below-station label, so the label flips to its clear side and the "
+        "diagonal no longer strikes the glyphs.",
+    ),
     # --- Branching and multipath ---
     (
         "asymmetric_tree",

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -270,6 +270,10 @@ COORD_TOLERANCE_FINE: float = 0.01
 SAME_Y_TOLERANCE: float = 0.1
 """Tolerance for treating two stations as sharing a base Y row."""
 
+DIAGONAL_SLOPE_RATIO: float = 0.05
+"""Slope above which a route segment counts as a diagonal (``|dy| >= |dx| *
+this``) rather than a flat trunk run.  A diagonal is what can rake a label."""
+
 CROSS_ROW_THRESHOLD: float = 80.0
 """Y gap threshold for detecting cross-row (fold) edges."""
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -539,21 +539,21 @@ def _compute_layout_scaled(
     # Strike-clearance: a fan-in/fan-out, convergence, or descent diagonal that
     # rakes a station's name label is cleared by lengthening the flat run at that
     # station by whole grid columns (the pitch stays fixed), seating the
-    # transition outside the label.  Two complementary, grid-quantized levers:
-    # the section's entry/exit runway for a boundary-fan strike, and a per-column
-    # gap before the struck station's layer for an intra-section descent.
+    # transition outside the label.  Three grid-quantized levers, each a
+    # ``(kind, section, layer)`` triple: the section's entry-side runway, its
+    # exit-side runway, and a per-column gap before the struck station's layer.
     # Need-driven: only stations the renderer would draw a strike through grow,
     # so a clean layout -- every gallery render at its default pitch -- is left
     # untouched.  Independent of pinned vs auto pitch: the room is local, not the
     # global pitch, so it applies even when the caller fixed x_spacing.
     #
-    # A grow step bumps both levers at every struck station -- which lever
-    # actually relocates a given strike is hard to know in advance -- then a
-    # minimization pass strips every lever that turns out not to be load-bearing,
-    # so the settled layout carries the least extra width that keeps the labels
-    # clear.  A step a collinear check rejects, or that fails to reduce the
-    # struck count, is rolled back, so the loop never ships a layout worse than
-    # it found.
+    # A grow step bumps every lever at each struck station -- which one relocates
+    # a given strike is hard to know in advance -- then a minimization pass
+    # strips each lever that turns out not to be load-bearing, so the settled
+    # layout carries the least extra width that keeps the labels clear (a strike
+    # cleared by one side does not leave the other's room behind).  A step a
+    # collinear check rejects, or that fails to reduce the struck count, is
+    # rolled back, so the loop never ships a layout worse than it found.
 
     def _relay() -> None:
         _layout_once(
@@ -580,62 +580,73 @@ def _compute_layout_scaled(
             return None
         return sec, st.layer
 
-    def _add_runway(sid: str, delta: int) -> None:
-        graph.sections[sid].label_strike_cols += delta
-
-    def _add_gap(sid: str, layer: int, delta: int) -> None:
-        lg = graph.sections[sid].label_strike_layer_gaps
-        lg[layer] = lg.get(layer, 0) + delta
-        if lg[layer] <= 0:
-            del lg[layer]
+    def _adjust(lever: tuple[str, str, int], delta: int) -> None:
+        kind, sid, layer = lever
+        sec = graph.sections[sid]
+        if kind == "entry":
+            sec.label_strike_entry_cols += delta
+        elif kind == "exit":
+            sec.label_strike_exit_cols += delta
+        else:
+            lg = sec.label_strike_layer_gaps
+            lg[layer] = lg.get(layer, 0) + delta
+            if lg[layer] <= 0:
+                del lg[layer]
 
     struck, _ = _struck_stations_and_collinear(graph)
     for _ in range(_MAX_SPREAD_ITERS):
-        targets = [t for sid in struck if (t := _growable_target(sid)) is not None]
-        runway = {sec.id for sec, _ in targets}
-        gaps = {(sec.id, layer) for sec, layer in targets}
-        if not runway and not gaps:
+        levers: set[tuple[str, str, int]] = set()
+        for sid in struck:
+            target = _growable_target(sid)
+            if target is None:
+                continue
+            sec, layer = target
+            levers |= {
+                ("entry", sec.id, 0),
+                ("exit", sec.id, 0),
+                ("gap", sec.id, layer),
+            }
+        if not levers:
             break
-        for sid in runway:
-            _add_runway(sid, 1)
-        for sid, layer in gaps:
-            _add_gap(sid, layer, 1)
+        for lever in levers:
+            _adjust(lever, 1)
         _relay()
         after, collinear = _struck_stations_and_collinear(graph)
         if collinear or len(after) >= len(struck):
-            for sid in runway:
-                _add_runway(sid, -1)
-            for sid, layer in gaps:
-                _add_gap(sid, layer, -1)
+            for lever in levers:
+                _adjust(lever, -1)
             _relay()
             break
         struck = after
 
-    # Minimization: drop each grown lever one at a time; keep the drop only when
-    # the labels stay clear and no collinear overlay appears, so a strike cleared
-    # by one lever does not leave the other's width behind.  Skipped entirely
-    # when nothing grew, so a clean layout never pays a re-lay (and is never
-    # perturbed by one).
-    grown: list[tuple[str, int | None]] = [
-        (sid, None) for sid, sec in graph.sections.items() if sec.label_strike_cols
-    ] + [
-        (sid, gap_layer)
-        for sid, sec in graph.sections.items()
-        for gap_layer in list(sec.label_strike_layer_gaps)
-    ]
+    # Minimization: drop each grown lever one at a time, keeping the drop only
+    # when the labels stay clear and no collinear overlay appears.  Skipped
+    # entirely when nothing grew, so a clean layout never pays a re-lay (and is
+    # never perturbed by one).
+    grown: list[tuple[str, str, int]] = (
+        [
+            ("entry", sid, 0)
+            for sid, sec in graph.sections.items()
+            if sec.label_strike_entry_cols
+        ]
+        + [
+            ("exit", sid, 0)
+            for sid, sec in graph.sections.items()
+            if sec.label_strike_exit_cols
+        ]
+        + [
+            ("gap", sid, layer)
+            for sid, sec in graph.sections.items()
+            for layer in list(sec.label_strike_layer_gaps)
+        ]
+    )
     if grown:
-        for sid, gap_layer in grown:
-            if gap_layer is None:
-                _add_runway(sid, -1)
-            else:
-                _add_gap(sid, gap_layer, -1)
+        for lever in grown:
+            _adjust(lever, -1)
             _relay()
             still_struck, collinear = _struck_stations_and_collinear(graph)
             if still_struck or collinear:
-                if gap_layer is None:
-                    _add_runway(sid, 1)
-                else:
-                    _add_gap(sid, gap_layer, 1)
+                _adjust(lever, 1)
         _relay()
 
     # Assure file-icon leaf sinks off the trunk by construction: a leaf icon

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -244,10 +244,9 @@ from nf_metro.layout.phases.snapshots import (
 from nf_metro.layout.phases.spacing import (  # noqa: F401
     _MAX_SPREAD_ITERS,
     _SPREAD_SLACK,
-    _layout_has_collinear,
     _residual_label_overlaps,
-    _residual_label_strike_sections,
     _spread_bump,
+    _strike_sections_and_collinear,
 )
 from nf_metro.parser.model import LineSpread, MetroGraph
 
@@ -562,8 +561,8 @@ def _compute_layout_scaled(
             validate=validate,
         )
 
+    struck, _ = _strike_sections_and_collinear(graph)
     for _ in range(_MAX_SPREAD_ITERS):
-        struck = _residual_label_strike_sections(graph)
         grow = {
             sid
             for sid in struck
@@ -576,13 +575,13 @@ def _compute_layout_scaled(
         for sid in grow:
             graph.sections[sid].label_strike_cols += 1
         _relay()
-        if _layout_has_collinear(graph) or len(
-            _residual_label_strike_sections(graph)
-        ) >= len(struck):
+        after, collinear = _strike_sections_and_collinear(graph)
+        if collinear or len(after) >= len(struck):
             for sid in grow:
                 graph.sections[sid].label_strike_cols -= 1
             _relay()
             break
+        struck = after
 
     # Assure file-icon leaf sinks off the trunk by construction: a leaf icon
     # the laid-out routes rake a line across is taken off-track and the layout

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -593,6 +593,15 @@ def _compute_layout_scaled(
             if lg[layer] <= 0:
                 del lg[layer]
 
+    def _lever_value(lever: tuple[str, str, int]) -> int:
+        kind, sid, layer = lever
+        sec = graph.sections[sid]
+        if kind == "entry":
+            return sec.label_strike_entry_cols
+        if kind == "exit":
+            return sec.label_strike_exit_cols
+        return sec.label_strike_layer_gaps.get(layer, 0)
+
     struck, _ = _struck_stations_and_collinear(graph)
     for _ in range(_MAX_SPREAD_ITERS):
         levers: set[tuple[str, str, int]] = set()
@@ -619,10 +628,10 @@ def _compute_layout_scaled(
             break
         struck = after
 
-    # Minimization: drop each grown lever one at a time, keeping the drop only
-    # when the labels stay clear and no collinear overlay appears.  Skipped
-    # entirely when nothing grew, so a clean layout never pays a re-lay (and is
-    # never perturbed by one).
+    # Minimization: shrink each grown lever column by column, keeping a drop only
+    # while the labels stay clear and no collinear overlay appears, so every
+    # lever lands at its least load-bearing value.  Skipped entirely when nothing
+    # grew, so a clean layout never pays a re-lay (and is never perturbed by one).
     grown: list[tuple[str, str, int]] = (
         [
             ("entry", sid, 0)
@@ -642,11 +651,13 @@ def _compute_layout_scaled(
     )
     if grown:
         for lever in grown:
-            _adjust(lever, -1)
-            _relay()
-            still_struck, collinear = _struck_stations_and_collinear(graph)
-            if still_struck or collinear:
-                _adjust(lever, 1)
+            while _lever_value(lever) > 0:
+                _adjust(lever, -1)
+                _relay()
+                still_struck, collinear = _struck_stations_and_collinear(graph)
+                if still_struck or collinear:
+                    _adjust(lever, 1)
+                    break
         _relay()
 
     # Assure file-icon leaf sinks off the trunk by construction: a leaf icon

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -246,9 +246,9 @@ from nf_metro.layout.phases.spacing import (  # noqa: F401
     _SPREAD_SLACK,
     _residual_label_overlaps,
     _spread_bump,
-    _strike_sections_and_collinear,
+    _struck_stations_and_collinear,
 )
-from nf_metro.parser.model import LineSpread, MetroGraph
+from nf_metro.parser.model import LineSpread, MetroGraph, Section
 
 # ---------------------------------------------------------------------------
 # Stage-boundary guards
@@ -536,16 +536,19 @@ def _compute_layout_scaled(
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y
 
-    # Strike-clearance loop: a fan-in/fan-out diagonal that rakes a stacked
-    # station's wide name label is cleared by lengthening that section's flat
-    # runs by whole grid columns (the pitch stays fixed), seating the diagonal
-    # transition outside the label.  Need-driven: only sections the renderer
-    # would draw a strike through grow, so a clean layout -- every gallery
-    # render at its default pitch -- is left untouched.  A growth a collinear
-    # check rejects, or that fails to reduce the struck-section count, is rolled
-    # back, so the loop never ships a layout worse than it found.  Independent
-    # of pinned vs auto pitch: growing a section's runway is local room, not the
-    # global pitch, so it applies even when the caller fixed x_spacing.
+    # Strike-clearance loop: a fan-in/fan-out, convergence, or descent diagonal
+    # that rakes a station's name label is cleared by lengthening the flat run
+    # at that station by whole grid columns (the pitch stays fixed), seating the
+    # transition outside the label.  Two complementary, grid-quantized levers:
+    # the section's entry/exit runway (clears strikes from the section's own
+    # port fan) and a per-column gap before the struck station's layer (clears
+    # an intra-section station-to-station descent).  Need-driven: only stations
+    # the renderer would draw a strike through grow, so a clean layout -- every
+    # gallery render at its default pitch -- is left untouched.  A growth a
+    # collinear check rejects, or that fails to reduce the struck count, is
+    # rolled back, so the loop never ships a layout worse than it found.
+    # Independent of pinned vs auto pitch: the room is local, not the global
+    # pitch, so it applies even when the caller fixed x_spacing.
 
     def _relay() -> None:
         _layout_once(
@@ -561,24 +564,39 @@ def _compute_layout_scaled(
             validate=validate,
         )
 
-    struck, _ = _strike_sections_and_collinear(graph)
+    def _growable_target(station_id: str) -> tuple[Section, int] | None:
+        st = graph.stations.get(station_id)
+        if st is None or not st.section_id:
+            return None
+        sec = graph.sections.get(st.section_id)
+        if sec is None or sec.direction not in ("LR", "RL"):
+            return None
+        if graph.is_rail_section(sec.id):
+            return None
+        return sec, st.layer
+
+    struck, _ = _struck_stations_and_collinear(graph)
     for _ in range(_MAX_SPREAD_ITERS):
-        grow = {
-            sid
-            for sid in struck
-            if (sec := graph.sections.get(sid)) is not None
-            and sec.direction in ("LR", "RL")
-            and not graph.is_rail_section(sid)
-        }
-        if not grow:
+        targets = [t for sid in struck if (t := _growable_target(sid)) is not None]
+        if not targets:
             break
-        for sid in grow:
+        runway = {sec.id for sec, _ in targets}
+        gaps = {(sec.id, layer) for sec, layer in targets}
+        for sid in runway:
             graph.sections[sid].label_strike_cols += 1
+        for sid, layer in gaps:
+            lg = graph.sections[sid].label_strike_layer_gaps
+            lg[layer] = lg.get(layer, 0) + 1
         _relay()
-        after, collinear = _strike_sections_and_collinear(graph)
+        after, collinear = _struck_stations_and_collinear(graph)
         if collinear or len(after) >= len(struck):
-            for sid in grow:
+            for sid in runway:
                 graph.sections[sid].label_strike_cols -= 1
+            for sid, layer in gaps:
+                lg = graph.sections[sid].label_strike_layer_gaps
+                lg[layer] -= 1
+                if lg[layer] <= 0:
+                    del lg[layer]
             _relay()
             break
         struck = after

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -128,6 +128,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_no_artefactual_counter_flow,
     _guard_no_coincident_station_coords,
     _guard_no_collinear_distinct_lines,
+    _guard_no_diagonal_strikes_horizontal_label,
     _guard_no_intra_section_collinear_distinct_lines,
     _guard_no_label_overlap,
     _guard_no_line_crosses_file_icon,
@@ -243,7 +244,9 @@ from nf_metro.layout.phases.snapshots import (
 from nf_metro.layout.phases.spacing import (  # noqa: F401
     _MAX_SPREAD_ITERS,
     _SPREAD_SLACK,
+    _layout_has_collinear,
     _residual_label_overlaps,
+    _residual_label_strike_sections,
     _spread_bump,
 )
 from nf_metro.parser.model import LineSpread, MetroGraph
@@ -534,6 +537,53 @@ def _compute_layout_scaled(
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y
 
+    # Strike-clearance loop: a fan-in/fan-out diagonal that rakes a stacked
+    # station's wide name label is cleared by lengthening that section's flat
+    # runs by whole grid columns (the pitch stays fixed), seating the diagonal
+    # transition outside the label.  Need-driven: only sections the renderer
+    # would draw a strike through grow, so a clean layout -- every gallery
+    # render at its default pitch -- is left untouched.  A growth a collinear
+    # check rejects, or that fails to reduce the struck-section count, is rolled
+    # back, so the loop never ships a layout worse than it found.  Independent
+    # of pinned vs auto pitch: growing a section's runway is local room, not the
+    # global pitch, so it applies even when the caller fixed x_spacing.
+
+    def _relay() -> None:
+        _layout_once(
+            graph,
+            x_spacing=x_spacing,
+            y_spacing=y_spacing,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+            section_x_gap=section_x_gap,
+            section_y_gap=section_y_gap,
+            validate=validate,
+        )
+
+    for _ in range(_MAX_SPREAD_ITERS):
+        struck = _residual_label_strike_sections(graph)
+        grow = {
+            sid
+            for sid in struck
+            if (sec := graph.sections.get(sid)) is not None
+            and sec.direction in ("LR", "RL")
+            and not graph.is_rail_section(sid)
+        }
+        if not grow:
+            break
+        for sid in grow:
+            graph.sections[sid].label_strike_cols += 1
+        _relay()
+        if _layout_has_collinear(graph) or len(
+            _residual_label_strike_sections(graph)
+        ) >= len(struck):
+            for sid in grow:
+                graph.sections[sid].label_strike_cols -= 1
+            _relay()
+            break
+
     # Assure file-icon leaf sinks off the trunk by construction: a leaf icon
     # the laid-out routes rake a line across is taken off-track and the layout
     # re-run once, so the off-track machinery lifts it clear of the passing
@@ -599,6 +649,7 @@ def _compute_layout_scaled(
 
     if validate:
         _guard_no_label_overlap(graph, "final")
+        _guard_no_diagonal_strikes_horizontal_label(graph, "final")
         _guard_no_wrapped_label_trunk_strike(graph, "final")
         _guard_file_icon_no_name_label(graph, "final")
         _guard_no_line_crosses_file_icon(graph, "final")

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -536,19 +536,24 @@ def _compute_layout_scaled(
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y
 
-    # Strike-clearance loop: a fan-in/fan-out, convergence, or descent diagonal
-    # that rakes a station's name label is cleared by lengthening the flat run
-    # at that station by whole grid columns (the pitch stays fixed), seating the
+    # Strike-clearance: a fan-in/fan-out, convergence, or descent diagonal that
+    # rakes a station's name label is cleared by lengthening the flat run at that
+    # station by whole grid columns (the pitch stays fixed), seating the
     # transition outside the label.  Two complementary, grid-quantized levers:
-    # the section's entry/exit runway (clears strikes from the section's own
-    # port fan) and a per-column gap before the struck station's layer (clears
-    # an intra-section station-to-station descent).  Need-driven: only stations
-    # the renderer would draw a strike through grow, so a clean layout -- every
-    # gallery render at its default pitch -- is left untouched.  A growth a
-    # collinear check rejects, or that fails to reduce the struck count, is
-    # rolled back, so the loop never ships a layout worse than it found.
-    # Independent of pinned vs auto pitch: the room is local, not the global
-    # pitch, so it applies even when the caller fixed x_spacing.
+    # the section's entry/exit runway for a boundary-fan strike, and a per-column
+    # gap before the struck station's layer for an intra-section descent.
+    # Need-driven: only stations the renderer would draw a strike through grow,
+    # so a clean layout -- every gallery render at its default pitch -- is left
+    # untouched.  Independent of pinned vs auto pitch: the room is local, not the
+    # global pitch, so it applies even when the caller fixed x_spacing.
+    #
+    # A grow step bumps both levers at every struck station -- which lever
+    # actually relocates a given strike is hard to know in advance -- then a
+    # minimization pass strips every lever that turns out not to be load-bearing,
+    # so the settled layout carries the least extra width that keeps the labels
+    # clear.  A step a collinear check rejects, or that fails to reduce the
+    # struck count, is rolled back, so the loop never ships a layout worse than
+    # it found.
 
     def _relay() -> None:
         _layout_once(
@@ -575,37 +580,63 @@ def _compute_layout_scaled(
             return None
         return sec, st.layer
 
+    def _add_runway(sid: str, delta: int) -> None:
+        graph.sections[sid].label_strike_cols += delta
+
+    def _add_gap(sid: str, layer: int, delta: int) -> None:
+        lg = graph.sections[sid].label_strike_layer_gaps
+        lg[layer] = lg.get(layer, 0) + delta
+        if lg[layer] <= 0:
+            del lg[layer]
+
     struck, _ = _struck_stations_and_collinear(graph)
     for _ in range(_MAX_SPREAD_ITERS):
         targets = [t for sid in struck if (t := _growable_target(sid)) is not None]
-        if not targets:
-            break
-        # Both levers fire for every struck station rather than attributing the
-        # strike to one: a port-fan strike clears on the runway, an intra-section
-        # descent on the gap, and bumping both avoids classifying the striking
-        # segment.  Extra room never raises the struck count, so the rollback
-        # below only discards a step that regressed or overshot into a collinear
-        # overlay -- never a working lever.
         runway = {sec.id for sec, _ in targets}
         gaps = {(sec.id, layer) for sec, layer in targets}
+        if not runway and not gaps:
+            break
         for sid in runway:
-            graph.sections[sid].label_strike_cols += 1
+            _add_runway(sid, 1)
         for sid, layer in gaps:
-            lg = graph.sections[sid].label_strike_layer_gaps
-            lg[layer] = lg.get(layer, 0) + 1
+            _add_gap(sid, layer, 1)
         _relay()
         after, collinear = _struck_stations_and_collinear(graph)
         if collinear or len(after) >= len(struck):
             for sid in runway:
-                graph.sections[sid].label_strike_cols -= 1
+                _add_runway(sid, -1)
             for sid, layer in gaps:
-                lg = graph.sections[sid].label_strike_layer_gaps
-                lg[layer] -= 1
-                if lg[layer] <= 0:
-                    del lg[layer]
+                _add_gap(sid, layer, -1)
             _relay()
             break
         struck = after
+
+    # Minimization: drop each grown lever one at a time; keep the drop only when
+    # the labels stay clear and no collinear overlay appears, so a strike cleared
+    # by one lever does not leave the other's width behind.  Skipped entirely
+    # when nothing grew, so a clean layout never pays a re-lay (and is never
+    # perturbed by one).
+    grown: list[tuple[str, int | None]] = [
+        (sid, None) for sid, sec in graph.sections.items() if sec.label_strike_cols
+    ] + [
+        (sid, gap_layer)
+        for sid, sec in graph.sections.items()
+        for gap_layer in list(sec.label_strike_layer_gaps)
+    ]
+    if grown:
+        for sid, gap_layer in grown:
+            if gap_layer is None:
+                _add_runway(sid, -1)
+            else:
+                _add_gap(sid, gap_layer, -1)
+            _relay()
+            still_struck, collinear = _struck_stations_and_collinear(graph)
+            if still_struck or collinear:
+                if gap_layer is None:
+                    _add_runway(sid, 1)
+                else:
+                    _add_gap(sid, gap_layer, 1)
+        _relay()
 
     # Assure file-icon leaf sinks off the trunk by construction: a leaf icon
     # the laid-out routes rake a line across is taken off-track and the layout

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -580,6 +580,12 @@ def _compute_layout_scaled(
         targets = [t for sid in struck if (t := _growable_target(sid)) is not None]
         if not targets:
             break
+        # Both levers fire for every struck station rather than attributing the
+        # strike to one: a port-fan strike clears on the runway, an intra-section
+        # descent on the gap, and bumping both avoids classifying the striking
+        # segment.  Extra room never raises the struck count, so the rollback
+        # below only discards a step that regressed or overshot into a collinear
+        # overlay -- never a working lever.
         runway = {sec.id for sec, _ in targets}
         gaps = {(sec.id, layer) for sec, layer in targets}
         for sid in runway:

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -29,6 +29,7 @@ from nf_metro.layout.constants import (
     COLLISION_MULTIPLIER,
     DESCENDER_CLEARANCE,
     DIAGONAL_LABEL_OFFSET,
+    DIAGONAL_SLOPE_RATIO,
     FONT_HEIGHT,
     GLYPH_ADVANCE_DEFAULT_EM,
     GLYPH_ADVANCE_EM,
@@ -1793,7 +1794,7 @@ def _avoid_diagonal_routes(
         for i in range(len(pts) - 1):
             (x1, y1), (x2, y2) = pts[i], pts[i + 1]
             dx, dy = x2 - x1, y2 - y1
-            if abs(dy) < max(abs(dx), 1.0) * 0.05:
+            if abs(dy) < max(abs(dx), 1.0) * DIAGONAL_SLOPE_RATIO:
                 continue  # ~horizontal; not a label obstacle.
             diag.append((x1, y1, x2, y2))
     if not diag:
@@ -1868,7 +1869,7 @@ def _foreign_route_segments(
             pts[0] = (pts[0][0], pts[0][1] + so)
             pts[-1] = (pts[-1][0], pts[-1][1] + to)
         for (x1, y1), (x2, y2) in zip(pts, pts[1:]):
-            is_diagonal = abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * 0.05
+            is_diagonal = abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * DIAGONAL_SLOPE_RATIO
             if is_diagonal != diagonal:
                 continue
             segs.append(

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -36,6 +36,33 @@ def _scoped_sections(graph: MetroGraph, section_ids: list[str]) -> Iterator[None
         graph.sections = original
 
 
+@contextmanager
+def _restoring_layout_geometry(graph: MetroGraph) -> Iterator[None]:
+    """Restore station coords and section bboxes on exit.
+
+    route_edges' diagonal-centring nudges Station.x and place_labels expands
+    section bboxes to fit labels, so a probe or guard that re-routes and
+    re-places to inspect the drawn geometry must undo those mutations:
+    inspecting the settled layout must not perturb it.
+    """
+    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bbox = {
+        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
+        for sid, s in graph.sections.items()
+    }
+    try:
+        yield
+    finally:
+        for sid, (x, y) in pos.items():
+            st = graph.stations.get(sid)
+            if st is not None:
+                st.x, st.y = x, y
+        for sid, (bx, by, bw, bh) in bbox.items():
+            s = graph.sections.get(sid)
+            if s is not None:
+                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+
+
 def _grid_rows_top_to_bottom(graph: MetroGraph) -> list[list[str]]:
     """Section ids grouped by grid row, rows ordered top-to-bottom.
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1085,6 +1085,62 @@ def _guard_no_line_strikes_label(
                         )
 
 
+def _guard_no_diagonal_strikes_horizontal_label(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: no foreign fan diagonal rakes a stacked station's name.
+
+    Protects the strike-clearance loop's result: a fan-in/fan-out or
+    convergence diagonal that transitions through a horizontal label reads as a
+    strike-through, and the loop grows the offending section's runway by whole
+    grid columns until the transition seats clear.  This guard fails loudly if a
+    layout ships such a strike anyway.
+
+    Narrower than :func:`_guard_no_line_strikes_label`: it excludes bypass-V
+    crossings (a V sits a fixed offset from the station, so runway growth cannot
+    relocate it) and angled labels (handled by their rotated footprint, not
+    column runway), so it can be wired into the validate pass while those
+    remain.
+    """
+    from nf_metro.layout.labels import place_labels
+    from nf_metro.layout.phases.spacing import _struck_label_station_ids
+    from nf_metro.render.svg import _compute_icon_obstacles
+    from nf_metro.themes import THEMES
+
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
+
+        offsets = compute_station_offsets(graph)
+
+    with _restoring_layout_geometry(graph):
+        if routes is None:
+            from nf_metro.layout.routing import route_edges
+
+            try:
+                routes = route_edges(graph, station_offsets=offsets)
+            except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+                return
+        placements = place_labels(
+            graph,
+            station_offsets=offsets,
+            icon_obstacles=_compute_icon_obstacles(graph, THEMES["nfcore"], offsets),
+            routes=routes,
+            label_angle=graph.label_angle or 0.0,
+        )
+        struck = _struck_label_station_ids(graph, offsets, routes, placements)
+        if struck:
+            names = ", ".join(
+                f"{sid!r} ({graph.stations[sid].label!r})" for sid in sorted(struck)
+            )
+            raise PhaseInvariantError(
+                f"{phase}: foreign fan diagonal strikes horizontal label(s): {names}"
+            )
+
+
 def _guard_no_wrapped_label_trunk_strike(
     graph: MetroGraph,
     phase: str,

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
@@ -25,6 +24,7 @@ from nf_metro.layout.geometry import BBoxXIndex, segment_intersects_bbox
 from nf_metro.layout.phases._common import (
     _bbox_cols_overlap,
     _canvas_width,
+    _restoring_layout_geometry,
     _route_crosses_section_boundary,
     _section_bundle_lines,
     _station_marker_bbox,
@@ -971,33 +971,6 @@ def _guard_no_line_crosses_file_icon(
                     )
 
 
-@contextmanager
-def _restoring_layout_geometry(graph: MetroGraph) -> Iterator[None]:
-    """Restore station coords and section bboxes on exit.
-
-    route_edges' diagonal-centring nudges Station.x and place_labels expands
-    section bboxes to fit labels, so a guard that re-routes and re-places to
-    inspect the drawn geometry must undo those mutations: validate=True must
-    not perturb the settled layout.
-    """
-    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bbox = {
-        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
-        for sid, s in graph.sections.items()
-    }
-    try:
-        yield
-    finally:
-        for sid, (x, y) in pos.items():
-            st = graph.stations.get(sid)
-            if st is not None:
-                st.x, st.y = x, y
-        for sid, (bx, by, bw, bh) in bbox.items():
-            s = graph.sections.get(sid)
-            if s is not None:
-                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
-
-
 def _guard_no_line_strikes_label(
     graph: MetroGraph,
     phase: str,
@@ -1088,9 +1061,6 @@ def _guard_no_line_strikes_label(
 def _guard_no_diagonal_strikes_horizontal_label(
     graph: MetroGraph,
     phase: str,
-    *,
-    offsets: dict[tuple[str, str], float] | None = None,
-    routes: list[RoutedPath] | None = None,
 ) -> None:
     """Final-phase: no foreign fan diagonal rakes a stacked station's name.
 
@@ -1098,7 +1068,8 @@ def _guard_no_diagonal_strikes_horizontal_label(
     convergence diagonal that transitions through a horizontal label reads as a
     strike-through, and the loop grows the offending section's runway by whole
     grid columns until the transition seats clear.  This guard fails loudly if a
-    layout ships such a strike anyway.
+    layout ships such a strike anyway.  It probes through the same helper the
+    loop uses, so it validates exactly the geometry the loop reasoned about.
 
     Narrower than :func:`_guard_no_line_strikes_label`: it excludes bypass-V
     crossings (a V sits a fixed offset from the station, so runway growth cannot
@@ -1106,39 +1077,23 @@ def _guard_no_diagonal_strikes_horizontal_label(
     column runway), so it can be wired into the validate pass while those
     remain.
     """
-    from nf_metro.layout.labels import place_labels
-    from nf_metro.layout.phases.spacing import _struck_label_station_ids
-    from nf_metro.render.svg import _compute_icon_obstacles
-    from nf_metro.themes import THEMES
+    from nf_metro.layout.phases.spacing import (
+        _probe_label_placements,
+        _struck_label_station_ids,
+    )
 
-    if offsets is None:
-        from nf_metro.layout.routing import compute_station_offsets
-
-        offsets = compute_station_offsets(graph)
-
-    with _restoring_layout_geometry(graph):
-        if routes is None:
-            from nf_metro.layout.routing import route_edges
-
-            try:
-                routes = route_edges(graph, station_offsets=offsets)
-            except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
-                return
-        placements = place_labels(
-            graph,
-            station_offsets=offsets,
-            icon_obstacles=_compute_icon_obstacles(graph, THEMES["nfcore"], offsets),
-            routes=routes,
-            label_angle=graph.label_angle or 0.0,
+    probe = _probe_label_placements(graph, allow_hyphenation=True)
+    if probe is None:
+        return
+    offsets, routes, placements = probe
+    struck = _struck_label_station_ids(graph, offsets, routes, placements)
+    if struck:
+        names = ", ".join(
+            f"{sid!r} ({graph.stations[sid].label!r})" for sid in sorted(struck)
         )
-        struck = _struck_label_station_ids(graph, offsets, routes, placements)
-        if struck:
-            names = ", ".join(
-                f"{sid!r} ({graph.stations[sid].label!r})" for sid in sorted(struck)
-            )
-            raise PhaseInvariantError(
-                f"{phase}: foreign fan diagonal strikes horizontal label(s): {names}"
-            )
+        raise PhaseInvariantError(
+            f"{phase}: foreign fan diagonal strikes horizontal label(s): {names}"
+        )
 
 
 def _guard_no_wrapped_label_trunk_strike(

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -734,22 +734,31 @@ def _apply_label_strike_runway(
     section: Section,
     x_spacing: float,
 ) -> None:
-    """LR/RL sections: lengthen both flat runs by ``label_strike_cols`` columns.
+    """LR/RL sections: lengthen the entry and/or exit runway by whole columns.
 
-    A label wider than its station's flat run lets a fan diagonal seat inside
-    the label's x-extent.  Adding a whole grid column of runway on each side
-    (stations shift right by the per-side amount; the bbox grows by twice it)
-    moves the diagonal transition clear of the label while keeping the column
-    pitch fixed and the stations centered.  The strike-clearance loop sets
-    ``label_strike_cols`` only for sections whose label is actually struck, so
-    this is a no-op (zero columns) for every other render.
+    A label wider than its station's flat run lets a boundary-fan diagonal seat
+    inside the label's x-extent.  Adding grid columns of runway on the struck
+    side (the entry side shifts stations along the flow so room opens before the
+    first column; the exit side grows the bbox past the last) moves the diagonal
+    transition clear of the label, keeping the column pitch fixed.  The
+    strike-clearance loop sets these only for the side of a section whose label
+    is actually struck, so this is a no-op (zero columns) for every other
+    render.
     """
-    if section.label_strike_cols <= 0 or section.direction not in ("LR", "RL"):
+    if section.direction not in ("LR", "RL"):
         return
-    per_side = section.label_strike_cols * x_spacing
-    for s in sub.stations.values():
-        s.x += per_side
-    section.bbox_w += 2 * per_side
+    entry = section.label_strike_entry_cols * x_spacing
+    exit_room = section.label_strike_exit_cols * x_spacing
+    # Entry is the flow-source boundary (left for LR, right for RL); shifting
+    # stations along the flow opens room between it and the first column.
+    if section.direction == "RL":
+        entry, exit_room = exit_room, entry
+    if entry > 0:
+        for s in sub.stations.values():
+            s.x += entry
+        section.bbox_w += entry
+    if exit_room > 0:
+        section.bbox_w += exit_room
 
 
 def _adjust_lr_label_clearance(

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -295,6 +295,7 @@ def _layout_single_section(
     _adjust_tb_entry_shifts(section, sub, graph, y_spacing)
     _adjust_lr_entry_inset(sub, section, graph, x_spacing)
     _adjust_lr_exit_gap(sub, section, graph, layers, x_spacing)
+    _apply_label_strike_runway(sub, section, x_spacing)
     _adjust_lr_label_clearance(sub, section)
     _adjust_terminus_icon_clearance(sub, section, graph)
 
@@ -713,6 +714,29 @@ def _adjust_lr_exit_gap(
         for s in sub.stations.values():
             s.x += shift
         section.bbox_w += exit_gap
+
+
+def _apply_label_strike_runway(
+    sub: MetroGraph,
+    section: Section,
+    x_spacing: float,
+) -> None:
+    """LR/RL sections: lengthen both flat runs by ``label_strike_cols`` columns.
+
+    A label wider than its station's flat run lets a fan diagonal seat inside
+    the label's x-extent.  Adding a whole grid column of runway on each side
+    (stations shift right by the per-side amount; the bbox grows by twice it)
+    moves the diagonal transition clear of the label while keeping the column
+    pitch fixed and the stations centered.  The strike-clearance loop sets
+    ``label_strike_cols`` only for sections whose label is actually struck, so
+    this is a no-op (zero columns) for every other render.
+    """
+    if section.label_strike_cols <= 0 or section.direction not in ("LR", "RL"):
+        return
+    per_side = section.label_strike_cols * x_spacing
+    for s in sub.stations.values():
+        s.x += per_side
+    section.bbox_w += 2 * per_side
 
 
 def _adjust_lr_label_clearance(

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -185,6 +185,19 @@ def _layout_single_section(
         sub, layers, tracks, x_spacing, graph, section_sids
     )
 
+    # Label-strike clearance: a gap declared before layer ``L`` pushes ``L`` and
+    # every downstream layer along the flow axis, lengthening the flat run into
+    # the struck station so its own descent/ascent diagonal seats clear of its
+    # name.  The strike-clearance loop populates this need-driven, so it is
+    # empty (a no-op) for every layout that draws no strike.
+    if section.label_strike_layer_gaps:
+        all_layers = set(layers.values())
+        for gap_layer, cols in section.label_strike_layer_gaps.items():
+            extra = cols * x_spacing
+            for layer in all_layers:
+                if layer >= gap_layer:
+                    layer_extra[layer] = layer_extra.get(layer, 0.0) + extra
+
     # Widen track spacing when multi-line labels need more vertical room
     effective_y_spacing = _multiline_track_spacing(sub, y_spacing)
 

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from nf_metro.parser.model import MetroGraph
 
 if TYPE_CHECKING:
     from nf_metro.layout.labels import LabelOverlap, LabelPlacement
+    from nf_metro.layout.routing.common import RoutedPath
 
 # Cap on spread-loop passes.  Each pass strictly widens the binding axis,
 # so a handful suffices to clear any realistic crowding before giving up.
@@ -17,20 +20,52 @@ _MAX_SPREAD_ITERS = 6
 # spacing, so the re-laid-out labels land with a small gap, not flush.
 _SPREAD_SLACK = 4.0
 
+# Slope above which a route segment counts as a diagonal (not a flat trunk
+# run): |dy| >= |dx| * this.  A diagonal is what can rake a station label.
+_DIAGONAL_SLOPE_RATIO = 0.05
+
+_Probe = tuple[
+    dict[tuple[str, str], float],
+    "list[RoutedPath]",
+    "list[LabelPlacement]",
+]
+
+
+@contextmanager
+def _restored_layout_geometry(graph: MetroGraph) -> Iterator[None]:
+    """Restore station coordinates and section bboxes on exit.
+
+    Routing and placement mutate the graph in place (route_edges nudges station
+    X for bundle separation; place_labels expands section bboxes to fit labels),
+    so a probe that runs them must undo the mutations before returning.
+    """
+    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    bbox = {
+        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
+        for sid, s in graph.sections.items()
+    }
+    try:
+        yield
+    finally:
+        for sid, (x, y) in pos.items():
+            st = graph.stations.get(sid)
+            if st is not None:
+                st.x, st.y = x, y
+        for sid, (bx, by, bw, bh) in bbox.items():
+            s = graph.sections.get(sid)
+            if s is not None:
+                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+
 
 def _probe_label_placements(
     graph: MetroGraph, *, allow_hyphenation: bool
-) -> tuple[dict[tuple[str, str], float], list[LabelPlacement]] | None:
+) -> _Probe | None:
     """Run the renderer's offset/route/label pipeline at the current layout.
 
-    Returns the computed ``(station_offsets, placements)`` so callers can
-    inspect the settled labelling the renderer would draw, or ``None`` if
-    routing/placement raises (a transient failure never blocks layout).
-
-    Routing and placement mutate the graph (route_edges nudges station X for
-    bundle separation; place_labels expands section bboxes to fit labels).
-    This probe snapshots station coordinates and section bboxes and restores
-    them, so it never leaks those mutations into the positioned state.
+    Returns the computed ``(station_offsets, routes, placements)`` so callers
+    can inspect the settled geometry and labelling the renderer would draw, or
+    ``None`` if routing/placement raises (a transient failure never blocks
+    layout).  Snapshots and restores the in-place mutations route/place make.
 
     The render-time wrapped-label trunk lift is held off here so the spacing
     search and the label-overlap guard reason about the unlifted geometry; the
@@ -40,54 +75,29 @@ def _probe_label_placements(
     from nf_metro.layout.labels import place_labels
     from nf_metro.layout.routing import compute_station_offsets, route_edges
 
-    # Resolve the effective label angle so the spread search sizes column
-    # spacing for the same (possibly rotated, hence narrower) footprint the
-    # renderer will draw.  graph.label_angle is None when no directive set it;
-    # the theme default is horizontal (0), so None -> 0 here (#527).
-    label_angle = graph.label_angle or 0.0
-
-    pos_snapshot = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bbox_snapshot = {
-        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
-        for sid, s in graph.sections.items()
-    }
-    try:
-        offsets = compute_station_offsets(graph)
-        routes = route_edges(graph, station_offsets=offsets)
-        placements = place_labels(
-            graph,
-            station_offsets=offsets,
-            routes=routes,
-            allow_hyphenation=allow_hyphenation,
-            label_angle=label_angle,
-            lift_wrapped_off_trunks=False,
-        )
-        return offsets, placements
-    except Exception:
-        return None
-    finally:
-        for sid, (x, y) in pos_snapshot.items():
-            st = graph.stations.get(sid)
-            if st is not None:
-                st.x, st.y = x, y
-        for sid, (bx, by, bw, bh) in bbox_snapshot.items():
-            s = graph.sections.get(sid)
-            if s is not None:
-                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
+    with _restored_layout_geometry(graph):
+        try:
+            offsets = compute_station_offsets(graph)
+            routes = route_edges(graph, station_offsets=offsets)
+            placements = place_labels(
+                graph,
+                station_offsets=offsets,
+                routes=routes,
+                allow_hyphenation=allow_hyphenation,
+                label_angle=graph.label_angle or 0.0,
+                lift_wrapped_off_trunks=False,
+            )
+            return offsets, routes, placements
+        except Exception:
+            return None
 
 
-def _residual_label_overlaps(
-    graph: MetroGraph, *, allow_hyphenation: bool
+def _overlaps_from(
+    graph: MetroGraph,
+    offsets: dict[tuple[str, str], float],
+    placements: list[LabelPlacement],
 ) -> list[LabelOverlap]:
-    """Place labels at the current layout and report leftover overlaps.
-
-    Returns the overlaps that wrapping could not resolve, or an empty list if
-    routing/placement raises.
-
-    The spread loop calls this with ``allow_hyphenation=False`` so residual
-    overlaps surface (to be cleared by widening spacing rather than by
-    hard-breaking words); the final guard calls it with True to validate the
-    settled, fully wrapped state the renderer will draw.
+    """Leftover label overlaps in a probed placement set.
 
     Overlaps involving a rail-section station are dropped: rail sections run a
     dedicated layout with their own column pitch, so widening the normal global
@@ -96,10 +106,6 @@ def _residual_label_overlaps(
     """
     from nf_metro.layout.labels import find_label_overlaps
 
-    probe = _probe_label_placements(graph, allow_hyphenation=allow_hyphenation)
-    if probe is None:
-        return []
-    offsets, placements = probe
     overlaps = find_label_overlaps(graph, placements, offsets)
     if not graph.has_rail_sections:
         return overlaps
@@ -109,6 +115,129 @@ def _residual_label_overlaps(
         return bool(st and st.section_id and graph.is_rail_section(st.section_id))
 
     return [o for o in overlaps if not (_in_rail(o.a) or _in_rail(o.b))]
+
+
+def _struck_label_station_ids(
+    graph: MetroGraph,
+    offsets: dict[tuple[str, str], float],
+    routes: list[RoutedPath],
+    placements: list[LabelPlacement],
+) -> set[str]:
+    """Stations whose horizontal name label a foreign diagonal route crosses.
+
+    The visual goal: a fan-in/fan-out or convergence diagonal transitioning
+    through a station's drawn name reads as a strike-through.  A line the
+    station carries, or whose edge ends at the station, legitimately touches it
+    and is exempt.
+
+    Excluded because growing a section's runway cannot relocate them:
+
+    - angled labels (a rotated strip is handled by its own footprint),
+    - bypass-V crossings (the V sits a fixed track offset from the station).
+    """
+    from nf_metro.layout.labels import segment_strikes_label
+    from nf_metro.render.svg import apply_route_offsets
+
+    seg_lists = [
+        (
+            r,
+            apply_route_offsets(r, offsets),
+            r.edge.source.startswith("__bypass_")
+            or r.edge.target.startswith("__bypass_"),
+        )
+        for r in routes
+    ]
+    struck: set[str] = set()
+    for p in placements:
+        station = graph.stations.get(p.station_id)
+        if station is None or not station.label.strip() or p.angle:
+            continue
+        carried = set(graph.station_lines(p.station_id))
+        for r, pts, is_bypass in seg_lists:
+            if is_bypass or r.line_id in carried:
+                continue
+            if r.edge.source == p.station_id or r.edge.target == p.station_id:
+                continue
+            if any(
+                segment_strikes_label(x1, y1, x2, y2, p)
+                and abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * _DIAGONAL_SLOPE_RATIO
+                for (x1, y1), (x2, y2) in zip(pts, pts[1:])
+            ):
+                struck.add(p.station_id)
+                break
+    return struck
+
+
+def _collinear_from(
+    graph: MetroGraph,
+    offsets: dict[tuple[str, str], float],
+    routes: list[RoutedPath],
+) -> bool:
+    """Whether probed routes draw two distinct lines on top of each other.
+
+    Runs the inter- and intra-section collinear-overlay checks the final-phase
+    guards enforce, so the strike-clearance loop can step back a widening that
+    would overshoot into a collinear defect rather than ship it.
+    """
+    from nf_metro.layout.routing.invariants import (
+        check_intra_section_collinear_distinct_lines,
+        check_no_collinear_distinct_lines,
+    )
+
+    return bool(
+        check_no_collinear_distinct_lines(graph, routes, offsets)
+        or check_intra_section_collinear_distinct_lines(graph, routes, offsets)
+    )
+
+
+def _residual_label_overlaps(
+    graph: MetroGraph, *, allow_hyphenation: bool
+) -> list[LabelOverlap]:
+    """Place labels at the current layout and report leftover overlaps.
+
+    The spread loop calls this with ``allow_hyphenation=False`` so residual
+    overlaps surface (to be cleared by widening spacing rather than by
+    hard-breaking words); the final guard calls it with True to validate the
+    settled, fully wrapped state the renderer will draw.  Returns an empty list
+    if routing/placement raises.
+    """
+    probe = _probe_label_placements(graph, allow_hyphenation=allow_hyphenation)
+    if probe is None:
+        return []
+    offsets, _routes, placements = probe
+    return _overlaps_from(graph, offsets, placements)
+
+
+def _residual_label_strike_sections(graph: MetroGraph) -> set[str]:
+    """Section ids holding a station whose label a foreign diagonal crosses.
+
+    Probes with ``allow_hyphenation=True`` -- the renderer-faithful wrapping --
+    so a strike is judged against the label the renderer actually draws.  A
+    struck station outside any section maps to nothing and is dropped (its
+    layout has no entry/exit runway to grow).  Returns an empty set on probe
+    failure.  See :func:`_struck_label_station_ids`.
+    """
+    probe = _probe_label_placements(graph, allow_hyphenation=True)
+    if probe is None:
+        return set()
+    offsets, routes, placements = probe
+    struck = _struck_label_station_ids(graph, offsets, routes, placements)
+    sections: set[str] = set()
+    for sid in struck:
+        section_id = graph.stations[sid].section_id
+        if section_id:
+            sections.add(section_id)
+    return sections
+
+
+def _layout_has_collinear(graph: MetroGraph) -> bool:
+    """Whether the current layout draws two distinct lines on top of each other
+    (or ``False`` on probe failure).  See :func:`_collinear_from`."""
+    probe = _probe_label_placements(graph, allow_hyphenation=False)
+    if probe is None:
+        return False
+    offsets, routes, _placements = probe
+    return _collinear_from(graph, offsets, routes)
 
 
 def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:
@@ -121,7 +250,7 @@ def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:
     probe = _probe_label_placements(graph, allow_hyphenation=True)
     if probe is None:
         return set()
-    _offsets, placements = probe
+    _offsets, _routes, placements = probe
     return {p.station_id for p in placements if p.station_id}
 
 

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
+from nf_metro.layout.constants import DIAGONAL_SLOPE_RATIO
+from nf_metro.layout.phases._common import _restoring_layout_geometry
 from nf_metro.parser.model import MetroGraph
 
 if TYPE_CHECKING:
@@ -20,41 +20,11 @@ _MAX_SPREAD_ITERS = 6
 # spacing, so the re-laid-out labels land with a small gap, not flush.
 _SPREAD_SLACK = 4.0
 
-# Slope above which a route segment counts as a diagonal (not a flat trunk
-# run): |dy| >= |dx| * this.  A diagonal is what can rake a station label.
-_DIAGONAL_SLOPE_RATIO = 0.05
-
 _Probe = tuple[
     dict[tuple[str, str], float],
     "list[RoutedPath]",
     "list[LabelPlacement]",
 ]
-
-
-@contextmanager
-def _restored_layout_geometry(graph: MetroGraph) -> Iterator[None]:
-    """Restore station coordinates and section bboxes on exit.
-
-    Routing and placement mutate the graph in place (route_edges nudges station
-    X for bundle separation; place_labels expands section bboxes to fit labels),
-    so a probe that runs them must undo the mutations before returning.
-    """
-    pos = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-    bbox = {
-        sid: (s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h)
-        for sid, s in graph.sections.items()
-    }
-    try:
-        yield
-    finally:
-        for sid, (x, y) in pos.items():
-            st = graph.stations.get(sid)
-            if st is not None:
-                st.x, st.y = x, y
-        for sid, (bx, by, bw, bh) in bbox.items():
-            s = graph.sections.get(sid)
-            if s is not None:
-                s.bbox_x, s.bbox_y, s.bbox_w, s.bbox_h = bx, by, bw, bh
 
 
 def _probe_label_placements(
@@ -75,7 +45,7 @@ def _probe_label_placements(
     from nf_metro.layout.labels import place_labels
     from nf_metro.layout.routing import compute_station_offsets, route_edges
 
-    with _restored_layout_geometry(graph):
+    with _restoring_layout_geometry(graph):
         try:
             offsets = compute_station_offsets(graph)
             routes = route_edges(graph, station_offsets=offsets)
@@ -160,7 +130,7 @@ def _struck_label_station_ids(
                 continue
             if any(
                 segment_strikes_label(x1, y1, x2, y2, p)
-                and abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * _DIAGONAL_SLOPE_RATIO
+                and abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * DIAGONAL_SLOPE_RATIO
                 for (x1, y1), (x2, y2) in zip(pts, pts[1:])
             ):
                 struck.add(p.station_id)
@@ -208,18 +178,26 @@ def _residual_label_overlaps(
     return _overlaps_from(graph, offsets, placements)
 
 
-def _residual_label_strike_sections(graph: MetroGraph) -> set[str]:
-    """Section ids holding a station whose label a foreign diagonal crosses.
+def _strike_sections_and_collinear(graph: MetroGraph) -> tuple[set[str], bool]:
+    """One probe: sections needing runway growth, and a collinear-defect flag.
+
+    Returns ``(section_ids, has_collinear)`` where ``section_ids`` hold a
+    station whose horizontal label a foreign diagonal crosses, and
+    ``has_collinear`` is whether the routes draw two distinct lines on top of
+    each other.  Both read the same probed routes, so the strike-clearance loop
+    decides growth and step-back from a single route+place pass.
 
     Probes with ``allow_hyphenation=True`` -- the renderer-faithful wrapping --
-    so a strike is judged against the label the renderer actually draws.  A
+    so a strike is judged against the label the renderer draws; the collinear
+    check ignores placements, so the hyphenation flag does not affect it.  A
     struck station outside any section maps to nothing and is dropped (its
-    layout has no entry/exit runway to grow).  Returns an empty set on probe
-    failure.  See :func:`_struck_label_station_ids`.
+    layout has no entry/exit runway to grow).  Returns ``(set(), False)`` on
+    probe failure.  See :func:`_struck_label_station_ids` and
+    :func:`_collinear_from`.
     """
     probe = _probe_label_placements(graph, allow_hyphenation=True)
     if probe is None:
-        return set()
+        return set(), False
     offsets, routes, placements = probe
     struck = _struck_label_station_ids(graph, offsets, routes, placements)
     sections: set[str] = set()
@@ -227,17 +205,7 @@ def _residual_label_strike_sections(graph: MetroGraph) -> set[str]:
         section_id = graph.stations[sid].section_id
         if section_id:
             sections.add(section_id)
-    return sections
-
-
-def _layout_has_collinear(graph: MetroGraph) -> bool:
-    """Whether the current layout draws two distinct lines on top of each other
-    (or ``False`` on probe failure).  See :func:`_collinear_from`."""
-    probe = _probe_label_placements(graph, allow_hyphenation=False)
-    if probe is None:
-        return False
-    offsets, routes, _placements = probe
-    return _collinear_from(graph, offsets, routes)
+    return sections, _collinear_from(graph, offsets, routes)
 
 
 def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -93,27 +93,39 @@ def _struck_label_station_ids(
     routes: list[RoutedPath],
     placements: list[LabelPlacement],
 ) -> set[str]:
-    """Stations whose horizontal name label a foreign diagonal route crosses.
+    """Stations whose horizontal name label a diagonal route crosses.
 
     The visual goal: a fan-in/fan-out or convergence diagonal transitioning
-    through a station's drawn name reads as a strike-through.  A line the
-    station carries, or whose edge ends at the station, legitimately touches it
-    and is exempt.
+    through a station's drawn name reads as a strike-through -- whether or not
+    the station carries that line.  A wide label sits in the path of its own
+    line's sweep to the section's entry/exit ports just as it sits in a foreign
+    line's, so ownership is not an exemption; the runway must lengthen until the
+    transition clears the glyphs either way.
 
-    Excluded because growing a section's runway cannot relocate them:
+    Only segments that cannot be relocated by widening a section's runway are
+    excluded:
 
-    - angled labels (a rotated strip is handled by its own footprint),
-    - bypass-V crossings (the V sits a fixed track offset from the station).
+    - flat (near-horizontal) trunk runs -- a line along a label's own row is not
+      a strike-through and a wider runway would not move it,
+    - bypass-V crossings (the V sits a fixed track offset from the station),
+    - off-track output sweeps (a producer-to-off-track-sink diagonal is placed
+      by the off-track machinery, not the in-grid runway),
+    - angled labels (a rotated strip is handled by its own footprint).
     """
     from nf_metro.layout.labels import segment_strikes_label
     from nf_metro.render.svg import apply_route_offsets
 
+    def _off_track(node_id: str) -> bool:
+        st = graph.stations.get(node_id)
+        return bool(st and st.off_track)
+
     seg_lists = [
         (
-            r,
             apply_route_offsets(r, offsets),
             r.edge.source.startswith("__bypass_")
-            or r.edge.target.startswith("__bypass_"),
+            or r.edge.target.startswith("__bypass_")
+            or _off_track(r.edge.source)
+            or _off_track(r.edge.target),
         )
         for r in routes
     ]
@@ -122,11 +134,8 @@ def _struck_label_station_ids(
         station = graph.stations.get(p.station_id)
         if station is None or not station.label.strip() or p.angle:
             continue
-        carried = set(graph.station_lines(p.station_id))
-        for r, pts, is_bypass in seg_lists:
-            if is_bypass or r.line_id in carried:
-                continue
-            if r.edge.source == p.station_id or r.edge.target == p.station_id:
+        for pts, skip in seg_lists:
+            if skip:
                 continue
             if any(
                 segment_strikes_label(x1, y1, x2, y2, p)
@@ -178,34 +187,27 @@ def _residual_label_overlaps(
     return _overlaps_from(graph, offsets, placements)
 
 
-def _strike_sections_and_collinear(graph: MetroGraph) -> tuple[set[str], bool]:
-    """One probe: sections needing runway growth, and a collinear-defect flag.
+def _struck_stations_and_collinear(graph: MetroGraph) -> tuple[set[str], bool]:
+    """One probe: stations whose label a diagonal crosses, and a collinear flag.
 
-    Returns ``(section_ids, has_collinear)`` where ``section_ids`` hold a
-    station whose horizontal label a foreign diagonal crosses, and
-    ``has_collinear`` is whether the routes draw two distinct lines on top of
-    each other.  Both read the same probed routes, so the strike-clearance loop
-    decides growth and step-back from a single route+place pass.
+    Returns ``(station_ids, has_collinear)`` where ``station_ids`` are stations
+    whose horizontal label a diagonal route rakes, and ``has_collinear`` is
+    whether the routes draw two distinct lines on top of each other.  Both read
+    the same probed routes, so the strike-clearance loop decides growth and
+    step-back from a single route+place pass.
 
     Probes with ``allow_hyphenation=True`` -- the renderer-faithful wrapping --
     so a strike is judged against the label the renderer draws; the collinear
-    check ignores placements, so the hyphenation flag does not affect it.  A
-    struck station outside any section maps to nothing and is dropped (its
-    layout has no entry/exit runway to grow).  Returns ``(set(), False)`` on
-    probe failure.  See :func:`_struck_label_station_ids` and
-    :func:`_collinear_from`.
+    check ignores placements, so the hyphenation flag does not affect it.
+    Returns ``(set(), False)`` on probe failure.  See
+    :func:`_struck_label_station_ids` and :func:`_collinear_from`.
     """
     probe = _probe_label_placements(graph, allow_hyphenation=True)
     if probe is None:
         return set(), False
     offsets, routes, placements = probe
     struck = _struck_label_station_ids(graph, offsets, routes, placements)
-    sections: set[str] = set()
-    for sid in struck:
-        section_id = graph.stations[sid].section_id
-        if section_id:
-            sections.add(section_id)
-    return sections, _collinear_from(graph, offsets, routes)
+    return struck, _collinear_from(graph, offsets, routes)
 
 
 def _placed_name_label_station_ids(graph: MetroGraph) -> set[str]:

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -95,22 +95,17 @@ def _struck_label_station_ids(
 ) -> set[str]:
     """Stations whose horizontal name label a diagonal route crosses.
 
-    The visual goal: a fan-in/fan-out or convergence diagonal transitioning
-    through a station's drawn name reads as a strike-through -- whether or not
-    the station carries that line.  A wide label sits in the path of its own
-    line's sweep to the section's entry/exit ports just as it sits in a foreign
-    line's, so ownership is not an exemption; the runway must lengthen until the
-    transition clears the glyphs either way.
+    The visual goal: a fan-in/fan-out, convergence, or descent diagonal
+    transitioning through a station's drawn name reads as a strike-through --
+    whether or not the station carries that line.  A wide label sits in the path
+    of its own line's sweep just as it sits in a foreign line's, so ownership is
+    not an exemption; the flat run must lengthen until the transition clears the
+    glyphs either way.
 
-    Only segments that cannot be relocated by widening a section's runway are
-    excluded:
-
-    - flat (near-horizontal) trunk runs -- a line along a label's own row is not
-      a strike-through and a wider runway would not move it,
-    - bypass-V crossings (the V sits a fixed track offset from the station),
-    - off-track output sweeps (a producer-to-off-track-sink diagonal is placed
-      by the off-track machinery, not the in-grid runway),
-    - angled labels (a rotated strip is handled by its own footprint).
+    Segments a longer flat run cannot relocate are excluded: flat (near-
+    horizontal) trunk runs, bypass-V crossings, off-track output sweeps (placed
+    by the off-track machinery, not the in-grid runway), and angled labels
+    (handled by their rotated footprint).
     """
     from nf_metro.layout.labels import segment_strikes_label
     from nf_metro.render.svg import apply_route_offsets

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -258,11 +258,13 @@ class Section:
     offset_y: float = 0.0
     # Implicit sections are auto-created for loose stations; no visible box
     is_implicit: bool = False
-    # Extra entry/exit runway, in whole grid columns, that the strike-clearance
-    # loop grows when a fan diagonal rakes a stacked station's name label.  The
-    # column pitch is left fixed; the section's flat runs lengthen so the
+    # Extra runway, in whole grid columns, that the strike-clearance loop grows
+    # on the entry/exit side when a boundary-fan diagonal rakes a station's name
+    # label.  Sides are independent so the loop grows only the struck one.  The
+    # column pitch is left fixed; the section's flat run lengthens so the
     # transition seats outside the label's x-extent.
-    label_strike_cols: int = 0
+    label_strike_entry_cols: int = 0
+    label_strike_exit_cols: int = 0
     # Extra columns of intra-section gap the strike-clearance loop inserts
     # before a given layer (keyed by layer index; pushes that layer and every
     # downstream layer along the flow axis).  Lengthens the flat run into a

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -258,6 +258,11 @@ class Section:
     offset_y: float = 0.0
     # Implicit sections are auto-created for loose stations; no visible box
     is_implicit: bool = False
+    # Extra entry/exit runway, in whole grid columns, that the strike-clearance
+    # loop grows when a fan diagonal rakes a stacked station's name label.  The
+    # column pitch is left fixed; the section's flat runs lengthen so the
+    # transition seats outside the label's x-extent.
+    label_strike_cols: int = 0
 
 
 @dataclass

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -263,6 +263,11 @@ class Section:
     # column pitch is left fixed; the section's flat runs lengthen so the
     # transition seats outside the label's x-extent.
     label_strike_cols: int = 0
+    # Extra columns of intra-section gap the strike-clearance loop inserts
+    # before a given layer (keyed by layer index; pushes that layer and every
+    # downstream layer along the flow axis).  Lengthens the flat run into a
+    # station whose own descent/ascent diagonal would otherwise rake its label.
+    label_strike_layer_gaps: dict[int, int] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1289,7 +1289,7 @@ _LABEL_STRIKE_DIAGONAL_XFAIL = {
 _LABEL_STRIKE_FIXTURES = _params_with_xfails(ALL_FIXTURES, _LABEL_STRIKE_DIAGONAL_XFAIL)
 
 
-def _label_glyph_strikes(fixture: str) -> list[tuple[str, str]]:
+def _label_glyph_strikes(fixture: str, **layout_kwargs) -> list[tuple[str, str]]:
     """Return ``(station_id, line_id)`` pairs where a foreign line strikes a label.
 
     Mirrors the renderer: ``route_edges`` mutates Station.x via diagonal
@@ -1297,8 +1297,11 @@ def _label_glyph_strikes(fixture: str) -> list[tuple[str, str]]:
     label glyph-ink boxes are built without restoring X.  A pair is reported
     when a segment of a line the station does not carry (and which is not an
     endpoint of the segment's edge) crosses the label's glyph-ink box.
+
+    ``layout_kwargs`` are forwarded to ``compute_layout`` (e.g. ``x_spacing``)
+    so callers can exercise the strike behaviour at a pinned column pitch.
     """
-    graph = _layout(fixture)
+    graph = _layout(fixture, **layout_kwargs)
     offsets = compute_station_offsets(graph)
     routes = route_edges(graph, station_offsets=offsets)
     theme = THEMES["nfcore"]
@@ -1347,6 +1350,35 @@ def test_no_line_strikes_through_label(fixture):
     )
 
 
+# A label wider than its station's flat run pushes the fan-in/fan-out diagonal
+# transition inside the label's x-extent, so a line the station does not carry
+# rakes its glyphs.  At a tight column pitch the proportional entry/exit runway
+# shrinks below the (fixed-width) label and the strike appears; the engine grows
+# the offending section's runway by whole grid columns until the transition
+# seats clear.  Each case strikes at the pinned pitch on a layout without that
+# growth.
+_TIGHT_PITCH_STRIKE_CASES = [
+    ("topologies/funcprofiler_upstream.mmd", 50),
+    ("topologies/funcprofiler_upstream.mmd", 45),
+    ("topologies/variant_calling.mmd", 45),
+]
+
+
+@pytest.mark.parametrize("fixture,x_spacing", _TIGHT_PITCH_STRIKE_CASES)
+def test_no_diagonal_strikes_label_at_tight_pitch(fixture, x_spacing):
+    """A port-side fan diagonal must not rake a stacked station's name label,
+    even when a tight pitch shrinks the proportional runway below the label.
+
+    The section's entry/exit runway is grown by whole grid columns (the pitch
+    stays fixed) so the fan transition completes outside the label's x-extent.
+    """
+    strikes = _label_glyph_strikes(fixture, x_spacing=x_spacing)
+    assert not strikes, (
+        f"{fixture} @ x_spacing={x_spacing}: foreign lines strike label glyph "
+        "ink: " + ", ".join(f"{lid!r} over {sid!r}" for sid, lid in strikes)
+    )
+
+
 def test_label_strike_guard_catches_a_strike():
     """The runtime guard fires on a genuine glyph strike and clears a graze.
 
@@ -1366,6 +1398,33 @@ def test_label_strike_guard_catches_a_strike():
 
     grazed = _layout("variantbenchmarking.mmd")
     _guard_no_line_strikes_label(grazed, "test")
+
+
+def test_diagonal_strike_guard_teeth_and_exemptions():
+    """The wired narrow guard fires on an unclearable fan-diagonal strike,
+    stays silent once the runway growth has cleared one, and exempts the
+    bypass-V crossing it cannot relocate.
+
+    A fan-into-stack section grown by the strike-clearance loop
+    (``funcprofiler_upstream`` at a tight pitch) must pass; an intra-section
+    fork whose strike the runway cannot move (``wide_label_fan`` at the same
+    pitch) must raise; and a bypass-V label rake (``guide/06a``) must pass,
+    since the guard excludes it.
+    """
+    from nf_metro.layout.phases.guards import (
+        PhaseInvariantError,
+        _guard_no_diagonal_strikes_horizontal_label,
+    )
+
+    cleared = _layout("topologies/funcprofiler_upstream.mmd", x_spacing=45)
+    _guard_no_diagonal_strikes_horizontal_label(cleared, "test")
+
+    unclearable = _layout("topologies/wide_label_fan.mmd", x_spacing=45)
+    with pytest.raises(PhaseInvariantError, match="strikes horizontal label"):
+        _guard_no_diagonal_strikes_horizontal_label(unclearable, "test")
+
+    bypass = _layout("guide/06a_without_hidden.mmd")
+    _guard_no_diagonal_strikes_horizontal_label(bypass, "test")
 
 
 @pytest.mark.parametrize("fixture", _FIXTURES_WITH_DOWNWARD_OUTPUT)

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1289,7 +1289,7 @@ _LABEL_STRIKE_DIAGONAL_XFAIL = {
 _LABEL_STRIKE_FIXTURES = _params_with_xfails(ALL_FIXTURES, _LABEL_STRIKE_DIAGONAL_XFAIL)
 
 
-def _label_glyph_strikes(fixture: str, **layout_kwargs) -> list[tuple[str, str]]:
+def _label_glyph_strikes(fixture: str) -> list[tuple[str, str]]:
     """Return ``(station_id, line_id)`` pairs where a foreign line strikes a label.
 
     Mirrors the renderer: ``route_edges`` mutates Station.x via diagonal
@@ -1297,11 +1297,8 @@ def _label_glyph_strikes(fixture: str, **layout_kwargs) -> list[tuple[str, str]]
     label glyph-ink boxes are built without restoring X.  A pair is reported
     when a segment of a line the station does not carry (and which is not an
     endpoint of the segment's edge) crosses the label's glyph-ink box.
-
-    ``layout_kwargs`` are forwarded to ``compute_layout`` (e.g. ``x_spacing``)
-    so callers can exercise the strike behaviour at a pinned column pitch.
     """
-    graph = _layout(fixture, **layout_kwargs)
+    graph = _layout(fixture)
     offsets = compute_station_offsets(graph)
     routes = route_edges(graph, station_offsets=offsets)
     theme = THEMES["nfcore"]
@@ -1350,33 +1347,48 @@ def test_no_line_strikes_through_label(fixture):
     )
 
 
-# A label wider than its station's flat run pushes the fan-in/fan-out diagonal
-# transition inside the label's x-extent, so a line the station does not carry
-# rakes its glyphs.  At a tight column pitch the proportional entry/exit runway
-# shrinks below the (fixed-width) label and the strike appears; the engine grows
-# the offending section's runway by whole grid columns until the transition
-# seats clear.  Each case strikes at the pinned pitch on a layout without that
-# growth.
+# A label wider than its station's flat run pushes a fan-in/fan-out,
+# convergence, or station-to-station descent diagonal inside the label's
+# x-extent, raking its glyphs.  At a tight column pitch the proportional flat
+# run shrinks below the (fixed-width) label and the strike appears; the engine
+# clears it by lengthening the run with whole grid columns (section runway for a
+# port fan, a per-column gap for an intra-section descent) at a fixed pitch.
+# Each case strikes at the pinned pitch on a layout without that growth.
+# ``None`` exercises the default (gallery) pitch, where these fixtures ship and
+# the strike-clearance loop must keep them clear; the pinned tighter pitches
+# stress the levers where the proportional flat run is shortest.
 _TIGHT_PITCH_STRIKE_CASES = [
+    ("topologies/funcprofiler_upstream.mmd", None),
     ("topologies/funcprofiler_upstream.mmd", 50),
     ("topologies/funcprofiler_upstream.mmd", 45),
+    ("topologies/variant_calling.mmd", None),
     ("topologies/variant_calling.mmd", 45),
+    ("rnaseq_sections.mmd", None),
+    ("topologies/wide_label_fan.mmd", 45),
 ]
 
 
 @pytest.mark.parametrize("fixture,x_spacing", _TIGHT_PITCH_STRIKE_CASES)
-def test_no_diagonal_strikes_label_at_tight_pitch(fixture, x_spacing):
-    """A port-side fan diagonal must not rake a stacked station's name label,
-    even when a tight pitch shrinks the proportional runway below the label.
+def test_no_diagonal_strikes_label(fixture, x_spacing):
+    """No diagonal may rake a station's name label.
 
-    The section's entry/exit runway is grown by whole grid columns (the pitch
-    stays fixed) so the fan transition completes outside the label's x-extent.
+    Uses the engine's own strike definition (the one the clearance loop and the
+    runtime guard share): a fan or descent diagonal -- of any line, the station's
+    own or foreign -- crossing the drawn glyphs, with flat runs, bypass-V
+    crossings, off-track sweeps, and angled labels excluded.  The loop lengthens
+    the flat run with whole grid columns until the transition clears.
     """
-    strikes = _label_glyph_strikes(fixture, x_spacing=x_spacing)
-    assert not strikes, (
-        f"{fixture} @ x_spacing={x_spacing}: foreign lines strike label glyph "
-        "ink: " + ", ".join(f"{lid!r} over {sid!r}" for sid, lid in strikes)
+    from nf_metro.layout.phases.spacing import _struck_stations_and_collinear
+
+    graph = (
+        _layout(fixture) if x_spacing is None else _layout(fixture, x_spacing=x_spacing)
     )
+    struck, collinear = _struck_stations_and_collinear(graph)
+    assert not struck, (
+        f"{fixture} @ x_spacing={x_spacing}: diagonals rake label glyph ink: "
+        + ", ".join(sorted(graph.stations[s].label for s in struck))
+    )
+    assert not collinear, f"{fixture} @ x_spacing={x_spacing}: collinear overlay"
 
 
 def test_label_strike_guard_catches_a_strike():
@@ -1401,15 +1413,14 @@ def test_label_strike_guard_catches_a_strike():
 
 
 def test_diagonal_strike_guard_teeth_and_exemptions():
-    """The wired narrow guard fires on an unclearable fan-diagonal strike,
-    stays silent once the runway growth has cleared one, and exempts the
-    bypass-V crossing it cannot relocate.
+    """The wired guard fires on a strike the clearance loop cannot relocate,
+    stays silent once the loop has cleared one, and exempts the bypass-V rake.
 
-    A fan-into-stack section grown by the strike-clearance loop
-    (``funcprofiler_upstream`` at a tight pitch) must pass; an intra-section
-    fork whose strike the runway cannot move (``wide_label_fan`` at the same
-    pitch) must raise; and a bypass-V label rake (``guide/06a``) must pass,
-    since the guard excludes it.
+    A section the strike-clearance loop grows (``funcprofiler_upstream`` at a
+    tight pitch) must pass; a sectionless flat graph (``centered_tracks`` at a
+    tight pitch), whose struck stations have no section runway or column gap to
+    grow, must raise; and a bypass-V label rake (``guide/06a``) must pass, since
+    the guard excludes it.
     """
     from nf_metro.layout.phases.guards import (
         PhaseInvariantError,
@@ -1419,7 +1430,7 @@ def test_diagonal_strike_guard_teeth_and_exemptions():
     cleared = _layout("topologies/funcprofiler_upstream.mmd", x_spacing=45)
     _guard_no_diagonal_strikes_horizontal_label(cleared, "test")
 
-    unclearable = _layout("topologies/wide_label_fan.mmd", x_spacing=45)
+    unclearable = _layout("centered_tracks.mmd", x_spacing=45)
     with pytest.raises(PhaseInvariantError, match="strikes horizontal label"):
         _guard_no_diagonal_strikes_horizontal_label(unclearable, "test")
 


### PR DESCRIPTION
## Summary

A fan-in/fan-out, convergence, or station-to-station descent diagonal that transitions through a station's name label reads as a strike-through. This happens even at the default column pitch (e.g. `funcprofiler_upstream` `FMH FunProfiler`/`MERGE_RUNS`, `rnaseq_sections` `Kraken2/Bracken`, `variant_calling` `DeepVariant`), and -- crucially -- the line is often one the station itself carries (its own sweep to the section's ports), which the previous foreign-only strike check did not catch.

This PR makes the strike detection match what the renderer draws, then clears the strikes by lengthening the flat run at the struck station with whole grid columns, leaving the column pitch fixed (the grid-quantized approach #513 calls for, not the column-pitch widening of the closed #633).

### Detection
A diagonal through a label's glyph ink is a strike whether or not the station carries the line -- ownership and edge-endpoint are no longer exemptions. Only flat trunk runs, bypass-V crossings, off-track output sweeps, and angled labels stay exempt (a wider flat run cannot relocate those).

### Clearance (two complementary grid-quantized levers, pitch fixed)
- **Section runway** (`Section.label_strike_cols`): lengthens a section's entry/exit runway, clearing a strike from the section's own port fan (e.g. FMH FunProfiler, DeepVariant).
- **Per-column gap** (`Section.label_strike_layer_gaps`): inserts a gap before the struck station's layer, lengthening the flat run into a station whose own descent rakes its label (e.g. MERGE_RUNS's `concat` descent, Kraken2/Bracken).

A strike-clearance loop after the spread loop probes the routed layout, grows both levers for each struck station, re-lays, and rolls back any growth a collinear-overlay check rejects or that fails to reduce the struck-station count. Need-driven: a clean station grows nothing.

### Guard
`_guard_no_diagonal_strikes_horizontal_label` is wired into the validate pass, sharing the loop's probe so it validates the exact geometry the loop reasoned about. It excludes bypass-V and angled labels, so it co-exists with the still-deferred broad `_guard_no_line_strikes_label`.

## Render impact
Five gallery renders gain section width as the diagonals seat clear of the labels (all label-clearance improvements): `funcprofiler_upstream` (added as a gallery entry, now demonstrating the cleared `MERGE_RUNS`/`FMH FunProfiler`), `rnaseq_sections`, `rnaseq_sections_manual`, `variant_calling` (topology). Every other render is byte-identical.

## Out of scope (flagged by the guard, left for follow-up)
- Off-track output sweeps raking a producer label (a separate routing mechanism).
- Strikes in sectionless flat graphs, which have no section runway or column gap to grow.

Fixes #513.

## Test plan
- [x] `pytest` passes (full suite, 6944 passed); `test_no_diagonal_strikes_label` (funcprofiler/variant_calling/wide_label_fan/rnaseq at default + tight pitch) fails on `main`, passes here
- [x] `test_diagonal_strike_guard_teeth_and_exemptions` locks the guard: fires on an unclearable sectionless strike, silent once cleared, exempts bypass-V
- [x] `ruff format --check` + `ruff check` + `mypy` clean on the whole repo
- [x] Gallery diff: 5 changed renders, all label-clearance improvements; remainder byte-identical
- [ ] Render-preview verdict captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
