### PR TITLE
fix(routing): seat bypass-V climb clear of bypassed station label (#632)

### DIFF
--- a/examples/topologies/README.md
+++ b/examples/topologies/README.md
@@ -34,6 +34,7 @@ Each fixture is tagged with the layout class(es) it primarily exercises. Use thi
 | `mixed_port_sides.mmd` | multi-side exit ports (RIGHT + BOTTOM) |
 | `off_track_convergence.mmd` | multiple off-track inputs converging on one consumer |
 | `upward_bypass.mmd` | tall section bypass (upward gap) |
+| `bypass_label_rake.mmd` | bypass V climbs clear of a wide bypassed-station label |
 | `rnaseq_lite.mmd` | realistic pipeline / TB+LR mix / diamond |
 | `variant_calling.mmd` | realistic pipeline / asymmetric fork-join / 4-way fan-in |
 | `funcprofiler_upstream.mmd` | dense fan-out + fan-in / known almost-horizontal defect |

--- a/examples/topologies/bypass_label_rake.mmd
+++ b/examples/topologies/bypass_label_rake.mmd
@@ -1,0 +1,31 @@
+%%metro title: Bypass V Past A Wide Label
+%%metro style: dark
+%%metro line: dna | DNA | #e63946
+%%metro line: rna | RNA | #0570b0
+%%metro line: prot | Protein | #2db572
+
+graph LR
+    subgraph input [Input]
+        fetch[Fetch Data]
+        validate[Validate]
+        fetch -->|dna,rna,prot| validate
+    end
+
+    subgraph processing [Processing]
+        branch[Branch]
+        align[Alignment]
+        quant[Quantification]
+        search[Database Search]
+        branch -->|dna,rna| align
+        branch -->|prot| search
+        align -->|rna| quant
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+    end
+
+    validate -->|dna,rna,prot| branch
+    align -->|dna| multiqc
+    quant -->|rna| multiqc
+    search -->|prot| multiqc

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -325,6 +325,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "Tall section bypass where the trunk is above the source (upward gap1).",
     ),
     (
+        "bypass_label_rake",
+        TOPOLOGIES_DIR,
+        "A foreign line dips below a station to bypass its marker, then climbs "
+        "back to the trunk past the wide 'Quantification' label. The router "
+        "lengthens the dip's flat run so the climb seats clear of the glyphs "
+        "(`_clear_bypass_v_label_strikes`).",
+    ),
+    (
         "off_track_convergence",
         TOPOLOGIES_DIR,
         "Multiple off-track file inputs converging on a single consumer. "

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -133,6 +133,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_no_label_overlap,
     _guard_no_line_crosses_file_icon,
     _guard_no_line_crosses_non_consumer,
+    _guard_no_line_strikes_label,
     _guard_no_negative_grid_columns,
     _guard_no_route_through_section,
     _guard_no_station_overlap,
@@ -244,6 +245,7 @@ from nf_metro.layout.phases.snapshots import (
 from nf_metro.layout.phases.spacing import (  # noqa: F401
     _MAX_SPREAD_ITERS,
     _SPREAD_SLACK,
+    _bypass_label_obstacles,
     _residual_label_overlaps,
     _spread_bump,
     _struck_stations_and_collinear,
@@ -716,6 +718,12 @@ def _compute_layout_scaled(
                 section_y_padding=section_y_padding,
             )
 
+    # Record the bypassed-station label box behind each bypass V so the router
+    # can seat the V's flat-run corners clear of the label.  Read on the render
+    # path, so it is populated independent of ``validate``; computed once the
+    # layout has fully settled so the box matches what the renderer draws.
+    graph.bypass_label_obstacles = _bypass_label_obstacles(graph)
+
     # Always-on backstop (independent of ``validate``): the settled layout
     # must never leave a station outside its own section bbox.  Runs on the
     # render path so an unsupported directive combination fails loudly
@@ -726,6 +734,7 @@ def _compute_layout_scaled(
     if validate:
         _guard_no_label_overlap(graph, "final")
         _guard_no_diagonal_strikes_horizontal_label(graph, "final")
+        _guard_no_line_strikes_label(graph, "final")
         _guard_no_wrapped_label_trunk_strike(graph, "final")
         _guard_file_icon_no_name_label(graph, "final")
         _guard_no_line_crosses_file_icon(graph, "final")

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1072,10 +1072,10 @@ def _guard_no_diagonal_strikes_horizontal_label(
     loop uses, so it validates exactly the geometry the loop reasoned about.
 
     Narrower than :func:`_guard_no_line_strikes_label`: it excludes bypass-V
-    crossings (a V sits a fixed offset from the station, so runway growth cannot
-    relocate it) and angled labels (handled by their rotated footprint, not
-    column runway), so it can be wired into the validate pass while those
-    remain.
+    crossings (cleared by the router seating the V's flat-run corners off the
+    label, not by runway growth) and angled labels (handled by their rotated
+    footprint).  It attributes a fan or convergence strike to the runway loop
+    that owns it.
     """
     from nf_metro.layout.phases.spacing import (
         _probe_label_placements,
@@ -1111,9 +1111,9 @@ def _guard_no_wrapped_label_trunk_strike(
     render-time lift in ``place_labels`` pulls such a label back to its
     un-pushed anchor; this asserts the settled render leaves none striking.
 
-    Narrower than :func:`_guard_no_line_strikes_label` (which is not wired into
-    the validate pass while diagonal-rake strikes remain): it covers only the
-    horizontal-trunk overrun the lift resolves, so it can run as an invariant.
+    Narrower than :func:`_guard_no_line_strikes_label`: it covers only the
+    horizontal-trunk overrun the lift resolves, reported against the unlifted
+    geometry the render-time lift then clears.
     """
     from nf_metro.layout.labels import (
         find_wrapped_label_trunk_strikes,

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -252,3 +252,42 @@ def _spread_bump(
     new_x = x_spacing + extra_x if auto_x else x_spacing
     new_y = y_spacing + extra_y if auto_y else y_spacing
     return new_x, new_y
+
+
+def _bypass_label_obstacles(
+    graph: MetroGraph,
+) -> dict[str, tuple[float, float, float, float]]:
+    """Glyph-ink bbox of each bypassed station's label, keyed by its bypass V.
+
+    Probes the renderer's settled labelling and, for every hidden bypass-V
+    helper station, records the drawn glyph-ink box of the station the V routes
+    around.  The router consumes this to seat the V's flat-run corners clear of
+    that label.  Boxes are in rendered (offset-applied) coordinates and only
+    cover Vs whose bypassed station carries a drawn name; the result is empty
+    when no bypass V exists or the probe fails.
+    """
+    from nf_metro.layout.labels import label_glyph_ink_bbox
+
+    vs = [
+        st
+        for st in graph.stations.values()
+        if st.is_hidden and st.bypasses_station_id is not None
+    ]
+    if not vs:
+        return {}
+    probe = _probe_label_placements(graph, allow_hyphenation=True)
+    if probe is None:
+        return {}
+    _offsets, _routes, placements = probe
+    ink_by_sid = {
+        p.station_id: label_glyph_ink_bbox(p)
+        for p in placements
+        if p.station_id and not p.angle
+    }
+    obstacles: dict[str, tuple[float, float, float, float]] = {}
+    for st in vs:
+        sid = st.bypasses_station_id
+        box = ink_by_sid.get(sid) if sid is not None else None
+        if box is not None:
+            obstacles[st.id] = box
+    return obstacles

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -113,6 +113,7 @@ from nf_metro.layout.routing.postprocess import (  # noqa: F401
     _BubbleCtx,
     _build_bubble_ctx,
     _center_bubble_stations,
+    _clear_bypass_v_label_strikes,
     _collect_centering_candidates,
     _is_diagonal_route,
     _spread_diagonal_bundles,
@@ -215,5 +216,6 @@ def route_edges(
     _align_peeloff_riser_gaps(routes, ctx)
     _coincide_convergent_port_approaches(routes)
     _join_fanout_upstream_tails(routes, ctx)
+    _clear_bypass_v_label_strikes(routes, ctx)
 
     return routes

--- a/src/nf_metro/layout/routing/postprocess.py
+++ b/src/nf_metro/layout/routing/postprocess.py
@@ -9,9 +9,14 @@ from dataclasses import dataclass
 from nf_metro.layout.constants import (
     COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
+    CURVE_RADIUS,
+    DIAGONAL_RUN,
+    LABEL_BBOX_MARGIN,
     MIN_STRAIGHT_EDGE,
+    MIN_STRAIGHT_PORT,
     STATION_MOVE_TOLERANCE,
 )
+from nf_metro.layout.geometry import segment_intersects_bbox
 from nf_metro.layout.routing.common import (
     RoutedPath,
 )
@@ -573,3 +578,80 @@ def _center_bubble_stations(routes: list[RoutedPath], graph: MetroGraph) -> None
     candidates = _collect_centering_candidates(graph, ctx)
     _apply_station_moves(graph, candidates, ctx.original_x)
     _align_uncentered_siblings(routes, graph, ctx.original_x)
+
+
+def _clear_bypass_v_label_strikes(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
+    """Lengthen a bypass V's flat run so its diagonal clears the bypassed label.
+
+    A bypass V dips its line below (or rises above) the station it routes around
+    and climbs back to the trunk on the far side.  When that station carries a
+    wide name label, the climbing diagonal can rake the label's glyph ink on the
+    overrun side -- a strike that neither a label side-flip nor a column-pitch
+    widening relocates, because the V sits a fixed track offset from the station
+    rather than a grid-column multiple.
+
+    For each V whose bypassed-station label box ``compute_layout`` recorded in
+    ``graph.bypass_label_obstacles``, this seats the V-side corner of any leg
+    whose diagonal crosses that box just outside the box on the overrun side, so
+    the diagonal climbs clear of the glyphs.  The far diagonal corner follows
+    within the room left before the leg's other endpoint, keeping a drawable
+    transition.  Legs whose diagonal already clears the box are untouched, so a
+    bypass V beside a narrow (or oppositely-placed) label is left as routed.
+
+    When the room before the leg's endpoint is too tight to fully seat the
+    corner clear, the corner is pulled back only as far as a drawable
+    ``CURVE_RADIUS`` transition allows, so clearance can be partial; the wired
+    ``_guard_no_line_strikes_label`` is the backstop for that residual.
+    """
+    obstacles = ctx.graph.bypass_label_obstacles
+    if not obstacles or ctx.station_offsets is None:
+        return
+
+    from nf_metro.render.svg import apply_route_offsets
+
+    legs_by_v: dict[str, list[RoutedPath]] = defaultdict(list)
+    for r in routes:
+        for nid in (r.edge.source, r.edge.target):
+            if nid in obstacles:
+                legs_by_v[nid].append(r)
+
+    for vid, legs in legs_by_v.items():
+        box = obstacles[vid]
+        bx0, _by0, bx1, _by1 = box
+        box_cx = (bx0 + bx1) / 2
+        for r in legs:
+            if not _is_diagonal_route(r):
+                continue
+            opts = apply_route_offsets(r, ctx.station_offsets)
+            (dx1, dy1), (dx2, dy2) = opts[1], opts[2]
+            if not segment_intersects_bbox(dx1, dy1, dx2, dy2, box):
+                continue
+            # On a 4-point bypass leg the V-adjacent corner is index 1 when the
+            # V is the source and index 2 when it is the target; the far corner
+            # climbs to the leg's other endpoint.
+            v_idx, far_idx = (1, 2) if r.edge.source == vid else (2, 1)
+            far_node = r.edge.target if v_idx == 1 else r.edge.source
+            far_st = ctx.graph.stations.get(far_node)
+            far_min = (
+                CURVE_RADIUS + MIN_STRAIGHT_PORT
+                if far_st is not None and far_st.is_port
+                else MIN_STRAIGHT_EDGE
+            )
+            # Push the corner toward whichever label edge it overruns: the V
+            # corner sits on the overrun side, so the half of the box it lies in
+            # picks the direction.
+            far_end_x = opts[3][0] if v_idx == 1 else opts[0][0]
+            if opts[v_idx][0] >= box_cx:
+                v_target = bx1 + LABEL_BBOX_MARGIN
+                far_target = min(v_target + DIAGONAL_RUN, far_end_x - far_min)
+                v_target = min(v_target, far_target - CURVE_RADIUS)
+            else:
+                v_target = bx0 - LABEL_BBOX_MARGIN
+                far_target = max(v_target - DIAGONAL_RUN, far_end_x + far_min)
+                v_target = max(v_target, far_target + CURVE_RADIUS)
+            # ``apply_route_offsets`` shifts only Y, so these X targets apply
+            # directly to the raw waypoints.
+            pts = list(r.points)
+            pts[v_idx] = (v_target, pts[v_idx][1])
+            pts[far_idx] = (far_target, pts[far_idx][1])
+            r.points = pts

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -126,6 +126,11 @@ class Station:
     section_id: str | None = None
     is_port: bool = False
     is_hidden: bool = False
+    # For a hidden bypass-V helper station, the id of the real station whose
+    # marker the routed line bypasses.  Lets the router seat the V's flat-run
+    # corners clear of that station's name label (the V carries no label of its
+    # own).  None for every non-bypass station.
+    bypasses_station_id: str | None = None
     # Per-station marker style from %%metro marker:; None = default pill.
     marker: MarkerStyle | None = None
     # When True, the station is lifted above the section's top track in a
@@ -333,6 +338,14 @@ class MetroGraph:
     # Opt-in diagonal station labels. None means "use the theme
     # default" (0 = horizontal); a directive value overrides the theme.
     label_angle: float | None = None
+    # Maps a hidden bypass-V station id to the glyph-ink bbox of the label of
+    # the station it bypasses, in rendered (offset-applied) coordinates.
+    # Populated by ``compute_layout`` once the layout settles; the router reads
+    # it to seat the V's flat-run corners clear of that label.  Empty until a
+    # bypass V's diagonal would otherwise rake the bypassed station's name.
+    bypass_label_obstacles: dict[str, tuple[float, float, float, float]] = field(
+        default_factory=dict
+    )
     # %%metro legend_combo entries: (line_ids, label) pairs.
     legend_combos: list[tuple[tuple[str, ...], str]] = field(default_factory=list)
     # Placement modifiers for the bundled legend+logo block. The corner/edge

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -334,6 +334,7 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                         label="",
                         section_id=section.id,
                         is_hidden=True,
+                        bypasses_station_id=sid,
                     )
                 )
 

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -1427,6 +1427,11 @@ def check_intra_section_chain_alignment(
             continue
         if src.is_port or tgt.is_port:
             continue
+        if src.is_hidden or tgt.is_hidden:
+            # A hidden bypass V dips off the trunk to route a line around a
+            # station marker, so an edge into or out of it is diagonal by
+            # design, not a chain misalignment.
+            continue
         if src.is_terminus or tgt.is_terminus:
             continue
         if src.section_id is None or src.section_id != tgt.section_id:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1276,15 +1276,12 @@ def test_off_track_outputs_below_downward_branch_producer(fixture):
         )
 
 
-# Fixtures where a foreign bypass V rakes a wide label's glyph ink on BOTH
-# sides of its station, so flipping the label to its other side does not clear
-# it (``_avoid_diagonal_strikethrough`` leaves a label whose flip target is also
-# struck).  Clearing these needs the V's flat run widened past the label or the
-# label moved, not a side flip -- tracked as a follow-up.
-_LABEL_STRIKE_DIAGONAL_XFAIL = {
-    "guide/06a_without_hidden.mmd": "bypass V rakes 'Quantification' both sides",
-    "guide/06b_with_hidden.mmd": "bypass V rakes 'Quantification' both sides",
-}
+# No known fixture leaves a line striking through a station's name label: fan
+# and convergence diagonals are cleared by the column-runway loop and a foreign
+# bypass V's climb is seated clear of the bypassed station's label by the router
+# (``_clear_bypass_v_label_strikes``).  New strikes are caught both here and by
+# the wired ``_guard_no_line_strikes_label`` validate guard.
+_LABEL_STRIKE_DIAGONAL_XFAIL: dict[str, str] = {}
 
 _LABEL_STRIKE_FIXTURES = _params_with_xfails(ALL_FIXTURES, _LABEL_STRIKE_DIAGONAL_XFAIL)
 
@@ -1394,10 +1391,12 @@ def test_no_diagonal_strikes_label(fixture, x_spacing):
 def test_label_strike_guard_catches_a_strike():
     """The runtime guard fires on a genuine glyph strike and clears a graze.
 
-    Locks the guard's teeth and its glyph-ink discrimination: a fixture whose
-    bypass V rakes a wide label's glyphs on both sides (no flip clears it) must
-    raise, while one where a line only clips a label's empty reserved margin
-    must pass.
+    Locks the guard's teeth and its glyph-ink discrimination.  ``guide/06a``'s
+    bypass V rakes a wide label's glyphs on both sides until the router seats
+    the V clear (``_clear_bypass_v_label_strikes``); emptying the obstacle map
+    the router reads reinstates that strike, so the guard -- the backstop behind
+    the router -- must raise on it.  A fixture where a line only clips a label's
+    empty reserved margin must pass.
     """
     from nf_metro.layout.phases.guards import (
         PhaseInvariantError,
@@ -1405,6 +1404,7 @@ def test_label_strike_guard_catches_a_strike():
     )
 
     struck = _layout("guide/06a_without_hidden.mmd")
+    struck.bypass_label_obstacles = {}
     with pytest.raises(PhaseInvariantError, match="strikes through label"):
         _guard_no_line_strikes_label(struck, "test")
 


### PR DESCRIPTION
## Summary

A foreign **bypass V** dips a line below (or above) the station it routes around and climbs back to the trunk on the far side. When that station carries a wide name label, the climbing diagonal raked the label's glyph ink on the overrun side. Neither a label side-flip (`_avoid_diagonal_strikethrough` finds no clear side) nor the #513 column-runway widening relocates it: the V sits a fixed track offset from the station, not a grid-column multiple, so the strike-clearance loop deliberately excludes it.

This was the residual case left after #513 (the `quant` "Quantification" station in `guide/06a_without_hidden` and `guide/06b_with_hidden`).

### Approach

- `Station` gains `bypasses_station_id` so a hidden bypass-V links to the real station it routes around (set in `_insert_bypass_stations`).
- `compute_layout` records each bypassed station's settled label glyph-ink box on `graph.bypass_label_obstacles` (engine decides, router executes, mirroring the `section.label_strike_*` levers). The probe is skipped entirely when the graph has no bypass V.
- A routing post-pass `_clear_bypass_v_label_strikes` lengthens the V's flat run so any leg whose diagonal crosses the box seats its V-side corner just outside the label on the overrun side; the far corner follows within the room before the leg's endpoint. Legs that already clear the box are untouched.
- The broad `_guard_no_line_strikes_label` is wired into the `validate` pass as the backstop (it was intentionally unwired while this clip remained).
- The chain-alignment validator skips hidden helper stations (a bypass V is diagonal by design).

The `guide/06a`/`06b` xfail entries in `test_no_line_strikes_through_label` are flipped out; a new `bypass_label_rake` gallery topology demonstrates the fix in the render diff.

Fixes #632

## Test plan
- [x] `pytest` passes (7026 passed, 0 failed; the 2 bypass-V xfails are now passing)
- [x] `ruff check` + `ruff format --check` clean on whole repo
- [x] `mypy` clean
- [x] Runtime validator `_guard_no_line_strikes_label` wired into validate
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/638/)
- [ ] Render-preview verdict: expect 1 new render (`bypass_label_rake`), existing renders byte-identical