### PR TITLE
fix(routing): merge same-line side-by-side runs into one trunk (#546)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -136,6 +136,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_no_line_strikes_label,
     _guard_no_negative_grid_columns,
     _guard_no_route_through_section,
+    _guard_no_same_line_parallel_descents,
     _guard_no_station_overlap,
     _guard_no_wrapped_label_trunk_strike,
     _guard_off_track_clear_of_anchor,
@@ -1570,6 +1571,9 @@ def _finalize_layout(
                 graph, phase, offsets=offsets, routes=routes
             )
             _guard_no_intra_section_collinear_distinct_lines(
+                graph, phase, offsets=offsets, routes=routes
+            )
+            _guard_no_same_line_parallel_descents(
                 graph, phase, offsets=offsets, routes=routes
             )
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -47,10 +47,13 @@ from nf_metro.layout.phases.spacing import (
 from nf_metro.parser.model import LineSpread, MetroGraph, PortSide, Section, Station
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
+    from typing import Protocol
 
     from nf_metro.layout.routing.common import RoutedPath
-    from nf_metro.layout.routing.invariants import CollinearOverlapViolation
+
+    class _HasMessage(Protocol):
+        def message(self) -> str: ...
 
 
 class PhaseInvariantError(Exception):
@@ -2244,7 +2247,7 @@ def _guard_no_collinear_distinct_lines(
         check_no_collinear_distinct_lines,
     )
 
-    _raise_on_collinear_overlay(
+    _raise_on_first_violation(
         graph, phase, check_no_collinear_distinct_lines, offsets, routes
     )
 
@@ -2267,22 +2270,45 @@ def _guard_no_intra_section_collinear_distinct_lines(
         check_intra_section_collinear_distinct_lines,
     )
 
-    _raise_on_collinear_overlay(
+    _raise_on_first_violation(
         graph, phase, check_intra_section_collinear_distinct_lines, offsets, routes
     )
 
 
-def _raise_on_collinear_overlay(
+def _guard_no_same_line_parallel_descents(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: one line never descends as two parallel adjacent tracks.
+
+    Wraps :func:`check_no_same_line_parallel_descents`: where a line fans out
+    from one source (or converges on one port), the branches must share a
+    single trunk over the span they travel together rather than occupying
+    adjacent offset slots that render as two same-colour tracks.
+    """
+    from nf_metro.layout.routing.invariants import (
+        check_no_same_line_parallel_descents,
+    )
+
+    _raise_on_first_violation(
+        graph, phase, check_no_same_line_parallel_descents, offsets, routes
+    )
+
+
+def _raise_on_first_violation(
     graph: MetroGraph,
     phase: str,
     check: Callable[
         [MetroGraph, list[RoutedPath], dict[tuple[str, str], float]],
-        list[CollinearOverlapViolation],
+        Sequence[_HasMessage],
     ],
     offsets: dict[tuple[str, str], float] | None,
     routes: list[RoutedPath] | None,
 ) -> None:
-    """Run a collinear-overlay *check* and raise on the first violation."""
+    """Run a route *check* and raise ``PhaseInvariantError`` on its first hit."""
     if offsets is None:
         from nf_metro.layout.routing import compute_station_offsets
 

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -80,6 +80,7 @@ from nf_metro.layout.routing.normalize import (  # noqa: F401
     _clamp_inter_row_band_top,
     _clear_channel_x_in_band,
     _coincide_convergent_port_approaches,
+    _coincide_divergent_fanout_descents,
     _coincident_trunk_slots,
     _collect_htrunks,
     _collect_vchannels,
@@ -101,8 +102,8 @@ from nf_metro.layout.routing.normalize import (  # noqa: F401
     _restack_channel,
     _restack_htrunk,
     _restack_trunk_band,
-    _set_port_approach_x,
     _set_riser_x_and_radii,
+    _set_vchannel_x,
     _suboptimal_trunk_bands,
     _VChannel,
 )
@@ -215,6 +216,7 @@ def route_edges(
     _normalize_bypass_trunks(routes, ctx)
     _align_peeloff_riser_gaps(routes, ctx)
     _coincide_convergent_port_approaches(routes)
+    _coincide_divergent_fanout_descents(routes)
     _join_fanout_upstream_tails(routes, ctx)
     _clear_bypass_v_label_strikes(routes, ctx)
 

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -28,6 +28,7 @@ from enum import Enum
 from nf_metro.layout.constants import (
     COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
+    EDGE_TO_BUNDLE_CLEARANCE,
     OFFSET_STEP,
     SAME_Y_TOLERANCE,
 )
@@ -869,17 +870,107 @@ def check_partial_branch_offset_gaps(
     return violations
 
 
+@dataclass(frozen=True)
+class SameLineParallelRun:
+    """Two same-line segments running parallel a few pixels apart over a span.
+
+    The two segments share an endpoint - one source fans out to several
+    targets, or several feeds converge on one port - yet travel their common
+    stretch in adjacent channels instead of one merged trunk, so the single
+    line renders as two parallel same-colour tracks.
+    """
+
+    line_id: str
+    edge_a: tuple[str, str]
+    edge_b: tuple[str, str]
+    axis: str
+    sep: float
+    span: float
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        return (
+            f"same-line parallel run: line {self.line_id!r} "
+            f"({self.edge_a[0]}->{self.edge_a[1]}) and "
+            f"({self.edge_b[0]}->{self.edge_b[1]}) run parallel on the "
+            f"{self.axis} axis {self.sep:.1f}px apart over {self.span:.1f}px"
+        )
+
+
+def check_no_same_line_parallel_descents(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[SameLineParallelRun]:
+    """Return same-line vertical descents that share an endpoint yet run parallel.
+
+    A line that fans out from one source to several targets (or converges
+    on one port from several feeds) must descend as a SINGLE trunk over the
+    span its branches travel together, splitting only where each branch
+    turns off.  When the branches instead occupy adjacent offset slots they
+    render as two parallel same-colour tracks that read as two routes.
+
+    Flags pairs of same-line vertical inter-section segments that share a
+    source or target endpoint, sit more than ``_COLLINEAR_LATERAL_TOL`` but
+    no more than ``EDGE_TO_BUNDLE_CLEARANCE`` apart (a merged trunk falls
+    below the floor; genuinely-distant corridors above the ceiling), and
+    overlap by more than ``_COLLINEAR_MIN_SPAN``.
+    """
+    segs: list[tuple[str, tuple[str, str], float, float, float]] = []
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        pts = _route_render_points(rp, offsets)
+        edge = (rp.edge.source, rp.edge.target)
+        for p1, p2 in zip(pts, pts[1:]):
+            axis, coord = _axis_aligned(p1, p2)
+            if axis != "V":
+                continue
+            lo, hi = sorted((p1[1], p2[1]))
+            segs.append((rp.line_id, edge, coord, lo, hi))
+
+    violations: list[SameLineParallelRun] = []
+    for i in range(len(segs)):
+        la, ea, xa, lo_a, hi_a = segs[i]
+        for j in range(i + 1, len(segs)):
+            lb, eb, xb, lo_b, hi_b = segs[j]
+            if la != lb:
+                continue
+            if ea[0] != eb[0] and ea[1] != eb[1]:
+                continue
+            sep = abs(xa - xb)
+            if sep <= _COLLINEAR_LATERAL_TOL or sep > EDGE_TO_BUNDLE_CLEARANCE:
+                continue
+            olo, ohi = max(lo_a, lo_b), min(hi_a, hi_b)
+            span = ohi - olo
+            if span <= _COLLINEAR_MIN_SPAN:
+                continue
+            violations.append(
+                SameLineParallelRun(
+                    line_id=la,
+                    edge_a=ea,
+                    edge_b=eb,
+                    axis="V",
+                    sep=sep,
+                    span=span,
+                )
+            )
+    return violations
+
+
 __all__ = [
     "BundleOrderViolation",
     "CollinearOverlapViolation",
     "FanoutTailGap",
     "MergePortApproachViolation",
     "PartialBranchGapViolation",
+    "SameLineParallelRun",
     "Side",
     "check_bundle_order_preserved",
     "check_fanout_tail_join",
     "check_merge_port_approach_side",
     "check_no_collinear_distinct_lines",
+    "check_no_same_line_parallel_descents",
     "check_partial_branch_offset_gaps",
     "classify_merge_port_feeders",
     "distinct_offset_levels",

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -675,33 +675,37 @@ def _coincide_convergent_port_approaches(routes: list[RoutedPath]) -> None:
     fused descents are a single track, so the concentric-bundle radii no
     longer apply.
     """
-    by_port: dict[tuple[float, float, str, bool], list[_VChannel]] = defaultdict(list)
+    by_port: dict[tuple[str, str, bool], list[_VChannel]] = defaultdict(list)
     for rp in routes:
         if not rp.is_inter_section:
             continue
         ch = _final_port_approach(rp)
         if ch is None:
             continue
-        ex, ey = rp.points[-1]
-        key = (round(ex, 1), round(ey, 1), rp.line_id, ch.down)
+        # Group by the destination port, not its exact terminal (x, y): two
+        # same-line descents into one port can land a per-line offset apart
+        # before render offsets are applied, and keying on the raw endpoint
+        # would split that single convergence into two.
+        key = (rp.edge.target, rp.line_id, ch.down)
         by_port[key].append(ch)
 
     band = EDGE_TO_BUNDLE_CLEARANCE
-    for (ex, _ey, _lid, _down), chans in by_port.items():
+    for chans in by_port.values():
         if len(chans) < 2:
             continue
+        ex = chans[0].route.points[-1][0]
         # Cluster by descent X proximity; widely-separated descents are
         # distinct corridors and must not be fused.
         chans.sort(key=lambda c: c.x)
         cluster: list[_VChannel] = []
 
-        def _flush(cluster: list[_VChannel]) -> None:
+        def _flush(cluster: list[_VChannel], ex: float = ex) -> None:
             if len(cluster) < 2:
                 return
             merge_x = min(cluster, key=lambda c: abs(c.x - ex)).x
             for c in cluster:
                 if abs(c.x - merge_x) > COORD_TOLERANCE:
-                    _set_port_approach_x(c, merge_x)
+                    _set_vchannel_x(c, merge_x)
 
         for ch in chans:
             if cluster and ch.x - cluster[-1].x > band:
@@ -711,11 +715,11 @@ def _coincide_convergent_port_approaches(routes: list[RoutedPath]) -> None:
         _flush(cluster)
 
 
-def _set_port_approach_x(ch: _VChannel, new_x: float) -> None:
-    """Move a final port-approach vertical to *new_x*, resetting its corners.
+def _set_vchannel_x(ch: _VChannel, new_x: float) -> None:
+    """Move a vertical channel to *new_x*, resetting its flanking corners.
 
-    The fused descents form one track, so both flanking corners take the base
-    ``CURVE_RADIUS`` (no concentric nesting remains to size them apart).
+    Fusing same-line descents into one track removes the concentric-bundle
+    nesting, so both flanking corners take the base ``CURVE_RADIUS``.
     """
     rp = ch.route
     pts = rp.points
@@ -727,6 +731,88 @@ def _set_port_approach_x(ch: _VChannel, new_x: float) -> None:
     for radius_idx in (k - 1, k):
         if 0 <= radius_idx < len(rp.curve_radii):
             rp.curve_radii[radius_idx] = reference_anchored_radius(0.0, CURVE_RADIUS)
+
+
+def _initial_fanout_descent(rp: RoutedPath) -> _VChannel | None:
+    """The first vertical descent leaving a route's source, when it leads H then V.
+
+    A fan-out branch starts ``(sx, sy) -> (vx, sy) -> (vx, dy) -> ...``: a
+    short horizontal lead off the shared source, then a vertical descent in
+    its own channel.  Returns the :class:`_VChannel` for that descent
+    (``idx`` points at ``points[1]``), or ``None`` when the route does not
+    open horizontal-then-vertical.
+    """
+    pts = rp.points
+    if len(pts) < 3:
+        return None
+    x0, y0 = pts[0]
+    x1, y1 = pts[1]
+    x2, y2 = pts[2]
+    if abs(y1 - y0) > COORD_TOLERANCE or abs(x1 - x0) <= COORD_TOLERANCE:
+        return None  # first segment is not a horizontal lead off the source
+    if abs(x2 - x1) > COORD_TOLERANCE or abs(y2 - y1) <= COORD_TOLERANCE:
+        return None  # second segment is not a vertical descent
+    return _VChannel(
+        route=rp,
+        idx=1,
+        x=x1,
+        y_lo=min(y1, y2),
+        y_hi=max(y1, y2),
+        down=y2 > y1,
+    )
+
+
+def _coincide_divergent_fanout_descents(routes: list[RoutedPath]) -> None:
+    """Fuse same-line vertical descents leaving one source into one track.
+
+    The mirror of :func:`_coincide_convergent_port_approaches`: where the
+    convergent pass merges same-line descents *arriving* at one port, this
+    merges same-line descents *leaving* one source (a junction or exit port).
+    Several inter-section edges of the SAME line fanning out from one source
+    each open with their own horizontal lead and vertical channel a few pixels
+    apart; over the span they descend together they read as two parallel
+    same-colour tracks rather than one trunk that splits where the branches
+    actually turn off.
+
+    Channels are clustered by source endpoint + line + descent direction;
+    only clusters whose members fall within ``EDGE_TO_BUNDLE_CLEARANCE`` of
+    each other are fused (widely-separated descents head down genuinely
+    distinct corridors and must stay apart).  The merge X is the member
+    nearest the source, keeping the fused trunk hugging the side the branches
+    leave from; each branch still splits off downstream at its own turn Y.
+    """
+    by_source: dict[tuple[str, str, bool], list[_VChannel]] = defaultdict(list)
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        ch = _initial_fanout_descent(rp)
+        if ch is None:
+            continue
+        key = (rp.edge.source, rp.line_id, ch.down)
+        by_source[key].append(ch)
+
+    band = EDGE_TO_BUNDLE_CLEARANCE
+    for chans in by_source.values():
+        if len(chans) < 2:
+            continue
+        sx = chans[0].route.points[0][0]
+        chans.sort(key=lambda c: c.x)
+
+        def _flush(cluster: list[_VChannel], sx: float = sx) -> None:
+            if len(cluster) < 2:
+                return
+            merge_x = min(cluster, key=lambda c: abs(c.x - sx)).x
+            for c in cluster:
+                if abs(c.x - merge_x) > COORD_TOLERANCE:
+                    _set_vchannel_x(c, merge_x)
+
+        cluster: list[_VChannel] = []
+        for ch in chans:
+            if cluster and ch.x - cluster[-1].x > band:
+                _flush(cluster)
+                cluster = []
+            cluster.append(ch)
+        _flush(cluster)
 
 
 def _normalize_bypass_trunks(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:

--- a/tests/test_same_line_parallel_run_invariant.py
+++ b/tests/test_same_line_parallel_run_invariant.py
@@ -1,0 +1,92 @@
+"""Tests for the same-line parallel-run invariant.
+
+A single metro line that fans out from one source to several targets (or
+converges on one port from several feeds) must travel the span its branches
+share as ONE trunk, splitting only where each branch turns off.  When the
+branches instead descend in adjacent offset slots they render as two parallel
+same-colour tracks that read as two distinct routes.
+
+Covers:
+
+* Happy-path: every gallery fixture and example routes with no same-line
+  parallel descent.
+* Targeted: ``variantbenchmarking`` / ``variantbenchmarking_auto`` (the
+  reported defect) route their ``test`` and ``truth`` fans as single trunks.
+* Meaningfulness: with the merge passes disabled the checker fires on the
+  reported fixtures, so the invariant genuinely encodes the bug.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import nf_metro.layout.routing.core as routing_core
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.invariants import (
+    check_no_same_line_parallel_descents,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOPOLOGIES = REPO_ROOT / "tests" / "fixtures" / "topologies"
+EXAMPLES = REPO_ROOT / "examples"
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = []
+    paths.extend(sorted(TOPOLOGIES.glob("*.mmd")))
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    return paths
+
+
+def _route(path: Path):
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    return graph, routes, offsets
+
+
+@pytest.mark.parametrize(
+    "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
+)
+def test_no_same_line_parallel_descents_in_gallery(path: Path) -> None:
+    """Every shipped topology and example routes without a same-line line
+    descending as two parallel adjacent tracks."""
+    graph, routes, offsets = _route(path)
+    violations = check_no_same_line_parallel_descents(graph, routes, offsets)
+    assert not violations, "\n".join(v.message() for v in violations)
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ["variantbenchmarking.mmd", "variantbenchmarking_auto.mmd"],
+)
+def test_variantbenchmarking_fans_are_single_trunks(fixture: str) -> None:
+    """The reported fan-out/fan-in duplications route as single trunks."""
+    graph, routes, offsets = _route(EXAMPLES / fixture)
+    violations = check_no_same_line_parallel_descents(graph, routes, offsets)
+    assert not violations, "\n".join(v.message() for v in violations)
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ["variantbenchmarking.mmd", "variantbenchmarking_auto.mmd"],
+)
+def test_checker_fires_without_merge_passes(
+    fixture: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disabling the merge passes reproduces the doubled descents the
+    invariant is meant to catch, proving the check is not vacuous."""
+    monkeypatch.setattr(
+        routing_core, "_coincide_divergent_fanout_descents", lambda routes: None
+    )
+    monkeypatch.setattr(
+        routing_core, "_coincide_convergent_port_approaches", lambda routes: None
+    )
+    graph, routes, offsets = _route(EXAMPLES / fixture)
+    violations = check_no_same_line_parallel_descents(graph, routes, offsets)
+    assert violations, "expected doubled same-line descents with merge passes off"


### PR DESCRIPTION
## Summary

A single metro line that fans out from one source to several targets (or converges on one port from several feeds) could render as **two parallel same-colour vertical tracks** a few pixels apart, reading as two distinct routes where there is really one. Visible on the `variantbenchmarking` renders (the `test` and `truth` fans through the benchmarking / ensembl-truth bundles).

This adds an eager same-line merge at routing time:

- New post-routing pass `_coincide_divergent_fanout_descents` fuses same-line descents **leaving** one source onto a shared channel - the mirror of the existing `_coincide_convergent_port_approaches`, which fuses descents **arriving** at one port. A new `_initial_fanout_descent` helper detects the leading descent.
- The convergent pass is keyed on the **destination port id** rather than the exact terminal `(x, y)`, so two same-line descents that reach one port a per-line offset apart (before render offsets are applied) are no longer split into two.
- Each branch still splits off downstream at its own turn; only the shared span collapses to one stroke.

Enforcement:

- `check_no_same_line_parallel_descents` (returns `SameLineParallelRun`) flags same-line vertical inter-section segments that share an endpoint and run parallel within `EDGE_TO_BUNDLE_CLEARANCE` over an overlapping span.
- `_guard_no_same_line_parallel_descents` raises under `compute_layout(validate=True)`.

Render impact: only `variantbenchmarking`, `variantbenchmarking_auto`, and `pipeline_variantbenchmarking` change; all other gallery renders are byte-identical.

Fixes #546

## Test plan

- [x] `pytest` passes (7061 passed); new `tests/test_same_line_parallel_run_invariant.py` includes a meaningfulness test that fails with the merge passes disabled
- [x] `ruff check` + `ruff format --check` clean on whole repo
- [x] `mypy` clean
- [x] Runtime validator added (`_guard_no_same_line_parallel_descents`)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/639/)
- [ ] Render-preview verdict captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
