### PR TITLE
feat(info): add --json + richer graph introspection

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar
@@ -9,6 +10,7 @@ from typing import Any, TypeVar
 import click
 
 from nf_metro import __version__
+from nf_metro.introspect import build_info, format_info_json, format_info_text
 from nf_metro.layout import PhaseInvariantError, compute_layout
 from nf_metro.options import LAYOUT_OPTIONS, LayoutOption
 from nf_metro.parser import ERROR, parse_metro_mermaid, validate_graph
@@ -302,27 +304,36 @@ def validate(input_file: Path) -> None:
 
 @cli.command()
 @click.argument("input_file", type=click.Path(exists=True, path_type=Path))
-def info(input_file: Path) -> None:
-    """Show information about a Mermaid metro map definition."""
-    text = input_file.read_text()
-    try:
-        graph = parse_metro_mermaid(text)
-    except ValueError as e:
-        raise click.ClickException(str(e))
+@click.option(
+    "--json", "as_json", is_flag=True, help="Emit the full introspection as JSON."
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Add the section dependency graph, per-line routes, inferred "
+    "auto-layout defaults, and synthetic ports/junctions to the text output.",
+)
+def info(input_file: Path, as_json: bool, verbose: bool) -> None:
+    """Show information about a Mermaid metro map definition.
 
-    click.echo(f"Title: {graph.title or '(none)'}")
-    click.echo(f"Style: {graph.style}")
-    click.echo(f"Stations: {len(graph.stations)}")
-    click.echo(f"Edges: {len(graph.edges)}")
-    click.echo(f"Lines: {len(graph.lines)}")
-    for lid, line in graph.lines.items():
-        stations = graph.line_stations(lid)
-        click.echo(f"  {line.display_name} ({line.color}): {len(stations)} stations")
-    click.echo(f"Sections: {len(graph.sections)}")
-    for section in graph.sections.values():
-        click.echo(
-            f"  [{section.number}] {section.name}: {len(section.station_ids)} stations"
-        )
+    The default output is a stable human summary. ``--verbose`` adds the
+    richer introspection (what nf-metro derived and inferred); ``--json``
+    emits the complete structure for scripting.
+    """
+    text = input_file.read_text()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            graph = parse_metro_mermaid(text)
+        except ValueError as e:
+            raise click.ClickException(str(e))
+    messages = [str(w.message) for w in caught]
+
+    report = build_info(graph, messages)
+    if as_json:
+        click.echo(format_info_json(report))
+    else:
+        click.echo(format_info_text(report, verbose=verbose))
 
 
 @cli.command(context_settings={"ignore_unknown_options": True})

--- a/src/nf_metro/introspect.py
+++ b/src/nf_metro/introspect.py
@@ -23,15 +23,17 @@ resolution internally; no full layout pass is required.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from nf_metro.parser.model import MetroGraph
 
 __all__ = ["build_info", "format_info_json", "format_info_text", "station_kind"]
 
+StationKind = Literal["station", "junction", "port", "bypass", "hidden", "unknown"]
 
-def station_kind(graph: MetroGraph, station_id: str) -> str:
+
+def station_kind(graph: MetroGraph, station_id: str) -> StationKind:
     """Classify a station as authored or synthetic.
 
     Returns one of ``"station"`` (an authored node), ``"junction"`` (a fan-out
@@ -60,9 +62,7 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
     *warnings* are parse-time warning messages captured by the caller (the
     parser emits these via :mod:`warnings`); pass ``None`` for none.
     """
-    real_sections = {
-        sid: sec for sid, sec in graph.sections.items() if not sec.is_implicit
-    }
+    real_sections = graph.real_sections
 
     lines = []
     for lid, line in graph.lines.items():
@@ -73,9 +73,7 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
                 "display_name": line.display_name,
                 "color": line.color,
                 "style": line.style,
-                # Raw membership count (includes synthetic ports/junctions on the
-                # resolved chain) drives the human headline; ``route`` is the
-                # authored stations only.
+                # route_raw includes synthetic ports/junctions; route excludes them.
                 "n_stations": len(route_raw),
                 "route": [
                     sid for sid in route_raw if station_kind(graph, sid) == "station"
@@ -102,9 +100,7 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
                 "grid_inferred": sid not in graph._explicit_grid,
                 "is_implicit": sec.is_implicit,
                 "stations": [
-                    st
-                    for st in sec.station_ids
-                    if station_kind(graph, st) == "station"
+                    st for st in sec.station_ids if station_kind(graph, st) == "station"
                 ],
                 "entry_ports": list(sec.entry_ports),
                 "exit_ports": list(sec.exit_ports),
@@ -211,8 +207,7 @@ def format_info_text(info: dict[str, Any], *, verbose: bool = False) -> str:
     out.append(f"Lines: {counts['lines']}")
     for line in info["lines"]:
         out.append(
-            f"  {line['display_name']} ({line['color']}): "
-            f"{line['n_stations']} stations"
+            f"  {line['display_name']} ({line['color']}): {line['n_stations']} stations"
         )
     out.append(f"Sections: {counts['sections']}")
     for sec in info["sections"]:
@@ -233,9 +228,7 @@ def format_info_text(info: dict[str, Any], *, verbose: bool = False) -> str:
     out.append("Section dependency graph:")
     if info["section_dag"]["edges"]:
         for edge in info["section_dag"]["edges"]:
-            out.append(
-                f"  {edge['from']} -> {edge['to']} [{', '.join(edge['lines'])}]"
-            )
+            out.append(f"  {edge['from']} -> {edge['to']} [{', '.join(edge['lines'])}]")
     else:
         out.append("  (no inter-section edges)")
 

--- a/src/nf_metro/introspect.py
+++ b/src/nf_metro/introspect.py
@@ -1,0 +1,298 @@
+"""Structured introspection of a parsed :class:`~nf_metro.parser.model.MetroGraph`.
+
+This is the data behind ``nf-metro info``: a faithful answer to "what did
+nf-metro actually build from my ``.mmd``?".  It surfaces three things a flat
+station/edge count cannot:
+
+* the section dependency graph and the ordered route of each line;
+* synthetic elements the author never wrote (entry/exit ports, fan-out
+  junctions) that ``_resolve_sections`` inserts;
+* the defaults auto-layout inferred where the author was silent (section
+  flow direction, port sides, grid placement and folding).
+
+The embedded SVG manifest (:mod:`nf_metro.render.manifest`) is the render-time,
+geometry-bearing consumer contract and deliberately *strips* these synthetic and
+derived internals; this module is their author-facing counterpart.  Coordinates
+are out of scope here -- render and read the manifest for laid-out geometry.
+
+Everything reported is available immediately after
+:func:`~nf_metro.parser.parse_metro_mermaid`, which runs auto-layout and section
+resolution internally; no full layout pass is required.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nf_metro.parser.model import MetroGraph
+
+__all__ = ["build_info", "format_info_json", "format_info_text", "station_kind"]
+
+
+def station_kind(graph: MetroGraph, station_id: str) -> str:
+    """Classify a station as authored or synthetic.
+
+    Returns one of ``"station"`` (an authored node), ``"junction"`` (a fan-out
+    helper from ``_resolve_sections``), ``"port"`` (a section-boundary entry or
+    exit point), ``"bypass"`` (a hidden V helper that routes a line clear of a
+    station marker), or ``"hidden"`` (any other non-rendered helper).  Junctions
+    are checked first because their stations also carry ``is_port=True``.
+    """
+    if station_id in graph.junction_ids:
+        return "junction"
+    station = graph.stations.get(station_id)
+    if station is None:
+        return "unknown"
+    if station.is_port:
+        return "port"
+    if station.bypasses_station_id is not None:
+        return "bypass"
+    if station.is_hidden:
+        return "hidden"
+    return "station"
+
+
+def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str, Any]:
+    """Assemble the structured introspection dict for a parsed graph.
+
+    *warnings* are parse-time warning messages captured by the caller (the
+    parser emits these via :mod:`warnings`); pass ``None`` for none.
+    """
+    real_sections = {
+        sid: sec for sid, sec in graph.sections.items() if not sec.is_implicit
+    }
+
+    lines = []
+    for lid, line in graph.lines.items():
+        route_raw = graph.line_stations(lid)
+        lines.append(
+            {
+                "id": lid,
+                "display_name": line.display_name,
+                "color": line.color,
+                "style": line.style,
+                # Raw membership count (includes synthetic ports/junctions on the
+                # resolved chain) drives the human headline; ``route`` is the
+                # authored stations only.
+                "n_stations": len(route_raw),
+                "route": [
+                    sid for sid in route_raw if station_kind(graph, sid) == "station"
+                ],
+            }
+        )
+
+    sections = []
+    for sid, sec in graph.sections.items():
+        sections.append(
+            {
+                "id": sid,
+                "name": sec.name,
+                "number": sec.number,
+                "n_stations": len(sec.station_ids),
+                "direction": sec.direction,
+                "direction_inferred": sid not in graph._explicit_directions,
+                "grid": {
+                    "col": sec.grid_col,
+                    "row": sec.grid_row,
+                    "row_span": sec.grid_row_span,
+                    "col_span": sec.grid_col_span,
+                },
+                "grid_inferred": sid not in graph._explicit_grid,
+                "is_implicit": sec.is_implicit,
+                "stations": [
+                    st
+                    for st in sec.station_ids
+                    if station_kind(graph, st) == "station"
+                ],
+                "entry_ports": list(sec.entry_ports),
+                "exit_ports": list(sec.exit_ports),
+                "entry_sides_inferred": sid not in graph._explicit_entry,
+                "exit_sides_inferred": sid not in graph._explicit_exit,
+            }
+        )
+
+    stations = []
+    for sid, station in graph.stations.items():
+        stations.append(
+            {
+                "id": sid,
+                "label": station.label,
+                "section_id": station.section_id,
+                "kind": station_kind(graph, sid),
+                "lines": graph.station_lines(sid),
+                "off_track": station.off_track,
+                "processes": list(graph.process_mapping.get(sid, [])),
+            }
+        )
+
+    ports = []
+    for pid, port in graph.ports.items():
+        explicit_set = graph._explicit_entry if port.is_entry else graph._explicit_exit
+        ports.append(
+            {
+                "id": pid,
+                "section_id": port.section_id,
+                "side": port.side.value,
+                "is_entry": port.is_entry,
+                "side_inferred": port.section_id not in explicit_set,
+            }
+        )
+
+    dag = graph.section_dag
+    dag_edges = []
+    if dag is not None:
+        for src, tgt in sorted(dag.section_edges):
+            dag_edges.append(
+                {
+                    "from": src,
+                    "to": tgt,
+                    "lines": sorted(dag.edge_lines[(src, tgt)]),
+                }
+            )
+
+    rows: dict[int, list[str]] = {}
+    for sid, sec in real_sections.items():
+        rows.setdefault(sec.grid_row, []).append(sid)
+
+    return {
+        "title": graph.title or None,
+        "style": graph.style,
+        "warnings": list(warnings or []),
+        "counts": {
+            "stations": len(graph.stations),
+            "edges": len(graph.edges),
+            "lines": len(graph.lines),
+            "sections": len(graph.sections),
+            "ports": len(graph.ports),
+            "junctions": len(graph.junctions),
+        },
+        "lines": lines,
+        "sections": sections,
+        "stations": stations,
+        "ports": ports,
+        "junctions": sorted(graph.junctions),
+        "section_dag": {"edges": dag_edges},
+        "layout": {
+            "rows": len(rows),
+            "folded": len(rows) > 1,
+            "sections_by_row": {
+                str(row): sorted(ids) for row, ids in sorted(rows.items())
+            },
+        },
+    }
+
+
+def format_info_json(info: dict[str, Any]) -> str:
+    """Serialize the introspection dict as indented JSON."""
+    return json.dumps(info, indent=2)
+
+
+def _format_inferred(inferred: bool) -> str:
+    return "inferred" if inferred else "explicit"
+
+
+def format_info_text(info: dict[str, Any], *, verbose: bool = False) -> str:
+    """Render the introspection dict as human-readable text.
+
+    The non-verbose form is the stable, headline summary (title, counts,
+    per-line and per-section station counts).  ``verbose`` appends the richer
+    introspection: warnings, the section dependency graph, fold/row layout,
+    ordered per-line routes, per-section detail with inferred/explicit flags,
+    and the synthetic ports and junctions.
+    """
+    out: list[str] = []
+    out.append(f"Title: {info['title'] or '(none)'}")
+    out.append(f"Style: {info['style']}")
+    counts = info["counts"]
+    out.append(f"Stations: {counts['stations']}")
+    out.append(f"Edges: {counts['edges']}")
+    out.append(f"Lines: {counts['lines']}")
+    for line in info["lines"]:
+        out.append(
+            f"  {line['display_name']} ({line['color']}): "
+            f"{line['n_stations']} stations"
+        )
+    out.append(f"Sections: {counts['sections']}")
+    for sec in info["sections"]:
+        out.append(f"  [{sec['number']}] {sec['name']}: {sec['n_stations']} stations")
+
+    if not verbose:
+        return "\n".join(out)
+
+    out.append("")
+    out.append("Warnings:")
+    if info["warnings"]:
+        for warning in info["warnings"]:
+            out.append(f"  - {warning}")
+    else:
+        out.append("  (none)")
+
+    out.append("")
+    out.append("Section dependency graph:")
+    if info["section_dag"]["edges"]:
+        for edge in info["section_dag"]["edges"]:
+            out.append(
+                f"  {edge['from']} -> {edge['to']} [{', '.join(edge['lines'])}]"
+            )
+    else:
+        out.append("  (no inter-section edges)")
+
+    layout = info["layout"]
+    fold = "folded" if layout["folded"] else "single row"
+    out.append("")
+    out.append(f"Layout: {layout['rows']} row(s), {fold}")
+    for row, ids in layout["sections_by_row"].items():
+        out.append(f"  row {row}: {', '.join(ids)}")
+
+    out.append("")
+    out.append("Per-line routes:")
+    for line in info["lines"]:
+        route = " -> ".join(line["route"]) if line["route"] else "(empty)"
+        out.append(f"  {line['display_name']}: {route}")
+
+    out.append("")
+    out.append("Sections (detail):")
+    for sec in info["sections"]:
+        tags = [
+            "implicit" if sec["is_implicit"] else "explicit-box",
+            f"{sec['direction']} ({_format_inferred(sec['direction_inferred'])})",
+            f"grid {sec['grid']['col']},{sec['grid']['row']} "
+            f"({_format_inferred(sec['grid_inferred'])})",
+        ]
+        out.append(f"  [{sec['number']}] {sec['name']}: {', '.join(tags)}")
+        if sec["stations"]:
+            out.append(f"      stations: {', '.join(sec['stations'])}")
+        if sec["entry_ports"]:
+            out.append(
+                f"      entry ports ({_format_inferred(sec['entry_sides_inferred'])}): "
+                f"{', '.join(sec['entry_ports'])}"
+            )
+        if sec["exit_ports"]:
+            out.append(
+                f"      exit ports ({_format_inferred(sec['exit_sides_inferred'])}): "
+                f"{', '.join(sec['exit_ports'])}"
+            )
+
+    out.append("")
+    out.append("Ports (synthetic):")
+    if info["ports"]:
+        for port in info["ports"]:
+            kind = "entry" if port["is_entry"] else "exit"
+            out.append(
+                f"  {port['id']}: {kind} {port['side']} "
+                f"({_format_inferred(port['side_inferred'])}) in {port['section_id']}"
+            )
+    else:
+        out.append("  (none)")
+
+    out.append("")
+    out.append("Junctions (synthetic):")
+    if info["junctions"]:
+        for jid in info["junctions"]:
+            out.append(f"  {jid}")
+    else:
+        out.append("  (none)")
+
+    return "\n".join(out)

--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -168,8 +168,10 @@ def _parse_port_hint(
     if section:
         if is_entry:
             section.entry_hints.append((side, line_ids))
+            graph._explicit_entry.add(section_id)
         else:
             section.exit_hints.append((side, line_ids))
+            graph._explicit_exit.add(section_id)
 
 
 def _parse_grid_directive(value: str, graph: MetroGraph) -> None:

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -367,6 +367,12 @@ class MetroGraph:
     section_dag: SectionDAG | None = None
     # Section IDs that had explicit %%metro direction: directives
     _explicit_directions: set[str] = field(default_factory=set)
+    # Section IDs whose entry/exit port sides were author-specified via
+    # %%metro entry:/exit: directives (tracked separately because auto_layout
+    # fills entry_hints/exit_hints for sections that have none, so the hint
+    # list alone cannot tell an author side from an inferred one).
+    _explicit_entry: set[str] = field(default_factory=set)
+    _explicit_exit: set[str] = field(default_factory=set)
     # Pending terminus designations: station_id ->
     # list of (label, icon_type, name, banner)
     _pending_terminus: dict[str, list[tuple[str, str, str, bool]]] = field(

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -585,3 +585,8 @@ class MetroGraph:
         if station:
             return station.section_id
         return None
+
+    @property
+    def real_sections(self) -> dict[str, Section]:
+        """Sections that draw a visible box (excludes implicit holders)."""
+        return {sid: sec for sid, sec in self.sections.items() if not sec.is_implicit}

--- a/src/nf_metro/render/manifest.py
+++ b/src/nf_metro/render/manifest.py
@@ -73,9 +73,7 @@ def build_manifest(
     a complete, future-proof inventory of addressable nodes rather than only the
     subset that lights up today.
     """
-    real_sections = {
-        sid: sec for sid, sec in graph.sections.items() if not sec.is_implicit
-    }
+    real_sections = graph.real_sections
 
     nodes: list[dict[str, Any]] = []
     for station in graph.stations.values():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,64 @@ def test_info_output():
     assert "Sections:" in result.output
 
 
+def test_info_default_matches_formatter():
+    """Default text output equals the non-verbose formatter, byte-for-byte."""
+    from nf_metro.introspect import build_info, format_info_text
+    from nf_metro.parser import parse_metro_mermaid
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["info", str(RNASEQ_MMD)])
+    assert result.exit_code == 0
+    graph = parse_metro_mermaid(RNASEQ_MMD.read_text())
+    expected = format_info_text(build_info(graph), verbose=False)
+    assert result.output == expected + "\n"
+    # The verbose-only sections must not leak into the default output.
+    assert "Section dependency graph:" not in result.output
+
+
+def test_info_json_is_valid_and_structured():
+    """--json emits parseable JSON carrying the full introspection structure."""
+    import json
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["info", str(RNASEQ_MMD), "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["title"] == "nf-core/rnaseq"
+    assert {"counts", "lines", "sections", "ports", "junctions", "section_dag"} <= set(
+        data
+    )
+    assert data["section_dag"]["edges"]
+
+
+def test_info_verbose_adds_introspection():
+    """--verbose appends the richer sections to the stable summary."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["info", str(RNASEQ_MMD), "--verbose"])
+    assert result.exit_code == 0
+    assert "Section dependency graph:" in result.output
+    assert "Per-line routes:" in result.output
+    assert "Ports (synthetic):" in result.output
+
+
+def test_info_captures_parse_warnings(tmp_path):
+    """A non-LR primary graph direction surfaces as a captured warning."""
+    import json
+
+    mmd = tmp_path / "tb.mmd"
+    mmd.write_text(
+        "%%metro title: TB warn\n"
+        "%%metro line: a | A | #ff0000\n"
+        "graph TB\n"
+        "    x[X] -->|a| y[Y]\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["info", str(mmd), "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert any("LR" in w for w in data["warnings"])
+
+
 def test_version():
     """--version flag prints version string."""
     runner = CliRunner()

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -123,7 +123,9 @@ def test_explicit_directives_reported_as_explicit() -> None:
     rnaseq_sections pins postprocessing to TB and qc_report to RL, and writes
     explicit entry/exit sides; the inferred sections around them stay inferred.
     """
-    sections = {s["id"]: s for s in build_info(_graph("rnaseq_sections.mmd"))["sections"]}
+    sections = {
+        s["id"]: s for s in build_info(_graph("rnaseq_sections.mmd"))["sections"]
+    }
 
     assert sections["postprocessing"]["direction"] == "TB"
     assert sections["postprocessing"]["direction_inferred"] is False
@@ -142,9 +144,7 @@ def test_port_side_inferred_tracks_section_directive() -> None:
     graph = _graph("rnaseq_sections.mmd")
     info = build_info(graph)
     for port in info["ports"]:
-        explicit = (
-            graph._explicit_entry if port["is_entry"] else graph._explicit_exit
-        )
+        explicit = graph._explicit_entry if port["is_entry"] else graph._explicit_exit
         assert port["side_inferred"] is (port["section_id"] not in explicit)
 
 

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -1,0 +1,182 @@
+"""Tests for structured `nf-metro info` introspection (``nf_metro.introspect``)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nf_metro.introspect import (
+    build_info,
+    format_info_json,
+    format_info_text,
+    station_kind,
+)
+from nf_metro.parser import parse_metro_mermaid
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+
+# A spread of gallery fixtures: fully-inferred auto layout, a hand-tuned mix of
+# explicit and inferred directives, and a couple of distinct topologies so the
+# invariants generalise beyond a single .mmd.
+FIXTURES = [
+    "rnaseq_auto.mmd",
+    "rnaseq_sections.mmd",
+    "genomeassembly.mmd",
+    "epitopeprediction.mmd",
+]
+
+
+def _graph(fixture: str):
+    return parse_metro_mermaid((EXAMPLES_DIR / fixture).read_text())
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_info_has_all_top_level_keys(fixture: str) -> None:
+    info = build_info(_graph(fixture))
+    assert set(info) == {
+        "title",
+        "style",
+        "warnings",
+        "counts",
+        "lines",
+        "sections",
+        "stations",
+        "ports",
+        "junctions",
+        "section_dag",
+        "layout",
+    }
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_counts_match_graph(fixture: str) -> None:
+    graph = _graph(fixture)
+    counts = build_info(graph)["counts"]
+    assert counts["stations"] == len(graph.stations)
+    assert counts["edges"] == len(graph.edges)
+    assert counts["lines"] == len(graph.lines)
+    assert counts["sections"] == len(graph.sections)
+    assert counts["ports"] == len(graph.ports)
+    assert counts["junctions"] == len(graph.junctions)
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_routes_exclude_synthetic_stations(fixture: str) -> None:
+    """A line's ``route`` lists only authored stations, never ports/junctions."""
+    graph = _graph(fixture)
+    info = build_info(graph)
+    for line in info["lines"]:
+        for sid in line["route"]:
+            assert sid not in graph.ports
+            assert sid not in graph.junction_ids
+            assert station_kind(graph, sid) == "station"
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_synthetic_elements_surfaced(fixture: str) -> None:
+    """Ports and junctions appear in the inventory with the right kind."""
+    graph = _graph(fixture)
+    info = build_info(graph)
+    by_id = {st["id"]: st for st in info["stations"]}
+
+    # Every junction is classified as a junction, not mislabelled a port, even
+    # though its underlying station carries is_port=True.
+    for jid in graph.junctions:
+        assert by_id[jid]["kind"] == "junction"
+    assert sorted(graph.junctions) == info["junctions"]
+
+    # Every port is present and classified as a port.
+    for pid in graph.ports:
+        assert by_id[pid]["kind"] == "port"
+    assert {p["id"] for p in info["ports"]} == set(graph.ports)
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_section_dag_edges_match(fixture: str) -> None:
+    graph = _graph(fixture)
+    info = build_info(graph)
+    reported = {(e["from"], e["to"]) for e in info["section_dag"]["edges"]}
+    assert reported == set(graph.section_dag.section_edges)
+    for edge in info["section_dag"]["edges"]:
+        assert edge["lines"] == sorted(
+            graph.section_dag.edge_lines[(edge["from"], edge["to"])]
+        )
+
+
+def test_inferred_when_no_directives() -> None:
+    """An all-auto fixture reports every direction, grid, and port side inferred."""
+    info = build_info(_graph("rnaseq_auto.mmd"))
+    for sec in info["sections"]:
+        assert sec["direction_inferred"] is True
+        assert sec["grid_inferred"] is True
+        assert sec["entry_sides_inferred"] is True
+        assert sec["exit_sides_inferred"] is True
+    for port in info["ports"]:
+        assert port["side_inferred"] is True
+
+
+def test_explicit_directives_reported_as_explicit() -> None:
+    """Authored direction:/entry:/exit: directives are flagged explicit, not inferred.
+
+    rnaseq_sections pins postprocessing to TB and qc_report to RL, and writes
+    explicit entry/exit sides; the inferred sections around them stay inferred.
+    """
+    sections = {s["id"]: s for s in build_info(_graph("rnaseq_sections.mmd"))["sections"]}
+
+    assert sections["postprocessing"]["direction"] == "TB"
+    assert sections["postprocessing"]["direction_inferred"] is False
+    assert sections["qc_report"]["direction"] == "RL"
+    assert sections["qc_report"]["direction_inferred"] is False
+    # A section without a direction: directive keeps the inferred default.
+    assert sections["preprocessing"]["direction_inferred"] is True
+
+    # preprocessing writes an explicit exit: but no entry: directive.
+    assert sections["preprocessing"]["exit_sides_inferred"] is False
+    assert sections["preprocessing"]["entry_sides_inferred"] is True
+
+
+def test_port_side_inferred_tracks_section_directive() -> None:
+    """A port's side_inferred mirrors whether its section authored that side."""
+    graph = _graph("rnaseq_sections.mmd")
+    info = build_info(graph)
+    for port in info["ports"]:
+        explicit = (
+            graph._explicit_entry if port["is_entry"] else graph._explicit_exit
+        )
+        assert port["side_inferred"] is (port["section_id"] not in explicit)
+
+
+def test_warnings_passed_through() -> None:
+    info = build_info(_graph("rnaseq_auto.mmd"), ["something happened"])
+    assert info["warnings"] == ["something happened"]
+
+
+def test_layout_rows_reflect_folding() -> None:
+    """sections_by_row partitions the real sections; folded iff >1 row."""
+    graph = _graph("rnaseq_sections.mmd")
+    info = build_info(graph)
+    layout = info["layout"]
+    placed = {sid for ids in layout["sections_by_row"].values() for sid in ids}
+    real = {sid for sid, s in graph.sections.items() if not s.is_implicit}
+    assert placed == real
+    assert layout["rows"] == len(layout["sections_by_row"])
+    assert layout["folded"] is (layout["rows"] > 1)
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_json_round_trips(fixture: str) -> None:
+    info = build_info(_graph(fixture))
+    assert json.loads(format_info_json(info)) == info
+
+
+@pytest.mark.parametrize("fixture", FIXTURES)
+def test_default_text_is_a_prefix_of_verbose(fixture: str) -> None:
+    """Verbose output extends, rather than rewrites, the stable summary."""
+    info = build_info(_graph(fixture))
+    plain = format_info_text(info, verbose=False)
+    verbose = format_info_text(info, verbose=True)
+    assert verbose.startswith(plain)
+    assert "Section dependency graph:" not in plain
+    assert "Section dependency graph:" in verbose


### PR DESCRIPTION
## Summary

Turns `nf-metro info` into a real introspection tool: "what did nf-metro actually build from my `.mmd`?".

- **`--json`** emits the complete structure for scripting / CI / docs tooling.
- **`--verbose`** adds richer text: the section dependency graph, ordered per-line routes, per-section detail with inferred/explicit flags, and the synthetic ports and junctions.
- The default (non-flagged) text output is unchanged for humans.

The reported structure surfaces what the engine derives that the author never wrote:
- section dependency graph (which section feeds which, with the lines on each edge);
- per-line ordered route (authored stations only);
- synthetic elements inserted by `_resolve_sections` (entry/exit ports, fan-out junctions), classified by kind;
- auto-layout-inferred defaults vs author-specified ones (section direction, port sides, grid placement, fold/row layout);
- parse-time warnings (e.g. a non-LR primary `graph` direction).

A new dependency-free `nf_metro.introspect` module owns `build_info` / `format_info_text` / `format_info_json`, so the structure is testable without the CLI (and is the author-facing counterpart to the consumer-facing embedded SVG manifest, which deliberately strips these internals).

To distinguish an author-written port side from an auto-inferred one (auto-layout backfills `entry_hints`/`exit_hints` for sections that have none), the parser records `_explicit_entry` / `_explicit_exit`, mirroring the existing `_explicit_directions` / `_explicit_grid` sets. The duplicated `not is_implicit` section filter is consolidated into a `MetroGraph.real_sections` property shared with `render/manifest.py`.

Coordinates are intentionally out of scope here; render and read the embedded manifest for laid-out geometry.

Fixes #563

## Test plan
- [x] pytest passes (new `tests/test_introspect.py` parametrized over four gallery fixtures + extended `tests/test_cli.py`)
- [x] ruff check + ruff format clean on whole repo
- [x] mypy clean
- [ ] Render preview verdict: no visual changes expected (info is a non-rendering command; the `manifest.py` change is a pure refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
