### PR TITLE
fix(layout): reserve fork/join + entry/exit room need-driven, not on label width (#635)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -613,10 +613,16 @@ def _compute_layout_scaled(
             if target is None:
                 continue
             sec, layer = target
+            # ``gap`` at the station's own layer lengthens its *incoming* flat
+            # run (clears a convergence/join diagonal raking the name); at the
+            # next layer it lengthens the *outgoing* run (clears a fan-out/fork
+            # diagonal).  Bumping both and letting minimization drop the
+            # non-load-bearing one clears a strike on either side.
             levers |= {
                 ("entry", sec.id, 0),
                 ("exit", sec.id, 0),
                 ("gap", sec.id, layer),
+                ("gap", sec.id, layer + 1),
             }
         if not levers:
             break

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -444,8 +444,9 @@ def _compute_fork_join_gaps(
             if lyr == layer:
                 station = sub.stations.get(sid)
                 if station and station.label.strip():
-                    label_half = label_text_width(station.label) / 2
-                    fj_label_half = max(fj_label_half, label_half)
+                    fj_label_half = max(
+                        fj_label_half, label_text_width(station.label) / 2
+                    )
                 if sid in tracks:
                     fj_tracks.add(tracks[sid])
 
@@ -561,20 +562,28 @@ def _compute_fork_join_gaps(
             )
             bubble_extra = max(bubble_extra, forced_reach)
 
-        # The router (``_route_diagonal``) reserves the fork/join station's
-        # label half-width as straight run so the diagonal starts past the
-        # (possibly tilted) label, but it abandons that clearance when the
-        # column gap can't also fit the diagonal run plus the branch-side
-        # minimum straight.  Reserve a gap that keeps the clearance, so the
-        # fork/join label never overlaps the divergence/convergence diagonal.
-        # A whole pitch already sits between the columns, so subtract it; the
-        # 1px cushion absorbs float rounding in the router's drop test.
-        routing_clearance = (
-            fj_label_half + DIAGONAL_RUN + MIN_STRAIGHT_EDGE - x_spacing + 1.0
-        )
-        layer_gap[layer] = max(
-            base_gap, fj_label_half + bubble_extra, routing_clearance
-        )
+        if label_angle:
+            # Angled labels are invisible to the horizontal-label strike loop
+            # (it skips them) and to the strike guard, so they keep the eager
+            # width-based reservation that seats the fan diagonal past the
+            # tilted name.  A whole pitch already sits between columns, so the
+            # routing clearance subtracts it; the 1px cushion absorbs float
+            # rounding in the router's drop test.
+            routing_clearance = (
+                fj_label_half + DIAGONAL_RUN + MIN_STRAIGHT_EDGE - x_spacing + 1.0
+            )
+            layer_gap[layer] = max(
+                base_gap, fj_label_half + bubble_extra, routing_clearance
+            )
+        else:
+            # Reserve only the diagonal-run minimum plus the interior-fan reach
+            # for a 3+ branch bubble.  Horizontal-label clearance for the
+            # fork/join station's own name is left to the strike-clearance
+            # loop, which lengthens the flat run by whole grid columns only
+            # where a diagonal would actually rake the name -- so a fork/join
+            # whose name already clears its transition does not pad its column
+            # on label width alone.
+            layer_gap[layer] = max(base_gap, bubble_extra)
 
     cumulative = 0.0
     layer_extra: dict[int, float] = {}

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -627,8 +627,13 @@ def _adjust_lr_entry_inset(
         section.bbox_w += entry_inset
         return
 
-    # Flow-side entry that fans out to multiple internal stations at
-    # different Y positions needs extra room for the diagonal transitions.
+    # Flow-side entry that fans out to multiple internal stations needs extra
+    # room for the diagonal transitions only when an angled label is in the
+    # fan: such labels are invisible to the strike-clearance loop.  With
+    # horizontal labels the loop's entry runway grows the room need-driven
+    # (only where a fan diagonal rakes a name), so no eager inset is reserved.
+    if not (graph.label_angle or 0.0):
+        return
     for pid in section.entry_ports:
         if pid not in graph.ports:
             continue
@@ -706,6 +711,13 @@ def _adjust_lr_exit_gap(
                 feeder_ys.add(sub.stations[src_id].y)
 
     if len(feeder_ys) <= 1:
+        return
+
+    # With horizontal labels the exit-fan clearance is handled need-driven by
+    # the strike-clearance loop's exit runway (grown only where a convergence
+    # diagonal rakes a name).  Reserve the eager gap only for angled labels,
+    # which the loop cannot see.
+    if not (graph.label_angle or 0.0):
         return
 
     exit_gap = x_spacing * EXIT_GAP_MULTIPLIER


### PR DESCRIPTION
## Summary

Horizontal-label sections no longer over-widen columns to reserve room for labels at the base pitch. They reserve only the room a diagonal transition genuinely needs (the diagonal-run minimum); the #513 strike-clearance loop then grows whole grid columns **only where a diagonal would actually rake a name**. A fork/join or entry/exit fan whose label already clears its flat run keeps its stations near the section corner.

Two mechanisms were reserving room on label width regardless of whether a diagonal struck the label:

- **`_compute_fork_join_gaps`** (the dominant one): reserved `fj_label_half` before every join / after every fork spanning tracks. This widened `rnaseq_sections` genome_align by ~135px for "UMI-tools Dedup" even though the converging diagonals clear that label. Now drops the width terms for horizontal labels, keeping the base diagonal run plus the interior-fan bubble reach.
- **`_adjust_lr_entry_inset` / `_adjust_lr_exit_gap`**: flat `0.6 × pitch` on any multi-track flow-side fan (pseudo_align's tximport/MultiQC sat 36px from the corner). Now skipped for horizontal labels.

Angled-label sections (sarek_metro, diagonal_labels, rail_mode) keep the eager width reservation: angled labels are invisible to both the strike-clearance loop and the strike guard, so they have no need-driven fallback. Those renders are unchanged.

The strike loop gains a **fork-side gap lever** (`layer+1`) so an outgoing fan-out diagonal raking the fork station's own name is cleared by lengthening the *outgoing* run, not only the incoming one (the existing lever only covered join/incoming strikes).

Fixes #635

## Verification

Cross-validated the flagship and the fork-strike cases with both the geometric strike detector and an independent pixel oracle (text-only ∩ no-text render-mask intersection, z-order independent):

- `rnaseq_sections` genome_align 655→588px, pseudo_align 420→384px: pixel-clean, "UMI-tools Dedup" / "Bowtie2" / "Kallisto" all clear.
- `rnaseq_auto` / `genomic_pipeline` / `differentialabundance_default`: the fork-side lever clears the fork strikes the reduction would otherwise expose (and lands narrower than before).
- Horizontal-label fixtures narrow (rnaseq_sections −103, genomic −219, sarek unchanged, da −104, longread −18, rnaseq_lite −63, marker_styles −31); angled fixtures unchanged.

## Test plan

- [ ] Render preview (visual review is authoritative here): https://pinin4fjords.github.io/nf-metro/_pr/641/
- [ ] Snapshot/byte-identical tests updated to the intentionally-changed renders
- [ ] Invariant test: a horizontal-label fork/join column carries no label-width gap where no diagonal strikes
- [ ] pytest + ruff green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
