### PR TITLE
test: speed up the test suite (~3.7min -> ~26s)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ nf-metro = "nf_metro.cli:cli"
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "pytest-xdist>=3.0",
     "ruff>=0.4",
     "mypy>=1.8",
     "types-networkx",
@@ -57,7 +58,7 @@ packages = ["src/nf_metro"]
 testpaths = ["tests"]
 pythonpath = ["src", "tests"]
 xfail_strict = true
-addopts = "-rxX"
+addopts = "-rxX -n auto"
 
 [tool.ruff]
 target-version = "py310"

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -13,7 +13,9 @@ two-section grid with simpler topology (variant calling).
 
 from __future__ import annotations
 
+import copy
 from collections import defaultdict
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -77,6 +79,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 _Y_TOL = 1.0
 
 
+@lru_cache(maxsize=None)
 def _resolve_fixture(name: str) -> Path:
     """Resolve a fixture name to a concrete .mmd path.
 
@@ -105,7 +108,17 @@ def _resolve_fixture(name: str) -> Path:
     )
 
 
-def _layout(fixture: str, **kwargs) -> MetroGraph:
+# Layout is deterministic, so the corpus-wide invariants share one computed
+# graph per (fixture, kwargs) rather than re-running the pipeline once per
+# invariant (~36 full-corpus invariants over 92 fixtures).  Each caller gets a
+# deep copy, so a test that mutates its graph (routing, label placement) cannot
+# leak into another.  A test that monkeypatches a layout phase must pass
+# ``_cache=False``: a cached graph would either return pre-patch geometry or, in
+# a probe-style test, skip the patched code entirely and pass vacuously.
+_LAYOUT_CACHE: dict[tuple[str, tuple], MetroGraph] = {}
+
+
+def _layout(fixture: str, *, _cache: bool = True, **kwargs) -> MetroGraph:
     """Parse a fixture file and run the full layout pipeline.
 
     ``fixture`` may be a name under ``tests/fixtures/`` (legacy) or a
@@ -116,6 +129,9 @@ def _layout(fixture: str, **kwargs) -> MetroGraph:
     directive directly.
     """
     path = _resolve_fixture(fixture)
+    key = (str(path), tuple(sorted(kwargs.items())))
+    if _cache and key in _LAYOUT_CACHE:
+        return copy.deepcopy(_LAYOUT_CACHE[key])
     text = path.read_text()
     graph = parse_metro_mermaid(text)
     # Legacy fixtures under tests/fixtures/ were authored before the
@@ -126,15 +142,24 @@ def _layout(fixture: str, **kwargs) -> MetroGraph:
     elif "center_ports" in kwargs:
         graph.center_ports = kwargs.pop("center_ports")
     compute_layout(graph, **kwargs)
-    return graph
+    if not _cache:
+        return graph
+    _LAYOUT_CACHE[key] = graph
+    return copy.deepcopy(graph)
 
 
-def _layout_example(name: str, **kwargs) -> MetroGraph:
+def _layout_example(name: str, *, _cache: bool = True, **kwargs) -> MetroGraph:
     """Parse an example file and run layout, honouring its own directives."""
-    text = (EXAMPLES / name).read_text()
-    graph = parse_metro_mermaid(text)
+    path = EXAMPLES / name
+    key = (str(path), tuple(sorted(kwargs.items())))
+    if _cache and key in _LAYOUT_CACHE:
+        return copy.deepcopy(_LAYOUT_CACHE[key])
+    graph = parse_metro_mermaid(path.read_text())
     compute_layout(graph, **kwargs)
-    return graph
+    if not _cache:
+        return graph
+    _LAYOUT_CACHE[key] = graph
+    return copy.deepcopy(graph)
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +213,7 @@ def _discover_fixtures() -> list[str]:
 ALL_FIXTURES = _discover_fixtures()
 
 
+@lru_cache(maxsize=None)
 def _fixture_text(name: str) -> str:
     """Return raw text of a fixture for precondition filtering."""
     return _resolve_fixture(name).read_text()
@@ -1521,7 +1547,7 @@ def test_leaf_file_icon_crossing_fixture_crosses_without_auto_lift(monkeypatch):
     monkeypatch.setattr(
         engine_module, "_line_crossed_file_icon_sinks", lambda graph: set()
     )
-    graph = _layout("leaf_file_icon_on_trunk.mmd")
+    graph = _layout("leaf_file_icon_on_trunk.mmd", _cache=False)
     assert not graph.stations["bam_out"].off_track
     assert _segments_crossing_icons(graph), (
         "fixture no longer crosses its icon without auto-lift; it can't "
@@ -5980,7 +6006,7 @@ def test_content_placement_leaves_port_anchors_frozen(fixture, monkeypatch):
     for name in CONTENT_PLACEMENT_PHASES:
         monkeypatch.setattr(engine, name, _make_probe(name, getattr(engine, name)))
 
-    _layout(fixture)
+    _layout(fixture, _cache=False)
     assert not moved, f"{fixture}: content placement moved port anchor(s): {moved[:3]}"
 
 
@@ -6019,7 +6045,7 @@ def test_anchor_guard_catches_a_displaced_port(monkeypatch, example, sides, axis
 
     monkeypatch.setattr(engine, "_balance_section_content_around_trunk", _evil)
     with pytest.raises(PhaseInvariantError, match="port anchor"):
-        _layout_example(example, validate=True)
+        _layout_example(example, validate=True, _cache=False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Cuts the test suite wall-clock from ~3.7 min to ~26s locally (and roughly halves total CPU work, which is what each CI runner does) without removing or weakening any test. Same result on every run: **6925 passed, 62 skipped, 9 xfailed**.

Two independent levers:

### 1. Run in parallel (`pytest-xdist`, `-n auto`)
The suite had no cross-test shared mutable state, it was just running serially on one core. Tests already use the per-test `tmp_path` fixture and the live-server tests bind `port=0` (OS-assigned), so process-level parallelism is safe.

`-n auto` adapts to the host core count, so it uses the 4 vCPUs on a GitHub-hosted ubuntu runner without oversubscribing a smaller one. No worker count is hardcoded. `pytest -n0` disables it for single-test debugging.

### 2. Memoize layout in the invariant suite
`test_layout_invariants.py` is 62% of the suite (4287 tests): ~36 invariants each parametrized over the same 92-fixture corpus, every one recomputing `compute_layout` from scratch. Since layout is deterministic, the same fixture's graph was recomputed dozens of times.

Each `(fixture, kwargs)` layout is now computed once and handed out as a deep copy (deep-copying a settled graph is ~45x cheaper than recomputing it), so a test that mutates its graph stays isolated. Fixture file reads are `lru_cache`d so the module-level corpus filtering at import doesn't re-read every `.mmd` several times.

Tests that monkeypatch a layout phase pass `_cache=False`: a cached graph would return pre-patch geometry or, for the probe-style guards, skip the patched phase entirely and pass vacuously.

This file alone: **129s -> 21s** serial.

## What this does NOT do

- **No tests removed.** An audit of the full suite found nothing genuinely wasteful: the apparent overlaps (pure vs idempotent vs validate-flag content-placement tests) each prove a distinct property, and the many small single-input tests are deliberate meaningfulness-locks that keep the corpus-wide parametrized tests from passing vacuously.
- **Caching is scoped to `test_layout_invariants`.** The shared `compute_corpus_layout` helper is deliberately left uncached because its main callers are probe/monkeypatch tests that must run the real phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)