### PR TITLE
Reduce cyclomatic complexity of the four worst layout functions (#454)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,12 @@ addopts = "-rxX -n auto"
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "ANN"]
+select = ["E", "F", "I", "W", "ANN", "C901"]
+
+[tool.ruff.lint.mccabe]
+# Ratchet against cyclomatic-complexity regressions; lower as functions
+# are decomposed.
+max-complexity = 43
 
 [tool.ruff.lint.per-file-ignores]
 # Type-annotation rules are enforced on the library only; tests favour

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -1295,10 +1295,10 @@ def _place_station_label(
     rail_panel = _rail_panel_label_offsets(station, ctx.panel_extents)
     if rail_panel is not None:
         min_off, max_off = rail_panel
-    rail_side = _rail_label_side(graph, station)
 
     if _is_tb_section(graph, station):
         return _place_tb_label(ctx, station, placements)
+    rail_side = _rail_label_side(graph, station)
     if ctx.label_angle:
         return _place_angled_label(ctx, station, min_off, max_off, rail_side)
     return _place_alternating_label(

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -1301,7 +1301,9 @@ def _place_station_label(
         return _place_tb_label(ctx, station, placements)
     if ctx.label_angle:
         return _place_angled_label(ctx, station, min_off, max_off, rail_side)
-    return _place_alternating_label(ctx, station, placements, min_off, max_off, rail_side)
+    return _place_alternating_label(
+        ctx, station, placements, min_off, max_off, rail_side
+    )
 
 
 def _place_tb_label(
@@ -1575,7 +1577,9 @@ def _place_alternating_label(
     candidate = _place_alternating_candidate(
         ctx, station, placements, min_off, max_off, start_above
     )
-    return _clamp_label_to_section(ctx, station, candidate, min_off, max_off, placements)
+    return _clamp_label_to_section(
+        ctx, station, candidate, min_off, max_off, placements
+    )
 
 
 def place_labels(

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -1150,37 +1150,31 @@ def _trial_cost(
     return cost
 
 
-def place_labels(
+@dataclass
+class _LabelCtx:
+    """Pre-computed state shared by the per-station label placers."""
+
+    graph: MetroGraph
+    label_offset: float
+    station_offsets: dict[tuple[str, str], float] | None
+    label_angle: float
+    section_y_range: dict[str, tuple[float, float]]
+    sections_with_multiline: set[str]
+    solo: dict[str, tuple[bool, bool]]
+    port_pref: dict[str, bool]
+    section_flip: dict[str, bool]
+    safe_offsets: dict[str, tuple[float, float]]
+    panel_extents: dict[str, tuple[float, float]]
+
+
+def _build_label_ctx(
     graph: MetroGraph,
-    label_offset: float = LABEL_OFFSET,
-    station_offsets: dict[tuple[str, str], float] | None = None,
-    icon_obstacles: list[tuple[float, float, float, float]] | None = None,
-    routes: list["RoutedPath"] | None = None,
-    allow_hyphenation: bool = True,
-    label_angle: float = 0.0,
-    lift_wrapped_off_trunks: bool = True,
-) -> list[LabelPlacement]:
-    """Place station labels, alternating above/below stations.
-
-    Strategy:
-    1. Default: alternate above/below based on layer index.
-    2. If it collides with an existing label, try the other side.
-    3. If still colliding, push further away.
-
-    Per-section trial: for each LR/RL section with multiple stations,
-    both alternation patterns are tested and the one with fewer
-    collisions is used.
-
-    When ``label_angle`` is non-zero, LR/RL section labels are instead
-    anchored at the pill and tilted (transit-map style); they hang on one
-    side and pack by their narrow rotated footprint.
-
-    ``lift_wrapped_off_trunks`` runs a final render-time pass that pulls a
-    wrapped label back to its un-pushed anchor when its grown block overruns a
-    foreign trunk.  Callers measuring overlaps for the layout (the spacing
-    search probe) pass False so the engine sees the pre-lift geometry and the
-    deliberate neighbour graze never trips the label-overlap guard.
-    """
+    label_offset: float,
+    station_offsets: dict[tuple[str, str], float] | None,
+    icon_obstacles: list[tuple[float, float, float, float]] | None,
+    label_angle: float,
+) -> tuple[_LabelCtx, list[Station]]:
+    """Sort the labelled stations and pre-compute the placement context."""
     sorted_stations = sorted(
         (
             s
@@ -1193,13 +1187,10 @@ def place_labels(
         key=lambda s: (s.layer, s.track),
     )
 
-    # Pre-compute per-section Y extremes for LR/RL sections so edge
-    # stations prefer outward-facing labels, centering visual content.
-    # Include port station Y positions so routes entering/exiting at a
-    # different Y than the station track inform the outward preference
-    # (prevents labels facing into an entry/exit route).
-    # Skip sections that contain multi-line labels: consistent layer
-    # alternation avoids cascading collisions between the taller labels.
+    # Per-section Y extremes for LR/RL sections so edge stations prefer
+    # outward-facing labels, centering visual content.  Sections with
+    # multi-line labels are skipped so consistent layer alternation avoids
+    # cascading collisions between the taller labels.
     section_y_range: dict[str, tuple[float, float]] = {}
     sections_with_multiline: set[str] = set()
     for s in sorted_stations:
@@ -1226,16 +1217,8 @@ def place_labels(
         lo, hi = section_y_range[s.section_id]
         section_y_range[s.section_id] = (min(lo, s.y), max(hi, s.y))
 
-    # Pre-compute which section edges have a sole station, so the
-    # outward-label override only fires when it won't kill alternation.
     solo = _edge_solo(sorted_stations, section_y_range)
-
-    # Pre-compute label side preference for stations connected to
-    # off-Y ports, so labels avoid overlapping diagonal port routes.
     port_pref = _compute_port_label_preference(graph, max_dx=PORT_LABEL_MAX_DX)
-
-    # Rail-mode panels: offset labels to the whole panel's outer edge so they
-    # alternate above the top rail / below the bottom rail (never between rails).
     panel_extents = _rail_panel_extents(graph)
 
     # Trial both alternation patterns per section, pick the better one.
@@ -1272,255 +1255,367 @@ def place_labels(
         if cost_flipped < cost_default:
             section_flip[sec_id] = True
 
-    # Pre-compute per-station safe label offsets so labels between
-    # vertically stacked stations stay closer to their own pill.
     safe_offsets = _compute_safe_offsets(
         sorted_stations, label_offset, station_offsets, graph
     )
 
-    placements: list[LabelPlacement] = _make_obstacle_placements(icon_obstacles)
+    ctx = _LabelCtx(
+        graph=graph,
+        label_offset=label_offset,
+        station_offsets=station_offsets,
+        label_angle=label_angle,
+        section_y_range=section_y_range,
+        sections_with_multiline=sections_with_multiline,
+        solo=solo,
+        port_pref=port_pref,
+        section_flip=section_flip,
+        safe_offsets=safe_offsets,
+        panel_extents=panel_extents,
+    )
+    return ctx, sorted_stations
 
-    for i, station in enumerate(sorted_stations):
-        # Offset labels from the pill edge (outermost served line), not station.y.
-        min_off, max_off = _pill_offsets(graph, station, station_offsets)
-        rail_panel = _rail_panel_label_offsets(station, panel_extents)
-        if rail_panel is not None:
-            min_off, max_off = rail_panel
-        rail_side = _rail_label_side(graph, station)
 
-        # Check if this is a TB section station (horizontal pill)
-        is_tb_vert = False
-        if station.section_id:
-            sec = graph.sections.get(station.section_id)
-            if sec and sec.direction == "TB":
-                is_tb_vert = True
+def _is_tb_section(graph: MetroGraph, station: Station) -> bool:
+    """Whether the station belongs to a TB (top-to-bottom) section."""
+    if not station.section_id:
+        return False
+    sec = graph.sections.get(station.section_id)
+    return bool(sec and sec.direction == "TB")
 
-        if is_tb_vert:
-            # Place label to the left of the horizontal pill
-            n_lines = len(graph.station_lines(station.id))
-            offset_span = (n_lines - 1) * TB_LINE_Y_OFFSET
-            pill_left = station.x - offset_span / 2 - TB_PILL_EDGE_OFFSET
-            pill_right = station.x + offset_span / 2 + TB_PILL_EDGE_OFFSET
-            candidate = LabelPlacement(
-                station_id=station.id,
-                text=station.label,
-                x=pill_left - TB_LABEL_H_SPACING,
-                y=station.y,
-                above=True,
-                text_anchor="end",
-                dominant_baseline="central",
+
+def _place_station_label(
+    ctx: _LabelCtx,
+    station: Station,
+    placements: list[LabelPlacement],
+) -> LabelPlacement:
+    """Place one station's label, dispatching by section style."""
+    graph = ctx.graph
+    # Offset labels from the pill edge (outermost served line), not station.y.
+    min_off, max_off = _pill_offsets(graph, station, ctx.station_offsets)
+    rail_panel = _rail_panel_label_offsets(station, ctx.panel_extents)
+    if rail_panel is not None:
+        min_off, max_off = rail_panel
+    rail_side = _rail_label_side(graph, station)
+
+    if _is_tb_section(graph, station):
+        return _place_tb_label(ctx, station, placements)
+    if ctx.label_angle:
+        return _place_angled_label(ctx, station, min_off, max_off, rail_side)
+    return _place_alternating_label(ctx, station, placements, min_off, max_off, rail_side)
+
+
+def _place_tb_label(
+    ctx: _LabelCtx,
+    station: Station,
+    placements: list[LabelPlacement],
+) -> LabelPlacement:
+    """Place a TB-section label beside the horizontal pill (left, else right)."""
+    graph = ctx.graph
+    n_lines = len(graph.station_lines(station.id))
+    offset_span = (n_lines - 1) * TB_LINE_Y_OFFSET
+    pill_left = station.x - offset_span / 2 - TB_PILL_EDGE_OFFSET
+    pill_right = station.x + offset_span / 2 + TB_PILL_EDGE_OFFSET
+    candidate = LabelPlacement(
+        station_id=station.id,
+        text=station.label,
+        x=pill_left - TB_LABEL_H_SPACING,
+        y=station.y,
+        above=True,
+        text_anchor="end",
+        dominant_baseline="central",
+    )
+    if _has_collision(candidate, placements):
+        candidate = LabelPlacement(
+            station_id=station.id,
+            text=station.label,
+            x=pill_right + TB_LABEL_H_SPACING,
+            y=station.y,
+            above=True,
+            text_anchor="start",
+            dominant_baseline="central",
+        )
+    if station.section_id:
+        tb_sec = graph.sections.get(station.section_id)
+        if tb_sec and tb_sec.bbox_w > 0:
+            margin = LABEL_BBOX_MARGIN
+            lx_min, _, lx_max, _ = _label_bbox(candidate)
+            lx_min -= margin
+            lx_max += margin
+            if lx_min < tb_sec.bbox_x:
+                old_right = tb_sec.bbox_x + tb_sec.bbox_w
+                tb_sec.bbox_x = lx_min
+                tb_sec.bbox_w = old_right - lx_min
+            if lx_max > tb_sec.bbox_x + tb_sec.bbox_w:
+                tb_sec.bbox_w = lx_max - tb_sec.bbox_x
+    return candidate
+
+
+def _place_angled_label(
+    ctx: _LabelCtx,
+    station: Station,
+    min_off: float,
+    max_off: float,
+    rail_side: bool | None,
+) -> LabelPlacement:
+    """Place an opt-in diagonal label, anchored at the pill and tilted.
+
+    Angled labels sit below the trunk on the same side (like real transit
+    maps), flipping above only to clear a fork sibling directly below.  A
+    single-rail station labels outward: the topmost rail above (sharing the
+    panel's top-rail baseline), every other rail below.
+    """
+    graph = ctx.graph
+    label_angle = ctx.label_angle
+    if rail_side is not None:
+        diag_above = rail_side
+    else:
+        diag_above = _diagonal_prefer_above(graph, station)
+    if diag_above:
+        candidate = LabelPlacement(
+            station_id=station.id,
+            text=station.label,
+            x=station.x,
+            y=station.y + min_off - ctx.label_offset - DIAGONAL_LABEL_OFFSET,
+            above=True,
+            angle=-label_angle,
+            text_anchor="start",
+        )
+    else:
+        candidate = LabelPlacement(
+            station_id=station.id,
+            text=station.label,
+            x=station.x,
+            y=station.y + max_off + ctx.label_offset + DIAGONAL_LABEL_OFFSET,
+            above=False,
+            angle=label_angle,
+            text_anchor="start",
+        )
+    if station.section_id:
+        sec = graph.sections.get(station.section_id)
+        if sec is not None and sec.bbox_w > 0:
+            _grow_section_for_box(sec, _label_bbox(candidate))
+    return candidate
+
+
+def _initial_label_side(
+    ctx: _LabelCtx,
+    station: Station,
+    rail_side: bool | None,
+) -> bool:
+    """Initial above/below choice for an alternating (non-angled) label."""
+    # Alternate by layer (column): even layers below, odd layers above.
+    start_above = station.layer % 2 == 1
+    if station.section_id and ctx.section_flip.get(station.section_id, False):
+        start_above = not start_above
+    # Isolated edge stations in LR/RL sections prefer outward labels.
+    start_above = _apply_edge_override(
+        station,
+        start_above,
+        ctx.section_y_range,
+        ctx.sections_with_multiline,
+        ctx.solo,
+    )
+    # Override when a port route would clash with the label.
+    if station.id in ctx.port_pref:
+        start_above = ctx.port_pref[station.id]
+    # Rail mode forces single-rail labels outward (never between rails).
+    if rail_side is not None:
+        start_above = rail_side
+    return start_above
+
+
+def _place_alternating_candidate(
+    ctx: _LabelCtx,
+    station: Station,
+    placements: list[LabelPlacement],
+    min_off: float,
+    max_off: float,
+    start_above: bool,
+) -> LabelPlacement:
+    """Try the preferred side, then nudge / flip / push to clear collisions."""
+    safe_above, safe_below = ctx.safe_offsets.get(
+        station.id, (ctx.label_offset, ctx.label_offset)
+    )
+    eff_offset = safe_above if start_above else safe_below
+    candidate = _try_place(
+        station, eff_offset, start_above, placements, min_off, max_off
+    )
+
+    if _has_collision(candidate, placements):
+        # Try a small horizontal nudge before flipping sides.
+        nudged = _nudge_to_clear(candidate, placements)
+        if nudged is not None:
+            candidate = nudged
+        else:
+            alt_offset = safe_below if start_above else safe_above
+            candidate = _try_place(
+                station,
+                alt_offset,
+                not start_above,
+                placements,
+                min_off,
+                max_off,
             )
             if _has_collision(candidate, placements):
-                # Try right side of the pill
-                candidate = LabelPlacement(
-                    station_id=station.id,
-                    text=station.label,
-                    x=pill_right + TB_LABEL_H_SPACING,
-                    y=station.y,
-                    above=True,
-                    text_anchor="start",
-                    dominant_baseline="central",
-                )
-            # Expand section bbox to contain the label
-            if station.section_id:
-                tb_sec = graph.sections.get(station.section_id)
-                if tb_sec and tb_sec.bbox_w > 0:
-                    margin = LABEL_BBOX_MARGIN
-                    lx_min, _, lx_max, _ = _label_bbox(candidate)
-                    lx_min -= margin
-                    lx_max += margin
-                    if lx_min < tb_sec.bbox_x:
-                        old_right = tb_sec.bbox_x + tb_sec.bbox_w
-                        tb_sec.bbox_x = lx_min
-                        tb_sec.bbox_w = old_right - lx_min
-                    if lx_max > tb_sec.bbox_x + tb_sec.bbox_w:
-                        tb_sec.bbox_w = lx_max - tb_sec.bbox_x
-            placements.append(candidate)
-            continue
-
-        # Opt-in diagonal labels (#527): for non-TB sections, anchor the
-        # label at the bottom of the pill and tilt it.  All angled labels
-        # sit below the trunk on the same side (like real transit maps),
-        # which lets densely-spaced stations share a compact horizontal
-        # line without their long names colliding.
-        if label_angle:
-            # A single-rail station labels outward: the topmost rail above,
-            # every other rail below, so names sit outside the bundle.  The
-            # above anchor measures from ``min_off`` (the panel's top rail), so
-            # the above-labels share a baseline.  Spanning and non-rail stations
-            # keep the default tilt -- below the trunk, flipping above only to
-            # clear a fork sibling sitting directly below.
-            rail_side = _rail_label_side(graph, station)
-            if rail_side is not None:
-                diag_above = rail_side
-            else:
-                diag_above = _diagonal_prefer_above(graph, station)
-            if diag_above:
-                # Mirror the tilt across the trunk: anchor at the pill top and
-                # read up-and-to-the-right, clearing a fork sibling below.
+                # Push further in the non-default direction.
+                direction = -1 if not start_above else 1
+                if direction < 0:
+                    y = station.y + min_off - safe_above * COLLISION_MULTIPLIER
+                else:
+                    y = station.y + max_off + safe_below * COLLISION_MULTIPLIER
                 candidate = LabelPlacement(
                     station_id=station.id,
                     text=station.label,
                     x=station.x,
-                    y=station.y + min_off - label_offset - DIAGONAL_LABEL_OFFSET,
-                    above=True,
-                    angle=-label_angle,
-                    text_anchor="start",
+                    y=y,
+                    above=(direction < 0),
                 )
-            else:
-                candidate = LabelPlacement(
-                    station_id=station.id,
-                    text=station.label,
-                    x=station.x,
-                    y=station.y + max_off + label_offset + DIAGONAL_LABEL_OFFSET,
-                    above=False,
-                    angle=label_angle,
-                    text_anchor="start",
-                )
-            if station.section_id:
-                sec = graph.sections.get(station.section_id)
-                if sec is not None and sec.bbox_w > 0:
-                    _grow_section_for_box(sec, _label_bbox(candidate))
-            placements.append(candidate)
+
+    if _has_collision(candidate, placements):
+        candidate = _clear_obstacle_overlap(
+            station, candidate, placements, min_off, max_off, safe_above, safe_below
+        )
+    return candidate
+
+
+def _clear_obstacle_overlap(
+    station: Station,
+    candidate: LabelPlacement,
+    placements: list[LabelPlacement],
+    min_off: float,
+    max_off: float,
+    safe_above: float,
+    safe_below: float,
+) -> LabelPlacement:
+    """Resolve a label overlapping an obstacle (e.g. a terminus file icon).
+
+    Flip to the opposite side of the station first (keeps the label close);
+    only push past the obstacle as a last resort.  When both sides have
+    obstacles, prefer whichever keeps the label closer to the station -- a
+    slight overlap beats pushing into an adjacent row.
+    """
+    cbox = _label_bbox(candidate)
+    for p in placements:
+        if p.obstacle_bbox is None:
+            continue
+        obox = _label_bbox(p)
+        if not _boxes_overlap(cbox, obox):
             continue
 
-        # Alternate by layer (column): even layers below, odd layers above
-        start_above = station.layer % 2 == 1
-        if station.section_id and section_flip.get(station.section_id, False):
-            start_above = not start_above
-
-        # For isolated edge stations in LR/RL sections, prefer labels
-        # extending outward (away from center).  Only applies when the
-        # station is the sole occupant at the section's Y extreme;
-        # crowded edges keep alternation to avoid horizontal collisions.
-        start_above = _apply_edge_override(
+        flip_above = not candidate.above
+        flip_off = safe_above if flip_above else safe_below
+        flipped = _try_place(
             station,
-            start_above,
-            section_y_range,
-            sections_with_multiline,
-            solo,
+            flip_off,
+            flip_above,
+            placements,
+            min_off,
+            max_off,
         )
+        if not _has_collision(flipped, placements):
+            return flipped
 
-        # Override when a port route would clash with the label.
-        if station.id in port_pref:
-            start_above = port_pref[station.id]
+        flip_dist = abs(flipped.y - station.y)
+        orig_dist = abs(candidate.y - station.y)
+        if flip_dist < orig_dist:
+            candidate = flipped
+        break
+    return candidate
 
-        # Rail mode: force single-rail labels outward (above their own rail in
-        # the top half, below in the bottom half) so they never sit between
-        # rails and a column of branch stations spreads its labels vertically.
-        if rail_side is not None:
-            start_above = rail_side
 
-        safe_above, safe_below = safe_offsets.get(
-            station.id, (label_offset, label_offset)
-        )
-        eff_offset = safe_above if start_above else safe_below
+def _clamp_label_to_section(
+    ctx: _LabelCtx,
+    station: Station,
+    candidate: LabelPlacement,
+    min_off: float,
+    max_off: float,
+    placements: list[LabelPlacement],
+) -> LabelPlacement:
+    """Keep a label within its section bbox, growing the box where needed."""
+    if not station.section_id:
+        return candidate
+    sec = ctx.graph.sections.get(station.section_id)
+    if not (sec and sec.bbox_w > 0):
+        return candidate
 
-        candidate = _try_place(
-            station, eff_offset, start_above, placements, min_off, max_off
-        )
+    text_half_w = label_text_width(candidate.text) / 2
+    margin = LABEL_BBOX_MARGIN
+    # Horizontal: expand section bbox if needed, keeping the label centered
+    # on its station.
+    label_left = candidate.x - text_half_w - margin
+    label_right = candidate.x + text_half_w + margin
+    if label_left < sec.bbox_x:
+        old_right = sec.bbox_x + sec.bbox_w
+        sec.bbox_x = label_left
+        sec.bbox_w = old_right - label_left
+    if label_right > sec.bbox_x + sec.bbox_w:
+        sec.bbox_w = label_right - sec.bbox_x
+    return _clamp_label_vertical(
+        candidate,
+        sec,
+        station,
+        ctx.label_offset,
+        min_off,
+        max_off,
+        margin,
+        placements,
+    )
 
-        if _has_collision(candidate, placements):
-            # Try a small horizontal nudge before flipping sides.
-            nudged = _nudge_to_clear(candidate, placements)
-            if nudged is not None:
-                candidate = nudged
-            else:
-                # Try the other side
-                alt_offset = safe_below if start_above else safe_above
-                candidate = _try_place(
-                    station,
-                    alt_offset,
-                    not start_above,
-                    placements,
-                    min_off,
-                    max_off,
-                )
 
-                if _has_collision(candidate, placements):
-                    # Push further in the non-default direction
-                    direction = -1 if not start_above else 1
-                    if direction < 0:
-                        y = station.y + min_off - safe_above * COLLISION_MULTIPLIER
-                    else:
-                        y = station.y + max_off + safe_below * COLLISION_MULTIPLIER
-                    candidate = LabelPlacement(
-                        station_id=station.id,
-                        text=station.label,
-                        x=station.x,
-                        y=y,
-                        above=(direction < 0),
-                    )
+def _place_alternating_label(
+    ctx: _LabelCtx,
+    station: Station,
+    placements: list[LabelPlacement],
+    min_off: float,
+    max_off: float,
+    rail_side: bool | None,
+) -> LabelPlacement:
+    """Place a standard label by layer alternation with collision handling."""
+    start_above = _initial_label_side(ctx, station, rail_side)
+    candidate = _place_alternating_candidate(
+        ctx, station, placements, min_off, max_off, start_above
+    )
+    return _clamp_label_to_section(ctx, station, candidate, min_off, max_off, placements)
 
-        # Final obstacle clearance: if the label still overlaps an
-        # obstacle (e.g. a terminus file icon), try flipping to the
-        # opposite side of the station first (keeps label close).
-        # Only push past the obstacle as a last resort.
-        if _has_collision(candidate, placements):
-            cbox = _label_bbox(candidate)
-            for p in placements:
-                if p.obstacle_bbox is None:
-                    continue
-                obox = _label_bbox(p)
-                if not _boxes_overlap(cbox, obox):
-                    continue
 
-                # Try flipping to the opposite side of the station.
-                flip_above = not candidate.above
-                flip_off = safe_above if flip_above else safe_below
-                flipped = _try_place(
-                    station,
-                    flip_off,
-                    flip_above,
-                    placements,
-                    min_off,
-                    max_off,
-                )
-                if not _has_collision(flipped, placements):
-                    candidate = flipped
-                    break
+def place_labels(
+    graph: MetroGraph,
+    label_offset: float = LABEL_OFFSET,
+    station_offsets: dict[tuple[str, str], float] | None = None,
+    icon_obstacles: list[tuple[float, float, float, float]] | None = None,
+    routes: list["RoutedPath"] | None = None,
+    allow_hyphenation: bool = True,
+    label_angle: float = 0.0,
+    lift_wrapped_off_trunks: bool = True,
+) -> list[LabelPlacement]:
+    """Place station labels, alternating above/below stations.
 
-                # Flipping also collides.  Pick whichever side keeps the
-                # label closer to the station.  When both sides have
-                # obstacles (e.g. tight grid between two terminus
-                # icons), prefer closeness over clearance - a slight
-                # overlap is better than pushing the label into an
-                # adjacent row.
-                flip_dist = abs(flipped.y - station.y)
-                orig_dist = abs(candidate.y - station.y)
-                if flip_dist < orig_dist:
-                    candidate = flipped
-                break
+    Strategy:
+    1. Default: alternate above/below based on layer index.
+    2. If it collides with an existing label, try the other side.
+    3. If still colliding, push further away.
 
-        # Clamp labels so they stay within section bbox
-        if station.section_id:
-            sec = graph.sections.get(station.section_id)
-            if sec and sec.bbox_w > 0:
-                text_half_w = label_text_width(candidate.text) / 2
-                margin = LABEL_BBOX_MARGIN
-                # Horizontal: expand section bbox if needed, keeping
-                # the label centered on its station.
-                label_left = candidate.x - text_half_w - margin
-                label_right = candidate.x + text_half_w + margin
-                if label_left < sec.bbox_x:
-                    old_right = sec.bbox_x + sec.bbox_w
-                    sec.bbox_x = label_left
-                    sec.bbox_w = old_right - label_left
-                if label_right > sec.bbox_x + sec.bbox_w:
-                    sec.bbox_w = label_right - sec.bbox_x
-                # Vertical clamping (with flip/expand on overlap)
-                candidate = _clamp_label_vertical(
-                    candidate,
-                    sec,
-                    station,
-                    label_offset,
-                    min_off,
-                    max_off,
-                    margin,
-                    placements,
-                )
+    Per-section trial: for each LR/RL section with multiple stations,
+    both alternation patterns are tested and the one with fewer
+    collisions is used.
 
-        placements.append(candidate)
+    When ``label_angle`` is non-zero, LR/RL section labels are instead
+    anchored at the pill and tilted (transit-map style); they hang on one
+    side and pack by their narrow rotated footprint.
+
+    ``lift_wrapped_off_trunks`` runs a final render-time pass that pulls a
+    wrapped label back to its un-pushed anchor when its grown block overruns a
+    foreign trunk.  Callers measuring overlaps for the layout (the spacing
+    search probe) pass False so the engine sees the pre-lift geometry and the
+    deliberate neighbour graze never trips the label-overlap guard.
+    """
+    ctx, sorted_stations = _build_label_ctx(
+        graph, label_offset, station_offsets, icon_obstacles, label_angle
+    )
+
+    placements: list[LabelPlacement] = _make_obstacle_placements(icon_obstacles)
+    for station in sorted_stations:
+        placements.append(_place_station_label(ctx, station, placements))
 
     if routes:
         _avoid_diagonal_routes(placements, graph, routes, station_offsets)
@@ -1533,7 +1628,7 @@ def place_labels(
 
     if lift_wrapped_off_trunks:
         _lift_wrapped_labels_off_foreign_trunks(
-            placements, graph, routes, station_offsets, safe_offsets, label_offset
+            placements, graph, routes, station_offsets, ctx.safe_offsets, label_offset
         )
 
     if graph.label_angle:

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -780,9 +780,7 @@ def _recenter_section_loop_sides(
             continue
         midpoint = (corner_left + corner_right) / 2.0
         if not (
-            min(corner_left, corner_right)
-            <= midpoint
-            <= max(corner_left, corner_right)
+            min(corner_left, corner_right) <= midpoint <= max(corner_left, corner_right)
         ):
             continue
         if abs(midpoint - st.x) < min_recenter_delta:
@@ -897,16 +895,12 @@ def _snap_column_to_anchors(
         visible_ins = [
             e
             for e in graph.edges_to(sid)
-            if (
-                (gs := graph.stations.get(e.source)) is not None and not gs.is_hidden
-            )
+            if ((gs := graph.stations.get(e.source)) is not None and not gs.is_hidden)
         ]
         visible_outs = [
             e
             for e in graph.edges_from(sid)
-            if (
-                (gs := graph.stations.get(e.target)) is not None and not gs.is_hidden
-            )
+            if ((gs := graph.stations.get(e.target)) is not None and not gs.is_hidden)
         ]
         if len(visible_ins) == 1 and len(visible_outs) == 1:
             anchor_xs.append(st.x)

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -788,20 +788,6 @@ def _recenter_section_loop_sides(
         st.x = midpoint
 
 
-def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
-    """The section's trunk Y, taken from a horizontal (LEFT/RIGHT) port."""
-    for pid in section.entry_ports + section.exit_ports:
-        ps = graph.stations.get(pid)
-        port = graph.ports.get(pid)
-        if (
-            ps is not None
-            and port is not None
-            and port.side in (PortSide.LEFT, PortSide.RIGHT)
-        ):
-            return ps.y
-    return None
-
-
 def _loop_column_key(
     graph: MetroGraph,
     section: Section,
@@ -919,7 +905,7 @@ def _snap_column_to_anchors(
 
 def _snap_loop_column_mates(graph: MetroGraph, section: Section) -> None:
     """Align loop-column-mate stations to the column X from pass-1 anchors."""
-    section_trunk_y = _section_trunk_y(graph, section)
+    section_trunk_y = _section_lr_port_anchor_y(graph, section)
     if section_trunk_y is None:
         return
     columns = _build_loop_columns(graph, section, section_trunk_y)

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -676,6 +676,265 @@ def _compact_below_trunk_band(
         graph.stations[sid].y -= y_spacing
 
 
+def _fork_join_station_sets(graph: MetroGraph) -> tuple[set[str], set[str]]:
+    """Stations that fan out (>1 target) and that fan in (>1 source)."""
+    fork_targets: dict[str, set[str]] = defaultdict(set)
+    join_sources: dict[str, set[str]] = defaultdict(set)
+    for e in graph.edges:
+        fork_targets[e.source].add(e.target)
+        join_sources[e.target].add(e.source)
+    fork_stations = {sid for sid, t in fork_targets.items() if len(t) > 1}
+    join_stations = {sid for sid, s in join_sources.items() if len(s) > 1}
+    return fork_stations, join_stations
+
+
+def _loop_side_endpoints(
+    graph: MetroGraph,
+    sid: str,
+    st: Station,
+) -> tuple[Station, Station, float] | None:
+    """The on-trunk (source, target, trunk_y) of a clean horizontal loop side.
+
+    A loop side station has exactly one in-edge and one out-edge, both
+    endpoints on a shared trunk Y, with the station itself off that trunk and
+    strictly between the two endpoints (a real horizontal loop, not a U-turn).
+    Returns ``None`` for any station that doesn't fit that shape.
+    """
+    ins = graph.edges_to(sid)
+    outs = graph.edges_from(sid)
+    if len(ins) != 1 or len(outs) != 1:
+        return None
+    src = graph.stations.get(ins[0].source)
+    tgt = graph.stations.get(outs[0].target)
+    if src is None or tgt is None:
+        return None
+    if abs(src.y - tgt.y) > 0.5:
+        return None
+    trunk_y = src.y
+    if abs(st.y - trunk_y) < 0.5:
+        return None
+    if not ((src.x < st.x < tgt.x) or (tgt.x < st.x < src.x)):
+        return None
+    return src, tgt, trunk_y
+
+
+def _has_off_trunk_sibling(
+    graph: MetroGraph,
+    section: Section,
+    sid: str,
+    src_id: str,
+    tgt_id: str,
+    trunk_y: float,
+) -> bool:
+    """Whether another off-trunk station shares this station's src and tgt.
+
+    A shared off-trunk sibling is what makes the column owned by a genuine
+    parallel fan-out rather than by an unrelated trunk station that merely
+    shares the layer-X.  A single side branch carries no fan, and recentering
+    it off the trunk station's column would visibly break the layout.
+    """
+    for other_sid in section.station_ids:
+        if other_sid == sid:
+            continue
+        other = graph.stations.get(other_sid)
+        if other is None or other.is_port or other.is_hidden:
+            continue
+        if abs(other.y - trunk_y) < 0.5:
+            continue
+        other_srcs = {e.source for e in graph.edges_to(other_sid)}
+        other_tgts = {e.target for e in graph.edges_from(other_sid)}
+        if other_srcs == {src_id} and other_tgts == {tgt_id}:
+            return True
+    return False
+
+
+def _recenter_section_loop_sides(
+    graph: MetroGraph,
+    section: Section,
+    fork_stations: set[str],
+    join_stations: set[str],
+) -> None:
+    """Re-centre off-trunk loop side stations on their diagonal midpoint.
+
+    Skips moves below a minimum visual-benefit threshold: an imperceptible
+    re-centre is not worth breaking incidental column alignment with stacked
+    on-trunk co-loopers.
+    """
+    min_recenter_delta = DIAGONAL_RUN / 3.0
+    port_ids = section.port_ids
+    for sid in section.station_ids:
+        if sid in port_ids:
+            continue
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.is_hidden:
+            continue
+        endpoints = _loop_side_endpoints(graph, sid, st)
+        if endpoints is None:
+            continue
+        src, tgt, trunk_y = endpoints
+        if not _has_off_trunk_sibling(graph, section, sid, src.id, tgt.id, trunk_y):
+            continue
+        corner_left = _loop_corner_x(src, st, fork_stations, join_stations, role="src")
+        corner_right = _loop_corner_x(st, tgt, fork_stations, join_stations, role="tgt")
+        if corner_left is None or corner_right is None:
+            continue
+        midpoint = (corner_left + corner_right) / 2.0
+        if not (
+            min(corner_left, corner_right)
+            <= midpoint
+            <= max(corner_left, corner_right)
+        ):
+            continue
+        if abs(midpoint - st.x) < min_recenter_delta:
+            continue
+        st.x = midpoint
+
+
+def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
+    """The section's trunk Y, taken from a horizontal (LEFT/RIGHT) port."""
+    for pid in section.entry_ports + section.exit_ports:
+        ps = graph.stations.get(pid)
+        port = graph.ports.get(pid)
+        if (
+            ps is not None
+            and port is not None
+            and port.side in (PortSide.LEFT, PortSide.RIGHT)
+        ):
+            return ps.y
+    return None
+
+
+def _loop_column_key(
+    graph: MetroGraph,
+    section: Section,
+    section_trunk_y: float,
+    sid: str,
+) -> tuple[float, float] | None:
+    """The (pred_x, succ_x) trunk-Y extent defining a station's loop column.
+
+    Returns ``None`` when the station has no trunk-Y neighbour on one side, or
+    when any visible neighbour sits off the trunk row (an off-track input
+    anchors the station elsewhere).
+    """
+    pred_x: float | None = None
+    succ_x: float | None = None
+    for e in graph.edges_to(sid):
+        p = graph.stations.get(e.source)
+        if p is None or p.is_hidden:
+            continue
+        if abs(p.y - section_trunk_y) > 0.5:
+            return None
+        if (
+            pred_x is None
+            or (section.direction == "LR" and p.x > pred_x)
+            or (section.direction == "RL" and p.x < pred_x)
+        ):
+            pred_x = p.x
+    for e in graph.edges_from(sid):
+        t = graph.stations.get(e.target)
+        if t is None or t.is_hidden:
+            continue
+        if abs(t.y - section_trunk_y) > 0.5:
+            return None
+        if (
+            succ_x is None
+            or (section.direction == "LR" and t.x < succ_x)
+            or (section.direction == "RL" and t.x > succ_x)
+        ):
+            succ_x = t.x
+    if pred_x is None or succ_x is None:
+        return None
+    return (round(pred_x, 3), round(succ_x, 3))
+
+
+def _build_loop_columns(
+    graph: MetroGraph,
+    section: Section,
+    section_trunk_y: float,
+) -> dict[tuple[float, float], list[str]]:
+    """Group section stations by loop column, keeping those strictly between
+    their trunk-Y neighbours (a meaningful horizontal extent)."""
+    columns: dict[tuple[float, float], list[str]] = defaultdict(list)
+    port_ids = section.port_ids
+    for sid in section.station_ids:
+        if sid in port_ids:
+            continue
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.is_hidden:
+            continue
+        key = _loop_column_key(graph, section, section_trunk_y, sid)
+        if key is None:
+            continue
+        pred_x, succ_x = key
+        lo, hi = min(pred_x, succ_x), max(pred_x, succ_x)
+        if not (lo < st.x < hi):
+            continue
+        columns[key].append(sid)
+    return columns
+
+
+def _snap_column_to_anchors(
+    graph: MetroGraph,
+    section_trunk_y: float,
+    members: list[str],
+    key: tuple[float, float],
+) -> None:
+    """Snap a loop column's movers to the mean X of its clean anchors.
+
+    Anchors are the off-trunk siblings pass 1 already placed at the loop
+    midpoint (restricted to the same single-in/single-out filter).  Movers are
+    the trunk-row station plus any off-trunk column-mate whose extra edge (e.g.
+    an exit-port feed alongside the trunk rejoin) disqualified it from pass 1
+    yet which belongs to the column.
+    """
+    movers: list[str] = []
+    anchor_xs: list[float] = []
+    for sid in members:
+        st = graph.stations[sid]
+        if abs(st.y - section_trunk_y) <= 0.5:
+            movers.append(sid)
+            continue
+        visible_ins = [
+            e
+            for e in graph.edges_to(sid)
+            if (
+                (gs := graph.stations.get(e.source)) is not None and not gs.is_hidden
+            )
+        ]
+        visible_outs = [
+            e
+            for e in graph.edges_from(sid)
+            if (
+                (gs := graph.stations.get(e.target)) is not None and not gs.is_hidden
+            )
+        ]
+        if len(visible_ins) == 1 and len(visible_outs) == 1:
+            anchor_xs.append(st.x)
+        else:
+            movers.append(sid)
+    if not movers or not anchor_xs:
+        return
+    target_x = sum(anchor_xs) / len(anchor_xs)
+    pred_x, succ_x = key
+    lo, hi = min(pred_x, succ_x), max(pred_x, succ_x)
+    if not (lo <= target_x <= hi):
+        return
+    for sid in movers:
+        graph.stations[sid].x = target_x
+
+
+def _snap_loop_column_mates(graph: MetroGraph, section: Section) -> None:
+    """Align loop-column-mate stations to the column X from pass-1 anchors."""
+    section_trunk_y = _section_trunk_y(graph, section)
+    if section_trunk_y is None:
+        return
+    columns = _build_loop_columns(graph, section, section_trunk_y)
+    for key, members in columns.items():
+        if len(members) < 2:
+            continue
+        _snap_column_to_anchors(graph, section_trunk_y, members, key)
+
+
 def _recenter_loop_side_stations(graph: MetroGraph) -> None:
     """Reposition fan-out side stations on the centre of their loop run.
 
@@ -711,235 +970,17 @@ def _recenter_loop_side_stations(graph: MetroGraph) -> None:
     skipped when shifting would leave fewer than ``DIAGONAL_RUN`` worth
     of horizontal room on either side.
     """
-    # Single pass over graph.edges to accumulate fork/join sets.
-    # (Adjacency itself is served by graph.edges_from / edges_to.)
-    fork_targets: dict[str, set[str]] = defaultdict(set)
-    join_sources: dict[str, set[str]] = defaultdict(set)
-    for e in graph.edges:
-        fork_targets[e.source].add(e.target)
-        join_sources[e.target].add(e.source)
-    fork_stations = {sid for sid, t in fork_targets.items() if len(t) > 1}
-    join_stations = {sid for sid, s in join_sources.items() if len(s) > 1}
+    fork_stations, join_stations = _fork_join_station_sets(graph)
 
-    # Minimum recenter delta below which we'd be moving the station
-    # without enough visual benefit to justify breaking any incidental
-    # column alignment with stacked siblings.  Anything smaller is in
-    # the noise where the layer-X placement already reads as centred.
-    min_recenter_delta = DIAGONAL_RUN / 3.0
-
-    # Pass 1: re-centre off-trunk loop side stations using the diagonal
-    # corner geometry.
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
             continue
-        port_ids = section.port_ids
-        # Each side station: not a port, not hidden, has exactly one
-        # incoming edge and one outgoing edge, both endpoints sit on
-        # the section trunk Y (single source / single target on-trunk).
-        for sid in section.station_ids:
-            if sid in port_ids:
-                continue
-            st = graph.stations.get(sid)
-            if st is None or st.is_port or st.is_hidden:
-                continue
-            ins = graph.edges_to(sid)
-            outs = graph.edges_from(sid)
-            if len(ins) != 1 or len(outs) != 1:
-                continue
-            src_id = ins[0].source
-            tgt_id = outs[0].target
-            src = graph.stations.get(src_id)
-            tgt = graph.stations.get(tgt_id)
-            if src is None or tgt is None:
-                continue
-            # Side station must sit OFF the trunk Y of its source and
-            # target (a vertical hop is needed at both endpoints).
-            if abs(src.y - tgt.y) > 0.5:
-                # Source and target aren't on the same trunk row, so
-                # this isn't a simple horizontal loop side station.
-                continue
-            trunk_y = src.y
-            if abs(st.y - trunk_y) < 0.5:
-                continue  # Already on trunk, no loop.
-            # Both endpoints must lie strictly to opposite sides of the
-            # side station (a real horizontal loop, not a U-turn).
-            if not ((src.x < st.x < tgt.x) or (tgt.x < st.x < src.x)):
-                continue
-            # Require at least one OFF-TRUNK sibling sharing the same
-            # single src and tgt: this is what makes the station part
-            # of a genuine parallel fan-out where the column is owned
-            # by the loop, not by an unrelated trunk station that just
-            # happens to share the layer-X.  Single side branches (e.g.
-            # ``search`` paired with the trunk continuation ``align``)
-            # carry no fan, and recentering them off the column where
-            # the trunk station sits visibly breaks the layout.
-            has_off_trunk_sibling = False
-            for other_sid in section.station_ids:
-                if other_sid == sid:
-                    continue
-                other = graph.stations.get(other_sid)
-                if other is None or other.is_port or other.is_hidden:
-                    continue
-                if abs(other.y - trunk_y) < 0.5:
-                    continue  # on-trunk co-loopers don't establish a fan
-                other_ins = graph.edges_to(other_sid)
-                other_outs = graph.edges_from(other_sid)
-                other_srcs = {e.source for e in other_ins}
-                other_tgts = {e.target for e in other_outs}
-                if other_srcs == {src_id} and other_tgts == {tgt_id}:
-                    has_off_trunk_sibling = True
-                    break
-            if not has_off_trunk_sibling:
-                continue
-            # Compute the two diagonal corner Xs using routing's
-            # placement rule (see _compute_diagonal_placement).
-            corner_left = _loop_corner_x(
-                src, st, fork_stations, join_stations, role="src"
-            )
-            corner_right = _loop_corner_x(
-                st, tgt, fork_stations, join_stations, role="tgt"
-            )
-            if corner_left is None or corner_right is None:
-                continue
-            # Ensure room on both sides for the horizontal run after
-            # the new midpoint.  Skip if the move would push the
-            # station past either corner.
-            midpoint = (corner_left + corner_right) / 2.0
-            if not (
-                min(corner_left, corner_right)
-                <= midpoint
-                <= max(corner_left, corner_right)
-            ):
-                continue
-            # Skip moves smaller than the minimum visual-benefit
-            # threshold: they trade an imperceptible re-centre for a
-            # visible column break against on-trunk co-loopers (e.g.
-            # rnaseq_lite ``star_align`` ↔ ``hisat_align``).
-            if abs(midpoint - st.x) < min_recenter_delta:
-                continue
-            st.x = midpoint
+        _recenter_section_loop_sides(graph, section, fork_stations, join_stations)
 
-    # Pass 2: snap loop-column-mate stations (trunk-row station and any
-    # off-trunk siblings whose multi-edge topology disqualified them
-    # from pass 1) to the column X defined by pass-1's clean siblings.
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
             continue
-        port_ids = section.port_ids
-        # Determine the section's trunk Y from a horizontal port.
-        section_trunk_y: float | None = None
-        for pid in section.entry_ports + section.exit_ports:
-            ps = graph.stations.get(pid)
-            port = graph.ports.get(pid)
-            if (
-                ps is not None
-                and port is not None
-                and port.side in (PortSide.LEFT, PortSide.RIGHT)
-            ):
-                section_trunk_y = ps.y
-                break
-        if section_trunk_y is None:
-            continue
-
-        # Visible trunk-Y predecessor/successor X-extent for a station.
-        # Returns ``None`` when the station has no trunk-Y neighbour on
-        # one side, or when any visible neighbour sits off the trunk
-        # row (off-track inputs anchor the station elsewhere).
-        def _column_key(sid: str) -> tuple[float, float] | None:
-            pred_x: float | None = None
-            succ_x: float | None = None
-            for e in graph.edges_to(sid):
-                p = graph.stations.get(e.source)
-                if p is None or p.is_hidden:
-                    continue
-                if abs(p.y - section_trunk_y) > 0.5:
-                    return None
-                if (
-                    pred_x is None
-                    or (section.direction == "LR" and p.x > pred_x)
-                    or (section.direction == "RL" and p.x < pred_x)
-                ):
-                    pred_x = p.x
-            for e in graph.edges_from(sid):
-                t = graph.stations.get(e.target)
-                if t is None or t.is_hidden:
-                    continue
-                if abs(t.y - section_trunk_y) > 0.5:
-                    return None
-                if (
-                    succ_x is None
-                    or (section.direction == "LR" and t.x < succ_x)
-                    or (section.direction == "RL" and t.x > succ_x)
-                ):
-                    succ_x = t.x
-            if pred_x is None or succ_x is None:
-                return None
-            return (round(pred_x, 3), round(succ_x, 3))
-
-        columns: dict[tuple[float, float], list[str]] = defaultdict(list)
-        for sid in section.station_ids:
-            if sid in port_ids:
-                continue
-            st = graph.stations.get(sid)
-            if st is None or st.is_port or st.is_hidden:
-                continue
-            key = _column_key(sid)
-            if key is None:
-                continue
-            # Station must sit strictly between its trunk-Y neighbours
-            # for the column to be a meaningful horizontal extent.
-            pred_x, succ_x = key
-            lo, hi = min(pred_x, succ_x), max(pred_x, succ_x)
-            if not (lo < st.x < hi):
-                continue
-            columns[key].append(sid)
-
-        for key, members in columns.items():
-            if len(members) < 2:
-                continue
-            movers: list[str] = []
-            anchor_xs: list[float] = []
-            for sid in members:
-                st = graph.stations[sid]
-                if abs(st.y - section_trunk_y) <= 0.5:
-                    movers.append(sid)
-                    continue
-                # Anchor X must come from a station pass-1 already
-                # placed at the loop midpoint; restrict to the same
-                # single-in/single-out filter pass-1 uses.
-                visible_ins = [
-                    e
-                    for e in graph.edges_to(sid)
-                    if (
-                        (gs := graph.stations.get(e.source)) is not None
-                        and not gs.is_hidden
-                    )
-                ]
-                visible_outs = [
-                    e
-                    for e in graph.edges_from(sid)
-                    if (
-                        (gs := graph.stations.get(e.target)) is not None
-                        and not gs.is_hidden
-                    )
-                ]
-                if len(visible_ins) == 1 and len(visible_outs) == 1:
-                    anchor_xs.append(st.x)
-                else:
-                    # Off-trunk column-mate whose extra edge (e.g. an
-                    # exit-port feed alongside the trunk rejoin) failed
-                    # pass 1's single-in/single-out filter.  It still
-                    # belongs to the column and must follow the anchors.
-                    movers.append(sid)
-            if not movers or not anchor_xs:
-                continue
-            target_x = sum(anchor_xs) / len(anchor_xs)
-            pred_x, succ_x = key
-            lo, hi = min(pred_x, succ_x), max(pred_x, succ_x)
-            if not (lo <= target_x <= hi):
-                continue
-            for sid in movers:
-                graph.stations[sid].x = target_x
+        _snap_loop_column_mates(graph, section)
 
 
 def _shift_and_propagate_loop_stations(

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -358,9 +358,7 @@ def _detect_fork_join_layers(
     making a visible-vs-owner diagonal trigger a gap while a V-only off-trunk
     peer does not.
     """
-    visible_tracks = {
-        t for sid, t in tracks.items() if not sid.startswith("__bypass_")
-    }
+    visible_tracks = {t for sid, t in tracks.items() if not sid.startswith("__bypass_")}
     is_single_track = len(visible_tracks) <= 1
 
     def _has_bypass(ids: set[str]) -> bool:
@@ -510,17 +508,13 @@ def _has_interior_branch(
     if layer in fork_layers:
         for fsid, ftgts in out_targets.items():
             if layers.get(fsid) == layer and fsid in tracks:
-                off = sum(
-                    1 for t in ftgts if t in tracks and tracks[t] != tracks[fsid]
-                )
+                off = sum(1 for t in ftgts if t in tracks and tracks[t] != tracks[fsid])
                 if off >= 2:
                     return True
     if layer in join_layers:
         for jsid, jsrcs in in_sources.items():
             if layers.get(jsid) == layer and jsid in tracks:
-                off = sum(
-                    1 for s in jsrcs if s in tracks and tracks[s] != tracks[jsid]
-                )
+                off = sum(1 for s in jsrcs if s in tracks and tracks[s] != tracks[jsid])
                 if off >= 2:
                     return True
     return False
@@ -622,7 +616,9 @@ def _layer_gap_for(
                 ),
             )
 
-    routing_clearance = fj_label_half + DIAGONAL_RUN + MIN_STRAIGHT_EDGE - x_spacing + 1.0
+    routing_clearance = (
+        fj_label_half + DIAGONAL_RUN + MIN_STRAIGHT_EDGE - x_spacing + 1.0
+    )
     return max(base_gap, fj_label_half + bubble_extra, routing_clearance)
 
 
@@ -650,9 +646,7 @@ def _compute_fork_join_gaps(
     and the extra spacing is purely wasteful.
     """
     label_angle = (full_graph or sub).label_angle or 0.0
-    out_targets, in_sources = _fork_join_adjacency(
-        sub, full_graph, section_station_ids
-    )
+    out_targets, in_sources = _fork_join_adjacency(sub, full_graph, section_station_ids)
     fork_layers, join_layers = _detect_fork_join_layers(
         out_targets, in_sources, layers, tracks
     )

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -306,75 +306,61 @@ def _bubble_anchor_has_lifted_output(
     return False
 
 
-def _compute_fork_join_gaps(
+def _fork_join_adjacency(
     sub: MetroGraph,
-    layers: dict[str, int],
-    tracks: dict[str, float],
-    x_spacing: float,
-    full_graph: MetroGraph | None = None,
-    section_station_ids: set[str] | None = None,
-) -> dict[int, float]:
-    """Compute extra X offset per layer at fork/join points.
+    full_graph: MetroGraph | None,
+    section_station_ids: set[str] | None,
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Successor/predecessor sets used for fork/join detection.
 
-    Adds a fractional gap after fork layers (where tracks diverge) and
-    before join layers (where tracks converge) so labels aren't obscured
-    by diagonal crossings.
-
-    When full_graph and section_station_ids are provided, fork/join
-    detection uses all edges within the section (including port-touching
-    edges). This catches divergences where a station connects to both
-    internal stations and exit ports.
-
-    In single-track sections (all stations on the same Y), port-bound
-    divergences are suppressed because there are no diagonal transitions
-    and the extra spacing is purely wasteful.
+    With ``full_graph`` and ``section_station_ids`` the adjacency is built
+    from every section-internal edge (including those touching exit/entry
+    ports), so a station feeding both an internal successor and a port counts
+    as a divergence.  Otherwise it falls back to ``sub``'s own edges.
     """
-    label_angle = (full_graph or sub).label_angle or 0.0
-
     out_targets: dict[str, set[str]] = defaultdict(set)
     in_sources: dict[str, set[str]] = defaultdict(set)
-
-    # Use full graph edges for fork/join detection when available,
-    # so that edges to/from port stations are counted as divergences.
     if full_graph is not None and section_station_ids is not None:
         for edge in full_graph.edges:
-            src_in = edge.source in section_station_ids
-            tgt_in = edge.target in section_station_ids
-            if src_in and tgt_in:
+            if (
+                edge.source in section_station_ids
+                and edge.target in section_station_ids
+            ):
                 out_targets[edge.source].add(edge.target)
                 in_sources[edge.target].add(edge.source)
     else:
         for edge in sub.edges:
             out_targets[edge.source].add(edge.target)
             in_sources[edge.target].add(edge.source)
+    return out_targets, in_sources
 
-    # Only count forks/joins that span multiple tracks (requiring a
-    # diagonal routing transition).  Same-track fan-outs (e.g. a station
-    # connecting to both an internal successor and an exit port on the
-    # same Y) don't need extra horizontal room.
-    #
-    # Port stations aren't in ``tracks`` (they're positioned later), so
-    # treat them conservatively: if any participant is missing from
-    # tracks, assume it may be on a different track and count the
-    # fork/join.
-    #
-    # Exception for **forks** in single-track sections: exit-side ports
-    # sit at the far section boundary, so the diagonal from the fork
-    # station has ample horizontal room without extra layer spacing.
-    # Join gaps are kept even in single-track sections because entry
-    # ports are close to the first internal station, and the diagonal
-    # from a different-Y entry needs the extra room.
-    # Bypass V helpers (id prefix ``__bypass_``) are routing-only.  A
-    # V on its own off-trunk track must not flip an otherwise
-    # single-track section into "multi-track", or it would turn
-    # port-bound divergences into fork gaps that shift visible stations
-    # rightward.  Specifically when a V is one of the fork/join peers:
-    # exclude its track AND fold the owner's own track into the visible
-    # set so that visible-vs-owner diagonals still trigger a gap, but a
-    # V-only off-trunk peer (e.g. ``trim -> {align, V}`` in the 05 guide
-    # family) does not.  When no V is involved, fall back to the original
-    # peer-set track count so non-bypass topologies stay byte-identical.
-    visible_tracks = {t for sid, t in tracks.items() if not sid.startswith("__bypass_")}
+
+def _detect_fork_join_layers(
+    out_targets: dict[str, set[str]],
+    in_sources: dict[str, set[str]],
+    layers: dict[str, int],
+    tracks: dict[str, float],
+) -> tuple[set[int], set[int]]:
+    """Layers where tracks diverge (forks) or converge (joins).
+
+    Only multi-track divergences/convergences count: a same-track fan-out
+    needs no diagonal transition and so no extra room.  Port stations are
+    absent from ``tracks`` and treated conservatively as possibly off-track.
+
+    Forks in a single visible-track section are an exception: an exit-side
+    port sits at the far boundary, so the diagonal already has ample room and
+    a missing-track fork is skipped.  Join gaps are kept even then, because an
+    entry port sits close to the first internal station.
+
+    Bypass-V helpers (``__bypass_`` ids) are routing-only.  A V on its own
+    off-trunk track must not flip an otherwise single-track section into
+    multi-track, so its track is excluded and the owner's own track folded in,
+    making a visible-vs-owner diagonal trigger a gap while a V-only off-trunk
+    peer does not.
+    """
+    visible_tracks = {
+        t for sid, t in tracks.items() if not sid.startswith("__bypass_")
+    }
     is_single_track = len(visible_tracks) <= 1
 
     def _has_bypass(ids: set[str]) -> bool:
@@ -421,169 +407,286 @@ def _compute_fork_join_gaps(
                 if len(source_tracks) > 1:
                     join_layers.add(layers[sid])
 
+    return fork_layers, join_layers
+
+
+def _fj_label_metrics(
+    layer: int,
+    layers: dict[str, int],
+    tracks: dict[str, float],
+    sub: MetroGraph,
+) -> tuple[float, set[float]]:
+    """Widest half-label and the set of occupied tracks on ``layer``."""
+    fj_label_half = 0.0
+    fj_tracks: set[float] = set()
+    for sid, lyr in layers.items():
+        if lyr == layer:
+            station = sub.stations.get(sid)
+            if station and station.label.strip():
+                fj_label_half = max(fj_label_half, label_text_width(station.label) / 2)
+            if sid in tracks:
+                fj_tracks.add(tracks[sid])
+    return fj_label_half, fj_tracks
+
+
+def _wide_fan_bubble_extra(
+    layer: int,
+    fork_layers: set[int],
+    join_layers: set[int],
+    out_targets: dict[str, set[str]],
+    in_sources: dict[str, set[str]],
+    layers: dict[str, int],
+    tracks: dict[str, float],
+    sub: MetroGraph,
+    x_spacing: float,
+    fj_tracks: set[float],
+) -> float:
+    """Extra bubble room for a wide (3+ branch) fan's off-track middle labels.
+
+    For a multi-target fork / multi-source join the router skips bubble-station
+    centring, so the flat run at the bubble end can be very short.  When a
+    bubble station on the adjacent layer sits on a different track and carries a
+    wide label, the flat run is widened to fit it.  The gap is added on both
+    sides (after fork, before join), so each side contributes half the total.
+    """
+    is_wide_fork = False
+    is_wide_join = False
+    if layer in fork_layers:
+        for sid, tgts in out_targets.items():
+            if layers.get(sid) == layer and sid in tracks:
+                off_track = sum(
+                    1 for t in tgts if t in tracks and tracks[t] != tracks[sid]
+                )
+                if off_track >= 3:
+                    is_wide_fork = True
+                    break
+    if layer in join_layers:
+        for sid, srcs in in_sources.items():
+            if layers.get(sid) == layer and sid in tracks:
+                off_track = sum(
+                    1 for s in srcs if s in tracks and tracks[s] != tracks[sid]
+                )
+                if off_track >= 3:
+                    is_wide_join = True
+                    break
+
+    bubble_label_half = 0.0
+    if is_wide_fork:
+        for sid, lyr in layers.items():
+            if lyr == layer + 1 and sid in tracks and tracks[sid] not in fj_tracks:
+                station = sub.stations.get(sid)
+                if station and station.label.strip():
+                    bubble_label_half = max(
+                        bubble_label_half, label_text_width(station.label) / 2
+                    )
+    if is_wide_join:
+        for sid, lyr in layers.items():
+            if lyr == layer - 1 and sid in tracks and tracks[sid] not in fj_tracks:
+                station = sub.stations.get(sid)
+                if station and station.label.strip():
+                    bubble_label_half = max(
+                        bubble_label_half, label_text_width(station.label) / 2
+                    )
+
+    return max(0.0, (bubble_label_half * 2 + DIAGONAL_RUN - x_spacing) / 1.5)
+
+
+def _has_interior_branch(
+    layer: int,
+    fork_layers: set[int],
+    join_layers: set[int],
+    out_targets: dict[str, set[str]],
+    in_sources: dict[str, set[str]],
+    layers: dict[str, int],
+    tracks: dict[str, float],
+) -> bool:
+    """Whether the fan puts a branch label inside the bubble.
+
+    This needs three or more branches (two or more off-trunk tracks): the
+    middle branch then has a diagonal on both sides.  A two-branch fork places
+    both labels outside the bubble, so the convergence diagonal never crosses
+    them.
+    """
+    if layer in fork_layers:
+        for fsid, ftgts in out_targets.items():
+            if layers.get(fsid) == layer and fsid in tracks:
+                off = sum(
+                    1 for t in ftgts if t in tracks and tracks[t] != tracks[fsid]
+                )
+                if off >= 2:
+                    return True
+    if layer in join_layers:
+        for jsid, jsrcs in in_sources.items():
+            if layers.get(jsid) == layer and jsid in tracks:
+                off = sum(
+                    1 for s in jsrcs if s in tracks and tracks[s] != tracks[jsid]
+                )
+                if off >= 2:
+                    return True
+    return False
+
+
+def _angled_interior_reach(
+    layer: int,
+    fork_layers: set[int],
+    layers: dict[str, int],
+    tracks: dict[str, float],
+    sub: MetroGraph,
+    fj_tracks: set[float],
+    label_angle: float,
+) -> float:
+    """Tilted-label horizontal reach on the adjacent bubble layer.
+
+    Angled labels hang to the lower-right of each fan caller; with a branch
+    label inside the bubble the convergence diagonal must start past the tilted
+    text or it rakes the label.
+    """
+    cos_a = abs(math.cos(math.radians(label_angle)))
+    adj_layer = layer + 1 if layer in fork_layers else layer - 1
+    angled_reach = 0.0
+    for sid, lyr in layers.items():
+        if lyr == adj_layer and sid in tracks and tracks[sid] not in fj_tracks:
+            station = sub.stations.get(sid)
+            if station and station.label.strip():
+                angled_reach = max(
+                    angled_reach, label_text_width(station.label) * cos_a
+                )
+    return angled_reach
+
+
+def _layer_gap_for(
+    layer: int,
+    fork_layers: set[int],
+    join_layers: set[int],
+    out_targets: dict[str, set[str]],
+    in_sources: dict[str, set[str]],
+    layers: dict[str, int],
+    tracks: dict[str, float],
+    sub: MetroGraph,
+    full_graph: MetroGraph | None,
+    x_spacing: float,
+    base_gap: float,
+    label_angle: float,
+) -> float:
+    """Column gap reserved at one fork/join layer.
+
+    The gap must be large enough that the diagonal transition starts past the
+    (possibly tilted) fork/join label and still has room for the transition.
+    The router reserves the fork/join label half-width as straight run but
+    abandons it when the column gap can't also fit the diagonal run plus the
+    branch-side minimum straight; the ``routing_clearance`` term reserves a gap
+    sized to preserve that clearance.  A whole pitch already sits between
+    columns, so it is subtracted; the 1px cushion absorbs float rounding in the
+    router's drop test.
+    """
+    fj_label_half, fj_tracks = _fj_label_metrics(layer, layers, tracks, sub)
+    bubble_extra = _wide_fan_bubble_extra(
+        layer,
+        fork_layers,
+        join_layers,
+        out_targets,
+        in_sources,
+        layers,
+        tracks,
+        sub,
+        x_spacing,
+        fj_tracks,
+    )
+    if label_angle:
+        if _has_interior_branch(
+            layer, fork_layers, join_layers, out_targets, in_sources, layers, tracks
+        ):
+            bubble_extra = max(
+                bubble_extra,
+                _angled_interior_reach(
+                    layer, fork_layers, layers, tracks, sub, fj_tracks, label_angle
+                ),
+            )
+        else:
+            # An off-track output above the top branch forces that branch's
+            # angled label down into the bubble, where it rakes the other
+            # branch's diagonal; widen by the forced label's horizontal reach.
+            bubble_extra = max(
+                bubble_extra,
+                _forced_branch_label_reach(
+                    layer,
+                    fork_layers,
+                    join_layers,
+                    out_targets,
+                    in_sources,
+                    layers,
+                    tracks,
+                    sub,
+                    full_graph,
+                    label_angle,
+                ),
+            )
+
+    routing_clearance = fj_label_half + DIAGONAL_RUN + MIN_STRAIGHT_EDGE - x_spacing + 1.0
+    return max(base_gap, fj_label_half + bubble_extra, routing_clearance)
+
+
+def _compute_fork_join_gaps(
+    sub: MetroGraph,
+    layers: dict[str, int],
+    tracks: dict[str, float],
+    x_spacing: float,
+    full_graph: MetroGraph | None = None,
+    section_station_ids: set[str] | None = None,
+) -> dict[int, float]:
+    """Compute extra X offset per layer at fork/join points.
+
+    Adds a fractional gap after fork layers (where tracks diverge) and
+    before join layers (where tracks converge) so labels aren't obscured
+    by diagonal crossings.
+
+    When full_graph and section_station_ids are provided, fork/join
+    detection uses all edges within the section (including port-touching
+    edges). This catches divergences where a station connects to both
+    internal stations and exit ports.
+
+    In single-track sections (all stations on the same Y), port-bound
+    divergences are suppressed because there are no diagonal transitions
+    and the extra spacing is purely wasteful.
+    """
+    label_angle = (full_graph or sub).label_angle or 0.0
+    out_targets, in_sources = _fork_join_adjacency(
+        sub, full_graph, section_station_ids
+    )
+    fork_layers, join_layers = _detect_fork_join_layers(
+        out_targets, in_sources, layers, tracks
+    )
+
     if not fork_layers and not join_layers:
         return {}
 
     max_layer = max(layers.values()) if layers else 0
     base_gap = x_spacing * EXIT_GAP_MULTIPLIER
 
-    # Compute per-layer gap scaled by label width at fork/join stations.
-    # The gap must be large enough that the diagonal transition starts
-    # past the label text and still has room for the transition itself.
-    #
-    # For multi-target forks / multi-source joins, bubble station
-    # centering is skipped in routing, so the flat run at the bubble
-    # end can be very short.  When bubble stations sit on different
-    # tracks from the fork/join and have wide labels, add extra space
-    # so the flat run accommodates them.
-    layer_gap: dict[int, float] = {}
-    for layer in fork_layers | join_layers:
-        fj_label_half = 0.0
-        fj_tracks: set[float] = set()
-        for sid, lyr in layers.items():
-            if lyr == layer:
-                station = sub.stations.get(sid)
-                if station and station.label.strip():
-                    label_half = label_text_width(station.label) / 2
-                    fj_label_half = max(fj_label_half, label_half)
-                if sid in tracks:
-                    fj_tracks.add(tracks[sid])
-
-        # Check adjacent bubble layer for off-track stations with
-        # wide labels.  Only applies for wide fan-outs (3+ off-track
-        # targets/sources) where bubble station centering is skipped
-        # in routing and middle stations must have inside labels.
-        bubble_label_half = 0.0
-        is_wide_fork = False
-        is_wide_join = False
-        if layer in fork_layers:
-            for sid, tgts in out_targets.items():
-                if layers.get(sid) == layer and sid in tracks:
-                    off_track = sum(
-                        1 for t in tgts if t in tracks and tracks[t] != tracks[sid]
-                    )
-                    if off_track >= 3:
-                        is_wide_fork = True
-                        break
-        if layer in join_layers:
-            for sid, srcs in in_sources.items():
-                if layers.get(sid) == layer and sid in tracks:
-                    off_track = sum(
-                        1 for s in srcs if s in tracks and tracks[s] != tracks[sid]
-                    )
-                    if off_track >= 3:
-                        is_wide_join = True
-                        break
-        if is_wide_fork:
-            for sid, lyr in layers.items():
-                if lyr == layer + 1 and sid in tracks and tracks[sid] not in fj_tracks:
-                    station = sub.stations.get(sid)
-                    if station and station.label.strip():
-                        bubble_label_half = max(
-                            bubble_label_half, label_text_width(station.label) / 2
-                        )
-        if is_wide_join:
-            for sid, lyr in layers.items():
-                if lyr == layer - 1 and sid in tracks and tracks[sid] not in fj_tracks:
-                    station = sub.stations.get(sid)
-                    if station and station.label.strip():
-                        bubble_label_half = max(
-                            bubble_label_half, label_text_width(station.label) / 2
-                        )
-
-        # The bubble station is centered on its flat run.  The total
-        # space needed is 2 * label_half + DIAGONAL_RUN, but the gap
-        # is added on BOTH sides (after fork, before join), so each
-        # side contributes half the total requirement.
-        bubble_extra = max(
-            0.0, (bubble_label_half * 2 + DIAGONAL_RUN - x_spacing) / 1.5
+    layer_gap = {
+        layer: _layer_gap_for(
+            layer,
+            fork_layers,
+            join_layers,
+            out_targets,
+            in_sources,
+            layers,
+            tracks,
+            sub,
+            full_graph,
+            x_spacing,
+            base_gap,
+            label_angle,
         )
-
-        # Angled labels (label_angle) hang to the lower-right of each fan
-        # caller; the fan-out/fan-in diagonal must start past the tilted text
-        # or it rakes the label.  This only bites once a branch label sits
-        # *inside* the bubble, which needs three or more branches (two or more
-        # off-trunk tracks): the middle branch then has a diagonal on both
-        # sides.  A 2-branch fork places both labels outside the bubble (above
-        # the top branch, below the bottom one), so the convergence diagonal
-        # never crosses them and no extra room is needed.
-        has_interior_branch = False
-        if layer in fork_layers:
-            for fsid, ftgts in out_targets.items():
-                if layers.get(fsid) == layer and fsid in tracks:
-                    off = sum(
-                        1 for t in ftgts if t in tracks and tracks[t] != tracks[fsid]
-                    )
-                    if off >= 2:
-                        has_interior_branch = True
-                        break
-        if not has_interior_branch and layer in join_layers:
-            for jsid, jsrcs in in_sources.items():
-                if layers.get(jsid) == layer and jsid in tracks:
-                    off = sum(
-                        1 for s in jsrcs if s in tracks and tracks[s] != tracks[jsid]
-                    )
-                    if off >= 2:
-                        has_interior_branch = True
-                        break
-        if label_angle and has_interior_branch:
-            cos_a = abs(math.cos(math.radians(label_angle)))
-            adj_layer = layer + 1 if layer in fork_layers else layer - 1
-            angled_reach = 0.0
-            for sid, lyr in layers.items():
-                if lyr == adj_layer and sid in tracks and tracks[sid] not in fj_tracks:
-                    station = sub.stations.get(sid)
-                    if station and station.label.strip():
-                        angled_reach = max(
-                            angled_reach, label_text_width(station.label) * cos_a
-                        )
-            bubble_extra = max(bubble_extra, angled_reach)
-
-        # A two-branch bubble places both branch labels outside it (above the
-        # top branch, below the bottom), so the convergence/divergence diagonal
-        # clears them.  But when an off-track output hangs directly above the
-        # top (on-trunk) branch, that branch's angled label cannot flip up and
-        # is forced down into the bubble, where it rakes the other branch's
-        # diagonal.  Widen the bubble by the forced label's horizontal reach so
-        # the diagonal starts past the tilted text.
-        if label_angle and not has_interior_branch:
-            forced_reach = _forced_branch_label_reach(
-                layer,
-                fork_layers,
-                join_layers,
-                out_targets,
-                in_sources,
-                layers,
-                tracks,
-                sub,
-                full_graph,
-                label_angle,
-            )
-            bubble_extra = max(bubble_extra, forced_reach)
-
-        # The router (``_route_diagonal``) reserves the fork/join station's
-        # label half-width as straight run so the diagonal starts past the
-        # (possibly tilted) label, but it abandons that clearance when the
-        # column gap can't also fit the diagonal run plus the branch-side
-        # minimum straight.  Reserve a gap that keeps the clearance, so the
-        # fork/join label never overlaps the divergence/convergence diagonal.
-        # A whole pitch already sits between the columns, so subtract it; the
-        # 1px cushion absorbs float rounding in the router's drop test.
-        routing_clearance = (
-            fj_label_half + DIAGONAL_RUN + MIN_STRAIGHT_EDGE - x_spacing + 1.0
-        )
-        layer_gap[layer] = max(
-            base_gap, fj_label_half + bubble_extra, routing_clearance
-        )
+        for layer in fork_layers | join_layers
+    }
 
     cumulative = 0.0
     layer_extra: dict[int, float] = {}
     for layer in range(max_layer + 1):
-        # Add gap before join layers
         if layer in join_layers:
             cumulative += layer_gap.get(layer, base_gap)
         layer_extra[layer] = cumulative
-        # Add gap after fork layers
         if layer in fork_layers:
             cumulative += layer_gap.get(layer, base_gap)
 

--- a/src/nf_metro/layout/phases/row_align.py
+++ b/src/nf_metro/layout/phases/row_align.py
@@ -168,7 +168,10 @@ def _build_grid_y_map(
         slot_gap = max(1, int(math.floor(gaps[0] / effective_y_spacing)))
         if has_diamond and slot_gap < 2:
             slot_gap = 2
-        y_map = {old_y: i * slot_gap * effective_y_spacing for i, old_y in enumerate(remap_ys)}
+        y_map = {
+            old_y: i * slot_gap * effective_y_spacing
+            for i, old_y in enumerate(remap_ys)
+        }
     else:
         y_map = _assign_nonuniform_slots(
             layer_stations, multi_layer_ys, remap_ys, effective_y_spacing, has_diamond
@@ -312,7 +315,12 @@ def _align_row_y_grids(
             for sec_id in sec_ids
         }
         spacing = _row_group_grid_spacing(
-            graph, section_subgraphs, sec_ids, section_class, section_y_padding, y_spacing
+            graph,
+            section_subgraphs,
+            sec_ids,
+            section_class,
+            section_y_padding,
+            y_spacing,
         )
         if spacing is None:
             continue

--- a/src/nf_metro/layout/phases/row_align.py
+++ b/src/nf_metro/layout/phases/row_align.py
@@ -45,13 +45,17 @@ def _row_group_grid_spacing(
     graph: MetroGraph,
     section_subgraphs: dict[str, MetroGraph],
     sec_ids: list[str],
-    section_class: dict[str, tuple[dict[int, list[float]], set[float]]],
     section_y_padding: float,
     y_spacing: float,
-) -> tuple[int, float, float] | None:
-    """Shared (grid_slots, max_y_pad, effective_y_spacing) for a row group.
+) -> (
+    tuple[int, float, float, dict[str, tuple[dict[int, list[float]], set[float]]]]
+    | None
+):
+    """Shared grid params for a row group, plus its per-section Y classification.
 
-    Returns ``None`` when the group needs no shared grid (one slot or fewer).
+    Returns ``(grid_slots, max_y_pad, effective_y_spacing, section_class)``, or
+    ``None`` when the group needs no shared grid (one slot or fewer) -- bailing
+    before the per-section classification so a skipped group does no extra work.
     The pitch is inflated past ``y_spacing`` when stations at multi-station
     layers carry enough lines that their rendered bundle plus label height
     would otherwise overlap an adjacent track.  Isolated hub stations (sole
@@ -62,6 +66,11 @@ def _row_group_grid_spacing(
         grid_slots = max(grid_slots, _max_stations_per_layer(section_subgraphs[sec_id]))
     if grid_slots <= 1:
         return None
+
+    section_class = {
+        sec_id: _classify_multi_station_ys(section_subgraphs[sec_id])
+        for sec_id in sec_ids
+    }
 
     max_y_pad = 0.0
     for sec_id in sec_ids:
@@ -82,7 +91,7 @@ def _row_group_grid_spacing(
         + FONT_HEIGHT * active_font_scale()
     )
     effective_y_spacing = max(y_spacing, min_track_gap)
-    return grid_slots, max_y_pad, effective_y_spacing
+    return grid_slots, max_y_pad, effective_y_spacing, section_class
 
 
 def _assign_nonuniform_slots(
@@ -310,21 +319,12 @@ def _align_row_y_grids(
         if len(sec_ids) < 2:
             continue
 
-        section_class: dict[str, tuple[dict[int, list[float]], set[float]]] = {
-            sec_id: _classify_multi_station_ys(section_subgraphs[sec_id])
-            for sec_id in sec_ids
-        }
         spacing = _row_group_grid_spacing(
-            graph,
-            section_subgraphs,
-            sec_ids,
-            section_class,
-            section_y_padding,
-            y_spacing,
+            graph, section_subgraphs, sec_ids, section_y_padding, y_spacing
         )
         if spacing is None:
             continue
-        grid_slots, max_y_pad, effective_y_spacing = spacing
+        grid_slots, max_y_pad, effective_y_spacing, section_class = spacing
 
         grid_info[row] = {
             "section_ids": list(sec_ids),

--- a/src/nf_metro/layout/phases/row_align.py
+++ b/src/nf_metro/layout/phases/row_align.py
@@ -25,6 +25,246 @@ from nf_metro.layout.phases.single_section import _multiline_label_padding
 from nf_metro.parser.model import MetroGraph, PortSide, RowGridInfo, Section
 
 
+def _group_sections_by_row(
+    graph: MetroGraph,
+    section_subgraphs: dict[str, MetroGraph],
+    row_assign: dict[str, int],
+) -> dict[tuple[int, str], list[str]]:
+    """Group non-TB sections by their (grid row, direction)."""
+    groups: dict[tuple[int, str], list[str]] = defaultdict(list)
+    for sec_id in section_subgraphs:
+        section = graph.sections[sec_id]
+        row = row_assign.get(sec_id, -1)
+        if row < 0 or section.direction == "TB":
+            continue
+        groups[(row, section.direction)].append(sec_id)
+    return groups
+
+
+def _row_group_grid_spacing(
+    graph: MetroGraph,
+    section_subgraphs: dict[str, MetroGraph],
+    sec_ids: list[str],
+    section_class: dict[str, tuple[dict[int, list[float]], set[float]]],
+    section_y_padding: float,
+    y_spacing: float,
+) -> tuple[int, float, float] | None:
+    """Shared (grid_slots, max_y_pad, effective_y_spacing) for a row group.
+
+    Returns ``None`` when the group needs no shared grid (one slot or fewer).
+    The pitch is inflated past ``y_spacing`` when stations at multi-station
+    layers carry enough lines that their rendered bundle plus label height
+    would otherwise overlap an adjacent track.  Isolated hub stations (sole
+    layer occupant) are excluded so they don't inflate the whole row.
+    """
+    grid_slots = 0
+    for sec_id in sec_ids:
+        grid_slots = max(grid_slots, _max_stations_per_layer(section_subgraphs[sec_id]))
+    if grid_slots <= 1:
+        return None
+
+    max_y_pad = 0.0
+    for sec_id in sec_ids:
+        y_pad = section_y_padding + _multiline_label_padding(section_subgraphs[sec_id])
+        max_y_pad = max(max_y_pad, y_pad)
+
+    max_lines = 0
+    for sec_id in sec_ids:
+        sub = section_subgraphs[sec_id]
+        multi_ys = section_class[sec_id][1]
+        for st in sub.stations.values():
+            if not st.is_port and st.y in multi_ys:
+                max_lines = max(max_lines, len(graph.station_lines(st.id)))
+    min_track_gap = (
+        (max_lines - 1) * OFFSET_STEP
+        + 2 * STATION_RADIUS_APPROX
+        + LABEL_OFFSET
+        + FONT_HEIGHT * active_font_scale()
+    )
+    effective_y_spacing = max(y_spacing, min_track_gap)
+    return grid_slots, max_y_pad, effective_y_spacing
+
+
+def _assign_nonuniform_slots(
+    layer_stations: dict[int, list[float]],
+    multi_layer_ys: set[float],
+    remap_ys: list[float],
+    effective_y_spacing: float,
+    has_diamond: bool,
+) -> dict[float, float]:
+    """Map non-uniformly-spaced Y values to grid slots.
+
+    Y values that co-occur at the same layer are forced onto different slots
+    (checked against every value already in the candidate slot, so non-adjacent
+    same-layer pairs are caught).  A diamond hub keeps at least a 2-slot gap.
+    """
+    must_separate: set[tuple[float, float]] = set()
+    for ys_at_layer in layer_stations.values():
+        unique_ys = sorted(set(y for y in ys_at_layer if y in multi_layer_ys))
+        for a_idx in range(len(unique_ys)):
+            for b_idx in range(a_idx + 1, len(unique_ys)):
+                must_separate.add((unique_ys[a_idx], unique_ys[b_idx]))
+
+    y_map: dict[float, float] = {}
+    slot_for_y: dict[float, int] = {}
+    prev_slot = 0
+    for old_y in remap_ys:
+        raw_slot = int(math.floor(old_y / effective_y_spacing))
+        slot = max(raw_slot, prev_slot)
+        _changed = True
+        while _changed:
+            _changed = False
+            for other_y, other_slot in slot_for_y.items():
+                if other_slot != slot:
+                    continue
+                pair = (min(other_y, old_y), max(other_y, old_y))
+                if pair in must_separate:
+                    slot += 1
+                    _changed = True
+                    break
+        if has_diamond and prev_slot > 0 and slot - prev_slot < 2:
+            slot = prev_slot + 2
+        elif has_diamond and prev_slot == 0 and slot < 2 and old_y > 0:
+            slot = 2
+        y_map[old_y] = slot * effective_y_spacing
+        slot_for_y[old_y] = slot
+        prev_slot = slot
+    return y_map
+
+
+def _build_grid_y_map(
+    sub: MetroGraph,
+    section_class_entry: tuple[dict[int, list[float]], set[float]],
+    effective_y_spacing: float,
+) -> tuple[dict[float, float], list[float], list[float], int]:
+    """Map a section's station Ys to the shared grid.
+
+    Returns ``(y_map, remap_ys, all_ys, max_layer_size)``.  Uniform input gaps
+    map to equally-spaced slots (avoiding asymmetric compression that clashes
+    labels); otherwise per-layer separation drives the slot assignment.  A
+    diamond hub (an isolated Y between two tracks for a small fan-out) keeps a
+    2-slot gap so it has visual room.
+    """
+    layer_stations, multi_layer_ys = section_class_entry
+    if multi_layer_ys:
+        remap_ys = sorted(multi_layer_ys)
+    else:
+        remap_ys = sorted(set(s.y for s in sub.stations.values()))
+
+    max_layer_size = max((len(ys) for ys in layer_stations.values()), default=0)
+    all_ys = sorted(set(s.y for s in sub.stations.values()))
+    isolated_ys = set(all_ys) - set(remap_ys)
+    has_diamond = False
+    if max_layer_size <= 3 and len(remap_ys) >= 2 and isolated_ys:
+        for iso_y in isolated_ys:
+            if remap_ys[0] < iso_y < remap_ys[-1]:
+                has_diamond = True
+                break
+
+    gaps = [remap_ys[i + 1] - remap_ys[i] for i in range(len(remap_ys) - 1)]
+    uniform_gap = len(gaps) >= 1 and all(abs(g - gaps[0]) < 1.0 for g in gaps)
+
+    if uniform_gap and len(gaps) >= 1:
+        slot_gap = max(1, int(math.floor(gaps[0] / effective_y_spacing)))
+        if has_diamond and slot_gap < 2:
+            slot_gap = 2
+        y_map = {old_y: i * slot_gap * effective_y_spacing for i, old_y in enumerate(remap_ys)}
+    else:
+        y_map = _assign_nonuniform_slots(
+            layer_stations, multi_layer_ys, remap_ys, effective_y_spacing, has_diamond
+        )
+    return y_map, remap_ys, all_ys, max_layer_size
+
+
+def _enforce_multiline_label_gap(
+    sub: MetroGraph,
+    y_map: dict[float, float],
+    remap_ys: list[float],
+    effective_y_spacing: float,
+) -> None:
+    """Widen the slot gap to 2 for a multi-line label sandwiched both sides.
+
+    A multi-line label station hemmed in by same-layer neighbours above AND
+    below needs the gap to fit its text; one at the top or bottom of its column
+    can extend outward and is left alone.
+    """
+    layer_at_y: dict[tuple[int, float], bool] = {}
+    for st in sub.stations.values():
+        if not st.is_port:
+            layer_at_y[(st.layer, st.y)] = True
+    needs_gap_ys: set[float] = set()
+    for st in sub.stations.values():
+        if st.is_port or not st.label or "\n" not in st.label:
+            continue
+        if st.y not in y_map:
+            continue
+        has_above = any(
+            (st.layer, ry) in layer_at_y for ry in remap_ys if ry < st.y - 0.5
+        )
+        has_below = any(
+            (st.layer, ry) in layer_at_y for ry in remap_ys if ry > st.y + 0.5
+        )
+        if has_above and has_below:
+            needs_gap_ys.add(st.y)
+    if not needs_gap_ys:
+        return
+    sorted_mapped = sorted(y_map.items(), key=lambda kv: kv[1])
+    for idx in range(1, len(sorted_mapped)):
+        old_y, new_y = sorted_mapped[idx]
+        prev_y = sorted_mapped[idx - 1][1]
+        if old_y not in needs_gap_ys:
+            continue
+        gap_slots = round((new_y - prev_y) / effective_y_spacing)
+        if gap_slots < 2:
+            extra = (2 - gap_slots) * effective_y_spacing
+            for j in range(idx, len(sorted_mapped)):
+                k = sorted_mapped[j][0]
+                y_map[k] += extra
+            sorted_mapped = sorted(y_map.items(), key=lambda kv: kv[1])
+
+
+def _remap_section_to_grid(
+    graph: MetroGraph,
+    sub: MetroGraph,
+    section: Section,
+    section_class_entry: tuple[dict[int, list[float]], set[float]],
+    effective_y_spacing: float,
+    max_y_pad: float,
+    section_y_padding: float,
+) -> None:
+    """Remap one section's station Ys onto the shared row grid and resize bbox."""
+    y_map, remap_ys, all_ys, max_layer_size = _build_grid_y_map(
+        sub, section_class_entry, effective_y_spacing
+    )
+    _enforce_multiline_label_gap(sub, y_map, remap_ys, effective_y_spacing)
+
+    # Snap isolated Y values to the nearest grid slot, keeping diamond join
+    # points on-grid without collapsing them onto a track endpoint.  Skipped
+    # for large fan-outs where snapping disrupts routing geometry.
+    if max_layer_size <= 3:
+        for old_y in all_ys:
+            if old_y not in y_map:
+                slot = round(old_y / effective_y_spacing)
+                y_map[old_y] = slot * effective_y_spacing
+
+    for station in sub.stations.values():
+        if station.y in y_map:
+            station.y = y_map[station.y]
+
+    # y_pad compensation: shift so the gap from the top of the Y range to the
+    # first station equals max_y_pad, making first_station_y consistent across
+    # sections with different multiline label padding after top-alignment.
+    y_pad = section_y_padding + _multiline_label_padding(sub)
+    shift = max_y_pad - y_pad
+    if shift > 0:
+        for station in sub.stations.values():
+            station.y += shift
+
+    ys = [s.y for s in sub.stations.values()]
+    section.bbox_y = min(ys) - max_y_pad
+    section.bbox_h = (max(ys) - min(ys)) + max_y_pad * 2
+
+
 def _align_row_y_grids(
     graph: MetroGraph,
     section_subgraphs: dict[str, MetroGraph],
@@ -56,72 +296,27 @@ def _align_row_y_grids(
     """
     from nf_metro.layout.section_placement import _assign_grid_layout
 
-    # Pre-compute grid rows (not yet set on Section objects at this point)
+    # Grid rows are not yet set on Section objects at this point.
     section_edges = graph.section_dag.section_edges if graph.section_dag else set()
     _, row_assign = _assign_grid_layout(graph, section_edges)
 
-    # Group sections by (row, direction), skipping TB sections
-    groups: dict[tuple[int, str], list[str]] = defaultdict(list)
-    for sec_id in section_subgraphs:
-        section = graph.sections[sec_id]
-        row = row_assign.get(sec_id, -1)
-        if row < 0 or section.direction == "TB":
-            continue
-        groups[(row, section.direction)].append(sec_id)
+    groups = _group_sections_by_row(graph, section_subgraphs, row_assign)
 
-    # Store grid info for debug overlay
     grid_info: dict[int, RowGridInfo] = {}
-
     for (row, _direction), sec_ids in groups.items():
         if len(sec_ids) < 2:
             continue
 
-        # Grid size = max stations stacked at any single layer across
-        # all sections in the group.
-        grid_slots = 0
-        for sec_id in sec_ids:
-            sub = section_subgraphs[sec_id]
-            grid_slots = max(grid_slots, _max_stations_per_layer(sub))
-
-        if grid_slots <= 1:
-            continue
-
-        # Compute max y_pad across group for compensation
-        max_y_pad = 0.0
-        for sec_id in sec_ids:
-            sub = section_subgraphs[sec_id]
-            y_pad = section_y_padding + _multiline_label_padding(sub)
-            max_y_pad = max(max_y_pad, y_pad)
-
-        # Scale effective y_spacing when stations carry many lines.
-        # Per-line offsets spread the rendered line bundle vertically;
-        # when the spread + label height exceeds the base y_spacing,
-        # labels on adjacent tracks overlap.  We inflate the grid
-        # pitch just enough to guarantee clearance.
-        #
-        # Only count stations at multi-station layers (i.e. Y values
-        # in remap_ys).  Isolated hub stations (sole layer occupant,
-        # e.g. bench_hub with 6 lines) don't represent inter-track
-        # crowding and should not inflate spacing for the entire row.
-        #
-        max_lines = 0
         section_class: dict[str, tuple[dict[int, list[float]], set[float]]] = {
             sec_id: _classify_multi_station_ys(section_subgraphs[sec_id])
             for sec_id in sec_ids
         }
-        for sec_id in sec_ids:
-            sub = section_subgraphs[sec_id]
-            _multi_ys = section_class[sec_id][1]
-            for st in sub.stations.values():
-                if not st.is_port and st.y in _multi_ys:
-                    max_lines = max(max_lines, len(graph.station_lines(st.id)))
-        min_track_gap = (
-            (max_lines - 1) * OFFSET_STEP
-            + 2 * STATION_RADIUS_APPROX
-            + LABEL_OFFSET
-            + FONT_HEIGHT * active_font_scale()
+        spacing = _row_group_grid_spacing(
+            graph, section_subgraphs, sec_ids, section_class, section_y_padding, y_spacing
         )
-        effective_y_spacing = max(y_spacing, min_track_gap)
+        if spacing is None:
+            continue
+        grid_slots, max_y_pad, effective_y_spacing = spacing
 
         grid_info[row] = {
             "section_ids": list(sec_ids),
@@ -130,175 +325,16 @@ def _align_row_y_grids(
             "max_y_pad": max_y_pad,
         }
 
-        # Remap each section's stations to the shared grid
         for sec_id in sec_ids:
-            sub = section_subgraphs[sec_id]
-            section = graph.sections[sec_id]
-
-            layer_stations, multi_layer_ys = section_class[sec_id]
-
-            # Remap multi-station-layer Y values first.
-            if multi_layer_ys:
-                remap_ys = sorted(multi_layer_ys)
-            else:
-                remap_ys = sorted(set(s.y for s in sub.stations.values()))
-
-            # Check for diamond patterns: isolated Y values that sit
-            # between adjacent remap_ys indicate a join/fork hub.
-            # These need at least 2 grid slots between tracks so the
-            # hub has visual room.  Only for small fan-outs; large
-            # fan-outs (>3 per layer) keep their original spacing.
-            max_layer_size = max((len(ys) for ys in layer_stations.values()), default=0)
-            all_ys = sorted(set(s.y for s in sub.stations.values()))
-            isolated_ys = set(all_ys) - set(remap_ys)
-            has_diamond = False
-            if max_layer_size <= 3 and len(remap_ys) >= 2 and isolated_ys:
-                for iso_y in isolated_ys:
-                    if remap_ys[0] < iso_y < remap_ys[-1]:
-                        has_diamond = True
-                        break
-
-            # Map Y values to grid slots.
-            #
-            # Uniform spacing preservation: when all input gaps are
-            # equal (e.g. [0, 68.8, 137.6] with gap 68.8), map to
-            # equally-spaced slots so the output gaps stay uniform.
-            # This avoids asymmetric compression that causes label
-            # clashes (e.g. floor gives [0,40,120] = gaps 40,80).
-            #
-            # Diamond gap enforcement: when a fork/join hub sits
-            # between tracks, ensure at least 2-slot gap so the hub
-            # has visual room.
-            y_map: dict[float, float] = {}
-
-            # Detect uniform input spacing
-            gaps = [remap_ys[i + 1] - remap_ys[i] for i in range(len(remap_ys) - 1)]
-            uniform_gap = len(gaps) >= 1 and all(abs(g - gaps[0]) < 1.0 for g in gaps)
-
-            if uniform_gap and len(gaps) >= 1:
-                # Floor the uniform gap to a whole number of grid
-                # slots (minimum 1).  Using floor instead of round
-                # prevents inflation (e.g. a 68.8px gap with 40px
-                # spacing stays at 1 slot, not 2).
-                slot_gap = max(1, int(math.floor(gaps[0] / effective_y_spacing)))
-                if has_diamond and slot_gap < 2:
-                    slot_gap = 2
-                for i, old_y in enumerate(remap_ys):
-                    y_map[old_y] = i * slot_gap * effective_y_spacing
-            else:
-                # Build set of Y-value pairs that MUST occupy different
-                # grid slots because they co-occur at the same layer.
-                # Unlike the previous "check only previous remap_y"
-                # approach, we check against ALL values already
-                # assigned to the candidate slot, so non-adjacent
-                # pairs (e.g. sortmerna and ribodetector separated by
-                # trimgalore in remap_ys) are still caught.
-                must_separate: set[tuple[float, float]] = set()
-                for ys_at_layer in layer_stations.values():
-                    unique_ys = sorted(
-                        set(y for y in ys_at_layer if y in multi_layer_ys)
-                    )
-                    for a_idx in range(len(unique_ys)):
-                        for b_idx in range(a_idx + 1, len(unique_ys)):
-                            must_separate.add((unique_ys[a_idx], unique_ys[b_idx]))
-
-                slot_for_y: dict[float, int] = {}
-                prev_slot = 0
-                for i, old_y in enumerate(remap_ys):
-                    raw_slot = int(math.floor(old_y / effective_y_spacing))
-                    slot = max(raw_slot, prev_slot)
-                    # Check if this Y must be separated from any value
-                    # already assigned to the same slot.  Re-check after
-                    # each bump in case the new slot also conflicts.
-                    _changed = True
-                    while _changed:
-                        _changed = False
-                        for other_y, other_slot in slot_for_y.items():
-                            if other_slot != slot:
-                                continue
-                            pair = (min(other_y, old_y), max(other_y, old_y))
-                            if pair in must_separate:
-                                slot += 1
-                                _changed = True
-                                break
-                    # Diamond: ensure at least 2-slot gap from previous
-                    if has_diamond and prev_slot > 0 and slot - prev_slot < 2:
-                        slot = prev_slot + 2
-                    elif has_diamond and prev_slot == 0 and slot < 2 and old_y > 0:
-                        slot = 2
-                    y_map[old_y] = slot * effective_y_spacing
-                    slot_for_y[old_y] = slot
-                    prev_slot = slot
-
-            # Multi-line label clearance: when a multi-line label station
-            # is sandwiched between same-layer neighbors above AND below,
-            # the label must fit within the gap.  Enforce a 2-slot gap
-            # from the preceding Y so the label text doesn't overlap.
-            # Stations at the top or bottom of their column can extend
-            # outward and don't need the extra gap.
-            layer_at_y: dict[tuple[int, float], bool] = {}
-            for st in sub.stations.values():
-                if not st.is_port:
-                    layer_at_y[(st.layer, st.y)] = True
-            _needs_gap_ys: set[float] = set()
-            for st in sub.stations.values():
-                if st.is_port or not st.label or "\n" not in st.label:
-                    continue
-                if st.y not in y_map:
-                    continue
-                has_above = any(
-                    (st.layer, ry) in layer_at_y for ry in remap_ys if ry < st.y - 0.5
-                )
-                has_below = any(
-                    (st.layer, ry) in layer_at_y for ry in remap_ys if ry > st.y + 0.5
-                )
-                if has_above and has_below:
-                    _needs_gap_ys.add(st.y)
-            if _needs_gap_ys:
-                sorted_mapped = sorted(y_map.items(), key=lambda kv: kv[1])
-                for idx in range(1, len(sorted_mapped)):
-                    old_y, new_y = sorted_mapped[idx]
-                    prev_y = sorted_mapped[idx - 1][1]
-                    if old_y not in _needs_gap_ys:
-                        continue
-                    gap_slots = round((new_y - prev_y) / effective_y_spacing)
-                    if gap_slots < 2:
-                        extra = (2 - gap_slots) * effective_y_spacing
-                        for j in range(idx, len(sorted_mapped)):
-                            k = sorted_mapped[j][0]
-                            y_map[k] += extra
-                        sorted_mapped = sorted(y_map.items(), key=lambda kv: kv[1])
-
-            # Snap isolated Y values to the nearest grid slot (any
-            # multiple of effective_y_spacing, not just mapped slots).
-            # This keeps diamond join points between tracks on-grid
-            # without collapsing them onto a track endpoint.  Skip for
-            # large fan-outs where snapping disrupts routing geometry.
-            if max_layer_size <= 3:
-                for old_y in all_ys:
-                    if old_y not in y_map:
-                        slot = round(old_y / effective_y_spacing)
-                        y_map[old_y] = slot * effective_y_spacing
-
-            for station in sub.stations.values():
-                if station.y in y_map:
-                    station.y = y_map[station.y]
-
-            # y_pad compensation: shift all stations so that the
-            # distance from the top of the Y range to the first
-            # station equals max_y_pad.  After Stage 3.5 top-aligns
-            # bbox_y, this makes first_station_y consistent across
-            # sections with different multiline label padding.
-            y_pad = section_y_padding + _multiline_label_padding(sub)
-            shift = max_y_pad - y_pad
-            if shift > 0:
-                for station in sub.stations.values():
-                    station.y += shift
-
-            # Recompute bbox to match remapped + shifted positions.
-            ys = [s.y for s in sub.stations.values()]
-            section.bbox_y = min(ys) - max_y_pad
-            section.bbox_h = (max(ys) - min(ys)) + max_y_pad * 2
+            _remap_section_to_grid(
+                graph,
+                section_subgraphs[sec_id],
+                graph.sections[sec_id],
+                section_class[sec_id],
+                effective_y_spacing,
+                max_y_pad,
+                section_y_padding,
+            )
 
     graph._row_y_grid_info = grid_info
 


### PR DESCRIPTION
## Summary

Breaks the four most tangled layout functions flagged in #454 into smaller, focused helpers, so each one is easier to read, test, and change safely. These were the functions with the most branching and nesting in the layout engine (the kind that are hard to follow and risky to edit). Behaviour is unchanged. Adds a lint guard so they can't quietly grow back to that state.

"Branch count" below is ruff's McCabe score (`C901`) — roughly, how many independent paths run through a function. Lower is easier to follow.

| Function | Module | Branch count before → after |
|---|---|---|
| `_compute_fork_join_gaps` | `phases/off_track.py` | 60 → <30 |
| `place_labels` | `labels.py` | 49 → <30 |
| `_recenter_loop_side_stations` | `phases/balancing.py` | 49 → <30 |
| `_align_row_y_grids` | `phases/row_align.py` | 47 → <30 |

(`convert_nextflow_dag`, listed in the issue at 49, was already brought down by the #560 split.)

Key changes:
- **off_track.py**: extract `_fork_join_adjacency`, `_detect_fork_join_layers`, `_fj_label_metrics`, `_wide_fan_bubble_extra`, `_has_interior_branch`, `_angled_interior_reach`, `_layer_gap_for`.
- **labels.py**: introduce a `_LabelCtx` dataclass for the precomputed placement state, and split the per-station body into `_place_station_label` dispatch plus `_place_tb_label`, `_place_angled_label`, `_initial_label_side`, `_place_alternating_candidate`, `_clear_obstacle_overlap`, `_clamp_label_to_section`.
- **balancing.py**: split the two passes into `_recenter_section_loop_sides` (with `_loop_side_endpoints`, `_has_off_trunk_sibling`) and `_snap_loop_column_mates` (with `_loop_column_key`, `_build_loop_columns`, `_snap_column_to_anchors`); the section-trunk lookup reuses the existing `_section_lr_port_anchor_y`.
- **row_align.py**: extract `_group_sections_by_row`, `_row_group_grid_spacing`, `_assign_nonuniform_slots`, `_build_grid_y_map`, `_enforce_multiline_label_gap`, `_remap_section_to_grid`.
- **pyproject.toml**: turn on ruff's `C901` check repo-wide with a ceiling of 43 (the most-branching function that remains, down from 60), so any future function that gets more tangled than that fails CI. The remaining offenders (branch count 31–43) and the plan to ratchet the ceiling down to 30 are tracked in #644.

No behavioural change: all gallery renders are byte-identical and the full suite passes.

Fixes #454

## Test plan
- [x] `pytest` passes (7098 passed, 5 pre-existing xfails)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] `mypy` clean
- [x] Gallery renders byte-identical to base (md5 of all 83 SVGs unchanged)
- [x] No function in the repo exceeds the new ceiling of 43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
