### PR TITLE
fix(layout): fail fast on cyclic / self-loop graphs with a node-naming error

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -13,7 +13,12 @@ from nf_metro import __version__
 from nf_metro.introspect import build_info, format_info_json, format_info_text
 from nf_metro.layout import PhaseInvariantError, compute_layout
 from nf_metro.options import LAYOUT_OPTIONS, LayoutOption
-from nf_metro.parser import ERROR, parse_metro_mermaid, validate_graph
+from nf_metro.parser import (
+    ERROR,
+    CyclicGraphError,
+    parse_metro_mermaid,
+    validate_graph,
+)
 from nf_metro.parser.directives import apply_legend_directive
 from nf_metro.parser.model import LineSpread, MetroGraph
 from nf_metro.render import render_svg
@@ -205,7 +210,7 @@ def render(
 
     try:
         compute_layout(graph)
-    except (ValueError, PhaseInvariantError) as e:
+    except (CyclicGraphError, PhaseInvariantError) as e:
         raise click.ClickException(str(e))
 
     theme_obj = _resolve_theme(theme, graph)

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -205,7 +205,7 @@ def render(
 
     try:
         compute_layout(graph)
-    except PhaseInvariantError as e:
+    except (ValueError, PhaseInvariantError) as e:
         raise click.ClickException(str(e))
 
     theme_obj = _resolve_theme(theme, graph)

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -252,6 +252,11 @@ from nf_metro.layout.phases.spacing import (  # noqa: F401
     _struck_stations_and_collinear,
 )
 from nf_metro.parser.model import LineSpread, MetroGraph, Section
+from nf_metro.parser.validate import (
+    CyclicGraphError,
+    find_cycle,
+    format_cycle_error,
+)
 
 # ---------------------------------------------------------------------------
 # Stage-boundary guards
@@ -376,6 +381,10 @@ def compute_layout(
     key phases.  Violations raise ``PhaseInvariantError`` instead of
     silently producing broken layouts.
     """
+    witness = find_cycle(graph)
+    if witness is not None:
+        raise CyclicGraphError(format_cycle_error(witness))
+
     if x_spacing is None:
         x_spacing = graph.x_spacing
     if y_spacing is None:

--- a/src/nf_metro/layout/layers.py
+++ b/src/nf_metro/layout/layers.py
@@ -11,6 +11,7 @@ __all__ = ["assign_layers", "build_station_digraph"]
 import networkx as nx
 
 from nf_metro.parser.model import MetroGraph
+from nf_metro.parser.validate import find_cycle, format_cycle_error
 
 
 def build_station_digraph(graph: MetroGraph) -> nx.DiGraph[str]:
@@ -39,7 +40,9 @@ def assign_layers(graph: MetroGraph) -> dict[str, int]:
     """
     G = build_station_digraph(graph)
 
-    # Topological sort (will raise if cycles exist)
+    witness = find_cycle(graph)
+    if witness is not None:
+        raise ValueError(format_cycle_error(witness))
     topo_order = list(nx.topological_sort(G))
 
     layers: dict[str, int] = {}

--- a/src/nf_metro/layout/layers.py
+++ b/src/nf_metro/layout/layers.py
@@ -11,7 +11,6 @@ __all__ = ["assign_layers", "build_station_digraph"]
 import networkx as nx
 
 from nf_metro.parser.model import MetroGraph
-from nf_metro.parser.validate import find_cycle, format_cycle_error
 
 
 def build_station_digraph(graph: MetroGraph) -> nx.DiGraph[str]:
@@ -40,9 +39,7 @@ def assign_layers(graph: MetroGraph) -> dict[str, int]:
     """
     G = build_station_digraph(graph)
 
-    witness = find_cycle(graph)
-    if witness is not None:
-        raise ValueError(format_cycle_error(witness))
+    # Topological sort (will raise if cycles exist)
     topo_order = list(nx.topological_sort(G))
 
     layers: dict[str, int] = {}

--- a/src/nf_metro/parser/__init__.py
+++ b/src/nf_metro/parser/__init__.py
@@ -4,6 +4,7 @@ from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.validate import (
     ERROR,
     WARNING,
+    CyclicGraphError,
     ValidationIssue,
     validate_graph,
 )
@@ -11,6 +12,7 @@ from nf_metro.parser.validate import (
 __all__ = [
     "ERROR",
     "WARNING",
+    "CyclicGraphError",
     "ValidationIssue",
     "parse_metro_mermaid",
     "validate_graph",

--- a/src/nf_metro/parser/validate.py
+++ b/src/nf_metro/parser/validate.py
@@ -10,10 +10,37 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import networkx as nx
+
 from nf_metro.parser.model import MetroGraph
 
 ERROR = "error"
 WARNING = "warning"
+
+
+def find_cycle(graph: MetroGraph) -> list[str] | None:
+    """Return a node sequence witnessing a cycle, or ``None`` if acyclic.
+
+    The returned path closes back on its first node (``["a", "b", "a"]`` for a
+    two-node cycle, ``["a", "a"]`` for a self-loop) so it reads directly as
+    ``a -> b -> a`` when joined. The layout engine requires a DAG, so a cycle
+    here is a fatal input error rather than a warning.
+    """
+    g: nx.DiGraph[str] = nx.DiGraph()
+    for edge in graph.edges:
+        g.add_edge(edge.source, edge.target)
+    try:
+        cycle_edges = nx.find_cycle(g)
+    except nx.NetworkXNoCycle:
+        return None
+    nodes = [source for source, _ in cycle_edges]
+    nodes.append(cycle_edges[0][0])
+    return nodes
+
+
+def format_cycle_error(witness: list[str]) -> str:
+    """Render a cycle witness path as a fatal error message."""
+    return f"Graph contains a cycle: {' -> '.join(witness)}"
 
 
 @dataclass(frozen=True)
@@ -30,6 +57,10 @@ class ValidationIssue:
 def validate_graph(graph: MetroGraph) -> list[ValidationIssue]:
     """Return graph-semantic findings for ``graph`` as structured data."""
     issues: list[ValidationIssue] = []
+
+    witness = find_cycle(graph)
+    if witness is not None:
+        issues.append(ValidationIssue(ERROR, format_cycle_error(witness)))
 
     for edge in graph.edges:
         if edge.line_id != "default" and edge.line_id not in graph.lines:

--- a/src/nf_metro/parser/validate.py
+++ b/src/nf_metro/parser/validate.py
@@ -18,21 +18,23 @@ ERROR = "error"
 WARNING = "warning"
 
 
+class CyclicGraphError(ValueError):
+    """Raised when a graph the layout engine requires to be a DAG has a cycle."""
+
+
 def find_cycle(graph: MetroGraph) -> list[str] | None:
     """Return a node sequence witnessing a cycle, or ``None`` if acyclic.
 
     The returned path closes back on its first node (``["a", "b", "a"]`` for a
     two-node cycle, ``["a", "a"]`` for a self-loop) so it reads directly as
-    ``a -> b -> a`` when joined. The layout engine requires a DAG, so a cycle
-    here is a fatal input error rather than a warning.
+    ``a -> b -> a`` when joined.
     """
     g: nx.DiGraph[str] = nx.DiGraph()
     for edge in graph.edges:
         g.add_edge(edge.source, edge.target)
-    try:
-        cycle_edges = nx.find_cycle(g)
-    except nx.NetworkXNoCycle:
+    if nx.is_directed_acyclic_graph(g):
         return None
+    cycle_edges = nx.find_cycle(g)
     nodes = [source for source, _ in cycle_edges]
     nodes.append(cycle_edges[0][0])
     return nodes

--- a/tests/test_cyclic_graph.py
+++ b/tests/test_cyclic_graph.py
@@ -1,4 +1,4 @@
-"""Cyclic / self-loop graphs must fail fast with a node-naming error (#645).
+"""Cyclic / self-loop graphs must fail fast with a node-naming error.
 
 The layout engine assumes a DAG (``assign_layers`` runs a topological sort).
 A cycle or self-loop in the parsed graph must be rejected on both the
@@ -12,7 +12,12 @@ from click.testing import CliRunner
 
 from nf_metro.cli import cli
 from nf_metro.layout import compute_layout
-from nf_metro.parser import ERROR, parse_metro_mermaid, validate_graph
+from nf_metro.parser import (
+    ERROR,
+    CyclicGraphError,
+    parse_metro_mermaid,
+    validate_graph,
+)
 
 _TWO_NODE_CYCLE = """\
 %%metro line: l1 | Line 1 | #ff0000 | solid
@@ -51,7 +56,7 @@ def test_validate_graph_flags_cycle(mmd: str):
 def test_compute_layout_rejects_cycle(mmd: str):
     graph = parse_metro_mermaid(mmd)
 
-    with pytest.raises(ValueError, match="cycle") as excinfo:
+    with pytest.raises(CyclicGraphError, match="cycle") as excinfo:
         compute_layout(graph)
 
     assert "a" in str(excinfo.value)

--- a/tests/test_cyclic_graph.py
+++ b/tests/test_cyclic_graph.py
@@ -1,0 +1,73 @@
+"""Cyclic / self-loop graphs must fail fast with a node-naming error (#645).
+
+The layout engine assumes a DAG (``assign_layers`` runs a topological sort).
+A cycle or self-loop in the parsed graph must be rejected on both the
+``validate`` plane (a structured :class:`ValidationIssue`) and the ``render``
+plane (a ``ValueError`` out of ``compute_layout``), naming at least one node
+so an author can locate the offending edge.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from nf_metro.cli import cli
+from nf_metro.layout import compute_layout
+from nf_metro.parser import ERROR, parse_metro_mermaid, validate_graph
+
+_TWO_NODE_CYCLE = """\
+%%metro line: l1 | Line 1 | #ff0000 | solid
+graph LR
+    a[A] -->|l1| b[B]
+    b -->|l1| a
+"""
+
+_SELF_LOOP = """\
+%%metro line: l1 | Line 1 | #ff0000 | solid
+graph LR
+    a[A] -->|l1| a
+"""
+
+_CYCLIC = [
+    pytest.param(_TWO_NODE_CYCLE, id="two-node-cycle"),
+    pytest.param(_SELF_LOOP, id="self-loop"),
+]
+
+
+@pytest.mark.parametrize("mmd", _CYCLIC)
+def test_validate_graph_flags_cycle(mmd: str):
+    graph = parse_metro_mermaid(mmd)
+
+    cycle_errors = [
+        issue
+        for issue in validate_graph(graph)
+        if issue.severity == ERROR and "cycle" in issue.message.lower()
+    ]
+
+    assert len(cycle_errors) == 1
+    assert "a" in cycle_errors[0].message
+
+
+@pytest.mark.parametrize("mmd", _CYCLIC)
+def test_compute_layout_rejects_cycle(mmd: str):
+    graph = parse_metro_mermaid(mmd)
+
+    with pytest.raises(ValueError, match="cycle") as excinfo:
+        compute_layout(graph)
+
+    assert "a" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("mmd", _CYCLIC)
+@pytest.mark.parametrize("command", ["render", "validate"])
+def test_cli_rejects_cycle(mmd: str, command: str, tmp_path):
+    src = tmp_path / "cyclic.mmd"
+    src.write_text(mmd)
+    args = [command, str(src)]
+    if command == "render":
+        args += ["-o", str(tmp_path / "out.svg")]
+
+    result = CliRunner().invoke(cli, args)
+
+    assert result.exit_code != 0
+    assert "cycle" in result.output.lower()
+    assert "a" in result.output


### PR DESCRIPTION
## Summary

- A cyclic or self-loop Mermaid graph previously crashed `render` with a raw `networkx.NetworkXUnfeasible` traceback out of `assign_layers`, and `validate` reported it as `Valid` and exited 0, because nothing on the parse/layout path checked acyclicity.
- Adds a `find_cycle` witness helper and a `format_cycle_error` formatter to the graph-semantic validator, shared by both planes so the message is identical: `Graph contains a cycle: a -> b -> a` (`a -> a` for a self-loop).
- `validate_graph` now emits an `ERROR` naming the cycle, so `validate` exits non-zero with an actionable message.
- `compute_layout` rejects a cyclic graph up front with a dedicated `CyclicGraphError(ValueError)`; the `render` CLI catches that specific type and surfaces a clean `ClickException` (exit 1) instead of a traceback. The check runs once per render and gates on `is_directed_acyclic_graph`, so acyclic renders pay no extra exception.
- New parametrised regression tests (2-node cycle + self-loop) covering `validate_graph`, `compute_layout`, and the `render`/`validate` CLI surfaces.

Existing acyclic fixtures are unaffected; rendered gallery output is unchanged.

Fixes #645

## Test plan
- [x] pytest passes (7106 passed; new `tests/test_cyclic_graph.py` included)
- [x] ruff check + ruff format clean on whole repo; `mypy` clean (74 files)
- [x] Acyclicity check wired into `compute_layout` (fails loudly with a node-naming error)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/647/)
- [ ] Render-preview verdict: expected "No visual changes detected"

Generated with Claude Code
