### PR TITLE
refactor: lower C901 ceiling to 30 by decomposing the remaining 15 offenders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,9 @@ target-version = "py310"
 select = ["E", "F", "I", "W", "ANN", "C901"]
 
 [tool.ruff.lint.mccabe]
-# Ratchet against cyclomatic-complexity regressions; lower as functions
-# are decomposed.
-max-complexity = 43
+# Keep function branch complexity readable; functions above this are
+# decomposed into named helpers rather than allowed to grow.
+max-complexity = 30
 
 [tool.ruff.lint.per-file-ignores]
 # Type-annotation rules are enforced on the library only; tests favour

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -273,27 +273,10 @@ def _place_with_tall_anchor(
     return set(), set(), set()
 
 
-def _assign_grid_positions(
-    graph: MetroGraph,
-    successors: dict[str, set[str]],
-    predecessors: dict[str, set[str]],
-    max_station_columns: int,
-) -> tuple[set[str], set[str], set[str]]:
-    """Assign grid (col, row) positions to sections without explicit grid overrides.
-
-    When cumulative station columns in a row exceed the threshold, the
-    overflowing topo column becomes a "fold section" - it stays at the
-    right edge of the current row as a TB bridge. Subsequent topo columns
-    go into a new row below.
-
-    Returns (fold_sections, below_fold_sections). below_fold_sections are
-    sections placed directly below a fold instead of on the return row,
-    used when the fold has a single successor and the band has stacked
-    sections (making a return row visually awkward).
-    """
-    section_ids = list(graph.sections.keys())
-
-    # BFS topological sort for column assignment
+def _bfs_section_columns(
+    section_ids: list[str], successors: dict[str, set[str]]
+) -> dict[str, int]:
+    """Longest-path topo column per section (disconnected sections get 0)."""
     all_sections = set(section_ids)
     in_degree: dict[str, int] = {sid: 0 for sid in section_ids}
     adj: dict[str, list[str]] = {sid: [] for sid in section_ids}
@@ -321,10 +304,157 @@ def _assign_grid_positions(
             if in_degree[tgt] == 0:
                 queue.append(tgt)
 
-    # Handle disconnected sections
     for sid in section_ids:
         if sid not in col_assign:
             col_assign[sid] = 0
+    return col_assign
+
+
+def _pack_topo_columns(
+    col_groups: dict[int, list[str]],
+    topo_col_width: dict[int, int],
+    successors: dict[str, set[str]],
+    max_station_columns: int,
+) -> tuple[dict[str, tuple[int, int]], set[str], set[str]]:
+    """Greedily pack topo columns into serpentine row bands.
+
+    When a column would overflow the current row it becomes a fold section
+    (TB bridge) at the right edge, and subsequent columns start a new row band
+    below flowing in the opposite direction.  Returns ``(folded, fold_sections,
+    below_fold_sections)``.
+    """
+    sorted_cols = sorted(col_groups.keys())
+    fold_sections: set[str] = set()
+    below_fold_sections: set[str] = set()
+    folded: dict[str, tuple[int, int]] = {}
+    skip_topo_cols: set[int] = set()
+
+    current_grid_col = 0
+    col_step = 1  # +1 in first row (LR), -1 after a fold (RL)
+    band_start_row = 0
+    max_stack_in_band = 0  # tallest topo column (stacking) in this band
+    cumulative_width = 0
+
+    for topo_idx, topo_col in enumerate(sorted_cols):
+        if topo_col in skip_topo_cols:
+            continue
+
+        sids = col_groups[topo_col]
+        w = topo_col_width[topo_col]
+        stack_size = len(sids)
+        is_last_col = topo_idx == len(sorted_cols) - 1
+        # Don't fold the final topo column: there are no further columns to
+        # wrap into the next row, so a fold here only creates a spurious TB
+        # bridge (and a negative grid column) instead of bending the chain.
+        need_fold = (
+            not is_last_col
+            and cumulative_width > 0
+            and cumulative_width + w > max_station_columns
+        )
+
+        if need_fold:
+            fold_col = current_grid_col
+            # This column is the fold point: place at right edge as TB bridge
+            for i, sid in enumerate(sids):
+                folded[sid] = (fold_col, band_start_row + i)
+                fold_sections.add(sid)
+            band_height = max(max_stack_in_band, stack_size)
+            # Start new row band below all stacked rows in the current band
+            band_start_row += max(band_height, 1)
+            # Post-fold sections flow in the opposite direction, starting
+            # one column past the fold (i.e. to its left on a return row).
+            # Toggle: +1 -> -1 -> +1 (serpentine/zigzag layout).
+            col_step = -col_step
+            current_grid_col = fold_col + col_step
+            cumulative_width = 0
+            max_stack_in_band = 0
+
+            _maybe_place_below_fold(
+                col_groups,
+                successors,
+                sorted_cols,
+                topo_idx,
+                sids,
+                fold_col,
+                band_start_row,
+                band_height,
+                folded,
+                below_fold_sections,
+                skip_topo_cols,
+            )
+        else:
+            # Normal placement in current band
+            for i, sid in enumerate(sids):
+                folded[sid] = (current_grid_col, band_start_row + i)
+            max_stack_in_band = max(max_stack_in_band, stack_size)
+            current_grid_col += col_step
+            cumulative_width += w
+
+    return folded, fold_sections, below_fold_sections
+
+
+def _maybe_place_below_fold(
+    col_groups: dict[int, list[str]],
+    successors: dict[str, set[str]],
+    sorted_cols: list[int],
+    topo_idx: int,
+    sids: list[str],
+    fold_col: int,
+    band_start_row: int,
+    band_height: int,
+    folded: dict[str, tuple[int, int]],
+    below_fold_sections: set[str],
+    skip_topo_cols: set[int],
+) -> None:
+    """Place a fold's single successors directly below it instead of on a return row.
+
+    When the band has stacked sections (``band_height > 1``) a return row would
+    route backward over that content.  If every fold section has exactly one
+    successor and those successors are the only sections in the next topo
+    column, seat them in the fold column below the bridge.
+    """
+    if band_height <= 1 or topo_idx + 1 >= len(sorted_cols):
+        return
+    next_topo = sorted_cols[topo_idx + 1]
+    next_sids = col_groups[next_topo]
+    fold_succs: set[str] = set()
+    all_single = True
+    for fs in sids:
+        fs_succs = successors.get(fs, set())
+        if len(fs_succs) != 1:
+            all_single = False
+            break
+        fold_succs.update(fs_succs)
+    if all_single and fold_succs == set(next_sids):
+        for j, ns in enumerate(next_sids):
+            folded[ns] = (fold_col, band_start_row + j)
+            below_fold_sections.add(ns)
+        skip_topo_cols.add(next_topo)
+        # Don't increment band_start_row: below-fold sections are in the fold
+        # column, so return-row sections (in adjacent columns) share the rows.
+
+
+def _assign_grid_positions(
+    graph: MetroGraph,
+    successors: dict[str, set[str]],
+    predecessors: dict[str, set[str]],
+    max_station_columns: int,
+) -> tuple[set[str], set[str], set[str]]:
+    """Assign grid (col, row) positions to sections without explicit grid overrides.
+
+    When cumulative station columns in a row exceed the threshold, the
+    overflowing topo column becomes a "fold section" - it stays at the
+    right edge of the current row as a TB bridge. Subsequent topo columns
+    go into a new row below.
+
+    Returns (fold_sections, below_fold_sections). below_fold_sections are
+    sections placed directly below a fold instead of on the return row,
+    used when the fold has a single successor and the band has stacked
+    sections (making a return row visually awkward).
+    """
+    section_ids = list(graph.sections.keys())
+
+    col_assign = _bfs_section_columns(section_ids, successors)
 
     # Skip sections already in grid_overrides
     auto_sections = {sid for sid in section_ids if sid not in graph.grid_overrides}
@@ -384,87 +514,9 @@ def _assign_grid_positions(
                 convergence_result,
             )
 
-    # Greedily pack topo columns into row bands.
-    # When overflow is detected, the overflowing column becomes the fold
-    # section (TB bridge) at the right edge of the current row. Subsequent
-    # columns start a new row band below.
-    sorted_cols = sorted(col_groups.keys())
-    fold_sections: set[str] = set()
-    below_fold_sections: set[str] = set()
-    folded: dict[str, tuple[int, int]] = {}
-    skip_topo_cols: set[int] = set()
-
-    current_grid_col = 0
-    col_step = 1  # +1 in first row (LR), -1 after a fold (RL)
-    band_start_row = 0
-    max_stack_in_band = 0  # tallest topo column (stacking) in this band
-    cumulative_width = 0
-
-    for topo_idx, topo_col in enumerate(sorted_cols):
-        if topo_col in skip_topo_cols:
-            continue
-
-        sids = col_groups[topo_col]
-        w = topo_col_width[topo_col]
-        stack_size = len(sids)
-        is_last_col = topo_idx == len(sorted_cols) - 1
-        # Don't fold the final topo column: there are no further columns to
-        # wrap into the next row, so a fold here only creates a spurious TB
-        # bridge (and a negative grid column) instead of bending the chain.
-        need_fold = (
-            not is_last_col
-            and cumulative_width > 0
-            and cumulative_width + w > max_station_columns
-        )
-
-        if need_fold:
-            fold_col = current_grid_col
-            # This column is the fold point: place at right edge as TB bridge
-            for i, sid in enumerate(sids):
-                folded[sid] = (fold_col, band_start_row + i)
-                fold_sections.add(sid)
-            band_height = max(max_stack_in_band, stack_size)
-            # Start new row band below all stacked rows in the current band
-            band_start_row += max(band_height, 1)
-            # Post-fold sections flow in the opposite direction, starting
-            # one column past the fold (i.e. to its left on a return row).
-            # Toggle: +1 -> -1 -> +1 (serpentine/zigzag layout).
-            col_step = -col_step
-            current_grid_col = fold_col + col_step
-            cumulative_width = 0
-            max_stack_in_band = 0
-
-            # Below-fold placement: when the band has stacked sections
-            # (band_height > 1), a return row would route backward over
-            # that content. If every fold section has exactly one successor
-            # and those successors are the only sections in the next topo
-            # column, place them directly below the fold instead.
-            if band_height > 1 and topo_idx + 1 < len(sorted_cols):
-                next_topo = sorted_cols[topo_idx + 1]
-                next_sids = col_groups[next_topo]
-                fold_succs: set[str] = set()
-                all_single = True
-                for fs in sids:
-                    fs_succs = successors.get(fs, set())
-                    if len(fs_succs) != 1:
-                        all_single = False
-                        break
-                    fold_succs.update(fs_succs)
-                if all_single and fold_succs == set(next_sids):
-                    for j, ns in enumerate(next_sids):
-                        folded[ns] = (fold_col, band_start_row + j)
-                        below_fold_sections.add(ns)
-                    skip_topo_cols.add(next_topo)
-                    # Don't increment band_start_row: below-fold sections
-                    # are in the fold column, so return-row sections (in
-                    # adjacent columns) can share the same rows.
-        else:
-            # Normal placement in current band
-            for i, sid in enumerate(sids):
-                folded[sid] = (current_grid_col, band_start_row + i)
-            max_stack_in_band = max(max_stack_in_band, stack_size)
-            current_grid_col += col_step
-            cumulative_width += w
+    folded, fold_sections, below_fold_sections = _pack_topo_columns(
+        col_groups, topo_col_width, successors, max_station_columns
+    )
 
     # Boustrophedon normalization: a return row built by stepping left from
     # the fold bridge can run off the left edge into negative columns. Shift

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -539,24 +539,109 @@ def _compute_layout_scaled(
             break  # can't widen the binding axis (e.g. pinned) -- give up
         x_spacing, y_spacing = new_x, new_y
 
-    # Strike-clearance: a fan-in/fan-out, convergence, or descent diagonal that
-    # rakes a station's name label is cleared by lengthening the flat run at that
-    # station by whole grid columns (the pitch stays fixed), seating the
-    # transition outside the label.  Three grid-quantized levers, each a
-    # ``(kind, section, layer)`` triple: the section's entry-side runway, its
-    # exit-side runway, and a per-column gap before the struck station's layer.
-    # Need-driven: only stations the renderer would draw a strike through grow,
-    # so a clean layout -- every gallery render at its default pitch -- is left
-    # untouched.  Independent of pinned vs auto pitch: the room is local, not the
-    # global pitch, so it applies even when the caller fixed x_spacing.
-    #
-    # A grow step bumps every lever at each struck station -- which one relocates
-    # a given strike is hard to know in advance -- then a minimization pass
-    # strips each lever that turns out not to be load-bearing, so the settled
-    # layout carries the least extra width that keeps the labels clear (a strike
-    # cleared by one side does not leave the other's room behind).  A step a
-    # collinear check rejects, or that fails to reduce the struck count, is
-    # rolled back, so the loop never ships a layout worse than it found.
+    _apply_label_strike_clearance(
+        graph,
+        x_spacing=x_spacing,
+        y_spacing=y_spacing,
+        x_offset=x_offset,
+        y_offset=y_offset,
+        section_x_padding=section_x_padding,
+        section_y_padding=section_y_padding,
+        section_x_gap=section_x_gap,
+        section_y_gap=section_y_gap,
+        validate=validate,
+    )
+
+    # Assure file-icon leaf sinks off the trunk by construction: a leaf icon
+    # the laid-out routes rake a line across is taken off-track and the layout
+    # re-run once, so the off-track machinery lifts it clear of the passing
+    # line.  Keyed on an observed crossing (not on icon presence), so an
+    # end-of-chain terminus that already sits clear is never disturbed.
+    crossed_sinks = _line_crossed_file_icon_sinks(graph)
+    if crossed_sinks:
+        for sid in crossed_sinks:
+            graph.stations[sid].off_track = True
+        _layout_once(
+            graph,
+            x_spacing=x_spacing,
+            y_spacing=y_spacing,
+            x_offset=x_offset,
+            y_offset=y_offset,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+            section_x_gap=section_x_gap,
+            section_y_gap=section_y_gap,
+            validate=validate,
+        )
+
+    _retrofit_section_rails_phase(
+        graph,
+        x_spacing=x_spacing,
+        y_spacing=y_spacing,
+        section_x_padding=section_x_padding,
+        section_y_padding=section_y_padding,
+    )
+
+    # Record the bypassed-station label box behind each bypass V so the router
+    # can seat the V's flat-run corners clear of the label.  Read on the render
+    # path, so it is populated independent of ``validate``; computed once the
+    # layout has fully settled so the box matches what the renderer draws.
+    graph.bypass_label_obstacles = _bypass_label_obstacles(graph)
+
+    # Always-on backstop (independent of ``validate``): the settled layout
+    # must never leave a station outside its own section bbox.  Runs on the
+    # render path so an unsupported directive combination fails loudly
+    # instead of shipping a silently-broken diagram (issue #424).
+    _guard_stations_within_bbox(graph, "final")
+    _snap(graph, "final")
+
+    if validate:
+        _guard_no_label_overlap(graph, "final")
+        _guard_no_diagonal_strikes_horizontal_label(graph, "final")
+        _guard_no_line_strikes_label(graph, "final")
+        _guard_no_wrapped_label_trunk_strike(graph, "final")
+        _guard_file_icon_no_name_label(graph, "final")
+        _guard_no_line_crosses_file_icon(graph, "final")
+        _guard_centered_line_spread_balanced(graph, "final")
+        _guard_rail_above_label_band(graph, "final")
+        _guard_rail_stations_seat_on_rails(graph, "final")
+        _guard_rail_one_station_per_column(graph, "final")
+        _guard_single_trunk_off_track_step(graph, "final")
+
+
+def _apply_label_strike_clearance(
+    graph: MetroGraph,
+    *,
+    x_spacing: float,
+    y_spacing: float,
+    x_offset: float,
+    y_offset: float,
+    section_x_padding: float,
+    section_y_padding: float,
+    section_x_gap: float,
+    section_y_gap: float,
+    validate: bool,
+) -> None:
+    """Lengthen flat runs at struck stations so diagonals clear their labels.
+
+    A fan-in/fan-out, convergence, or descent diagonal that rakes a station's
+    name label is cleared by lengthening the flat run at that station by whole
+    grid columns (the pitch stays fixed), seating the transition outside the
+    label.  Three grid-quantized levers, each a ``(kind, section, layer)``
+    triple: the section's entry-side runway, its exit-side runway, and a
+    per-column gap before the struck station's layer.  Need-driven: only
+    stations the renderer would draw a strike through grow, so a clean layout
+    (every gallery render at its default pitch) is left untouched.  Independent
+    of pinned vs auto pitch: the room is local, not the global pitch, so it
+    applies even when the caller fixed x_spacing.
+
+    A grow step bumps every lever at each struck station (which one relocates a
+    given strike is hard to know in advance), then a minimization pass strips
+    each lever that turns out not to be load-bearing, so the settled layout
+    carries the least extra width that keeps the labels clear.  A step a
+    collinear check rejects, or that fails to reduce the struck count, is rolled
+    back, so the loop never ships a layout worse than it found.
+    """
 
     def _relay() -> None:
         _layout_once(
@@ -663,87 +748,52 @@ def _compute_layout_scaled(
                     break
         _relay()
 
-    # Assure file-icon leaf sinks off the trunk by construction: a leaf icon
-    # the laid-out routes rake a line across is taken off-track and the layout
-    # re-run once, so the off-track machinery lifts it clear of the passing
-    # line.  Keyed on an observed crossing (not on icon presence), so an
-    # end-of-chain terminus that already sits clear is never disturbed.
-    crossed_sinks = _line_crossed_file_icon_sinks(graph)
-    if crossed_sinks:
-        for sid in crossed_sinks:
-            graph.stations[sid].off_track = True
-        _layout_once(
-            graph,
-            x_spacing=x_spacing,
-            y_spacing=y_spacing,
-            x_offset=x_offset,
-            y_offset=y_offset,
-            section_x_padding=section_x_padding,
-            section_y_padding=section_y_padding,
-            section_x_gap=section_x_gap,
-            section_y_gap=section_y_gap,
-            validate=validate,
-        )
 
-    # Per-section rail mode: the normal pipeline has positioned every
-    # section's bbox and inter-section ports.  Now overwrite the *internal*
-    # geometry of each rail-flagged section with the rail-mode layout (rails
-    # + spanning pills), anchored at the bbox the placement chose.  Non-rail
-    # sections and all inter-section placement keep the normal machinery.
+def _retrofit_section_rails_phase(
+    graph: MetroGraph,
+    *,
+    x_spacing: float,
+    y_spacing: float,
+    section_x_padding: float,
+    section_y_padding: float,
+) -> None:
+    """Overwrite each rail-flagged section's internal geometry with rail layout.
+
+    The normal pipeline has positioned every section's bbox and inter-section
+    ports; this replaces only the *internal* geometry of rail-flagged sections
+    (rails + spanning pills), anchored at the bbox the placement chose.  Non-rail
+    sections and all inter-section placement keep the normal machinery.
+    """
     rail_section_ids = [
         sid
         for sid, mode in graph.line_spread_overrides.items()
         if mode is LineSpread.RAILS
     ]
-    if rail_section_ids and graph.line_spread is not LineSpread.RAILS:
-        from nf_metro.layout.labels import diagonal_label_pitch_by_section
-        from nf_metro.layout.rail_mode import retrofit_section_rails
+    if not rail_section_ids or graph.line_spread is LineSpread.RAILS:
+        return
 
-        section_pitch_map = diagonal_label_pitch_by_section(graph, x_spacing)
-        # Rails sit one base grid pitch apart and their labels hang above or
-        # below the bundle, so the diagonal-label widening of the global
-        # y_spacing (the spread loop, for between-station label clearance) must
-        # not also push the rails apart.  Column X still uses the label-aware
-        # pitch, where horizontal label room genuinely matters.
-        rail_pitch = getattr(graph, "_base_y_spacing", y_spacing)
-        for sid in rail_section_ids:
-            section = graph.sections.get(sid)
-            if section is None:
-                continue
-            retrofit_section_rails(
-                graph,
-                section,
-                x_spacing=section_pitch_map.get(sid, x_spacing),
-                y_spacing=rail_pitch,
-                section_x_padding=section_x_padding,
-                section_y_padding=section_y_padding,
-            )
+    from nf_metro.layout.labels import diagonal_label_pitch_by_section
+    from nf_metro.layout.rail_mode import retrofit_section_rails
 
-    # Record the bypassed-station label box behind each bypass V so the router
-    # can seat the V's flat-run corners clear of the label.  Read on the render
-    # path, so it is populated independent of ``validate``; computed once the
-    # layout has fully settled so the box matches what the renderer draws.
-    graph.bypass_label_obstacles = _bypass_label_obstacles(graph)
-
-    # Always-on backstop (independent of ``validate``): the settled layout
-    # must never leave a station outside its own section bbox.  Runs on the
-    # render path so an unsupported directive combination fails loudly
-    # instead of shipping a silently-broken diagram (issue #424).
-    _guard_stations_within_bbox(graph, "final")
-    _snap(graph, "final")
-
-    if validate:
-        _guard_no_label_overlap(graph, "final")
-        _guard_no_diagonal_strikes_horizontal_label(graph, "final")
-        _guard_no_line_strikes_label(graph, "final")
-        _guard_no_wrapped_label_trunk_strike(graph, "final")
-        _guard_file_icon_no_name_label(graph, "final")
-        _guard_no_line_crosses_file_icon(graph, "final")
-        _guard_centered_line_spread_balanced(graph, "final")
-        _guard_rail_above_label_band(graph, "final")
-        _guard_rail_stations_seat_on_rails(graph, "final")
-        _guard_rail_one_station_per_column(graph, "final")
-        _guard_single_trunk_off_track_step(graph, "final")
+    section_pitch_map = diagonal_label_pitch_by_section(graph, x_spacing)
+    # Rails sit one base grid pitch apart and their labels hang above or below
+    # the bundle, so the diagonal-label widening of the global y_spacing (the
+    # spread loop, for between-station label clearance) must not also push the
+    # rails apart.  Column X still uses the label-aware pitch, where horizontal
+    # label room genuinely matters.
+    rail_pitch = getattr(graph, "_base_y_spacing", y_spacing)
+    for sid in rail_section_ids:
+        section = graph.sections.get(sid)
+        if section is None:
+            continue
+        retrofit_section_rails(
+            graph,
+            section,
+            x_spacing=section_pitch_map.get(sid, x_spacing),
+            y_spacing=rail_pitch,
+            section_x_padding=section_x_padding,
+            section_y_padding=section_y_padding,
+        )
 
 
 def _snap(graph: MetroGraph, phase_id: str) -> None:

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -456,155 +456,179 @@ def _balance_section_content_around_trunk(
                 st.y = _ref_y(graph, sid)
 
     for section in graph.sections.values():
-        if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
-            continue
-        bundle = _section_bundle_lines(graph, section)
-        if not bundle:
-            continue
-        port_set = section.port_ids
-        internal_ids = [
-            sid
-            for sid in section.station_ids
-            if sid not in port_set
-            and sid in graph.stations
-            and not graph.stations[sid].is_port
-            and not graph.stations[sid].is_hidden
-            and not graph.stations[sid].off_track
-        ]
-        if not internal_ids:
-            continue
+        _balance_one_section(graph, section, y_spacing)
 
-        trunk_y = _section_lr_port_anchor_y(graph, section)
-        if trunk_y is None:
-            full_ys = sorted(
-                graph.stations[s].y
-                for s in internal_ids
-                if set(graph.station_lines(s)) == bundle
-            )
-            if not full_ys:
+
+def _movable_partial_bundle_stations(
+    graph: MetroGraph, cols: dict[float, list[str]], bundle: set[str]
+) -> list[str]:
+    """Non-trunk stations sharing a column with a trunk, carrying a sub-bundle."""
+    movable: list[str] = []
+    for sids in cols.values():
+        trunks_in_col = [s for s in sids if set(graph.station_lines(s)) == bundle]
+        if not trunks_in_col:
+            continue
+        for s in sids:
+            if s in trunks_in_col:
                 continue
-            trunk_y = full_ys[len(full_ys) // 2]
+            lines = set(graph.station_lines(s))
+            if not lines or not (lines < bundle):
+                continue
+            movable.append(s)
+    return movable
 
-        cols: dict[float, list[str]] = defaultdict(list)
-        for sid in internal_ids:
-            cols[round(graph.stations[sid].x, 3)].append(sid)
 
+def _column_occupied_ys(
+    graph: MetroGraph, section: Section, col_x: float, skip_sid: str
+) -> list[float]:
+    """Ys of every other visible station (incl. off-track icons) at ``col_x``.
+
+    Lift candidates must avoid these slots or the lifted marker overlaps an
+    existing marker / icon at render time.
+    """
+    occ: list[float] = []
+    for sid2 in section.station_ids:
+        if sid2 == skip_sid:
+            continue
+        st2 = graph.stations.get(sid2)
+        if st2 is None or st2.is_port or st2.is_hidden:
+            continue
+        if abs(st2.x - col_x) > 0.5:
+            continue
+        occ.append(st2.y)
+    return occ
+
+
+def _balance_one_section(graph: MetroGraph, section: Section, y_spacing: float) -> None:
+    """Rebalance one section's fan-out siblings into the empty band above trunk."""
+    if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
+        return
+    bundle = _section_bundle_lines(graph, section)
+    if not bundle:
+        return
+    port_set = section.port_ids
+    internal_ids = [
+        sid
+        for sid in section.station_ids
+        if sid not in port_set
+        and sid in graph.stations
+        and not graph.stations[sid].is_port
+        and not graph.stations[sid].is_hidden
+        and not graph.stations[sid].off_track
+    ]
+    if not internal_ids:
+        return
+
+    trunk_y = _section_lr_port_anchor_y(graph, section)
+    if trunk_y is None:
+        full_ys = sorted(
+            graph.stations[s].y
+            for s in internal_ids
+            if set(graph.station_lines(s)) == bundle
+        )
+        if not full_ys:
+            return
+        trunk_y = full_ys[len(full_ys) // 2]
+
+    cols: dict[float, list[str]] = defaultdict(list)
+    for sid in internal_ids:
+        cols[round(graph.stations[sid].x, 3)].append(sid)
+
+    section_top_y = min(graph.stations[s].y for s in internal_ids)
+    top_band = section_top_y - _ref_bbox_top(graph, section)
+    if top_band <= y_spacing + 0.5:
+        return
+
+    movable = _movable_partial_bundle_stations(graph, cols, bundle)
+    if not movable:
+        return
+
+    ys = [graph.stations[s].y for s in movable]
+    above_count = sum(1 for y in ys if y < trunk_y - 0.5)
+    below_count = sum(1 for y in ys if y > trunk_y + 0.5)
+    if below_count <= above_count:
+        return
+
+    _lift_below_trunk_siblings(
+        graph, section, movable, trunk_y, y_spacing, internal_ids
+    )
+
+    # Below-trunk compaction: when the first row below the trunk is empty but
+    # content sits two or more slots below, lift all below-trunk stations up by
+    # one ``y_spacing`` so they pack against the trunk row.  Honours the
+    # column-occupied guard so off-track icons and marker clearance hold.
+    _compact_below_trunk_band(graph, section, trunk_y, y_spacing)
+
+
+def _lift_below_trunk_siblings(
+    graph: MetroGraph,
+    section: Section,
+    movable: list[str],
+    trunk_y: float,
+    y_spacing: float,
+    internal_ids: list[str],
+) -> None:
+    """Iteratively lift (or swap) below-trunk siblings into the empty top band."""
+    section_internal_set = set(internal_ids)
+    for _ in range(len(movable)):
         section_top_y = min(graph.stations[s].y for s in internal_ids)
         top_band = section_top_y - _ref_bbox_top(graph, section)
         if top_band <= y_spacing + 0.5:
-            continue
-
-        movable: list[str] = []
-        for x, sids in cols.items():
-            trunks_in_col = [s for s in sids if set(graph.station_lines(s)) == bundle]
-            if not trunks_in_col:
+            break
+        ys_by_sid = {s: graph.stations[s].y for s in movable}
+        above = [s for s, y in ys_by_sid.items() if y < trunk_y - 0.5]
+        below = [s for s, y in ys_by_sid.items() if y > trunk_y + 0.5]
+        if len(below) <= len(above):
+            break
+        line_sets = {frozenset(graph.station_lines(s)) for s in movable}
+        if len(line_sets) == 1:
+            below.sort(key=lambda s: graph.stations[s].y, reverse=True)
+        else:
+            below.sort(key=lambda s: graph.stations[s].y)
+        # First below-trunk candidate whose lift Y doesn't collide with
+        # another station/icon already occupying the same column.
+        candidate = None
+        new_y = section_top_y - y_spacing
+        for cand in below:
+            col_x = graph.stations[cand].x
+            occ = _column_occupied_ys(graph, section, col_x, cand)
+            if any(abs(oy - new_y) < y_spacing - 0.5 for oy in occ):
                 continue
-            for s in sids:
-                if s in trunks_in_col:
-                    continue
-                lines = set(graph.station_lines(s))
-                if not lines or not (lines < bundle):
-                    continue
-                movable.append(s)
-
-        if not movable:
-            continue
-
-        ys = [graph.stations[s].y for s in movable]
-        above_count = sum(1 for y in ys if y < trunk_y - 0.5)
-        below_count = sum(1 for y in ys if y > trunk_y + 0.5)
-        if below_count <= above_count:
-            continue
-
-        section_internal_set = set(internal_ids)
-
-        # Ys of every other station (incl. off-track icons) at ``col_x``.
-        # Lift candidates must avoid these slots or the lifted marker
-        # overlaps an existing marker / icon at render time.
-        def _column_occupied_ys(col_x: float, skip_sid: str) -> list[float]:
-            occ: list[float] = []
-            for sid2 in section.station_ids:
-                if sid2 == skip_sid:
-                    continue
-                st2 = graph.stations.get(sid2)
-                if st2 is None or st2.is_port or st2.is_hidden:
-                    continue
-                if abs(st2.x - col_x) > 0.5:
-                    continue
-                occ.append(st2.y)
-            return occ
-
-        max_iters = len(movable)
-        for _ in range(max_iters):
-            section_top_y = min(graph.stations[s].y for s in internal_ids)
-            top_band = section_top_y - _ref_bbox_top(graph, section)
-            if top_band <= y_spacing + 0.5:
+            candidate = cand
+            break
+        if candidate is None:
+            break
+        st = graph.stations.get(candidate)
+        has_above_label = bool(st and st.label and st.label.strip())
+        label_clearance = y_spacing / 2 if has_above_label else 0.0
+        # Off-track file icons reach ~16 px above centre; on-track markers
+        # reach ~9.5 px.  Use the wider reach when relevant.
+        marker_clearance = 16.0 if (st and st.off_track) else 9.5
+        min_y = _ref_bbox_top(graph, section) + max(label_clearance, marker_clearance)
+        if new_y < min_y - 0.5:
+            if not above:
                 break
-            ys_by_sid = {s: graph.stations[s].y for s in movable}
-            above = [s for s, y in ys_by_sid.items() if y < trunk_y - 0.5]
-            below = [s for s, y in ys_by_sid.items() if y > trunk_y + 0.5]
-            if len(below) <= len(above):
+            above.sort(key=lambda s: graph.stations[s].y)
+            top_above = above[0]
+            ya = graph.stations[top_above].y
+            yc = graph.stations[candidate].y
+            if candidate != below[0]:
                 break
-            line_sets = {frozenset(graph.station_lines(s)) for s in movable}
-            if len(line_sets) == 1:
-                below.sort(key=lambda s: graph.stations[s].y, reverse=True)
-            else:
-                below.sort(key=lambda s: graph.stations[s].y)
-            # First below-trunk candidate whose lift Y doesn't collide
-            # with another station/icon already occupying the same column.
-            candidate = None
-            new_y = section_top_y - y_spacing
-            for cand in below:
-                col_x = graph.stations[cand].x
-                occ = _column_occupied_ys(col_x, cand)
-                if any(abs(oy - new_y) < y_spacing - 0.5 for oy in occ):
-                    continue
-                candidate = cand
-                break
-            if candidate is None:
-                break
-            st = graph.stations.get(candidate)
-            has_above_label = bool(st and st.label and st.label.strip())
-            label_clearance = y_spacing / 2 if has_above_label else 0.0
-            # Off-track file icons reach ~16 px above centre; on-track
-            # markers reach ~9.5 px.  Use the wider reach when relevant.
-            marker_clearance = 16.0 if (st and st.off_track) else 9.5
-            min_y = _ref_bbox_top(graph, section) + max(
-                label_clearance, marker_clearance
+            graph.stations[candidate].y = ya
+            graph.stations[top_above].y = yc
+            _shift_linear_consumer_chain(
+                graph, candidate, ya - yc, section_internal_set
             )
-            if new_y < min_y - 0.5:
-                if not above:
-                    break
-                above.sort(key=lambda s: graph.stations[s].y)
-                top_above = above[0]
-                ya = graph.stations[top_above].y
-                yc = graph.stations[candidate].y
-                if candidate != below[0]:
-                    break
-                graph.stations[candidate].y = ya
-                graph.stations[top_above].y = yc
-                _shift_linear_consumer_chain(
-                    graph, candidate, ya - yc, section_internal_set
-                )
-                _shift_linear_consumer_chain(
-                    graph, top_above, yc - ya, section_internal_set
-                )
-                break
-            ext_feeders = _balance_direct_external_feeder_ys(
-                graph, candidate, section.id
+            _shift_linear_consumer_chain(
+                graph, top_above, yc - ya, section_internal_set
             )
-            if len(ext_feeders) >= 2 and all(fy >= new_y - 0.5 for fy in ext_feeders):
-                break
-            delta = new_y - graph.stations[candidate].y
-            graph.stations[candidate].y = new_y
-            _shift_linear_consumer_chain(graph, candidate, delta, section_internal_set)
-
-        # Below-trunk compaction: when the first row below the trunk is
-        # empty but content sits two or more slots below, lift all
-        # below-trunk stations up by one ``y_spacing`` so they pack
-        # against the trunk row.  Honours the existing column-occupied
-        # guard so off-track icons and marker clearance aren't violated.
-        _compact_below_trunk_band(graph, section, trunk_y, y_spacing)
+            break
+        ext_feeders = _balance_direct_external_feeder_ys(graph, candidate, section.id)
+        if len(ext_feeders) >= 2 and all(fy >= new_y - 0.5 for fy in ext_feeders):
+            break
+        delta = new_y - graph.stations[candidate].y
+        graph.stations[candidate].y = new_y
+        _shift_linear_consumer_chain(graph, candidate, delta, section_internal_set)
 
 
 def _compact_below_trunk_band(

--- a/src/nf_metro/layout/phases/grid_snap.py
+++ b/src/nf_metro/layout/phases/grid_snap.py
@@ -76,94 +76,113 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
             groups[("solo", sec.id)] = (y_spacing, [sec.id])
 
     for pitch, sec_ids in groups.values():
-        half = pitch / 2.0
-        # Collect non-port, on-track station Ys across the whole group
-        # to estimate the row's shared grid offset.  Off-track stations
-        # were lifted by Stage 5.2 relative to their consumers; they
-        # snap to the same grid (so the y_spacing gap above the
-        # consumer is preserved) but don't influence the origin.
-        residues: Counter[float] = Counter()
-        per_section_ports: dict[str, set[str]] = {}
-        half_grid_ids = graph.half_grid_station_ids
-        for sec_id in sec_ids:
-            section = graph.sections.get(sec_id)
-            if section is None or section.bbox_h <= 0:
-                continue
-            port_ids = section.port_ids
-            per_section_ports[sec_id] = port_ids
-            for sid in section.station_ids:
-                if sid in port_ids:
-                    continue
-                if sid in half_grid_ids:
-                    # Half-grid stations sit at origin + 0.5 * pitch by
-                    # design; don't let them shift the row's grid origin.
-                    continue
-                st = graph.stations.get(sid)
-                if st is None or st.off_track:
-                    continue
-                residues[round(st.y % pitch, 3)] += 1
-        if not residues:
+        _snap_group_to_grid(graph, pitch, sec_ids, convergence_sources)
+
+    _restore_convergence_midpoints(graph, convergence_sources)
+
+
+def _slot_snap(y: float, origin: float, pitch: float, half: float) -> float:
+    """Snap ``y`` to ``origin + n*pitch`` unless that shifts it over half a pitch."""
+    snapped = origin + round((y - origin) / pitch) * pitch
+    return snapped if abs(snapped - y) <= half + 1e-6 else y
+
+
+def _group_grid_origin(
+    graph: MetroGraph, sec_ids: list[str], pitch: float
+) -> tuple[float, dict[str, set[str]]] | None:
+    """Mode of ``y % pitch`` across the group's on-grid stations, with port map.
+
+    Returns ``(origin, per_section_ports)`` or None when the group has no
+    on-grid majority.  Off-track stations were lifted relative to their
+    consumers; they snap to the same grid but don't influence the origin.
+    """
+    residues: Counter[float] = Counter()
+    per_section_ports: dict[str, set[str]] = {}
+    half_grid_ids = graph.half_grid_station_ids
+    for sec_id in sec_ids:
+        section = graph.sections.get(sec_id)
+        if section is None or section.bbox_h <= 0:
             continue
-        origin_r, top = residues.most_common(1)[0]
-        if top < 2 and len(residues) > 1:
-            continue
-
-        def _snap(
-            y: float, origin: float = origin_r, p: float = pitch, h: float = half
-        ) -> float:
-            snapped = origin + round((y - origin) / p) * p
-            return snapped if abs(snapped - y) <= h + 1e-6 else y
-
-        # Independent snapping can round two same-column stations onto one
-        # slot; the later one keeps its pre-snap Y rather than collapsing.
-        column_slots: dict[float, set[float]] = {}
-
-        for sec_id, port_ids in per_section_ports.items():
-            section = graph.sections.get(sec_id)
-            if section is None:
+        port_ids = section.port_ids
+        per_section_ports[sec_id] = port_ids
+        for sid in section.station_ids:
+            if sid in port_ids:
                 continue
-            is_tb_section = section.direction == "TB"
-            for sid in section.station_ids:
-                if sid in port_ids:
-                    continue
-                if sid in half_grid_ids:
-                    continue
-                st = graph.stations.get(sid)
-                if st is None:
-                    continue
-                if sid in convergence_sources:
-                    continue
-                target = _snap(st.y)
-                slots = column_slots.setdefault(round(st.x, 3), set())
-                if round(target, 3) in slots:
-                    target = st.y
-                slots.add(round(target, 3))
-                st.y = target
-            for pid in port_ids:
-                port = graph.ports.get(pid)
-                port_st = graph.stations.get(pid)
-                if port is None or port_st is None:
-                    continue
-                if port.side not in (PortSide.LEFT, PortSide.RIGHT):
-                    continue
-                # TB exit ports are anchored to the downstream entry-port
-                # Y by _resolve_tb_exit_y; preserve that alignment.
-                if is_tb_section and not port.is_entry:
-                    continue
-                if pid in convergence_sources:
-                    continue
-                port_st.y = _snap(port_st.y)
+            # Half-grid stations sit at origin + 0.5 * pitch by design; don't
+            # let them shift the row's grid origin.
+            if sid in half_grid_ids:
+                continue
+            st = graph.stations.get(sid)
+            if st is None or st.off_track:
+                continue
+            residues[round(st.y % pitch, 3)] += 1
+    if not residues:
+        return None
+    origin_r, top = residues.most_common(1)[0]
+    if top < 2 and len(residues) > 1:
+        return None
+    return origin_r, per_section_ports
 
-    # Restore convergence midpoints after snap: if a convergence
-    # target's source Ys moved during snap, re-place the target at the
-    # new midpoint so a fan-in still visually converges symmetrically.
+
+def _snap_group_to_grid(
+    graph: MetroGraph,
+    pitch: float,
+    sec_ids: list[str],
+    convergence_sources: dict[str, list[str]],
+) -> None:
+    """Snap one row-group's stations and LEFT/RIGHT ports to its shared grid."""
+    half = pitch / 2.0
+    origin_info = _group_grid_origin(graph, sec_ids, pitch)
+    if origin_info is None:
+        return
+    origin_r, per_section_ports = origin_info
+    half_grid_ids = graph.half_grid_station_ids
+
+    # Independent snapping can round two same-column stations onto one slot;
+    # the later one keeps its pre-snap Y rather than collapsing.
+    column_slots: dict[float, set[float]] = {}
+
+    for sec_id, port_ids in per_section_ports.items():
+        section = graph.sections.get(sec_id)
+        if section is None:
+            continue
+        is_tb_section = section.direction == "TB"
+        for sid in section.station_ids:
+            if sid in port_ids or sid in half_grid_ids:
+                continue
+            st = graph.stations.get(sid)
+            if st is None or sid in convergence_sources:
+                continue
+            target = _slot_snap(st.y, origin_r, pitch, half)
+            slots = column_slots.setdefault(round(st.x, 3), set())
+            if round(target, 3) in slots:
+                target = st.y
+            slots.add(round(target, 3))
+            st.y = target
+        for pid in port_ids:
+            port = graph.ports.get(pid)
+            port_st = graph.stations.get(pid)
+            if port is None or port_st is None:
+                continue
+            if port.side not in (PortSide.LEFT, PortSide.RIGHT):
+                continue
+            # TB exit ports are anchored to the downstream entry-port Y by
+            # _resolve_tb_exit_y; preserve that alignment.
+            if is_tb_section and not port.is_entry:
+                continue
+            if pid in convergence_sources:
+                continue
+            port_st.y = _slot_snap(port_st.y, origin_r, pitch, half)
+
+
+def _restore_convergence_midpoints(
+    graph: MetroGraph, convergence_sources: dict[str, list[str]]
+) -> None:
+    """Re-centre each fan-in target on its post-snap source midpoint."""
     for target_id, src_ids in convergence_sources.items():
         st = graph.stations.get(target_id)
         if st is None or st.off_track:
             continue
-        # Convergence sources whose snap displaced them away from their
-        # original Y may break the midpoint relationship; recompute
-        # from the post-snap source coordinates.
         new_src_ys = [graph.stations[sid].y for sid in src_ids if sid in graph.stations]
         if len(set(round(y, 3) for y in new_src_ys)) < 2:
             continue

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1243,49 +1243,6 @@ def _guard_row_trunk_cy_consistent(
 
         offsets = compute_station_offsets(graph)
 
-    def _section_trunk_info(
-        sec: Section,
-    ) -> tuple[float, float, float, set[str]] | None:
-        bundle = _section_bundle_lines(graph, sec)
-        if not bundle:
-            return None
-        port_ys: list[float] = []
-        for pid in list(sec.entry_ports) + list(sec.exit_ports):
-            pst = graph.stations.get(pid)
-            pport = graph.ports.get(pid)
-            if (
-                pst is not None
-                and pport is not None
-                and pport.side in (PortSide.LEFT, PortSide.RIGHT)
-            ):
-                port_ys.append(pst.y)
-        if not port_ys:
-            return None
-        port_y = port_ys[0]
-        port_set = sec.port_ids
-        best: tuple[float, float, float, float] | None = None
-        for sid in sec.station_ids:
-            if sid in port_set:
-                continue
-            st = graph.stations.get(sid)
-            if st is None or st.is_port or st.is_hidden:
-                continue
-            lines = graph.station_lines(sid)
-            if set(lines) != bundle:
-                continue
-            line_offs = [offsets.get((sid, lid), 0.0) for lid in lines]
-            if not line_offs:
-                continue
-            y_min = st.y + min(line_offs)
-            y_max = st.y + max(line_offs)
-            cy = st.y + (min(line_offs) + max(line_offs)) / 2
-            dist = abs(cy - port_y)
-            if best is None or dist < best[0]:
-                best = (dist, cy, y_min, y_max)
-        if best is None:
-            return None
-        return (best[1], best[2], best[3], bundle)
-
     rows: dict[int, list[Section]] = {}
     for sec in graph.sections.values():
         if (
@@ -1298,49 +1255,108 @@ def _guard_row_trunk_cy_consistent(
         rows.setdefault(sec.grid_row, []).append(sec)
 
     for row, sections in rows.items():
-        info: dict[str, tuple[float, float, float, set[str]]] = {}
-        for sec in sections:
-            t = _section_trunk_info(sec)
-            if t is not None:
-                info[sec.id] = t
-        if len(info) < 2:
+        _check_row_trunk_cy(graph, phase, row, sections, offsets)
+
+
+def _section_trunk_cy_band(
+    graph: MetroGraph,
+    sec: Section,
+    offsets: dict[tuple[str, str], float],
+) -> tuple[float, float, float, set[str]] | None:
+    """Trunk ``(cy, y_min, y_max, bundle)`` of the bundle-carrying station
+    nearest the LR/RL port Y, or None when the section has no such trunk."""
+    bundle = _section_bundle_lines(graph, sec)
+    if not bundle:
+        return None
+    port_ys: list[float] = []
+    for pid in list(sec.entry_ports) + list(sec.exit_ports):
+        pst = graph.stations.get(pid)
+        pport = graph.ports.get(pid)
+        if (
+            pst is not None
+            and pport is not None
+            and pport.side in (PortSide.LEFT, PortSide.RIGHT)
+        ):
+            port_ys.append(pst.y)
+    if not port_ys:
+        return None
+    port_y = port_ys[0]
+    port_set = sec.port_ids
+    best: tuple[float, float, float, float] | None = None
+    for sid in sec.station_ids:
+        if sid in port_set:
             continue
-        parent = {sid: sid for sid in info}
+        st = graph.stations.get(sid)
+        if st is None or st.is_port or st.is_hidden:
+            continue
+        lines = graph.station_lines(sid)
+        if set(lines) != bundle:
+            continue
+        line_offs = [offsets.get((sid, lid), 0.0) for lid in lines]
+        if not line_offs:
+            continue
+        y_min = st.y + min(line_offs)
+        y_max = st.y + max(line_offs)
+        cy = st.y + (min(line_offs) + max(line_offs)) / 2
+        dist = abs(cy - port_y)
+        if best is None or dist < best[0]:
+            best = (dist, cy, y_min, y_max)
+    if best is None:
+        return None
+    return (best[1], best[2], best[3], bundle)
 
-        def _find(x: str) -> str:
-            while parent[x] != x:
-                parent[x] = parent[parent[x]]
-                x = parent[x]
-            return x
 
-        ids = list(info)
-        for i, a in enumerate(ids):
-            cy_a, lo_a, hi_a, bun_a = info[a]
-            for b in ids[i + 1 :]:
-                cy_b, lo_b, hi_b, bun_b = info[b]
-                bands_overlap = min(hi_a, hi_b) - max(lo_a, lo_b) >= -GUARD_TOLERANCE
-                if bands_overlap and bun_a == bun_b:
-                    ra, rb = _find(a), _find(b)
-                    if ra != rb:
-                        parent[ra] = rb
+def _check_row_trunk_cy(
+    graph: MetroGraph,
+    phase: str,
+    row: int,
+    sections: list[Section],
+    offsets: dict[tuple[str, str], float],
+) -> None:
+    """Raise if same-bundle, band-overlapping sections in one row drift in cy."""
+    info: dict[str, tuple[float, float, float, set[str]]] = {}
+    for sec in sections:
+        t = _section_trunk_cy_band(graph, sec, offsets)
+        if t is not None:
+            info[sec.id] = t
+    if len(info) < 2:
+        return
+    parent = {sid: sid for sid in info}
 
-        groups: dict[str, list[str]] = {}
-        for sid in ids:
-            groups.setdefault(_find(sid), []).append(sid)
+    def _find(x: str) -> str:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
 
-        for members in groups.values():
-            if len(members) < 2:
-                continue
-            anchor = members[0]
-            anchor_cy = info[anchor][0]
-            for sid in members[1:]:
-                cy = info[sid][0]
-                if abs(cy - anchor_cy) > GUARD_TOLERANCE:
-                    raise PhaseInvariantError(
-                        f"{phase}: row {row} trunk cy drift: "
-                        f"section {sid!r} cy={cy:.1f} vs "
-                        f"section {anchor!r} cy={anchor_cy:.1f}"
-                    )
+    ids = list(info)
+    for i, a in enumerate(ids):
+        _cy_a, lo_a, hi_a, bun_a = info[a]
+        for b in ids[i + 1 :]:
+            _cy_b, lo_b, hi_b, bun_b = info[b]
+            bands_overlap = min(hi_a, hi_b) - max(lo_a, lo_b) >= -GUARD_TOLERANCE
+            if bands_overlap and bun_a == bun_b:
+                ra, rb = _find(a), _find(b)
+                if ra != rb:
+                    parent[ra] = rb
+
+    groups: dict[str, list[str]] = {}
+    for sid in ids:
+        groups.setdefault(_find(sid), []).append(sid)
+
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        anchor = members[0]
+        anchor_cy = info[anchor][0]
+        for sid in members[1:]:
+            cy = info[sid][0]
+            if abs(cy - anchor_cy) > GUARD_TOLERANCE:
+                raise PhaseInvariantError(
+                    f"{phase}: row {row} trunk cy drift: "
+                    f"section {sid!r} cy={cy:.1f} vs "
+                    f"section {anchor!r} cy={anchor_cy:.1f}"
+                )
 
 
 def _guard_inter_section_routes_in_row_band(

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -107,6 +107,198 @@ def _build_gap_intervals(
     return intervals
 
 
+def _build_row_bands(graph: MetroGraph) -> dict[int, tuple[float, float]]:
+    """Per grid-row vertical band (top/bottom Y) spanned by its sections.
+
+    Lets a channel be matched to the row whose gap it actually travels in,
+    not merely the first row whose x-interval brackets it: two channels in
+    the same column gap but different grid rows (e.g. a row-0 fan and a
+    row-1 bypass) must NOT merge into one bundle.
+    """
+    row_bands: dict[int, tuple[float, float]] = {}
+    for s in graph.sections.values():
+        if s.bbox_h <= 0:
+            continue
+        for r in range(s.grid_row, s.grid_row + max(1, s.grid_row_span)):
+            top, bot = row_bands.get(r, (s.bbox_y, s.bbox_y + s.bbox_h))
+            row_bands[r] = (min(top, s.bbox_y), max(bot, s.bbox_y + s.bbox_h))
+    return row_bands
+
+
+def _match_channel_gap(
+    ch: _VChannel,
+    gap_intervals: dict[int | None, list[tuple[int, float, float]]],
+    row_bands: dict[int, tuple[float, float]],
+) -> tuple[int, int | None, float, float] | None:
+    """Match a channel to ``(lo_col, row, gap_left, gap_right)``.
+
+    Prefer the row whose x-interval brackets the channel AND whose vertical
+    band the channel overlaps; fall back to any bracketing row, then to the
+    row-agnostic union.
+
+    A channel that vertically crosses several rows must clear sections in
+    ALL of them, so its gap is narrowed to the intersection of every crossed
+    row's gap in the same column.  Otherwise a fan climbing out of a row
+    whose section edge sits further out than a sibling row's would centre in
+    the wider sibling gap and step back behind its source section edge (#386).
+    """
+    x = ch.x
+    overlap_match: tuple[int, int | None, float, float] | None = None
+    bracket_match: tuple[int, int | None, float, float] | None = None
+    for row in gap_intervals:
+        if row is None:
+            continue
+        for lo, left, right in gap_intervals[row]:
+            if not (left - COORD_TOLERANCE <= x <= right + COORD_TOLERANCE):
+                continue
+            if bracket_match is None:
+                bracket_match = (lo, row, left, right)
+            band = row_bands.get(row)
+            if band is not None and ch.y_lo < band[1] and band[0] < ch.y_hi:
+                if overlap_match is None:
+                    overlap_match = (lo, row, left, right)
+    match = overlap_match or bracket_match
+    if match is not None:
+        lo, row, left, right = match
+        for r, band in row_bands.items():
+            if not (ch.y_lo < band[1] and band[0] < ch.y_hi):
+                continue
+            for rlo, rleft, rright in gap_intervals.get(r, []):
+                if rlo == lo:
+                    left = max(left, rleft)
+                    right = min(right, rright)
+        return (lo, row, left, right)
+    for lo, left, right in gap_intervals.get(None, []):
+        if left - COORD_TOLERANCE <= x <= right + COORD_TOLERANCE:
+            return (lo, None, left, right)
+    return None
+
+
+def _split_corridors(chans: list[_VChannel]) -> list[list[_VChannel]]:
+    """Split a bucket into corridors of y-overlapping channels.
+
+    Only channels whose y-spans overlap share a true corridor; independent
+    vertical runs at different heights must NOT be merged.
+    """
+    chans = sorted(chans, key=lambda c: (c.y_lo, c.y_hi))
+    groups: list[list[_VChannel]] = []
+    for ch in chans:
+        placed = False
+        for g in groups:
+            if any(
+                ch.y_lo < o.y_hi - COORD_TOLERANCE
+                and o.y_lo < ch.y_hi - COORD_TOLERANCE
+                for o in g
+            ):
+                g.append(ch)
+                placed = True
+                break
+        if not placed:
+            groups.append([ch])
+    return groups
+
+
+def _section_intrudes(graph: MetroGraph, x: float, y_lo: float, y_hi: float) -> bool:
+    """True if a re-stacked channel at ``x`` would land inside any section bbox."""
+    for s in graph.sections.values():
+        if s.bbox_w <= 0:
+            continue
+        sx_l = s.bbox_x
+        sx_r = s.bbox_x + s.bbox_w
+        if sx_l - COORD_TOLERANCE < x < sx_r + COORD_TOLERANCE:
+            sy_t = s.bbox_y
+            sy_b = s.bbox_y + s.bbox_h
+            if y_lo < sy_b and sy_t < y_hi:
+                return True
+    return False
+
+
+def _bucket_gap_channels(
+    channels: list[_VChannel],
+    gap_intervals: dict[int | None, list[tuple[int, float, float]]],
+    row_bands: dict[int, tuple[float, float]],
+) -> tuple[
+    dict[tuple[int, int | None, bool], list[_VChannel]],
+    dict[tuple[int, int | None], tuple[float, float]],
+]:
+    """Bucket channels per ``(gap lo_col, row, direction)`` with shared bounds.
+
+    A channel is only a candidate when its x lands strictly inside the gap
+    interior (so a near-vertical drop hugging a section edge is left
+    untouched).  Bundles sharing a ``(gap, row)`` are laid out together in
+    one x-range, so the shared bound is narrowed to the intersection of every
+    member's crossed rows rather than letting the last channel win.
+    """
+    buckets: dict[tuple[int, int | None, bool], list[_VChannel]] = defaultdict(list)
+    gap_bounds: dict[tuple[int, int | None], tuple[float, float]] = {}
+    for ch in channels:
+        gap = _match_channel_gap(ch, gap_intervals, row_bands)
+        if gap is None:
+            continue
+        lo, row, left, right = gap
+        if not (left + COORD_TOLERANCE < ch.x < right - COORD_TOLERANCE):
+            # x sits on / outside a section edge: not a clean gap channel.
+            if not (left <= ch.x <= right):
+                continue
+        prev = gap_bounds.get((lo, row))
+        if prev is not None:
+            left = max(left, prev[0])
+            right = min(right, prev[1])
+        gap_bounds[(lo, row)] = (left, right)
+        buckets[(lo, row, ch.down)].append(ch)
+    return buckets, gap_bounds
+
+
+def _layout_gap_bundle(
+    bundles: list[tuple[bool, list[_VChannel]]],
+    gap_left: float,
+    gap_right: float,
+    ctx: _RoutingCtx,
+) -> None:
+    """Lay out one ``(gap, row)``'s bundles concentrically, centred in the gap."""
+    step = ctx.offset_step
+    # Stable left-to-right order: by current bundle centre.
+    bundles.sort(key=lambda b: sum(c.x for c in b[1]) / len(b[1]))
+    # Distinct-line count per bundle drives the bundle width and the
+    # per-line slotting: multiple segments sharing one line_id (a fan
+    # whose line feeds several targets) overlay at a single x rather
+    # than each claiming an OFFSET_STEP slot.
+    line_orders = [_distinct_line_order(c) for _, c in bundles]
+    # Skip a lone bundle carrying a single distinct line: nothing to
+    # re-bundle and centring risks disturbing wrap geometry.
+    if len(bundles) == 1 and len(line_orders[0]) <= 1:
+        return
+    widths = [max(0, len(o) - 1) * step for o in line_orders]
+    # A lone bundle centres on the true gap midpoint (symmetric clearance
+    # both sides) rather than flooring one edge at A, which would push the
+    # bundle off-centre when the gap is sized tighter than 2A + width.
+    # Multi-bundle gaps keep the symmetric A/B layout.
+    lone = len(bundles) == 1
+    for bi, (_down, chans) in enumerate(bundles):
+        order = line_orders[bi]
+        if lone:
+            mid = (gap_left + gap_right) / 2
+        else:
+            mid = symmetric_bundle_midpoint(gap_left, gap_right, widths, bi)
+        n = len(order)
+        # line_id -> (slot index, x); every segment of that line overlays
+        # at its single slot rather than claiming an OFFSET_STEP each.
+        line_slot = {
+            lid: (i, mid + (i - (n - 1) / 2) * step) for i, lid in enumerate(order)
+        }
+        targets = [(ch, line_slot[ch.route.line_id]) for ch in chans]
+        # Intrusion guard: if any target x would land inside a section bbox
+        # (e.g. the gap bounds came from another row), leave this bundle
+        # untouched rather than route through a section.
+        if any(
+            _section_intrudes(ctx.graph, nx, ch.y_lo, ch.y_hi)
+            for ch, (_li, nx) in targets
+        ):
+            continue
+        for ch, (li, nx) in targets:
+            _restack_channel(ch, nx, li, n, step, ctx.curve_radius)
+
+
 def _normalize_gap_channels(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
     """Re-bundle inter-section vertical channels sharing a gap + direction.
 
@@ -126,178 +318,25 @@ def _normalize_gap_channels(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
     re-stacked channel are recomputed so the bundle stays concentric.
     """
     graph = ctx.graph
-    step = ctx.offset_step
     channels = _collect_vchannels(routes)
     if not channels:
         return
     gap_intervals = _build_gap_intervals(graph)
+    row_bands = _build_row_bands(graph)
 
-    # Per-row vertical band (top/bottom Y) so a channel can be matched to
-    # the row whose gap it actually travels in, not merely the first row
-    # whose x-interval brackets it.  Two channels in the same column gap
-    # but different grid rows (e.g. a row-0 fan and a row-1 bypass) must
-    # NOT be merged into one bundle: each centres on its own row's gap.
-    row_bands: dict[int, tuple[float, float]] = {}
-    for s in graph.sections.values():
-        if s.bbox_h <= 0:
-            continue
-        for r in range(s.grid_row, s.grid_row + max(1, s.grid_row_span)):
-            top, bot = row_bands.get(r, (s.bbox_y, s.bbox_y + s.bbox_h))
-            row_bands[r] = (min(top, s.bbox_y), max(bot, s.bbox_y + s.bbox_h))
-
-    def _find_gap(ch: _VChannel) -> tuple[int, int | None, float, float] | None:
-        """Match a channel to ``(lo_col, row, gap_left, gap_right)``.
-
-        Prefer the row whose x-interval brackets the channel AND whose
-        vertical band the channel overlaps; fall back to any bracketing
-        row, then to the row-agnostic union.
-
-        A channel that vertically crosses several rows must clear sections
-        in ALL of them, so its gap is narrowed to the intersection of every
-        crossed row's gap in the same column.  Otherwise a fan climbing out
-        of a row whose section edge sits further out than a sibling row's
-        would centre in the wider sibling gap and step back behind its source
-        section edge (#386).
-        """
-        x = ch.x
-        overlap_match: tuple[int, int | None, float, float] | None = None
-        bracket_match: tuple[int, int | None, float, float] | None = None
-        for row in gap_intervals:
-            if row is None:
-                continue
-            for lo, left, right in gap_intervals[row]:
-                if not (left - COORD_TOLERANCE <= x <= right + COORD_TOLERANCE):
-                    continue
-                if bracket_match is None:
-                    bracket_match = (lo, row, left, right)
-                band = row_bands.get(row)
-                if band is not None and ch.y_lo < band[1] and band[0] < ch.y_hi:
-                    if overlap_match is None:
-                        overlap_match = (lo, row, left, right)
-        match = overlap_match or bracket_match
-        if match is not None:
-            lo, row, left, right = match
-            for r, band in row_bands.items():
-                if not (ch.y_lo < band[1] and band[0] < ch.y_hi):
-                    continue
-                for rlo, rleft, rright in gap_intervals.get(r, []):
-                    if rlo == lo:
-                        left = max(left, rleft)
-                        right = min(right, rright)
-            return (lo, row, left, right)
-        for lo, left, right in gap_intervals.get(None, []):
-            if left - COORD_TOLERANCE <= x <= right + COORD_TOLERANCE:
-                return (lo, None, left, right)
-        return None
-
-    # Bucket channels per (gap lo_col, row, direction).  A channel is only
-    # a candidate when its x lands strictly inside the gap interior (so a
-    # near-vertical drop hugging a section edge is left untouched).
-    buckets: dict[tuple[int, int | None, bool], list[_VChannel]] = defaultdict(list)
-    gap_bounds: dict[tuple[int, int | None], tuple[float, float]] = {}
-    for ch in channels:
-        gap = _find_gap(ch)
-        if gap is None:
-            continue
-        lo, row, left, right = gap
-        if not (left + COORD_TOLERANCE < ch.x < right - COORD_TOLERANCE):
-            # x sits on / outside a section edge: not a clean gap channel.
-            if not (left <= ch.x <= right):
-                continue
-        # Bundles sharing a (gap, row) are laid out together in one x-range,
-        # so the shared bound must clear every member's crossed rows: narrow
-        # to the intersection rather than letting the last channel win.
-        prev = gap_bounds.get((lo, row))
-        if prev is not None:
-            left = max(left, prev[0])
-            right = min(right, prev[1])
-        gap_bounds[(lo, row)] = (left, right)
-        buckets[(lo, row, ch.down)].append(ch)
-
-    # Within a (gap, direction) bucket, split into corridors by vertical
-    # overlap: only channels whose y-spans overlap share a true corridor
-    # (independent vertical runs at different heights must NOT be merged).
-    def _corridors(chans: list[_VChannel]) -> list[list[_VChannel]]:
-        chans = sorted(chans, key=lambda c: (c.y_lo, c.y_hi))
-        groups: list[list[_VChannel]] = []
-        for ch in chans:
-            placed = False
-            for g in groups:
-                if any(
-                    ch.y_lo < o.y_hi - COORD_TOLERANCE
-                    and o.y_lo < ch.y_hi - COORD_TOLERANCE
-                    for o in g
-                ):
-                    g.append(ch)
-                    placed = True
-                    break
-            if not placed:
-                groups.append([ch])
-        return groups
+    buckets, gap_bounds = _bucket_gap_channels(channels, gap_intervals, row_bands)
 
     # Assemble bundles per (gap, row): one per corridor, both directions,
     # laid out together so a down/up pair sharing a gap is B-separated.
     by_gap: dict[tuple[int, int | None], list[tuple[bool, list[_VChannel]]]]
     by_gap = defaultdict(list)
     for (lo, row, down), chans in buckets.items():
-        for corridor in _corridors(chans):
+        for corridor in _split_corridors(chans):
             by_gap[(lo, row)].append((down, corridor))
 
-    # Intrusion guard (row-agnostic): a re-stacked channel must never land
-    # inside any section's bbox.
-    def _intrudes(x: float, y_lo: float, y_hi: float) -> bool:
-        for s in graph.sections.values():
-            if s.bbox_w <= 0:
-                continue
-            sx_l = s.bbox_x
-            sx_r = s.bbox_x + s.bbox_w
-            if sx_l - COORD_TOLERANCE < x < sx_r + COORD_TOLERANCE:
-                sy_t = s.bbox_y
-                sy_b = s.bbox_y + s.bbox_h
-                if y_lo < sy_b and sy_t < y_hi:
-                    return True
-        return False
-
     for (lo, _row), bundles in by_gap.items():
-        # Stable left-to-right order: by current bundle centre.
-        bundles.sort(key=lambda b: sum(c.x for c in b[1]) / len(b[1]))
-        # Distinct-line count per bundle drives the bundle width and the
-        # per-line slotting: multiple segments sharing one line_id (a fan
-        # whose line feeds several targets) overlay at a single x rather
-        # than each claiming an OFFSET_STEP slot.
-        line_orders = [_distinct_line_order(c) for _, c in bundles]
-        # Skip a lone bundle carrying a single distinct line: nothing to
-        # re-bundle and centring risks disturbing wrap geometry.
-        if len(bundles) == 1 and len(line_orders[0]) <= 1:
-            continue
         gap_left, gap_right = gap_bounds[(lo, _row)]
-        widths = [max(0, len(o) - 1) * step for o in line_orders]
-        # A lone bundle centres on the true gap midpoint (symmetric
-        # clearance both sides) rather than flooring one edge at A, which
-        # would push the bundle off-centre when the gap is sized tighter
-        # than 2A + width.  Multi-bundle gaps keep the symmetric A/B
-        # layout from symmetric_bundle_midpoint.
-        lone = len(bundles) == 1
-        for bi, (down, chans) in enumerate(bundles):
-            order = line_orders[bi]
-            if lone:
-                mid = (gap_left + gap_right) / 2
-            else:
-                mid = symmetric_bundle_midpoint(gap_left, gap_right, widths, bi)
-            n = len(order)
-            # line_id -> (slot index, x); every segment of that line overlays
-            # at its single slot rather than claiming an OFFSET_STEP each.
-            line_slot = {
-                lid: (i, mid + (i - (n - 1) / 2) * step) for i, lid in enumerate(order)
-            }
-            targets = [(ch, line_slot[ch.route.line_id]) for ch in chans]
-            # Intrusion guard: if any target x would land inside a section
-            # bbox (e.g. the gap bounds came from another row), leave this
-            # bundle untouched rather than route through a section.
-            if any(_intrudes(nx, ch.y_lo, ch.y_hi) for ch, (_li, nx) in targets):
-                continue
-            for ch, (li, nx) in targets:
-                _restack_channel(ch, nx, li, n, step, ctx.curve_radius)
+        _layout_gap_bundle(bundles, gap_left, gap_right, ctx)
 
 
 @dataclass

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -16,7 +16,7 @@ from nf_metro.layout.routing.invariants import (
     distinct_offset_levels,
 )
 from nf_metro.layout.routing.reversal import detect_reversed_sections
-from nf_metro.parser.model import LineSpread, MetroGraph, PortSide, Section
+from nf_metro.parser.model import LineSpread, MetroGraph, PortSide, Section, Station
 
 # Tolerances used across offset phases
 _SAME_Y_TOLERANCE: float = SAME_Y_TOLERANCE
@@ -383,7 +383,14 @@ def _reorder_exit_only_lines(ctx: _OffsetCtx) -> None:
 
         for lid in exit_only:
             _reorder_one_exit_line(
-                ctx, same_y_adj, outbound_target, station, sid, lines, lid
+                ctx,
+                same_y_adj,
+                outbound_target,
+                station,
+                station.section_id,
+                sid,
+                lines,
+                lid,
             )
 
 
@@ -404,13 +411,13 @@ def _reorder_one_exit_line(
     same_y_adj: dict[str, dict[str, list[tuple[str, str]]]],
     outbound_target: dict[tuple[str, str], str],
     station: Station,
+    sec_id: str,
     sid: str,
     lines: list[str],
     lid: str,
 ) -> None:
     """Move one exit-only line to its crossing-free slot, propagating the swap."""
     graph = ctx.graph
-    sec_id = station.section_id
     target_id = outbound_target.get((sid, lid))
     if not target_id:
         return

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -16,7 +16,7 @@ from nf_metro.layout.routing.invariants import (
     distinct_offset_levels,
 )
 from nf_metro.layout.routing.reversal import detect_reversed_sections
-from nf_metro.parser.model import LineSpread, MetroGraph, PortSide
+from nf_metro.parser.model import LineSpread, MetroGraph, PortSide, Section
 
 # Tolerances used across offset phases
 _SAME_Y_TOLERANCE: float = SAME_Y_TOLERANCE
@@ -184,20 +184,9 @@ def _compute_base_offsets(ctx: _OffsetCtx) -> None:
                     ctx.offsets[(sid, lid)] = p * ctx.offset_step
 
 
-def _reindex_section_local(ctx: _OffsetCtx) -> None:
-    """Re-index offsets per-section to close priority gaps (non-compact only).
-
-    Lines absent from a section should not reserve offset slots within it.
-    Also applies reconvergence ordering: when multiple upstream sections
-    feed into one section, lines from the primary feeder keep their
-    relative offsets at the top.
-    """
-    if ctx.compact:
-        return
-
+def _reindex_local_priority_gaps(ctx: _OffsetCtx) -> dict[str, dict[str, int]]:
+    """Close priority gaps per-section, returning the section-local orderings."""
     graph = ctx.graph
-
-    # --- Section-local priority re-indexing ---
     section_local: dict[str, dict[str, int]] = {}
     for sec_id in graph.sections:
         present: set[str] = set()
@@ -225,29 +214,42 @@ def _reindex_section_local(ctx: _OffsetCtx) -> None:
                 ctx.offsets[(sid_s, lid)] = (local_max - p) * ctx.offset_step
             else:
                 ctx.offsets[(sid_s, lid)] = p * ctx.offset_step
+    return section_local
 
-    # --- Reconvergence ordering ---
+
+def _section_line_feeders(ctx: _OffsetCtx, section: Section) -> dict[str, str]:
+    """Map each entering line to the upstream section that feeds it."""
+    graph = ctx.graph
+    line_feeder: dict[str, str] = {}
+    for pid in section.entry_ports:
+        for edge in graph.edges_to(pid):
+            src = graph.stations.get(edge.source)
+            if not src:
+                continue
+            feeder_sec = None
+            if src.is_port:
+                feeder_sec = src.section_id
+            elif edge.source in graph.junctions:
+                for je in graph.edges_to(edge.source):
+                    if je.line_id == edge.line_id:
+                        js = graph.stations.get(je.source)
+                        if js and js.is_port:
+                            feeder_sec = js.section_id
+                            break
+            if feeder_sec is not None:
+                line_feeder[edge.line_id] = feeder_sec
+    return line_feeder
+
+
+def _reorder_reconvergence(
+    ctx: _OffsetCtx, section_local: dict[str, dict[str, int]]
+) -> None:
+    """Keep primary-feeder lines together at the top of each reconvergence section."""
+    graph = ctx.graph
     for sec_id, section in graph.sections.items():
         if not section.entry_ports:
             continue
-        line_feeder: dict[str, str] = {}
-        for pid in section.entry_ports:
-            for edge in graph.edges_to(pid):
-                src = graph.stations.get(edge.source)
-                if not src:
-                    continue
-                feeder_sec = None
-                if src.is_port:
-                    feeder_sec = src.section_id
-                elif edge.source in graph.junctions:
-                    for je in graph.edges_to(edge.source):
-                        if je.line_id == edge.line_id:
-                            js = graph.stations.get(je.source)
-                            if js and js.is_port:
-                                feeder_sec = js.section_id
-                                break
-                if feeder_sec is not None:
-                    line_feeder[edge.line_id] = feeder_sec
+        line_feeder = _section_line_feeders(ctx, section)
         if not line_feeder:
             continue
 
@@ -294,6 +296,20 @@ def _reindex_section_local(ctx: _OffsetCtx) -> None:
                     ctx.offsets[(sid_s, lid)] = (local_max - p) * ctx.offset_step
                 else:
                     ctx.offsets[(sid_s, lid)] = p * ctx.offset_step
+
+
+def _reindex_section_local(ctx: _OffsetCtx) -> None:
+    """Re-index offsets per-section to close priority gaps (non-compact only).
+
+    Lines absent from a section should not reserve offset slots within it.
+    Also applies reconvergence ordering: when multiple upstream sections
+    feed into one section, lines from the primary feeder keep their
+    relative offsets at the top.
+    """
+    if ctx.compact:
+        return
+    section_local = _reindex_local_priority_gaps(ctx)
+    _reorder_reconvergence(ctx, section_local)
 
 
 def _entry_fed_in_section(graph: MetroGraph, sid: str, lid: str, sec_id: str) -> bool:
@@ -360,127 +376,156 @@ def _reorder_exit_only_lines(ctx: _OffsetCtx) -> None:
         if len(lines) < 2:
             continue
 
-        sec_id = station.section_id
-
         # Find lines that originate at this station (no inbound edge)
         exit_only = [lid for lid in lines if lid not in ctx.inbound.get(sid, set())]
         if not exit_only:
             continue
 
         for lid in exit_only:
-            target_id = outbound_target.get((sid, lid))
-            if not target_id:
+            _reorder_one_exit_line(
+                ctx, same_y_adj, outbound_target, station, sid, lines, lid
+            )
+
+
+def _desired_exit_slot(
+    ctx: _OffsetCtx, station: Station, target_st: Station, lines: list[str], sid: str
+) -> float | None:
+    """Top slot when the exit port is above, bottom when below, else None."""
+    all_offs = [ctx.offsets.get((sid, ol), 0.0) for ol in lines]
+    if target_st.y < station.y - _SAME_Y_TOLERANCE:
+        return min(all_offs)
+    if target_st.y > station.y + _SAME_Y_TOLERANCE:
+        return max(all_offs)
+    return None
+
+
+def _reorder_one_exit_line(
+    ctx: _OffsetCtx,
+    same_y_adj: dict[str, dict[str, list[tuple[str, str]]]],
+    outbound_target: dict[tuple[str, str], str],
+    station: Station,
+    sid: str,
+    lines: list[str],
+    lid: str,
+) -> None:
+    """Move one exit-only line to its crossing-free slot, propagating the swap."""
+    graph = ctx.graph
+    sec_id = station.section_id
+    target_id = outbound_target.get((sid, lid))
+    if not target_id:
+        return
+    target_st = graph.stations.get(target_id)
+    if not target_st:
+        return
+
+    # Only act when the target is an exit port
+    target_port = graph.ports.get(target_id)
+    if not target_port or target_port.is_entry:
+        return
+
+    cur_off = ctx.offsets.get((sid, lid), 0.0)
+    desired_off = _desired_exit_slot(ctx, station, target_st, lines, sid)
+    if desired_off is None:
+        return
+    if abs(cur_off - desired_off) < _OFFSET_EQ_TOLERANCE:
+        return  # already in the right slot
+
+    # Find which line currently occupies the desired slot
+    swap_lid = None
+    for other in lines:
+        if (
+            other != lid
+            and abs(ctx.offsets.get((sid, other), 0.0) - desired_off)
+            < _OFFSET_EQ_TOLERANCE
+        ):
+            swap_lid = other
+            break
+    if swap_lid is None:
+        return
+
+    # Don't displace the continuing through-trunk when the exit-only line
+    # co-travels with it to the *same* exit port: the reorder then prevents
+    # no crossing (both leave together) but steps the trunk's offset mid-run,
+    # slanting its junction-to-entry segment downstream (#420).  When the two
+    # diverge to different targets the swap is genuinely separating them and
+    # must stand (#125).
+    if outbound_target.get((sid, swap_lid)) == target_id and _entry_fed_in_section(
+        graph, sid, swap_lid, sec_id
+    ):
+        return
+
+    _propagate_offset_swap(
+        ctx, same_y_adj, sec_id, sid, lid, swap_lid, desired_off, cur_off
+    )
+
+
+def _propagate_offset_swap(
+    ctx: _OffsetCtx,
+    same_y_adj: dict[str, dict[str, list[tuple[str, str]]]],
+    sec_id: str,
+    sid: str,
+    lid: str,
+    swap_lid: str,
+    desired_off: float,
+    cur_off: float,
+) -> None:
+    """Apply an offset swap and propagate it along same-Y edges in the section."""
+    graph = ctx.graph
+    pending: dict[str, dict[str, float]] = {sid: {lid: desired_off, swap_lid: cur_off}}
+
+    visited: set[tuple[str, str]] = set()
+    queue: deque[tuple[str, str, float]] = deque(
+        [
+            (sid, lid, desired_off),
+            (sid, swap_lid, cur_off),
+        ]
+    )
+    max_steps = len(graph.stations) * len(graph.lines)
+
+    while queue and max_steps > 0:
+        max_steps -= 1
+        cur_sid, cur_lid, new_off = queue.popleft()
+        if (cur_sid, cur_lid) in visited:
+            continue
+        visited.add((cur_sid, cur_lid))
+
+        adj = same_y_adj.get(sec_id, {}).get(cur_sid, [])
+        for nbr_sid, edge_lid in adj:
+            if edge_lid != cur_lid:
+                continue
+            if (nbr_sid, cur_lid) in visited:
                 continue
 
-            target_st = graph.stations.get(target_id)
-            if not target_st:
+            nbr_cur = ctx.offsets.get((nbr_sid, cur_lid), 0.0)
+            if abs(nbr_cur - new_off) < _OFFSET_EQ_TOLERANCE:
+                continue  # already matches
+
+            nbr_lines = graph.station_lines(nbr_sid)
+            pending.setdefault(nbr_sid, {})[cur_lid] = new_off
+            queue.append((nbr_sid, cur_lid, new_off))
+
+            if len(nbr_lines) < 2:
                 continue
 
-            # Only act when the target is an exit port
-            target_port = graph.ports.get(target_id)
-            if not target_port or target_port.is_entry:
-                continue
-
-            cur_off = ctx.offsets.get((sid, lid), 0.0)
-            all_offs = [ctx.offsets.get((sid, ol), 0.0) for ol in lines]
-            min_off = min(all_offs)
-            max_off = max(all_offs)
-
-            # Determine desired slot based on exit direction
-            if target_st.y < station.y - _SAME_Y_TOLERANCE:
-                desired_off = min_off  # above -> top slot
-            elif target_st.y > station.y + _SAME_Y_TOLERANCE:
-                desired_off = max_off  # below -> bottom slot
-            else:
-                continue
-
-            if abs(cur_off - desired_off) < _OFFSET_EQ_TOLERANCE:
-                continue  # already in the right slot
-
-            # Find which line currently occupies the desired slot
-            swap_lid = None
-            for other in lines:
+            # Multi-line station: check for collision and swap
+            for other_lid in nbr_lines:
+                if other_lid == cur_lid:
+                    continue
                 if (
-                    other != lid
-                    and abs(ctx.offsets.get((sid, other), 0.0) - desired_off)
+                    abs(ctx.offsets.get((nbr_sid, other_lid), 0.0) - new_off)
                     < _OFFSET_EQ_TOLERANCE
                 ):
-                    swap_lid = other
+                    pending[nbr_sid][other_lid] = nbr_cur
+                    queue.append((nbr_sid, other_lid, nbr_cur))
                     break
-            if swap_lid is None:
-                continue
 
-            # Don't displace the continuing through-trunk when the
-            # exit-only line co-travels with it to the *same* exit port:
-            # the reorder then prevents no crossing (both leave together)
-            # but steps the trunk's offset mid-run, slanting its
-            # junction-to-entry segment downstream (#420).  When the two
-            # diverge to different targets the swap is genuinely separating
-            # them and must stand (#125).
-            if outbound_target.get(
-                (sid, swap_lid)
-            ) == target_id and _entry_fed_in_section(graph, sid, swap_lid, sec_id):
-                continue
+    if max_steps <= 0:
+        return
 
-            # Prepare swap: lid -> desired_off, swap_lid -> cur_off
-            pending: dict[str, dict[str, float]] = {
-                sid: {lid: desired_off, swap_lid: cur_off}
-            }
-
-            # Propagate along same-Y edges within the section
-            visited: set[tuple[str, str]] = set()
-            queue: deque[tuple[str, str, float]] = deque(
-                [
-                    (sid, lid, desired_off),
-                    (sid, swap_lid, cur_off),
-                ]
-            )
-            max_steps = len(graph.stations) * len(graph.lines)
-
-            while queue and max_steps > 0:
-                max_steps -= 1
-                cur_sid, cur_lid, new_off = queue.popleft()
-                if (cur_sid, cur_lid) in visited:
-                    continue
-                visited.add((cur_sid, cur_lid))
-
-                adj = same_y_adj.get(sec_id, {}).get(cur_sid, [])
-                for nbr_sid, edge_lid in adj:
-                    if edge_lid != cur_lid:
-                        continue
-                    if (nbr_sid, cur_lid) in visited:
-                        continue
-
-                    nbr_cur = ctx.offsets.get((nbr_sid, cur_lid), 0.0)
-                    if abs(nbr_cur - new_off) < _OFFSET_EQ_TOLERANCE:
-                        continue  # already matches
-
-                    nbr_lines = graph.station_lines(nbr_sid)
-                    pending.setdefault(nbr_sid, {})[cur_lid] = new_off
-                    queue.append((nbr_sid, cur_lid, new_off))
-
-                    if len(nbr_lines) < 2:
-                        continue
-
-                    # Multi-line station: check for collision and swap
-                    for other_lid in nbr_lines:
-                        if other_lid == cur_lid:
-                            continue
-                        if (
-                            abs(ctx.offsets.get((nbr_sid, other_lid), 0.0) - new_off)
-                            < _OFFSET_EQ_TOLERANCE
-                        ):
-                            pending[nbr_sid][other_lid] = nbr_cur
-                            queue.append((nbr_sid, other_lid, nbr_cur))
-                            break
-
-            if max_steps <= 0:
-                continue
-
-            # Apply all pending changes
-            for s_id, line_offsets in pending.items():
-                for lid, off in line_offsets.items():
-                    ctx.offsets[(s_id, lid)] = off
+    # Apply all pending changes
+    for s_id, line_offsets in pending.items():
+        for lid_, off in line_offsets.items():
+            ctx.offsets[(s_id, lid_)] = off
 
 
 def _apply_compact_section_consistency(ctx: _OffsetCtx) -> None:
@@ -664,20 +709,9 @@ def _propagate_to_junctions(ctx: _OffsetCtx) -> None:
                 break
 
 
-def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
-    """Compute entry port offsets and propagate to downstream stations.
-
-    Handles three cases:
-    1. TOP entry ports fed by TB BOTTOM exits: match the reversed offset
-       scheme used by inter-section routing.
-    2. LEFT/RIGHT entry ports fed by a single LR/RL exit: propagate
-       spatial ordering to prevent bundle crossings.
-    3. Compact mode: ensure multi-line entry ports have separated offsets
-       and propagate to upstream exit ports.
-    """
+def _entry_top_from_tb_bottom_exits(ctx: _OffsetCtx) -> None:
+    """Match TOP entry ports to the reversed offsets of feeding TB BOTTOM exits."""
     graph = ctx.graph
-
-    # --- TOP entry ports fed by TB BOTTOM exits ---
     tb_right_entry: set[str] = set()
     for port_obj in graph.ports.values():
         if (
@@ -719,7 +753,10 @@ def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
                     ctx.offsets[(port_id, lid)] = max_exit_off - exit_off
             break
 
-    # --- LR/RL exit-to-entry port propagation ---
+
+def _propagate_lr_rl_exit_to_entry(ctx: _OffsetCtx) -> None:
+    """Propagate single LR/RL exit-port offsets onto fed LEFT/RIGHT entry ports."""
+    graph = ctx.graph
     for port_id, port_obj in graph.ports.items():
         if not port_obj.is_entry:
             continue
@@ -759,39 +796,58 @@ def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
                         for lid in overlap:
                             ctx.offsets[(e2.target, lid)] = entry_offs[lid]
 
-    # --- Compact entry port offset separation ---
-    if ctx.compact:
-        for sec_id, section in graph.sections.items():
-            compact_entry_lines: list[str] = []
+
+def _separate_compact_entry_offsets(ctx: _OffsetCtx) -> None:
+    """Give multi-line entry ports separated offsets and feed them upstream."""
+    graph = ctx.graph
+    for sec_id, section in graph.sections.items():
+        compact_entry_lines: list[str] = []
+        for pid in section.entry_ports:
+            compact_entry_lines.extend(graph.station_lines(pid))
+        unique = sorted(
+            set(compact_entry_lines), key=lambda x: ctx.line_priority.get(x, 0)
+        )
+        if len(unique) < 2:
+            continue
+        existing = [
+            ctx.offsets.get((pid, lid), 0.0)
+            for pid in section.entry_ports
+            for lid in unique
+            if lid in graph.station_lines(pid)
+        ]
+        if len(set(existing)) >= 2:
+            continue
+        sec_reverse = sec_id in ctx.reversed_sections
+        for i, lid in enumerate(unique):
+            if sec_reverse:
+                off = (len(unique) - 1 - i) * ctx.offset_step
+            else:
+                off = i * ctx.offset_step
             for pid in section.entry_ports:
-                compact_entry_lines.extend(graph.station_lines(pid))
-            unique = sorted(
-                set(compact_entry_lines), key=lambda x: ctx.line_priority.get(x, 0)
-            )
-            if len(unique) < 2:
-                continue
-            existing = [
-                ctx.offsets.get((pid, lid), 0.0)
-                for pid in section.entry_ports
-                for lid in unique
-                if lid in graph.station_lines(pid)
-            ]
-            if len(set(existing)) >= 2:
-                continue
-            sec_reverse = sec_id in ctx.reversed_sections
-            for i, lid in enumerate(unique):
-                if sec_reverse:
-                    off = (len(unique) - 1 - i) * ctx.offset_step
-                else:
-                    off = i * ctx.offset_step
-                for pid in section.entry_ports:
-                    if lid in graph.station_lines(pid):
-                        ctx.offsets[(pid, lid)] = off
-                        for edge in graph.edges_to(pid):
-                            if edge.line_id == lid:
-                                src_port = graph.ports.get(edge.source)
-                                if src_port and not src_port.is_entry:
-                                    ctx.offsets[(edge.source, lid)] = off
+                if lid in graph.station_lines(pid):
+                    ctx.offsets[(pid, lid)] = off
+                    for edge in graph.edges_to(pid):
+                        if edge.line_id == lid:
+                            src_port = graph.ports.get(edge.source)
+                            if src_port and not src_port.is_entry:
+                                ctx.offsets[(edge.source, lid)] = off
+
+
+def _compute_entry_port_offsets(ctx: _OffsetCtx) -> None:
+    """Compute entry port offsets and propagate to downstream stations.
+
+    Handles three cases:
+    1. TOP entry ports fed by TB BOTTOM exits: match the reversed offset
+       scheme used by inter-section routing.
+    2. LEFT/RIGHT entry ports fed by a single LR/RL exit: propagate
+       spatial ordering to prevent bundle crossings.
+    3. Compact mode: ensure multi-line entry ports have separated offsets
+       and propagate to upstream exit ports.
+    """
+    _entry_top_from_tb_bottom_exits(ctx)
+    _propagate_lr_rl_exit_to_entry(ctx)
+    if ctx.compact:
+        _separate_compact_entry_offsets(ctx)
 
 
 def _compact_station_gaps(ctx: _OffsetCtx) -> None:
@@ -839,119 +895,174 @@ def _compact_station_gaps(ctx: _OffsetCtx) -> None:
         for seed_sid in sec_stations:
             if seed_sid in already_compacted:
                 continue
-            seed_lines = graph.station_lines(seed_sid)
-            if len(seed_lines) < 2:
-                continue
-
-            current = {lid: ctx.offsets.get((seed_sid, lid), 0.0) for lid in seed_lines}
-            sorted_by_off = sorted(current.items(), key=lambda x: x[1])
-            base_off = sorted_by_off[0][1]
-            expected = [
-                base_off + i * ctx.offset_step for i in range(len(sorted_by_off))
-            ]
-            actual = [off for _, off in sorted_by_off]
-            if actual == expected:
-                continue
-
-            compacted: dict[str, float] = {}
-            for i, (lid, _) in enumerate(sorted_by_off):
-                compacted[lid] = base_off + i * ctx.offset_step
-
-            changed_lids = {
-                lid
-                for lid in seed_lines
-                if abs(compacted[lid] - current[lid]) > _OFFSET_EQ_TOLERANCE
-            }
-            if not changed_lids:
-                continue
-
-            # BFS to collect all stations needing consistent updates.
-            # Map: station_id -> {line_id: new_offset}
-            pending: dict[str, dict[str, float]] = {seed_sid: compacted}
-            visited: set[tuple[str, str]] = set()
-            queue: deque[tuple[str, str]] = deque(
-                (seed_sid, lid) for lid in changed_lids
+            already_compacted |= _compact_one_seed(
+                ctx, same_y_adj, sec_layer_stations, sec_id, seed_sid, len(sec_stations)
             )
-            safe = True
-            max_steps = len(sec_stations) * len(graph.lines)
 
-            while queue and safe and max_steps > 0:
-                max_steps -= 1
-                cur_sid, lid = queue.popleft()
-                if (cur_sid, lid) in visited:
-                    continue
-                visited.add((cur_sid, lid))
 
-                new_off = pending[cur_sid][lid]
+def _seed_compaction(ctx: _OffsetCtx, seed_sid: str) -> dict[str, float] | None:
+    """Target offsets that pack the seed's lines into consecutive slots, or None."""
+    seed_lines = ctx.graph.station_lines(seed_sid)
+    if len(seed_lines) < 2:
+        return None
 
-                adj = same_y_adj.get(sec_id, {}).get(cur_sid, [])
-                for nbr_sid, edge_lid in adj:
-                    if edge_lid != lid:
-                        continue
-                    if (nbr_sid, lid) in visited:
-                        continue
+    current = {lid: ctx.offsets.get((seed_sid, lid), 0.0) for lid in seed_lines}
+    sorted_by_off = sorted(current.items(), key=lambda x: x[1])
+    base_off = sorted_by_off[0][1]
+    expected = [base_off + i * ctx.offset_step for i in range(len(sorted_by_off))]
+    if [off for _, off in sorted_by_off] == expected:
+        return None
 
-                    # Read pending value if a prior BFS step already
-                    # scheduled a change, otherwise use current offset.
-                    nbr_cur = pending.get(nbr_sid, {}).get(
-                        lid, ctx.offsets.get((nbr_sid, lid), 0.0)
-                    )
-                    if abs(nbr_cur - new_off) < _OFFSET_EQ_TOLERANCE:
-                        continue
+    compacted = {
+        lid: base_off + i * ctx.offset_step for i, (lid, _) in enumerate(sorted_by_off)
+    }
+    if not any(
+        abs(compacted[lid] - current[lid]) > _OFFSET_EQ_TOLERANCE for lid in seed_lines
+    ):
+        return None
+    return compacted
 
-                    nbr_lines = graph.station_lines(nbr_sid)
 
-                    # Bail if a visible same-layer peer also carries
-                    # this line - compaction can't guarantee consistency
-                    # without cascading into unrelated stations.
-                    nbr_st = graph.stations[nbr_sid]
-                    layer_peers = sec_layer_stations.get(sec_id, {}).get(
-                        nbr_st.layer, []
-                    )
-                    for peer_sid in layer_peers:
-                        if peer_sid == nbr_sid:
-                            continue
-                        if graph.stations[peer_sid].is_hidden:
-                            continue
-                        if lid in graph.station_lines(peer_sid):
-                            safe = False
-                            break
-                    if not safe:
-                        break
+def _compact_one_seed(
+    ctx: _OffsetCtx,
+    same_y_adj: dict[str, dict[str, list[tuple[str, str]]]],
+    sec_layer_stations: dict[str, dict[int, list[str]]],
+    sec_id: str,
+    seed_sid: str,
+    n_sec_stations: int,
+) -> set[str]:
+    """Compact one seed station's gaps, returning the stations it touched."""
+    graph = ctx.graph
+    compacted = _seed_compaction(ctx, seed_sid)
+    if compacted is None:
+        return set()
+    changed_lids = {
+        lid
+        for lid in graph.station_lines(seed_sid)
+        if abs(compacted[lid] - ctx.offsets.get((seed_sid, lid), 0.0))
+        > _OFFSET_EQ_TOLERANCE
+    }
 
-                    if len(nbr_lines) == 1:
-                        pending.setdefault(nbr_sid, {})[lid] = new_off
-                        queue.append((nbr_sid, lid))
-                        continue
+    pending = _propagate_compaction(
+        ctx,
+        same_y_adj,
+        sec_layer_stations,
+        sec_id,
+        seed_sid,
+        compacted,
+        changed_lids,
+        n_sec_stations,
+    )
+    if pending is None:
+        return set()
 
-                    # Check for collision with another line's offset
-                    collision_lid = None
-                    for other_lid in nbr_lines:
-                        if other_lid == lid:
-                            continue
-                        other_off = pending.get(nbr_sid, {}).get(
-                            other_lid,
-                            ctx.offsets.get((nbr_sid, other_lid), 0.0),
-                        )
-                        if abs(other_off - new_off) < _OFFSET_EQ_TOLERANCE:
-                            collision_lid = other_lid
-                            break
+    for sid, line_offsets in pending.items():
+        for lid, off in line_offsets.items():
+            ctx.offsets[(sid, lid)] = off
+    return set(pending)
 
-                    nbr_pending = pending.setdefault(nbr_sid, {})
-                    nbr_pending[lid] = new_off
-                    queue.append((nbr_sid, lid))
-                    if collision_lid is not None:
-                        # Swap: move collider to the slot we're vacating
-                        nbr_pending[collision_lid] = nbr_cur
-                        queue.append((nbr_sid, collision_lid))
 
-            if not safe or max_steps <= 0:
+def _compaction_peer_conflict(
+    graph: MetroGraph,
+    sec_layer_stations: dict[str, dict[int, list[str]]],
+    sec_id: str,
+    nbr_sid: str,
+    lid: str,
+) -> bool:
+    """True if a visible same-layer peer also carries this line.
+
+    Compaction can't guarantee consistency in that case without cascading
+    into unrelated stations, so propagation must abort.
+    """
+    nbr_st = graph.stations[nbr_sid]
+    layer_peers = sec_layer_stations.get(sec_id, {}).get(nbr_st.layer, [])
+    for peer_sid in layer_peers:
+        if peer_sid == nbr_sid:
+            continue
+        if graph.stations[peer_sid].is_hidden:
+            continue
+        if lid in graph.station_lines(peer_sid):
+            return True
+    return False
+
+
+def _propagate_compaction(
+    ctx: _OffsetCtx,
+    same_y_adj: dict[str, dict[str, list[tuple[str, str]]]],
+    sec_layer_stations: dict[str, dict[int, list[str]]],
+    sec_id: str,
+    seed_sid: str,
+    compacted: dict[str, float],
+    changed_lids: set[str],
+    n_sec_stations: int,
+) -> dict[str, dict[str, float]] | None:
+    """BFS the compaction along same-Y edges; return updates, or None if unsafe."""
+    graph = ctx.graph
+    # Map: station_id -> {line_id: new_offset}
+    pending: dict[str, dict[str, float]] = {seed_sid: compacted}
+    visited: set[tuple[str, str]] = set()
+    queue: deque[tuple[str, str]] = deque((seed_sid, lid) for lid in changed_lids)
+    max_steps = n_sec_stations * len(graph.lines)
+
+    while queue and max_steps > 0:
+        max_steps -= 1
+        cur_sid, lid = queue.popleft()
+        if (cur_sid, lid) in visited:
+            continue
+        visited.add((cur_sid, lid))
+
+        new_off = pending[cur_sid][lid]
+
+        adj = same_y_adj.get(sec_id, {}).get(cur_sid, [])
+        for nbr_sid, edge_lid in adj:
+            if edge_lid != lid:
+                continue
+            if (nbr_sid, lid) in visited:
                 continue
 
-            for sid, line_offsets in pending.items():
-                for lid, off in line_offsets.items():
-                    ctx.offsets[(sid, lid)] = off
-                already_compacted.add(sid)
+            # Read pending value if a prior BFS step already scheduled a
+            # change, otherwise use current offset.
+            nbr_cur = pending.get(nbr_sid, {}).get(
+                lid, ctx.offsets.get((nbr_sid, lid), 0.0)
+            )
+            if abs(nbr_cur - new_off) < _OFFSET_EQ_TOLERANCE:
+                continue
+
+            if _compaction_peer_conflict(
+                graph, sec_layer_stations, sec_id, nbr_sid, lid
+            ):
+                return None
+
+            nbr_lines = graph.station_lines(nbr_sid)
+            if len(nbr_lines) == 1:
+                pending.setdefault(nbr_sid, {})[lid] = new_off
+                queue.append((nbr_sid, lid))
+                continue
+
+            # Check for collision with another line's offset
+            collision_lid = None
+            for other_lid in nbr_lines:
+                if other_lid == lid:
+                    continue
+                other_off = pending.get(nbr_sid, {}).get(
+                    other_lid,
+                    ctx.offsets.get((nbr_sid, other_lid), 0.0),
+                )
+                if abs(other_off - new_off) < _OFFSET_EQ_TOLERANCE:
+                    collision_lid = other_lid
+                    break
+
+            nbr_pending = pending.setdefault(nbr_sid, {})
+            nbr_pending[lid] = new_off
+            queue.append((nbr_sid, lid))
+            if collision_lid is not None:
+                # Swap: move collider to the slot we're vacating
+                nbr_pending[collision_lid] = nbr_cur
+                queue.append((nbr_sid, collision_lid))
+
+    if max_steps <= 0:
+        return None
+    return pending
 
 
 def _same_section(graph: MetroGraph, id_a: str, id_b: str) -> bool:

--- a/src/nf_metro/layout/routing/postprocess.py
+++ b/src/nf_metro/layout/routing/postprocess.py
@@ -25,6 +25,7 @@ from nf_metro.layout.routing.context import (
 )
 from nf_metro.parser.model import (
     MetroGraph,
+    Station,
 )
 
 
@@ -223,206 +224,246 @@ _StationMoveCandidate = tuple[
 ]
 
 
+def _is_internal_station(graph: MetroGraph, sid: str) -> bool:
+    """A visible, non-port internal station."""
+    st = graph.stations.get(sid)
+    return st is not None and not st.is_port and not st.is_hidden
+
+
+def _is_chain_predecessor(graph: MetroGraph, ctx: _BubbleCtx, sid: str) -> bool:
+    """Internal upstream station that acts as a flat-chain predecessor.
+
+    When a station being considered for centring has a flat-side connection
+    coming FROM ``sid``, this predicate decides whether ``sid`` should block
+    centring.  Normal internal stations do block it.  A true fan-out
+    divergence hub (matching ``engine._divergence_target_ys``: >= 2 outbound
+    real-station targets at distinct Ys, with at least one above and one below
+    the hub's own Y) is exempt: its flat-side connection to one branch is
+    incidental (induced by grid snapping the hub onto that branch's track), not
+    a topological chain.  Without this exemption the branch's column would fail
+    to centre.
+
+    Exemption applies only to the upstream/source side of a flat connection.
+    Downstream chain predecessors (an anchor sitting as the target of a flat
+    connection from the station being centred) reflect a natural same-Y chain,
+    not a snap artefact, and are still treated as chain-internal.
+    """
+    if not _is_internal_station(graph, sid):
+        return False
+    return sid not in ctx.divergence_anchors
+
+
+def _classify_centering_routes(
+    ctx: _BubbleCtx,
+    sid: str,
+    in_routes: list[RoutedPath],
+    out_routes: list[RoutedPath],
+    flat_in: list[RoutedPath],
+    flat_out: list[RoutedPath],
+) -> (
+    tuple[
+        RoutedPath | None, RoutedPath | None, RoutedPath | None, RoutedPath | None, bool
+    ]
+    | None
+):
+    """Pick the routes bounding the flat segment, or None if not centerable.
+
+    Returns ``(in_rp, out_rp, flat_in_rp, flat_out_rp, multi_diag)``.
+    """
+    is_fork_join = (
+        len(ctx.all_targets.get(sid, set())) > 1
+        or len(ctx.all_sources.get(sid, set())) > 1
+    )
+
+    in_rp = None
+    out_rp = None
+    flat_in_rp = None
+    flat_out_rp = None
+
+    # Count physically distinct edges (unique source-target pairs).
+    n_unique_in = len(set((rp.edge.source, rp.edge.target) for rp in in_routes))
+    n_unique_out = len(set((rp.edge.source, rp.edge.target) for rp in out_routes))
+    n_unique_flat_in = len(set((rp.edge.source, rp.edge.target) for rp in flat_in))
+    n_unique_flat_out = len(set((rp.edge.source, rp.edge.target) for rp in flat_out))
+
+    multi_diag = False
+    if not is_fork_join and (
+        (n_unique_in + n_unique_flat_in) >= 1
+        and n_unique_out >= 1
+        and (
+            n_unique_in > 1
+            or n_unique_out > 1
+            or (n_unique_in >= 1 and n_unique_flat_in >= 1)
+        )
+    ):
+        in_rp = in_routes[0] if in_routes else None
+        flat_in_rp = flat_in[0] if (not in_routes and flat_in) else None
+        out_rp = out_routes[0]
+        multi_diag = True
+    elif is_fork_join:
+        return None
+    elif n_unique_in == 1 and n_unique_out == 1:
+        in_rp = in_routes[0]
+        out_rp = out_routes[0]
+    elif n_unique_in == 0 and n_unique_flat_in == 1 and n_unique_out == 1:
+        flat_in_rp = flat_in[0]
+        out_rp = out_routes[0]
+    elif n_unique_in == 1 and n_unique_out == 0 and n_unique_flat_out == 1:
+        in_rp = in_routes[0]
+        flat_out_rp = flat_out[0]
+    else:
+        return None
+    return in_rp, out_rp, flat_in_rp, flat_out_rp, multi_diag
+
+
+def _flat_connects_to_internal_chain(
+    graph: MetroGraph,
+    ctx: _BubbleCtx,
+    multi_diag: bool,
+    flat_in_rp: RoutedPath | None,
+    flat_out_rp: RoutedPath | None,
+    flat_in: list[RoutedPath],
+    flat_out: list[RoutedPath],
+) -> bool:
+    """True when a flat connection ties the station into an internal chain.
+
+    Upstream sources may be fork-hub-exempted (a snap-induced flat from a true
+    divergence anchor does not represent a real chain).  Downstream targets are
+    checked strictly: a same-Y predecessor->successor pair on a downstream
+    internal station is a natural chain regardless of whether the successor
+    happens to be a divergence anchor.
+    """
+    if flat_in_rp and _is_chain_predecessor(graph, ctx, flat_in_rp.edge.source):
+        return True
+    if flat_out_rp and _is_internal_station(graph, flat_out_rp.edge.target):
+        return True
+    if multi_diag:
+        if any(_is_chain_predecessor(graph, ctx, r.edge.source) for r in flat_in):
+            return True
+        if any(_is_internal_station(graph, r.edge.target) for r in flat_out):
+            return True
+    return False
+
+
+def _centering_candidate(
+    graph: MetroGraph, ctx: _BubbleCtx, sid: str, station: Station
+) -> _StationMoveCandidate | None:
+    """Centre one station's diagonals in place, or return a move candidate.
+
+    Simple single-diagonal-per-side cases shift both diagonals to equalise the
+    flat runs and return None.  Complex cases (shared bundles, flat+diagonal
+    mixes) return a station-move candidate for the second pass.
+    """
+    in_routes = ctx.incoming.get(sid, [])
+    out_routes = ctx.outgoing.get(sid, [])
+    flat_in = ctx.flat_incoming.get(sid, [])
+    flat_out = ctx.flat_outgoing.get(sid, [])
+
+    classified = _classify_centering_routes(
+        ctx, sid, in_routes, out_routes, flat_in, flat_out
+    )
+    if classified is None:
+        return None
+    in_rp, out_rp, flat_in_rp, flat_out_rp, multi_diag = classified
+
+    # Check bundle convergence/divergence at neighbours.
+    shared_source = False
+    shared_target = False
+    if out_rp:
+        out_tgt = graph.stations.get(out_rp.edge.target)
+        if len(ctx.diag_in_sources.get(out_rp.edge.target, set())) > 1 and not (
+            out_tgt and out_tgt.is_port
+        ):
+            shared_target = True
+    if in_rp:
+        in_src = graph.stations.get(in_rp.edge.source)
+        if len(ctx.diag_out_targets.get(in_rp.edge.source, set())) > 1 and not (
+            in_src and in_src.is_port
+        ):
+            shared_source = True
+
+    # Determine X extent of the flat segment at station Y.
+    if multi_diag:
+        in_xs = [r.points[2][0] for r in in_routes]
+        in_xs += [r.points[0][0] for r in flat_in]
+        out_xs = [r.points[1][0] for r in out_routes]
+        in_diag_end_x = max(in_xs) if in_xs else station.x
+        out_diag_start_x = min(out_xs) if out_xs else station.x
+    elif in_rp:
+        in_diag_end_x = in_rp.points[2][0]
+    else:
+        assert flat_in_rp is not None
+        in_diag_end_x = flat_in_rp.points[0][0]
+
+    if not multi_diag:
+        if out_rp:
+            out_diag_start_x = out_rp.points[1][0]
+        else:
+            assert flat_out_rp is not None
+            out_diag_start_x = flat_out_rp.points[-1][0]
+
+    in_flat = station.x - in_diag_end_x
+    out_flat = out_diag_start_x - station.x
+
+    if abs(in_flat) < 1 or abs(out_flat) < 1:
+        return None
+    if abs(in_flat - out_flat) < 1:
+        return None
+
+    has_flat_side = flat_in_rp is not None or flat_out_rp is not None
+
+    if (has_flat_side or multi_diag) and _flat_connects_to_internal_chain(
+        graph, ctx, multi_diag, flat_in_rp, flat_out_rp, flat_in, flat_out
+    ):
+        return None
+
+    if shared_source or shared_target or has_flat_side or multi_diag:
+        new_x = (in_diag_end_x + out_diag_start_x) / 2
+        return (new_x, in_routes, flat_in, out_routes, flat_out)
+
+    # Simple case: shift both diagonals to equalise the flats.
+    shift = (in_flat - out_flat) / 2
+
+    if abs(shift) > min(abs(in_flat), abs(out_flat)):
+        return None
+
+    # Guard: don't shift in convergence/divergence bundles.  Bypass V
+    # helpers have no marker so the convergence-guard doesn't apply.
+    is_bypass_v = sid.startswith("__bypass_")
+    if not is_bypass_v:
+        if out_rp and len(ctx.diag_in_sources.get(out_rp.edge.target, set())) > 1:
+            return None
+        if in_rp and len(ctx.diag_out_targets.get(in_rp.edge.source, set())) > 1:
+            return None
+
+    for rp in in_routes:
+        rp.points[1] = (rp.points[1][0] + shift, rp.points[1][1])
+        rp.points[2] = (rp.points[2][0] + shift, rp.points[2][1])
+    for rp in out_routes:
+        rp.points[1] = (rp.points[1][0] + shift, rp.points[1][1])
+        rp.points[2] = (rp.points[2][0] + shift, rp.points[2][1])
+    return None
+
+
 def _collect_centering_candidates(
     graph: MetroGraph, ctx: _BubbleCtx
 ) -> dict[str, _StationMoveCandidate]:
     """First pass: shift simple diagonals and collect station-move candidates.
 
-    For stations with a single diagonal on each side and no bundle
-    conflicts, shifts both diagonals to equalise the flat runs.
-    For more complex cases (shared bundles, flat+diagonal mixes),
-    collects a station-move candidate for the second pass.
+    For stations with a single diagonal on each side and no bundle conflicts,
+    shifts both diagonals to equalise the flat runs.  For more complex cases
+    (shared bundles, flat+diagonal mixes), collects a station-move candidate
+    for the second pass.
     """
     station_move_candidates: dict[str, _StationMoveCandidate] = {}
-
-    def _is_internal(sid: str) -> bool:
-        st = graph.stations.get(sid)
-        return st is not None and not st.is_port and not st.is_hidden
-
-    def _is_chain_predecessor(sid: str) -> bool:
-        """Internal upstream station that acts as a flat-chain predecessor.
-
-        When a station being considered for centring has a flat-side
-        connection coming FROM ``sid``, this predicate decides whether
-        ``sid`` should block centring.  Normal internal stations do
-        block it.  A true fan-out divergence hub (matching
-        ``engine._divergence_target_ys``: >= 2 outbound real-station
-        targets at distinct Ys, with at least one above and one below
-        the hub's own Y) is exempt: its flat-side connection to one
-        branch is incidental (induced by grid snapping the hub onto
-        that branch's track), not a topological chain.  Without this
-        exemption the branch's column would fail to centre.
-
-        Exemption applies only to the upstream/source side of a flat
-        connection.  Downstream chain predecessors (an anchor sitting
-        as the target of a flat connection from the station being
-        centred) reflect a natural same-Y chain, not a snap artefact,
-        and are still treated as chain-internal.
-        """
-        if not _is_internal(sid):
-            return False
-        return sid not in ctx.divergence_anchors
-
     for sid, station in graph.stations.items():
         if station.is_port:
             continue
         if station.is_hidden and not sid.startswith("__bypass_"):
             continue
-
-        in_routes = ctx.incoming.get(sid, [])
-        out_routes = ctx.outgoing.get(sid, [])
-        flat_in = ctx.flat_incoming.get(sid, [])
-        flat_out = ctx.flat_outgoing.get(sid, [])
-
-        is_fork_join = (
-            len(ctx.all_targets.get(sid, set())) > 1
-            or len(ctx.all_sources.get(sid, set())) > 1
-        )
-
-        # Determine which routes bound the station's flat segment.
-        in_rp = None
-        out_rp = None
-        flat_in_rp = None
-        flat_out_rp = None
-
-        # Count physically distinct edges (unique source-target pairs).
-        n_unique_in = len(set((rp.edge.source, rp.edge.target) for rp in in_routes))
-        n_unique_out = len(set((rp.edge.source, rp.edge.target) for rp in out_routes))
-        n_unique_flat_in = len(set((rp.edge.source, rp.edge.target) for rp in flat_in))
-        n_unique_flat_out = len(
-            set((rp.edge.source, rp.edge.target) for rp in flat_out)
-        )
-
-        multi_diag = False
-        if not is_fork_join and (
-            (n_unique_in + n_unique_flat_in) >= 1
-            and n_unique_out >= 1
-            and (
-                n_unique_in > 1
-                or n_unique_out > 1
-                or (n_unique_in >= 1 and n_unique_flat_in >= 1)
-            )
-        ):
-            in_rp = in_routes[0] if in_routes else None
-            flat_in_rp = flat_in[0] if (not in_routes and flat_in) else None
-            out_rp = out_routes[0]
-            multi_diag = True
-        elif is_fork_join:
-            continue
-        elif n_unique_in == 1 and n_unique_out == 1:
-            in_rp = in_routes[0]
-            out_rp = out_routes[0]
-        elif n_unique_in == 0 and n_unique_flat_in == 1 and n_unique_out == 1:
-            flat_in_rp = flat_in[0]
-            out_rp = out_routes[0]
-        elif n_unique_in == 1 and n_unique_out == 0 and n_unique_flat_out == 1:
-            in_rp = in_routes[0]
-            flat_out_rp = flat_out[0]
-        else:
-            continue
-
-        # Check bundle convergence/divergence at neighbours.
-        shared_source = False
-        shared_target = False
-        if out_rp:
-            out_tgt = graph.stations.get(out_rp.edge.target)
-            if len(ctx.diag_in_sources.get(out_rp.edge.target, set())) > 1 and not (
-                out_tgt and out_tgt.is_port
-            ):
-                shared_target = True
-        if in_rp:
-            in_src = graph.stations.get(in_rp.edge.source)
-            if len(ctx.diag_out_targets.get(in_rp.edge.source, set())) > 1 and not (
-                in_src and in_src.is_port
-            ):
-                shared_source = True
-
-        # Determine X extent of the flat segment at station Y.
-        if multi_diag:
-            in_xs = [r.points[2][0] for r in in_routes]
-            in_xs += [r.points[0][0] for r in flat_in]
-            out_xs = [r.points[1][0] for r in out_routes]
-            in_diag_end_x = max(in_xs) if in_xs else station.x
-            out_diag_start_x = min(out_xs) if out_xs else station.x
-        elif in_rp:
-            in_diag_end_x = in_rp.points[2][0]
-        else:
-            assert flat_in_rp is not None
-            in_diag_end_x = flat_in_rp.points[0][0]
-
-        if not multi_diag:
-            if out_rp:
-                out_diag_start_x = out_rp.points[1][0]
-            else:
-                assert flat_out_rp is not None
-                out_diag_start_x = flat_out_rp.points[-1][0]
-
-        in_flat = station.x - in_diag_end_x
-        out_flat = out_diag_start_x - station.x
-
-        if abs(in_flat) < 1 or abs(out_flat) < 1:
-            continue
-        if abs(in_flat - out_flat) < 1:
-            continue
-
-        has_flat_side = flat_in_rp is not None or flat_out_rp is not None
-
-        # Guard: skip when a flat connection goes to/from an internal
-        # chain station.  Upstream sources may be fork-hub-exempted (a
-        # snap-induced flat from a true divergence anchor does not
-        # represent a real chain).  Downstream targets are checked
-        # strictly: a same-Y predecessor->successor pair on a downstream
-        # internal station is a natural chain regardless of whether the
-        # successor happens to be a divergence anchor.
-        if has_flat_side or multi_diag:
-            flat_to_internal = False
-            if flat_in_rp and _is_chain_predecessor(flat_in_rp.edge.source):
-                flat_to_internal = True
-            if flat_out_rp and _is_internal(flat_out_rp.edge.target):
-                flat_to_internal = True
-            if multi_diag:
-                for r in flat_in:
-                    if _is_chain_predecessor(r.edge.source):
-                        flat_to_internal = True
-                for r in flat_out:
-                    if _is_internal(r.edge.target):
-                        flat_to_internal = True
-            if flat_to_internal:
-                continue
-
-        if shared_source or shared_target or has_flat_side or multi_diag:
-            new_x = (in_diag_end_x + out_diag_start_x) / 2
-            station_move_candidates[sid] = (
-                new_x,
-                in_routes,
-                flat_in,
-                out_routes,
-                flat_out,
-            )
-            continue
-
-        # Simple case: shift both diagonals to equalise the flats.
-        shift = (in_flat - out_flat) / 2
-
-        if abs(shift) > min(abs(in_flat), abs(out_flat)):
-            continue
-
-        # Guard: don't shift in convergence/divergence bundles.  Bypass
-        # V helpers have no marker so the convergence-guard doesn't apply.
-        is_bypass_v = sid.startswith("__bypass_")
-        if not is_bypass_v:
-            if out_rp and len(ctx.diag_in_sources.get(out_rp.edge.target, set())) > 1:
-                continue
-            if in_rp and len(ctx.diag_out_targets.get(in_rp.edge.source, set())) > 1:
-                continue
-
-        for rp in in_routes:
-            rp.points[1] = (rp.points[1][0] + shift, rp.points[1][1])
-            rp.points[2] = (rp.points[2][0] + shift, rp.points[2][1])
-        for rp in out_routes:
-            rp.points[1] = (rp.points[1][0] + shift, rp.points[1][1])
-            rp.points[2] = (rp.points[2][0] + shift, rp.points[2][1])
-
+        candidate = _centering_candidate(graph, ctx, sid, station)
+        if candidate is not None:
+            station_move_candidates[sid] = candidate
     return station_move_candidates
 
 

--- a/src/nf_metro/layout/routing/reversal.py
+++ b/src/nf_metro/layout/routing/reversal.py
@@ -7,7 +7,7 @@ assignments in compute_station_offsets().
 
 from __future__ import annotations
 
-from nf_metro.parser.model import MetroGraph, Port, PortSide
+from nf_metro.parser.model import MetroGraph, Port, PortSide, Section
 
 
 def _fed_by_bottom_exit_fold(
@@ -58,7 +58,33 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
     reversed_secs: set[str] = set()
     junction_ids = graph.junction_ids
 
-    # Phase 1a: detect sections directly fed by TB BOTTOM exits
+    _detect_tb_bottom_top_entries(graph, tb_sections, reversed_secs)
+    _detect_fold_right_entries(graph, junction_ids, reversed_secs)
+
+    sec_successors, horizontal_succ_pairs = _build_section_adjacency(graph)
+
+    # Propagate Phase 1a reversals to horizontal successors
+    # (e.g. stat_analysis -> reporting via LEFT exit -> RIGHT entry).
+    _propagate_reversal_along_rows(
+        graph, reversed_secs, tb_sections, sec_successors, horizontal_succ_pairs
+    )
+
+    _detect_tb_lr_exit_fed(
+        graph,
+        reversed_secs,
+        tb_sections,
+        junction_ids,
+        sec_successors,
+        horizontal_succ_pairs,
+    )
+
+    return reversed_secs
+
+
+def _detect_tb_bottom_top_entries(
+    graph: MetroGraph, tb_sections: set[str], reversed_secs: set[str]
+) -> None:
+    """Phase 1a: mark sections whose TOP entry is fed by a TB BOTTOM exit."""
     for sec_id, section in graph.sections.items():
         for port_id in section.entry_ports:
             port = graph.ports.get(port_id)
@@ -77,8 +103,11 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
                 ):
                     reversed_secs.add(sec_id)
 
-    # Phase 1c: detect sections whose RIGHT entry is fed through a fold
-    # junction by a BOTTOM exit (down->left concentric corner).
+
+def _detect_fold_right_entries(
+    graph: MetroGraph, junction_ids: set[str], reversed_secs: set[str]
+) -> None:
+    """Phase 1c: mark RIGHT entries fed through a fold junction by a BOTTOM exit."""
     for sec_id, section in graph.sections.items():
         if sec_id in reversed_secs:
             continue
@@ -90,10 +119,15 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
                 reversed_secs.add(sec_id)
                 break
 
-    # Build section adjacency from inter-section edges (used by
-    # propagation phases below).  Also pre-compute the section-pair set
-    # for which the inter-section edge runs between LEFT/RIGHT ports on
-    # both sides (a direction-preserving continuation).
+
+def _build_section_adjacency(
+    graph: MetroGraph,
+) -> tuple[dict[str, set[str]], set[tuple[str, str]]]:
+    """Section successors plus the LEFT/RIGHT-to-LEFT/RIGHT continuation pairs.
+
+    The horizontal pairs are those whose inter-section edge runs between
+    LEFT/RIGHT ports on both sides (a direction-preserving continuation).
+    """
     sec_successors: dict[str, set[str]] = {}
     horizontal_succ_pairs: set[tuple[str, str]] = set()
     for edge in graph.edges:
@@ -114,118 +148,135 @@ def detect_reversed_sections(graph: MetroGraph) -> set[str]:
                 and tgt_port.side in (PortSide.LEFT, PortSide.RIGHT)
             ):
                 horizontal_succ_pairs.add((src.section_id, tgt.section_id))
+    return sec_successors, horizontal_succ_pairs
 
-    def _propagate_along_rows() -> bool:
-        """Propagate reversal to horizontal successors.
 
-        Propagates when the successor is on the same row or is reached
-        via a direct horizontal port connection (LEFT/RIGHT exit to
-        LEFT/RIGHT entry), which is effectively a straight continuation
-        with no direction change.
+def _propagate_reversal_along_rows(
+    graph: MetroGraph,
+    reversed_secs: set[str],
+    tb_sections: set[str],
+    sec_successors: dict[str, set[str]],
+    horizontal_succ_pairs: set[tuple[str, str]],
+) -> bool:
+    """Propagate reversal to horizontal successors.
 
-        Returns True if any new sections were added.
-        """
-        added_any = False
-        changed = True
-        while changed:
-            changed = False
-            for sec_id in list(reversed_secs):
-                section = graph.sections.get(sec_id)
-                if not section:
+    Propagates when the successor is on the same row or is reached via a
+    direct horizontal port connection (LEFT/RIGHT exit to LEFT/RIGHT entry),
+    which is effectively a straight continuation with no direction change.
+
+    Returns True if any new sections were added.
+    """
+    added_any = False
+    changed = True
+    while changed:
+        changed = False
+        for sec_id in list(reversed_secs):
+            section = graph.sections.get(sec_id)
+            if not section:
+                continue
+            # TB sections transform ordering in their exit L-shape; don't
+            # propagate reversal through them to downstream sections (the
+            # exit already un-reverses the bundle).
+            if sec_id in tb_sections:
+                continue
+            for succ_id in sec_successors.get(sec_id, set()):
+                if succ_id in reversed_secs:
                     continue
-                # TB sections transform ordering in their exit L-shape;
-                # don't propagate reversal through them to downstream
-                # sections (the exit already un-reverses the bundle).
-                if sec_id in tb_sections:
+                succ = graph.sections.get(succ_id)
+                if not succ:
                     continue
-                for succ_id in sec_successors.get(sec_id, set()):
-                    if succ_id in reversed_secs:
+                if (
+                    succ.grid_row == section.grid_row
+                    or (sec_id, succ_id) in horizontal_succ_pairs
+                ):
+                    reversed_secs.add(succ_id)
+                    changed = True
+                    added_any = True
+    return added_any
+
+
+def _is_tb_lr_exit_nonreversed(
+    port_obj: Port | None, tb_sections: set[str], reversed_secs: set[str]
+) -> bool:
+    """Check if port is an LR exit of a non-reversed TB section."""
+    return (
+        port_obj is not None
+        and not port_obj.is_entry
+        and port_obj.side in (PortSide.LEFT, PortSide.RIGHT)
+        and port_obj.section_id in tb_sections
+        and port_obj.section_id not in reversed_secs
+    )
+
+
+def _section_fed_by_tb_lr_exit(
+    graph: MetroGraph,
+    section: Section,
+    tb_sections: set[str],
+    junction_ids: set[str],
+    reversed_secs: set[str],
+) -> bool:
+    """True if any LEFT/RIGHT entry of *section* is fed by a non-reversed TB LR exit."""
+    for port_id in section.entry_ports:
+        port = graph.ports.get(port_id)
+        if not port or port.side not in (PortSide.LEFT, PortSide.RIGHT):
+            continue
+        for edge in graph.edges_to(port_id):
+            src = graph.stations.get(edge.source)
+            if not src:
+                continue
+            if edge.source in junction_ids:
+                # Look through junction to find upstream exit port
+                for e2 in graph.edges_to(edge.source):
+                    s2 = graph.stations.get(e2.source)
+                    if not s2 or not s2.is_port:
                         continue
-                    succ = graph.sections.get(succ_id)
-                    if not succ:
-                        continue
-                    if (
-                        succ.grid_row == section.grid_row
-                        or (sec_id, succ_id) in horizontal_succ_pairs
-                    ):
-                        reversed_secs.add(succ_id)
-                        changed = True
-                        added_any = True
-        return added_any
+                    s2_port = graph.ports.get(e2.source)
+                    if _is_tb_lr_exit_nonreversed(s2_port, tb_sections, reversed_secs):
+                        return True
+            elif src.is_port:
+                src_port = graph.ports.get(edge.source)
+                if _is_tb_lr_exit_nonreversed(src_port, tb_sections, reversed_secs):
+                    return True
+    return False
 
-    # Propagate Phase 1a reversals to horizontal successors
-    # (e.g. stat_analysis -> reporting via LEFT exit -> RIGHT entry).
-    _propagate_along_rows()
 
-    # Phase 1b + Phase 2: iteratively detect sections fed by TB
-    # LEFT/RIGHT exits and propagate along rows.  The concentric
-    # corner reverses the bundle ordering ONLY when the TB section
-    # uses non-reversed internal offsets.  If the TB section is
-    # itself already reversed (e.g. via propagation from an earlier
-    # TB exit), its exit L-shape un-reverses back to standard, so
-    # the downstream section should NOT be marked reversed.
-    #
-    # We iterate because a later TB section may become reversed
-    # through row propagation from an earlier TB section's
-    # downstream (e.g. calling -> hard_filter -> ... -> integration).
-    def _is_tb_lr_exit_nonreversed(port_obj: Port | None) -> bool:
-        """Check if port is an LR exit of a non-reversed TB section."""
-        return (
-            port_obj is not None
-            and not port_obj.is_entry
-            and port_obj.side in (PortSide.LEFT, PortSide.RIGHT)
-            and port_obj.section_id in tb_sections
-            and port_obj.section_id not in reversed_secs
-        )
+def _detect_tb_lr_exit_fed(
+    graph: MetroGraph,
+    reversed_secs: set[str],
+    tb_sections: set[str],
+    junction_ids: set[str],
+    sec_successors: dict[str, set[str]],
+    horizontal_succ_pairs: set[tuple[str, str]],
+) -> None:
+    """Phase 1b + Phase 2: mark sections fed by TB LEFT/RIGHT exits, iteratively.
 
-    # Process one TB exit at a time: add the downstream section,
-    # propagate along rows (which may mark the next TB section as
-    # reversed), then re-scan.  This ensures that propagation from
-    # an earlier TB exit's downstream is visible when checking later
-    # TB exits.
+    The concentric corner reverses the bundle ordering ONLY when the TB
+    section uses non-reversed internal offsets.  If the TB section is itself
+    already reversed (e.g. via propagation from an earlier TB exit), its exit
+    L-shape un-reverses back to standard, so the downstream section should
+    NOT be marked reversed.
+
+    Process one TB exit at a time: add the downstream section, propagate along
+    rows (which may mark the next TB section as reversed), then re-scan.  This
+    ensures propagation from an earlier TB exit's downstream is visible when
+    checking later TB exits (e.g. calling -> hard_filter -> ... -> integration).
+    """
     stable = False
     while not stable:
         stable = True
-
         for sec_id, section in graph.sections.items():
             if sec_id in reversed_secs:
                 continue
-            added = False
-            for port_id in section.entry_ports:
-                if added:
-                    break
-                port = graph.ports.get(port_id)
-                if not port or port.side not in (
-                    PortSide.LEFT,
-                    PortSide.RIGHT,
-                ):
-                    continue
-                for edge in graph.edges_to(port_id):
-                    if added:
-                        break
-                    src = graph.stations.get(edge.source)
-                    if not src:
-                        continue
-                    matched = False
-                    if edge.source in junction_ids:
-                        # Look through junction to find upstream exit port
-                        for e2 in graph.edges_to(edge.source):
-                            s2 = graph.stations.get(e2.source)
-                            if not s2 or not s2.is_port:
-                                continue
-                            s2_port = graph.ports.get(e2.source)
-                            if _is_tb_lr_exit_nonreversed(s2_port):
-                                matched = True
-                                break
-                    elif src.is_port:
-                        src_port = graph.ports.get(edge.source)
-                        matched = _is_tb_lr_exit_nonreversed(src_port)
-                    if matched:
-                        reversed_secs.add(sec_id)
-                        _propagate_along_rows()
-                        stable = False
-                        added = True
-            if added:
+            if _section_fed_by_tb_lr_exit(
+                graph, section, tb_sections, junction_ids, reversed_secs
+            ):
+                reversed_secs.add(sec_id)
+                _propagate_reversal_along_rows(
+                    graph,
+                    reversed_secs,
+                    tb_sections,
+                    sec_successors,
+                    horizontal_succ_pairs,
+                )
+                stable = False
                 break  # restart outer scan
-
-    return reversed_secs

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -160,35 +160,9 @@ def _compute_section_offsets(
         min_col = min(min_col, col)
         max_col = max(max_col, col + cspan - 1)
 
-    # Right reach re-anchored to the standard left edge so that bbox_x
-    # pushed further left (e.g. by terminus-icon clearance) doesn't
-    # inflate the column.  Stage 1.5 of compute_layout absorbs the
-    # leftward overhang via a global x_offset bump.
-    def _effective_width(section: Section) -> float:
-        return section.bbox_x + section.bbox_w + SECTION_X_PADDING
-
-    col_widths: dict[int, float] = defaultdict(float)
-    for sid, section in scoped.items():
-        if section.grid_col_span == 1:
-            col = col_assign.get(sid, 0)
-            col_widths[col] = max(col_widths[col], _effective_width(section))
-
-    for c in range(min_col, max_col + 1):
-        if c not in col_widths:
-            col_widths[c] = 0.0
-
-    # Expand columns if a spanning section exceeds spanned column widths
-    for sid, section in scoped.items():
-        cspan = section.grid_col_span
-        if cspan <= 1:
-            continue
-        start_col = col_assign.get(sid, 0)
-        spanned = sum(col_widths[c] for c in range(start_col, start_col + cspan))
-        spanned += (cspan - 1) * section_x_gap
-        eff_w = _effective_width(section)
-        if eff_w > spanned:
-            deficit = eff_w - spanned
-            col_widths[start_col + cspan - 1] += deficit
+    col_widths = _compute_col_widths(
+        scoped, col_assign, min_col, max_col, section_x_gap
+    )
 
     # Cumulative x offsets
     col_offsets: dict[int, float] = {}
@@ -197,13 +171,100 @@ def _compute_section_offsets(
         col_offsets[col] = cumulative_x
         cumulative_x += col_widths.get(col, 0) + section_x_gap
 
-    # Global row heights (only single-row non-TB sections)
     max_row = max(row_assign.values()) if row_assign else 0
     for sid in scoped:
         span = scoped[sid].grid_row_span
         row = row_assign.get(sid, 0)
         max_row = max(max_row, row + span - 1)
 
+    row_heights = _compute_row_heights(scoped, row_assign, max_row, section_y_gap)
+
+    # Cumulative y offsets per row
+    row_offsets: dict[int, float] = {}
+    cumulative_y = 0.0
+    for r in range(max_row + 1):
+        row_offsets[r] = cumulative_y
+        cumulative_y += row_heights[r] + section_y_gap
+
+    _apply_tb_fold_spans(
+        scoped, row_assign, row_offsets, row_heights, max_row, section_y_gap
+    )
+
+    # Right-align columns containing RL or TB sections
+    right_align_cols: set[int] = set()
+    for sid, section in scoped.items():
+        if section.direction in ("RL", "TB") and section.grid_col_span == 1:
+            right_align_cols.add(col_assign.get(sid, 0))
+
+    # Set section offsets and adjust for spanning
+    for sid, section in scoped.items():
+        section.grid_col = col_assign.get(sid, 0)
+        section.grid_row = row_assign.get(sid, 0)
+        section.offset_x = col_offsets.get(section.grid_col, 0)
+        section.offset_y = row_offsets.get(section.grid_row, 0)
+
+        if section.grid_col_span == 1 and (
+            section.direction in ("RL", "TB") or section.grid_col in right_align_cols
+        ):
+            col_w = col_widths.get(section.grid_col, 0)
+            if col_w > section.bbox_w:
+                section.offset_x += col_w - section.bbox_w
+
+    _finalize_spanning_sections(
+        scoped, col_widths, row_heights, section_x_gap, section_y_gap
+    )
+
+    return min_col, max_col
+
+
+def _effective_section_width(section: Section) -> float:
+    """Section right reach re-anchored to the standard left edge.
+
+    Keeps bbox_x pushed further left (e.g. by terminus-icon clearance) from
+    inflating the column; Stage 1.5 of compute_layout absorbs the leftward
+    overhang via a global x_offset bump.
+    """
+    return section.bbox_x + section.bbox_w + SECTION_X_PADDING
+
+
+def _compute_col_widths(
+    scoped: dict[str, Section],
+    col_assign: dict[str, int],
+    min_col: int,
+    max_col: int,
+    section_x_gap: float,
+) -> dict[int, float]:
+    """Per-column width: widest single-span section, expanded for spans."""
+    col_widths: dict[int, float] = defaultdict(float)
+    for sid, section in scoped.items():
+        if section.grid_col_span == 1:
+            col = col_assign.get(sid, 0)
+            col_widths[col] = max(col_widths[col], _effective_section_width(section))
+
+    for c in range(min_col, max_col + 1):
+        if c not in col_widths:
+            col_widths[c] = 0.0
+
+    for sid, section in scoped.items():
+        cspan = section.grid_col_span
+        if cspan <= 1:
+            continue
+        start_col = col_assign.get(sid, 0)
+        spanned = sum(col_widths[c] for c in range(start_col, start_col + cspan))
+        spanned += (cspan - 1) * section_x_gap
+        eff_w = _effective_section_width(section)
+        if eff_w > spanned:
+            col_widths[start_col + cspan - 1] += eff_w - spanned
+    return col_widths
+
+
+def _compute_row_heights(
+    scoped: dict[str, Section],
+    row_assign: dict[str, int],
+    max_row: int,
+    section_y_gap: float,
+) -> dict[int, float]:
+    """Per-row height: tallest single-row non-TB section, expanded for spans."""
     row_heights: dict[int, float] = defaultdict(float)
     for sid, section in scoped.items():
         if section.grid_row_span == 1 and section.direction != "TB":
@@ -214,7 +275,6 @@ def _compute_section_offsets(
         if r not in row_heights:
             row_heights[r] = 0.0
 
-    # Expand rows if a spanning section exceeds spanned row heights
     for sid, section in scoped.items():
         rspan = section.grid_row_span
         if rspan <= 1:
@@ -223,17 +283,19 @@ def _compute_section_offsets(
         spanned = sum(row_heights[r] for r in range(start_row, start_row + rspan))
         spanned += (rspan - 1) * section_y_gap
         if section.bbox_h > spanned:
-            deficit = section.bbox_h - spanned
-            row_heights[start_row + rspan - 1] += deficit
+            row_heights[start_row + rspan - 1] += section.bbox_h - spanned
+    return row_heights
 
-    # Cumulative y offsets per row
-    row_offsets: dict[int, float] = {}
-    cumulative_y = 0.0
-    for r in range(max_row + 1):
-        row_offsets[r] = cumulative_y
-        cumulative_y += row_heights[r] + section_y_gap
 
-    # TB fold sections visually span into the next row
+def _apply_tb_fold_spans(
+    scoped: dict[str, Section],
+    row_assign: dict[str, int],
+    row_offsets: dict[int, float],
+    row_heights: dict[int, float],
+    max_row: int,
+    section_y_gap: float,
+) -> None:
+    """Push lower rows down where a TB fold section spills into the next row."""
     tb_sections = sorted(
         [
             (sid, section)
@@ -258,36 +320,24 @@ def _compute_section_offsets(
         next_row_bottom = row_offsets[next_row] + row_heights[next_row]
         section.bbox_h = next_row_bottom - row_offsets[row]
 
-    # Right-align columns containing RL or TB sections
-    right_align_cols: set[int] = set()
-    for sid, section in scoped.items():
-        if section.direction in ("RL", "TB") and section.grid_col_span == 1:
-            right_align_cols.add(col_assign.get(sid, 0))
 
-    # Set section offsets and adjust for spanning
-    for sid, section in scoped.items():
-        section.grid_col = col_assign.get(sid, 0)
-        section.grid_row = row_assign.get(sid, 0)
-        section.offset_x = col_offsets.get(section.grid_col, 0)
-        section.offset_y = row_offsets.get(section.grid_row, 0)
+def _finalize_spanning_sections(
+    scoped: dict[str, Section],
+    col_widths: dict[int, float],
+    row_heights: dict[int, float],
+    section_x_gap: float,
+    section_y_gap: float,
+) -> None:
+    """Align spanning-section left edges to their column and size their bbox.
 
-        if section.grid_col_span == 1 and (
-            section.direction in ("RL", "TB") or section.grid_col in right_align_cols
-        ):
-            col_w = col_widths.get(section.grid_col, 0)
-            if col_w > section.bbox_w:
-                section.offset_x += col_w - section.bbox_w
-
-    # Align left edges of spanning sections with their starting column.
-    # A section that spans multiple columns may have a different local
-    # bbox_x from internal layout, causing its left edge to be offset
-    # from single-span sections in the same starting column.
+    A section that spans multiple columns may have a different local bbox_x
+    from internal layout, offsetting its left edge from single-span sections
+    in the same starting column.
+    """
     for section in scoped.values():
         if section.grid_col_span <= 1:
             continue
         col = section.grid_col
-        # Find the representative left edge from single-span sections
-        # in the same column.
         peers = [
             s for s in scoped.values() if s.grid_col == col and s.grid_col_span == 1
         ]
@@ -315,8 +365,6 @@ def _compute_section_offsets(
             )
             spanned_width += (cspan - 1) * section_x_gap
             section.bbox_w = spanned_width
-
-    return min_col, max_col
 
 
 def _weakly_connected_components(

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -9,6 +9,7 @@ junctions, and resolving inter-section edges into port-to-port chains.
 from __future__ import annotations
 
 import warnings
+from dataclasses import dataclass
 
 import networkx as nx
 
@@ -206,125 +207,18 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
     edges_to_remove: set[int] = set()
     bypass_count = 0
 
-    def _section_layers(section_ids: set[str]) -> dict[str, int]:
-        sub: nx.DiGraph[str] = nx.DiGraph()
-        for sid in section_ids:
-            sub.add_node(sid)
-        for edge in graph.edges:
-            if edge.source in section_ids and edge.target in section_ids:
-                sub.add_edge(edge.source, edge.target)
-        try:
-            topo = list(nx.topological_sort(sub))
-        except nx.NetworkXUnfeasible:
-            return {}
-        layers: dict[str, int] = {}
-        for node in topo:
-            preds = list(sub.predecessors(node))
-            layers[node] = (
-                max((layers[p] for p in preds), default=-1) + 1 if preds else 0
-            )
-        return layers
-
     for section in graph.sections.values():
         station_ids = set(section.station_ids)
         if not station_ids:
             continue
-
-        sec_layers = _section_layers(station_ids)
-        exit_port_ids = set(section.exit_ports)
-        # Pin exit ports past every internal station so longest-path layering
-        # doesn't tie an exit port with an internal station sharing its
-        # predecessor (which would suppress the bypass trigger).
-        if exit_port_ids and sec_layers:
-            internal_max = max(
-                v for k, v in sec_layers.items() if k not in exit_port_ids
-            )
-            for pid in exit_port_ids:
-                if sec_layers.get(pid, 0) <= internal_max:
-                    sec_layers[pid] = internal_max + 1
-
-        in_section_edges = [
-            e
-            for e in graph.edges
-            if e.source in station_ids and e.target in station_ids
-        ]
-        in_preds_by_target: dict[str, set[str]] = {}
-        consumed_lines_by_target: dict[str, set[str]] = {}
-        for e in in_section_edges:
-            in_preds_by_target.setdefault(e.target, set()).add(e.source)
-            consumed_lines_by_target.setdefault(e.target, set()).add(e.line_id)
-
-        entry_port_ids = set(section.entry_ports)
-        internal_ids = [
-            sid
-            for sid in station_ids
-            if sid not in exit_port_ids
-            and sid not in entry_port_ids
-            and sid in sec_layers
-        ]
-        if not internal_ids:
+        ctx = _build_bypass_section_ctx(graph, section, station_ids)
+        if ctx is None:
             continue
-        min_internal_layer = min(sec_layers[sid] for sid in internal_ids)
-        head_count = sum(
-            1 for sid in internal_ids if sec_layers[sid] == min_internal_layer
-        )
-        single_trunk_section = head_count <= 1
 
         for sid in section.station_ids:
-            station = graph.stations.get(sid)
-            if station is None or station.is_port or station.is_hidden:
-                continue
-            if station.is_terminus or sid in pending_terminus_ids:
-                continue
-
-            s_layer = sec_layers.get(sid)
-            if s_layer is None:
-                continue
-            s_lines = set(graph.station_lines(sid))
-
-            in_section_preds = in_preds_by_target.get(sid, set())
-            # In multi-trunk sections, only fan-in convergence points
-            # (S has >=2 in-section predecessors) need bypass help, and
-            # only from a direct predecessor of S - other lines already
-            # have their own parallel tracks.
-            if not single_trunk_section and len(in_section_preds) < 2:
-                continue
-
-            # Skip stations that only consume a spur line - the bypass
-            # would snap S's spur track to the section trunk Y, opening
-            # an unnecessary vertical gap to S.  A consumed line is
-            # "trunk" when it has at least one in-section edge that
-            # doesn't touch S.
-            consumed_lines = consumed_lines_by_target.get(sid, set())
-            trunk_lines = {
-                e.line_id
-                for e in in_section_edges
-                if e.source != sid and e.target != sid
-            }
-            if consumed_lines and not (consumed_lines & trunk_lines):
-                continue
-
-            candidate_preds = sorted(
-                station_ids if single_trunk_section else in_section_preds
+            bypass_by_pred = _station_bypass_groups(
+                graph, sid, ctx, edges_by_source, pending_terminus_ids
             )
-
-            bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
-            for pred_id in candidate_preds:
-                if pred_id == sid:
-                    continue
-                pred_layer = sec_layers.get(pred_id)
-                if pred_layer is None or pred_layer >= s_layer:
-                    continue
-                for i, edge in edges_by_source.get(pred_id, []):
-                    if edge.target not in exit_port_ids:
-                        continue
-                    if edge.line_id in s_lines:
-                        continue
-                    t_layer = sec_layers.get(edge.target)
-                    if t_layer is None or t_layer <= s_layer:
-                        continue
-                    bypass_by_pred.setdefault(pred_id, []).append((i, edge))
-
             for pred_id, bypass_edges in bypass_by_pred.items():
                 bypass_count += 1
                 v_id = f"__bypass_{sid}_{pred_id}_{bypass_count}"
@@ -337,7 +231,6 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                         bypasses_station_id=sid,
                     )
                 )
-
                 for idx, edge in bypass_edges:
                     edges_to_remove.add(idx)
                     new_edges.append(
@@ -359,6 +252,144 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
         )
     for edge in new_edges:
         graph.add_edge(edge)
+
+
+def _section_topo_layers(graph: MetroGraph, section_ids: set[str]) -> dict[str, int]:
+    """Longest-path layer index for the in-section subgraph (empty if cyclic)."""
+    sub: nx.DiGraph[str] = nx.DiGraph()
+    for sid in section_ids:
+        sub.add_node(sid)
+    for edge in graph.edges:
+        if edge.source in section_ids and edge.target in section_ids:
+            sub.add_edge(edge.source, edge.target)
+    try:
+        topo = list(nx.topological_sort(sub))
+    except nx.NetworkXUnfeasible:
+        return {}
+    layers: dict[str, int] = {}
+    for node in topo:
+        preds = list(sub.predecessors(node))
+        layers[node] = max((layers[p] for p in preds), default=-1) + 1 if preds else 0
+    return layers
+
+
+@dataclass
+class _BypassSectionCtx:
+    """Per-section state the bypass trigger reads for each candidate station."""
+
+    station_ids: set[str]
+    sec_layers: dict[str, int]
+    exit_port_ids: set[str]
+    in_preds_by_target: dict[str, set[str]]
+    consumed_lines_by_target: dict[str, set[str]]
+    in_section_edges: list[Edge]
+    single_trunk_section: bool
+
+
+def _build_bypass_section_ctx(
+    graph: MetroGraph, section: Section, station_ids: set[str]
+) -> _BypassSectionCtx | None:
+    """Compute bypass context for one section, or None when it has no internals."""
+    sec_layers = _section_topo_layers(graph, station_ids)
+    exit_port_ids = set(section.exit_ports)
+    # Pin exit ports past every internal station so longest-path layering
+    # doesn't tie an exit port with an internal station sharing its
+    # predecessor (which would suppress the bypass trigger).
+    if exit_port_ids and sec_layers:
+        internal_max = max(v for k, v in sec_layers.items() if k not in exit_port_ids)
+        for pid in exit_port_ids:
+            if sec_layers.get(pid, 0) <= internal_max:
+                sec_layers[pid] = internal_max + 1
+
+    in_section_edges = [
+        e for e in graph.edges if e.source in station_ids and e.target in station_ids
+    ]
+    in_preds_by_target: dict[str, set[str]] = {}
+    consumed_lines_by_target: dict[str, set[str]] = {}
+    for e in in_section_edges:
+        in_preds_by_target.setdefault(e.target, set()).add(e.source)
+        consumed_lines_by_target.setdefault(e.target, set()).add(e.line_id)
+
+    entry_port_ids = set(section.entry_ports)
+    internal_ids = [
+        sid
+        for sid in station_ids
+        if sid not in exit_port_ids and sid not in entry_port_ids and sid in sec_layers
+    ]
+    if not internal_ids:
+        return None
+    min_internal_layer = min(sec_layers[sid] for sid in internal_ids)
+    head_count = sum(1 for sid in internal_ids if sec_layers[sid] == min_internal_layer)
+
+    return _BypassSectionCtx(
+        station_ids=station_ids,
+        sec_layers=sec_layers,
+        exit_port_ids=exit_port_ids,
+        in_preds_by_target=in_preds_by_target,
+        consumed_lines_by_target=consumed_lines_by_target,
+        in_section_edges=in_section_edges,
+        single_trunk_section=head_count <= 1,
+    )
+
+
+def _station_bypass_groups(
+    graph: MetroGraph,
+    sid: str,
+    ctx: _BypassSectionCtx,
+    edges_by_source: dict[str, list[tuple[int, Edge]]],
+    pending_terminus_ids: set[str],
+) -> dict[str, list[tuple[int, Edge]]]:
+    """Bypassing exit edges grouped by predecessor for one station, or empty."""
+    station = graph.stations.get(sid)
+    if station is None or station.is_port or station.is_hidden:
+        return {}
+    if station.is_terminus or sid in pending_terminus_ids:
+        return {}
+
+    s_layer = ctx.sec_layers.get(sid)
+    if s_layer is None:
+        return {}
+    s_lines = set(graph.station_lines(sid))
+
+    in_section_preds = ctx.in_preds_by_target.get(sid, set())
+    # In multi-trunk sections, only fan-in convergence points (S has >=2
+    # in-section predecessors) need bypass help, and only from a direct
+    # predecessor of S - other lines already have their own parallel tracks.
+    if not ctx.single_trunk_section and len(in_section_preds) < 2:
+        return {}
+
+    # Skip stations that only consume a spur line - the bypass would snap S's
+    # spur track to the section trunk Y, opening an unnecessary vertical gap to
+    # S.  A consumed line is "trunk" when it has at least one in-section edge
+    # that doesn't touch S.
+    consumed_lines = ctx.consumed_lines_by_target.get(sid, set())
+    trunk_lines = {
+        e.line_id for e in ctx.in_section_edges if e.source != sid and e.target != sid
+    }
+    if consumed_lines and not (consumed_lines & trunk_lines):
+        return {}
+
+    candidate_preds = sorted(
+        ctx.station_ids if ctx.single_trunk_section else in_section_preds
+    )
+
+    bypass_by_pred: dict[str, list[tuple[int, Edge]]] = {}
+    for pred_id in candidate_preds:
+        if pred_id == sid:
+            continue
+        pred_layer = ctx.sec_layers.get(pred_id)
+        if pred_layer is None or pred_layer >= s_layer:
+            continue
+        for i, edge in edges_by_source.get(pred_id, []):
+            if edge.target not in ctx.exit_port_ids:
+                continue
+            if edge.line_id in s_lines:
+                continue
+            t_layer = ctx.sec_layers.get(edge.target)
+            if t_layer is None or t_layer <= s_layer:
+                continue
+            bypass_by_pred.setdefault(pred_id, []).append((i, edge))
+    return bypass_by_pred
 
 
 def _resolve_sections(graph: MetroGraph) -> None:

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -1120,11 +1120,10 @@ def check_route_segment_crossings(
     return violations
 
 
-def _pt_at_station(pt, station_xy, hub_tol) -> bool:
-    """True if *pt* lands within ``hub_tol`` of a real (non-port) station."""
-    x, y = pt
-    for sx, sy in station_xy:
-        if abs(sx - x) <= hub_tol and abs(sy - y) <= hub_tol:
+def _pt_near(pt, points, tol) -> bool:
+    """True if *pt* is within ``tol`` of any ``(x, y)`` in *points* on both axes."""
+    for px, py in points:
+        if abs(px - pt[0]) <= tol and abs(py - pt[1]) <= tol:
             return True
     return False
 
@@ -1164,14 +1163,6 @@ def _shared_port_endpoints(graph, ra_edge, rb_edge) -> list[tuple[float, float]]
     return result
 
 
-def _pt_near_shared_port(pt, ports, fan_tol) -> bool:
-    """True if *pt* sits within ``fan_tol`` of any shared port endpoint."""
-    for px, py in ports:
-        if abs(px - pt[0]) <= fan_tol and abs(py - pt[1]) <= fan_tol:
-            return True
-    return False
-
-
 def _seg_near_vertical(p0, p1, vertical_dx_tol) -> bool:
     """True if the segment is near-vertical (small dx, non-zero dy)."""
     return abs(p1[0] - p0[0]) <= vertical_dx_tol and abs(p1[1] - p0[1]) > 0
@@ -1203,9 +1194,9 @@ def _route_pair_crossing(graph, ra, pa, rb, pb, station_xy, hub_tol):
             pt = _segments_cross(pa[ai], pa[ai + 1], pb[bi], pb[bi + 1])
             if pt is None:
                 continue
-            if _pt_at_station(pt, station_xy, hub_tol):
+            if _pt_near(pt, station_xy, hub_tol):
                 continue
-            if shared_ports and _pt_near_shared_port(pt, shared_ports, fan_tol):
+            if shared_ports and _pt_near(pt, shared_ports, fan_tol):
                 seg_a = (pa[ai], pa[ai + 1])
                 seg_b = (pb[bi], pb[bi + 1])
                 if not (

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -1073,137 +1073,148 @@ def check_route_segment_crossings(
     station_xy = [(st.x, st.y) for st in graph.stations.values() if not st.is_port]
     hub_tol = Y_SPACING / 4.0
 
-    def at_station(pt: tuple[float, float]) -> bool:
-        x, y = pt
-        for sx, sy in station_xy:
-            if abs(sx - x) <= hub_tol and abs(sy - y) <= hub_tol:
-                return True
-        return False
-
     # Precompute post-offset point lists once per route.
     paths = [(r, apply_route_offsets(r, offsets)) for r in routes]
-
-    # A shared endpoint at a multi-line real-station hub means the two
-    # edges are part of a fork or join at a station that genuinely
-    # carries multiple lines. Crossings near such hubs are part of the
-    # natural divergence and acceptable. Junction endpoints (synthetic
-    # routing artefacts, is_port=True) do NOT trigger this exclusion.
-    def shared_real_hub(ra_edge, rb_edge) -> bool:
-        shared = {ra_edge.source, ra_edge.target} & {
-            rb_edge.source,
-            rb_edge.target,
-        }
-        for sid in shared:
-            st = graph.stations.get(sid)
-            if st is not None and not st.is_port and len(graph.station_lines(sid)) > 1:
-                return True
-        return False
-
-    def involves_hidden(edge) -> bool:
-        for sid in (edge.source, edge.target):
-            st = graph.stations.get(sid)
-            if st is not None and st.is_hidden:
-                return True
-        return False
-
-    def shared_port_endpoints(ra_edge, rb_edge) -> list[tuple[float, float]]:
-        """Coordinates of port stations shared as endpoints by both edges."""
-        shared = {ra_edge.source, ra_edge.target} & {rb_edge.source, rb_edge.target}
-        result: list[tuple[float, float]] = []
-        for sid in shared:
-            st = graph.stations.get(sid)
-            if st is not None and st.is_port:
-                result.append((st.x, st.y))
-        return result
-
-    # A crossing near a shared port endpoint can be a benign fan-out
-    # (one port -> many destinations) or fan-in (many -> one port)
-    # divergence artefact: the lines have to split or merge at the port
-    # and may visually intersect within a few pixels of it. We exclude
-    # such crossings ONLY when both crossing segments transition to their
-    # next track via a diagonal - that's the natural way to enter a new
-    # row. If either segment is near-vertical at the crossing, one line is
-    # plunging up/down past its source y to detour around something, which
-    # is the awkward case we want to flag (e.g. variant_calling Main/QC
-    # leaving Section 1: qc immediately drops y=157 -> y=260 to bypass
-    # alignment, crossing main on the way).
-    fan_tol = Y_SPACING
-    vertical_dx_tol = 2.0
-
-    def near_shared_port(
-        pt: tuple[float, float], ports: list[tuple[float, float]]
-    ) -> bool:
-        for px, py in ports:
-            if abs(px - pt[0]) <= fan_tol and abs(py - pt[1]) <= fan_tol:
-                return True
-        return False
-
-    def segment_near_vertical(p0: tuple[float, float], p1: tuple[float, float]) -> bool:
-        return abs(p1[0] - p0[0]) <= vertical_dx_tol and abs(p1[1] - p0[1]) > 0
 
     seen: set[tuple] = set()
     for i in range(len(paths)):
         ra, pa = paths[i]
         for j in range(i + 1, len(paths)):
             rb, pb = paths[j]
-            if ra.line_id == rb.line_id:
+            pt = _route_pair_crossing(graph, ra, pa, rb, pb, station_xy, hub_tol)
+            if pt is None:
                 continue
-            if shared_real_hub(ra.edge, rb.edge):
+            key = tuple(
+                sorted(
+                    [
+                        (ra.edge.source, ra.edge.target, ra.line_id),
+                        (rb.edge.source, rb.edge.target, rb.line_id),
+                    ]
+                )
+            )
+            if key in seen:
                 continue
-            # Hidden helper stations are inserted by the layout to extend
-            # terminus or branch geometry; their crossings are intentional.
-            if involves_hidden(ra.edge) or involves_hidden(rb.edge):
-                continue
-            shared_ports = shared_port_endpoints(ra.edge, rb.edge)
-            for ai in range(len(pa) - 1):
-                for bi in range(len(pb) - 1):
-                    pt = _segments_cross(pa[ai], pa[ai + 1], pb[bi], pb[bi + 1])
-                    if pt is None:
-                        continue
-                    if at_station(pt):
-                        continue
-                    if shared_ports and near_shared_port(pt, shared_ports):
-                        seg_a = (pa[ai], pa[ai + 1])
-                        seg_b = (pb[bi], pb[bi + 1])
-                        if not (
-                            segment_near_vertical(*seg_a)
-                            or segment_near_vertical(*seg_b)
-                        ):
-                            continue
-                    key = tuple(
-                        sorted(
-                            [
-                                (ra.edge.source, ra.edge.target, ra.line_id),
-                                (rb.edge.source, rb.edge.target, rb.line_id),
-                            ]
-                        )
-                    )
-                    if key in seen:
-                        continue
-                    seen.add(key)
-                    violations.append(
-                        Violation(
-                            check="route_segment_crossing",
-                            severity=Severity.WARNING,
-                            message=(
-                                f"Lines '{ra.line_id}' "
-                                f"({ra.edge.source}->{ra.edge.target}) and "
-                                f"'{rb.line_id}' "
-                                f"({rb.edge.source}->{rb.edge.target}) "
-                                f"cross at ({pt[0]:.0f},{pt[1]:.0f}) - not "
-                                f"at a station, so the crossing is avoidable"
-                            ),
-                            context={
-                                "line_a": ra.line_id,
-                                "line_b": rb.line_id,
-                                "edge_a": (ra.edge.source, ra.edge.target),
-                                "edge_b": (rb.edge.source, rb.edge.target),
-                                "intersection": pt,
-                            },
-                        )
-                    )
+            seen.add(key)
+            violations.append(
+                Violation(
+                    check="route_segment_crossing",
+                    severity=Severity.WARNING,
+                    message=(
+                        f"Lines '{ra.line_id}' "
+                        f"({ra.edge.source}->{ra.edge.target}) and "
+                        f"'{rb.line_id}' "
+                        f"({rb.edge.source}->{rb.edge.target}) "
+                        f"cross at ({pt[0]:.0f},{pt[1]:.0f}) - not "
+                        f"at a station, so the crossing is avoidable"
+                    ),
+                    context={
+                        "line_a": ra.line_id,
+                        "line_b": rb.line_id,
+                        "edge_a": (ra.edge.source, ra.edge.target),
+                        "edge_b": (rb.edge.source, rb.edge.target),
+                        "intersection": pt,
+                    },
+                )
+            )
 
     return violations
+
+
+def _pt_at_station(pt, station_xy, hub_tol) -> bool:
+    """True if *pt* lands within ``hub_tol`` of a real (non-port) station."""
+    x, y = pt
+    for sx, sy in station_xy:
+        if abs(sx - x) <= hub_tol and abs(sy - y) <= hub_tol:
+            return True
+    return False
+
+
+def _edges_share_real_hub(graph, ra_edge, rb_edge) -> bool:
+    """True if the edges share an endpoint at a multi-line real-station hub.
+
+    Such a shared endpoint means the two edges fork or join at a station that
+    genuinely carries multiple lines, so crossings near it are natural
+    divergence.  Junction endpoints (synthetic, is_port=True) do NOT count.
+    """
+    shared = {ra_edge.source, ra_edge.target} & {rb_edge.source, rb_edge.target}
+    for sid in shared:
+        st = graph.stations.get(sid)
+        if st is not None and not st.is_port and len(graph.station_lines(sid)) > 1:
+            return True
+    return False
+
+
+def _edge_involves_hidden(graph, edge) -> bool:
+    """True if either endpoint of *edge* is a hidden helper station."""
+    for sid in (edge.source, edge.target):
+        st = graph.stations.get(sid)
+        if st is not None and st.is_hidden:
+            return True
+    return False
+
+
+def _shared_port_endpoints(graph, ra_edge, rb_edge) -> list[tuple[float, float]]:
+    """Coordinates of port stations shared as endpoints by both edges."""
+    shared = {ra_edge.source, ra_edge.target} & {rb_edge.source, rb_edge.target}
+    result: list[tuple[float, float]] = []
+    for sid in shared:
+        st = graph.stations.get(sid)
+        if st is not None and st.is_port:
+            result.append((st.x, st.y))
+    return result
+
+
+def _pt_near_shared_port(pt, ports, fan_tol) -> bool:
+    """True if *pt* sits within ``fan_tol`` of any shared port endpoint."""
+    for px, py in ports:
+        if abs(px - pt[0]) <= fan_tol and abs(py - pt[1]) <= fan_tol:
+            return True
+    return False
+
+
+def _seg_near_vertical(p0, p1, vertical_dx_tol) -> bool:
+    """True if the segment is near-vertical (small dx, non-zero dy)."""
+    return abs(p1[0] - p0[0]) <= vertical_dx_tol and abs(p1[1] - p0[1]) > 0
+
+
+def _route_pair_crossing(graph, ra, pa, rb, pb, station_xy, hub_tol):
+    """First avoidable crossing point between two routed paths, or None.
+
+    A crossing near a shared port endpoint can be a benign fan-out/fan-in
+    divergence artefact (lines split or merge at the port and may intersect
+    within a few pixels of it).  Such crossings are excluded ONLY when both
+    crossing segments transition via a diagonal; if either is near-vertical,
+    one line is plunging past its source Y to detour, which is the awkward
+    case worth flagging.
+    """
+    if ra.line_id == rb.line_id:
+        return None
+    if _edges_share_real_hub(graph, ra.edge, rb.edge):
+        return None
+    # Hidden helper stations are inserted by the layout to extend terminus or
+    # branch geometry; their crossings are intentional.
+    if _edge_involves_hidden(graph, ra.edge) or _edge_involves_hidden(graph, rb.edge):
+        return None
+    shared_ports = _shared_port_endpoints(graph, ra.edge, rb.edge)
+    fan_tol = Y_SPACING
+    vertical_dx_tol = 2.0
+    for ai in range(len(pa) - 1):
+        for bi in range(len(pb) - 1):
+            pt = _segments_cross(pa[ai], pa[ai + 1], pb[bi], pb[bi + 1])
+            if pt is None:
+                continue
+            if _pt_at_station(pt, station_xy, hub_tol):
+                continue
+            if shared_ports and _pt_near_shared_port(pt, shared_ports, fan_tol):
+                seg_a = (pa[ai], pa[ai + 1])
+                seg_b = (pb[bi], pb[bi + 1])
+                if not (
+                    _seg_near_vertical(*seg_a, vertical_dx_tol)
+                    or _seg_near_vertical(*seg_b, vertical_dx_tol)
+                ):
+                    continue
+            return pt
+    return None
 
 
 def check_inter_section_line_crossings(


### PR DESCRIPTION
## Summary

Brings the 15 remaining functions with cyclomatic complexity 31-43 under 30 and lowers the ruff `C901` ceiling from 43 to **30**, completing the ratchet started in #454/#643. `C901` is now a real "keep functions readable" guard rather than just a regression backstop.

Pure structural decomposition: each over-complex function is split into named module-level helpers (or has its nested closures lifted out), with no change to behaviour. The two functions sitting exactly at 30 (`_route_inter_section`, `_snap_inter_section_port_pairs`) are at the new boundary and untouched.

Functions decomposed, by file:

- `routing/offsets.py` — `_compute_entry_port_offsets`, `_reindex_section_local`, `_reorder_exit_only_lines`, `_compact_station_gaps`
- `routing/normalize.py` — `_normalize_gap_channels`
- `routing/reversal.py` — `detect_reversed_sections`
- `routing/postprocess.py` — `_collect_centering_candidates`
- `layout/engine.py` — `_compute_layout_scaled` (strike-clearance and rail-retrofit phases extracted)
- `phases/balancing.py` — `_balance_section_content_around_trunk`
- `section_placement.py` — `_compute_section_offsets`
- `parser/resolve.py` — `_insert_bypass_stations`
- `layout/auto_layout.py` — `_assign_grid_positions`
- `phases/grid_snap.py` — `_snap_all_y_to_grid`
- `phases/guards.py` — `_guard_row_trunk_cy_consistent`
- `tests/layout_validator.py` — `check_route_segment_crossings`

`pyproject.toml`: `[tool.ruff.lint.mccabe] max-complexity` set to 30.

Fixes #644

## Test plan

- [x] `pytest` passes: 7098 passed, 62 skipped, 5 xfailed (all pre-existing known xfails)
- [x] `ruff check src/ tests/` + `ruff format --check` clean on the whole repo
- [x] `mypy` clean (74 source files)
- [x] `ruff check . --select C901` passes at `max-complexity=30`
- [x] Gallery renders byte-identical (`build_gallery.py` produces zero changes vs committed renders)
- [x] Render-preview verdict: **No visual changes detected** (all renders match `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
