### PR TITLE
feat(explain): add nf-metro explain command

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -10,6 +10,7 @@ from typing import Any, TypeVar
 import click
 
 from nf_metro import __version__
+from nf_metro.explain import build_explain, format_explain_json, format_explain_text
 from nf_metro.introspect import build_info, format_info_json, format_info_text
 from nf_metro.layout import PhaseInvariantError, compute_layout
 from nf_metro.options import LAYOUT_OPTIONS, LayoutOption
@@ -334,6 +335,64 @@ def info(input_file: Path, as_json: bool, verbose: bool) -> None:
         click.echo(format_info_json(report))
     else:
         click.echo(format_info_text(report, verbose=verbose))
+
+
+@cli.command()
+@click.argument("input_file", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--json", "as_json", is_flag=True, help="Emit the full explanation as JSON."
+)
+@click.option(
+    "--section",
+    "section_filter",
+    default=None,
+    metavar="SECTION_ID",
+    help="Restrict output to decisions involving this section.",
+)
+@click.option(
+    "--station",
+    "station_filter",
+    default=None,
+    metavar="STATION_ID",
+    help="Restrict output to decisions involving this station.",
+)
+def explain(
+    input_file: Path,
+    as_json: bool,
+    section_filter: str | None,
+    station_filter: str | None,
+) -> None:
+    """Explain WHY nf-metro made each layout decision.
+
+    Surfaces the rule that fired for each inferred decision (section direction,
+    port sides, fold/row layout) and each synthetic element the engine inserted
+    (fan-out junctions, bypass-V stations).
+
+    Pairs with ``nf-metro info``, which shows WHAT was built; this command
+    shows WHY each non-trivial choice was made.
+
+    Use ``--section SECTION_ID`` or ``--station STATION_ID`` to focus the
+    output on decisions involving a specific element.
+    """
+    text = input_file.read_text()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            graph = parse_metro_mermaid(text)
+        except ValueError as e:
+            raise click.ClickException(str(e))
+    messages = [str(w.message) for w in caught]
+
+    report = build_explain(
+        graph,
+        messages,
+        section_filter=section_filter,
+        station_filter=station_filter,
+    )
+    if as_json:
+        click.echo(format_explain_json(report))
+    else:
+        click.echo(format_explain_text(report))
 
 
 @cli.command(context_settings={"ignore_unknown_options": True})

--- a/src/nf_metro/explain.py
+++ b/src/nf_metro/explain.py
@@ -1,0 +1,611 @@
+"""Explains WHY nf-metro made each layout decision for a parsed graph.
+
+This is the data behind ``nf-metro explain``: a causal answer to "why did
+nf-metro do that?".  It surfaces the rule that fired for each non-trivial
+inferred decision and each synthetic element the engine inserted.
+
+:mod:`nf_metro.introspect` answers "what did nf-metro build" (structure);
+this module answers "why did it choose that" (causation).
+
+Everything reported is available immediately after
+:func:`~nf_metro.parser.parse_metro_mermaid`; no full layout pass is
+required.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nf_metro.parser.model import MetroGraph, Section
+
+from nf_metro.introspect import station_kind
+
+__all__ = ["build_explain", "format_explain_json", "format_explain_text"]
+
+# Aspect keys — used in both the formatter's _ASPECT_ORDER and each decision dict.
+_A_LAYOUT = "layout"
+_A_DIRECTION = "direction"
+_A_ENTRY = "entry_side"
+_A_EXIT = "exit_side"
+_A_JUNCTION = "junction"
+_A_BYPASS = "bypass"
+
+# Source labels
+_SRC_INFERRED = "inferred"
+_SRC_SYNTHETIC = "synthetic"
+
+_ASPECT_ORDER = [_A_LAYOUT, _A_DIRECTION, _A_ENTRY, _A_EXIT, _A_JUNCTION, _A_BYPASS]
+_ASPECT_HEADERS = {
+    _A_LAYOUT: "Layout structure",
+    _A_DIRECTION: "Section directions (inferred)",
+    _A_ENTRY: "Entry port sides (inferred)",
+    _A_EXIT: "Exit port sides (inferred)",
+    _A_JUNCTION: "Fan-out junctions (synthetic)",
+    _A_BYPASS: "Bypass stations (synthetic)",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_explain(
+    graph: MetroGraph,
+    warnings: list[str] | None = None,
+    *,
+    section_filter: str | None = None,
+    station_filter: str | None = None,
+) -> dict[str, Any]:
+    """Build the structured explanation dict for a parsed graph.
+
+    *warnings* are parse-time warning messages captured by the caller.
+
+    *section_filter* restricts decisions to those involving the named section.
+    *station_filter* restricts decisions to those involving the named station.
+    """
+    dag = graph.section_dag
+    dag_succs: dict[str, set[str]] = dag.successors if dag is not None else {}
+    dag_preds: dict[str, set[str]] = dag.predecessors if dag is not None else {}
+
+    decisions: list[dict[str, Any]] = []
+
+    _add_layout_decisions(graph, decisions)
+    _add_direction_decisions(graph, dag_succs, dag_preds, decisions)
+    _add_port_decisions(graph, dag_preds, decisions)
+    _add_junction_decisions(graph, decisions)
+    _add_bypass_decisions(graph, decisions)
+
+    if section_filter:
+        decisions = [d for d in decisions if section_filter in d.get("sections", [])]
+    if station_filter:
+        decisions = [d for d in decisions if d.get("subject") == station_filter]
+
+    inferred = sum(1 for d in decisions if d["source"] == _SRC_INFERRED)
+    synthetic = sum(1 for d in decisions if d["source"] == _SRC_SYNTHETIC)
+
+    return {
+        "title": graph.title or None,
+        "warnings": list(warnings or []),
+        "decisions": decisions,
+        "summary": {"inferred": inferred, "synthetic": synthetic},
+        "filter": {"section": section_filter, "station": station_filter},
+    }
+
+
+def format_explain_json(data: dict[str, Any]) -> str:
+    """Serialise the explanation dict as indented JSON."""
+    return json.dumps(data, indent=2)
+
+
+def format_explain_text(data: dict[str, Any]) -> str:
+    """Render the explanation dict as human-readable text."""
+    out: list[str] = []
+    out.append(f"Explain: {data['title'] or '(untitled)'}")
+
+    if data["warnings"]:
+        out.append("")
+        out.append("Warnings:")
+        for w in data["warnings"]:
+            out.append(f"  ! {w}")
+
+    decisions = data["decisions"]
+    if not decisions:
+        out.append("")
+        filt = data.get("filter", {})
+        subject = filt.get("section") or filt.get("station")
+        if subject:
+            out.append(f"No layout decisions found for '{subject}'.")
+        else:
+            out.append("No layout decisions to explain (all settings are explicit).")
+        return "\n".join(out)
+
+    summary = data["summary"]
+    parts = []
+    if summary["inferred"]:
+        parts.append(f"{summary['inferred']} inferred")
+    if summary["synthetic"]:
+        parts.append(f"{summary['synthetic']} synthetic")
+    if parts:
+        out.append(f"({', '.join(parts)})")
+
+    by_aspect: dict[str, list[dict[str, Any]]] = {}
+    for d in decisions:
+        by_aspect.setdefault(d["aspect"], []).append(d)
+
+    for aspect in _ASPECT_ORDER:
+        group = by_aspect.get(aspect, [])
+        if not group:
+            continue
+        out.append("")
+        out.append(f"{_ASPECT_HEADERS.get(aspect, aspect)}:")
+        for d in group:
+            subject = d["subject"]
+            decision = d["decision"]
+            detail = d["detail"]
+            if aspect == _A_LAYOUT:
+                out.append(f"  {detail}")
+            elif aspect in (_A_JUNCTION, _A_BYPASS):
+                out.append(f"  {subject}: {detail}")
+            else:
+                out.append(f"  [{subject}] -> {decision}: {detail}")
+
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Decision builders
+# ---------------------------------------------------------------------------
+
+
+def _decision(
+    subject: str,
+    subject_type: str,
+    aspect: str,
+    decision: str,
+    source: str,
+    rule: str,
+    detail: str,
+    sections: list[str],
+) -> dict[str, Any]:
+    return {
+        "subject": subject,
+        "subject_type": subject_type,
+        "aspect": aspect,
+        "decision": decision,
+        "source": source,
+        "rule": rule,
+        "detail": detail,
+        "sections": sections,
+    }
+
+
+def _add_layout_decisions(
+    graph: MetroGraph,
+    decisions: list[dict[str, Any]],
+) -> None:
+    """Emit a fold/row explanation when the layout spans multiple rows."""
+    real_sections = graph.real_sections
+    if not real_sections:
+        return
+
+    sid_rows = {sid: _section_grid_row(graph, sid) for sid in real_sections}
+    rows: dict[int, list[str]] = {}
+    for sid, row in sid_rows.items():
+        rows.setdefault(row, []).append(sid)
+
+    if len(rows) <= 1:
+        return
+
+    if not any(
+        row > 0 and sid not in graph._explicit_grid for sid, row in sid_rows.items()
+    ):
+        return
+
+    threshold = graph.fold_threshold if graph.fold_threshold is not None else 15
+    n_rows = len(rows)
+    section_list = ", ".join(
+        f"row {r}: [{', '.join(sorted(sids))}]" for r, sids in sorted(rows.items())
+    )
+    decisions.append(
+        _decision(
+            "layout",
+            "layout",
+            _A_LAYOUT,
+            f"{n_rows} rows",
+            _SRC_INFERRED,
+            "fold-threshold",
+            (
+                f"Layout spans {n_rows} rows because the section chain exceeded "
+                f"the fold threshold ({threshold} station-columns). "
+                f"{section_list}."
+            ),
+            list(real_sections),
+        )
+    )
+
+
+def _add_direction_decisions(
+    graph: MetroGraph,
+    dag_succs: dict[str, set[str]],
+    dag_preds: dict[str, set[str]],
+    decisions: list[dict[str, Any]],
+) -> None:
+    """Emit a direction decision for each section whose direction was inferred."""
+    for sec_id, section in graph.sections.items():
+        if sec_id in graph._explicit_directions:
+            continue
+        # Sections with explicit grids are skipped by _infer_directions;
+        # their direction keeps the LR default without inference running.
+        if sec_id in graph._explicit_grid:
+            continue
+
+        rule, detail = _explain_direction(graph, sec_id, section, dag_succs, dag_preds)
+        decisions.append(
+            _decision(
+                sec_id,
+                "section",
+                _A_DIRECTION,
+                section.direction,
+                _SRC_INFERRED,
+                rule,
+                detail,
+                [sec_id],
+            )
+        )
+
+
+def _add_port_decisions(
+    graph: MetroGraph,
+    dag_preds: dict[str, set[str]],
+    decisions: list[dict[str, Any]],
+) -> None:
+    """Emit entry/exit side decisions for sections whose port sides were inferred."""
+    for sec_id, section in graph.sections.items():
+        if sec_id not in graph._explicit_entry and section.entry_hints:
+            sides = sorted({s.value for s, _ in section.entry_hints})
+            rule, detail = _explain_entry_side(graph, sec_id, section, dag_preds, sides)
+            decisions.append(
+                _decision(
+                    sec_id,
+                    "section",
+                    _A_ENTRY,
+                    ", ".join(sides),
+                    _SRC_INFERRED,
+                    rule,
+                    detail,
+                    [sec_id],
+                )
+            )
+
+        if sec_id not in graph._explicit_exit and section.exit_hints:
+            sides = sorted({s.value for s, _ in section.exit_hints})
+            rule, detail = _explain_exit_side(section, sides)
+            decisions.append(
+                _decision(
+                    sec_id,
+                    "section",
+                    _A_EXIT,
+                    ", ".join(sides),
+                    _SRC_INFERRED,
+                    rule,
+                    detail,
+                    [sec_id],
+                )
+            )
+
+
+def _add_junction_decisions(graph: MetroGraph, decisions: list[dict[str, Any]]) -> None:
+    """Emit an explanation for each junction inserted by _resolve_sections."""
+    for jid in graph.junctions:
+        out_edges = graph.edges_from(jid)
+        in_edges = graph.edges_to(jid)
+
+        if jid.startswith("__merge_"):
+            src_sections = sorted(
+                {
+                    graph.section_for_station(e.source) or "?"
+                    for e in in_edges
+                    if e.source != jid
+                }
+            )
+            lines = sorted({e.line_id for e in in_edges})
+            tgt_port = out_edges[0].target if out_edges else "?"
+            tgt_sec = (
+                graph.ports[tgt_port].section_id if tgt_port in graph.ports else "?"
+            )
+            all_secs = sorted(set(src_sections) | {tgt_sec})
+            decisions.append(
+                _decision(
+                    jid,
+                    "station",
+                    _A_JUNCTION,
+                    "merge-junction",
+                    _SRC_SYNTHETIC,
+                    "merge-junction",
+                    (
+                        f"Merge junction: {len(in_edges)} same-line paths "
+                        f"({', '.join(lines)}) from sections "
+                        f"[{', '.join(src_sections)}] "
+                        f"converge on a single entry port in '{tgt_sec}'."
+                    ),
+                    all_secs,
+                )
+            )
+        else:
+            tgt_ports = {e.target for e in out_edges if e.target in graph.ports}
+            tgt_sections = sorted(
+                {graph.ports[pid].section_id for pid in tgt_ports if pid in graph.ports}
+            )
+            in_ports = {e.source for e in in_edges if e.source in graph.ports}
+            src_section = "?"
+            for pid in in_ports:
+                port = graph.ports.get(pid)
+                if port and not port.is_entry:
+                    src_section = port.section_id
+                    break
+
+            all_lines = sorted({e.line_id for e in out_edges})
+            all_secs = sorted({src_section} | set(tgt_sections))
+            decisions.append(
+                _decision(
+                    jid,
+                    "station",
+                    _A_JUNCTION,
+                    "fan-out-junction",
+                    _SRC_SYNTHETIC,
+                    "fan-out-junction",
+                    (
+                        f"Fan-out junction: lines [{', '.join(all_lines)}] leave "
+                        f"'{src_section}' and diverge to "
+                        f"{len(tgt_sections)} section(s): [{', '.join(tgt_sections)}]."
+                    ),
+                    all_secs,
+                )
+            )
+
+
+def _add_bypass_decisions(graph: MetroGraph, decisions: list[dict[str, Any]]) -> None:
+    """Emit an explanation for each bypass-V station."""
+    for sid, station in graph.stations.items():
+        if station_kind(graph, sid) != "bypass":
+            continue
+        bypassed = graph.stations.get(station.bypasses_station_id)  # type: ignore[arg-type]
+        bypassed_label = (
+            f"'{bypassed.label}'"
+            if bypassed and bypassed.label
+            else f"station {station.bypasses_station_id!r}"
+        )
+        lines = sorted(graph.station_lines(sid))
+        sec_id = station.section_id or "?"
+        decisions.append(
+            _decision(
+                sid,
+                "station",
+                _A_BYPASS,
+                "bypass-v",
+                _SRC_SYNTHETIC,
+                "bypass-v",
+                (
+                    f"Hidden bypass-V station routes line(s) [{', '.join(lines)}] "
+                    f"clear of {bypassed_label}'s label marker in "
+                    f"section '{sec_id}'."
+                ),
+                [sec_id],
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule derivation helpers
+# ---------------------------------------------------------------------------
+
+
+def _section_grid_col(graph: MetroGraph, sec_id: str) -> int:
+    """Return the effective grid column, consulting grid_overrides first."""
+    if sec_id in graph.grid_overrides:
+        return graph.grid_overrides[sec_id][0]
+    return graph.sections[sec_id].grid_col
+
+
+def _section_grid_row(graph: MetroGraph, sec_id: str) -> int:
+    """Return the effective grid row for *sec_id*, consulting grid_overrides first."""
+    if sec_id in graph.grid_overrides:
+        return graph.grid_overrides[sec_id][1]
+    return graph.sections[sec_id].grid_row
+
+
+def _explain_direction(
+    graph: MetroGraph,
+    sec_id: str,
+    section: Section,
+    dag_succs: dict[str, set[str]],
+    dag_preds: dict[str, set[str]],
+) -> tuple[str, str]:
+    """Return (rule, detail) explaining why *section* got its direction."""
+    direction = section.direction
+    succs = dag_succs.get(sec_id, set())
+    preds = dag_preds.get(sec_id, set())
+    my_col = _section_grid_col(graph, sec_id)
+    my_row = _section_grid_row(graph, sec_id)
+
+    if direction == "TB":
+        for tgt in succs:
+            tgt_row = _section_grid_row(graph, tgt) if tgt in graph.sections else -1
+            if tgt_row != my_row and tgt_row >= 0:
+                return (
+                    "fold-bridge",
+                    f"Section acts as a vertical bridge between row {my_row} and "
+                    f"row {tgt_row}; TB direction routes lines downward "
+                    f"at the fold point.",
+                )
+        below_succs = [
+            tgt
+            for tgt in succs
+            if tgt in graph.sections and _section_grid_row(graph, tgt) == my_row + 1
+        ]
+        if below_succs:
+            names = [graph.sections[t].name for t in below_succs]
+            return (
+                "successors-below",
+                f"All successors are in the row directly below "
+                f"(row {my_row + 1}): {', '.join(names)}.",
+            )
+        return (
+            "successors-below",
+            f"All successors are positioned directly below section '{section.name}'.",
+        )
+
+    if direction == "RL":
+        succ_cols = [
+            (tgt, _section_grid_col(graph, tgt))
+            for tgt in succs
+            if tgt in graph.sections
+        ]
+        if succ_cols and all(c < my_col for _, c in succ_cols):
+            succ_desc = ", ".join(
+                f"'{graph.sections[t].name}' (col {c})" for t, c in succ_cols
+            )
+            return (
+                "successors-to-left",
+                f"All successors are to the left (col {my_col}): {succ_desc}; "
+                f"RL direction reads right-to-left.",
+            )
+        if not succs and preds:
+            pred_cols = [
+                (src, _section_grid_col(graph, src))
+                for src in preds
+                if src in graph.sections
+            ]
+            if pred_cols and any(c >= my_col for _, c in pred_cols):
+                pred_desc = ", ".join(
+                    f"'{graph.sections[src].name}' (col {c})" for src, c in pred_cols
+                )
+                return (
+                    "return-row-leaf",
+                    f"Terminal section on a return row; predecessor(s) "
+                    f"{pred_desc} are to the right.",
+                )
+        return (
+            "reverse-flow",
+            "Right-to-left flow: predecessors are positioned to the right.",
+        )
+
+    # LR (default)
+    if not preds:
+        return (
+            "source-section",
+            f"Section '{section.name}' has no upstream predecessors; LR is the "
+            f"default flow direction for pipeline heads.",
+        )
+    pred_descs = [
+        f"'{graph.sections[src].name}' (col {_section_grid_col(graph, src)})"
+        for src in preds
+        if src in graph.sections
+    ]
+    if pred_descs:
+        return (
+            "flow-aligned-default",
+            f"Predecessor(s) {', '.join(pred_descs)} are to the left; LR is "
+            f"the default downstream flow direction.",
+        )
+    return (
+        "flow-aligned-default",
+        "Default left-to-right flow direction.",
+    )
+
+
+def _explain_entry_side(
+    graph: MetroGraph,
+    sec_id: str,
+    section: Section,
+    dag_preds: dict[str, set[str]],
+    sides: list[str],
+) -> tuple[str, str]:
+    """Return (rule, detail) explaining the inferred entry port side."""
+    if not sides:
+        return ("no-predecessors", "No upstream predecessors; no entry port created.")
+
+    side_str = ", ".join(sides)
+    direction = section.direction
+
+    preds = dag_preds.get(sec_id, set())
+    for src in preds:
+        src_sec = graph.sections.get(src)
+        if not src_sec:
+            continue
+        if (
+            src_sec.direction == "TB"
+            and _section_grid_row(graph, src) < _section_grid_row(graph, sec_id)
+            and "top" in sides
+        ):
+            return (
+                "vertical-drop",
+                f"Predecessor '{src_sec.name}' is a vertical (TB) section "
+                f"in the row above; entry placed on TOP to receive the "
+                f"downward flow.",
+            )
+
+    if direction in ("LR", "RL"):
+        expected = "left" if direction == "LR" else "right"
+        if expected in sides:
+            return (
+                "flow-aligned-entry",
+                f"Section flows {direction}; entry placed on {side_str.upper()} "
+                f"(the leading edge) to receive the incoming flow.",
+            )
+
+    pred_descs = []
+    for src in preds:
+        src_sec = graph.sections.get(src)
+        if src_sec:
+            pred_descs.append(
+                f"'{src_sec.name}' "
+                f"(col {_section_grid_col(graph, src)}, "
+                f"row {_section_grid_row(graph, src)})"
+            )
+    pred_part = (
+        f"predecessor(s) {', '.join(pred_descs)}"
+        if pred_descs
+        else "predecessor position"
+    )
+    return (
+        "relative-position",
+        f"Entry placed on {side_str.upper()} based on the grid position of "
+        f"{pred_part} relative to this section.",
+    )
+
+
+def _explain_exit_side(
+    section: Section,
+    sides: list[str],
+) -> tuple[str, str]:
+    """Return (rule, detail) explaining the inferred exit port side."""
+    if not sides:
+        return ("no-successors", "No downstream successors; no exit port created.")
+
+    side_str = ", ".join(sides)
+    direction = section.direction
+
+    if direction == "TB" and any(s in sides for s in ("left", "bottom")):
+        return (
+            "fold-exit",
+            f"Fold bridge section; exit placed on {side_str.upper()} toward "
+            f"the successor(s) on the return row.",
+        )
+
+    if direction in ("LR", "RL"):
+        expected = "right" if direction == "LR" else "left"
+        if expected in sides:
+            return (
+                "flow-aligned-exit",
+                f"Section flows {direction}; exit placed on {side_str.upper()} "
+                f"(the trailing edge) toward downstream sections.",
+            )
+
+    return (
+        "relative-position",
+        f"Exit placed on {side_str.upper()} based on successor grid position.",
+    )

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,325 @@
+"""Tests for nf-metro explain: the causal layout decision reporter."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nf_metro.cli import cli
+from nf_metro.explain import build_explain, format_explain_json, format_explain_text
+from nf_metro.parser import parse_metro_mermaid
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+RNASEQ_AUTO_MMD = EXAMPLES_DIR / "rnaseq_auto.mmd"
+RNASEQ_SECTIONS_MMD = EXAMPLES_DIR / "rnaseq_sections.mmd"
+DA_MMD = EXAMPLES_DIR / "differentialabundance.mmd"
+
+
+# ---------------------------------------------------------------------------
+# build_explain contract
+# ---------------------------------------------------------------------------
+
+
+def test_explain_returns_required_keys():
+    """build_explain returns a dict with the documented top-level keys."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+    assert {"title", "warnings", "decisions", "summary"} <= set(data)
+    assert isinstance(data["decisions"], list)
+    assert isinstance(data["summary"], dict)
+    assert {"inferred", "synthetic"} <= set(data["summary"])
+
+
+def test_explain_decision_schema():
+    """Every decision has the required fields."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+    required = {
+        "subject",
+        "subject_type",
+        "aspect",
+        "decision",
+        "source",
+        "rule",
+        "detail",
+    }
+    for d in data["decisions"]:
+        assert required <= set(d), f"Decision missing keys: {d}"
+        assert d["source"] in ("inferred", "synthetic")
+        assert d["subject_type"] in ("section", "station", "layout")
+
+
+def test_explain_rnaseq_auto_directions():
+    """rnaseq_auto.mmd infers all section directions; each appears with correct rule."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+
+    dir_decisions = {
+        d["subject"]: d for d in data["decisions"] if d["aspect"] == "direction"
+    }
+    # preprocessing: source section -> LR
+    assert "preprocessing" in dir_decisions
+    assert dir_decisions["preprocessing"]["decision"] == "LR"
+    assert dir_decisions["preprocessing"]["rule"] == "source-section"
+
+    # postprocessing: fold bridge -> TB
+    assert "postprocessing" in dir_decisions
+    assert dir_decisions["postprocessing"]["decision"] == "TB"
+    assert dir_decisions["postprocessing"]["rule"] == "fold-bridge"
+
+    # qc_report: return-row terminal -> RL
+    assert "qc_report" in dir_decisions
+    assert dir_decisions["qc_report"]["decision"] == "RL"
+    assert dir_decisions["qc_report"]["rule"] == "return-row-leaf"
+
+
+def test_explain_fold_fires_for_auto_layout():
+    """A fold explanation is emitted when auto-layout wraps into multiple rows."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+
+    fold_decisions = [d for d in data["decisions"] if d["aspect"] == "layout"]
+    assert fold_decisions, "Expected a fold/layout explanation"
+    assert fold_decisions[0]["rule"] == "fold-threshold"
+    assert "rows" in fold_decisions[0]["decision"]
+
+
+def test_explain_fold_silent_for_explicit_grid():
+    """No fold explanation when all sections are author-placed with %%metro grid:."""
+    graph = parse_metro_mermaid(DA_MMD.read_text())
+    data = build_explain(graph)
+
+    fold_decisions = [d for d in data["decisions"] if d["aspect"] == "layout"]
+    assert not fold_decisions, (
+        "Fold explanation must not fire when all grid positions are explicit"
+    )
+
+
+def test_explain_explicit_direction_not_reported():
+    """Sections with explicit %%metro direction: do not appear in inferred decisions."""
+    graph = parse_metro_mermaid(RNASEQ_SECTIONS_MMD.read_text())
+    data = build_explain(graph)
+
+    inferred_dir_subjects = {
+        d["subject"] for d in data["decisions"] if d["aspect"] == "direction"
+    }
+    # rnaseq_sections.mmd has two explicit direction directives; check none of
+    # those sections show up as inferred.
+    for sid in graph._explicit_directions:
+        assert sid not in inferred_dir_subjects, (
+            f"Section {sid!r} has an explicit direction but appeared as inferred"
+        )
+
+
+def test_explain_explicit_grid_sections_skipped_in_directions():
+    """Sections in _explicit_grid do not appear in direction decisions."""
+    graph = parse_metro_mermaid(DA_MMD.read_text())
+    data = build_explain(graph)
+
+    dir_subjects = {
+        d["subject"] for d in data["decisions"] if d["aspect"] == "direction"
+    }
+    for sid in graph._explicit_grid:
+        assert sid not in dir_subjects, (
+            f"Explicitly-gridded section {sid!r} appeared in direction decisions"
+        )
+
+
+def test_explain_fan_out_junction():
+    """Fan-out junctions are reported with source and target section details."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+
+    junctions = [d for d in data["decisions"] if d["aspect"] == "junction"]
+    assert junctions, "Expected at least one junction explanation"
+    j = junctions[0]
+    assert j["source"] == "synthetic"
+    assert j["rule"] == "fan-out-junction"
+    assert "preprocessing" in j["detail"]
+
+
+def test_explain_bypass_station():
+    """Bypass-V stations are reported with the bypassed station's label."""
+    graph = parse_metro_mermaid(DA_MMD.read_text())
+    data = build_explain(graph)
+
+    bypasses = [d for d in data["decisions"] if d["aspect"] == "bypass"]
+    assert bypasses, (
+        "Expected at least one bypass explanation for differentialabundance"
+    )
+    b = bypasses[0]
+    assert b["source"] == "synthetic"
+    assert b["rule"] == "bypass-v"
+    assert "Annotate results" in b["detail"]
+
+
+def test_explain_port_sides_inferred():
+    """Inferred entry/exit port sides appear for rnaseq_auto sections."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+
+    entry_sides = {
+        d["subject"]: d["rule"]
+        for d in data["decisions"]
+        if d["aspect"] == "entry_side"
+    }
+    # qc_report gets TOP entry because postprocessing TB predecessor drops down
+    assert entry_sides.get("qc_report") == "vertical-drop"
+    # genome_align is LR -> flow-aligned LEFT entry
+    assert entry_sides.get("genome_align") == "flow-aligned-entry"
+
+
+def test_explain_no_decisions_single_section(tmp_path):
+    """Single-section graph with no inferences produces an empty decisions list."""
+    mmd = tmp_path / "simple.mmd"
+    mmd.write_text(
+        "%%metro title: Simple\n"
+        "%%metro line: a | A | #ff0000\n"
+        "graph LR\n"
+        "    x[X] -->|a| y[Y]\n"
+    )
+    graph = parse_metro_mermaid(mmd.read_text())
+    data = build_explain(graph)
+    assert data["decisions"] == []
+    assert data["summary"]["inferred"] == 0
+    assert data["summary"]["synthetic"] == 0
+
+
+def test_explain_summary_counts():
+    """summary.inferred + summary.synthetic equals len(decisions)."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+    total = data["summary"]["inferred"] + data["summary"]["synthetic"]
+    assert total == len(data["decisions"])
+
+
+# ---------------------------------------------------------------------------
+# Section and station filters
+# ---------------------------------------------------------------------------
+
+
+def test_explain_section_filter_restricts_output():
+    """section_filter uses the structural sections field, not string matching."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph, section_filter="preprocessing")
+    for d in data["decisions"]:
+        assert "preprocessing" in d["sections"], (
+            f"Decision for {d['subject']!r} slipped through section filter: "
+            f"sections={d['sections']}"
+        )
+
+
+def test_explain_station_filter():
+    """station_filter returns only decisions for the named station id."""
+    graph = parse_metro_mermaid(DA_MMD.read_text())
+    # Find a junction id to filter on
+    if not graph.junctions:
+        pytest.skip("No junctions in graph")
+    jid = graph.junctions[0]
+    data = build_explain(graph, station_filter=jid)
+    assert all(d["subject"] == jid for d in data["decisions"])
+
+
+def test_explain_section_filter_unknown_section():
+    """Filtering by a non-existent section returns an empty decisions list."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph, section_filter="does_not_exist")
+    assert data["decisions"] == []
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+def test_format_explain_json_is_valid():
+    """format_explain_json produces valid, parseable JSON."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+    text = format_explain_json(data)
+    parsed = json.loads(text)
+    assert parsed["title"] == data["title"]
+    assert len(parsed["decisions"]) == len(data["decisions"])
+
+
+def test_format_explain_text_structure():
+    """format_explain_text produces headers for each aspect present."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph)
+    text = format_explain_text(data)
+    assert "Explain:" in text
+    assert "Section directions" in text
+    assert "Entry port sides" in text
+    assert "Fan-out junctions" in text
+
+
+def test_format_explain_text_empty_graph(tmp_path):
+    """Empty decisions list renders as 'no decisions' message."""
+    mmd = tmp_path / "s.mmd"
+    mmd.write_text(
+        "%%metro title: Simple\n%%metro line: a | A | #ff0000\n"
+        "graph LR\n    x[X] -->|a| y[Y]\n"
+    )
+    graph = parse_metro_mermaid(mmd.read_text())
+    data = build_explain(graph)
+    text = format_explain_text(data)
+    assert "No layout decisions" in text
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_explain_cli_runs():
+    """explain CLI command exits 0 and prints the title."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["explain", str(RNASEQ_AUTO_MMD)])
+    assert result.exit_code == 0, result.output
+    assert "Explain:" in result.output
+
+
+def test_explain_cli_json():
+    """explain --json emits valid JSON with decisions and summary keys."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["explain", str(RNASEQ_AUTO_MMD), "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert {"title", "warnings", "decisions", "summary"} <= set(data)
+
+
+def test_explain_cli_section_filter():
+    """explain --section restricts output to the requested section."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["explain", str(RNASEQ_AUTO_MMD), "--section", "preprocessing"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "preprocessing" in result.output
+
+
+def test_explain_cli_matches_formatter():
+    """CLI default output matches format_explain_text byte-for-byte."""
+    graph = parse_metro_mermaid(RNASEQ_AUTO_MMD.read_text())
+    data = build_explain(graph, warnings=[])
+    expected = format_explain_text(data)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["explain", str(RNASEQ_AUTO_MMD)])
+    assert result.exit_code == 0
+    assert result.output == expected + "\n"
+
+
+@pytest.mark.parametrize(
+    "mmd_path",
+    sorted((EXAMPLES_DIR).glob("*.mmd"))
+    + sorted((EXAMPLES_DIR / "topologies").glob("*.mmd")),
+    ids=lambda p: p.stem,
+)
+def test_explain_all_fixtures_no_crash(mmd_path):
+    """explain never raises on any gallery or topology fixture."""
+    graph = parse_metro_mermaid(mmd_path.read_text())
+    data = build_explain(graph)
+    _ = format_explain_text(data)
+    _ = format_explain_json(data)


### PR DESCRIPTION
## Summary

- Adds a new `nf-metro explain` CLI command that surfaces WHY the engine made each layout decision, pairing with the existing `nf-metro info` (which shows WHAT was built)
- New `src/nf_metro/explain.py` module (`build_explain` / `format_explain_text` / `format_explain_json`) with the same API shape as `introspect.py`; all data is available post-parse, no full layout pass required
- The command covers six decision categories: fold/row layout, inferred section directions, inferred entry/exit port sides, fan-out and merge junctions, and bypass-V stations
- `--json` flag emits structured JSON; `--section` and `--station` flags filter decisions to a named element
- 90 tests in `tests/test_explain.py`: schema, all decision types, filters, formatters, CLI integration, and a no-crash parametrized sweep over every gallery and topology fixture

Fixes #564

## Test plan
- [x] pytest passes (7188 passed, 62 skipped, 5 xfailed)
- [x] ruff format + ruff check clean on whole repo
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/645/) — no production code path change, render-diff expected to be byte-identical

Generated with Claude Code