### PR TITLE
feat(skills): add nf-metro-stress-render bug-hunting skill

### DIFF
--- a/.claude/skills/nf-metro-stress-render/SKILL.md
+++ b/.claude/skills/nf-metro-stress-render/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: nf-metro-stress-render
+description: Stress-test the nf-metro layout engine by composing a brand-new, deliberately complex pipeline metro map, rendering it, and hunting for layout bugs the way a real never-seen-before pipeline would surface them. Use this whenever the user wants to fuzz / stress / probe the layout engine, find new layout bugs, check robustness against novelty, "throw a weird pipeline at it", generate a novel test render, or run an ad-hoc bug-hunting pass. Each run invents ONE novel topology (braiding structural axes that have not been combined before), renders it, runs the programmatic layout validator, and PRESENTS the render for you to eyeball the aesthetic bugs a validator can't see. Every candidate defect - whether the validator flagged it or you reported it by eye - is CONFIRMED against the laid-out geometry (exact coordinates, off-trunk drags, off-track gaps, inter-row gaps) and understood at the mechanism level before anything is filed; reports are never filed on eyeball alone. Confirmed bugs are FILED as GitHub issues (after dedup + your confirmation) AND wired with regression infra - a fixture in examples/topologies/, a gallery render so CI's render-diff tracks it, and a strict-xfail test that reds CI when the bug is fixed - so the defect can't silently return. Trigger on "stress test the layout", "fuzz nf-metro", "find layout bugs", "try a novel/complex render", "probe the engine for robustness", "what breaks if we render something new", "confirm and file these layout bugs". This is the operational answer to issues #364 (mutation/fuzz testing) and #323 (fragility on new pipelines).
+---
+
+# nf-metro stress render
+
+Every genuinely new pipeline we render tends to surface a layout bug, because
+the engine is robust on shapes it has seen and brittle on novel combinations.
+This skill simulates "a new pipeline arrives" on demand: it **composes one
+novel, sufficiently-complex metro map**, renders it, catches the obvious
+structural defects programmatically, and puts the render in front of you for the
+aesthetic defects only a human eye catches. Every candidate - flagged or
+eyeballed - is then confirmed against the laid-out geometry and understood at
+the mechanism level before it's filed, and each confirmed bug ships with a
+regression fixture + gallery render + guard test so it can't silently return.
+Run it ad-hoc; over time, as confirmed finds become permanent guarded fixtures,
+novelty stops being a risk.
+
+The unit of work is **one rich render per run**, reviewed deeply - not a batch.
+
+## Prerequisites
+
+- Work from the nf-metro checkout (default `~/projects/nf-metro`). This is a
+  read-mostly probing task; no worktree needed unless you end up promoting a
+  fixture or the user asks you to also fix the bug.
+- Activate the env in the same command chain: `source ~/.local/bin/mm-activate nf-metro && ...`
+  (the env has nf-metro editable-installed plus cairosvg for PNG).
+- `gh` for issue dedup + filing.
+
+## The loop
+
+### 1. Choose a novel combination
+
+Read `references/failure_modes.md` (the axis menu + known-fragile list) and
+`coverage_log.md` (at the skill root, next to this SKILL.md - what past runs
+already drew). Pick **2-4 structural axes
+that have not been braided together before**. The goal is a combination that is
+new to both the `examples/topologies/` corpus and the coverage log - the seams
+next to known cracks are where the next crack hides.
+
+Do not reproduce an existing fixture. Coverage of an axis *alone* is not
+novelty; novelty is a never-drawn *triple* (e.g. "off-track output feeding a
+station inside a folded return row that also carries a bypass"). Decide the
+combination explicitly and say it out loud to the user before authoring, so the
+intent is on record.
+
+To keep runs genuinely varied rather than gravitating to the same favourites,
+let the choice be arbitrary: glance at the least-recently-exercised axes in the
+log and force yourself toward those.
+
+### 2. Author a correct-by-construction `.mmd`
+
+Compose a single connected pipeline that braids the chosen axes. Give it a
+believable bioinformatics surface (real-ish tool names, line names like
+`dna`/`rna`/`qc`) so it reads like a pipeline, not a graph-theory toy - realism
+is what makes the render's aesthetic problems legible.
+
+**Correctness is non-negotiable** (see the authoring rules in
+`references/failure_modes.md`): lines only stop at stations they consume, every
+line id is declared, off-track nodes carry their directive, ports match the
+crossing edges. **Prefer auto-layout** - omit `grid:`/`direction:` unless the
+axis under test *is* manual placement. A bug found on inferred layout is worth
+ten found on a hand-pinned one.
+
+Aim for "sufficiently complex": roughly 4-7 sections, 3-5 lines, 20-40
+stations, with at least one fan, one convergence, and one of the trickier axes
+(fold / mixed ports / off-track / bypass). Enough moving parts that an
+interaction can go wrong, not so many that you can't reason about the result.
+Gauge complexity by the probe's **station** count, not its edge count - a
+comma-separated line list explodes into one edge per line, so `edges` runs
+several times higher than the authored arrow count and overstates size.
+
+Save it to a fresh workspace so the `.mmd` *is* the reproducer:
+
+```bash
+WS="/tmp/nf_metro_stress/$(date +%Y%m%d-%H%M%S)-<short-slug>"
+mkdir -p "$WS"
+# write the composed mmd to "$WS/layout.mmd"
+```
+
+### 3. Probe
+
+```bash
+source ~/.local/bin/mm-activate nf-metro && \
+python .claude/skills/nf-metro-stress-render/scripts/probe_layout.py \
+    "$WS/layout.mmd" --png "$WS/layout.png" --json | tee "$WS/verdict.json"
+```
+
+`probe_layout.py` runs the same stages a real render does and sorts findings
+into four buckets, weakest-to-strongest engine-bug signal: `parse_issues`
+(authoring), `validator` warnings/errors, `layout_crash`, `guard_failure`. It
+exits non-zero only on an engine-level ERROR. Read `scripts/probe_layout.py`'s
+header for the full contract.
+
+### 4. Triage the verdict
+
+- **`parse_issues` (error) present** -> the `.mmd` is malformed (a rule-1..4
+  violation). This is *your* mistake, not an engine bug. Fix the `.mmd` and
+  re-probe. Do not file.
+- **`layout_crash` or `guard_failure`** -> hard engine failure / invariant
+  violation on well-formed input. Strongest obvious-bug signal.
+- **`validator` ERROR** -> structural defect (overlap, station-as-elbow, kink,
+  containment...). Obvious bug.
+- **clean** (`engine_error=false`, maybe warnings) -> no obvious structural
+  bug; go to the visual review in step 5. Warnings are eyeball-worthy but not
+  auto-file material on their own.
+
+Validator findings are *candidates*, not yet filed bugs - they go through the
+confirm-and-understand pass in step 6 alongside whatever the user's eye catches.
+
+### 5. Present the render for the user's eye
+
+The validator is blind to the defects that matter most visually (ugly detours,
+asymmetric fans, near-miss label grazes, scrambled bundle identity,
+reading-direction confusion). See the "only your eye catches" list in
+`references/failure_modes.md`. Do this every run, even when nothing structural
+fired.
+
+1. **Look at it yourself first.** Read the PNG (`$WS/layout.png`) into context
+   and do a genuine visual pass - call out anything that looks off, with
+   region/coordinates. Catching a candidate before the user is part of the value.
+2. **Open it for the user**: `open "$WS/layout.png"`.
+3. Tell them what you composed (the axis combination), what the probe found, and
+   what *you* noticed by eye, then ask them to report any other visual bugs.
+
+The user's reported bugs and your own + the validator's candidates all feed the
+next step. They are reports, not yet confirmed findings.
+
+### 6. Confirm and understand every candidate before filing
+
+This is the heart of credible bug-filing, and it applies equally to a validator
+warning, something you spotted, and a defect the **user reported by eye**. A
+report like "section 2 content is pulled too low" or "that input floats too
+high" is a *hypothesis*; never file it on the strength of the eyeball alone.
+Turn each one into a quantified, mechanism-level finding first. A filed issue
+that names exact coordinates and a likely cause is actionable; one that says
+"looks wrong" wastes the maintainer's time and erodes trust in the skill.
+
+For each candidate:
+
+1. **Quantify it.** Run the bundled inspector to get the real geometry:
+
+   ```bash
+   source ~/.local/bin/mm-activate nf-metro && \
+   python .claude/skills/nf-metro-stress-render/scripts/inspect_layout.py "$WS/layout.mmd"
+   ```
+
+   It prints every station's `(x, y)` per section, flags stations sitting **off
+   their section trunk**, off-track inputs/outputs **far from their consumer**,
+   and **oversized inter-row gaps** - which directly confirm reports like
+   "pulled too low" (off-trunk by +Npx), "floats too high" (gap to consumer),
+   or "section too far down" (inter-row gap vs siblings). Cross-reference the
+   probe's `validator` warnings (e.g. `route_segment_crossing`,
+   `almost_horizontal_edge`) for the routing-level reports.
+2. **Zoom in.** Crop the affected region from the PNG (PIL/`cairosvg`; remember
+   the PNG is `scale=2` vs the SVG/inspector coordinates) and read it, so the
+   numbers and the picture agree.
+3. **Understand the mechanism.** State *why* it happens in engine terms (which
+   phase / which placement rule), not just *that* it looks wrong. The engine can
+   explain itself: `nf-metro explain "$WS/layout.mmd"` reports the rule that
+   fired for each inferred decision (section direction, port sides, fold/row
+   layout) and each synthetic element (fan-out junctions, bypass-V stations) -
+   use it to name the cause behind a confirmed symptom, and `nf-metro info`
+   (`--json`) for the structural WHAT. Where it's cheap, **try to reduce** to a
+   minimal `.mmd` that still trips it (re-probe to confirm). If a plausible
+   minimal repro does **not** reproduce, that negative result is itself signal -
+   it tells the maintainer the trigger is a combination, so record it.
+4. If confirmation fails - the geometry is actually fine, or it's an authoring
+   artefact - **say so and drop it.** A candidate that dissolves under
+   inspection is the triage working, not a miss.
+
+### 7. File each confirmed bug AND wire its regression infra
+
+A bug that's filed but not guarded will silently come back. Every confirmed
+finding gets **both** an issue and the test/gallery wiring that catches a
+regression - this is the core of how "novelty presents less of a risk over
+time" (and it directly advances #364). Treat the regression infra as part of
+filing, not an optional follow-up.
+
+This step edits the repo, so work in a **worktree** per the repo conventions
+(`../nf-metro-stress-<slug>`), and batch all of a run's findings into one PR.
+
+1. **Dedup**: `gh issue list --state open --search "<symptom keywords>"`, scan
+   titles/labels (`bug`, `layout`, `routing`, `parser`), and check the
+   known-fragile list in `references/failure_modes.md`. If it already exists,
+   add a comment with your confirmed repro + coordinates instead of duplicating.
+2. **Draft + confirm + file** the issue. Include: plain-English symptom; the
+   quantified evidence from step 6 (a small coordinate table reads well); the
+   probe verdict line if any; the structural class (braided axes); and the
+   correct-by-construction repro `.mmd` in a `<details>` block so it's
+   self-contained. Show the draft to the user and get a yes before
+   `gh issue create`. Suggest `bug` + the subsystem label.
+3. **Add the regression fixture.** Drop the (reduced if possible) repro into
+   `examples/topologies/<descriptive_name>.mmd` and add a row to that dir's
+   `README.md` structural-class table, citing the issue number. Fixtures there
+   are auto-collected by `tests/test_topology_validation.py`
+   (`TOPOLOGY_FILES = sorted(TOPOLOGIES_DIR.glob("*.mmd"))`) into the validator
+   and several always-on parametrized checks.
+4. **Add the render to the gallery** so CI's render-diff tracks it: append a
+   `(stem, source_dir, description)` tuple to `GALLERY_ENTRIES` in
+   `scripts/build_gallery.py`. The render then shows up on every PR preview, so
+   any future change to this layout is visible.
+5. **Lock the defect with a test** so a fix is noticed and a regression reds CI.
+   Follow the repo's existing patterns (read `tests/test_topology_validation.py`):
+   - If the defect is **validator-detectable**, add a targeted test asserting the
+     specific check is clean, marked `@pytest.mark.xfail(strict=True, reason="...#NNN")`
+     (mirror `TestVariantCallingDefects` / `_VARIANT_CALLING_XFAIL`). It xfails
+     now; when the engine fix lands it flips to XPASS and reds CI, prompting
+     removal of the marker and closing the issue.
+   - If the defect is **aesthetic / not yet validator-detectable**, the gallery
+     render is the guard (CI render-diff surfaces any change), and note on the
+     issue that a new validator check would let it be locked harder - or add one
+     if it's tractable.
+   - **Gotcha**: a new fixture is also fed to the always-on parametrized checks
+     (chain alignment, etc.). Run `pytest tests/test_topology_validation.py` after
+     adding it; if it reds on a check *other* than the one you're locking, either
+     reduce the fixture so it only exhibits the target defect, or add matching
+     xfail locks. Don't let a new fixture red CI on an unrelated check.
+6. Open the PR (additive; per repo PR hygiene). The render-diff preview lets the
+   user see every new fixture render and confirm the issues in context.
+
+### 8. Log the run
+
+Append one row to `coverage_log.md` (at the skill root): the date, the axis
+combination, the workspace path, and the outcome (clean / filed #N + fixture /
+known-dup #N / dropped-on-inspection). This keeps successive runs pushing into
+fresh territory and shows novelty risk shrinking as fixtures accumulate.
+
+## Scope boundaries
+
+- This skill **finds, confirms, files, and guards** (fixture + gallery + xfail);
+  it does not *fix* the engine. When the user wants a filed bug fixed, hand off
+  to the `nf-metro-layout-fix` skill (code-level fixes with invariant tests +
+  gallery regression vetting), or `fix-issue` for the full issue->PR workflow.
+  The strict-xfail this skill leaves behind is what tells the fixer they're done.
+- A finding that turns out to be an authoring mistake is a *success of the
+  triage*, not a failure of the run - it means the engine was right. Say so.
+- If the user wants to author a faithful map for a *real* pipeline (not a
+  synthetic stressor), that's `pipeline-metro-diagram`, not this.

--- a/.claude/skills/nf-metro-stress-render/coverage_log.md
+++ b/.claude/skills/nf-metro-stress-render/coverage_log.md
@@ -1,0 +1,10 @@
+# Stress-render coverage log
+
+One row per run, appended by the `nf-metro-stress-render` skill. The point is
+to keep successive runs pushing into structural territory that earlier runs and
+the `examples/topologies/` corpus have not drawn, and to watch novelty risk
+shrink as confirmed finds become permanent fixtures.
+
+| Date | Axis combination | Workspace | Outcome |
+|---|---|---|---|
+| _seed_ | (corpus baseline - see examples/topologies/README.md for axes already covered in isolation) | - | - |

--- a/.claude/skills/nf-metro-stress-render/references/failure_modes.md
+++ b/.claude/skills/nf-metro-stress-render/references/failure_modes.md
@@ -1,0 +1,118 @@
+# Layout-engine failure modes & structural axes
+
+This is the menu the stress-render skill draws from when composing a novel
+layout. The engine is solid on shapes it has seen; it breaks on *new
+combinations*. Your job is to pick axes that have not been combined before
+and braid them into one believable pipeline.
+
+## Table of contents
+- [How to use this](#how-to-use-this)
+- [Structural axes (the dice)](#structural-axes-the-dice)
+- [Known-fragile areas (likely dup, not novel)](#known-fragile-areas-likely-dup-not-novel)
+- [What the probe catches vs what only your eye catches](#what-the-probe-catches-vs-what-only-your-eye-catches)
+- [Authoring-correctness rules (so a defect is the engine's fault)](#authoring-correctness-rules)
+
+## How to use this
+
+The existing `examples/topologies/` corpus (see its README) already covers
+each axis *in isolation* and a handful of pairs. Coverage of an axis alone is
+not novelty. Novelty is **A x B x C where that triple has never been drawn** -
+e.g. "a fold whose return row also carries an off-track output feeding a
+station inside a TB section." Read `coverage_log.md` to see what past runs
+already tried, and deliberately go somewhere else.
+
+Bias toward combinations that sit *near* an open issue or known-fragile area
+but are not that issue - the seams next to known cracks are where the next
+crack usually is.
+
+## Structural axes (the dice)
+
+Pick 2-4. The more axes you braid into one connected graph (not separate
+disconnected toys), the more likely an interaction bug surfaces.
+
+| Axis | What it stresses | Engine machinery exercised |
+|---|---|---|
+| **Fan-out** (1 -> N) | junction insertion, port spacing, bundle slot reservation | `_create_ports_and_junctions`, ordering |
+| **Fan-in** (N -> 1) | bundle ordering at L-corners, merge junctions | inter-section handlers |
+| **Diamond / fork-join** | distinct track per branch, uneven branch lengths | `_equalize_fork_groups`, diamond detection (#610) |
+| **Fold / serpentine** | wrap to RL return row, double fold, reading direction | `auto_layout` fold threshold, `reversal.py` - **a fold only fires on a near-linear section spine that exceeds ~15 station-columns; a branchy DAG stacks vertically instead and never folds. To exercise this axis, build a long mostly-linear chain, or pin `%%metro fold_threshold:` low.** |
+| **Fan across a fold** | fan-out/in spanning the row boundary | rowspan optimisation |
+| **Mixed port sides** | TOP+BOTTOM exits, LEFT+RIGHT on TB | `ports.py`, station-as-elbow risk |
+| **TB + LR mix** | perpendicular ports, diagonal-label gating | `_infer_directions`, TB guards |
+| **Off-track inputs** | inputs sit above their consumer, not on a line | `off_track.py` |
+| **Off-track outputs** | producer-fed sinks below the line (#573) | `_space_off_track_output_columns` |
+| **Wide labels** | auto-wrap, column spread, diagonal strike-through | `labels.py`, label-strike levers (#513) |
+| **Dense bundle** | many lines sharing a trunk, tall station pills | `offsets.py`, `compute_bundle_info` |
+| **Bypass** | line routing around an intervening section box | bypass handlers (#484), bypass-V (#632) |
+| **Skip edges on a spine** | linear chain with forward jumps | fold-suppression gate (#551) |
+| **Tall-narrow anchor** | one dominant tall fan beside a narrow chain | `_detect_tall_anchor_chain` (#552) |
+| **Same-line divergence/convergence** | one colour splitting then rejoining a port | coincide-fanout passes (#546) |
+| **Multi-source convergence** | several sources, one line, one sink | merge-junction routing |
+| **Disconnected components** | independent sub-pipelines, row stacking | component packing |
+| **Rails / line_spread** | bundle vs centered vs rails convergence | `rail_mode.py`, `line_spread` |
+| **Cycle / self-loop** | a back-edge or `a --> a` | now rejected fast with a node-naming error (#645, fixed) - the probe surfaces it as a parse issue; expected behaviour, not a find |
+
+## Known-fragile areas (likely dup, not novel)
+
+If your render trips one of these, it is almost certainly a *known* defect.
+Cross-check the open issue before drafting - link/append, don't re-file. These
+are also areas where a validator ERROR may be expected, so don't treat them as
+fresh discoveries:
+
+- **#255** station-as-elbow recurrence in TB-direction sections (OPEN bug).
+- **#248** funcprofiler upstream layout quality (dense fan-out + fan-in).
+- **#533** `graph TB` primary direction is not honoured (silently warns).
+- **#556** diagonal labels gated to LR-only; TB sections get horizontal labels.
+- **#555** diagonal-label column pitch is graph-wide (sparse fans inherit dense pitch).
+- **#589** debug grid lines at logical `station.y`, not bundle-centred markers.
+- **#349** triage red bboxes don't mark the true label position.
+
+A novel find is one that does *not* map onto any of these and is not already in
+`gh issue list`.
+
+## What the probe catches vs what only your eye catches
+
+`probe_layout.py` is good at *structural* defects but blind to *aesthetic*
+ones. Know the split so you review the render for what the validator can't see.
+
+**Probe catches (file as obvious bug):**
+- layout crash / `PhaseInvariantError` guard failure
+- section box overlap, station outside its box, port off the boundary
+- coincident stations, station-as-elbow (line passes through a marker it doesn't stop at)
+- near-horizontal-but-not edges, excessive column gaps, route-segment crossings
+- label/label and label/box overlap (geometric)
+
+**Only your eye catches (present to user, draft only with their nod):**
+- a line that is *technically* clear but reads as an ugly detour or wobble
+- asymmetric fans that "should" mirror
+- a diagonal that grazes a label the geometric check rounded as clear
+- bundle ordering that is legal but visually scrambles line identity
+- overall balance / whitespace / "does this look like a metro map"
+- reading-direction confusion across a fold
+
+## Authoring-correctness rules
+
+A filed bug is only credible if the `.mmd` is well-formed - otherwise you are
+reporting your own mistake. Before probing, verify:
+
+1. **Lines only traverse stations they consume.** An edge `a -->|rna| b` means
+   the `rna` line stops at both `a` and `b`. Never route a line *through* a
+   station it doesn't serve - that is the #1 authoring mistake that masquerades
+   as a "line crosses non-consumer" engine bug. If a line must pass a section
+   without stopping, that is a genuine *bypass* (model it with the line simply
+   not having an edge into that section's internals).
+2. **Every `%%metro line:` id used in an edge is declared**, and every edge line
+   id is declared (the parser raises otherwise - the probe surfaces it as a
+   parse issue).
+3. **Off-track inputs/outputs carry their directive** (`%%metro off_track:`),
+   or they will be treated as on-line stations.
+4. **Ports match the inter-section edges** - entry/exit directives name the
+   lines that actually cross that boundary.
+5. **Prefer auto-layout.** Omit `%%metro grid:` / `direction:` unless the axis
+   you are testing *is* manual placement. The strongest finds come from what
+   the engine infers, not what you pin. (If you pin everything, you have tested
+   your own arithmetic, not the engine.)
+
+If the probe reports a parse issue, it is a rule-1..4 violation: fix the `.mmd`
+and re-probe. Only a clean parse with an engine-level finding is a bug worth
+drafting.

--- a/.claude/skills/nf-metro-stress-render/scripts/inspect_layout.py
+++ b/.claude/skills/nf-metro-stress-render/scripts/inspect_layout.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Dump the laid-out geometry of a .mmd so a reported defect can be confirmed.
+
+`probe_layout.py` answers "did anything trip a check?". This answers "where is
+everything?" - the coordinates you need to turn an eyeballed report ("section 2
+content is pulled too low", "that input floats too high") into a quantified,
+credible bug ("`al_minimap` y=392 vs the trunk at y=216.8, a 175px drag").
+
+For each section it prints the bbox extents and every station's (x, y) with a
+PORT / OFF(-track) tag, then a few derived red flags:
+  - stations that sit off their section's trunk (modal y of non-port stations)
+  - off-track inputs/outputs more than ~one row from their nearest neighbour
+  - the inter-section gaps between vertically-stacked sections
+
+Usage:
+    python inspect_layout.py INPUT.mmd
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+tests_dir = _REPO_ROOT / "tests"
+if (tests_dir / "layout_validator.py").exists():
+    sys.path.insert(0, str(tests_dir))
+
+from nf_metro.layout.engine import compute_layout  # noqa: E402
+from nf_metro.parser.mermaid import parse_metro_mermaid  # noqa: E402
+from nf_metro.parser.model import Station  # noqa: E402
+
+
+def _is_port(st: Station) -> bool:
+    return bool(getattr(st, "is_port", False))
+
+
+def _is_off(st: Station) -> bool:
+    return bool(getattr(st, "off_track", False))
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    path = Path(sys.argv[1])
+    graph = parse_metro_mermaid(path.read_text(), max_station_columns=15)
+    compute_layout(graph)
+
+    print(f"=== {path.name} ===")
+
+    # Per-section dump.
+    boxes: list[tuple[float, float, int, int, str]] = []
+    for sid, sec in graph.sections.items():
+        x0, y0 = sec.bbox_x, sec.bbox_y
+        x1, y1 = x0 + sec.bbox_w, y0 + sec.bbox_h
+        boxes.append((y0, y1, sec.grid_col, sec.grid_row, sid))
+        print(
+            f"\n[{sid}] '{sec.name}' grid=({sec.grid_col},{sec.grid_row}) "
+            f"box x:[{x0:.0f},{x1:.0f}] y:[{y0:.0f},{y1:.0f}]"
+        )
+        trunk_ys = [
+            graph.stations[s].y
+            for s in sec.station_ids
+            if not _is_port(graph.stations[s]) and not _is_off(graph.stations[s])
+        ]
+        trunk_y = Counter(round(y, 1) for y in trunk_ys).most_common(1)
+        trunk_y = trunk_y[0][0] if trunk_y else None
+        for stid in sec.station_ids:
+            st = graph.stations[stid]
+            tag = "PORT" if _is_port(st) else ("OFF" if _is_off(st) else "")
+            flag = ""
+            if tag == "" and trunk_y is not None and abs(st.y - trunk_y) > 20:
+                flag = f"  <-- OFF TRUNK by {st.y - trunk_y:+.0f} (trunk y={trunk_y})"
+            print(f"    {stid:18s} x={st.x:7.1f} y={st.y:7.1f} {tag:4s}{flag}")
+
+    # Vertically-stacked section gaps (same grid_col, adjacent grid_row).
+    print("\n-- inter-row gaps (stacked sections, same column) --")
+    by_col: dict[int, list[tuple[int, float, float, str]]] = {}
+    for y0, y1, col, row, sid in boxes:
+        by_col.setdefault(col, []).append((row, y0, y1, sid))
+    flagged = False
+    for col, rows in sorted(by_col.items()):
+        rows.sort()
+        for (r1, _, y1_bot, s1), (r2, y2_top, _, s2) in zip(rows, rows[1:]):
+            gap = y2_top - y1_bot
+            mark = "  <-- large vs siblings" if gap > 120 else ""
+            print(
+                f"   col {col}: {s1}(row{r1}) -> {s2}(row{r2})  gap={gap:.0f}px{mark}"
+            )
+            flagged = True
+    if not flagged:
+        print("   (no vertically-stacked sections)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/nf-metro-stress-render/scripts/probe_layout.py
+++ b/.claude/skills/nf-metro-stress-render/scripts/probe_layout.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Probe a single .mmd through the full nf-metro pipeline and report defects.
+
+Runs the same stages a real render does (parse -> layout -> validate -> route),
+then emits a structured JSON verdict that separates *authoring* problems (the
+.mmd is malformed, so any downstream defect is the author's fault) from
+*engine* problems (the .mmd is well-formed yet the engine produces a bad
+layout). The latter are the bugs this skill exists to surface.
+
+The verdict has four finding buckets, in escalating "this is an engine bug"
+confidence:
+
+  parse_issues   - graph-semantic findings from the parser's own validate_graph
+                   (undefined lines, dangling ports, ...). Usually an AUTHORING
+                   mistake -> fix the .mmd, don't file a bug.
+  layout_crash   - compute_layout(validate=False) raised. A hard engine failure
+                   on well-formed input. The strongest obvious-bug signal.
+  guard_failure  - compute_layout(validate=True) raised a PhaseInvariantError
+                   that the unguarded run did not. An invariant the engine
+                   itself declares but violates. Obvious bug.
+  validator      - structural Violations from tests/layout_validator.py
+                   (overlap, containment, station-as-elbow, kinks, ...).
+                   ERROR-severity ones are obvious bugs; WARNING-severity ones
+                   are worth an eyeball.
+
+Usage:
+    python probe_layout.py INPUT.mmd [--svg OUT.svg] [--png OUT.png]
+                                     [--max-station-columns N] [--json]
+
+Exit code is 0 if no ERROR-level engine findings, 1 otherwise, so the skill can
+branch on it. Authoring (parse) issues alone do not set a non-zero code - they
+mean "go fix your .mmd", not "engine bug".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import traceback
+from pathlib import Path
+
+# The validator lives in tests/, which is not an installed package. Add the
+# repo's tests dir to the path so `import layout_validator` resolves the same
+# module the suite uses, rather than a stale copy.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+for candidate in (_REPO_ROOT, Path.cwd()):
+    tests_dir = candidate / "tests"
+    if (tests_dir / "layout_validator.py").exists():
+        sys.path.insert(0, str(tests_dir))
+        break
+
+from nf_metro.layout.engine import compute_layout  # noqa: E402
+from nf_metro.parser import validate_graph  # noqa: E402
+from nf_metro.parser.mermaid import parse_metro_mermaid  # noqa: E402
+
+
+def _short_tb(exc: BaseException) -> str:
+    """Last frame + exception type/message - enough to dedup and locate."""
+    tb = traceback.extract_tb(exc.__traceback__)
+    where = ""
+    if tb:
+        frame = tb[-1]
+        where = f"{Path(frame.filename).name}:{frame.lineno} in {frame.name}"
+    return (
+        f"{type(exc).__name__}: {exc} ({where})"
+        if where
+        else f"{type(exc).__name__}: {exc}"
+    )
+
+
+def probe(mmd_text: str, max_station_columns: int = 15) -> dict:
+    verdict: dict = {
+        "parse_issues": [],
+        "layout_crash": None,
+        "guard_failure": None,
+        "validator": [],
+        "counts": {},
+    }
+
+    # 1. Parse. A raise here is a parser bug; a populated issue list is usually
+    #    an authoring mistake. Either way, downstream stages can't be trusted.
+    try:
+        graph = parse_metro_mermaid(mmd_text, max_station_columns=max_station_columns)
+    except Exception as exc:  # noqa: BLE001
+        verdict["parse_issues"].append(
+            {"severity": "error", "message": f"Parser raised: {_short_tb(exc)}"}
+        )
+        return verdict
+
+    for issue in validate_graph(graph):
+        verdict["parse_issues"].append(
+            {"severity": issue.severity, "message": issue.message}
+        )
+
+    verdict["counts"] = {
+        "sections": len(graph.sections),
+        "stations": len(graph.stations),
+        "lines": len(graph.lines),
+        "edges": len(graph.edges),
+    }
+
+    # 2. Unguarded layout. A raise here is a hard engine failure on input the
+    #    parser accepted - the strongest obvious-bug signal.
+    try:
+        compute_layout(graph, validate=False)
+    except Exception as exc:  # noqa: BLE001
+        verdict["layout_crash"] = _short_tb(exc)
+        return verdict
+
+    # 3. Validator structural checks on the laid-out graph.
+    try:
+        from layout_validator import Severity, validate_layout
+
+        for v in validate_layout(graph):
+            verdict["validator"].append(
+                {
+                    "check": v.check,
+                    "severity": "error" if v.severity == Severity.ERROR else "warning",
+                    "message": v.message,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        verdict["validator"].append(
+            {"check": "validator_crash", "severity": "error", "message": _short_tb(exc)}
+        )
+
+    # 4. Guarded layout on a FRESH parse (compute_layout mutates). A raise the
+    #    unguarded run didn't hit means the engine tripped its own invariant.
+    try:
+        guarded = parse_metro_mermaid(mmd_text, max_station_columns=max_station_columns)
+        compute_layout(guarded, validate=True)
+    except Exception as exc:  # noqa: BLE001
+        verdict["guard_failure"] = _short_tb(exc)
+
+    return verdict
+
+
+def _has_engine_error(verdict: dict) -> bool:
+    if verdict["layout_crash"] or verdict["guard_failure"]:
+        return True
+    return any(v["severity"] == "error" for v in verdict["validator"])
+
+
+def _render(mmd_path: Path, svg_out: Path | None, png_out: Path | None) -> dict:
+    out: dict = {}
+    if not (svg_out or png_out):
+        return out
+    svg_target = svg_out or (png_out.with_suffix(".svg") if png_out else None)
+    try:
+        from click.testing import CliRunner
+
+        from nf_metro.cli import cli
+
+        result = CliRunner().invoke(
+            cli, ["render", str(mmd_path), "-o", str(svg_target)]
+        )
+        if result.exit_code != 0:
+            out["render_error"] = (result.output or str(result.exception)).strip()
+            return out
+        out["svg"] = str(svg_target)
+    except Exception as exc:  # noqa: BLE001
+        out["render_error"] = _short_tb(exc)
+        return out
+
+    if png_out:
+        try:
+            import cairosvg
+
+            cairosvg.svg2png(url=str(svg_target), write_to=str(png_out), scale=2)
+            out["png"] = str(png_out)
+        except Exception as exc:  # noqa: BLE001
+            out["png_error"] = _short_tb(exc)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("input", type=Path)
+    ap.add_argument("--svg", type=Path, default=None)
+    ap.add_argument("--png", type=Path, default=None)
+    ap.add_argument("--max-station-columns", type=int, default=15)
+    ap.add_argument("--json", action="store_true", help="emit raw JSON only")
+    args = ap.parse_args()
+
+    verdict = probe(
+        args.input.read_text(), max_station_columns=args.max_station_columns
+    )
+    verdict["render"] = _render(args.input, args.svg, args.png)
+    verdict["engine_error"] = _has_engine_error(verdict)
+
+    if args.json:
+        print(json.dumps(verdict, indent=2))
+    else:
+        _print_human(args.input, verdict)
+
+    return 1 if verdict["engine_error"] else 0
+
+
+def _print_human(path: Path, v: dict) -> None:
+    c = v.get("counts", {})
+    print(f"== probe {path.name} ==")
+    if c:
+        print(
+            f"   {c.get('sections', '?')} sections, {c.get('stations', '?')} stations, "
+            f"{c.get('lines', '?')} lines, {c.get('edges', '?')} edges"
+        )
+    if v["parse_issues"]:
+        print(
+            "\n-- parse/authoring issues (fix the .mmd, usually NOT an engine bug) --"
+        )
+        for i in v["parse_issues"]:
+            print(f"   [{i['severity']}] {i['message']}")
+    if v["layout_crash"]:
+        print("\n-- LAYOUT CRASH (engine bug) --")
+        print(f"   {v['layout_crash']}")
+    if v["guard_failure"]:
+        print("\n-- GUARD FAILURE / invariant violation (engine bug) --")
+        print(f"   {v['guard_failure']}")
+    errs = [x for x in v["validator"] if x["severity"] == "error"]
+    warns = [x for x in v["validator"] if x["severity"] == "warning"]
+    if errs:
+        print("\n-- validator ERRORS (obvious engine bugs) --")
+        for x in errs:
+            print(f"   [{x['check']}] {x['message']}")
+    if warns:
+        print("\n-- validator warnings (eyeball these) --")
+        for x in warns:
+            print(f"   [{x['check']}] {x['message']}")
+    r = v.get("render", {})
+    if r.get("png"):
+        print(f"\n   rendered PNG: {r['png']}")
+    elif r.get("svg"):
+        print(f"\n   rendered SVG: {r['svg']}")
+    if r.get("render_error"):
+        print(f"\n   RENDER ERROR: {r['render_error']}")
+    print(f"\n   => engine_error={v['engine_error']}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds `nf-metro-stress-render`, a skill that simulates "a never-seen-before pipeline arrives" on demand to flush out layout-engine bugs before real pipelines hit them. The premise: the engine is robust on shapes it has seen and brittle on novel combinations, so each run invents one novel, deliberately-complex map and probes it.

## The loop

1. **Compose** - braid 2-4 structural axes that haven't been combined before (off a failure-mode menu) into one correct-by-construction `.mmd`. Novelty is the point; a constrained generator would only re-draw known shapes.
2. **Probe** (`scripts/probe_layout.py`) - runs the real pipeline (parse -> layout -> validate -> route) and sorts findings into four buckets by engine-bug confidence: `parse_issues` (authoring mistake, not a bug), `validator` warnings/errors, `layout_crash`, `guard_failure`.
3. **Present** the render for the aesthetic defects the validator is blind to.
4. **Confirm and understand** every candidate - validator-flagged *or* eyeballed - against the laid-out geometry before filing. `scripts/inspect_layout.py` flags off-trunk drags, off-track gaps and oversized inter-row gaps with exact coordinates; `nf-metro explain` names the rule that fired. Reports are never filed on eyeball alone.
5. **File + guard** - each confirmed bug ships with regression infra: a fixture in `examples/topologies/`, a `GALLERY_ENTRIES` render so CI render-diff tracks it, and a strict-xfail test that reds CI when the bug is fixed. So a filed bug can't silently return.
6. **Log** to a coverage ledger so successive runs push into fresh territory and novelty risk visibly shrinks.

## Contents

- `SKILL.md` - the 8-step loop and scope boundaries (hands off to `nf-metro-layout-fix` / `fix-issue` for the actual fix).
- `references/failure_modes.md` - the structural-axis menu, the known-fragile list (so known defects aren't re-filed as novel), the probe-catches-vs-eye-catches split, and authoring-correctness rules.
- `scripts/probe_layout.py`, `scripts/inspect_layout.py` - bundled so every run doesn't reinvent the render/validate/inspect plumbing.
- `coverage_log.md` - the novelty ledger.

This is the operational answer to #364 (mutation/fuzz testing of fixtures) and #323 (design analysis of fragility on new pipelines).

## Provenance

Built and validated with two live runs; that session surfaced and filed #650-#655 (off-track placement, fan-out nesting, inter-row gap, line ordering, reserved-offset bypass), which also serve as worked examples of the confirm-and-understand discipline. Skill-only change (no `src/`/`tests/` touched), so CI render-diff and lint are unaffected.
