### PR TITLE
fix(off-track): keep multi-line entry consumer on the section trunk (#650)

### DIFF
--- a/examples/topologies/off_track_convergence_multiline.mmd
+++ b/examples/topologies/off_track_convergence_multiline.mmd
@@ -1,0 +1,35 @@
+%%metro title: Off-Track Convergence Multiline
+%%metro style: dark
+%%metro line: dna | DNA | #2db572
+%%metro line: rna | RNA | #e63946
+%%metro line: qc | QC | #f4a261
+%%metro file: ref_in | FASTA | Reference
+%%metro file: gtf_in | GTF | Annotation
+%%metro off_track: ref_in, gtf_in
+
+graph LR
+    subgraph input [Input]
+        reads[Reads]
+        prep[Prepare]
+        reads -->|dna,rna,qc| prep
+    end
+
+    subgraph process [Process]
+        ref_in[ ]
+        gtf_in[ ]
+        align[Align]
+        sort[Sort]
+        index[Index]
+
+        ref_in -->|dna,rna| align
+        gtf_in -->|rna| align
+        align -->|dna,rna,qc| sort
+        sort -->|dna,rna,qc| index
+    end
+
+    subgraph output [Output]
+        report[Report]
+    end
+
+    prep -->|dna,rna,qc| align
+    index -->|dna,rna,qc| report

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -339,6 +339,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "The trunk stays horizontal while the inputs stack above the consumer column.",
     ),
     (
+        "off_track_convergence_multiline",
+        TOPOLOGIES_DIR,
+        "A multi-line bundle enters a section and converges on a deep first "
+        "station that also consumes off-track file inputs. The consumer stays "
+        "on the section trunk, level with its continuation, rather than being "
+        "dragged to the section floor (issue #650).",
+    ),
+    (
         "around_section_below",
         TOPOLOGIES_DIR,
         "Cross-row route to a LEFT-entry target where the natural inter-row "

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -140,6 +140,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_no_station_overlap,
     _guard_no_wrapped_label_trunk_strike,
     _guard_off_track_clear_of_anchor,
+    _guard_off_track_consumer_on_trunk,
     _guard_off_track_output_clears_non_producer,
     _guard_partial_branch_offset_gaps,
     _guard_ports_on_boundaries,
@@ -616,6 +617,7 @@ def _compute_layout_scaled(
         _guard_rail_stations_seat_on_rails(graph, "final")
         _guard_rail_one_station_per_column(graph, "final")
         _guard_single_trunk_off_track_step(graph, "final")
+        _guard_off_track_consumer_on_trunk(graph, "final")
 
 
 def _apply_label_strike_clearance(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -776,6 +776,50 @@ def _guard_single_trunk_off_track_step(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _guard_off_track_consumer_on_trunk(graph: MetroGraph, phase: str) -> None:
+    """An off-track input's consumer that continues straight into the
+    section trunk sits level with that successor.
+
+    When a multi-line bundle enters a section and converges on one deep
+    first station (the off-track-input consumer), that station heads the
+    section trunk.  Dragging it off the trunk (issue #650) leaves the
+    onward edge a near-vertical climb whose lines merge into one stroke.
+    Restricted to consumers with exactly one on-track in-section successor
+    so a genuine on-track fork's off-row branches don't trip it.
+    """
+    junction_ids = graph.junction_ids
+    tol = 1.0
+    consumers = {
+        anchor_id
+        for off_id, anchor_id in _off_track_anchor_of(graph).items()
+        if any(e.target == anchor_id for e in graph.edges_from(off_id))
+    }
+    for cons_id in consumers:
+        cons = graph.stations.get(cons_id)
+        if cons is None or cons.is_port or cons_id in junction_ids:
+            continue
+        succs = [
+            tgt
+            for e in graph.edges_from(cons_id)
+            if (tgt := graph.stations.get(e.target)) is not None
+            and not tgt.is_port
+            and tgt.id not in junction_ids
+            and not tgt.off_track
+            and tgt.section_id == cons.section_id
+        ]
+        distinct = {s.id for s in succs}
+        if len(distinct) != 1:
+            continue
+        succ = succs[0]
+        if abs(cons.y - succ.y) > tol:
+            raise PhaseInvariantError(
+                f"{phase}: off-track consumer {cons_id!r} y={cons.y:.1f} "
+                f"dragged off the section trunk; its continuation "
+                f"{succ.id!r} sits at y={succ.y:.1f} "
+                f"({abs(cons.y - succ.y):.0f}px climb)"
+            )
+
+
 def _guard_no_station_overlap(
     graph: MetroGraph,
     phase: str,

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -214,15 +214,25 @@ def _align_phantom_pass_throughs(
     Moving the convergence node (the phantom's sole successor) to that
     track keeps the trunk horizontal so the optional branch visually
     "bubbles" away from it.
+
+    A convergence node fed by *several* phantoms -- one per line when a
+    multi-line bundle enters a section and meets at one deep first
+    station -- is the head of the section trunk, not a bubble. Snapping
+    it to any single phantom's track would drag it off the trunk into a
+    near-vertical onward climb, so such a node is left on its assigned
+    trunk track.
     """
+    phantom_track_of: dict[str, list[float]] = defaultdict(list)
     for sid, station in sub.stations.items():
         if not station.is_hidden or sid not in tracks:
             continue
         succs = {e.target for e in sub.edges_from(sid)}
         if len(succs) == 1:
-            succ = next(iter(succs))
-            if succ in tracks:
-                tracks[succ] = tracks[sid]
+            phantom_track_of[next(iter(succs))].append(tracks[sid])
+
+    for succ, phantom_tracks in phantom_track_of.items():
+        if len(phantom_tracks) == 1 and succ in tracks:
+            tracks[succ] = phantom_tracks[0]
 
 
 def _forced_branch_label_reach(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -345,20 +345,37 @@ def _fixtures_with_above_output() -> list[str]:
 _FIXTURES_WITH_ABOVE_OUTPUT = _fixtures_with_above_output()
 
 
+def _off_track_input_consumer_map(
+    graph: MetroGraph, junction_ids: set[str]
+) -> dict[str, str]:
+    """Map each off-track input to its on-track consumer (first edge wins).
+
+    Re-derived from edges here rather than via production's
+    :func:`_off_track_anchor_of`, so an invariant built on this map stays an
+    independent oracle of the engine's own consumer resolution.
+    """
+    consumer_of: dict[str, str] = {}
+    for edge in graph.edges:
+        src = graph.stations.get(edge.source)
+        tgt = graph.stations.get(edge.target)
+        if (
+            src is None
+            or tgt is None
+            or not src.off_track
+            or src.is_port
+            or src.id in junction_ids
+            or tgt.is_port
+            or tgt.id in junction_ids
+            or tgt.off_track
+        ):
+            continue
+        consumer_of.setdefault(src.id, tgt.id)
+    return consumer_of
+
+
 def _off_track_consumer_ids(graph: MetroGraph, junction_ids: set[str]) -> set[str]:
     """On-track stations fed directly by an off-track input."""
-    return {
-        graph.stations[e.target].id
-        for e in graph.edges
-        if (src := graph.stations.get(e.source)) is not None
-        and src.off_track
-        and not src.is_port
-        and src.id not in junction_ids
-        and (tgt := graph.stations.get(e.target)) is not None
-        and not tgt.is_port
-        and tgt.id not in junction_ids
-        and not tgt.off_track
-    }
+    return set(_off_track_input_consumer_map(graph, junction_ids).values())
 
 
 def _in_section_on_track_successors(
@@ -397,8 +414,7 @@ def _fixtures_with_linear_off_track_consumer() -> list[str]:
         jids = set(g.junctions)
         consumers = _off_track_consumer_ids(g, jids)
         if any(
-            len(_in_section_on_track_successors(g, cid, jids)) == 1
-            for cid in consumers
+            len(_in_section_on_track_successors(g, cid, jids)) == 1 for cid in consumers
         ):
             out.append(name)
     return out
@@ -1137,23 +1153,7 @@ def test_off_track_inputs_above_consumer(fixture):
     """
     graph = _layout(fixture)
     junction_ids = set(graph.junctions)
-    # Build off_track -> consumer map from edges
-    consumer_of: dict[str, str] = {}
-    for edge in graph.edges:
-        src = graph.stations.get(edge.source)
-        tgt = graph.stations.get(edge.target)
-        if (
-            src is None
-            or tgt is None
-            or not src.off_track
-            or src.is_port
-            or src.id in junction_ids
-            or tgt.is_port
-            or tgt.id in junction_ids
-            or tgt.off_track
-        ):
-            continue
-        consumer_of.setdefault(src.id, tgt.id)
+    consumer_of = _off_track_input_consumer_map(graph, junction_ids)
 
     assert consumer_of, f"{fixture}: no off-track edges found"
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -345,6 +345,68 @@ def _fixtures_with_above_output() -> list[str]:
 _FIXTURES_WITH_ABOVE_OUTPUT = _fixtures_with_above_output()
 
 
+def _off_track_consumer_ids(graph: MetroGraph, junction_ids: set[str]) -> set[str]:
+    """On-track stations fed directly by an off-track input."""
+    return {
+        graph.stations[e.target].id
+        for e in graph.edges
+        if (src := graph.stations.get(e.source)) is not None
+        and src.off_track
+        and not src.is_port
+        and src.id not in junction_ids
+        and (tgt := graph.stations.get(e.target)) is not None
+        and not tgt.is_port
+        and tgt.id not in junction_ids
+        and not tgt.off_track
+    }
+
+
+def _in_section_on_track_successors(
+    graph: MetroGraph, station_id: str, junction_ids: set[str]
+) -> list[str]:
+    """On-track, non-port, same-section successors of ``station_id``."""
+    sec = graph.stations[station_id].section_id
+    succs: list[str] = []
+    for edge in graph.edges_from(station_id):
+        tgt = graph.stations.get(edge.target)
+        if (
+            tgt is None
+            or tgt.is_port
+            or tgt.id in junction_ids
+            or tgt.off_track
+            or tgt.section_id != sec
+        ):
+            continue
+        if tgt.id not in succs:
+            succs.append(tgt.id)
+    return succs
+
+
+def _fixtures_with_linear_off_track_consumer() -> list[str]:
+    """Off-track-input fixtures with at least one consumer that continues
+    straight into the section trunk (exactly one on-track in-section
+    successor), the precondition of
+    :func:`test_off_track_consumer_on_section_trunk`.
+    """
+    out: list[str] = []
+    for name in _FIXTURES_WITH_OFF_TRACK_INPUT:
+        try:
+            g = _layout(name)
+        except Exception:
+            continue
+        jids = set(g.junctions)
+        consumers = _off_track_consumer_ids(g, jids)
+        if any(
+            len(_in_section_on_track_successors(g, cid, jids)) == 1
+            for cid in consumers
+        ):
+            out.append(name)
+    return out
+
+
+_FIXTURES_WITH_LINEAR_OFF_TRACK_CONSUMER = _fixtures_with_linear_off_track_consumer()
+
+
 # Pre-existing layout regressions surfaced by parametrizing single-fixture
 # invariants over the full corpus.  Each entry pins a fixture/invariant
 # pair as ``xfail(strict=False)`` so the bug is documented in code while
@@ -1102,6 +1164,41 @@ def test_off_track_inputs_above_consumer(fixture):
             f"Off-track {off_id} y={off_st.y} not above consumer "
             f"{consumer_id} y={cons_st.y}"
         )
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_WITH_LINEAR_OFF_TRACK_CONSUMER)
+def test_off_track_consumer_on_section_trunk(fixture):
+    """An off-track input's consumer that continues straight into the
+    section trunk must share that successor's Y.
+
+    When several lines enter a section through an entry port and converge
+    on one deep first station (the off-track-input consumer), that station
+    is the head of the section trunk. It must sit level with its on-track
+    continuation, not be dragged to the section floor -- otherwise the
+    onward edge climbs near-vertically and the multi-line bundle merges
+    into a single stroke (issue #650).
+
+    Restricted to consumers with exactly one on-track in-section successor
+    (a linear trunk continuation): a genuine on-track fork legitimately
+    places its branches off the entry station's row.
+    """
+    graph = _layout(fixture)
+    junction_ids = set(graph.junctions)
+    consumers = _off_track_consumer_ids(graph, junction_ids)
+    checked = 0
+    for cons_id in consumers:
+        succs = _in_section_on_track_successors(graph, cons_id, junction_ids)
+        if len(succs) != 1:
+            continue
+        checked += 1
+        cons_st = graph.stations[cons_id]
+        succ_st = graph.stations[succs[0]]
+        assert abs(cons_st.y - succ_st.y) <= _Y_TOL, (
+            f"{fixture}: off-track consumer {cons_id} y={cons_st.y} dragged "
+            f"off the section trunk; its continuation {succs[0]} sits at "
+            f"y={succ_st.y} ({abs(cons_st.y - succ_st.y):.0f}px climb)"
+        )
+    assert checked, f"{fixture}: no linear off-track consumer to check"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- A multi-line bundle entering a section through an entry port to a deep first station inserts one phantom pass-through per line, all converging on that station. `_align_phantom_pass_throughs` snapped the convergence node onto a phantom's track once per phantom, so the last-iterated phantom's track won and the consumer was dragged off the trunk (175px in the issue's `Alignment` section), leaving a near-vertical onward climb where the multi-line bundle merged into one stroke.
- Snap only when a convergence node has a **single** phantom predecessor (a genuine bubble); a node fed by several phantoms is the section trunk head and stays on its assigned trunk track.
- New runtime guard `_guard_off_track_consumer_on_trunk` (wired into the `validate` block) and a parametrised invariant `test_off_track_consumer_on_section_trunk` covering both the single-line bubble (`off_track_convergence`, must stay snapped) and the multi-line trunk-head case (`off_track_convergence_multiline`, must stay level).
- New topology fixture `off_track_convergence_multiline.mmd` plus a gallery entry so CI render-diff tracks the case.

Fixes #650

## Test plan
- [x] pytest passes (7283 passed; new invariant + guard verified to fire on the pre-fix behaviour)
- [x] ruff check + ruff format clean on src/ tests/
- [x] mypy clean
- [x] Runtime validator added (`_guard_off_track_consumer_on_trunk`)
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/658/)
- [x] Render-preview verdict: 1 new additive render (`off_track_convergence_multiline`); all pre-existing gallery renders byte-identical (verified locally vs `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

