### PR TITLE
test: lock #650-#655 with stress-render regression fixtures

### DIFF
--- a/examples/topologies/README.md
+++ b/examples/topologies/README.md
@@ -48,6 +48,8 @@ Each fixture is tagged with the layout class(es) it primarily exercises. Use thi
 | `self_crossing_bridge.mmd` | same-colour self-crossing bridge glyph (issue #484) |
 | `convergence_stacked_sink.mmd` | convergence return-row stacked-sibling migration (issue #484) |
 | `cross_row_gap_wrap.mmd` | cross-row feed wrapping via the inter-row gap, no counter-flow (issue #484) |
+| `longread_methylation_atlas.mmd` | off-track in/outputs + 5-way fan-out into stacked rows + QC bypass; known defects (issues #650-#653) |
+| `multiomics_integration.mmd` | dense 5-line trunk, mixed-side fan-out, QC bypass at reconvergence; known line-order / reserved-offset defects (issues #654-#655) |
 
 ---
 
@@ -230,3 +232,15 @@ A main spine (Prep, Align, Dedup) converges at Merge, which is fed both by the s
 ### Cross-Row Gap Wrap
 
 A convergence layout (Ingest, Align, Dedup on row 0; Merge, Report on the return row) where the `feed` line runs from Ingest down to the rightmost return-row section. Tests that the feed wraps via the clear inter-row gap above the return row (then drops straight into the port) rather than diving under the whole return row counter to its flow. Backs `test_no_artefactual_counter_flow`, `test_entry_approach_arrives_from_port_side`, and their guards.
+
+## Stress-render Fixtures
+
+Realistic, deliberately-complex maps composed by the `nf-metro-stress-render` skill, kept as regression fixtures for the defects they surfaced. Each holds known defects locked via strict xfail in `tests/test_topology_validation.py` (so an engine fix flips the test to XPASS and reds CI); defects with no validator check are guarded by the gallery render diff.
+
+### Long-read Methylation & Variant Atlas
+
+A long-read pipeline braiding off-track file inputs and outputs, a five-way fan-out from alignment into stacked analysis rows (variants, expression, fusion), and a QC bypass to the report. Surfaced: off-track inputs dragging the consuming station off the section trunk (#650), an off-track input floating too far above its consumer (#651), the QC bypass crossing the descending fan branches instead of nesting (#652), and an oversized vertical gap below the spine row (#653).
+
+### Multi-Omics Integration
+
+A multi-omics pipeline with a dense five-line trunk that fans from a branch hub into mixed-side sections (alignment, quantification, peak calling) and reconverges at integration, with a QC line bypassing the factor model. Surfaced: within-bundle line order forcing an almost-horizontal slot-shift at the hub fan-out (#654) and reserved-offset gaps forcing an unnecessary bypass dip at reconvergence (#655).

--- a/examples/topologies/longread_methylation_atlas.mmd
+++ b/examples/topologies/longread_methylation_atlas.mmd
@@ -1,0 +1,109 @@
+%%metro title: Long-read Methylation & Variant Atlas
+%%metro style: dark
+%%metro line: dna | DNA variants | #2db572
+%%metro line: rna | RNA expression | #e63946
+%%metro line: qc | QC stream | #f4a261
+
+%%metro file: ref_fa | FASTA | Reference
+%%metro file: gtf_in | GTF | Annotation
+%%metro file: cpg_bed | BED | CpG islands
+%%metro off_track: ref_fa, gtf_in, cpg_bed
+
+%%metro file: raw_bam | BAM | Aligned
+%%metro file: meth_bw | bigWig | Methylation
+%%metro off_track: raw_bam, meth_bw
+
+graph LR
+    subgraph intake [Intake & Basecall]
+        in_pod5[POD5]
+        in_basecall[Basecall]
+        in_demux[Demux]
+        in_qc[ReadQC]
+
+        in_pod5 -->|dna,rna,qc| in_basecall
+        in_basecall -->|dna,rna,qc| in_demux
+        in_demux -->|dna,rna,qc| in_qc
+    end
+
+    subgraph align [Alignment]
+        ref_fa[ ]
+        gtf_in[ ]
+        al_minimap[minimap2]
+        al_sort[Sort]
+        al_index[Index]
+        raw_bam[ ]
+
+        ref_fa -->|dna,rna| al_minimap
+        gtf_in -->|rna| al_minimap
+        al_minimap -->|dna,rna,qc| al_sort
+        al_sort -->|dna,rna,qc| al_index
+        al_sort -->|dna| raw_bam
+    end
+
+    subgraph methcall [Methylation Calling]
+        mc_modkit[modkit]
+        mc_pileup[Pileup]
+        mc_dmr[DMR]
+        cpg_bed[ ]
+        meth_bw[ ]
+
+        cpg_bed -->|dna| mc_pileup
+        mc_modkit -->|dna| mc_pileup
+        mc_pileup -->|dna| mc_dmr
+        mc_pileup -->|dna| meth_bw
+    end
+
+    subgraph variants [Variant Calling]
+        vc_clair[Clair3]
+        vc_phase[Phase]
+        vc_filter[Filter]
+
+        vc_clair -->|dna| vc_phase
+        vc_phase -->|dna| vc_filter
+    end
+
+    subgraph expr [Expression]
+        ex_isoquant[IsoQuant]
+        ex_count[Count]
+        ex_norm[Normalize]
+
+        ex_isoquant -->|rna| ex_count
+        ex_count -->|rna| ex_norm
+    end
+
+    subgraph fusion [Fusion Detection]
+        fu_jaffal[JAFFAL]
+        fu_annotate[Annotate]
+
+        fu_jaffal -->|rna| fu_annotate
+    end
+
+    subgraph merge [Merge & Annotate]
+        mg_collect[Collect]
+        mg_vep[VEP]
+        mg_classify[Classify]
+
+        mg_collect -->|dna,rna| mg_vep
+        mg_vep -->|dna,rna| mg_classify
+    end
+
+    subgraph report [Report]
+        rp_aggregate[Aggregate]
+        rp_multiqc[MultiQC]
+        rp_final[Report]
+
+        rp_aggregate -->|dna,rna,qc| rp_multiqc
+        rp_multiqc -->|dna,rna,qc| rp_final
+    end
+
+    in_qc -->|dna,rna,qc| al_minimap
+    al_index -->|dna| mc_modkit
+    al_index -->|dna| vc_clair
+    al_index -->|rna| ex_isoquant
+    al_index -->|rna| fu_jaffal
+    al_index -->|qc| rp_aggregate
+    mc_dmr -->|dna| mg_collect
+    vc_filter -->|dna| mg_collect
+    ex_norm -->|rna| mg_collect
+    fu_annotate -->|rna| mg_collect
+    mg_classify -->|dna,rna| rp_aggregate

--- a/examples/topologies/multiomics_integration.mmd
+++ b/examples/topologies/multiomics_integration.mmd
@@ -1,0 +1,60 @@
+%%metro title: Multi-Omics Integration
+%%metro style: dark
+%%metro line: dna | DNA | #e63946
+%%metro line: rna | RNA | #2db572
+%%metro line: meth | Methylation | #0570b0
+%%metro line: atac | ATAC | #f5c542
+%%metro line: qc | QC | #ff8c00
+
+graph LR
+    subgraph ingest [Ingest]
+        samplesheet[Samplesheet]
+        demux[Demultiplex]
+        samplesheet -->|dna,rna,meth,atac,qc| demux
+    end
+
+    subgraph trim [Trim & QC]
+        fastp[Fastp]
+        screen[Contam Screen]
+        fastp -->|dna,rna,meth,atac,qc| screen
+    end
+
+    subgraph hub [Branch Hub]
+        dispatch[Dispatch]
+    end
+
+    subgraph align_right [Alignment]
+        bwa[BWA-MEM]
+        markdup[MarkDup]
+        bwa -->|dna,meth| markdup
+    end
+
+    subgraph quant_bottom [Quantification]
+        salmon[Salmon]
+        tximport[Tximport]
+        salmon -->|rna| tximport
+    end
+
+    subgraph peaks_bottom [Peak Calling]
+        macs[MACS2]
+        macs -->|atac| macs2anno[Annotate Peaks]
+    end
+
+    subgraph integrate [Integration]
+        mofa[MOFA Factor Model]
+        report[MultiQC Report]
+        mofa -->|dna,rna,meth,atac| report
+    end
+
+    demux -->|dna,rna,meth,atac,qc| fastp
+    screen -->|dna,rna,meth,atac,qc| dispatch
+
+    dispatch -->|dna,meth| bwa
+    dispatch -->|rna| salmon
+    dispatch -->|atac| macs
+
+    markdup -->|dna,meth| mofa
+    tximport -->|rna| mofa
+    macs2anno -->|atac| mofa
+
+    screen -->|qc| report

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -378,6 +378,24 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "straight in, rather than diving under the return row counter to its "
         "flow.",
     ),
+    # --- Stress-render fixtures ---
+    (
+        "longread_methylation_atlas",
+        TOPOLOGIES_DIR,
+        "A long-read methylation and variant pipeline braiding off-track file "
+        "inputs and outputs, a five-way fan-out from alignment into stacked "
+        "analysis rows, and a QC bypass to the report. Holds known defects "
+        "around off-track placement, fan nesting, and the bypass corridor "
+        "(#650-#653).",
+    ),
+    (
+        "multiomics_integration",
+        TOPOLOGIES_DIR,
+        "A multi-omics pipeline with a dense five-line trunk that fans from a "
+        "branch hub into mixed-side sections and reconverges at integration, "
+        "with a QC line bypassing the factor model. Holds known line-ordering "
+        "and reserved-offset defects (#654-#655).",
+    ),
 ]
 
 # Category headers inserted before specific entries
@@ -389,6 +407,7 @@ CATEGORY_HEADERS: dict[str, str] = {
     "multi_line_bundle": "Multi-line Bundles",
     "rnaseq_lite": "Realistic Pipelines",
     "fold_fan_across": "Fold Topologies",
+    "longread_methylation_atlas": "Stress-render Fixtures",
 }
 
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -381,7 +381,12 @@ _XFAIL_ROW_TRUNK_CY: dict[str, str] = {}
 # Inter-section exit-port cy drifts from the matching entry-port cy in
 # the next section.  See nf-metro audit item 1 (the "limma kink"
 # regression family).  Limited to multi-section fixtures.
-_XFAIL_NO_KINK: dict[str, str] = {}
+_XFAIL_NO_KINK: dict[str, str] = {
+    "topologies/longread_methylation_atlas.mmd": (
+        "off-track inputs drag minimap2 off the Alignment trunk, kinking the "
+        "section entry boundary; #650"
+    ),
+}
 
 
 # Symmetric-fan pairs (two full-bundle stations in the same column) end

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -113,6 +113,13 @@ class TestTopologyValidation:
         # humann3 junction routing is a known defect (see #241 family).
         if "funcprofiler_upstream" in request.node.name:
             pytest.xfail("funcprofiler_upstream has a known almost-horizontal edge")
+        # multiomics_integration: meth changes bundle slot at the Branch Hub
+        # fan-out, a known line-ordering defect (#654). Strict flip-detector
+        # lives in TestMultiomicsIntegrationDefects.
+        if "multiomics_integration" in request.node.name:
+            pytest.xfail(
+                "multiomics_integration has a known almost-horizontal edge (#654)"
+            )
         violations = check_almost_horizontal_edges(topology_graph)
         warnings = [v for v in violations if v.severity == Severity.WARNING]
         assert not warnings, "\n".join(v.message for v in warnings)
@@ -324,6 +331,66 @@ class TestVariantCallingDefects:
         v = check_excessive_column_gaps(graph)
         assert not v, "\n".join(vi.message for vi in v)
 
+    def test_no_route_segment_crossings(self, graph):
+        v = check_route_segment_crossings(graph)
+        assert not v, "\n".join(vi.message for vi in v)
+
+
+# Stress-render fixtures (#650-#655): each locks the validator-detectable
+# defects a confirmed bug exhibits via strict xfail, so an engine fix flips the
+# matching test to XPASS and reds CI, prompting the marker removal and issue
+# close. The section-boundary kink (#650) is locked in test_layout_invariants
+# via _XFAIL_NO_KINK. Defects with no validator check (#653 oversized inter-row
+# gap, #655 reserved-offset bypass dip) are guarded by the gallery render diff.
+
+LONGREAD_ATLAS_FILE = TOPOLOGIES_DIR / "longread_methylation_atlas.mmd"
+MULTIOMICS_FILE = TOPOLOGIES_DIR / "multiomics_integration.mmd"
+
+
+class TestLongreadMethylationAtlasDefects:
+    """Lock the longread_methylation_atlas defects via strict xfail.
+
+    Off-track input floating far above its consumer (#651) and the QC bypass
+    crossing the descending fan branches (#652).
+    """
+
+    @pytest.fixture
+    def graph(self):
+        return _load_and_layout(LONGREAD_ATLAS_FILE)
+
+    @pytest.mark.xfail(
+        strict=True, reason="off-track input floats above consumer; #651"
+    )
+    def test_no_excessive_column_gaps(self, graph):
+        v = check_excessive_column_gaps(graph)
+        assert not v, "\n".join(vi.message for vi in v)
+
+    @pytest.mark.xfail(strict=True, reason="QC bypass crosses fan branches; #652")
+    def test_no_route_segment_crossings(self, graph):
+        v = check_route_segment_crossings(graph)
+        assert not v, "\n".join(vi.message for vi in v)
+
+
+class TestMultiomicsIntegrationDefects:
+    """Lock the multiomics_integration defects via strict xfail.
+
+    Within-bundle line order forces meth to change slot at the Branch Hub
+    fan-out, surfacing as an almost-horizontal slot-shift edge and avoidable
+    hub-fan crossings (#654).
+    """
+
+    @pytest.fixture
+    def graph(self):
+        return _load_and_layout(MULTIOMICS_FILE)
+
+    @pytest.mark.xfail(
+        strict=True, reason="meth slot-shift almost-horizontal edge; #654"
+    )
+    def test_no_almost_horizontal_edges(self, graph):
+        v = check_almost_horizontal_edges(graph)
+        assert not v, "\n".join(vi.message for vi in v)
+
+    @pytest.mark.xfail(strict=True, reason="line-order hub-fan crossings; #654")
     def test_no_route_segment_crossings(self, graph):
         v = check_route_segment_crossings(graph)
         assert not v, "\n".join(vi.message for vi in v)


### PR DESCRIPTION
## What

Wires the regression infrastructure for the six bugs surfaced by the `nf-metro-stress-render` skill (#650-#655) - the first real application of that skill's "every confirmed bug ships a fixture + gallery render + guard test" step. No engine code changes; this is purely fixtures, gallery registration, and test locks.

## Changes

**Two correct-by-construction fixtures** in `examples/topologies/` (the exact maps the skill composed, which reproduce the defects at parse/layout level):
- `longread_methylation_atlas.mmd` - off-track in/outputs + a five-way fan-out from alignment into stacked rows + a QC bypass to the report.
- `multiomics_integration.mmd` - a dense five-line trunk fanning from a branch hub into mixed-side sections and reconverging at integration, with a QC bypass.

Both get README structural-class rows and a "Stress-render Fixtures" section, and are registered in `GALLERY_ENTRIES` so the CI render-diff tracks them.

**Strict-xfail locks** on the validator/invariant-detectable defects (a fix flips the test to XPASS and reds CI, prompting marker removal + issue close):

| Issue | Defect | Lock |
|---|---|---|
| #650 | off-track inputs drag the consumer off the trunk -> section-boundary kink | `_XFAIL_NO_KINK` in `test_layout_invariants.py` |
| #651 | off-track input floats too far above its consumer | `TestLongreadMethylationAtlasDefects::test_no_excessive_column_gaps` |
| #652 | QC bypass crosses the descending fan branches | `TestLongreadMethylationAtlasDefects::test_no_route_segment_crossings` |
| #654 | within-bundle line order forces an almost-horizontal slot-shift + hub-fan crossings | `TestMultiomicsIntegrationDefects` (+ generic `test_no_almost_horizontal_edges` xfail) |

**Gallery-guarded** (no validator check exists): #653 (oversized inter-row gap) and #655 (reserved-offset bypass dip) are tracked by the CI render-diff; a note on each test block records that a dedicated check would let them be locked harder.

## Test plan
- [x] `pytest` green: 7365 passed, 11 xfailed, no failures, no unexpected XPASS
- [x] `ruff check` + `ruff format --check` clean
- [x] both fixtures render without error; gallery entries resolve
- [ ] CI render-diff shows the two new fixture renders (additive; existing renders byte-identical)

When any of #650/#651/#652/#654 is fixed, its strict-xfail flips to XPASS and reds CI - remove the marker and close the issue then.
