### PR TITLE
fix(layout): stack off-track inputs per column, not per anchor group (#651)

### DIFF
--- a/examples/topologies/off_track_input_above_consumer.mmd
+++ b/examples/topologies/off_track_input_above_consumer.mmd
@@ -1,0 +1,109 @@
+%%metro title: Long-read Methylation & Variant Atlas
+%%metro style: dark
+%%metro line: dna | DNA variants | #2db572
+%%metro line: rna | RNA expression | #e63946
+%%metro line: qc | QC stream | #f4a261
+
+%%metro file: ref_fa | FASTA | Reference
+%%metro file: gtf_in | GTF | Annotation
+%%metro file: cpg_bed | BED | CpG islands
+%%metro off_track: ref_fa, gtf_in, cpg_bed
+
+%%metro file: raw_bam | BAM | Aligned
+%%metro file: meth_bw | bigWig | Methylation
+%%metro off_track: raw_bam, meth_bw
+
+graph LR
+    subgraph intake [Intake & Basecall]
+        in_pod5[POD5]
+        in_basecall[Basecall]
+        in_demux[Demux]
+        in_qc[ReadQC]
+
+        in_pod5 -->|dna,rna,qc| in_basecall
+        in_basecall -->|dna,rna,qc| in_demux
+        in_demux -->|dna,rna,qc| in_qc
+    end
+
+    subgraph align [Alignment]
+        ref_fa[ ]
+        gtf_in[ ]
+        al_minimap[minimap2]
+        al_sort[Sort]
+        al_index[Index]
+        raw_bam[ ]
+
+        ref_fa -->|dna,rna| al_minimap
+        gtf_in -->|rna| al_minimap
+        al_minimap -->|dna,rna,qc| al_sort
+        al_sort -->|dna,rna,qc| al_index
+        al_sort -->|dna| raw_bam
+    end
+
+    subgraph methcall [Methylation Calling]
+        mc_modkit[modkit]
+        mc_pileup[Pileup]
+        mc_dmr[DMR]
+        cpg_bed[ ]
+        meth_bw[ ]
+
+        cpg_bed -->|dna| mc_pileup
+        mc_modkit -->|dna| mc_pileup
+        mc_pileup -->|dna| mc_dmr
+        mc_pileup -->|dna| meth_bw
+    end
+
+    subgraph variants [Variant Calling]
+        vc_clair[Clair3]
+        vc_phase[Phase]
+        vc_filter[Filter]
+
+        vc_clair -->|dna| vc_phase
+        vc_phase -->|dna| vc_filter
+    end
+
+    subgraph expr [Expression]
+        ex_isoquant[IsoQuant]
+        ex_count[Count]
+        ex_norm[Normalize]
+
+        ex_isoquant -->|rna| ex_count
+        ex_count -->|rna| ex_norm
+    end
+
+    subgraph fusion [Fusion Detection]
+        fu_jaffal[JAFFAL]
+        fu_annotate[Annotate]
+
+        fu_jaffal -->|rna| fu_annotate
+    end
+
+    subgraph merge [Merge & Annotate]
+        mg_collect[Collect]
+        mg_vep[VEP]
+        mg_classify[Classify]
+
+        mg_collect -->|dna,rna| mg_vep
+        mg_vep -->|dna,rna| mg_classify
+    end
+
+    subgraph report [Report]
+        rp_aggregate[Aggregate]
+        rp_multiqc[MultiQC]
+        rp_final[Report]
+
+        rp_aggregate -->|dna,rna,qc| rp_multiqc
+        rp_multiqc -->|dna,rna,qc| rp_final
+    end
+
+    in_qc -->|dna,rna,qc| al_minimap
+    al_index -->|dna| mc_modkit
+    al_index -->|dna| vc_clair
+    al_index -->|rna| ex_isoquant
+    al_index -->|rna| fu_jaffal
+    al_index -->|qc| rp_aggregate
+    mc_dmr -->|dna| mg_collect
+    vc_filter -->|dna| mg_collect
+    ex_norm -->|rna| mg_collect
+    fu_annotate -->|rna| mg_collect
+    mg_classify -->|dna,rna| rp_aggregate

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -347,6 +347,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "dragged to the section floor (issue #650).",
     ),
     (
+        "off_track_input_above_consumer",
+        TOPOLOGIES_DIR,
+        "A section whose mid-trunk station consumes an off-track input while a "
+        "neighbouring station feeds an off-track output. The input hugs one row "
+        "above its consumer instead of towering an extra slot up because it "
+        "shares an anchor with the differently-columned output (issue #651).",
+    ),
+    (
         "around_section_below",
         TOPOLOGIES_DIR,
         "Cross-row route to a LEFT-entry target where the natural inter-row "

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -141,6 +141,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_no_wrapped_label_trunk_strike,
     _guard_off_track_clear_of_anchor,
     _guard_off_track_consumer_on_trunk,
+    _guard_off_track_input_column_stack,
     _guard_off_track_output_clears_non_producer,
     _guard_partial_branch_offset_gaps,
     _guard_ports_on_boundaries,
@@ -618,6 +619,7 @@ def _compute_layout_scaled(
         _guard_rail_one_station_per_column(graph, "final")
         _guard_single_trunk_off_track_step(graph, "final")
         _guard_off_track_consumer_on_trunk(graph, "final")
+        _guard_off_track_input_column_stack(graph, "final")
 
 
 def _apply_label_strike_clearance(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -37,6 +37,7 @@ from nf_metro.layout.phases.bbox import _section_fit_top
 from nf_metro.layout.phases.off_track import (
     _is_single_trunk_lr_section,
     _off_track_anchor_of,
+    _off_track_lift_step,
     _off_track_output_below,
 )
 from nf_metro.layout.phases.single_section import _terminus_y_overhang
@@ -773,6 +774,56 @@ def _guard_single_trunk_off_track_step(graph: MetroGraph, phase: str) -> None:
                 f"{anchor_id!r} on single-trunk section {section.id!r}, not an "
                 f"integer multiple of the base step {base:.1f} -- the widened "
                 f"diagonal-label pitch leaked into the lift"
+            )
+
+
+def _guard_off_track_input_column_stack(graph: MetroGraph, phase: str) -> None:
+    """On a single-trunk section, an off-track input hugs its consumer by its
+    same-column stack depth, not the whole anchor group's size.
+
+    When a consumer is fed by off-track stations in different columns (an input
+    above it, a producer-fed output beside it), the lift step is counted per
+    column.  Counting the whole anchor group instead strands a lone-in-its-column
+    input an extra slot up over an empty row above an earlier trunk station
+    (issue #651).  Restricted to single-trunk sections, whose lift pitch carries
+    no stacked horizontal line bands that could legitimately bump an input past
+    its slot.
+    """
+    from nf_metro.layout.engine import compute_min_y_spacing
+
+    junction_ids = graph.junction_ids
+    y_spacing = compute_min_y_spacing(graph)
+    anchor_of = _off_track_anchor_of(graph)
+    tol = 1.0
+
+    col_group: dict[tuple[str | None, float, str], int] = defaultdict(int)
+    for off_id, anchor_id in anchor_of.items():
+        st = graph.stations.get(off_id)
+        if st is not None:
+            col_group[(st.section_id, round(st.x, 1), anchor_id)] += 1
+
+    for off_id, anchor_id in anchor_of.items():
+        off_st = graph.stations.get(off_id)
+        anchor = graph.stations.get(anchor_id)
+        if off_st is None or anchor is None:
+            continue
+        if not any(e.target == anchor_id for e in graph.edges_from(off_id)):
+            continue  # producer-fed sink, not an input
+        section = graph.sections.get(off_st.section_id or "")
+        if section is None or not _is_single_trunk_lr_section(
+            graph, section, junction_ids
+        ):
+            continue
+        step = _off_track_lift_step(graph, section, junction_ids, y_spacing)
+        n = col_group[(off_st.section_id, round(off_st.x, 1), anchor_id)]
+        gap = anchor.y - off_st.y
+        if gap > n * step + tol:
+            raise PhaseInvariantError(
+                f"{phase}: off-track input {off_id!r} sits {gap:.1f}px "
+                f"({gap / step:.1f} slots) above consumer {anchor_id!r} on "
+                f"single-trunk section {section.id!r}, but only {n} off-track "
+                f"station(s) share its column and anchor -- it is stranded above "
+                f"an empty row (expected at most {n * step:.1f}px)"
             )
 
 

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -960,6 +960,23 @@ def _off_track_lift_step(
     return base
 
 
+def _per_column_stack_steps(innermost_first: list[Station]) -> dict[str, int]:
+    """Stack rank (1 = innermost, nearest the anchor) keyed per column.
+
+    ``innermost_first`` lists the off-track stations sharing one anchor in
+    order of increasing distance from it.  Each column counts its own stack
+    independently, so two stations sharing an anchor but sitting in different
+    columns each start at rank 1 rather than towering one above the other.
+    """
+    steps: dict[str, int] = {}
+    per_col: dict[float, int] = defaultdict(int)
+    for st in innermost_first:
+        col = round(st.x, 1)
+        per_col[col] += 1
+        steps[st.id] = per_col[col]
+    return steps
+
+
 def _place_off_track_relative_to_anchors(
     graph: MetroGraph,
     y_spacing: float,
@@ -1028,9 +1045,10 @@ def _place_off_track_relative_to_anchors(
         up_stations = [s for s in stations if s.id not in below]
         down_stations = [s for s in stations if s.id in below]
 
-        n_up = len(up_stations)
-        for i, st in enumerate(up_stations):
-            base_step = n_up - i
+        up_steps = _per_column_stack_steps(list(reversed(up_stations)))
+        down_steps = _per_column_stack_steps(down_stations)
+        for st in up_stations:
+            base_step = up_steps[st.id]
             candidate_y = consumer_y - base_step * step
             if section is not None and sec_dir in ("LR", "RL"):
                 candidate_y = _bump_off_track_clear_of_trunks(
@@ -1048,8 +1066,8 @@ def _place_off_track_relative_to_anchors(
             if highest_y is None or st.y < highest_y:
                 highest_y = st.y
 
-        for i, st in enumerate(down_stations):
-            base_step = i + 1
+        for st in down_stations:
+            base_step = down_steps[st.id]
             candidate_y = consumer_y + base_step * step
             if section is not None and sec_dir in ("LR", "RL"):
                 candidate_y = _bump_off_track_clear_of_trunks(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -52,9 +52,11 @@ from nf_metro.layout.phases.bbox import (
     _section_fit_top,
 )
 from nf_metro.layout.phases.off_track import (
+    _is_single_trunk_lr_section,
     _off_track_anchor_of,
     _off_track_fit_top,
     _off_track_groups,
+    _off_track_lift_step,
     _off_track_output_below,
     _reanchor_off_track_to_consumer,
     _section_distinct_trunk_ys,
@@ -1199,6 +1201,92 @@ def test_off_track_consumer_on_section_trunk(fixture):
             f"y={succ_st.y} ({abs(cons_st.y - succ_st.y):.0f}px climb)"
         )
     assert checked, f"{fixture}: no linear off-track consumer to check"
+
+
+def _single_trunk_off_track_input_lifts(graph: MetroGraph):
+    """Yield ``(off_id, consumer_id, gap, n, step)`` for each off-track input
+    whose consumer lives in a single-trunk section.
+
+    ``n`` is the number of off-track stations sharing the input's column *and*
+    its anchor (its expected stack depth); ``gap`` is its lift above the
+    consumer; ``step`` is the section's off-track lift pitch.
+
+    Restricted to single-trunk LR/RL sections (one distinct on-track Y): those
+    carry no stacked horizontal line bands, so an off-track input cannot be
+    legitimately bumped past its natural slot to clear a foreign feed-line (the
+    multi-track ``differentialabundance`` ``functional`` bump).  On a single
+    trunk the lift must therefore equal the same-column stack rank exactly.
+    """
+    junction_ids = set(graph.junctions)
+    y_spacing = compute_min_y_spacing(graph)
+    anchor_of = _off_track_anchor_of(graph)
+    inputs = {
+        off_id: anc
+        for off_id, anc in anchor_of.items()
+        if any(e.target == anc for e in graph.edges_from(off_id))
+    }
+    col_group: dict[tuple[str | None, float, str], int] = defaultdict(int)
+    for off_id, anc in anchor_of.items():
+        st = graph.stations[off_id]
+        col_group[(st.section_id, round(st.x, 1), anc)] += 1
+
+    for off_id, anc in inputs.items():
+        off_st = graph.stations[off_id]
+        cons_st = graph.stations[anc]
+        section = graph.sections.get(off_st.section_id)
+        if section is None or not _is_single_trunk_lr_section(
+            graph, section, junction_ids
+        ):
+            continue
+        step = _off_track_lift_step(graph, section, junction_ids, y_spacing)
+        n = col_group[(off_st.section_id, round(off_st.x, 1), anc)]
+        yield off_id, anc, cons_st.y - off_st.y, n, step
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES_WITH_OFF_TRACK_INPUT)
+def test_off_track_input_lift_matches_column_stack_depth(fixture):
+    """On a single-trunk section, an off-track input hugs its consumer by
+    exactly its same-column stack depth, not the whole anchor group's size.
+
+    When one consumer is fed by off-track stations in *different* columns (e.g.
+    an input above it and a producer-fed output beside it), the lift step must
+    be counted per column.  Counting the whole anchor group instead pushes a
+    lone-in-its-column input an extra slot up, stranding it over an empty row
+    above an earlier trunk station (issue #651).
+    """
+    graph = _layout(fixture)
+    checked = 0
+    for off_id, cons_id, gap, n, step in _single_trunk_off_track_input_lifts(graph):
+        checked += 1
+        assert gap <= n * step + _Y_TOL, (
+            f"{fixture}: off-track input {off_id} lifted {gap:.0f}px above "
+            f"consumer {cons_id} ({gap / step:.1f} slots) but only {n} off-track "
+            f"station(s) share its column and anchor; expected at most "
+            f"{n * step:.0f}px - it is stranded above an empty row"
+        )
+    if not checked:
+        pytest.skip(f"{fixture}: no single-trunk off-track input to check")
+
+
+def test_off_track_input_column_stack_guard_catches_over_lift():
+    """The runtime guard fires when a lone-in-its-column input is over-lifted.
+
+    Locks the guard's teeth: dragging an off-track input one extra slot above
+    its consumer on a single-trunk section, where nothing shares its column,
+    must make ``_guard_off_track_input_column_stack`` raise rather than pass.
+    """
+    from nf_metro.layout.phases.guards import (
+        PhaseInvariantError,
+        _guard_off_track_input_column_stack,
+    )
+
+    graph = _layout("topologies/off_track_input_above_consumer.mmd")
+    _guard_off_track_input_column_stack(graph, "test")
+    y_spacing = compute_min_y_spacing(graph)
+    graph.stations["cpg_bed"].y -= y_spacing
+
+    with pytest.raises(PhaseInvariantError, match="stranded above an empty row"):
+        _guard_off_track_input_column_stack(graph, "test")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

An off-track input that shares a consumer-anchor with a differently-columned off-track station (an input above the consumer plus a producer-fed output beside it) was lifted by the whole anchor group's stack depth instead of its own column's. A lone-in-its-column input was stranded an extra slot up, floating over an empty row above an earlier trunk station - the layout validator flags this as `excessive_column_gap`.

- Count the off-track lift step **per column** in `_place_off_track_relative_to_anchors` (new `_per_column_stack_steps` helper). Stations sharing an anchor across different columns each hug one row above their consumer; genuine same-column stacks (e.g. two file inputs feeding one station) are unchanged.
- The input now sits one row above its consumer in the natural upstream-feed column, exactly like a section-entry input, instead of towering near the top of the section.
- Add `_guard_off_track_input_column_stack` to the `compute_layout` validate block, raising on a single-trunk section where a lone-in-its-column input is over-lifted.
- Add a parametrised invariant test over single-trunk off-track-input fixtures, a guard-teeth test, a `examples/topologies/off_track_input_above_consumer.mmd` fixture, and a `GALLERY_ENTRIES` row.

Every existing gallery render is byte-identical (the only multi-column off-track anchor group in the corpus is the new fixture); the sole render change is the new fixture itself.

Sibling of #650 (off-track consumer dragged *down* off the trunk); both concern off-track vertical placement in `layout/phases/off_track.py`.

Fixes #651

## Test plan
- [x] `pytest` passes (7376 passed), including the new invariant + guard tests
- [x] new test fails on the pre-fix tree (`cpg_bed` lifted 2 slots), passes after
- [x] `ruff format --check` + `ruff check` clean on whole repo; `mypy` clean
- [x] Runtime validator `_guard_off_track_input_column_stack` added + wired
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/660/)
- [ ] Render-preview verdict: expect one additive new render (`off_track_input_above_consumer`), all others byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)