### PR TITLE
fix(routing): distribute stacked inter-section descenders so opposing elbows don't graze (#663)

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -239,6 +239,21 @@ DIAGONAL_RUN: float = 30.0
 CURVE_RADIUS: float = 10.0
 """Default corner radius for routed paths."""
 
+MIN_CORRIDOR_Y_OVERLAP: float = 2 * CURVE_RADIUS
+"""Minimum vertical overlap for two gap channels to share one corridor.
+
+Channels in the same inter-section gap and direction are grouped into a
+concentric corridor only when their vertical spans overlap by more than
+this much.  Two channels that overlap by less are not running parallel -
+they are stacked segments meeting at a single elbow (a deep descender
+landing on a port lane that another channel then leaves), and their
+turning corners sit within one corner-radius zone of each other.  Packing
+them into one ``OFFSET_STEP`` corridor makes those opposing elbows graze;
+treating them as separate corridors lets the gap layout distribute them
+across the gap width so the elbows stay clear.  Sized at twice the corner
+radius: an overlap that small is entirely inside the two corners' rounding
+zones, never a real parallel run."""
+
 MERGE_ROUTE_MARGIN: float = 2 * CURVE_RADIUS
 """Distance between a section bbox edge and any merge branch/trunk
 vertical line in the inter-section gap."""

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -137,6 +137,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_no_negative_grid_columns,
     _guard_no_route_through_section,
     _guard_no_same_line_parallel_descents,
+    _guard_no_stacked_elbow_graze,
     _guard_no_station_overlap,
     _guard_no_wrapped_label_trunk_strike,
     _guard_off_track_clear_of_anchor,
@@ -1639,6 +1640,7 @@ def _finalize_layout(
             _guard_no_same_line_parallel_descents(
                 graph, phase, offsets=offsets, routes=routes
             )
+            _guard_no_stacked_elbow_graze(graph, phase, offsets=offsets, routes=routes)
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)
             _guard_inter_section_route_no_backtrack(graph, phase, routes=routes)
             _guard_inter_section_route_no_full_width_backtrack(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -871,6 +871,29 @@ def _guard_off_track_consumer_on_trunk(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _guard_no_stacked_elbow_graze(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Two stacked, non-parallel inter-section risers must not graze.
+
+    When two different lines descend the same inter-section gap as risers
+    that merely meet at one elbow band (their Y spans overlap by less than
+    ``MIN_CORRIDOR_Y_OVERLAP``, rather than running parallel), they are two
+    separate corridors and must be distributed across the gap width.  Packed
+    within ``BUNDLE_TO_BUNDLE_CLEARANCE`` of each other their opposing elbows
+    overlap and the lines graze instead of reading as distinct streams.
+    """
+    from nf_metro.layout.routing.invariants import check_stacked_elbow_clearance
+
+    _raise_on_first_violation(
+        graph, phase, check_stacked_elbow_clearance, offsets, routes
+    )
+
+
 def _guard_no_station_overlap(
     graph: MetroGraph,
     phase: str,

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -26,9 +26,11 @@ from dataclasses import dataclass
 from enum import Enum
 
 from nf_metro.layout.constants import (
+    BUNDLE_TO_BUNDLE_CLEARANCE,
     COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
     EDGE_TO_BUNDLE_CLEARANCE,
+    MIN_CORRIDOR_Y_OVERLAP,
     OFFSET_STEP,
     SAME_Y_TOLERANCE,
 )
@@ -958,6 +960,129 @@ def check_no_same_line_parallel_descents(
     return violations
 
 
+def _merge_spans(spans: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Merge overlapping / touching ``(lo, hi)`` intervals into maximal runs."""
+    out: list[tuple[float, float]] = []
+    for lo, hi in sorted(spans):
+        if out and lo <= out[-1][1] + COORD_TOLERANCE:
+            out[-1] = (out[-1][0], max(out[-1][1], hi))
+        else:
+            out.append((lo, hi))
+    return out
+
+
+@dataclass(frozen=True)
+class StackedElbowGraze:
+    """Two opposing elbows in one inter-section gap whose corners graze.
+
+    Two different lines descend the same gap in vertical risers that are
+    *stacked* (their spans meet at one elbow band rather than running
+    parallel), yet sit within ``BUNDLE_TO_BUNDLE_CLEARANCE`` of each other in
+    X.  Their turning corners then overlap, so the elbow of one line touches
+    the riser/elbow of the other instead of the two being distributed across
+    the gap width.
+    """
+
+    line_a: str
+    line_b: str
+    edge_a: tuple[str, str]
+    edge_b: tuple[str, str]
+    x_a: float
+    x_b: float
+    y_overlap: float
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        return (
+            f"stacked-elbow graze: risers of {self.line_a!r} "
+            f"({self.edge_a[0]}->{self.edge_a[1]}) at x={self.x_a:.1f} and "
+            f"{self.line_b!r} ({self.edge_b[0]}->{self.edge_b[1]}) at "
+            f"x={self.x_b:.1f} overlap only {self.y_overlap:.1f}px in Y yet sit "
+            f"{abs(self.x_a - self.x_b):.1f}px apart (< {BUNDLE_TO_BUNDLE_CLEARANCE}); "
+            f"their opposing elbows graze instead of distributing across the gap"
+        )
+
+
+def check_stacked_elbow_clearance(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[StackedElbowGraze]:
+    """Return stacked, non-parallel inter-section risers packed too tightly.
+
+    Two vertical inter-section risers of different lines that merely *meet*
+    at one elbow band - their Y spans overlap by less than
+    ``MIN_CORRIDOR_Y_OVERLAP`` - are not a parallel bundle: one is a deep
+    descent landing on a lane the other then leaves.  When such a pair sits
+    within ``BUNDLE_TO_BUNDLE_CLEARANCE`` in X, the corners off the two risers
+    overlap and graze.  They must instead be distributed across the gap as
+    separate corridors, which puts at least ``BUNDLE_TO_BUNDLE_CLEARANCE``
+    between them.
+
+    Risers that genuinely overlap in Y (a real parallel bundle) are exempt:
+    their concentric corners are expected to nest at ``OFFSET_STEP``.  Risers
+    sharing a source or target endpoint are exempt too: those are one fan-out
+    or fan-in, whose branches legitimately stack at one elbow as they diverge
+    from / converge on the shared node.
+
+    Each line's vertical inter-section segments are first merged into maximal
+    runs per X column, so a bundle whose riser is split into segments by
+    intermediate corners is compared as one tall run (and so reads as a long
+    parallel overlap, exempt) rather than as short segment fragments that
+    could each show a spurious tiny overlap.
+    """
+    by_line_x: dict[tuple[str, float], list[tuple[float, float]]] = defaultdict(list)
+    edge_of: dict[tuple[str, float], tuple[str, str]] = {}
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        pts = _route_render_points(rp, offsets)
+        edge = (rp.edge.source, rp.edge.target)
+        for p1, p2 in zip(pts, pts[1:]):
+            axis, coord = _axis_aligned(p1, p2)
+            if axis != "V":
+                continue
+            xkey = round(coord / COORD_TOLERANCE) * COORD_TOLERANCE
+            lo, hi = sorted((p1[1], p2[1]))
+            by_line_x[(rp.line_id, xkey)].append((lo, hi))
+            edge_of[(rp.line_id, xkey)] = edge
+
+    risers: list[tuple[str, tuple[str, str], float, float, float]] = []
+    for (line_id, xkey), spans in by_line_x.items():
+        for lo, hi in _merge_spans(spans):
+            risers.append((line_id, edge_of[(line_id, xkey)], xkey, lo, hi))
+
+    violations: list[StackedElbowGraze] = []
+    for i in range(len(risers)):
+        la, ea, xa, lo_a, hi_a = risers[i]
+        for j in range(i + 1, len(risers)):
+            lb, eb, xb, lo_b, hi_b = risers[j]
+            if la == lb:
+                continue
+            if ea[0] == eb[0] or ea[1] == eb[1]:
+                continue
+            if abs(xa - xb) >= BUNDLE_TO_BUNDLE_CLEARANCE - COORD_TOLERANCE:
+                continue
+            overlap = min(hi_a, hi_b) - max(lo_a, lo_b)
+            # Lower bound: the two risers must genuinely meet (a non-meeting
+            # pair leaves a Y gap and so cannot graze); upper bound is the
+            # parallel-run floor.
+            if not (COORD_TOLERANCE < overlap < MIN_CORRIDOR_Y_OVERLAP):
+                continue
+            violations.append(
+                StackedElbowGraze(
+                    line_a=la,
+                    line_b=lb,
+                    edge_a=ea,
+                    edge_b=eb,
+                    x_a=xa,
+                    x_b=xb,
+                    y_overlap=overlap,
+                )
+            )
+    return violations
+
+
 __all__ = [
     "BundleOrderViolation",
     "CollinearOverlapViolation",
@@ -966,11 +1091,13 @@ __all__ = [
     "PartialBranchGapViolation",
     "SameLineParallelRun",
     "Side",
+    "StackedElbowGraze",
     "check_bundle_order_preserved",
     "check_fanout_tail_join",
     "check_merge_port_approach_side",
     "check_no_collinear_distinct_lines",
     "check_no_same_line_parallel_descents",
+    "check_stacked_elbow_clearance",
     "check_partial_branch_offset_gaps",
     "classify_merge_port_feeders",
     "distinct_offset_levels",

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -15,6 +15,7 @@ from nf_metro.layout.constants import (
     CURVE_RADIUS,
     EDGE_TO_BUNDLE_CLEARANCE,
     INTER_ROW_HEADER_CLEARANCE,
+    MIN_CORRIDOR_Y_OVERLAP,
     OFFSET_STEP,
     SECTION_HEADER_PROTRUSION,
 )
@@ -175,10 +176,14 @@ def _match_channel_gap(
 
 
 def _split_corridors(chans: list[_VChannel]) -> list[list[_VChannel]]:
-    """Split a bucket into corridors of y-overlapping channels.
+    """Split a bucket into corridors of substantially y-overlapping channels.
 
-    Only channels whose y-spans overlap share a true corridor; independent
-    vertical runs at different heights must NOT be merged.
+    Only channels whose y-spans overlap by more than
+    :data:`MIN_CORRIDOR_Y_OVERLAP` share a true corridor; independent
+    vertical runs at different heights - including two stacked descents that
+    merely touch at a shared elbow band - must NOT be merged, so the gap
+    layout can distribute them across the gap width instead of packing their
+    opposing elbows together.
     """
     chans = sorted(chans, key=lambda c: (c.y_lo, c.y_hi))
     groups: list[list[_VChannel]] = []
@@ -186,8 +191,7 @@ def _split_corridors(chans: list[_VChannel]) -> list[list[_VChannel]]:
         placed = False
         for g in groups:
             if any(
-                ch.y_lo < o.y_hi - COORD_TOLERANCE
-                and o.y_lo < ch.y_hi - COORD_TOLERANCE
+                min(ch.y_hi, o.y_hi) - max(ch.y_lo, o.y_lo) > MIN_CORRIDOR_Y_OVERLAP
                 for o in g
             ):
                 g.append(ch)

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -847,6 +847,61 @@ def test_intra_section_collinear_check_detects_overlay():
     assert {violations[0].line_a, violations[0].line_b} == {"red", "blue"}
 
 
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_no_stacked_elbow_graze(fixture):
+    """Two stacked, non-parallel inter-section risers must not graze.
+
+    Two different lines descending one inter-section gap as risers that merely
+    meet at a shared elbow band - a deep descent landing on a port lane that a
+    shallow descent then leaves - are separate corridors, not a parallel
+    bundle.  Packed within ``BUNDLE_TO_BUNDLE_CLEARANCE`` of each other their
+    opposing elbows overlap and the lines graze.  The gap layout must
+    distribute them across the gap width instead.
+    """
+    from nf_metro.layout.routing.invariants import check_stacked_elbow_clearance
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    violations = check_stacked_elbow_clearance(graph, routes, offsets)
+    assert not violations, "; ".join(v.message() for v in violations)
+
+
+def test_stacked_elbow_check_detects_graze():
+    """Meaningfulness guard: the stacked-elbow check fires on a genuine graze.
+
+    Locks the detector so the corpus test above is not vacuously green: two
+    different-line vertical risers in one gap, stacked (their spans meet at one
+    elbow band rather than overlapping) and within
+    ``BUNDLE_TO_BUNDLE_CLEARANCE`` of each other in X, must be flagged.
+    """
+    from types import SimpleNamespace
+
+    from nf_metro.layout.routing.common import RoutedPath
+    from nf_metro.layout.routing.invariants import check_stacked_elbow_clearance
+    from nf_metro.parser.model import Edge
+
+    def _riser(src, tgt, line, x, y_lo, y_hi):
+        return RoutedPath(
+            edge=Edge(source=src, target=tgt, line_id=line),
+            line_id=line,
+            points=[(x, y_lo), (x, y_hi)],
+            is_inter_section=True,
+            offsets_applied=True,
+        )
+
+    # A deep descent landing at y=100 and a shallow descent leaving it, 6px
+    # apart in X (< BUNDLE_TO_BUNDLE_CLEARANCE), overlapping only 3px in Y.
+    graph = SimpleNamespace(stations={})
+    routes = [
+        _riser("up_src", "port", "red", 0.0, 0.0, 100.0),
+        _riser("hub", "down_dst", "blue", 6.0, 97.0, 200.0),
+    ]
+    violations = check_stacked_elbow_clearance(graph, routes, {})
+    assert violations, "expected a stacked-elbow graze to be detected"
+    assert {violations[0].line_a, violations[0].line_b} == {"red", "blue"}
+
+
 @pytest.mark.parametrize("fixture", _FIXTURES_MULTI_SECTION)
 def test_distinct_trunk_not_hidden_behind_exempt(fixture):
     """A distinct-line bypass trunk must not sit within a bundle gap of an


### PR DESCRIPTION
## Summary

Right of section 7 (Joint Calling) in `longread_variant_calling.mmd`, the purple `SV VCF` line ran flush against the yellow `Other` + red `SNV VCF` bundle, their opposing elbows grazing instead of staying separate.

Root cause: in an inter-section gap, four descenders were lumped into one tight `OFFSET_STEP` (3px) corridor even though they are two **stacked** bundles that only meet at the elbow band - the deep `snvvcf`/`bam` descent into the port lane, and the shallow `svvcf` descent leaving it. `_split_corridors` merged them on a spurious ~3px Y overlap, packing their opposing turns 3px apart so the corners overlapped.

The fix recognises these as separate corridors and lets the existing gap layout distribute them across the gap width.

### Changes
- `MIN_CORRIDOR_Y_OVERLAP` (`2 * CURVE_RADIUS`): two gap channels share one corridor only when their Y spans overlap by more than this. Below it they are stacked segments meeting at one elbow, not a parallel run.
- `_split_corridors` requires that overlap before merging; separate corridors are then distributed `BUNDLE_TO_BUNDLE_CLEARANCE` (12px) apart. Curve radii unchanged.
- `check_stacked_elbow_clearance` + `_guard_no_stacked_elbow_graze` (wired into the shared-routes validate block) fail loudly if two stacked, non-parallel risers of different lines pack within `BUNDLE_TO_BUNDLE_CLEARANCE`. Fan-in/out (shared-endpoint) bundles and genuine parallel bundles are exempt.
- Corpus invariant test over all fixtures + a meaningfulness lock.

### Blast radius
Only `longread_variant_calling.mmd` changes; all 106 other gallery renders are byte-identical to `main` (md5-verified). The threshold sits in a clean gap: the spurious overlaps here are 3-6px, the smallest legitimate corridor overlap anywhere in the gallery is 35px.

Fixes #663

## Test plan
- [x] `pytest` passes (7553 passed; new corpus invariant + meaningfulness lock; verified the check fires on `main` and is clean after the fix)
- [x] `ruff format --check` + `ruff check` clean on whole repo; `mypy` clean
- [x] Runtime validator added (`_guard_no_stacked_elbow_graze`)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/668/)
- [ ] Render-preview verdict captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
