### PR TITLE
fix(routing): nest fan-out down/up-turn bundles on a shared arc centre (#664)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -110,6 +110,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_anchors_frozen_during_placement,
     _guard_bundle_order_preserved,
     _guard_centered_line_spread_balanced,
+    _guard_concentric_fanout_lead_ins,
     _guard_coordinates_finite,
     _guard_entry_approach_from_port_side,
     _guard_explicit_grid_directions,
@@ -620,6 +621,7 @@ def _compute_layout_scaled(
         _guard_single_trunk_off_track_step(graph, "final")
         _guard_off_track_consumer_on_trunk(graph, "final")
         _guard_off_track_input_column_stack(graph, "final")
+        _guard_concentric_fanout_lead_ins(graph, "final")
 
 
 def _apply_label_strike_clearance(

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -54,6 +54,34 @@ def segment_intersects_quad(
     return False
 
 
+def segments_cross(
+    p1: tuple[float, float],
+    p2: tuple[float, float],
+    p3: tuple[float, float],
+    p4: tuple[float, float],
+) -> bool:
+    """``True`` iff open segment ``p1-p2`` properly crosses ``p3-p4``.
+
+    Proper crossing only: shared endpoints and collinear overlaps return
+    ``False`` (the two segments must straddle each other).  Used to detect when
+    one routed leg passes through another rather than merely touching it.
+    """
+
+    eps = 1e-6
+
+    def _orient(
+        a: tuple[float, float], b: tuple[float, float], c: tuple[float, float]
+    ) -> float:
+        return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+
+    def _straddle(d1: float, d2: float) -> bool:
+        return (d1 > eps and d2 < -eps) or (d1 < -eps and d2 > eps)
+
+    return _straddle(_orient(p3, p4, p1), _orient(p3, p4, p2)) and _straddle(
+        _orient(p1, p2, p3), _orient(p1, p2, p4)
+    )
+
+
 def segment_intersects_bbox(
     x1: float,
     y1: float,

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1026,6 +1026,9 @@ def _guard_concentric_fanout_lead_ins(
     from nf_metro.layout.routing import compute_station_offsets
     from nf_metro.layout.routing.normalize import (
         _apply_fanout_nest,
+        _fanout_centres_coincide,
+        _fanout_foreign_segments,
+        _fanout_lead_centres,
         _fanout_lead_radius,
         _iter_fanout_clusters,
         _lead_crossings,
@@ -1049,23 +1052,17 @@ def _guard_concentric_fanout_lead_ins(
     for cluster, down in _iter_fanout_clusters(routes):
         if len({round(_fanout_lead_radius(ch), 3) for ch in cluster}) < 2:
             continue
-        centres = []
-        for ch in cluster:
-            corner = ch.route.points[ch.idx]
-            r = _fanout_lead_radius(ch)
-            hs = 1.0 if corner[0] > ch.route.points[ch.idx - 1][0] else -1.0
-            vs = 1.0 if down else -1.0
-            centres.append((corner[0] - hs * r, corner[1] + vs * r))
-        cx0, cy0 = centres[0]
-        if all(abs(px - cx0) < 0.6 and abs(py - cy0) < 0.6 for px, py in centres):
-            continue  # already concentric
+        centres = _fanout_lead_centres(cluster, down)
+        if _fanout_centres_coincide(centres):
+            continue
 
         # Not concentric: legitimate only if nesting it would rake a foreign
         # line (the pass reverts those).  Re-derive that decision; routes here
         # are this guard's throwaway copy, so mutating them is safe.
-        before = _lead_crossings(cluster, routes, offsets)
+        foreign = _fanout_foreign_segments(cluster, routes, offsets)
+        before = _lead_crossings(cluster, foreign, offsets)
         _apply_fanout_nest(cluster, down)
-        if _lead_crossings(cluster, routes, offsets) > before:
+        if _lead_crossings(cluster, foreign, offsets) > before:
             continue
         raise PhaseInvariantError(
             f"{phase}: fan-out bundle at source "

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1006,6 +1006,75 @@ def _guard_no_line_crosses_non_consumer(
                     )
 
 
+def _guard_concentric_fanout_lead_ins(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: a multi-line fan-out down/up turn nests on one arc centre.
+
+    Each branch leaving a junction turns with a concentric corner radius (inner
+    line ``CURVE_RADIUS``, each outer line ``+OFFSET_STEP``).  If every branch's
+    lead-in stayed at the junction Y the arcs would be tangent to that Y at a
+    common point and centre at ``Y +/- radius`` - not a shared centre, so the
+    radial gap bows past ``OFFSET_STEP`` through the bend.
+    ``_concentric_fanout_lead_ins`` shifts each outer corner off the junction Y
+    by ``radius - inner_radius`` so all bend centres coincide; this guards that
+    invariant against silent regression.
+    """
+    from nf_metro.layout.routing import compute_station_offsets
+    from nf_metro.layout.routing.normalize import (
+        _apply_fanout_nest,
+        _fanout_lead_radius,
+        _iter_fanout_clusters,
+        _lead_crossings,
+    )
+
+    offsets = compute_station_offsets(graph)
+    if routes is None:
+        from nf_metro.layout.routing import route_edges
+
+        # route_edges' diagonal-centring pass mutates Station.x in place; a
+        # guard must stay observational, so snapshot and restore X around it.
+        saved_x = {sid: s.x for sid, s in graph.stations.items()}
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+            return
+        finally:
+            for sid, x in saved_x.items():
+                graph.stations[sid].x = x
+
+    for cluster, down in _iter_fanout_clusters(routes):
+        if len({round(_fanout_lead_radius(ch), 3) for ch in cluster}) < 2:
+            continue
+        centres = []
+        for ch in cluster:
+            corner = ch.route.points[ch.idx]
+            r = _fanout_lead_radius(ch)
+            hs = 1.0 if corner[0] > ch.route.points[ch.idx - 1][0] else -1.0
+            vs = 1.0 if down else -1.0
+            centres.append((corner[0] - hs * r, corner[1] + vs * r))
+        cx0, cy0 = centres[0]
+        if all(abs(px - cx0) < 0.6 and abs(py - cy0) < 0.6 for px, py in centres):
+            continue  # already concentric
+
+        # Not concentric: legitimate only if nesting it would rake a foreign
+        # line (the pass reverts those).  Re-derive that decision; routes here
+        # are this guard's throwaway copy, so mutating them is safe.
+        before = _lead_crossings(cluster, routes, offsets)
+        _apply_fanout_nest(cluster, down)
+        if _lead_crossings(cluster, routes, offsets) > before:
+            continue
+        raise PhaseInvariantError(
+            f"{phase}: fan-out bundle at source "
+            f"{cluster[0].route.edge.source!r} left non-concentric "
+            f"(centres {[(round(x, 1), round(y, 1)) for x, y in centres]}) "
+            f"though nesting introduces no crossing"
+        )
+
+
 def _guard_no_line_crosses_file_icon(
     graph: MetroGraph,
     phase: str,

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -84,6 +84,7 @@ from nf_metro.layout.routing.normalize import (  # noqa: F401
     _coincident_trunk_slots,
     _collect_htrunks,
     _collect_vchannels,
+    _concentric_fanout_lead_ins,
     _distinct_line_order,
     _dogleg_off_exempt_trunks,
     _final_port_approach,
@@ -217,6 +218,7 @@ def route_edges(
     _align_peeloff_riser_gaps(routes, ctx)
     _coincide_convergent_port_approaches(routes)
     _coincide_divergent_fanout_descents(routes)
+    _concentric_fanout_lead_ins(routes, ctx)
     _join_fanout_upstream_tails(routes, ctx)
     _clear_bypass_v_label_strikes(routes, ctx)
 

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import itertools
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import NamedTuple
 
@@ -852,6 +853,171 @@ def _coincide_divergent_fanout_descents(routes: list[RoutedPath]) -> None:
                 cluster = []
             cluster.append(ch)
         _flush(cluster)
+
+
+def _concentric_fanout_lead_ins(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
+    """Nest a fan-out down/up-turn bundle onto a single shared arc centre.
+
+    A multi-line fan leaving one junction opens ``(jx, jy) -> (vx, jy) ->
+    (vx, dy)``: a horizontal lead off the shared junction, then each line's
+    vertical channel a step apart, with concentric corner radii from
+    :func:`l_shape_radii` (inner line ``base_radius``, each outer line
+    ``+OFFSET_STEP``).  Because every line's lead-in sits at the same junction
+    Y, the per-line arcs are tangent to that Y at a common point and therefore
+    do NOT share a centre: an inner arc of radius ``r`` centres at ``jy + r``
+    while an outer arc of radius ``r + step`` centres at ``jy + r + step``.
+    The radial gap then pinches to zero at the bend entry and bows past
+    ``step`` through the turn instead of holding constant.
+
+    True concentricity needs every arc to share one centre, which requires the
+    outer lines' lead-in to sit a step OFF the inner line's (above for a DOWN
+    turn, below for UP) so ``centre = corner -/+ r`` lands at the same point
+    for all.  This pass anchors the innermost line (smallest radius) at its
+    current junction Y and shifts each outer line's *corner* waypoint by
+    ``radius - inner_radius`` along the turn's perpendicular.  Only the corner
+    moves; the lead START stays pinned at the junction, so the lead-in becomes
+    a short gentle ramp into the bend rather than a stepped offset that would
+    weave across the junction apex (the line keeps flowing out of the shared
+    source instead of peeling up and back).
+
+    Channels are grouped by source + turn direction and clustered within
+    ``EDGE_TO_BUNDLE_CLEARANCE`` (widely-separated descents head into distinct
+    corridors and never share a centre).  A cluster is nested only when it
+    carries at least two distinct corner radii - a genuine concentric bundle;
+    same-line descents already fused onto one track by
+    :func:`_coincide_divergent_fanout_descents` share a radius and are left
+    flat.  Shifting an outer corner off the junction Y tilts its lead into a
+    short ramp; a deep fan ramped into a busy trunk can rake a foreign line, so
+    each cluster's nesting is kept only when it adds no new inter-line crossing
+    on those leads (a fan whose ramp would tangle stays flat and keeps the
+    minor bend bow instead).
+    """
+    offsets = ctx.station_offsets or {}
+    for cluster, down in _iter_fanout_clusters(routes):
+        _nest_fanout_cluster(cluster, down, routes, offsets)
+
+
+def _iter_fanout_clusters(
+    routes: list[RoutedPath],
+) -> Iterator[tuple[list[_VChannel], bool]]:
+    """Yield ``(cluster, down)`` for each fan-out lead bundle in *routes*.
+
+    A bundle is the set of initial H-then-V descents leaving one source in one
+    turn direction, split into clusters whose vertical legs sit within
+    ``EDGE_TO_BUNDLE_CLEARANCE`` of one another (wider gaps are distinct
+    corridors).  Shared by the nesting pass and its guard so both see the same
+    bundles.
+    """
+    by_source: dict[tuple[str, bool], list[_VChannel]] = defaultdict(list)
+    for rp in routes:
+        if not rp.is_inter_section or rp.curve_radii is None:
+            continue
+        ch = _initial_fanout_descent(rp)
+        if ch is None or ch.idx - 1 >= len(rp.curve_radii):
+            continue
+        by_source[(rp.edge.source, ch.down)].append(ch)
+
+    band = EDGE_TO_BUNDLE_CLEARANCE
+    for (_source, down), chans in by_source.items():
+        if len(chans) < 2:
+            continue
+        chans.sort(key=lambda c: c.x)
+        cluster: list[_VChannel] = []
+        for ch in chans:
+            if cluster and ch.x - cluster[-1].x > band:
+                yield cluster, down
+                cluster = []
+            cluster.append(ch)
+        yield cluster, down
+
+
+def _lead_crossings(
+    cluster: list[_VChannel],
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> int:
+    """Count proper crossings of the cluster's bend legs by foreign lines.
+
+    Moving a member's corner tilts its lead (``points[idx-1] -> points[idx]``)
+    and lengthens its vertical leg (``points[idx] -> points[idx+1]``); both can
+    rake a foreign line, so both are tested.  A foreign segment is any segment
+    of a route carrying a different ``line_id`` - same-line segments merge,
+    never tangle.  Tested in rendered coordinates (per-line offsets applied):
+    a sibling that leaves the same junction sits on the trunk centre in raw
+    waypoints, so only the offset positions reveal whether a lifted leg truly
+    rakes it or merely diverges from it at the fork.
+    """
+    from nf_metro.layout.geometry import segments_cross
+    from nf_metro.render.svg import apply_route_offsets
+
+    cluster_ids = {id(ch.route) for ch in cluster}
+    foreign = [
+        (rp.line_id, apply_route_offsets(rp, offsets))
+        for rp in routes
+        if id(rp) not in cluster_ids
+    ]
+    n = 0
+    for ch in cluster:
+        lid = ch.route.line_id
+        rpts = apply_route_offsets(ch.route, offsets)
+        legs = [(rpts[ch.idx - 1], rpts[ch.idx]), (rpts[ch.idx], rpts[ch.idx + 1])]
+        for flid, fpts in foreign:
+            if flid == lid:
+                continue
+            for a, b in legs:
+                for k in range(len(fpts) - 1):
+                    if segments_cross(a, b, fpts[k], fpts[k + 1]):
+                        n += 1
+    return n
+
+
+def _fanout_lead_radius(ch: _VChannel) -> float:
+    """The lead-corner radius of a fan-out channel (``curve_radii[idx-1]``)."""
+    assert ch.route.curve_radii is not None
+    return ch.route.curve_radii[ch.idx - 1]
+
+
+def _apply_fanout_nest(
+    cluster: list[_VChannel], down: bool
+) -> list[tuple[float, float]]:
+    """Shift a cluster's corners onto a shared arc centre; return prior corners.
+
+    The innermost line (smallest lead-corner radius) anchors at its junction Y;
+    every other line's corner moves ``radius - inner_radius`` toward the inside
+    of the turn (up for DOWN, down for UP) so all arcs centre on one point.
+    The returned originals let a caller revert the move.
+    """
+    original = [ch.route.points[ch.idx] for ch in cluster]
+    r_inner = min(_fanout_lead_radius(ch) for ch in cluster)
+    anchor = min(cluster, key=_fanout_lead_radius)
+    anchor_y = anchor.route.points[anchor.idx][1]
+    sign = -1.0 if down else 1.0
+    for ch in cluster:
+        px, _ = ch.route.points[ch.idx]
+        shift = sign * (_fanout_lead_radius(ch) - r_inner)
+        ch.route.points[ch.idx] = (px, anchor_y + shift)
+    return original
+
+
+def _nest_fanout_cluster(
+    cluster: list[_VChannel],
+    down: bool,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> None:
+    """Nest one fan-out cluster onto a shared arc centre, gated on crossings.
+
+    Skipped unless the cluster carries at least two distinct lead radii;
+    reverted wholesale if the tilted leads introduce a foreign-line crossing the
+    flat leads did not have.
+    """
+    if len({round(_fanout_lead_radius(ch), 3) for ch in cluster}) < 2:
+        return
+    before = _lead_crossings(cluster, routes, offsets)
+    original = _apply_fanout_nest(cluster, down)
+    if _lead_crossings(cluster, routes, offsets) > before:
+        for ch, pt in zip(cluster, original):
+            ch.route.points[ch.idx] = pt
 
 
 def _normalize_bypass_trunks(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -931,43 +931,59 @@ def _iter_fanout_clusters(
         yield cluster, down
 
 
-def _lead_crossings(
+def _fanout_foreign_segments(
     cluster: list[_VChannel],
     routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[tuple[str, list[tuple[float, float]]]]:
+    """Rendered ``(line_id, points)`` of every route outside *cluster*.
+
+    The foreign set is fixed across one cluster's flat-vs-nested crossing
+    comparison (only the cluster's own corners move), so building it once and
+    reusing it avoids re-applying offsets to the whole corpus per probe.
+    """
+    from nf_metro.render.svg import apply_route_offsets
+
+    cluster_ids = {id(ch.route) for ch in cluster}
+    return [
+        (rp.line_id, apply_route_offsets(rp, offsets))
+        for rp in routes
+        if id(rp) not in cluster_ids
+    ]
+
+
+def _lead_crossings(
+    cluster: list[_VChannel],
+    foreign: list[tuple[str, list[tuple[float, float]]]],
     offsets: dict[tuple[str, str], float],
 ) -> int:
     """Count proper crossings of the cluster's bend legs by foreign lines.
 
     Moving a member's corner tilts its lead (``points[idx-1] -> points[idx]``)
     and lengthens its vertical leg (``points[idx] -> points[idx+1]``); both can
-    rake a foreign line, so both are tested.  A foreign segment is any segment
-    of a route carrying a different ``line_id`` - same-line segments merge,
-    never tangle.  Tested in rendered coordinates (per-line offsets applied):
-    a sibling that leaves the same junction sits on the trunk centre in raw
-    waypoints, so only the offset positions reveal whether a lifted leg truly
-    rakes it or merely diverges from it at the fork.
+    rake a foreign line, so both are tested against the *foreign* segments (from
+    :func:`_fanout_foreign_segments`).  Same-``line_id`` segments merge rather
+    than tangle and are skipped.  Tested in rendered coordinates (per-line
+    offsets applied): a sibling that leaves the same junction sits on the trunk
+    centre in raw waypoints, so only the offset positions reveal whether a
+    lifted leg truly rakes it or merely diverges from it at the fork.
     """
     from nf_metro.layout.geometry import segments_cross
     from nf_metro.render.svg import apply_route_offsets
 
-    cluster_ids = {id(ch.route) for ch in cluster}
-    foreign = [
-        (rp.line_id, apply_route_offsets(rp, offsets))
-        for rp in routes
-        if id(rp) not in cluster_ids
-    ]
     n = 0
     for ch in cluster:
         lid = ch.route.line_id
         rpts = apply_route_offsets(ch.route, offsets)
-        legs = [(rpts[ch.idx - 1], rpts[ch.idx]), (rpts[ch.idx], rpts[ch.idx + 1])]
+        legs = ((rpts[ch.idx - 1], rpts[ch.idx]), (rpts[ch.idx], rpts[ch.idx + 1]))
         for flid, fpts in foreign:
             if flid == lid:
                 continue
             for a, b in legs:
-                for k in range(len(fpts) - 1):
-                    if segments_cross(a, b, fpts[k], fpts[k + 1]):
-                        n += 1
+                n += sum(
+                    segments_cross(a, b, fpts[k], fpts[k + 1])
+                    for k in range(len(fpts) - 1)
+                )
     return n
 
 
@@ -975,6 +991,32 @@ def _fanout_lead_radius(ch: _VChannel) -> float:
     """The lead-corner radius of a fan-out channel (``curve_radii[idx-1]``)."""
     assert ch.route.curve_radii is not None
     return ch.route.curve_radii[ch.idx - 1]
+
+
+def _fanout_lead_centres(
+    cluster: list[_VChannel], down: bool
+) -> list[tuple[float, float]]:
+    """Arc centre of each member's lead corner; shared iff the bundle nests.
+
+    A right-then-vertical bend of radius ``r`` whose corner is at ``corner``
+    centres at ``(corner_x - hsign * r, corner_y +/- r)`` (``+`` for a DOWN
+    turn, ``-`` for UP), where ``hsign`` is the lead's travel direction.
+    """
+    centres = []
+    for ch in cluster:
+        corner = ch.route.points[ch.idx]
+        r = _fanout_lead_radius(ch)
+        hsign = 1.0 if corner[0] > ch.route.points[ch.idx - 1][0] else -1.0
+        centres.append((corner[0] - hsign * r, corner[1] + (r if down else -r)))
+    return centres
+
+
+def _fanout_centres_coincide(
+    centres: list[tuple[float, float]], tol: float = 0.6
+) -> bool:
+    """``True`` iff every lead-corner arc centre falls within *tol* of the first."""
+    cx0, cy0 = centres[0]
+    return all(abs(px - cx0) < tol and abs(py - cy0) < tol for px, py in centres)
 
 
 def _apply_fanout_nest(
@@ -1013,9 +1055,10 @@ def _nest_fanout_cluster(
     """
     if len({round(_fanout_lead_radius(ch), 3) for ch in cluster}) < 2:
         return
-    before = _lead_crossings(cluster, routes, offsets)
+    foreign = _fanout_foreign_segments(cluster, routes, offsets)
+    before = _lead_crossings(cluster, foreign, offsets)
     original = _apply_fanout_nest(cluster, down)
-    if _lead_crossings(cluster, routes, offsets) > before:
+    if _lead_crossings(cluster, foreign, offsets) > before:
         for ch, pt in zip(cluster, original):
             ch.route.points[ch.idx] = pt
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1142,6 +1142,59 @@ def test_top_entry_lead_corner_concentric(fixture):
 
 
 # ---------------------------------------------------------------------------
+# Fan-out down/up-turn bundles nest on a shared arc centre
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_fanout_lead_corners_concentric(fixture):
+    """A multi-line fan-out down/up turn must nest on one shared arc centre.
+
+    Each branch leaving a junction gets a concentric corner radius (inner line
+    ``CURVE_RADIUS``, each outer line ``+OFFSET_STEP``).  If every branch's
+    lead-in stays at the junction Y, the arcs are tangent to that Y at a common
+    point and centre at ``Y +/- radius`` - so they do NOT share a centre and
+    the radial gap bows past ``OFFSET_STEP`` through the bend.  The lead-in must
+    shift each outer corner off the junction Y by ``radius - inner_radius`` so
+    ``centre = corner -/+ radius`` coincides for the whole bundle.
+
+    Exempts a bundle whose nesting would rake a foreign line (the pass keeps
+    those flat); encoded by tentatively nesting any non-concentric bundle and
+    accepting it only when that introduces a crossing.
+    """
+    from nf_metro.layout.routing.normalize import (
+        _apply_fanout_nest,
+        _fanout_lead_radius,
+        _iter_fanout_clusters,
+        _lead_crossings,
+    )
+
+    graph = _layout(fixture)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    for cluster, down in _iter_fanout_clusters(routes):
+        if len({round(_fanout_lead_radius(ch), 3) for ch in cluster}) < 2:
+            continue
+        centres = []
+        for ch in cluster:
+            corner = ch.route.points[ch.idx]
+            r = _fanout_lead_radius(ch)
+            hs = 1.0 if corner[0] > ch.route.points[ch.idx - 1][0] else -1.0
+            centres.append((corner[0] - hs * r, corner[1] + (r if down else -r)))
+        cx0, cy0 = centres[0]
+        if all(abs(px - cx0) < 0.6 and abs(py - cy0) < 0.6 for px, py in centres):
+            continue
+        before = _lead_crossings(cluster, routes, offsets)
+        _apply_fanout_nest(cluster, down)
+        rounded = [(round(x, 1), round(y, 1)) for x, y in centres]
+        assert _lead_crossings(cluster, routes, offsets) > before, (
+            f"{fixture}: fan-out bundle at {cluster[0].route.edge.source!r} left "
+            f"non-concentric (centres {rounded}) though nesting adds no crossing"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Off-track inputs sit above their consumer
 # ---------------------------------------------------------------------------
 

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1164,6 +1164,9 @@ def test_fanout_lead_corners_concentric(fixture):
     """
     from nf_metro.layout.routing.normalize import (
         _apply_fanout_nest,
+        _fanout_centres_coincide,
+        _fanout_foreign_segments,
+        _fanout_lead_centres,
         _fanout_lead_radius,
         _iter_fanout_clusters,
         _lead_crossings,
@@ -1176,19 +1179,14 @@ def test_fanout_lead_corners_concentric(fixture):
     for cluster, down in _iter_fanout_clusters(routes):
         if len({round(_fanout_lead_radius(ch), 3) for ch in cluster}) < 2:
             continue
-        centres = []
-        for ch in cluster:
-            corner = ch.route.points[ch.idx]
-            r = _fanout_lead_radius(ch)
-            hs = 1.0 if corner[0] > ch.route.points[ch.idx - 1][0] else -1.0
-            centres.append((corner[0] - hs * r, corner[1] + (r if down else -r)))
-        cx0, cy0 = centres[0]
-        if all(abs(px - cx0) < 0.6 and abs(py - cy0) < 0.6 for px, py in centres):
+        centres = _fanout_lead_centres(cluster, down)
+        if _fanout_centres_coincide(centres):
             continue
-        before = _lead_crossings(cluster, routes, offsets)
+        foreign = _fanout_foreign_segments(cluster, routes, offsets)
+        before = _lead_crossings(cluster, foreign, offsets)
         _apply_fanout_nest(cluster, down)
         rounded = [(round(x, 1), round(y, 1)) for x, y in centres]
-        assert _lead_crossings(cluster, routes, offsets) > before, (
+        assert _lead_crossings(cluster, foreign, offsets) > before, (
             f"{fixture}: fan-out bundle at {cluster[0].route.edge.source!r} left "
             f"non-concentric (centres {rounded}) though nesting adds no crossing"
         )


### PR DESCRIPTION
## Summary

A multi-line fan leaving a junction gave each branch a concentric corner radius (inner line `CURVE_RADIUS`, each outer line `+OFFSET_STEP`) but kept every branch's lead-in at the junction Y. The per-line arcs were then tangent to that Y at a common point and centred at `Y +/- radius` rather than a shared point, so the radial gap pinched to zero at the bend entry and bowed past one `OFFSET_STEP` through the turn instead of holding constant. On `examples/genomeassembly.mmd` the Assembly/Hi-C down-turn out of section 1 measured ~4.2px through the bend versus the 3px straight-run spacing.

This adds a routing post-pass `_concentric_fanout_lead_ins` that shifts each outer branch's corner off the junction Y by `radius - inner_radius` so all arcs in the bundle share one centre, leaving the lead a short gentle ramp into the bend (the inner anchor line is untouched). The nest is reverted per cluster when its tilted leads would introduce a foreign-line crossing the flat leads did not have, evaluated in rendered coordinates, so a deep fan ramping into a busy trunk (e.g. `differentialabundance`) stays flat and keeps the minor bow rather than tangling.

Also adds:
- `segments_cross`, a proper segment-segment crossing primitive, in `layout/geometry.py`.
- A parametrised invariant test (`test_fanout_lead_corners_concentric`) over all fixtures, with a crossing-based exemption mirroring the pass.
- A runtime guard (`_guard_concentric_fanout_lead_ins`) wired into the `validate` block.

Fixes #664

## Test plan
- [x] pytest passes (7552 passed), including the new invariant test (verified failing on `main`)
- [x] ruff check + ruff format clean on whole repo; mypy clean
- [x] Runtime validator added and wired into `compute_layout(validate=True)`
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/669/)
- [ ] Render-preview verdict captured (expect deltas: small concentric tightening on fan-out down-turns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)