### PR TITLE
refactor: tolerance hygiene - name inline epsilons and assert cross-constant orderings

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -282,6 +282,17 @@ COORD_TOLERANCE: float = 1.0
 COORD_TOLERANCE_FINE: float = 0.01
 """Fine tolerance for detecting nearly identical Y coordinates."""
 
+SAME_COORD_TOLERANCE: float = 0.5
+"""Sub-pixel tolerance for treating two coordinates as the same assigned
+row / track / value.
+
+Layout phases assign coordinates onto integer-ish grids; this half-pixel
+band absorbs float drift so "is this station on that trunk / row / column?"
+and threshold-residual checks (``slack <= SAME_COORD_TOLERANCE``) answer
+consistently across call sites.  It must stay well below
+:data:`OFFSET_STEP` (3.0) so adjacent per-line offset slots are never merged
+into one coordinate."""
+
 SAME_Y_TOLERANCE: float = 0.1
 """Tolerance for treating two stations as sharing a base Y row."""
 
@@ -662,3 +673,51 @@ multiples of ``y_spacing``.  Below the threshold, sections sit at
 multiple distinct residues by construction, so
 no single shift can align them all and the per-section snap from Stage
 6.4 is honoured as the best-effort alignment."""
+
+
+# ---------------------------------------------------------------------------
+# Cross-constant relations
+# ---------------------------------------------------------------------------
+def _check_constant_relations() -> None:
+    """Assert the geometric orderings several constants depend on.
+
+    Unlike the derived constants above (expressed as formulas of their
+    parents), these constants are set independently but are only correct
+    *relative to each other*.  Encoding the relationships as import-time
+    asserts turns a silent mis-tuning into an immediate, located failure.
+    """
+    # Coordinate-tolerance tiers must stay strictly ordered so each answers
+    # "same coordinate?" at its own precision without colliding with the next.
+    assert COORD_TOLERANCE_FINE < SAME_COORD_TOLERANCE < COORD_TOLERANCE, (
+        "coordinate tolerances must be strictly ordered "
+        f"fine ({COORD_TOLERANCE_FINE}) < same ({SAME_COORD_TOLERANCE}) "
+        f"< coarse ({COORD_TOLERANCE})"
+    )
+    # A same-coordinate test must never swallow an adjacent per-line offset
+    # slot, or two parallel lines collapse onto one coordinate.
+    assert SAME_COORD_TOLERANCE < OFFSET_STEP, (
+        f"SAME_COORD_TOLERANCE ({SAME_COORD_TOLERANCE}) must stay below "
+        f"OFFSET_STEP ({OFFSET_STEP}) so offset slots are not merged"
+    )
+    # Bypass corners turn with CURVE_RADIUS each side; without 2*CURVE_RADIUS
+    # of vertical clearance the two corners overlap the channel.
+    assert BYPASS_CLEARANCE >= 2 * CURVE_RADIUS, (
+        f"BYPASS_CLEARANCE ({BYPASS_CLEARANCE}) must be >= 2*CURVE_RADIUS "
+        f"({2 * CURVE_RADIUS}) so bypass corners clear the channel"
+    )
+    # Nesting multiple bypass routes must step them apart by more than the
+    # per-line offset, else stacked bypasses read as one bundle.
+    assert OFFSET_STEP < BYPASS_NEST_STEP, (
+        f"OFFSET_STEP ({OFFSET_STEP}) must stay below BYPASS_NEST_STEP "
+        f"({BYPASS_NEST_STEP}) so nested bypass routes separate visibly"
+    )
+    # A port offset from a station by up to the bundle's offset span must not
+    # be mistaken for an elbow at that station.  The current value is
+    # 4 * OFFSET_STEP; only the floor (>= OFFSET_STEP) is required to hold.
+    assert STATION_ELBOW_TOLERANCE >= OFFSET_STEP, (
+        f"STATION_ELBOW_TOLERANCE ({STATION_ELBOW_TOLERANCE}) must be "
+        f">= OFFSET_STEP ({OFFSET_STEP})"
+    )
+
+
+_check_constant_relations()

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -679,12 +679,11 @@ no single shift can align them all and the per-section snap from Stage
 # Cross-constant relations
 # ---------------------------------------------------------------------------
 def _check_constant_relations() -> None:
-    """Assert the geometric orderings several constants depend on.
+    """Assert the geometric orderings that independently-set constants depend on.
 
     Unlike the derived constants above (expressed as formulas of their
-    parents), these constants are set independently but are only correct
-    *relative to each other*.  Encoding the relationships as import-time
-    asserts turns a silent mis-tuning into an immediate, located failure.
+    parents), each of these holds only *relative to another*, so encode the
+    relationships as import-time asserts.
     """
     # Coordinate-tolerance tiers must stay strictly ordered so each answers
     # "same coordinate?" at its own precision without colliding with the next.

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -43,6 +43,7 @@ from nf_metro.layout.constants import (
     LABEL_OVERLAP_TOL,
     LABEL_WRAP_MIN_LINE_CHARS,
     PORT_LABEL_MAX_DX,
+    SAME_COORD_TOLERANCE,
     TB_LABEL_H_SPACING,
     TB_LINE_Y_OFFSET,
     TB_PILL_EDGE_OFFSET,
@@ -602,7 +603,7 @@ def find_label_overlaps(
     Shared by the wrapping pass, the runtime guard, and the layout validator
     so all three agree on what "overlap" means.
     """
-    eps = 0.5
+    eps = SAME_COORD_TOLERANCE
     labels = [
         p
         for p in placements

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -15,10 +15,12 @@ from collections import defaultdict
 import networkx as nx
 
 from nf_metro.layout.constants import (
+    COORD_TOLERANCE_FINE,
     DEFAULT_LINE_PRIORITY,
     DIAMOND_COMPRESSION,
     FANOUT_SPACING,
     LINE_GAP,
+    SAME_COORD_TOLERANCE,
     SIDE_BRANCH_NUDGE,
 )
 from nf_metro.parser.model import LineSpread, MetroGraph
@@ -234,7 +236,7 @@ def _is_track_occupied_at_layer(
     layer: int,
     layer_occupancy: dict[int, dict[str, float]],
     exclude_node: str,
-    tolerance: float = 0.5,
+    tolerance: float = SAME_COORD_TOLERANCE,
 ) -> bool:
     """Check if any already-placed station at this layer occupies the given track."""
     placed = layer_occupancy.get(layer, {})
@@ -264,7 +266,7 @@ def _find_free_nearby_track(
     # Rank by distance from pred_track (prefer closer to predecessor)
     existing.sort(key=lambda t: abs(t - pred_track))
     for t in existing:
-        if abs(t - pred_track) < 0.01:
+        if abs(t - pred_track) < COORD_TOLERANCE_FINE:
             # Skip the predecessor's own track (would be a flat line)
             continue
         if not _is_track_occupied_at_layer(t, layer, layer_occupancy, exclude_node):
@@ -799,10 +801,10 @@ def _equalize_fork_groups(
         #   2 stations  - gap exceeds line_gap (multi-line station padding)
         #   3+ stations - spacing is uneven
         if len(group) == 2:
-            if spacings[0] <= line_gap + 0.01:
+            if spacings[0] <= line_gap + COORD_TOLERANCE_FINE:
                 continue
         else:
-            if max(spacings) - min(spacings) < 0.01:
+            if max(spacings) - min(spacings) < COORD_TOLERANCE_FINE:
                 continue
 
         # Distribute as signed offsets around an anchor so the column

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
     COORD_TOLERANCE,
+    SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
     STATION_RADIUS_APPROX,
 )
@@ -363,9 +364,9 @@ def is_loop_side_branch_station(graph: MetroGraph, sid: str) -> bool:
     tgt = graph.stations.get(outs[0].target)
     if src is None or tgt is None:
         return False
-    if abs(src.y - tgt.y) > 0.5:
+    if abs(src.y - tgt.y) > SAME_COORD_TOLERANCE:
         return False
-    if abs(st.y - src.y) < 0.5:
+    if abs(st.y - src.y) < SAME_COORD_TOLERANCE:
         return False
     if not ((src.x < st.x < tgt.x) or (tgt.x < st.x < src.x)):
         return False

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from nf_metro.layout.constants import (
     DIAGONAL_RUN,
     ICON_HALF_HEIGHT,
+    SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
     STATION_RADIUS_APPROX,
 )
@@ -89,7 +90,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
         if not targets:
             continue
         target_y = min(targets, key=lambda y: abs(y - port_st.y))
-        if abs(port_st.y - target_y) < 0.5:
+        if abs(port_st.y - target_y) < SAME_COORD_TOLERANCE:
             continue
 
         # Fan-in exits (multiple distinct internal source Ys) want to
@@ -121,7 +122,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
                     if ds_sec is None or ds_sec.grid_row != section.grid_row:
                         continue
                     ep_st = graph.stations.get(eid)
-                    if ep_st is None or abs(ep_st.y - port_st.y) < 0.5:
+                    if ep_st is None or abs(ep_st.y - port_st.y) < SAME_COORD_TOLERANCE:
                         continue
                     _set_port_y(graph, eid, port_st.y)
             continue
@@ -174,7 +175,7 @@ def _fan_free_content_upward(
             continue
         top_y = min(_ref_y(graph, sid) for sid in internal_ids)
         slack = top_y - _ref_bbox_top(graph, section) - section_y_padding
-        if slack < y_spacing - 0.5:
+        if slack < y_spacing - SAME_COORD_TOLERANCE:
             continue
         slots = int(slack // y_spacing)
         if slots <= 0:
@@ -357,7 +358,7 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         for i, src in enumerate(sources[:n_lift], 1):
             new_y = trunk_y - i * y_spacing
             delta = new_y - _ref_y(graph, src)
-            if abs(delta) < 0.5:
+            if abs(delta) < SAME_COORD_TOLERANCE:
                 continue
             graph.stations[src].y = new_y
             _shift_linear_consumer_chain(graph, src, delta, internal_set, from_ref=True)
@@ -371,7 +372,7 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         for i, src in enumerate(sources[n_lift:], 1):
             new_y = trunk_y + i * y_spacing
             delta = new_y - _ref_y(graph, src)
-            if abs(delta) < 0.5:
+            if abs(delta) < SAME_COORD_TOLERANCE:
                 continue
             graph.stations[src].y = new_y
             _shift_linear_consumer_chain(graph, src, delta, internal_set, from_ref=True)
@@ -493,7 +494,7 @@ def _column_occupied_ys(
         st2 = graph.stations.get(sid2)
         if st2 is None or st2.is_port or st2.is_hidden:
             continue
-        if abs(st2.x - col_x) > 0.5:
+        if abs(st2.x - col_x) > SAME_COORD_TOLERANCE:
             continue
         occ.append(st2.y)
     return occ
@@ -536,7 +537,7 @@ def _balance_one_section(graph: MetroGraph, section: Section, y_spacing: float) 
 
     section_top_y = min(graph.stations[s].y for s in internal_ids)
     top_band = section_top_y - _ref_bbox_top(graph, section)
-    if top_band <= y_spacing + 0.5:
+    if top_band <= y_spacing + SAME_COORD_TOLERANCE:
         return
 
     movable = _movable_partial_bundle_stations(graph, cols, bundle)
@@ -544,8 +545,8 @@ def _balance_one_section(graph: MetroGraph, section: Section, y_spacing: float) 
         return
 
     ys = [graph.stations[s].y for s in movable]
-    above_count = sum(1 for y in ys if y < trunk_y - 0.5)
-    below_count = sum(1 for y in ys if y > trunk_y + 0.5)
+    above_count = sum(1 for y in ys if y < trunk_y - SAME_COORD_TOLERANCE)
+    below_count = sum(1 for y in ys if y > trunk_y + SAME_COORD_TOLERANCE)
     if below_count <= above_count:
         return
 
@@ -573,11 +574,11 @@ def _lift_below_trunk_siblings(
     for _ in range(len(movable)):
         section_top_y = min(graph.stations[s].y for s in internal_ids)
         top_band = section_top_y - _ref_bbox_top(graph, section)
-        if top_band <= y_spacing + 0.5:
+        if top_band <= y_spacing + SAME_COORD_TOLERANCE:
             break
         ys_by_sid = {s: graph.stations[s].y for s in movable}
-        above = [s for s, y in ys_by_sid.items() if y < trunk_y - 0.5]
-        below = [s for s, y in ys_by_sid.items() if y > trunk_y + 0.5]
+        above = [s for s, y in ys_by_sid.items() if y < trunk_y - SAME_COORD_TOLERANCE]
+        below = [s for s, y in ys_by_sid.items() if y > trunk_y + SAME_COORD_TOLERANCE]
         if len(below) <= len(above):
             break
         line_sets = {frozenset(graph.station_lines(s)) for s in movable}
@@ -592,7 +593,7 @@ def _lift_below_trunk_siblings(
         for cand in below:
             col_x = graph.stations[cand].x
             occ = _column_occupied_ys(graph, section, col_x, cand)
-            if any(abs(oy - new_y) < y_spacing - 0.5 for oy in occ):
+            if any(abs(oy - new_y) < y_spacing - SAME_COORD_TOLERANCE for oy in occ):
                 continue
             candidate = cand
             break
@@ -605,7 +606,7 @@ def _lift_below_trunk_siblings(
         # reach ~9.5 px.  Use the wider reach when relevant.
         marker_clearance = 16.0 if (st and st.off_track) else 9.5
         min_y = _ref_bbox_top(graph, section) + max(label_clearance, marker_clearance)
-        if new_y < min_y - 0.5:
+        if new_y < min_y - SAME_COORD_TOLERANCE:
             if not above:
                 break
             above.sort(key=lambda s: graph.stations[s].y)
@@ -624,7 +625,9 @@ def _lift_below_trunk_siblings(
             )
             break
         ext_feeders = _balance_direct_external_feeder_ys(graph, candidate, section.id)
-        if len(ext_feeders) >= 2 and all(fy >= new_y - 0.5 for fy in ext_feeders):
+        if len(ext_feeders) >= 2 and all(
+            fy >= new_y - SAME_COORD_TOLERANCE for fy in ext_feeders
+        ):
             break
         delta = new_y - graph.stations[candidate].y
         graph.stations[candidate].y = new_y
@@ -658,7 +661,7 @@ def _compact_below_trunk_band(
         st = graph.stations.get(sid)
         if st is None or st.is_port or st.is_hidden:
             continue
-        if st.y > trunk_y + 0.5:
+        if st.y > trunk_y + SAME_COORD_TOLERANCE:
             movables.append(sid)
     if not movables:
         return
@@ -666,7 +669,8 @@ def _compact_below_trunk_band(
     # station at trunk_y + y_spacing within half a slot.
     first_row_y = trunk_y + y_spacing
     has_first_row = any(
-        abs(graph.stations[s].y - first_row_y) < y_spacing / 2 - 0.5 for s in movables
+        abs(graph.stations[s].y - first_row_y) < y_spacing / 2 - SAME_COORD_TOLERANCE
+        for s in movables
     )
     if has_first_row:
         return
@@ -691,7 +695,7 @@ def _compact_below_trunk_band(
         new_y = st.y - y_spacing
         col_x = round(st.x, 3)
         if any(
-            abs(oy - new_y) < y_spacing / 2 - 0.5
+            abs(oy - new_y) < y_spacing / 2 - SAME_COORD_TOLERANCE
             for oy in cols_nonmovable.get(col_x, set())
         ):
             return  # collision; abort
@@ -732,10 +736,10 @@ def _loop_side_endpoints(
     tgt = graph.stations.get(outs[0].target)
     if src is None or tgt is None:
         return None
-    if abs(src.y - tgt.y) > 0.5:
+    if abs(src.y - tgt.y) > SAME_COORD_TOLERANCE:
         return None
     trunk_y = src.y
-    if abs(st.y - trunk_y) < 0.5:
+    if abs(st.y - trunk_y) < SAME_COORD_TOLERANCE:
         return None
     if not ((src.x < st.x < tgt.x) or (tgt.x < st.x < src.x)):
         return None
@@ -763,7 +767,7 @@ def _has_off_trunk_sibling(
         other = graph.stations.get(other_sid)
         if other is None or other.is_port or other.is_hidden:
             continue
-        if abs(other.y - trunk_y) < 0.5:
+        if abs(other.y - trunk_y) < SAME_COORD_TOLERANCE:
             continue
         other_srcs = {e.source for e in graph.edges_to(other_sid)}
         other_tgts = {e.target for e in graph.edges_from(other_sid)}
@@ -830,7 +834,7 @@ def _loop_column_key(
         p = graph.stations.get(e.source)
         if p is None or p.is_hidden:
             continue
-        if abs(p.y - section_trunk_y) > 0.5:
+        if abs(p.y - section_trunk_y) > SAME_COORD_TOLERANCE:
             return None
         if (
             pred_x is None
@@ -842,7 +846,7 @@ def _loop_column_key(
         t = graph.stations.get(e.target)
         if t is None or t.is_hidden:
             continue
-        if abs(t.y - section_trunk_y) > 0.5:
+        if abs(t.y - section_trunk_y) > SAME_COORD_TOLERANCE:
             return None
         if (
             succ_x is None
@@ -899,7 +903,7 @@ def _snap_column_to_anchors(
     anchor_xs: list[float] = []
     for sid in members:
         st = graph.stations[sid]
-        if abs(st.y - section_trunk_y) <= 0.5:
+        if abs(st.y - section_trunk_y) <= SAME_COORD_TOLERANCE:
             movers.append(sid)
             continue
         visible_ins = [
@@ -1075,13 +1079,16 @@ def _shift_sparse_loop_stations_to_clear_bundle(
             tgt = graph.stations.get(outs[0].target)
             if src is None or tgt is None:
                 continue
-            if abs(src.y - trunk_y) > 0.5 or abs(tgt.y - trunk_y) > 0.5:
+            if (
+                abs(src.y - trunk_y) > SAME_COORD_TOLERANCE
+                or abs(tgt.y - trunk_y) > SAME_COORD_TOLERANCE
+            ):
                 continue
             # S must sit clearly off the trunk and share its Y row
             # with a same-section sibling whose inbound bundle is
             # busier than S's.
             dy = st.y - trunk_y
-            if abs(dy) < 0.5:
+            if abs(dy) < SAME_COORD_TOLERANCE:
                 continue
             s_lines = _consumed_lines(sid)
             sibling: Station | None = None
@@ -1097,7 +1104,7 @@ def _shift_sparse_loop_stations_to_clear_bundle(
                     or sib.is_terminus
                 ):
                     continue
-                if abs(sib.y - st.y) > 0.5:
+                if abs(sib.y - st.y) > SAME_COORD_TOLERANCE:
                     continue
                 sib_lines = _consumed_lines(sib_id)
                 if len(sib_lines) > len(s_lines):

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -11,6 +11,7 @@ from nf_metro.layout.constants import (
     MIN_STATION_FLAT_LENGTH,
     MIN_STRAIGHT_EDGE,
     MIN_STRAIGHT_PORT,
+    SAME_COORD_TOLERANCE,
     SECTION_HEADER_PROTRUSION,
 )
 from nf_metro.layout.labels import font_scale_context, label_text_width
@@ -196,7 +197,7 @@ def _push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) ->
                 d = (bypass_bot + section_y_gap) - ls.bbox_y
                 if d > deficit:
                     deficit = d
-        if deficit <= 0.5:
+        if deficit <= SAME_COORD_TOLERANCE:
             continue
 
         shifted_section_ids = {
@@ -310,7 +311,7 @@ def _lift_would_cause_uturn(
     _collect(station_id)
     if len(feeder_ys) < 2:
         return False
-    return all(y >= anchor_y - 0.5 for y in feeder_ys)
+    return all(y >= anchor_y - SAME_COORD_TOLERANCE for y in feeder_ys)
 
 
 def _shrink_and_tighten_rows(
@@ -498,7 +499,7 @@ def _shrink_bboxes_to_content_bottom(
         if content_bot is None:
             continue
         current_bot = section.bbox_y + section.bbox_h
-        if content_bot > current_bot + 0.5:
+        if content_bot > current_bot + SAME_COORD_TOLERANCE:
             section.bbox_h = content_bot - section.bbox_y
             continue
         desired_bot = content_bot
@@ -506,7 +507,7 @@ def _shrink_bboxes_to_content_bottom(
         if mate_bots:
             desired_bot = max(desired_bot, max(mate_bots))
         new_h = desired_bot - section.bbox_y
-        if new_h < section.bbox_h - 0.5:
+        if new_h < section.bbox_h - SAME_COORD_TOLERANCE:
             section.bbox_h = max(0.0, new_h)
 
 
@@ -605,7 +606,9 @@ def _section_band_is_empty(graph: MetroGraph, section: Section) -> bool:
         st = graph.stations.get(sid)
         if st is None:
             continue
-        if (st.is_port or sid.startswith("__bypass_")) and st.y < topmost - 0.5:
+        if (
+            st.is_port or sid.startswith("__bypass_")
+        ) and st.y < topmost - SAME_COORD_TOLERANCE:
             return False
     return True
 
@@ -642,13 +645,13 @@ def _fit_bboxes_to_content_top(
         if section.bbox_h <= 0:
             continue
         target = _section_fit_top(graph, section, section_y_padding, section_y_gap)
-        if target is not None and target < section.bbox_y - 0.5:
+        if target is not None and target < section.bbox_y - SAME_COORD_TOLERANCE:
             _set_section_bbox_top(graph, section, target)
             continue
         hug = _section_content_hug_top(graph, section, section_y_padding)
         if (
             hug is not None
-            and hug > section.bbox_y + 0.5
+            and hug > section.bbox_y + SAME_COORD_TOLERANCE
             and _section_band_is_empty(graph, section)
         ):
             _set_section_bbox_top(graph, section, hug)
@@ -713,7 +716,7 @@ def _tighten_lower_rows_after_shrink(graph: MetroGraph, section_y_gap: float) ->
         current_top = min(s.bbox_y for s in lower)
         target_gap = max(section_y_gap, wrap_min.get((r - 1, r), 0.0))
         slack = current_top - (effective_floor + target_gap)
-        if slack <= 0.5:
+        if slack <= SAME_COORD_TOLERANCE:
             continue
 
         for s in graph.sections.values():

--- a/src/nf_metro/layout/phases/fan_bundles.py
+++ b/src/nf_metro/layout/phases/fan_bundles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 from nf_metro.layout.constants import (
+    SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
 )
 from nf_metro.layout.phases._common import (
@@ -111,8 +112,8 @@ def _divergence_target_ys(graph: MetroGraph) -> set[str]:
         # at or beyond either extreme can snap freely - the snap won't
         # collapse a diagonal onto a target track.
         sy = st.y
-        has_below = any(ty < sy - 0.5 for ty in tgt_ys)
-        has_above = any(ty > sy + 0.5 for ty in tgt_ys)
+        has_below = any(ty < sy - SAME_COORD_TOLERANCE for ty in tgt_ys)
+        has_above = any(ty > sy + SAME_COORD_TOLERANCE for ty in tgt_ys)
         if has_below and has_above:
             anchors.add(src_id)
     return anchors
@@ -320,7 +321,7 @@ def _apply_half_grid_2branch_symfan(
         if content_ys:
             new_top = min(content_ys) - section_y_padding
             delta = new_top - section.bbox_y
-            if delta > 0.5:
+            if delta > SAME_COORD_TOLERANCE:
                 section.bbox_y = new_top
                 section.bbox_h = max(0.0, section.bbox_h - delta)
 
@@ -370,7 +371,7 @@ def _section_symfan_uses_half_grid(graph: MetroGraph, section: Section) -> bool:
         by_col[round(st.x, 3)] += 1
     if has_off_track or len(branches) != 2:
         return False
-    if abs(branches[0].x - branches[1].x) >= 0.5:
+    if abs(branches[0].x - branches[1].x) >= SAME_COORD_TOLERANCE:
         return False
     # No other column may have a multi-branch population (would force
     # full-grid height anyway).  With exactly two branches sharing one

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -17,6 +17,7 @@ from nf_metro.layout.constants import (
     INTER_ROW_EDGE_CLEARANCE,
     OFFSET_STEP,
     ROW_BAND_SLACK,
+    SAME_COORD_TOLERANCE,
     SECTION_Y_GAP,
     STATION_RADIUS_APPROX,
     X_SPACING,
@@ -564,7 +565,7 @@ def _guard_row_gaps(graph: MetroGraph, phase: str, *, section_y_gap: float) -> N
     Sections that don't share horizontal extent are unconstrained --
     their vertical proximity has no visual impact.
     """
-    tol = 0.5
+    tol = SAME_COORD_TOLERANCE
     sections_by_row_start: dict[int, list[tuple[str, Section]]] = defaultdict(list)
     for sid, sec in graph.sections.items():
         if sec.bbox_w <= 0 or sec.bbox_h <= 0:
@@ -917,7 +918,7 @@ def _guard_no_station_overlap(
         if b is not None:
             boxes.append((sid, b))
     boxes.sort(key=lambda item: item[1][0])
-    tol = 0.5
+    tol = SAME_COORD_TOLERANCE
     n = len(boxes)
     for i in range(n):
         s1, (x1, y1, X1, Y1) = boxes[i]

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -14,6 +14,7 @@ from nf_metro.layout.constants import (
     LABEL_BBOX_MARGIN,
     MIN_STRAIGHT_EDGE,
     OFFSET_STEP,
+    SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
     TERMINUS_WIDTH,
     X_SPACING,
@@ -1139,9 +1140,9 @@ def _bump_off_track_clear_of_trunks(
             continue
         # Only stations on the OTHER side of the icon (i.e. the trunk
         # the entry port feeds) have tracks crossing the icon's column.
-        if section.direction == "LR" and st2.x <= off_st.x + 0.5:
+        if section.direction == "LR" and st2.x <= off_st.x + SAME_COORD_TOLERANCE:
             continue
-        if section.direction == "RL" and st2.x >= off_st.x - 0.5:
+        if section.direction == "RL" and st2.x >= off_st.x - SAME_COORD_TOLERANCE:
             continue
         # Collect the line-track band Y range at the icon's column.
         # Tracks run horizontally so each line's Y here equals
@@ -1325,7 +1326,7 @@ def _reanchor_off_track_to_consumer(
             desired_top = _off_track_fit_top(
                 graph, section, highest_y, section_y_padding
             )
-            if abs(desired_top - section.bbox_y) > 0.5:
+            if abs(desired_top - section.bbox_y) > SAME_COORD_TOLERANCE:
                 _set_section_bbox_top(graph, section, desired_top)
         if lowest_y is not None:
             _grow_section_bbox_downward(graph, section, lowest_y + section_y_padding)

--- a/src/nf_metro/layout/phases/ports.py
+++ b/src/nf_metro/layout/phases/ports.py
@@ -8,6 +8,7 @@ from nf_metro.layout.constants import (
     CURVE_RADIUS,
     MAX_PORT_ALIGN_BBOX_EXPANSION_FRAC,
     MIN_PORT_STATION_GAP,
+    SAME_COORD_TOLERANCE,
     STATION_ELBOW_TOLERANCE,
 )
 from nf_metro.layout.phases._common import _expand_bbox_for_y, _grid_group_section_ids
@@ -933,7 +934,7 @@ def _align_tb_section_bbox_bottoms(graph: MetroGraph) -> None:
         if not target_bots:
             continue
         desired_bot = max(target_bots)
-        if desired_bot - current_bot <= 0.5:
+        if desired_bot - current_bot <= SAME_COORD_TOLERANCE:
             continue
         section.bbox_h = desired_bot - section.bbox_y
 

--- a/src/nf_metro/layout/phases/row_align.py
+++ b/src/nf_metro/layout/phases/row_align.py
@@ -9,6 +9,7 @@ from nf_metro.layout.constants import (
     FONT_HEIGHT,
     LABEL_OFFSET,
     OFFSET_STEP,
+    SAME_COORD_TOLERANCE,
     STATION_RADIUS_APPROX,
 )
 from nf_metro.layout.labels import active_font_scale
@@ -211,10 +212,14 @@ def _enforce_multiline_label_gap(
         if st.y not in y_map:
             continue
         has_above = any(
-            (st.layer, ry) in layer_at_y for ry in remap_ys if ry < st.y - 0.5
+            (st.layer, ry) in layer_at_y
+            for ry in remap_ys
+            if ry < st.y - SAME_COORD_TOLERANCE
         )
         has_below = any(
-            (st.layer, ry) in layer_at_y for ry in remap_ys if ry > st.y + 0.5
+            (st.layer, ry) in layer_at_y
+            for ry in remap_ys
+            if ry > st.y + SAME_COORD_TOLERANCE
         )
         if has_above and has_below:
             needs_gap_ys.add(st.y)
@@ -509,7 +514,7 @@ def _align_row_trunk_ys(graph: MetroGraph) -> None:
                 if ty is None:
                     continue
                 delta = target_y - ty
-                if delta < 0.5:
+                if delta < SAME_COORD_TOLERANCE:
                     continue
                 for sid in section.station_ids:
                     st = graph.stations.get(sid)
@@ -536,7 +541,7 @@ def _align_row_trunk_ys(graph: MetroGraph) -> None:
                         p is None
                         or port_st is None
                         or p.side not in (PortSide.LEFT, PortSide.RIGHT)
-                        or abs(port_st.y - target_y) < 0.5
+                        or abs(port_st.y - target_y) < SAME_COORD_TOLERANCE
                     ):
                         continue
                     connected_ys: set[float] = set()
@@ -552,7 +557,7 @@ def _align_row_trunk_ys(graph: MetroGraph) -> None:
                         st = graph.stations.get(other_id)
                         if st and not st.is_port:
                             connected_ys.add(round(st.y, 1))
-                            if abs(st.y - target_y) < 0.5:
+                            if abs(st.y - target_y) < SAME_COORD_TOLERANCE:
                                 target_aligned = True
                     if len(connected_ys) < 2 and target_aligned:
                         _set_port_y(graph, pid, target_y)
@@ -594,7 +599,11 @@ def _compact_row_content_to_bbox_top(
             return True
         a_t = _section_trunk_y(graph, a)
         b_t = _section_trunk_y(graph, b)
-        return a_t is not None and b_t is not None and abs(a_t - b_t) < 0.5
+        return (
+            a_t is not None
+            and b_t is not None
+            and abs(a_t - b_t) < SAME_COORD_TOLERANCE
+        )
 
     for sections in row_sections.values():
         if not sections:
@@ -632,7 +641,7 @@ def _compact_row_content_to_bbox_top(
                 allowed_shifts.append(max(0.0, shift))
             delta = min(allowed_shifts) if allowed_shifts else 0.0
 
-            if delta >= 0.5:
+            if delta >= SAME_COORD_TOLERANCE:
                 for section in group:
                     # bbox_y is preserved; only bbox_h shrinks.  Clamp
                     # edge-pinned ports so the shift doesn't push them
@@ -665,5 +674,5 @@ def _compact_row_content_to_bbox_top(
                 if port_ys:
                     desired_bot = max(desired_bot, max(port_ys))
                 new_h = desired_bot - section.bbox_y
-                if new_h < section.bbox_h - 0.5:
+                if new_h < section.bbox_h - SAME_COORD_TOLERANCE:
                     section.bbox_h = max(0.0, new_h)

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -23,6 +23,7 @@ from nf_metro.layout.constants import (
     LABEL_PAD,
     LINE_GAP,
     MIN_STATION_FLAT_LENGTH,
+    SAME_COORD_TOLERANCE,
     TB_LINE_Y_OFFSET,
     TERMINUS_ICON_CLEARANCE,
     TERMINUS_ICON_CLEARANCE_V,
@@ -81,7 +82,7 @@ def _align_terminus_to_upstream(graph: MetroGraph) -> None:
             if len(preds) != 1:
                 continue
             src = graph.stations[next(iter(preds))]
-            if abs(src.y - st.y) < 0.5:
+            if abs(src.y - st.y) < SAME_COORD_TOLERANCE:
                 continue
             collision = False
             for sib_sid in section.station_ids:
@@ -90,9 +91,9 @@ def _align_terminus_to_upstream(graph: MetroGraph) -> None:
                 sib = graph.stations.get(sib_sid)
                 if sib is None or sib.is_port or sib.is_hidden:
                     continue
-                if abs(sib.x - st.x) > 0.5:
+                if abs(sib.x - st.x) > SAME_COORD_TOLERANCE:
                     continue
-                if abs(sib.y - src.y) < 0.5:
+                if abs(sib.y - src.y) < SAME_COORD_TOLERANCE:
                     collision = True
                     break
             if collision:
@@ -335,7 +336,7 @@ def _resolve_station_collisions(
     else:
         primary, secondary, primary_step, step = "x", "y", x_spacing, y_spacing
 
-    EPS = 0.5
+    EPS = SAME_COORD_TOLERANCE
     # Off-track stations carry a placeholder Y here (the off-track lift in
     # Stage 5.2 overwrites it); letting that placeholder occupy a cell would
     # cascade on-track siblings off their true rows.

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -27,6 +27,7 @@ from nf_metro.layout.constants import (
     PLACEMENT_X_GAP,
     PLACEMENT_Y_GAP,
     PORT_MIN_GAP,
+    SAME_COORD_TOLERANCE,
     SECTION_HEADER_PROTRUSION,
     SECTION_X_PADDING,
 )
@@ -345,7 +346,7 @@ def _finalize_spanning_sections(
             continue
         target_left = min(s.offset_x + s.bbox_x for s in peers)
         current_left = section.offset_x + section.bbox_x
-        if abs(current_left - target_left) > 0.5:
+        if abs(current_left - target_left) > SAME_COORD_TOLERANCE:
             section.offset_x -= current_left - target_left
 
         rspan = section.grid_row_span

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -13,7 +13,11 @@ from typing import Any, NamedTuple
 
 import drawsvg as draw
 
-from nf_metro.layout.constants import LABEL_LINE_HEIGHT, Y_SPACING
+from nf_metro.layout.constants import (
+    LABEL_LINE_HEIGHT,
+    SAME_COORD_TOLERANCE,
+    Y_SPACING,
+)
 from nf_metro.layout.geometry import segment_intersects_bbox
 from nf_metro.layout.labels import (
     LabelPlacement,
@@ -1201,7 +1205,7 @@ def _render_rail_pill(
     # metro interchange.  A non-bridging station (a single used rail, hence no
     # link bar) has nothing to bulge from, so its lone marker uses the standard
     # radius rather than the inflated interchange knob size.
-    is_spanning = (bot_y - top_y) > 0.5
+    is_spanning = (bot_y - top_y) > SAME_COORD_TOLERANCE
     knob_r = r * RAIL_KNOB_RADIUS_RATIO if is_spanning else r
     bar_half = r * RAIL_LINK_HALF_WIDTH_RATIO
     # rail_used_ys is recorded parallel to the line-definition order (see
@@ -1213,7 +1217,7 @@ def _render_rail_pill(
         # A round-capped line of the given width is a capsule; used here only
         # for its straight body between top and bottom used rails (the caps are
         # covered by the circles), so it joins the knobs with no seam.
-        if bot_y - top_y <= 0.5:
+        if bot_y - top_y <= SAME_COORD_TOLERANCE:
             return
         d.append(
             draw.Line(

--- a/tests/test_constant_relations.py
+++ b/tests/test_constant_relations.py
@@ -1,0 +1,56 @@
+"""Lock the cross-constant geometric orderings enforced at import.
+
+``constants._check_constant_relations`` runs at module import and turns a
+mis-tuned constant (one whose value is only correct relative to another)
+into an immediate, located failure rather than a silent layout regression.
+"""
+
+import importlib
+
+import pytest
+
+from nf_metro.layout import constants as c
+
+
+def test_relations_hold_on_current_values():
+    # The live module already ran this at import; re-running must not raise.
+    c._check_constant_relations()
+
+
+def test_module_imports_cleanly():
+    # A reload re-executes the import-time assert block.
+    importlib.reload(c)
+
+
+def test_coordinate_tolerance_tiers_strictly_ordered():
+    assert c.COORD_TOLERANCE_FINE < c.SAME_COORD_TOLERANCE < c.COORD_TOLERANCE
+
+
+def test_same_coord_tolerance_below_offset_step():
+    assert c.SAME_COORD_TOLERANCE < c.OFFSET_STEP
+
+
+def test_bypass_clearance_holds_two_corner_radii():
+    assert c.BYPASS_CLEARANCE >= 2 * c.CURVE_RADIUS
+
+
+def test_offset_step_below_bypass_nest_step():
+    assert c.OFFSET_STEP < c.BYPASS_NEST_STEP
+
+
+def test_station_elbow_tolerance_at_least_offset_step():
+    assert c.STATION_ELBOW_TOLERANCE >= c.OFFSET_STEP
+
+
+@pytest.mark.parametrize(
+    "attr, bad_value",
+    [
+        ("SAME_COORD_TOLERANCE", 5.0),  # exceeds OFFSET_STEP and COORD_TOLERANCE
+        ("BYPASS_CLEARANCE", 1.0),  # below 2*CURVE_RADIUS
+        ("OFFSET_STEP", 99.0),  # exceeds BYPASS_NEST_STEP
+    ],
+)
+def test_violation_raises(monkeypatch, attr, bad_value):
+    monkeypatch.setattr(c, attr, bad_value)
+    with pytest.raises(AssertionError):
+        c._check_constant_relations()

--- a/tests/test_constant_relations.py
+++ b/tests/test_constant_relations.py
@@ -5,21 +5,13 @@ mis-tuned constant (one whose value is only correct relative to another)
 into an immediate, located failure rather than a silent layout regression.
 """
 
-import importlib
-
 import pytest
 
 from nf_metro.layout import constants as c
 
 
 def test_relations_hold_on_current_values():
-    # The live module already ran this at import; re-running must not raise.
     c._check_constant_relations()
-
-
-def test_module_imports_cleanly():
-    # A reload re-executes the import-time assert block.
-    importlib.reload(c)
 
 
 def test_coordinate_tolerance_tiers_strictly_ordered():
@@ -48,6 +40,7 @@ def test_station_elbow_tolerance_at_least_offset_step():
         ("SAME_COORD_TOLERANCE", 5.0),  # exceeds OFFSET_STEP and COORD_TOLERANCE
         ("BYPASS_CLEARANCE", 1.0),  # below 2*CURVE_RADIUS
         ("OFFSET_STEP", 99.0),  # exceeds BYPASS_NEST_STEP
+        ("STATION_ELBOW_TOLERANCE", 0.0),  # below OFFSET_STEP
     ],
 )
 def test_violation_raises(monkeypatch, attr, bad_value):


### PR DESCRIPTION
## Summary

Tolerance hygiene for `layout/constants.py` and its call sites (part of the #323 fragility theme). Two byte-identical changes:

- **Name the inline coordinate-sameness epsilons.** The bare `0.5` / `0.01` literals scattered across the layout package that answer "is this the same assigned row/track/value?" are swept into a new named `SAME_COORD_TOLERANCE` (0.5) and the existing `COORD_TOLERANCE_FINE` (0.01), so the flip points are searchable and consistent. Genuine arithmetic literals are left alone (`0.5 * y_spacing`, `0.5 * width`, the `consumer_col - 0.5` half-grid offset, the `(slack + 0.5) // y_spacing` rounding nudge).
- **Assert cross-constant orderings at import.** A `_check_constant_relations()` run at module import encodes the geometric relationships several independently-set constants depend on (tolerance tiers; `SAME_COORD_TOLERANCE < OFFSET_STEP`; `BYPASS_CLEARANCE >= 2*CURVE_RADIUS`; `OFFSET_STEP < BYPASS_NEST_STEP`; `STATION_ELBOW_TOLERANCE >= OFFSET_STEP`). A mis-tuning now fails loudly at import instead of silently regressing layout.

Values are unchanged throughout, so every gallery render is byte-identical (verified: all 87 SVGs match `main`).

Fixes #676

## Test plan
- [x] pytest passes (7643 passed; new `tests/test_constant_relations.py` locks the orderings + negative paths)
- [x] ruff check + ruff format clean on whole repo
- [x] Runtime validator added (`_check_constant_relations`, import-time)
- [ ] Visual review of render preview
- [x] Render-preview verdict expected: no visual changes (byte-identical gallery)

Generated with Claude Code