### PR TITLE
feat(ci): passive layout-quality metrics in the render-diff

### DIFF
--- a/.github/workflows/pr-renders.yml
+++ b/.github/workflows/pr-renders.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           mkdir -p /tmp/pr_renders
           cp docs/assets/renders/*.svg docs/assets/renders/manifest.json /tmp/pr_renders/
+          cp docs/assets/renders/metrics.json /tmp/pr_renders/ 2>/dev/null || true
 
       # --- Render with base branch code ---
       - name: Clean renders before base render
@@ -49,6 +50,7 @@ jobs:
           mkdir -p /tmp/base_renders
           cp docs/assets/renders/*.svg /tmp/base_renders/
           cp docs/assets/renders/manifest.json /tmp/base_renders/ 2>/dev/null || true
+          cp docs/assets/renders/metrics.json /tmp/base_renders/ 2>/dev/null || true
 
       # --- Generate diff ---
       - name: Checkout PR branch (for diff script)

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -9,12 +9,16 @@ Usage:
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
+sys.path.insert(0, str(project_root / "tests"))
+
+from layout_metrics import compute_metrics  # noqa: E402
 
 from nf_metro.convert import convert_nextflow_dag  # noqa: E402
 from nf_metro.layout.engine import compute_layout  # noqa: E402
@@ -482,6 +486,12 @@ PIPELINE_ENTRIES: list[tuple[str, str, str, str]] = [
 # Populated by each render function, written to RENDERS_DIR/manifest.json.
 _manifest: dict[str, str] = {}
 
+# Layout-quality scorecard per SVG filename, written to RENDERS_DIR/metrics.json
+# and reported as per-render deltas in the render-diff page. Advisory only.
+_metrics: dict[str, dict[str, float]] = {}
+
+_SVG_DIMS_RE = re.compile(r'<svg[^>]*\bwidth="([\d.]+)"[^>]*\bheight="([\d.]+)"')
+
 
 def render_drawn_svg(graph, theme, **kwargs) -> str:
     """Render the drawn map only, with the embedded data manifest disabled.
@@ -494,6 +504,20 @@ def render_drawn_svg(graph, theme, **kwargs) -> str:
     return render_svg(graph, theme, **kwargs)
 
 
+def _record_metrics(graph, svg_name: str, svg_str: str) -> None:
+    """Compute the layout-quality scorecard for a freshly rendered graph.
+
+    Computed alongside the render so the scores reflect the same engine version
+    that drew the SVG. A failure here never aborts a render.
+    """
+    match = _SVG_DIMS_RE.search(svg_str)
+    canvas = (float(match.group(1)), float(match.group(2))) if match else None
+    try:
+        _metrics[svg_name] = compute_metrics(graph, canvas=canvas)
+    except Exception as e:  # noqa: BLE001 - metrics are advisory, never fatal
+        print(f"    metrics FAIL for {svg_name}: {e}")
+
+
 def render_mmd(mmd_path: Path, svg_path: Path, *, debug: bool = DEBUG_RENDERS) -> None:
     """Parse, layout, and render a .mmd file to SVG."""
     text = mmd_path.read_text()
@@ -503,6 +527,7 @@ def render_mmd(mmd_path: Path, svg_path: Path, *, debug: bool = DEBUG_RENDERS) -
     theme = THEMES[theme_name]
     svg_str = render_drawn_svg(graph, theme, debug=debug)
     svg_path.write_text(svg_str)
+    _record_metrics(graph, svg_path.name, svg_str)
 
 
 def clean_name(stem: str) -> str:
@@ -554,6 +579,7 @@ def render_guide_examples() -> None:
             theme = THEMES[theme_name]
             svg_str = render_drawn_svg(graph, theme, debug=True)
             debug_svg.write_text(svg_str)
+            _record_metrics(graph, debug_svg.name, svg_str)
             _manifest[debug_svg.name] = section
             print("  rnaseq_auto_debug: OK")
         except Exception as e:
@@ -647,6 +673,7 @@ def render_nextflow_examples() -> None:
             theme = THEMES[graph.style if graph.style in THEMES else "nfcore"]
             svg_str = render_drawn_svg(graph, theme, debug=DEBUG_RENDERS)
             svg_path.write_text(svg_str)
+            _record_metrics(graph, svg_path.name, svg_str)
             _manifest[svg_path.name] = section
             print(f"  nf_{mmd_path.stem}: OK")
         except Exception as e:
@@ -771,6 +798,13 @@ def write_manifest() -> None:
     print(f"Manifest written to {manifest_path} ({len(_manifest)} entries)")
 
 
+def write_metrics() -> None:
+    """Write the per-render layout-quality scorecard for the render-diff page."""
+    metrics_path = RENDERS_DIR / "metrics.json"
+    metrics_path.write_text(json.dumps(_metrics, indent=2, sort_keys=True) + "\n")
+    print(f"Metrics written to {metrics_path} ({len(_metrics)} entries)")
+
+
 if __name__ == "__main__":
     # Clean stale renders so removed gallery entries don't persist
     if RENDERS_DIR.exists():
@@ -782,3 +816,4 @@ if __name__ == "__main__":
     render_test_fixtures()
     build_gallery()
     write_manifest()
+    write_metrics()

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -24,6 +24,15 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tests"))
+
+from layout_metrics import (  # noqa: E402
+    METRICS,
+    delta_direction,
+    format_delta,
+    format_value,
+)
+
 HTML_TEMPLATE = """\
 <!DOCTYPE html>
 <html lang="en">
@@ -218,6 +227,48 @@ HTML_TEMPLATE = """\
   .intro a {{
     color: var(--accent);
   }}
+  .metrics {{
+    margin-bottom: 2rem;
+    padding: 1rem 1.5rem;
+    background: var(--surface);
+    border-radius: 8px;
+    border: 1px solid var(--border);
+  }}
+  .metrics h2 {{
+    font-size: 1rem;
+    margin-bottom: 0.25rem;
+    color: var(--accent);
+  }}
+  .metrics .caption {{
+    color: var(--muted);
+    font-size: 0.8rem;
+    margin-bottom: 0.75rem;
+  }}
+  .metrics table {{
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.82rem;
+  }}
+  .metrics th, .metrics td {{
+    padding: 0.3rem 0.6rem;
+    text-align: right;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }}
+  .metrics th:first-child, .metrics td:first-child {{
+    text-align: left;
+  }}
+  .metrics th {{
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.7rem;
+  }}
+  .metrics td a {{ color: var(--text); text-decoration: none; }}
+  .metrics td a:hover {{ color: var(--accent); }}
+  .m-flat {{ color: var(--muted); }}
+  .m-better {{ color: #4ec9b0; font-weight: 600; }}
+  .m-worse {{ color: #f38ba8; font-weight: 600; }}
 </style>
 </head>
 <body>
@@ -248,6 +299,7 @@ switch between side-by-side, base-only, and PR-only views.
     (red <em>removed</em> badge)</li>
 </ul>
 </details>
+{metrics}
 {toc}
 {entries}
 <script>
@@ -282,12 +334,69 @@ document.querySelectorAll('.toggle-bar button').forEach(btn => {{
 """
 
 
-def _load_manifest(render_dir: Path) -> dict[str, str]:
-    """Load manifest.json from a render directory, or return empty dict."""
-    manifest_path = render_dir / "manifest.json"
-    if manifest_path.exists():
-        return json.loads(manifest_path.read_text())
+def _load_json(render_dir: Path, filename: str) -> dict:
+    """Load a JSON sidecar from a render directory, or return an empty dict."""
+    path = render_dir / filename
+    if path.exists():
+        return json.loads(path.read_text())
     return {}
+
+
+def _build_metrics_html(
+    changed: list[tuple[str, str]],
+    base_metrics: dict[str, dict[str, float]],
+    pr_metrics: dict[str, dict[str, float]],
+) -> str:
+    """Build the advisory layout-quality delta table for the changed renders.
+
+    Returns an empty string when no scorecard is available on either side (the
+    base branch predates the metric, or computation failed everywhere).
+    """
+    if not base_metrics and not pr_metrics:
+        return ""
+
+    header_cells = "".join(f"<th>{spec.label}</th>" for spec in METRICS)
+    rows: list[str] = []
+    for name, _kind in changed:
+        stem = name.removesuffix(".svg")
+        base = base_metrics.get(name)
+        pr = pr_metrics.get(name)
+        if base is None and pr is None:
+            continue
+        cells = [f'<td><a href="#{stem}">{stem}</a></td>']
+        for spec in METRICS:
+            bv = base.get(spec.key) if base else None
+            pv = pr.get(spec.key) if pr else None
+            direction = delta_direction(bv, pv)
+            cls = {-1: "m-better", 1: "m-worse", 0: "m-flat"}[direction]
+            both_present = bv is not None and pv is not None
+            if both_present and direction != 0:
+                text = (
+                    f"{format_value(spec, bv)}&rarr;{format_value(spec, pv)} "
+                    f"({format_delta(spec, bv, pv)})"
+                )
+            elif both_present:
+                text = format_value(spec, pv)
+            elif bv is None:
+                text = f"&ndash;&rarr;{format_value(spec, pv)}"
+            else:
+                text = f"{format_value(spec, bv)}&rarr;&ndash;"
+            cells.append(f'<td class="{cls}">{text}</td>')
+        rows.append(f"<tr>{''.join(cells)}</tr>")
+
+    if not rows:
+        return ""
+
+    return (
+        '<div class="metrics">\n<h2>Layout-quality metrics</h2>\n'
+        '<p class="caption">Advisory only &mdash; nothing gates on these. '
+        "Lower is better; "
+        '<span class="m-better">green</span> improved, '
+        '<span class="m-worse">red</span> regressed.</p>\n'
+        f"<table>\n<tr><th>Render</th>{header_cells}</tr>\n"
+        + "\n".join(rows)
+        + "\n</table>\n</div>"
+    )
 
 
 def build_diff(
@@ -314,11 +423,14 @@ def build_diff(
         return False
 
     # Load manifest from PR renders (preferred) with base as fallback
-    manifest = _load_manifest(pr_dir)
-    base_manifest = _load_manifest(base_dir)
+    manifest = _load_json(pr_dir, "manifest.json")
+    base_manifest = _load_json(base_dir, "manifest.json")
     for name, _ in changed:
         if name not in manifest and name in base_manifest:
             manifest[name] = base_manifest[name]
+
+    base_metrics = _load_json(base_dir, "metrics.json")
+    pr_metrics = _load_json(pr_dir, "metrics.json")
 
     # Group changed files by section
     section_order: list[str] = []
@@ -436,9 +548,15 @@ def build_diff(
                 )
             entries_html.append(entry)
 
+    ordered_changed = [
+        item for section in section_order for item in by_section[section]
+    ]
+    metrics_html = _build_metrics_html(ordered_changed, base_metrics, pr_metrics)
+
     html = HTML_TEMPLATE.format(
         title_suffix=title_suffix,
         summary=summary,
+        metrics=metrics_html,
         toc=toc,
         entries="\n\n".join(entries_html),
     )

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from nf_metro.layout.constants import (
     COMPONENT_BAND_OVERLAP_TOLERANCE,
@@ -1093,14 +1093,25 @@ def _guard_no_line_crosses_file_icon(
                     )
 
 
-def _guard_no_line_strikes_label(
+class LabelStrike(NamedTuple):
+    """One rendered line segment striking through a station's label glyph ink."""
+
+    line_id: str
+    src: str
+    tgt: str
+    station_id: str
+    bbox: tuple[float, float, float, float]
+    p1: tuple[float, float]
+    p2: tuple[float, float]
+
+
+def iter_line_label_strikes(
     graph: MetroGraph,
-    phase: str,
     *,
     offsets: dict[tuple[str, str], float] | None = None,
     routes: list[RoutedPath] | None = None,
-) -> None:
-    """Final-phase: no rendered line segment may strike through a station label.
+) -> Iterator[LabelStrike]:
+    """Yield every rendered line segment that strikes through a station label.
 
     A line dipping, fanning, or running across a station's name label reads as
     a strike-through.  The label glyph-ink box (the reserved label width
@@ -1110,6 +1121,10 @@ def _guard_no_line_strikes_label(
     crossing the glyphs does.  A segment is exempt when it belongs to a line
     the label's station carries, or when the label's station is an endpoint of
     the segment's edge (that line legitimately touches the station).
+
+    This is the single strike definition shared by
+    ``_guard_no_line_strikes_label`` (which raises on the first) and the passive
+    label-strike CI metric (which counts them all).
     """
     from nf_metro.layout.labels import (
         LabelPlacement,
@@ -1171,13 +1186,25 @@ def _guard_no_line_strikes_label(
                     if segment_strikes_label(
                         p1[0], p1[1], p2[0], p2[1], placement_by_sid[sid]
                     ):
-                        raise PhaseInvariantError(
-                            f"{phase}: line {line_id!r} on edge {src!r} -> {tgt!r} "
-                            f"strikes through label of {sid!r} "
-                            f"glyph-ink bbox ({bbox[0]:.1f},{bbox[1]:.1f})-"
-                            f"({bbox[2]:.1f},{bbox[3]:.1f}); segment "
-                            f"({p1[0]:.1f},{p1[1]:.1f})->({p2[0]:.1f},{p2[1]:.1f})"
-                        )
+                        yield LabelStrike(line_id, src, tgt, sid, bbox, p1, p2)
+
+
+def _guard_no_line_strikes_label(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: no rendered line segment may strike through a station label."""
+    for s in iter_line_label_strikes(graph, offsets=offsets, routes=routes):
+        raise PhaseInvariantError(
+            f"{phase}: line {s.line_id!r} on edge {s.src!r} -> {s.tgt!r} "
+            f"strikes through label of {s.station_id!r} "
+            f"glyph-ink bbox ({s.bbox[0]:.1f},{s.bbox[1]:.1f})-"
+            f"({s.bbox[2]:.1f},{s.bbox[3]:.1f}); segment "
+            f"({s.p1[0]:.1f},{s.p1[1]:.1f})->({s.p2[0]:.1f},{s.p2[1]:.1f})"
+        )
 
 
 def _guard_no_diagonal_strikes_horizontal_label(

--- a/tests/layout_metrics.py
+++ b/tests/layout_metrics.py
@@ -1,0 +1,177 @@
+"""Passive layout-quality metrics for the CI render-diff.
+
+Computes a small scorecard of geometric quality scores from a laid-out
+``MetroGraph`` so the render-diff page can report per-render *deltas* alongside
+the visual comparison.
+
+Strictly an instrument: nothing in the layout engine reads these scores and CI
+never fails on them.  The defect counts reuse the same detectors as the layout
+validator (crossings, near-horizontal segments, single-segment diagonals,
+excessive column gaps) and the label-strike count reuses the engine's own
+strike definition (``iter_line_label_strikes``), so a score only moves when a
+real geometric property of the render moves.
+
+Module-level imports are kept stdlib-only so the spec and formatting helpers
+can be imported by ``build_render_diff.py`` without pulling in the layout
+engine; the heavy ``nf_metro`` imports live inside ``compute_metrics``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nf_metro.layout.routing.common import RoutedPath
+    from nf_metro.parser.model import MetroGraph
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """One layout-quality score: its JSON key, display label, and value kind."""
+
+    key: str
+    label: str
+    kind: str  # "count" or "ratio"
+
+
+# Every metric is oriented so LOWER IS BETTER: a negative delta is an
+# improvement.  This list is the canonical schema for ``metrics.json`` and the
+# column order of the render-diff metrics table.
+METRICS: list[MetricSpec] = [
+    MetricSpec("crossings", "Crossings", "count"),
+    MetricSpec("near_horizontal", "Near-horiz.", "count"),
+    MetricSpec("single_diagonals", "Lone diag.", "count"),
+    MetricSpec("label_strikes", "Label strikes", "count"),
+    MetricSpec("excessive_gaps", "Excess gaps", "count"),
+    MetricSpec("wasted_canvas", "Wasted canvas", "ratio"),
+]
+
+METRIC_KEYS: list[str] = [m.key for m in METRICS]
+
+
+def compute_metrics(
+    graph: MetroGraph, *, canvas: tuple[float, float] | None = None
+) -> dict[str, float]:
+    """Compute the layout-quality scorecard for one laid-out graph.
+
+    ``canvas`` is the rendered SVG ``(width, height)`` in user units; when
+    omitted (unit tests) the canvas extent is estimated from the laid-out
+    geometry.
+    """
+    from collections import Counter
+
+    from layout_validator import validate_layout
+
+    from nf_metro.layout.phases.guards import iter_line_label_strikes
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    counts = Counter(v.check for v in validate_layout(graph))
+
+    try:
+        offsets = compute_station_offsets(graph)
+        routes = route_edges(graph, station_offsets=offsets)
+    except Exception:  # noqa: BLE001 - routing failure surfaces in the validator
+        offsets, routes = {}, []
+
+    # Distinct (line, station) strikes: one visual mark per line crossing a
+    # label, not one per route segment that happens to clip it.
+    strikes = {
+        (s.line_id, s.station_id)
+        for s in iter_line_label_strikes(graph, offsets=offsets, routes=routes)
+    }
+
+    return {
+        "crossings": float(
+            counts["route_segment_crossing"] + counts["inter_section_line_crossing"]
+        ),
+        "near_horizontal": float(counts["almost_horizontal_edge"]),
+        "single_diagonals": float(counts["single_segment_diagonal"]),
+        "label_strikes": float(len(strikes)),
+        "excessive_gaps": float(counts["excessive_column_gap"]),
+        "wasted_canvas": _wasted_canvas_ratio(graph, routes, canvas),
+    }
+
+
+def _wasted_canvas_ratio(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    canvas: tuple[float, float] | None,
+) -> float:
+    """Fraction of the canvas area not enclosed by the content bounding box.
+
+    Content spans the visible stations, section boxes, and routed waypoints;
+    the canvas is the rendered ``(width, height)``.  A diagram whose content
+    fills the canvas scores ~0; one stranded in a corner of a large canvas
+    scores high.
+    """
+    xs: list[float] = []
+    ys: list[float] = []
+    for s in graph.stations.values():
+        if s.is_port or s.is_hidden:
+            continue
+        xs.append(s.x)
+        ys.append(s.y)
+    for sec in graph.sections.values():
+        if sec.bbox_w > 0:
+            xs.extend((sec.bbox_x, sec.bbox_x + sec.bbox_w))
+            ys.extend((sec.bbox_y, sec.bbox_y + sec.bbox_h))
+    for r in routes:
+        for px, py in r.points:
+            xs.append(px)
+            ys.append(py)
+    if not xs or not ys:
+        return 0.0
+
+    content_w = max(xs) - min(xs)
+    content_h = max(ys) - min(ys)
+    if canvas is not None:
+        canvas_w, canvas_h = canvas
+    else:
+        from nf_metro.render.constants import CANVAS_PADDING
+
+        canvas_w = max(xs) + CANVAS_PADDING
+        canvas_h = max(ys) + CANVAS_PADDING
+    if canvas_w <= 0 or canvas_h <= 0:
+        return 0.0
+
+    used = (content_w * content_h) / (canvas_w * canvas_h)
+    return round(max(0.0, min(1.0, 1.0 - used)), 3)
+
+
+def _format_magnitude(kind: str, value: float) -> str:
+    """Format a non-negative magnitude as a percentage (ratio) or integer (count)."""
+    if kind == "ratio":
+        return f"{value:.0%}"
+    return f"{value:.0f}"
+
+
+def format_value(spec: MetricSpec, value: float | None) -> str:
+    """Render a metric value for display (``n/a`` when missing)."""
+    if value is None:
+        return "n/a"
+    return _format_magnitude(spec.kind, value)
+
+
+def format_delta(spec: MetricSpec, base: float | None, pr: float | None) -> str:
+    """Render a base->PR delta as a signed magnitude, or ``""`` when undefined."""
+    if base is None or pr is None:
+        return ""
+    delta = pr - base
+    if abs(delta) < 1e-9:
+        return "0"
+    sign = "+" if delta > 0 else "−"
+    return f"{sign}{_format_magnitude(spec.kind, abs(delta))}"
+
+
+def delta_direction(base: float | None, pr: float | None) -> int:
+    """Sign of a base->PR change: ``-1`` better, ``+1`` worse, ``0`` flat/undefined.
+
+    Every metric is lower-is-better, so a drop is an improvement.
+    """
+    if base is None or pr is None:
+        return 0
+    delta = pr - base
+    if abs(delta) < 1e-9:
+        return 0
+    return 1 if delta > 0 else -1

--- a/tests/test_layout_metrics.py
+++ b/tests/test_layout_metrics.py
@@ -1,0 +1,157 @@
+"""Tests for the passive layout-quality metrics (layout_metrics)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from conftest import parse_and_layout
+from layout_metrics import (
+    METRIC_KEYS,
+    METRICS,
+    MetricSpec,
+    compute_metrics,
+    delta_direction,
+    format_delta,
+    format_value,
+)
+
+from nf_metro.layout.phases import guards
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from build_render_diff import _build_metrics_html  # noqa: E402
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+# A spread of real fixtures: a minimal map, dense pipelines, and a wide fan.
+FIXTURES = [
+    EXAMPLES / "simple_pipeline.mmd",
+    EXAMPLES / "rnaseq_auto.mmd",
+    EXAMPLES / "variantbenchmarking.mmd",
+    EXAMPLES / "topologies" / "wide_fan_out.mmd",
+    EXAMPLES / "topologies" / "complex_multipath.mmd",
+]
+
+
+def _layout(path: Path):
+    return parse_and_layout(path.read_text())
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_compute_metrics_returns_full_schema(path: Path) -> None:
+    """Every fixture yields exactly the canonical metric keys, all sane."""
+    metrics = compute_metrics(_layout(path))
+    assert set(metrics) == set(METRIC_KEYS)
+    for spec in METRICS:
+        value = metrics[spec.key]
+        assert isinstance(value, float)
+        assert value >= 0.0
+        if spec.kind == "count":
+            assert value == float(int(value)), f"{spec.key} count must be integral"
+        else:
+            assert 0.0 <= value <= 1.0
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_compute_metrics_is_deterministic(path: Path) -> None:
+    """The same laid-out graph scores identically on repeat computation."""
+    graph = _layout(path)
+    assert compute_metrics(graph) == compute_metrics(graph)
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_canvas_argument_changes_only_wasted_canvas(path: Path) -> None:
+    """Supplying the real canvas affects wasted_canvas alone, never the counts."""
+    graph = _layout(path)
+    estimated = compute_metrics(graph)
+    with_canvas = compute_metrics(graph, canvas=(5000.0, 5000.0))
+    for key in METRIC_KEYS:
+        if key == "wasted_canvas":
+            continue
+        assert estimated[key] == with_canvas[key]
+    # A vastly oversized canvas strands the content, so waste cannot fall.
+    assert with_canvas["wasted_canvas"] >= estimated["wasted_canvas"]
+
+
+def test_simple_pipeline_is_defect_free() -> None:
+    """The minimal example carries no crossings, kinks, or strikes."""
+    metrics = compute_metrics(_layout(EXAMPLES / "simple_pipeline.mmd"))
+    for key in ("crossings", "near_horizontal", "single_diagonals", "label_strikes"):
+        assert metrics[key] == 0.0
+
+
+def test_busy_pipeline_reports_positive_counts() -> None:
+    """A dense pipeline scores nonzero crossings and gaps, proving the metric
+    keys map onto live validator check names (a rename would silently zero them)."""
+    metrics = compute_metrics(_layout(EXAMPLES / "variantbenchmarking.mmd"))
+    assert metrics["crossings"] > 0
+    assert metrics["excessive_gaps"] > 0
+
+
+def test_label_strike_metric_matches_guard_enumerator() -> None:
+    """The strike count equals distinct (line, station) pairs from the shared
+    enumerator the guard consumes, so metric and guard cannot drift."""
+    graph = _layout(EXAMPLES / "rnaseq_auto.mmd")
+    pairs = {(s.line_id, s.station_id) for s in guards.iter_line_label_strikes(graph)}
+    assert compute_metrics(graph)["label_strikes"] == float(len(pairs))
+
+
+def test_guard_and_enumerator_share_strike_definition(monkeypatch) -> None:
+    """Forcing every segment to strike makes the enumerator yield and the guard
+    raise on the same fixture, proving they read one definition."""
+    graph = _layout(EXAMPLES / "rnaseq_auto.mmd")
+
+    monkeypatch.setattr(
+        "nf_metro.layout.labels.segment_strikes_label",
+        lambda *args, **kwargs: True,
+    )
+    assert next(guards.iter_line_label_strikes(graph), None) is not None
+    with pytest.raises(guards.PhaseInvariantError):
+        guards._guard_no_line_strikes_label(graph, "test")
+
+
+# --- Formatting + delta helpers ---
+
+COUNT = MetricSpec("c", "C", "count")
+RATIO = MetricSpec("r", "R", "ratio")
+
+
+def test_format_value() -> None:
+    assert format_value(COUNT, None) == "n/a"
+    assert format_value(COUNT, 3.0) == "3"
+    assert format_value(RATIO, 0.125) == "12%"
+
+
+def test_format_delta_sign_and_zero() -> None:
+    assert format_delta(COUNT, 5.0, 2.0) == "−3"
+    assert format_delta(COUNT, 2.0, 5.0) == "+3"
+    assert format_delta(COUNT, 4.0, 4.0) == "0"
+    assert format_delta(RATIO, 0.5, 0.39) == "−11%"
+    assert format_delta(COUNT, None, 2.0) == ""
+
+
+def test_delta_direction() -> None:
+    assert delta_direction(5.0, 2.0) == -1  # lower is better
+    assert delta_direction(2.0, 5.0) == 1
+    assert delta_direction(3.0, 3.0) == 0
+    assert delta_direction(None, 3.0) == 0
+
+
+# --- Render-diff table assembly ---
+
+
+def test_metrics_table_omitted_when_no_scorecards() -> None:
+    assert _build_metrics_html([("a.svg", "changed")], {}, {}) == ""
+
+
+def test_metrics_table_marks_better_and_worse() -> None:
+    base = {"a.svg": {k: 0.0 for k in METRIC_KEYS}}
+    pr = {"a.svg": {**{k: 0.0 for k in METRIC_KEYS}, "crossings": 4.0}}
+    html = _build_metrics_html([("a.svg", "changed")], base, pr)
+    assert "m-worse" in html  # crossings rose: worse
+    assert "0&rarr;4 (+4)" in html
+
+    html_better = _build_metrics_html([("a.svg", "changed")], pr, base)
+    assert "m-better" in html_better
+    assert "4&rarr;0 (−4)" in html_better


### PR DESCRIPTION
## Summary

Adds a passive, per-render geometric quality scorecard to the CI render-diff. For every gallery render, `build_gallery.py` now writes a `metrics.json` sidecar; `build_render_diff.py` reads the base and PR sidecars and renders an **advisory delta table** at the top of the diff page so the manual visual-review pass can jump straight to the renders whose numbers moved the wrong way.

Resurrects only the *measurement* half of #634 (which was closed not-planned as a layout *control*). The rejected downsides all attach to using measurements to *change* layout; this uses them only to *report*.

### Metrics (all lower-is-better)
- **Crossings** - line-crossing count (validator `route_segment_crossing` + `inter_section_line_crossing`)
- **Near-horizontal** segments (`almost_horizontal_edge`)
- **Lone diagonals** (`single_segment_diagonal`)
- **Label strikes** - lines crossing a station label
- **Excess gaps** - excessive column gaps
- **Wasted canvas** - fraction of the canvas not enclosed by the content bbox

### Strictly an instrument
- Not a CLI flag, not a layout input; no engine code reads the scores.
- CI never fails on a score; the table is advisory context only.
- Cross-arch float concerns don't apply because nothing branches on the values.

The defect counts reuse the layout validator's detectors and the label-strike count reuses the engine's own strike definition, factored into a shared `iter_line_label_strikes` enumerator (the guard raises on the first strike; the metric counts all). A score only moves when a real geometric property of the render moves.

### Why no runtime `_guard_*`
The skill normally pairs a fix with a loud runtime validator, but this feature's defining constraint is that it *gates nothing*. The engine-touching change (the strike-enumerator extraction) is instead protected by a parity test asserting the guard and the metric read one definition.

### Bootstrap note
`main` has no `metrics.json` until this merges, so the first run shows PR-side values only; the diff script tolerates a missing base sidecar. Renders themselves are byte-identical (metrics are computed after each SVG is written), so this PR's own render preview should report no visual changes.

Fixes #680

## Test plan
- [x] `pytest` passes, incl. new `tests/test_layout_metrics.py` (schema, determinism, defect-free + positive-count wiring, guard/enumerator parity, formatting, table assembly) and the full 7656-test suite
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` + bare `mypy` clean (matching CI)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/684/) - expected verdict: no visual changes (renders byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
