### PR TITLE
chore(skills): install dev extra in fix-issue env setup

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -36,7 +36,7 @@ git worktree add /tmp/nf-metro-fix-<N> -b fix/<N>-<slug> origin/main
 # Fix environment
 ulimit -n 1000000 && export CONDA_OVERRIDE_OSX=15.0 && /opt/homebrew/bin/micromamba create -n nf-metro-fix-<N> python=3.11 cairo -y
 source ~/.local/bin/mm-activate nf-metro-fix-<N>
-pip install -e "/tmp/nf-metro-fix-<N>[docs]"
+pip install -e "/tmp/nf-metro-fix-<N>[dev,docs]"
 ```
 
 All subsequent work happens inside `/tmp/nf-metro-fix-<N>`.


### PR DESCRIPTION
## Summary

The `fix-issue` skill creates a fresh conda env and installs the package, then runs `pytest`, `ruff`, `mypy`, and the `jsonschema`- and `coverage`-dependent gate-coverage / manifest tests. But its env setup installed only the `docs` extra, so fix-issue sessions repeatedly hit missing `pytest` / `jsonschema` / `coverage` and had to `pip install` them by hand.

Change the env install from `.[docs]` to `.[dev,docs]` so the `dev` extra (pytest, pytest-cov → coverage, pytest-xdist, ruff, mypy, types-networkx, jsonschema) is present alongside the `docs` render deps (cairosvg).

The `dev` extra already declares all of these in `pyproject.toml`; this just installs it in the session env. No code or dependency-declaration changes.

## Test plan
- [x] One-line doc change to `.claude/skills/fix-issue/SKILL.md`; no code touched
- Verified the other `.[docs]` install sites are render/docs-only (render-topologies skill, pr-renders/docs workflows) and don't need `dev`; CI tests + README + CONTRIBUTING already use `.[dev]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)