### PR TITLE
test(routing): triage reversal.py gate arms (#731)

### DIFF
--- a/docs/dev/routing_gate_coverage.md
+++ b/docs/dev/routing_gate_coverage.md
@@ -8,7 +8,7 @@ Each row is a branch point (a *gate*) in a `layout/routing/` dispatch handler or
 
 Modules scoped to routing decision gates; `invariants.py` (the `validate=True` checker) and `__init__.py` are excluded.
 
-The Triage column carries a curated verdict for gaps no fixture can close: **defensive** (a guard arm a valid topology never violates), **candidate-dead** (no constructible topology reaches it; left in place pending a separate deletion review), or **needs-review** (not yet classified). A blank cell means the gap is still open for a fixture. **257** gaps carry a triage verdict.
+The Triage column carries a curated verdict for gaps no fixture can close: **defensive** (a guard arm a valid topology never violates), **candidate-dead** (no constructible topology reaches it; left in place pending a separate deletion review), or **needs-review** (not yet classified). A blank cell means the gap is still open for a fixture. **267** gaps carry a triage verdict.
 
 ## `common.py`
 
@@ -423,16 +423,16 @@ Gates with an un-exercised arm:
 
 | Line | Gate | Un-exercised arm(s) | Triage |
 | ---: | --- | --- | --- |
-| 95 | `if not src or not src.is_port:` | `->L96` |  |
-| 98 | `if (` | `->L104` |  |
-| 136 | `if not src or not tgt:` | `->L137` |  |
-| 142 | `if (` | `->L133`, `->L150` |  |
-| 175 | `if not section:` | `->L176` |  |
-| 186 | `if not succ:` | `->L187`, `->L188` |  |
-| 188 | `if (` | `->L182`, `->L192` |  |
-| 225 | `if not src:` | `->L226` |  |
-| 231 | `if not s2 or not s2.is_port:` | `->L232` |  |
-| 236 | `elif src.is_port:` | `->L223` |  |
+| 95 | `if not src or not src.is_port:` | `->L96` | **defensive** -- Phase 1a (_detect_tb_bottom_top_entries) iterates edges feeding a TOP entry port. Entry ports are synthetic nodes created by section resolution; the only edges targeting them are the resolved chain's exit_port->entry_port and junction->entry_port links, so edge.source is always a registered port or junction station (both is_port=True). The continue (missing or non-port source) is a structural-contract guard no valid topology reaches. |
+| 98 | `if (` | `->L104` | **defensive** -- PHANTOM multi-line short-circuit arc. CPython emits no branch bytecode at the opening `if (` line, so the static arc into the body L104 never executes; the Phase 1a reversal mark is exercised via the last-operand arc L102->104 (a TOP entry fed by a TB BOTTOM exit). Not an un-taken branch. |
+| 136 | `if not src or not tgt:` | `->L137` | **defensive** -- _build_section_adjacency iterates graph.edges; every edge endpoint is a registered station, so graph.stations.get never returns None for edge.source or edge.target. The continue is a defensive null guard no valid graph reaches. |
+| 142 | `if (` | `->L133`, `->L150` | **defensive** -- PHANTOM multi-line short-circuit arc. No branch bytecode at the opening `if (` line, so both static arms (->150 body, ->133 loop-back) are phantom; the horizontal_succ_pairs body is exercised via the last-operand arc L148->150 and the negative case via operand short-circuit. Not un-taken branches. |
+| 175 | `if not section:` | `->L176` | **defensive** -- _propagate_reversal_along_rows iterates sec_id values drawn from reversed_secs, which only ever holds real section ids added from graph.sections. graph.sections.get(sec_id) is never None; the continue is a defensive null guard. |
+| 186 | `if not succ:` | `->L187`, `->L188` | **defensive** -- succ_id comes from sec_successors, built only from real tgt.section_id values, so graph.sections.get(succ_id) is never None and the continue (->187) is a defensive null guard. The fall-through static arm (->188) is phantom: control falls into the following multi-line `if (`, whose first operand line carries the real arc L186->189. |
+| 188 | `if (` | `->L182`, `->L192` | **defensive** -- PHANTOM multi-line short-circuit arc. No branch bytecode at the opening `if (` line, so both static arms (->192 body, ->182 loop-back) are phantom; the reversal-propagation body is exercised via the operand arcs L189->192 and L190->192. Not un-taken branches. |
+| 225 | `if not src:` | `->L226` | **defensive** -- _section_fed_by_tb_lr_exit iterates edges feeding a LEFT/RIGHT entry port; edge.source is always a registered station, so graph.stations.get is never None. Defensive null guard. |
+| 231 | `if not s2 or not s2.is_port:` | `->L232` | **defensive** -- Junction look-through: s2 is the source of an edge feeding a fold junction. Junctions are synthetic resolution nodes fed only by exit ports or upstream junctions (both is_port=True), so s2 is always present and port-like. The continue is a structural-contract guard no valid topology reaches. |
+| 236 | `elif src.is_port:` | `->L223` | **defensive** -- Edge feeding a LEFT/RIGHT entry port whose source is not a junction; src is then always an exit port (is_port=True), because resolved chains feed entry ports only from exit ports or junctions. The elif is always true, so the implicit fall-through to the loop (->223) is a structural-contract guard no valid topology reaches. |
 
 ## `tb_handlers.py`
 

--- a/tests/data/routing_gate_triage.json
+++ b/tests/data/routing_gate_triage.json
@@ -1026,5 +1026,45 @@
   "offsets.py::while stack:::#1": {
     "note": "In the exit-only-line reorder / same-Y offset propagation; reachable only via a multi-line LR/RL section with a perpendicular (TOP/BOTTOM) exit port, which the engine lays out as a station-as-elbow + collinear overlay PhaseInvariantError (#706). Exercise with a clean fixture once #706 is fixed.",
     "status": "needs-review"
+  },
+  "reversal.py::elif src.is_port:::#1": {
+    "note": "Edge feeding a LEFT/RIGHT entry port whose source is not a junction; src is then always an exit port (is_port=True), because resolved chains feed entry ports only from exit ports or junctions. The elif is always true, so the implicit fall-through to the loop (->223) is a structural-contract guard no valid topology reaches.",
+    "status": "defensive"
+  },
+  "reversal.py::if (::#1": {
+    "note": "PHANTOM multi-line short-circuit arc. CPython emits no branch bytecode at the opening `if (` line, so the static arc into the body L104 never executes; the Phase 1a reversal mark is exercised via the last-operand arc L102->104 (a TOP entry fed by a TB BOTTOM exit). Not an un-taken branch.",
+    "status": "defensive"
+  },
+  "reversal.py::if (::#2": {
+    "note": "PHANTOM multi-line short-circuit arc. No branch bytecode at the opening `if (` line, so both static arms (->150 body, ->133 loop-back) are phantom; the horizontal_succ_pairs body is exercised via the last-operand arc L148->150 and the negative case via operand short-circuit. Not un-taken branches.",
+    "status": "defensive"
+  },
+  "reversal.py::if (::#3": {
+    "note": "PHANTOM multi-line short-circuit arc. No branch bytecode at the opening `if (` line, so both static arms (->192 body, ->182 loop-back) are phantom; the reversal-propagation body is exercised via the operand arcs L189->192 and L190->192. Not un-taken branches.",
+    "status": "defensive"
+  },
+  "reversal.py::if not s2 or not s2.is_port:::#1": {
+    "note": "Junction look-through: s2 is the source of an edge feeding a fold junction. Junctions are synthetic resolution nodes fed only by exit ports or upstream junctions (both is_port=True), so s2 is always present and port-like. The continue is a structural-contract guard no valid topology reaches.",
+    "status": "defensive"
+  },
+  "reversal.py::if not section:::#1": {
+    "note": "_propagate_reversal_along_rows iterates sec_id values drawn from reversed_secs, which only ever holds real section ids added from graph.sections. graph.sections.get(sec_id) is never None; the continue is a defensive null guard.",
+    "status": "defensive"
+  },
+  "reversal.py::if not src or not src.is_port:::#1": {
+    "note": "Phase 1a (_detect_tb_bottom_top_entries) iterates edges feeding a TOP entry port. Entry ports are synthetic nodes created by section resolution; the only edges targeting them are the resolved chain's exit_port->entry_port and junction->entry_port links, so edge.source is always a registered port or junction station (both is_port=True). The continue (missing or non-port source) is a structural-contract guard no valid topology reaches.",
+    "status": "defensive"
+  },
+  "reversal.py::if not src or not tgt:::#1": {
+    "note": "_build_section_adjacency iterates graph.edges; every edge endpoint is a registered station, so graph.stations.get never returns None for edge.source or edge.target. The continue is a defensive null guard no valid graph reaches.",
+    "status": "defensive"
+  },
+  "reversal.py::if not src:::#1": {
+    "note": "_section_fed_by_tb_lr_exit iterates edges feeding a LEFT/RIGHT entry port; edge.source is always a registered station, so graph.stations.get is never None. Defensive null guard.",
+    "status": "defensive"
+  },
+  "reversal.py::if not succ:::#1": {
+    "note": "succ_id comes from sec_successors, built only from real tgt.section_id values, so graph.sections.get(succ_id) is never None and the continue (->187) is a defensive null guard. The fall-through static arm (->188) is phantom: control falls into the following multi-line `if (`, whose first operand line carries the real arc L186->189.",
+    "status": "defensive"
   }
 }


### PR DESCRIPTION
## Summary

Classifies all 10 un-exercised routing-gate arms in `reversal.py` from the #677 coverage matrix - the #687 slice for this module. Triage-only: a sidecar verdict per gate plus the regenerated coverage doc. No fixtures, no gallery entries, no `src/` changes.

Every arm is **defensive**, by one of three mechanisms (all proven against the full render corpus and the coverage arc data):

- **Structural-contract guards** - entry ports and fold junctions are synthetic section-resolution nodes, fed only by exit ports or upstream junctions. Corpus-wide: entry ports fed by 383 port + 267 junction + **0 internal**; junctions fed by 201 port + 36 junction + **0 internal**. (`L95`, `L231`, `L236`)
- **Null guards** on lookups of known-valid ids - `graph.edges` endpoints, `reversed_secs`/`sec_successors` section ids, entry-port edge sources - which never return `None`. (`L136`, `L175`, `L186`, `L225`)
- **Phantom multi-line `if (` arcs** - CPython emits no branch bytecode at the opening paren, so the static opening-line arcs never execute; the bodies are exercised via the last-operand arcs (`L104`←102, `L150`←148, `L192`←189/190). (`L98`, `L142`, `L188`, and `L186`'s fall-through arm)

The coverage baseline is byte-unchanged (no arms flipped exercised). `docs/dev/routing_gate_coverage.md` now shows zero blank-triage rows for `reversal.py`, and the #677 ratchet stays green.

Fixes #731

## Test plan
- [x] `pytest` passes (9235 passed; ratchet `tests/test_routing_gate_coverage.py` green)
- [x] `ruff format --check` + `ruff check` clean on whole repo
- [x] Runtime validator: N/A (no `src/` change; triage classification only)
- [x] Render preview: N/A (no fixtures shipped; renders byte-unchanged)

Generated with Claude Code