### PR TITLE
test(routing): triage core/inter_section/corners gate arms (#733)

### DIFF
--- a/docs/dev/routing_gate_coverage.md
+++ b/docs/dev/routing_gate_coverage.md
@@ -8,7 +8,7 @@ Each row is a branch point (a *gate*) in a `layout/routing/` dispatch handler or
 
 Modules scoped to routing decision gates; `invariants.py` (the `validate=True` checker) and `__init__.py` are excluded.
 
-The Triage column carries a curated verdict for gaps no fixture can close: **defensive** (a guard arm a valid topology never violates), **candidate-dead** (no constructible topology reaches it; left in place pending a separate deletion review), or **needs-review** (not yet classified). A blank cell means the gap is still open for a fixture. **267** gaps carry a triage verdict.
+The Triage column carries a curated verdict for gaps no fixture can close: **defensive** (a guard arm a valid topology never violates), **candidate-dead** (no constructible topology reaches it; left in place pending a separate deletion review), or **needs-review** (not yet classified). A blank cell means the gap is still open for a fixture. **277** gaps carry a triage verdict.
 
 ## `common.py`
 

--- a/docs/dev/routing_gate_coverage.md
+++ b/docs/dev/routing_gate_coverage.md
@@ -8,7 +8,7 @@ Each row is a branch point (a *gate*) in a `layout/routing/` dispatch handler or
 
 Modules scoped to routing decision gates; `invariants.py` (the `validate=True` checker) and `__init__.py` are excluded.
 
-The Triage column carries a curated verdict for gaps no fixture can close: **defensive** (a guard arm a valid topology never violates), **candidate-dead** (no constructible topology reaches it; left in place pending a separate deletion review), or **needs-review** (not yet classified). A blank cell means the gap is still open for a fixture. **257** gaps carry a triage verdict.
+The Triage column carries a curated verdict for gaps no fixture can close: **defensive** (a guard arm a valid topology never violates), **candidate-dead** (no constructible topology reaches it; left in place pending a separate deletion review), or **needs-review** (not yet classified). A blank cell means the gap is still open for a fixture. **267** gaps carry a triage verdict.
 
 ## `common.py`
 
@@ -102,10 +102,10 @@ Gates with an un-exercised arm:
 
 | Line | Gate | Un-exercised arm(s) | Triage |
 | ---: | --- | --- | --- |
-| 167 | `if src is None or tgt is None or src.is_port or tgt.is_port:` | `->L169` |  |
-| 169 | `if (` | `->L164`, `->L174` |  |
-| 189 | `if not src or not tgt:` | `->L190` |  |
-| 208 | `if result is not None:` | `->L181` |  |
+| 167 | `if src is None or tgt is None or src.is_port or tgt.is_port:` | `->L169` | **defensive** -- Per-section rail-mode edge filter. The True/continue arm (skip port or missing-station edges) IS exercised: rail fixtures carry inter-section port chains past this loop. When the guard is False, execution falls through to the inner rail-section if and is recorded as the arc to that if's first operand line, so the static fall-through arc to the bare opening-paren line is a phantom no execution takes. Both real branches are covered. |
+| 169 | `if (` | `->L164`, `->L174` | **defensive** -- Multiline if(...) opening-paren line for the rail-section internal-edge test (src.section_id == tgt.section_id and ... is not None and is_rail_section(...)). Python attributes the branch decisions to the operand lines, all of which have executed arcs including the is-not-None short-circuit exit and the rail_edges.append body. The static arcs from the opening-paren line are phantoms no execution traverses. |
+| 189 | `if not src or not tgt:` | `->L190` | **defensive** -- Main edge-loop guard against a missing endpoint station. After section resolution every edge endpoint exists in graph.stations (parse _ensure_station's all referenced nodes; resolved chains insert their own ports/junctions), so the guard never fires and only the proceed-to-routing arm is reachable. |
+| 208 | `if result is not None:` | `->L181` | **defensive** -- Append-guard after the priority-ordered handler chain. The final handler _route_intra_section is total: its three early returns and its _route_diagonal fallback (annotated -> RoutedPath, single return statement) always yield a RoutedPath, so result is never None and every edge appends. The None arm is unreachable. |
 
 ## `corners.py`
 
@@ -115,8 +115,8 @@ Gates with an un-exercised arm:
 
 | Line | Gate | Un-exercised arm(s) | Triage |
 | ---: | --- | --- | --- |
-| 84 | `if i > 1:` | `->L85` |  |
-| 95 | `if i < len(points) - 2:` | `->L96` |  |
+| 84 | `if i > 1:` | `->L85` | **defensive** -- Proportional segment-budget allocation for a corner sharing its incoming segment with a previous corner. The True branch IS taken on multi-corner paths (>=2 corners are common in the corpus): the executed true arc lands on the prev_r conditional-expression condition line, not the static arc to the assignment-target line, because the ternary evaluates its condition first. The static true arc is a phantom of the multiline ternary. |
+| 95 | `if i < len(points) - 2:` | `->L96` | **defensive** -- Mirror of the i>1 split for a corner sharing its outgoing segment with a following corner. The True branch is exercised on multi-corner paths via the next_r conditional-expression condition line; the static true arc to the assignment-target line is a phantom of the multiline ternary (condition evaluates before the assignment target). |
 
 ## `inter_section.py`
 
@@ -126,10 +126,10 @@ Gates with an un-exercised arm:
 
 | Line | Gate | Un-exercised arm(s) | Triage |
 | ---: | --- | --- | --- |
-| 98 | `if pair not in _CW_TURNS and pair not in _CCW_TURNS:` | `->L-96`, `->L99` |  |
-| 107 | `if (self.in_tangent, self.out_tangent) in _CW_TURNS:` | `->L108`, `->L109` |  |
-| 155 | `for prev, curr in zip(self.corners, self.corners[1:]):` | `->L156`, `->L158` |  |
-| 156 | `if prev.handedness != curr.handedness:` | `->L155`, `->L157` |  |
+| 98 | `if pair not in _CW_TURNS and pair not in _CCW_TURNS:` | `->L-96`, `->L99` | **defensive** -- Corner.__post_init__ turn-validity check. inter_section.py is the descriptor/documentation module (distinct from inter_section_handlers.py); no src module imports it, so it never loads during the render-corpus sweep (confirmed absent from sys.modules after rendering the whole corpus) and both arms show 0 hits. Corner instances are module-level constants built from valid right-angle turns, so the raise can only fire on a source edit. Exercised by test_inter_section_descriptor.py. |
+| 107 | `if (self.in_tangent, self.out_tangent) in _CW_TURNS:` | `->L108`, `->L109` | **defensive** -- Corner.handedness property. Same module-load story: inter_section.py is never imported on the render path, so neither the CW nor the CCW arm is reachable by any render topology. Both branches are exercised by test_inter_section_descriptor.py. |
+| 155 | `for prev, curr in zip(self.corners, self.corners[1:]):` | `->L156`, `->L158` | **defensive** -- TurnSequence.parity loop over consecutive corners. parity is descriptor-level documentation (runtime wrap handlers preserve bundle ordering via per-corner offset propagation regardless of this value); nothing on the render path reads it, and the module is never imported during the sweep. Exercised by test_inter_section_descriptor.py. |
+| 156 | `if prev.handedness != curr.handedness:` | `->L155`, `->L157` | **defensive** -- Handedness-change counter inside TurnSequence.parity. Off the render path for the same reason (inter_section.py never loaded during rendering); both arms are exercised by test_inter_section_descriptor.py's parity-contract tests. |
 
 ## `inter_section_handlers.py`
 

--- a/tests/data/routing_gate_triage.json
+++ b/tests/data/routing_gate_triage.json
@@ -263,6 +263,46 @@
     "status": "defensive",
     "note": "A junction's port/junction target always resolves to a grid column; the unresolved-column continue never fires."
   },
+  "core.py::if (::#1": {
+    "note": "Multiline if(...) opening-paren line for the rail-section internal-edge test (src.section_id == tgt.section_id and ... is not None and is_rail_section(...)). Python attributes the branch decisions to the operand lines, all of which have executed arcs including the is-not-None short-circuit exit and the rail_edges.append body. The static arcs from the opening-paren line are phantoms no execution traverses.",
+    "status": "defensive"
+  },
+  "core.py::if not src or not tgt:::#1": {
+    "note": "Main edge-loop guard against a missing endpoint station. After section resolution every edge endpoint exists in graph.stations (parse _ensure_station's all referenced nodes; resolved chains insert their own ports/junctions), so the guard never fires and only the proceed-to-routing arm is reachable.",
+    "status": "defensive"
+  },
+  "core.py::if result is not None:::#1": {
+    "note": "Append-guard after the priority-ordered handler chain. The final handler _route_intra_section is total: its three early returns and its _route_diagonal fallback (annotated -> RoutedPath, single return statement) always yield a RoutedPath, so result is never None and every edge appends. The None arm is unreachable.",
+    "status": "defensive"
+  },
+  "core.py::if src is None or tgt is None or src.is_port or tgt.is_port:::#1": {
+    "note": "Per-section rail-mode edge filter. The True/continue arm (skip port or missing-station edges) IS exercised: rail fixtures carry inter-section port chains past this loop. When the guard is False, execution falls through to the inner rail-section if and is recorded as the arc to that if's first operand line, so the static fall-through arc to the bare opening-paren line is a phantom no execution takes. Both real branches are covered.",
+    "status": "defensive"
+  },
+  "corners.py::if i < len(points) - 2:::#1": {
+    "note": "Mirror of the i>1 split for a corner sharing its outgoing segment with a following corner. The True branch is exercised on multi-corner paths via the next_r conditional-expression condition line; the static true arc to the assignment-target line is a phantom of the multiline ternary (condition evaluates before the assignment target).",
+    "status": "defensive"
+  },
+  "corners.py::if i > 1:::#1": {
+    "note": "Proportional segment-budget allocation for a corner sharing its incoming segment with a previous corner. The True branch IS taken on multi-corner paths (>=2 corners are common in the corpus): the executed true arc lands on the prev_r conditional-expression condition line, not the static arc to the assignment-target line, because the ternary evaluates its condition first. The static true arc is a phantom of the multiline ternary.",
+    "status": "defensive"
+  },
+  "inter_section.py::for prev, curr in zip(self.corners, self.corners[1:]):::#1": {
+    "note": "TurnSequence.parity loop over consecutive corners. parity is descriptor-level documentation (runtime wrap handlers preserve bundle ordering via per-corner offset propagation regardless of this value); nothing on the render path reads it, and the module is never imported during the sweep. Exercised by test_inter_section_descriptor.py.",
+    "status": "defensive"
+  },
+  "inter_section.py::if (self.in_tangent, self.out_tangent) in _CW_TURNS:::#1": {
+    "note": "Corner.handedness property. Same module-load story: inter_section.py is never imported on the render path, so neither the CW nor the CCW arm is reachable by any render topology. Both branches are exercised by test_inter_section_descriptor.py.",
+    "status": "defensive"
+  },
+  "inter_section.py::if pair not in _CW_TURNS and pair not in _CCW_TURNS:::#1": {
+    "note": "Corner.__post_init__ turn-validity check. inter_section.py is the descriptor/documentation module (distinct from inter_section_handlers.py); no src module imports it, so it never loads during the render-corpus sweep (confirmed absent from sys.modules after rendering the whole corpus) and both arms show 0 hits. Corner instances are module-level constants built from valid right-angle turns, so the raise can only fire on a source edit. Exercised by test_inter_section_descriptor.py.",
+    "status": "defensive"
+  },
+  "inter_section.py::if prev.handedness != curr.handedness:::#1": {
+    "note": "Handedness-change counter inside TurnSequence.parity. Off the render path for the same reason (inter_section.py never loaded during rendering); both arms are exercised by test_inter_section_descriptor.py's parity-contract tests.",
+    "status": "defensive"
+  },
   "inter_section_handlers.py::elif gap_bottom > gap_top:::#1": {
     "note": "Reachable only via a defective render (inter-row corridor on a <78px gap); see #722.",
     "status": "needs-review"


### PR DESCRIPTION
## Summary

Triages the 10 un-exercised routing-gate arms in the #677 coverage matrix for the tiny trio (`core.py`, `inter_section.py`, `corners.py`), the next slice of #687. **All ten are defensive** - no shipped or constructible render topology can flip them - so this slice ships **zero fixtures** and touches no source.

- **`core.py`** (4 arms): the rail-mode edge filter's fall-through and the multiline rail-section `if` are phantom opening-paren arcs whose real branches fire from the operand lines (all covered); the main-loop missing-endpoint guard never fires after section resolution inserts every endpoint into `graph.stations`; and the append-guard's `None` arm is unreachable because the handler chain's `_route_intra_section` -> `_route_diagonal` fallback is total (`-> RoutedPath`, single return).
- **`corners.py`** (2 arms): both segment-budget splits take their True branch on multi-corner paths, but via the conditional-expression *condition* line - the static arcs to the assignment-target lines are phantoms of the multiline ternaries that no execution traverses.
- **`inter_section.py`** (4 arms): the `Corner` / `TurnSequence` descriptor module is imported only by tests; no `src/` module imports it, so it never loads during the render-corpus sweep (confirmed absent from `sys.modules` after rendering the whole corpus). All four arms are off the render path and exercised by `test_inter_section_descriptor.py`.

Verdicts are recorded in `tests/data/routing_gate_triage.json` and rendered into `docs/dev/routing_gate_coverage.md`, which now shows **zero blank-triage rows** for these three modules. The baseline gap set is unchanged and the #677 coverage ratchet stays green.

Fixes #733

## Test plan
- [x] `pytest` passes (full suite: 9235 passed, known xfails only)
- [x] `tests/test_routing_gate_coverage.py` green (no new gaps, baseline in sync, no stale triage keys)
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [x] No fixtures shipped -> nothing to verdict on the visual-review page
- [ ] Render-preview verdict: expected **No visual changes** (no source touched)

Generated with Claude Code