### PR TITLE
Triage rail.py routing gate arms (#732)

### DIFF
--- a/docs/dev/routing_gate_coverage.md
+++ b/docs/dev/routing_gate_coverage.md
@@ -8,7 +8,7 @@ Each row is a branch point (a *gate*) in a `layout/routing/` dispatch handler or
 
 Modules scoped to routing decision gates; `invariants.py` (the `validate=True` checker) and `__init__.py` are excluded.
 
-The Triage column carries a curated verdict for gaps no fixture can close: **defensive** (a guard arm a valid topology never violates), **candidate-dead** (no constructible topology reaches it; left in place pending a separate deletion review), or **needs-review** (not yet classified). A blank cell means the gap is still open for a fixture. **257** gaps carry a triage verdict.
+The Triage column carries a curated verdict for gaps no fixture can close: **defensive** (a guard arm a valid topology never violates), **candidate-dead** (no constructible topology reaches it; left in place pending a separate deletion review), or **needs-review** (not yet classified). A blank cell means the gap is still open for a fixture. **264** gaps carry a triage verdict.
 
 ## `common.py`
 
@@ -407,13 +407,13 @@ Gates with an un-exercised arm:
 
 | Line | Gate | Un-exercised arm(s) | Triage |
 | ---: | --- | --- | --- |
-| 38 | `if st is None:` | `->L39` |  |
-| 44 | `if port is not None:` | `->L45` |  |
-| 46 | `if line_id in section_rails:` | `->L47`, `->L49` |  |
-| 57 | `if line_id in served and len(st.rail_used_ys) == len(served):` | `->L59` |  |
-| 94 | `if edge.line_id not in order or len(order) <= 1:` | `->L95` |  |
-| 154 | `if src is None or tgt is None:` | `->L155` |  |
-| 176 | `if off_tgt:` | `->L177` |  |
+| 38 | `if st is None:` | `->L39` | **defensive** -- _line_rail_y is only ever called with a real station id (on_rail.id, edge.source/target, or a sibling edge endpoint), all of which exist in graph.stations - the route loop pre-filters None endpoints at the src/tgt guard. The None arm is a contract guard no render-path call reaches. |
+| 44 | `if port is not None:` | `->L45` | **needs-review** -- The port branch is reachable only via whole-graph line_spread:rails with an inter-section edge (per-section rail mode excludes port edges from the rail router), and that topology renders defectively (dangling port stubs + avoidable crossings). Parked pending #743 rather than fixtured (reachable-but-defective, the #688 pattern). |
+| 46 | `if line_id in section_rails:` | `->L47`, `->L49` | **needs-review** -- Gated behind the port branch, so reachable only via the same connected-whole-graph-rails topology (#743). A port always carries a line present in its own section's rail map, so the in-rails arm is the live one and the fall-through is a structural fallback. Parked pending #743 (reachable-but-defective). |
+| 57 | `if line_id in served and len(st.rail_used_ys) == len(served):` | `->L59` | **defensive** -- Reached only for a non-port spanning station, whose rail_used_ys is station_lines_ordered filtered to the section's per_line_y - itself built from the same _section_lines_in_order. So a served line is always in per_line_y (lengths match) and _line_rail_y is only called with a line the touching edge carries (always served). The fall-through return st.y is a defensive fallback no render-path call reaches. |
+| 94 | `if edge.line_id not in order or len(order) <= 1:` | `->L95` | **needs-review** -- The single-feeder early-return (len(order)<=1) is reachable only via a single-line off-track input or output, and off-track I/O renders defectively in rail mode (bare rail-ends, label overlap). Parked pending #744 (reachable-but-defective). The 'not in order' disjunct is dead: the edge itself is always in the feeder<->consumer set that builds order. |
+| 154 | `if src is None or tgt is None:` | `->L155` | **defensive** -- Null guard over an edge's endpoints; every graph.edges endpoint exists in graph.stations, so the continue arm is a contract guard no render-path call reaches. |
+| 176 | `if off_tgt:` | `->L177` | **needs-review** -- The off-track-output arm (reverse the L-route when the target is off-track) is reachable only via an off-track output, which renders defectively in rail mode (bare line-end, detached label). Parked pending #744 (reachable-but-defective). |
 
 ## `reversal.py`
 

--- a/tests/data/routing_gate_triage.json
+++ b/tests/data/routing_gate_triage.json
@@ -896,7 +896,7 @@
     "status": "candidate-dead"
   },
   "offsets.py::if lid not in seen:::#1": {
-    "note": "The iterator at L554 is `sorted(set(sec_entry_lines), ...)`. The outer `set()` deduplicates the list before iteration, so each `lid` appears exactly once and `seen` never contains it when processed. The false arm (lid already in seen) is logically unreachable \u2014 the dedup happens at set construction, making the `seen` guard dead code.",
+    "note": "The iterator at L554 is `sorted(set(sec_entry_lines), ...)`. The outer `set()` deduplicates the list before iteration, so each `lid` appears exactly once and `seen` never contains it when processed. The false arm (lid already in seen) is logically unreachable — the dedup happens at set construction, making the `seen` guard dead code.",
     "status": "candidate-dead"
   },
   "offsets.py::if max_steps <= 0:::#1": {
@@ -1004,7 +1004,7 @@
     "status": "needs-review"
   },
   "offsets.py::if src_st and not src_st.is_port:::#1": {
-    "note": "In `_rewrite_edges_with_junctions` (resolve.py L594), edges to exit ports are always created as `Edge(source=edge.source, target=exit_port_id)` where `edge.source` is the original inter-section edge's source \u2014 an internal section station, not a port. So `src_st` is never None and `src_st.is_port` is always False. The false arm cannot be taken by any valid parsed graph.",
+    "note": "In `_rewrite_edges_with_junctions` (resolve.py L594), edges to exit ports are always created as `Edge(source=edge.source, target=exit_port_id)` where `edge.source` is the original inter-section edge's source — an internal section station, not a port. So `src_st` is never None and `src_st.is_port` is always False. The false arm cannot be taken by any valid parsed graph.",
     "status": "defensive"
   },
   "offsets.py::if src_st and not src_st.is_port:::#2": {
@@ -1026,5 +1026,33 @@
   "offsets.py::while stack:::#1": {
     "note": "In the exit-only-line reorder / same-Y offset propagation; reachable only via a multi-line LR/RL section with a perpendicular (TOP/BOTTOM) exit port, which the engine lays out as a station-as-elbow + collinear overlay PhaseInvariantError (#706). Exercise with a clean fixture once #706 is fixed.",
     "status": "needs-review"
+  },
+  "rail.py::if edge.line_id not in order or len(order) <= 1:::#1": {
+    "status": "needs-review",
+    "note": "The single-feeder early-return (len(order)<=1) is reachable only via a single-line off-track input or output, and off-track I/O renders defectively in rail mode (bare rail-ends, label overlap). Parked pending #744 (reachable-but-defective). The 'not in order' disjunct is dead: the edge itself is always in the feeder<->consumer set that builds order."
+  },
+  "rail.py::if line_id in section_rails:::#1": {
+    "status": "needs-review",
+    "note": "Gated behind the port branch, so reachable only via the same connected-whole-graph-rails topology (#743). A port always carries a line present in its own section's rail map, so the in-rails arm is the live one and the fall-through is a structural fallback. Parked pending #743 (reachable-but-defective)."
+  },
+  "rail.py::if line_id in served and len(st.rail_used_ys) == len(served):::#1": {
+    "status": "defensive",
+    "note": "Reached only for a non-port spanning station, whose rail_used_ys is station_lines_ordered filtered to the section's per_line_y - itself built from the same _section_lines_in_order. So a served line is always in per_line_y (lengths match) and _line_rail_y is only called with a line the touching edge carries (always served). The fall-through return st.y is a defensive fallback no render-path call reaches."
+  },
+  "rail.py::if off_tgt:::#1": {
+    "status": "needs-review",
+    "note": "The off-track-output arm (reverse the L-route when the target is off-track) is reachable only via an off-track output, which renders defectively in rail mode (bare line-end, detached label). Parked pending #744 (reachable-but-defective)."
+  },
+  "rail.py::if port is not None:::#1": {
+    "status": "needs-review",
+    "note": "The port branch is reachable only via whole-graph line_spread:rails with an inter-section edge (per-section rail mode excludes port edges from the rail router), and that topology renders defectively (dangling port stubs + avoidable crossings). Parked pending #743 rather than fixtured (reachable-but-defective, the #688 pattern)."
+  },
+  "rail.py::if src is None or tgt is None:::#1": {
+    "status": "defensive",
+    "note": "Null guard over an edge's endpoints; every graph.edges endpoint exists in graph.stations, so the continue arm is a contract guard no render-path call reaches."
+  },
+  "rail.py::if st is None:::#1": {
+    "status": "defensive",
+    "note": "_line_rail_y is only ever called with a real station id (on_rail.id, edge.source/target, or a sibling edge endpoint), all of which exist in graph.stations - the route loop pre-filters None endpoints at the src/tgt guard. The None arm is a contract guard no render-path call reaches."
   }
 }


### PR DESCRIPTION
## Summary

Triages all 7 un-exercised `rail.py` routing-gate arms from the #677 coverage matrix (the `rail.py` slice of #687). Ships **zero fixtures** and no src change: the gap set is unchanged so the ratchet baseline is byte-identical; only the triage sidecar (`tests/data/routing_gate_triage.json`, +7) and the regenerated coverage doc change. `rail.py` now shows zero blank-triage rows.

Verdicts:

| Arm | Verdict | Why |
| --- | --- | --- |
| L38 `if st is None:` | **defensive** | null guard; `_line_rail_y` only called with real station ids |
| L57 `len(rail_used_ys)==len(served)` | **defensive** | a non-port spanning station always serves the line with matching lengths by construction |
| L154 `if src/tgt is None:` | **defensive** | null guard; `graph.edges` endpoints always exist |
| L44 `if port is not None:` | **needs-review** → #743 | reachable only via connected whole-graph rails (defective) |
| L46 `if line_id in section_rails:` | **needs-review** → #743 | downstream of L44's defective-only path |
| L94 `len(order)<=1` | **needs-review** → #744 | single off-track feeder; off-track I/O renders defectively |
| L176 `if off_tgt:` | **needs-review** → #744 | off-track output; same |

The four reachable arms are reachable only via topologies that render defectively, so they are parked `needs-review` rather than fixtured (the #688 reachable-but-defective pattern). Two issues filed with repros:

- **#743** - whole-graph rail mode routes connected sections with dangling port stubs and avoidable crossings (L44/L46).
- **#744** - off-track inputs/outputs render bare rail-ends and overlapping labels in rail mode (L94/L176).

Closes #732.

## Test plan
- [x] `pytest tests/test_routing_gate_coverage.py` passes (ratchet: no new arm, no stale triage key, baseline in sync)
- [x] full `pytest` passes (9235 passed, 6 pre-existing xfails)
- [x] `ruff format --check` + `ruff check` clean on whole repo
- [x] `docs/dev/routing_gate_coverage.md` shows zero blank-triage rows for `rail.py`
- [x] no fixtures shipped, ratchet baseline byte-identical
