### PR TITLE
docs: document the routing gate-arm triage methodology

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -7,7 +7,7 @@ preamble at the top of the relevant `SKILL.md`.
 
 ## Cohort map
 
-The six skills fall into three conceptual groups.
+The skills fall into three conceptual groups.
 
 ### Pipeline-side
 
@@ -26,6 +26,7 @@ For someone changing nf-metro itself:
 |---|---|
 | [`fix-issue`](fix-issue/SKILL.md) | General end-to-end workflow for a GitHub issue: worktree, environment, implement, test, push, PR. The "skeleton" most other nf-metro authoring tasks build on. |
 | [`nf-metro-layout-fix`](nf-metro-layout-fix/SKILL.md) | Drive code-level fixes to nf-metro layout when a real pipeline render exposes a bug. Savepoint pattern, invariant-test-first-then-fix-then-runtime-validator loop, conditional gating, the "improvement ratchet". |
+| [`nf-metro-gate-triage`](nf-metro-gate-triage/SKILL.md) | Run a routing gate-arm triage slice: give every un-exercised branch in a `layout/routing/` module a verdict (reachable -> fixture, defensive, candidate-dead, or reachable-but-defective -> file a bug). Wraps the methodology in [`docs/dev/routing_gate_triage.md`](../../docs/dev/routing_gate_triage.md). |
 | [`pr-chain-vet`](pr-chain-vet/SKILL.md) | Per-PR vetting on a stacked PR chain: gallery diff vs `main`, classify every changed example, `/simplify` pass, sweep narrative comments, get CI green, post-merge cleanup in the right order. |
 
 ### Visual verification

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -162,6 +162,42 @@ Then run the test suite:
 pytest
 ```
 
+### If your change touched `layout/routing/`: the gate-coverage ratchet
+
+Adding, removing, or rewriting an `if`/`while` in a `layout/routing/`
+module - or adding a topology fixture that closes a gap - can red one of
+the three ratchet tests in `tests/test_routing_gate_coverage.py`. These
+are **not** flaky; each names a specific reconciliation you owe in this
+same PR. Do not silence them by hand-editing the baseline or the
+generated matrix doc, and do not delete a triage entry just to make a
+test pass.
+
+- `test_no_new_un_exercised_routing_gate_arm` - your change added a gate
+  with an un-exercised arm. Either author a fixture that hits both arms,
+  or - if the arm is genuinely unreachable - confirm that and regenerate
+  the baseline to acknowledge it.
+- `test_gate_coverage_baseline_in_sync` - your change closed a gap or
+  removed a gate the baseline still lists. Regenerate the baseline.
+- `test_triage_sidecar_references_open_gaps` - you edited a gate's
+  condition text or removed it, so its entry in
+  `tests/data/routing_gate_triage.json` now names a non-gap. Prune (or
+  re-key) that entry.
+
+Regenerate with the coverage script (needs the `[dev]` extra and the
+pinned interpreter):
+
+```bash
+python scripts/routing_gate_coverage.py --write   # rewrites the matrix doc + baseline
+```
+
+**Gotcha:** the arc model is CPython-version-specific, so these tests
+**skip** off the pinned `BASELINE_PYTHON` (3.11). If your fix env is a
+different Python you will not see the failure locally - it surfaces only
+in CI. When in doubt, regenerate under 3.11. The full methodology (the
+four verdicts, why these tests exist, the phantom-arc trap) is in
+[`docs/dev/routing_gate_triage.md`](../../../docs/dev/routing_gate_triage.md);
+for a dedicated triage campaign use the `nf-metro-gate-triage` skill.
+
 ## Step 8: Visual Review via Render Preview
 
 ### Primary method: CI render preview (authoritative)

--- a/.claude/skills/nf-metro-gate-triage/SKILL.md
+++ b/.claude/skills/nf-metro-gate-triage/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: nf-metro-gate-triage
+description: Run a routing gate-arm triage slice on nf-metro - give every un-exercised branch arm in a layout/routing module a verdict (reachable -> author a fixture, defensive, candidate-dead, or reachable-but-defective -> file a bug). Use when the user wants to triage routing gate arms, close coverage-matrix gaps, work a #687 slice, classify un-exercised gates, run or resume the gate-coverage triage campaign, or regenerate the routing gate coverage matrix. Trigger on phrases like "triage the <module> gate arms", "close the gate coverage gaps", "work the #687 triage", "classify the un-exercised routing arms", "run a gate-arm triage slice". The full methodology, lane rules, and gotchas live in docs/dev/routing_gate_triage.md; this skill drives one module slice end-to-end on top of the fix-issue workflow. For finding new layout bugs by composing novel renders, see nf-metro-stress-render; for fixing an engine bug the triage spawned, see fix-issue / nf-metro-layout-fix.
+---
+
+# nf-metro gate-arm triage
+
+Every `if`/`while` in `layout/routing/` is a *gate* whose arms a novel pipeline
+can hit untested, producing a visual defect. The `scripts/routing_gate_coverage.py`
+matrix enumerates which corpus fixtures reach each arm; this skill works the
+un-exercised arms of one module to zero open gaps.
+
+**The methodology is documented in full at
+[`docs/dev/routing_gate_triage.md`](../../../docs/dev/routing_gate_triage.md).**
+Read it first - it is the source of truth for the four verdicts, the artifacts,
+the workflow, and the hard-won gotchas. This skill is the thin operational
+wrapper; it does not restate the detail.
+
+**Conventions** (substitute if your setup differs):
+- Local nf-metro checkout: `~/projects/nf-metro`; upstream `pinin4fjords/nf-metro`.
+- Render preview: `pinin4fjords.github.io/nf-metro/_pr/<N>/`.
+- This skill builds on `fix-issue` for worktree/env/PR hygiene - follow that
+  skill's setup and additive-only rules.
+
+## What this skill does
+
+Drives **one module slice** (or a cluster of tiny modules) end-to-end: from a
+worktree off `origin/main`, through per-arm classification, the human visual
+verdict, a regenerated matrix, to a reviewable PR. It ships **verdicts and
+fixtures only** - never engine behaviour changes.
+
+## Steps
+
+1. **Scope.** Confirm which module (or tiny-module cluster) this slice covers.
+   Re-run `python scripts/routing_gate_coverage.py` in a fresh worktree to get
+   that module's *live* un-exercised arms - gap counts drift, so never trust a
+   number from an issue body. If a per-module issue exists (the #727-#733 family,
+   #748), it carries the arm list; reconfirm it against the live matrix.
+
+2. **Classify every arm** into exactly one of the four verdicts from the doc:
+   **reachable** (author a minimal fixture, wire `GALLERY_ENTRIES`, verify the arm
+   flipped via the coverage script - the oracle), **reachable-but-defective**
+   (file a bug, park `needs-review`, do NOT commit/distort the fixture),
+   **defensive** (annotate why no valid topology takes it), **candidate-dead**
+   (flag with reachability evidence, do NOT delete - that is the #689 pass).
+   Opus drives; fan the reachable lane out to sonnet sub-agents, each confirming
+   its flip with the coverage script. Append a triage-JSON card per fixture.
+
+   Watch the two traps the doc calls out: **phantom arcs** (multi-line
+   condition/literal/ternary mis-attribution - tooling noise, see #746, do not
+   hand-classify as defensive) and **"corpus doesn't hit it" ≠ defensive** (a
+   correction-pass arm with zero hits is usually reachable - author a fixture).
+
+3. **Human visual verdict before PR-open.** Build the review page and get a
+   verdict on every new fixture - the validator has blind spots the eyeball
+   catches:
+   ```
+   source ~/.local/bin/mm-activate nf-metro && export PYTHONPATH="$PWD/src"
+   python .claude/skills/nf-metro-layout-triage/build_review.py --worktree "$PWD" \
+       --output-dir /tmp/gate-triage-out --violations /tmp/gate-triage-<module>.json
+   cd /tmp/gate-triage-out && python -m http.server 8765
+   ```
+   Any **Bug** verdict not already classified defective: pull the fixture from
+   `GALLERY_ENTRIES`, file an issue with the repro, park its arm `needs-review`
+   linked to that issue. Nothing flagged gets silently dropped.
+
+4. **Regenerate + ratchet.** Run the script with `--write` to regenerate
+   `docs/dev/routing_gate_coverage.md` + the baseline. Keep the three ratchet
+   tests in `tests/test_routing_gate_coverage.py` green (they skip off the pinned
+   CPython - regenerate only under `BASELINE_PYTHON`). The stale-key test means a
+   removed gap needs its triage entry removed in the same PR.
+
+5. **Ship per `fix-issue` hygiene.** Invariant-test-first where a fixture asserts a
+   layout property, validator pass, `/simplify` as its own commit, full CI lint
+   (`ruff format --check` + `ruff check` + `mypy`), additive commits only, no
+   force-push, verify origin after each push. Stop at PR-open against `main`.
+
+**Done when** the module shows zero blank-Triage rows in the matrix and the PR is
+open for review. The slice carries no engine behaviour change; any bug it
+surfaced is filed separately (the `reachable-but-defective` lane).
+
+## Mid-campaign merges
+
+If another PR lands while this slice is in flight, resolve the shared coverage
+files by **union**: start from `main`'s triage JSON, add only this module's keys,
+then regenerate the doc + baseline. Never hand-merge the generated files.

--- a/docs/dev/routing_gate_triage.md
+++ b/docs/dev/routing_gate_triage.md
@@ -1,0 +1,213 @@
+# Routing gate-arm triage
+
+How to run a campaign that gives every un-exercised branch in `layout/routing/`
+a verdict. This is the *process* doc; the auto-generated matrix it operates on
+is [`routing_gate_coverage.md`](routing_gate_coverage.md), and the tool that
+produces it is `scripts/routing_gate_coverage.py`.
+
+## Why this exists
+
+Every `if`/`while` in the routing subpackage is a *gate* with two or more arms.
+A gate written for the topologies in hand can fire (or fail to fire) on a novel
+pipeline and produce a visual defect - that is the fragility the engine is prone
+to. An arm reached by **zero corpus fixtures** is an untested assumption. The
+coverage matrix turns "every new pipeline stress-tests every implicit
+assumption" into a finite, enumerated checklist; triage is the act of working
+that checklist to zero open gaps.
+
+The payoff is twofold: the campaign hardens the engine (each *reachable* arm
+gets a fixture, and arms that only reach via a defective render spawn bug
+reports), and it documents the rest (defensive guards and dead code get a
+recorded reason so no future reader re-investigates them cold).
+
+## Artifacts
+
+| File | Role |
+|---|---|
+| `scripts/routing_gate_coverage.py` | The tool. Renders the whole `examples/` corpus under per-fixture branch coverage, restricted to routing modules, and maps each gate arm to the fixtures reaching it. `--write` regenerates the doc + baseline; `--json` dumps machine-readable. |
+| `docs/dev/routing_gate_coverage.md` | Generated matrix. One row per gap gate, with a **Triage** column carrying the verdict. Do not hand-edit; regenerate. |
+| `tests/data/routing_gate_triage.json` | The verdict sidecar. One keyed entry per triaged arm (`module.py::<gate text>::#<n>`) with `status` + `note`. |
+| `tests/data/routing_gate_coverage_baseline.json` | The ratchet baseline (the frozen gap set). |
+| `tests/test_routing_gate_coverage.py` | The ratchet. Three tests gate the program (below). |
+
+The ratchet (skipped off the pinned interpreter):
+
+- `test_no_new_un_exercised_routing_gate_arm` - a new gate must ship with a
+  fixture hitting both arms, or the gap set grows and this reds.
+- `test_gate_coverage_baseline_in_sync` - the committed baseline matches what the
+  script computes now.
+- `test_triage_sidecar_references_open_gaps` - every triage key still corresponds
+  to a live gap (no **stale keys**); closing or removing a gap requires removing
+  its triage entry in the same change.
+
+## The four verdicts (lane rules)
+
+Every un-exercised arm resolves to exactly one of these. This is the heart of
+the methodology - apply it per arm.
+
+- **reachable** - a valid topology takes this arm; no shipped fixture does yet.
+  Author a **minimal valid** topology fixture in `examples/topologies/`, wire it
+  into `GALLERY_ENTRIES` (`scripts/build_gallery.py`), and **verify the arm
+  flipped** un-exercised -> exercised by re-running the coverage script. The
+  script is the oracle that makes this lane safe to delegate. If it didn't flip,
+  the fixture is wrong - iterate, don't commit.
+- **reachable-but-defective** (the #688 pattern) - the *only* topology that
+  reaches the arm exposes a render you would not ship (curve through a label,
+  bypass-V collision, kink, overlap, route through a section box). Do **not**
+  commit the fixture, and do **not** distort it (shrunk labels, hacked spacing)
+  to dodge the defect - that is cheating. **File a bug** with the repro `.mmd`,
+  the arm reference, and the expected clean behaviour, then park the arm as
+  `needs-review` linked to that issue.
+- **defensive** - a guard clause no valid topology can violate (null/contract
+  checks, empty-collection skips, coincidence guards). Annotate with *why* a
+  valid graph never takes it. No code deletion.
+- **candidate-dead** - no constructible topology reaches it, but it is live code.
+  Flag it `candidate-dead` **with reachability evidence**; do **not** delete it
+  here. Deletion is a separate, deliberate pass (#689), because byte-identical
+  renders are not proof of deadness.
+
+`needs-review` is a *holding* status, not a final verdict: an arm waiting on a
+filed bug, or one not yet classified. A campaign is not done while any arm is
+`needs-review`.
+
+## Running a slice
+
+1. **Worktree off current `origin/main`.** Re-run
+   `python scripts/routing_gate_coverage.py` first - gap counts drift as
+   fixtures land elsewhere, so never trust a stale number from an issue body.
+2. **One PR per module** (cluster the tiny modules - e.g.
+   `core.py` + `inter_section.py` + `corners.py` - into one PR). Keeps each
+   reviewable and mergeable.
+3. **Opus drives; fan the reachable lane out to sonnet sub-agents.** Each sonnet
+   agent reads one gate condition, authors a candidate fixture, and confirms the
+   flip via the coverage script. The script being the oracle is what makes the
+   fan-out safe.
+4. **Classify every arm** into one of the four verdicts. Append a card per new
+   fixture to a shared triage JSON.
+5. **Human visual verdict before PR-open.** Build the review page and get a
+   verdict on *every* new fixture:
+   ```
+   source ~/.local/bin/mm-activate nf-metro && export PYTHONPATH="$PWD/src"
+   python .claude/skills/nf-metro-layout-triage/build_review.py --worktree "$PWD" \
+       --output-dir /tmp/gate-triage-out --violations /tmp/gate-triage-<module>.json
+   cd /tmp/gate-triage-out && python -m http.server 8765
+   ```
+   Any fixture flagged **Bug** that was not already classified defective: pull it
+   from `GALLERY_ENTRIES`, file an issue with the repro, park its arm
+   `needs-review` linked to that issue. Nothing flagged gets silently dropped.
+6. **Regenerate** the doc + baseline (`--write`) and keep the ratchet green.
+7. **Full fix-issue hygiene** (see the `fix-issue` skill): invariant-test-first
+   where a fixture asserts a layout property, runtime validator pass, `/simplify`
+   as its own commit, full CI lint (`ruff format --check` + `ruff check` +
+   `mypy`), additive commits only, no force-push, verify origin after each push.
+   Stop at PR-open against `main` for review.
+
+A slice is **done** when its module shows zero blank-Triage rows in the matrix:
+every arm is reachable-fixtured / defensive-annotated / candidate-dead-flagged /
+needs-review-linked.
+
+## Gotchas (hard-won)
+
+- **Phantom arcs inflate the backlog (#746).** `FileReporter.arcs()` attributes a
+  branch arc to the *opening* line of a multi-line `if (`, list/tuple literal, or
+  ternary, while CPython records the executed arc from an *operand* line. The
+  matrix then reports a gap on a gate whose arms both actually run. These are
+  tooling noise - do not hand-classify them as `defensive`; fix the detector in
+  the script instead (an un-exercised arc `(src, dst)` is phantom when `dst` is
+  reached by an executed arc from a different source line in the same construct).
+- **"Corpus doesn't hit it" is not "no valid topology reaches it."** A *correction
+  pass* arm with zero corpus hits is usually **reachable** (author a fixture that
+  triggers the correction), not **defensive**. Labeling such an arm defensive on a
+  "never fires across N corpus calls" basis loses a regression fixture for a real
+  defect class - this is exactly how the `clear_channel_of_section_edge` graze arm
+  was misjudged before #736 was filed.
+- **Validators have blind spots; the human eyeball is load-bearing.**
+  `probe_layout.py` only sees `validate=True`-block guards, and route crossings are
+  warnings, not failures. Neither the validator nor the suite caught the
+  eager-bundling violations (#702) or the graze (#736). Always run the *full* suite
+  **and** put the new fixtures in front of a human via the review page.
+- **The arc model is CPython-version-specific.** The script pins
+  `BASELINE_PYTHON = (3, 11)`; the ratchet tests skip on any other interpreter.
+  Regenerate the baseline only under the pinned version.
+- **Use `FileReporter.arcs()`, not `missing_branch_arcs()`**, and exclude
+  `invariants.py` (it is the `validate=True` checker, not a routing decision gate)
+  and `__init__.py`.
+- **Triage JSON hygiene.** Keep it ordered, `indent=2`, trailing newline. The
+  stale-key ratchet means removing a gap (e.g. closing it with a fixture, or a
+  phantom-arc fix dropping it) requires removing its triage entry in the same PR.
+- **Mid-campaign merges.** When another PR lands while a slice is in flight,
+  resolve the shared coverage files by **union**: start from `main`'s triage JSON,
+  add only your module's keys, then regenerate the doc + baseline. Do not
+  hand-merge the generated files.
+
+## Program structure
+
+The campaign is sliced by module under one umbrella, with a separate deletion
+pass and a tooling-quality issue:
+
+- **#677** built the coverage matrix (tool + doc + ratchet).
+- **#687** is the umbrella: triage and close every un-exercised arm.
+- Module slices: #690 `intra_handlers`, #691 `offsets`, #692
+  `inter_section_handlers`, #701 `normalize` (with #748 for its tail), and
+  #727-#733 the long-tail modules.
+- **#689** is the deferred **deletion** pass over the `candidate-dead` arms.
+- **#746** fixes the phantom-arc tooling defect so future slices triage only real
+  gaps.
+
+The triage program is also a bug *finder*: the `reachable-but-defective` lane has
+spawned engine fixes (#688, #695, #696, #698, #736, ...). Those are filed and
+fixed on their own, outside the triage PRs - a triage slice ships verdicts and
+fixtures, never engine behaviour changes.
+
+## Lifecycle: permanent infra vs episodic campaign
+
+The distinction matters, because it answers "do I have to babysit this?":
+
+- **The infra is permanent and self-maintaining.** The tool, the matrix doc, the
+  baseline, the triage JSON, and the three ratchet tests live in the repo forever
+  and are kept honest by CI on *every* routing change - not by a standing owner.
+- **A campaign is episodic.** "Drive the open gaps down to zero verdicts" is a
+  finite project you run when the backlog has grown. Between campaigns the ratchet
+  holds the line; it does not require a campaign to be running.
+
+What the ratchet does *not* do is force a pre-existing open gap to get a verdict.
+So the open-gap backlog drifts slowly upward as gates are added and acknowledged
+(see below), and a campaign is what pays it back down. That is the intended
+rhythm, not a leak.
+
+## Maintaining the infra as routing evolves
+
+Three CI-enforced events keep everything in sync; each is handled in the PR that
+causes it, by whoever touches `layout/routing/`:
+
+1. **A new gate gains an un-exercised arm** -> `test_no_new_un_exercised_routing_gate_arm`
+   reds. Resolve it *consciously*: either author a fixture that hits both arms
+   (close it), or - if the arm is genuinely unreachable - confirm that and
+   regenerate the baseline (`--write`) to acknowledge it as a new open gap. The
+   baseline diff makes the acknowledgement visible to a reviewer; gaps cannot slip
+   in silently. (Acknowledging is the cheap path, which is why backlogs accrete
+   and campaigns exist.)
+2. **A change closes a gap or removes a gate** -> `test_gate_coverage_baseline_in_sync`
+   reds (the baseline now claims a gap the corpus exercises, or that no longer
+   exists). Regenerate the baseline in the same PR so the ratchet stays tight.
+3. **A gate's condition text is edited, removed, or its gap closes** -> its triage
+   entry goes stale and `test_triage_sidecar_references_open_gaps` reds. Prune or
+   update that entry in `tests/data/routing_gate_triage.json` in the same PR.
+
+The reason this is low-friction in practice: **triage keys are
+`module.py::<gate text>::#<ordinal>`, not line numbers.** The most common churn -
+code shifting up or down - does not touch any key; the matrix doc's line numbers
+simply regenerate. Only *semantic* edits (changing a gate's condition, deleting a
+gate, reordering identical-text gates) disturb a key, and the stale-key test
+catches exactly those.
+
+So: run `--write` and reconcile the triage JSON as a normal part of any routing PR
+that adds, removes, or rewrites a gate. No separate maintenance pass is needed
+between campaigns.
+
+## Re-running a campaign in future
+
+Run a fresh campaign when the open-gap backlog has grown enough to be worth a
+sweep - typically after a routing module has accreted new gates over several PRs,
+or after a refactor changes the dispatch structure. Start at step 1 of *Running a
+slice* per module; the four verdicts and the gotchas above do not change.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,5 +48,6 @@ nav:
     - Layout pipeline: dev/layout_pipeline.md
     - Routing: dev/routing.md
     - Routing gate coverage: dev/routing_gate_coverage.md
+    - Routing gate triage: dev/routing_gate_triage.md
     - Parser: dev/parser.md
     - Testing: dev/testing.md


### PR DESCRIPTION
## Summary

Captures the routing gate-arm triage methodology as a durable, repeatable artifact so the campaign run across #677/#687/#689/#727-#733/#746/#748 can be re-run and, more importantly, *maintained* as the codebase evolves.

- **`docs/dev/routing_gate_triage.md`** (new) - the source of truth: the four verdicts (reachable / reachable-but-defective / defensive / candidate-dead), the artifacts + three ratchet tests, the per-module slice workflow, the human visual-verdict checkpoint, and the hard-won gotchas (phantom arcs #746, "corpus-absence != defensive", validator blind spots, CPython arc pinning, "byte-identical != dead"). Includes an explicit **lifecycle** section: the infra is permanent and ratchet-maintained; a *campaign* is episodic.
- **`.claude/skills/nf-metro-gate-triage/SKILL.md`** (new) - a thin skill that drives one module slice end-to-end on top of `fix-issue`, pointing at the doc rather than restating it.
- **`fix-issue` Step 7** - a maintenance subsection so any routing PR (where most work happens) knows how to reconcile the three gate-coverage ratchet tests, with the CPython-3.11-skip gotcha called out.
- Indexed in the skills README and the mkdocs nav.

Docs/skills only - no `src/`, tests, or fixtures touched.

## Test plan
- [ ] ruff format + ruff check clean on whole repo (no Python changed)
- [ ] mkdocs nav resolves the new page
- [ ] Relative doc links resolve (README, both skills -> docs/dev/routing_gate_triage.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)