### PR TITLE
feat(themes): add Seqera Platform theme

### DIFF
--- a/src/nf_metro/themes/__init__.py
+++ b/src/nf_metro/themes/__init__.py
@@ -2,10 +2,12 @@
 
 from nf_metro.themes.light import LIGHT_THEME
 from nf_metro.themes.nfcore import NFCORE_THEME
+from nf_metro.themes.seqera import SEQERA_THEME
 
 THEMES = {
     "nfcore": NFCORE_THEME,
     "light": LIGHT_THEME,
+    "seqera": SEQERA_THEME,
 }
 
-__all__ = ["THEMES", "NFCORE_THEME", "LIGHT_THEME"]
+__all__ = ["THEMES", "NFCORE_THEME", "LIGHT_THEME", "SEQERA_THEME"]

--- a/src/nf_metro/themes/seqera.py
+++ b/src/nf_metro/themes/seqera.py
@@ -7,6 +7,8 @@ Colors sourced from the Seqera Platform design system
   $body-background:  #f8f9fa   - Platform body background
   $app-purple-neutral-1: #F3F3F4  - lightest Seqera-tinted neutral (section fill)
   $app-purple-neutral-2: #E8E7E9  - second step (section border)
+  $app-purple-neutral-10: #2D273C - dark brand purple (station stroke)
+  $app-purple-neutral-3:  #D0CFD4 - mid neutral (section border)
   $clr-border:       #dee2e6   - Platform default border
   $app-grey-neutral-black: #242424 - Platform primary text
   $app-text-muted:   #6c757d   - Platform muted/secondary text
@@ -20,7 +22,7 @@ SEQERA_THEME = Theme(
     name="seqera",
     background_color="#f8f9fa",
     station_fill="#ffffff",
-    station_stroke="#dee2e6",
+    station_stroke="#2D273C",
     station_stroke_width=2.0,
     line_width=4.0,
     label_color="#242424",
@@ -32,13 +34,13 @@ SEQERA_THEME = Theme(
     title_color="#160F26",
     title_font_size=26.0,
     section_fill="#F3F3F4",
-    section_stroke="#E8E7E9",
+    section_stroke="#D0CFD4",
     section_label_color="#6c757d",
     section_label_font_size=17.0,
     legend_background="rgba(248, 249, 250, 0.9)",
     legend_text_color="#242424",
     legend_font_size=16.0,
     animation_ball_color="#ffffff",
-    animation_ball_stroke="#dee2e6",
+    animation_ball_stroke="#2D273C",
     animation_ball_stroke_width=1.5,
 )

--- a/src/nf_metro/themes/seqera.py
+++ b/src/nf_metro/themes/seqera.py
@@ -1,0 +1,44 @@
+"""Seqera Platform light theme.
+
+Colors sourced from the Seqera Platform design system
+(tower-web/src/styles/_variables.scss):
+
+  $app-brand-seqera: #160F26   - Seqera brand dark navy (title color)
+  $body-background:  #f8f9fa   - Platform body background
+  $app-purple-neutral-1: #F3F3F4  - lightest Seqera-tinted neutral (section fill)
+  $app-purple-neutral-2: #E8E7E9  - second step (section border)
+  $clr-border:       #dee2e6   - Platform default border
+  $app-grey-neutral-black: #242424 - Platform primary text
+  $app-text-muted:   #6c757d   - Platform muted/secondary text
+
+Font: Inter Variable - tower-web/src/styles/foundations/_typography.scss.
+"""
+
+from nf_metro.render.style import Theme
+
+SEQERA_THEME = Theme(
+    name="seqera",
+    background_color="#f8f9fa",
+    station_fill="#ffffff",
+    station_stroke="#dee2e6",
+    station_stroke_width=2.0,
+    line_width=4.0,
+    label_color="#242424",
+    label_font_family=(
+        "'Inter Variable', Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    ),
+    label_font_size=14.0,
+    label_font_weight="600",
+    title_color="#160F26",
+    title_font_size=26.0,
+    section_fill="#F3F3F4",
+    section_stroke="#E8E7E9",
+    section_label_color="#6c757d",
+    section_label_font_size=17.0,
+    legend_background="rgba(248, 249, 250, 0.9)",
+    legend_text_color="#242424",
+    legend_font_size=16.0,
+    animation_ball_color="#ffffff",
+    animation_ball_stroke="#dee2e6",
+    animation_ball_stroke_width=1.5,
+)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -10,7 +10,7 @@ from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import Station
 from nf_metro.render.svg import _terminus_icon_centers, render_svg
-from nf_metro.themes import LIGHT_THEME, NFCORE_THEME
+from nf_metro.themes import LIGHT_THEME, NFCORE_THEME, SEQERA_THEME
 
 
 def _render_simple():
@@ -103,6 +103,19 @@ def test_render_light_theme():
     # Light theme uses transparent background (no background rectangle)
     assert LIGHT_THEME.background_color == "none"
     assert "#333333" in svg  # label/stroke color present
+
+
+def test_render_seqera_theme():
+    graph = parse_metro_mermaid(
+        "%%metro title: Seqera Test\n"
+        "%%metro line: main | Main | #ff0000\n"
+        "graph LR\n"
+        "    a -->|main| b\n"
+    )
+    compute_layout(graph)
+    svg = render_svg(graph, SEQERA_THEME)
+    assert SEQERA_THEME.background_color in svg  # #f8f9fa present
+    assert SEQERA_THEME.title_color in svg  # #160F26 brand dark present
 
 
 def test_render_dashed_line_has_dasharray():


### PR DESCRIPTION
## Summary

- Adds a new `seqera` theme (`src/nf_metro/themes/seqera.py`) matching the Seqera Platform UI aesthetic, so metro maps embedded in Platform look native
- Registers the theme in `THEMES` dict and `__all__` in `themes/__init__.py` - available via `--theme seqera` (CLI) or `%%metro style: seqera` (directive)
- Adds `test_render_seqera_theme` to `tests/test_render.py` verifying background and brand title colors are present in rendered SVG

**Color sources** - all values from `tower-web/src/styles/_variables.scss` in the platform repo:

| Value | Variable | Role |
|-------|----------|------|
| `#f8f9fa` | `$body-background` | Canvas background |
| `#160F26` | `$app-brand-seqera` | Title color (Seqera brand dark) |
| `#F3F3F4` | `$app-purple-neutral-1` | Section fill (Seqera-tinted neutral) |
| `#E8E7E9` | `$app-purple-neutral-2` | Section border |
| `#dee2e6` | `$clr-border` | Station/ball stroke |
| `#242424` | `$app-grey-neutral-black` | Label text |
| `#6c757d` | `$app-text-muted` | Section labels |

**Font**: `Inter Variable` - from `tower-web/src/styles/foundations/_typography.scss` (Platform's primary sans-serif).

Fixes #765

## Test plan
- [x] `pytest tests/test_render.py` passes (52 tests)
- [x] Full test suite passes (9523 passed, 6 xfailed - all pre-existing)
- [x] `ruff format` + `ruff check` clean on whole repo
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/766/)

Generated with Claude Code