### PR TITLE
fix(routing): guarantee bundle corners are concentric (#786)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -120,6 +120,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_bypass_port_no_slot_gaps,
     _guard_bypass_v_flat_visible,
     _guard_centered_line_spread_balanced,
+    _guard_concentric_bundle_corners,
     _guard_coordinates_finite,
     _guard_entry_approach_from_port_side,
     _guard_entry_port_fed_only_by_ports,
@@ -1686,6 +1687,9 @@ def _finalize_layout(
                 graph, phase, offsets=offsets, routes=routes
             )
             _guard_bundle_order_preserved(graph, phase, offsets=offsets, routes=routes)
+            _guard_concentric_bundle_corners(
+                graph, phase, offsets=offsets, routes=routes
+            )
             _guard_no_collinear_distinct_lines(
                 graph, phase, offsets=offsets, routes=routes
             )

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -2664,6 +2664,30 @@ def _guard_no_same_line_parallel_descents(
     )
 
 
+def _guard_concentric_bundle_corners(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: wholesale-translated bundle corners share an arc centre.
+
+    Wraps :func:`check_concentric_bundle_corners`, the correctness check the
+    corner-radius source ratchet (``test_corner_radius_ratchet``) cannot do:
+    a radius can trace to an approved helper yet nest non-concentrically when
+    the caller hand-picks the wrong sign.  A bundle turning a 90-degree corner
+    as a unit must keep its arcs concentric or it pinches through the bend.
+    """
+    from nf_metro.layout.routing.invariants import (
+        check_concentric_bundle_corners,
+    )
+
+    _raise_on_first_violation(
+        graph, phase, check_concentric_bundle_corners, offsets, routes
+    )
+
+
 def _guard_no_split_same_line_fanout_descents(
     graph: MetroGraph,
     phase: str,

--- a/src/nf_metro/layout/routing/corners.py
+++ b/src/nf_metro/layout/routing/corners.py
@@ -238,6 +238,52 @@ def concentric_corner_radius(
     return reference_anchored_radius(-dx * ux, base_radius, min_radius=min_radius)
 
 
+def _corner_travel_units(
+    prev: tuple[float, float],
+    corner: tuple[float, float],
+    nxt: tuple[float, float],
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Axis-aligned unit travel vectors into and out of an axis-aligned corner.
+
+    Each leg snaps to its dominant axis, so a segment carrying sub-pixel
+    off-axis drift resolves to a clean cardinal unit.
+    """
+
+    def unit(a: tuple[float, float], b: tuple[float, float]) -> tuple[float, float]:
+        sx, sy = b[0] - a[0], b[1] - a[1]
+        if abs(sx) >= abs(sy):
+            return (math.copysign(1.0, sx) if sx else 0.0, 0.0)
+        return (0.0, math.copysign(1.0, sy) if sy else 0.0)
+
+    return unit(prev, corner), unit(corner, nxt)
+
+
+def concentric_corner_radius_at(
+    prev: tuple[float, float],
+    corner: tuple[float, float],
+    nxt: tuple[float, float],
+    dx: float,
+    base_radius: float = CURVE_RADIUS,
+    *,
+    min_radius: float | None = None,
+) -> float:
+    """Concentric radius for one bundle line, deriving the turn from the points.
+
+    Geometry-keyed entry point for a wholesale-translated 90° corner: it reads
+    the two travel vectors from the corner's own three waypoints (*prev* ->
+    *corner* -> *nxt*) and forwards them to :func:`concentric_corner_radius`, so
+    a caller supplies only the corner geometry and this line's signed
+    displacement *dx* from the bundle reference - never a hand-picked sign.  Use
+    this at every wholesale-translated bundle corner; reserve raw
+    :func:`reference_anchored_radius` for transition corners (one leg pinned,
+    e.g. a converging port jog) where non-concentric is intended.
+    """
+    turn_in, turn_out = _corner_travel_units(prev, corner, nxt)
+    return concentric_corner_radius(
+        turn_in, turn_out, dx, base_radius, min_radius=min_radius
+    )
+
+
 def reference_anchored_radius(
     signed_offset: float,
     base_radius: float = CURVE_RADIUS,

--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -50,6 +50,8 @@ from nf_metro.layout.routing.context import (
 )
 from nf_metro.layout.routing.corners import (
     bypass_radii,
+    concentric_corner_radius,
+    concentric_corner_radius_at,
     corner_radius,
     l_shape_radii,
     reference_anchored_radius,
@@ -440,15 +442,18 @@ def _route_bottom_exit_junction(
         x_off = ((n - 1) / 2 - i) * ctx.offset_step
 
     tgt_off = _get_offset(ctx, edge.target, edge.line_id)
-    r = reference_anchored_radius(x_off, ctx.curve_radius)
+    points = [
+        (src.x + x_off, src.y),
+        (src.x + x_off, tgt.y + tgt_off),
+        (tgt.x, tgt.y + tgt_off),
+    ]
+    r = concentric_corner_radius_at(
+        points[0], points[1], points[2], x_off, ctx.curve_radius
+    )
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[
-            (src.x + x_off, src.y),
-            (src.x + x_off, tgt.y + tgt_off),
-            (tgt.x, tgt.y + tgt_off),
-        ],
+        points=points,
         is_inter_section=True,
         curve_radii=[r],
         offsets_applied=True,
@@ -1028,26 +1033,28 @@ def _route_l_shape(
 
     # When fan is active, vx == sx (corner at junction).  The first
     # segment (sx, sy) -> (vx, sy) is zero-length, which prevents the
-    # renderer from drawing the corner curve.  Extend pts[0] back by
-    # curve_radius LEFT of the junction so the first corner gets a
-    # standard CURVE_RADIUS arc with horizontal lead-in (overlapping
-    # the upstream exit_port->junction segment's last curve_radius
-    # pixels, fine since they share the same line colour).
+    # renderer from drawing the corner curve.  Extend pts[0] back by the
+    # lead-in corner's own radius LEFT of the junction so the first corner
+    # gets its full arc with a horizontal lead-in (overlapping the upstream
+    # exit_port->junction segment, fine since they share the line colour).
+    # The lead-in corner sits at the fanned vertical X (vx == mid_x + delta),
+    # so it must take the concentric ``r_first`` for this fan position; a flat
+    # base radius would pinch the bundle through the bend.
     if fan is not None:
         src_off = _get_offset(ctx, edge.source, edge.line_id)
         tgt_off = _get_offset(ctx, edge.target, edge.line_id)
-        r_lead = reference_anchored_radius(0.0, ctx.curve_radius)
+        lead_len = max(r_first, ctx.curve_radius)
         return RoutedPath(
             edge=edge,
             line_id=edge.line_id,
             points=[
-                (vx - r_lead, sy + src_off),
+                (vx - lead_len, sy + src_off),
                 (vx, sy + src_off),
                 (vx, ty + tgt_off),
                 (tx, ty + tgt_off),
             ],
             is_inter_section=True,
-            curve_radii=[r_lead, r_second],
+            curve_radii=[r_first, r_second],
             offsets_applied=True,
         )
 
@@ -1217,8 +1224,8 @@ def _route_perp_exit_over(
             (descent_x, ty),
         ]
         radii = [
-            reference_anchored_radius(-d, base),  # rise -> over
-            reference_anchored_radius(-d, base),  # over -> descend
+            concentric_corner_radius_at(points[0], points[1], points[2], d, base),
+            concentric_corner_radius_at(points[1], points[2], points[3], -d, base),
         ]
     else:
         # Side entry: descend in the inter-column gap to the consumer's row and
@@ -1237,9 +1244,9 @@ def _route_perp_exit_over(
             (tx, final_y),
         ]
         radii = [
-            reference_anchored_radius(-d, base),  # rise -> over
-            reference_anchored_radius(-d, base),  # over -> descend
-            reference_anchored_radius(d, base),  # descend -> turn into target
+            concentric_corner_radius_at(points[0], points[1], points[2], d, base),
+            concentric_corner_radius_at(points[1], points[2], points[3], -d, base),
+            concentric_corner_radius_at(points[2], points[3], points[4], -d, base),
         ]
 
     return RoutedPath(
@@ -1478,13 +1485,14 @@ def _route_top_entry_offset_bundle(
     drop2_x = tx - offset
 
     # The reference line drops straight into the port; offset lines step down,
-    # across and down, sitting inside the lead-in bend (radius base-offset for
-    # an East lead, base+offset for a West lead), and on opposite sides of the
-    # two trunk bends.  Each radius is the reference-anchored concentric form
-    # base + signed_offset; the trunk-bend signs flip for the double-back.
-    r1 = reference_anchored_radius(-lead_sign * offset, base_radius)
-    r2 = reference_anchored_radius(bsign * offset, base_radius)
-    r3 = reference_anchored_radius(-bsign * offset, base_radius)
+    # across and down, sitting inside the lead-in bend and on opposite sides of
+    # the two trunk bends.  Each line's legs are a constant ``offset`` from the
+    # reference, so each bend takes the concentric radius for that displacement;
+    # the turn vectors (lead-in ``lead_sign``, trunk ``bsign``, drops downward)
+    # carry the sign, so the double-back's flipped trunk is handled by geometry.
+    r1 = concentric_corner_radius((lead_sign, 0.0), (0.0, 1.0), -offset, base_radius)
+    r2 = concentric_corner_radius((0.0, 1.0), (bsign, 0.0), -offset, base_radius)
+    r3 = concentric_corner_radius((bsign, 0.0), (0.0, 1.0), -offset, base_radius)
 
     if land_x is not None:
         # Straight drop onto the trunk X; no converging port jog.

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -1442,16 +1442,203 @@ def check_stacked_elbow_clearance(
     return violations
 
 
+# ---------------------------------------------------------------------------
+# Bundle-corner concentricity
+# ---------------------------------------------------------------------------
+
+# Arc-centre spread above this reads as a visible pinch/gap through the bend.
+_CONCENTRIC_CENTRE_TOLERANCE = 1.0
+# A corner counts as wholesale-translated only when both flanking legs are
+# offset from the bundle-mate by the same amount; a difference above this means
+# one leg is pinned (a transition corner), where non-concentric is intended.
+_WHOLESALE_LEG_TOLERANCE = 1.0
+
+
+@dataclass(frozen=True)
+class NonConcentricCornerViolation:
+    """A wholesale-translated bundle corner whose arcs don't share a centre.
+
+    At a corner where the whole bend translates per line (both flanking legs
+    offset by the same perpendicular distance), the bundle-mates' arcs must
+    share a common centre so the inter-line gap stays constant through the
+    bend.  ``centre_spread`` is the distance between the two arc centres;
+    anything above tolerance pinches or gaps the bundle mid-curve.
+    """
+
+    edge_source: str
+    edge_target: str
+    line_a: str
+    line_b: str
+    corner_index: int
+    corner_xy: tuple[float, float]
+    centre_spread: float
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        cx, cy = self.corner_xy
+        return (
+            f"non-concentric bundle corner {self.edge_source!r}->"
+            f"{self.edge_target!r} at ({cx:.1f},{cy:.1f}) "
+            f"(corner #{self.corner_index}): lines {self.line_a!r} and "
+            f"{self.line_b!r} translate the whole corner together yet their "
+            f"arc centres are {self.centre_spread:.1f}px apart "
+            f"(> {_CONCENTRIC_CENTRE_TOLERANCE:.1f}px) - the bundle pinches "
+            f"through the bend.  Size the corner via "
+            f"concentric_corner_radius(_at), not a hand-signed radius"
+        )
+
+
+def _arc_centre(
+    corner: tuple[float, float],
+    radius: float,
+    turn_in: tuple[float, float],
+    turn_out: tuple[float, float],
+) -> tuple[float, float]:
+    """Centre of the rounded-corner arc: ``corner + radius * (turn_out - turn_in)``."""
+    ux = turn_out[0] - turn_in[0]
+    uy = turn_out[1] - turn_in[1]
+    return (corner[0] + radius * ux, corner[1] + radius * uy)
+
+
+def _resolved_corner_radii(
+    rp: RoutedPath, pts: list[tuple[float, float]]
+) -> list[float]:
+    """Effective (segment-clamped) radius at each corner of *pts*."""
+    from nf_metro.layout.routing.corners import resolve_curve_radii
+
+    return resolve_curve_radii(pts, rp.curve_radii)
+
+
+def check_concentric_bundle_corners(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[NonConcentricCornerViolation]:
+    """Return wholesale-translated bundle corners whose arcs aren't concentric.
+
+    The correctness check the corner-radius *source* ratchet
+    (``tests/test_corner_radius_ratchet.py``) explicitly cannot perform: a
+    radius traceable to an approved helper can nest non-concentrically when the
+    caller hand-picks the wrong sign.
+
+    Routes are grouped by ``(edge.source, edge.target)``.  For each bundled
+    pair sharing a waypoint count, every interior corner is classified from the
+    *final* offset-applied geometry: a corner is **wholesale-translated** (must
+    be concentric) when the two flanking legs are each offset from the mate by
+    the same perpendicular distance, and a **transition** corner (skipped) when
+    one leg is pinned.  At a wholesale corner the two arc centres
+    (``corner + radius * (turn_out - turn_in)``, using the segment-clamped
+    radius) must coincide within tolerance; a larger spread is a visible pinch.
+    """
+    bundles: dict[tuple[str, str], list[RoutedPath]] = defaultdict(list)
+    for r in routes:
+        bundles[(r.edge.source, r.edge.target)].append(r)
+
+    violations: list[NonConcentricCornerViolation] = []
+    for (src_id, tgt_id), bundle in bundles.items():
+        if len(bundle) < 2:
+            continue
+        rendered = [(r, _route_render_points(r, offsets)) for r in bundle]
+        radii = {id(r): _resolved_corner_radii(r, pts) for r, pts in rendered}
+        for ai in range(len(rendered)):
+            ra, pa = rendered[ai]
+            for bi in range(ai + 1, len(rendered)):
+                rb, pb = rendered[bi]
+                if len(pa) != len(pb) or len(pa) < 3:
+                    continue
+                v = _pair_corner_violation(
+                    src_id, tgt_id, ra, pa, radii[id(ra)], rb, pb, radii[id(rb)]
+                )
+                if v is not None:
+                    violations.append(v)
+    return violations
+
+
+def _pair_corner_violation(
+    src_id: str,
+    tgt_id: str,
+    ra: RoutedPath,
+    pa: list[tuple[float, float]],
+    radii_a: list[float],
+    rb: RoutedPath,
+    pb: list[tuple[float, float]],
+    radii_b: list[float],
+) -> NonConcentricCornerViolation | None:
+    """First non-concentric wholesale corner between two bundled routes."""
+    for k in range(1, len(pa) - 1):
+        turn_in = _segment_unit(pa[k - 1], pa[k])
+        turn_out = _segment_unit(pa[k], pa[k + 1])
+        if turn_in is None or turn_out is None:
+            continue
+        # Real 90-degree turn only: a straight pass-through has turn_out == turn_in
+        # so (turn_out - turn_in) is zero and the centre test is degenerate.
+        if (
+            abs(turn_in[0] * turn_out[0] + turn_in[1] * turn_out[1])
+            > COORD_TOLERANCE_FINE
+        ):
+            continue
+        # Corner displacement of B from A, split into the offset of the
+        # incoming leg (component along turn_out) and the outgoing leg
+        # (component along turn_in).
+        vx = pb[k][0] - pa[k][0]
+        vy = pb[k][1] - pa[k][1]
+        d_in_leg = abs(vx * turn_out[0] + vy * turn_out[1])
+        d_out_leg = abs(vx * turn_in[0] + vy * turn_in[1])
+        if max(d_in_leg, d_out_leg) <= _WHOLESALE_LEG_TOLERANCE:
+            continue  # coincident corner: no bundle offset to nest
+        if abs(d_in_leg - d_out_leg) > _WHOLESALE_LEG_TOLERANCE:
+            continue  # transition corner: one leg pinned, non-concentric by design
+        if k - 1 >= len(radii_a) or k - 1 >= len(radii_b):
+            continue
+        ca = _arc_centre(pa[k], radii_a[k - 1], turn_in, turn_out)
+        cb = _arc_centre(pb[k], radii_b[k - 1], turn_in, turn_out)
+        spread = ((ca[0] - cb[0]) ** 2 + (ca[1] - cb[1]) ** 2) ** 0.5
+        if spread > _CONCENTRIC_CENTRE_TOLERANCE:
+            return NonConcentricCornerViolation(
+                edge_source=src_id,
+                edge_target=tgt_id,
+                line_a=ra.line_id,
+                line_b=rb.line_id,
+                corner_index=k,
+                corner_xy=pa[k],
+                centre_spread=spread,
+            )
+    return None
+
+
+def _segment_unit(
+    p1: tuple[float, float], p2: tuple[float, float]
+) -> tuple[float, float] | None:
+    """Unit travel vector for an axis-aligned segment.
+
+    Returns ``None`` for a sub-pixel segment or a diagonal one (both axes
+    significant): concentric nesting is defined only for the orthogonal
+    horizontal/vertical legs of a 90-degree bend, so a diagonal leg carries no
+    corner to test.
+    """
+    dx = p2[0] - p1[0]
+    dy = p2[1] - p1[1]
+    if abs(dx) < _MIN_SEGMENT_LENGTH and abs(dy) < _MIN_SEGMENT_LENGTH:
+        return None
+    if min(abs(dx), abs(dy)) > COORD_TOLERANCE:
+        return None  # diagonal: not an orthogonal corner leg
+    if abs(dx) >= abs(dy):
+        return (1.0 if dx > 0 else -1.0, 0.0)
+    return (0.0, 1.0 if dy > 0 else -1.0)
+
+
 __all__ = [
     "BundleOrderViolation",
     "CollinearOverlapViolation",
     "FanoutTailGap",
     "MergePortApproachViolation",
+    "NonConcentricCornerViolation",
     "PartialBranchGapViolation",
     "SameLineParallelRun",
     "Side",
     "StackedElbowGraze",
     "check_bundle_order_preserved",
+    "check_concentric_bundle_corners",
     "check_fanout_tail_join",
     "check_merge_port_approach_side",
     "check_no_collinear_distinct_lines",

--- a/src/nf_metro/layout/routing/rail.py
+++ b/src/nf_metro/layout/routing/rail.py
@@ -17,11 +17,13 @@ from __future__ import annotations
 __all__ = ["route_rail_edges"]
 
 from nf_metro.layout.constants import (
+    CURVE_RADIUS,
     DIAGONAL_RUN,
     MIN_STRAIGHT_EDGE,
     RAIL_TERMINUS_FAN_LEAD,
 )
 from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.layout.routing.corners import concentric_corner_radius_at
 from nf_metro.parser.model import Edge, MetroGraph, Station
 
 
@@ -175,11 +177,19 @@ def route_rail_edges(
             ]
             if off_tgt:
                 l_points.reverse()
+            # Staggered sibling drops fan the elbow's vertical leg by
+            # ``drop_x - feeder.x``; the turn onto the rail takes the
+            # concentric radius for that offset so the bundle keeps a
+            # constant gap through the bend instead of a base-radius pinch.
+            elbow_r = concentric_corner_radius_at(
+                l_points[0], l_points[1], l_points[2], drop_x - feeder.x, CURVE_RADIUS
+            )
             routes.append(
                 RoutedPath(
                     edge=edge,
                     line_id=edge.line_id,
                     points=l_points,
+                    curve_radii=[elbow_r],
                     offsets_applied=True,
                 )
             )

--- a/src/nf_metro/layout/routing/tb_handlers.py
+++ b/src/nf_metro/layout/routing/tb_handlers.py
@@ -20,6 +20,7 @@ from nf_metro.layout.routing.context import (
 )
 from nf_metro.layout.routing.corners import (
     concentric_corner_radius,
+    concentric_corner_radius_at,
     reference_anchored_radius,
     tb_entry_corner,
     tb_exit_corner,
@@ -296,7 +297,11 @@ def _route_perp_entry(
             (drop_x, ty + tgt_off),
             (tx, ty + tgt_off),
         ]
-        radii = [reference_anchored_radius(src_off, ctx.curve_radius)]
+        radii = [
+            concentric_corner_radius_at(
+                pts[0], pts[1], pts[2], drop_x - sx, ctx.curve_radius
+            )
+        ]
     else:
         pts = [
             (sx + src_off, sy),
@@ -306,7 +311,9 @@ def _route_perp_entry(
         ]
         radii = [
             reference_anchored_radius(0.0, ctx.curve_radius),
-            reference_anchored_radius(src_off, ctx.curve_radius),
+            concentric_corner_radius_at(
+                pts[1], pts[2], pts[3], drop_x - sx, ctx.curve_radius
+            ),
         ]
     return RoutedPath(
         edge=edge,

--- a/tests/test_concentric_bundle_corners.py
+++ b/tests/test_concentric_bundle_corners.py
@@ -1,0 +1,126 @@
+"""Tests for the bundle-corner concentricity invariant.
+
+Covers:
+
+* Happy-path: every gallery fixture and example routes without a
+  non-concentric wholesale bundle corner.
+* Route-level positive/negative: hand-built bundles exercise the
+  wholesale-vs-transition discriminator and the arc-centre test, so the
+  invariant is shown to catch a real pinch rather than passing by accident.
+
+The correctness check here is the one the corner-radius *source* ratchet
+(``tests/test_corner_radius_ratchet.py``) explicitly cannot perform.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.layout.routing.invariants import check_concentric_bundle_corners
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import Edge
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOPOLOGIES = REPO_ROOT / "tests" / "fixtures" / "topologies"
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+EXAMPLES = REPO_ROOT / "examples"
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = []
+    paths.extend(sorted(TOPOLOGIES.glob("*.mmd")))
+    paths.extend(sorted(FIXTURES.glob("*.mmd")))
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    paths.extend(sorted((EXAMPLES / "topologies").glob("*.mmd")))
+    return paths
+
+
+@pytest.mark.parametrize(
+    "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
+)
+def test_no_non_concentric_bundle_corners_in_gallery(path: Path) -> None:
+    """Every shipped fixture must route with concentric wholesale corners.
+
+    A handler that sizes a wholesale-translated bundle corner with a base
+    or hand-signed radius (instead of the geometry-derived concentric one)
+    surfaces here as a failing fixture, even when that radius traces to an
+    approved helper and so slips past the source ratchet.
+    """
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    violations = check_concentric_bundle_corners(graph, routes, offsets)
+    assert violations == [], (
+        f"{path.name}: {len(violations)} non-concentric corner(s); "
+        f"first: {violations[0].message() if violations else ''}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route-level positive/negative tests
+# ---------------------------------------------------------------------------
+
+
+def _route(
+    line_id: str,
+    points: list[tuple[float, float]],
+    radii: list[float] | None = None,
+) -> RoutedPath:
+    """A bundled ``RoutedPath`` (shared src/tgt) with baked geometry."""
+    return RoutedPath(
+        edge=Edge(source="__src__", target="__tgt__", line_id=line_id),
+        line_id=line_id,
+        points=points,
+        is_inter_section=True,
+        offsets_applied=True,
+        curve_radii=radii,
+    )
+
+
+# A down->right corner offset wholesale by (3, -3): the concentric radii are
+# 10 (inner) and 7 (outer) so both arc centres land at (10, 90).
+_CONCENTRIC_A = _route("a", [(0.0, 0.0), (0.0, 100.0), (50.0, 100.0)], [10.0])
+_CONCENTRIC_B = _route("b", [(3.0, 0.0), (3.0, 97.0), (50.0, 97.0)], [7.0])
+
+
+def test_concentric_wholesale_corner_passes() -> None:
+    """A wholesale-translated corner with correctly nested radii is clean."""
+    assert (
+        check_concentric_bundle_corners(None, [_CONCENTRIC_A, _CONCENTRIC_B], {}) == []
+    )
+
+
+def test_non_concentric_wholesale_corner_is_caught() -> None:
+    """The same geometry with a base (un-nested) outer radius pinches."""
+    bad_b = _route("b", [(3.0, 0.0), (3.0, 97.0), (50.0, 97.0)], [10.0])
+    violations = check_concentric_bundle_corners(None, [_CONCENTRIC_A, bad_b], {})
+    assert len(violations) == 1
+    assert violations[0].centre_spread > 1.0
+
+
+def test_transition_corner_with_one_pinned_leg_is_skipped() -> None:
+    """A converging corner (vertical legs offset, horizontals coincident) is
+    a transition, not a wholesale translation, so non-concentric is allowed.
+    """
+    a = _route("a", [(0.0, 0.0), (0.0, 100.0), (50.0, 100.0)], [10.0])
+    # b's vertical leg is offset 3px but both horizontals share y=100.
+    b = _route("b", [(3.0, 0.0), (3.0, 100.0), (50.0, 100.0)], [10.0])
+    assert check_concentric_bundle_corners(None, [a, b], {}) == []
+
+
+def test_diagonal_leg_is_not_a_corner() -> None:
+    """A 45-degree diagonal leg carries no orthogonal corner to nest."""
+    a = _route("a", [(0.0, 0.0), (100.0, 0.0), (130.0, 117.0), (180.0, 117.0)])
+    b = _route("b", [(0.0, 3.0), (97.0, 3.0), (127.0, 120.0), (180.0, 120.0)])
+    assert check_concentric_bundle_corners(None, [a, b], {}) == []
+
+
+def test_single_line_bundle_is_skipped() -> None:
+    """One line has no bundle-mate to be concentric with."""
+    assert check_concentric_bundle_corners(None, [_CONCENTRIC_A], {}) == []

--- a/tests/test_corner_radius_ratchet.py
+++ b/tests/test_corner_radius_ratchet.py
@@ -52,6 +52,7 @@ APPROVED_RADIUS_HELPERS = frozenset(
         "tb_exit_corner",
         "tb_entry_corner",
         "concentric_corner_radius",
+        "concentric_corner_radius_at",
         "reference_anchored_radius",
         "resolve_curve_radii",
     }


### PR DESCRIPTION
## Summary

The corner-radius source ratchet (`test_corner_radius_ratchet`) checks that every `curve_radii` value traces to a `corners.py` helper, but it cannot check *correctness*: `reference_anchored_radius` takes a caller-supplied sign, so a hand-picked wrong sign passes the ratchet yet nests the arcs non-concentrically and pinches the bundle through the bend (the class behind #706 and #775).

This closes that gap on both axes the issue asks for - a geometry-keyed API so the sign is never hand-written, plus a runtime invariant that locks it.

- **`concentric_corner_radius_at(prev, corner, nxt, dx, base)`** - a points-derived wrapper that reads the two travel vectors from a corner's own three waypoints and forwards them to `concentric_corner_radius`, so a caller supplies only geometry and the line's displacement, never a radius sign.
- **Three handlers that emitted base/stale radii on offset geometry now derive the corner radius from the same per-line offset that fans the points**: `_route_l_shape` fan lead-in, `_route_perp_entry` drop, and rail-mode's off-track drop. This makes the previously non-concentric corners in `cross_row_gap_wrap`, `genomeassembly_staggered`, and `rail_mode` concentric.
- **The hand-signed wholesale-corner sites are migrated to the geometry-driven helpers** (`_route_bottom_exit_junction`, `_route_perp_exit_over`, the TOP-entry staircase). Raw `reference_anchored_radius` now only sizes genuine transition corners (a converging port jog). These migrations are byte-identical.
- **`check_concentric_bundle_corners` + a strict `_guard_concentric_bundle_corners`** wired into `compute_layout`'s final validate block. It classifies each corner from the final offset-applied geometry as wholesale-translated (both legs equally offset -> must be concentric) or transition (one leg pinned -> skipped), and asserts the wholesale corners' arc centres coincide. A future hand-signed radius reds CI instead of shipping a pinch.

### Render impact

- Fixed (now concentric): `cross_row_gap_wrap`, `genomeassembly_staggered`, `rail_mode`.
- Neutral side-effects (radii identical; a sub-2px junction nudge from the lead-in change feeding the route-during-layout pass): `da_pipeline`, `differentialabundance`, `differentialabundance_default`, `fan_bypass_nesting`. Verified visually indistinguishable.
- All other renders byte-identical.

Fixes #786

## Test plan
- [x] `pytest` passes (11242 passed), including the new `test_concentric_bundle_corners` (corpus happy-path + route-level positive/negative/transition/diagonal/single-line cases) and the unchanged corner-radius ratchet
- [x] New corpus test verified to red on `main` (the 3 fixtures) before the fix
- [x] `ruff check` + `ruff format --check` clean on the whole repo
- [x] Runtime validator `_guard_concentric_bundle_corners` added and wired
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/788/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
