### PR TITLE
fix(routing): fold the perp-exit up-and-over onto the centreline builder (#796)

### DIFF
--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -60,7 +60,6 @@ from nf_metro.layout.routing.context import (
 )
 from nf_metro.layout.routing.corners import (
     bypass_radii,
-    concentric_corner_radius_at,
     corner_radius,
     l_shape_radii,
     reference_anchored_radius,
@@ -1223,11 +1222,12 @@ def _route_perp_exit_over(
         (lift)     (corridor)      (descent)      (into target)
         port -> up -> over -> down to station Y -> straight into entry
 
-    The bundle is a constant perpendicular offset of its reference line: the
-    vertical legs continue the in-section riser's per-line X and the corridor
-    stacks the same offset in Y, so the per-line gap is constant.  Each corner
-    radius is the reference-anchored concentric form ``base +/- offset`` so the
-    arcs share a centre and the gap never pinches through the bends.
+    The polyline above is the bundle's centreline; every co-travelling line is
+    fanned as a perpendicular offset of it by the bundle builder, which anchors
+    each corner on the bundle's innermost-of-turn line so no arc pinches below
+    the floor radius.  The vertical legs carry the source-side riser lateral and
+    the final turn-in carries the target's per-line Y, so a side entry tapers
+    between the two while a perp-entry trunk drop stays rigid.
     """
     graph = ctx.graph
     sx, sy = src.x, src.y
@@ -1240,9 +1240,22 @@ def _route_perp_exit_over(
     is_top = src_port.side == PortSide.TOP
     row = src_sec.grid_row if src_sec is not None else None
 
-    d = _perp_riser_lateral(
-        ctx, edge.source, edge.line_id, src_port.side, src.section_id
-    )
+    # The co-travelling bundle: every line leaving this perpendicular exit for
+    # the same target rises into the corridor together.  Each contributes its
+    # source-side lateral so the builder anchors every corner on the bundle's
+    # innermost-of-turn line.
+    member_edges = [e for e in graph.edges_to(edge.target) if e.source == edge.source]
+    line_ids = list(dict.fromkeys(e.line_id for e in member_edges))
+
+    def source_lateral(line_id: str) -> float:
+        """The centreline's source-side perpendicular offset for *line_id*.
+
+        ``_perp_riser_lateral`` keeps the raw per-line X on a TOP riser and
+        reverses it on a BOTTOM one; the right-hand normal on the centreline's
+        vertical legs reverses the BOTTOM sign back, so it is negated here.
+        """
+        d = _perp_riser_lateral(ctx, edge.source, line_id, src_port.side, src.section_id)
+        return d if is_top else -d
 
     # Corridor Y: the header band clearing the source section's near edge.
     cy_base = (
@@ -1252,11 +1265,6 @@ def _route_perp_exit_over(
         if is_top
         else sy + base
     )
-
-    # The larger-offset line sits toward the source section on the corridor
-    # (south of a TOP run, north of a BOTTOM run) and west on the descent, which
-    # preserves bundle order through the rise/over/descend/turn-in sequence.
-    corridor_y = cy_base + (d if is_top else -d)
 
     perp_entry = (
         tgt_port is not None
@@ -1268,17 +1276,15 @@ def _route_perp_exit_over(
         # X and stop there.  The matching entry drop continues from that same
         # X, so ending the corridor short of the port centre keeps the two
         # legs one continuous line instead of jogging onto the port marker.
-        descent_x = tx - d
-        points = [
-            (sx + d, sy),
-            (sx + d, corridor_y),
-            (descent_x, corridor_y),
-            (descent_x, ty),
-        ]
-        radii = [
-            concentric_corner_radius_at(points[0], points[1], points[2], d, base),
-            concentric_corner_radius_at(points[1], points[2], points[3], -d, base),
-        ]
+        centerline = [(sx, sy), (sx, cy_base), (tx, cy_base), (tx, ty)]
+        src_offs = {lid: source_lateral(lid) for lid in line_ids}
+        route = route_along(
+            edge,
+            [(edge, edge.line_id, src_offs[edge.line_id])],
+            centerline,
+            base_radius=ctx.curve_radius,
+            bundle_offsets=[src_offs[lid] for lid in line_ids],
+        )
     else:
         # Side entry: descend in the inter-column gap to the consumer's row and
         # turn straight in, holding each line on the target section's per-line Y
@@ -1286,30 +1292,27 @@ def _route_perp_exit_over(
         # collapsing onto the entry-port Y (which would hide all but one line).
         src_col = src_sec.grid_col if src_sec is not None else 0
         tgt_col = tgt_sec.grid_col if tgt_sec is not None else src_col
-        descent_x = column_gap_midpoint(graph, src_col, tgt_col, row) - d
-        final_y = ty + _get_offset(ctx, edge.target, edge.line_id)
-        points = [
-            (sx + d, sy),
-            (sx + d, corridor_y),
-            (descent_x, corridor_y),
-            (descent_x, final_y),
-            (tx, final_y),
+        gap_x = column_gap_midpoint(graph, src_col, tgt_col, row)
+        centerline = [
+            (sx, sy),
+            (sx, cy_base),
+            (gap_x, cy_base),
+            (gap_x, ty),
+            (tx, ty),
         ]
-        radii = [
-            concentric_corner_radius_at(points[0], points[1], points[2], d, base),
-            concentric_corner_radius_at(points[1], points[2], points[3], -d, base),
-            concentric_corner_radius_at(points[2], points[3], points[4], -d, base),
-        ]
+        src_offs = {lid: source_lateral(lid) for lid in line_ids}
+        tgt_offs = {lid: _get_offset(ctx, edge.target, lid) for lid in line_ids}
+        routes = build_tapered_bundle(
+            [(edge, edge.line_id, src_offs[edge.line_id], tgt_offs[edge.line_id])],
+            centerline,
+            transition_leg=3,
+            base_radius=ctx.curve_radius,
+            bundle_offsets=[(src_offs[lid], tgt_offs[lid]) for lid in line_ids],
+        )
+        route = next((r for r in routes if r.line_id == edge.line_id), None)
 
-    return RoutedPath(
-        edge=edge,
-        line_id=edge.line_id,
-        points=points,
-        is_inter_section=True,
-        normalize_exempt=True,
-        offsets_applied=True,
-        curve_radii=radii,
-    )
+    assert route is not None
+    return route
 
 
 def _route_top_entry_l_shape(

--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -1254,8 +1254,12 @@ def _route_perp_exit_over(
         reverses it on a BOTTOM one; the right-hand normal on the centreline's
         vertical legs reverses the BOTTOM sign back, so it is negated here.
         """
-        d = _perp_riser_lateral(ctx, edge.source, line_id, src_port.side, src.section_id)
+        d = _perp_riser_lateral(
+            ctx, edge.source, line_id, src_port.side, src.section_id
+        )
         return d if is_top else -d
+
+    src_offs = {lid: source_lateral(lid) for lid in line_ids}
 
     # Corridor Y: the header band clearing the source section's near edge.
     cy_base = (
@@ -1277,7 +1281,6 @@ def _route_perp_exit_over(
         # X, so ending the corridor short of the port centre keeps the two
         # legs one continuous line instead of jogging onto the port marker.
         centerline = [(sx, sy), (sx, cy_base), (tx, cy_base), (tx, ty)]
-        src_offs = {lid: source_lateral(lid) for lid in line_ids}
         route = route_along(
             edge,
             [(edge, edge.line_id, src_offs[edge.line_id])],
@@ -1300,7 +1303,6 @@ def _route_perp_exit_over(
             (gap_x, ty),
             (tx, ty),
         ]
-        src_offs = {lid: source_lateral(lid) for lid in line_ids}
         tgt_offs = {lid: _get_offset(ctx, edge.target, lid) for lid in line_ids}
         routes = build_tapered_bundle(
             [(edge, edge.line_id, src_offs[edge.line_id], tgt_offs[edge.line_id])],

--- a/tests/test_corner_radius_ratchet.py
+++ b/tests/test_corner_radius_ratchet.py
@@ -256,7 +256,7 @@ def test_every_curve_radius_traces_to_a_corners_helper() -> None:
     total = sum(len(slots) for slots in per_file.values())
 
     # Guard against the finder silently matching nothing (e.g. modules moved).
-    assert total >= 17, (
+    assert total >= 16, (
         f"expected to find many curve_radii sites, found {total} - "
         "the finder may be broken or the routing modules restructured"
     )

--- a/tests/test_perp_exit_over_centreline.py
+++ b/tests/test_perp_exit_over_centreline.py
@@ -1,0 +1,110 @@
+"""The perpendicular-exit up-and-over route is built via a centreline + builder.
+
+``_route_perp_exit_over`` describes the rise -> corridor -> descent -> turn-in
+loop out of a TOP/BOTTOM exit as a centreline and fans it with the bundle
+builder rather than assembling per-line ``points`` / ``curve_radii`` by hand.  It
+declares the co-travelling bundle via ``bundle_offsets``, so the builder anchors
+every corner on the bundle's innermost-of-turn line and no inside-of-turn arc
+falls below the floor radius.
+
+These tests pin that on the fixtures whose perpendicular exits run the
+up-and-over route: TOP and BOTTOM exits into both a perpendicular entry (a
+column-offset trunk drop) and a side entry (a turn into a LEFT-entry station).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.constants import CURVE_RADIUS
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.invariants import (
+    assert_render_curve_invariants,
+    check_bundle_order_preserved,
+    check_concentric_bundle_corners,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import PortSide
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES = REPO_ROOT / "examples"
+
+# Fixtures whose inter-section routing exercises the up-and-over perp exit:
+# TOP and BOTTOM exits, each feeding a perpendicular entry and a side entry.
+PERP_EXIT_FIXTURES = [
+    EXAMPLES / "topologies" / "lr_perp_top_exit_perp_entry.mmd",
+    EXAMPLES / "topologies" / "lr_perp_top_exit_side_entry.mmd",
+    EXAMPLES / "topologies" / "lr_perp_bottom_exit_perp_entry.mmd",
+    EXAMPLES / "topologies" / "lr_perp_bottom_exit_side_entry.mmd",
+    EXAMPLES / "topologies" / "lr_perp_top_exit_perp_entry_diverging.mmd",
+]
+
+
+def _route(path: Path):
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    return graph, offsets, routes
+
+
+def _over_routes(graph, routes):
+    """Inter-section routes leaving a perpendicular exit by the up-and-over path.
+
+    A perpendicular (TOP/BOTTOM) exit that does not drop straight rises into the
+    header corridor and turns over; its route has four waypoints (a perp-entry
+    trunk drop) or five (a side-entry turn-in), distinguishing it from the
+    two-waypoint straight drop.
+    """
+    over = []
+    for r in routes:
+        port = graph.ports.get(r.edge.source)
+        if (
+            port is not None
+            and not port.is_entry
+            and port.side in (PortSide.TOP, PortSide.BOTTOM)
+            and r.is_inter_section
+            and len(r.points) in (4, 5)
+            and r.curve_radii
+        ):
+            over.append(r)
+    return over
+
+
+@pytest.mark.parametrize("path", PERP_EXIT_FIXTURES, ids=lambda p: p.stem)
+def test_perp_exit_over_corners_are_concentric_and_unflipped(path: Path) -> None:
+    graph, offsets, routes = _route(path)
+    assert check_concentric_bundle_corners(graph, routes, offsets) == []
+    assert check_bundle_order_preserved(routes) == []
+    assert_render_curve_invariants(graph, routes, offsets)
+
+
+@pytest.mark.parametrize("path", PERP_EXIT_FIXTURES, ids=lambda p: p.stem)
+def test_perp_exit_over_corner_radii_anchored_at_floor(path: Path) -> None:
+    """Every up-and-over corner sits at or above the floor radius.
+
+    The builder anchors the bundle's innermost-of-turn line at ``CURVE_RADIUS``
+    from the declared fan, so no inside-of-turn arc falls below it.  The
+    hand-rolled route anchored its corners on the raw port centre instead, so an
+    inside-of-turn line dipped below the floor; this catches that.
+    """
+    graph, _offsets, routes = _route(path)
+    over = _over_routes(graph, routes)
+    assert over, f"{path.stem}: expected at least one up-and-over perp-exit route"
+    offenders = [
+        (r.edge.source, r.edge.target, r.line_id, r.curve_radii)
+        for r in over
+        if any(radius < CURVE_RADIUS - 0.01 for radius in r.curve_radii)
+    ]
+    assert not offenders, f"{path.stem}: perp-exit corners below the floor: {offenders}"
+
+
+@pytest.mark.parametrize("path", PERP_EXIT_FIXTURES, ids=lambda p: p.stem)
+def test_perp_exit_over_routes_are_offset_baked(path: Path) -> None:
+    graph, _offsets, routes = _route(path)
+    over = _over_routes(graph, routes)
+    assert over, f"{path.stem}: expected at least one up-and-over perp-exit route"
+    assert all(r.offsets_applied for r in over)

--- a/tests/test_perp_exit_over_centreline.py
+++ b/tests/test_perp_exit_over_centreline.py
@@ -87,9 +87,9 @@ def test_perp_exit_over_corner_radii_anchored_at_floor(path: Path) -> None:
     """Every up-and-over corner sits at or above the floor radius.
 
     The builder anchors the bundle's innermost-of-turn line at ``CURVE_RADIUS``
-    from the declared fan, so no inside-of-turn arc falls below it.  The
-    hand-rolled route anchored its corners on the raw port centre instead, so an
-    inside-of-turn line dipped below the floor; this catches that.
+    from the declared fan, so no inside-of-turn arc falls below it.  Anchoring
+    corners on the raw port centre rather than the declared fan lets an
+    inside-of-turn line dip below the floor; this catches that.
     """
     graph, _offsets, routes = _route(path)
     over = _over_routes(graph, routes)


### PR DESCRIPTION
## Summary
- Build `_route_perp_exit_over` from a centreline plus the bundle builder instead of hand-assembling per-line `points` and a `curve_radii` list of `concentric_corner_radius_at` calls. The perp-entry trunk drop fans through `route_along`; the side-entry turn-in fans through `build_tapered_bundle` (the vertical legs carry the source-side riser lateral, the final turn-in carries the target's per-line Y).
- The route declares its co-travelling bundle via `bundle_offsets`, so the builder anchors every corner on the bundle's innermost-of-turn line and no inside-of-turn arc falls below the floor radius.
- Routed points are byte-identical. Only the corner radii change, from the reference-anchored form (an inside-of-turn line dipped to 7, below the 10px floor) to the innermost-anchored concentric form (floor 10, fanning to 13) - matching the rest of the #791 family.
- Add `tests/test_perp_exit_over_centreline.py` (concentric/unflipped, floor-anchored radii, offset-baked) across the five TOP/BOTTOM exit fixtures. The floor test fails on `main`.
- Drop the now-unused `concentric_corner_radius_at` import and lower the corner-radius-ratchet site floor by one (one fewer hand-rolled `curve_radii=` site).

Part of #791. Fixes #796.

## Test plan
- [x] pytest passes (including new invariant test); 11520 passed
- [x] ruff check + ruff format clean on whole repo
- [x] mypy clean
- [x] Runtime guard: always-on `assert_render_curve_invariants` green; new floor test fails on `main`, passes here
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/807/)
- [x] Render-preview verdict: 5 changed renders (the `lr_perp_*` exit fixtures), all **neutral** - routed points byte-identical, corner radii widen to the innermost-anchored concentric form; no flips, pinches, or topology changes

Generated with Claude Code
