### PR TITLE
refactor(routing): route _route_bypass through route_tapered_anchored (#814)

### DIFF
--- a/src/nf_metro/layout/routing/centrelines.py
+++ b/src/nf_metro/layout/routing/centrelines.py
@@ -178,6 +178,49 @@ def route_tapered(
     return next((r for r in routes if r.line_id == edge.line_id), None)
 
 
+def route_tapered_anchored(
+    member: _TaperedMember,
+    centerline: list[_Vec],
+    *,
+    transition_leg: int,
+    base_radius: float,
+    src_bundle_offsets: Sequence[float],
+    tgt_bundle_offsets: Sequence[float],
+    min_radius: float | None = None,
+    normalize_exempt: bool = True,
+) -> RoutedPath:
+    """Route one tapering *member* anchored on two independent channel fans.
+
+    :func:`route_tapered` derives the corner anchors from the members it routes,
+    so the source-region and target-region corners share one fan.  A bundle
+    whose two ends are *separately* fanned -- the source-region legs by one
+    channel's line count and the target-region legs by another's, the two paired
+    asymmetrically so neither channel's spread pulls the other's per-corner
+    anchor -- cannot describe its anchors that way.  This routes a single member
+    (``(edge, line_id, src_offset, tgt_offset)``) and assembles that paired
+    ``bundle_offsets`` from the two fans: every source-channel offset paired with
+    *member*'s own target offset, and *member*'s own source offset paired with
+    every target-channel offset.  The builder then anchors the source-region
+    corners on the source channel's innermost-of-turn line and the target-region
+    corners on the target channel's, so a tapering loop whose two channels carry
+    different line counts nests correctly at both ends.
+    """
+    _e, _lid, src_off, tgt_off = member
+    bundle = [(s, tgt_off) for s in src_bundle_offsets] + [
+        (src_off, t) for t in tgt_bundle_offsets
+    ]
+    routes = build_tapered_bundle(
+        [member],
+        centerline,
+        transition_leg,
+        base_radius=base_radius,
+        min_radius=min_radius,
+        bundle_offsets=bundle,
+        normalize_exempt=normalize_exempt,
+    )
+    return routes[0]
+
+
 def route_hvh_tapered(
     ctx: _RoutingCtx,
     edge: Edge,

--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -34,6 +34,7 @@ from nf_metro.layout.routing.centrelines import (
     route_hvh_tapered,
     route_straight,
     route_tapered,
+    route_tapered_anchored,
 )
 from nf_metro.layout.routing.common import (
     Direction,
@@ -1075,19 +1076,15 @@ def _route_bypass(
 
     src_anchor = channel_fan(sigma1, g1_j, g1_n, n1x)
     tgt_anchor = channel_fan(sigma2, g2_j, g2_n, n3x)
-    # Pair each gap's fan with THIS line's offset in the other gap (not 0): the
-    # source corners read only the source spread and the target corners only the
-    # target spread, so neither gap's fan pulls the other's per-corner anchor.
-    bundle = [(s, sigma2) for s in src_anchor] + [(sigma1, t) for t in tgt_anchor]
-    routes = build_tapered_bundle(
-        [(edge, edge.line_id, sigma1, sigma2)],
+    return route_tapered_anchored(
+        (edge, edge.line_id, sigma1, sigma2),
         centerline,
         transition_leg=3,
         base_radius=ctx.curve_radius,
-        bundle_offsets=bundle,
+        src_bundle_offsets=src_anchor,
+        tgt_bundle_offsets=tgt_anchor,
         normalize_exempt=False,
     )
-    return routes[0]
 
 
 def _route_l_shape(

--- a/tests/test_bypass_centreline.py
+++ b/tests/test_bypass_centreline.py
@@ -22,12 +22,15 @@ import pytest
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.bundle import build_tapered_bundle
+from nf_metro.layout.routing.centrelines import route_tapered_anchored
 from nf_metro.layout.routing.invariants import (
     assert_render_curve_invariants,
     check_bundle_order_preserved,
     check_concentric_bundle_corners,
 )
 from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import Edge
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES = REPO_ROOT / "examples"
@@ -111,3 +114,52 @@ def test_single_line_bypass_descent_turns_tight() -> None:
     # curve_radii[0:2] are the two source-side (gap1 descent) corners.
     assert qc.curve_radii[0] == pytest.approx(CURVE_RADIUS, abs=0.01)
     assert qc.curve_radii[1] == pytest.approx(CURVE_RADIUS, abs=0.01)
+
+
+def test_route_tapered_anchored_pairs_the_two_channel_fans() -> None:
+    """The anchored helper reproduces the bypass's hand-paired ``bundle_offsets``.
+
+    ``_route_bypass`` describes its U as a centreline plus two *independent*
+    channel fans (the source gap's and the target gap's), paired so each gap's
+    spread anchors only its own corners.  ``route_tapered_anchored`` assembles
+    that pairing internally; building the same single member through
+    ``build_tapered_bundle`` with the pairing done by hand must yield the
+    identical route.  Asymmetric fan sizes (a two-line source gap, a three-line
+    target gap) exercise the tapering case the helper exists for.
+    """
+    edge = Edge(source="a", target="b", line_id="x")
+    centerline = [
+        (0.0, 0.0),
+        (10.0, 0.0),
+        (10.0, -30.0),
+        (40.0, -30.0),
+        (40.0, -60.0),
+        (60.0, -60.0),
+    ]
+    src_off, tgt_off = 4.0, -3.0
+    src_fan = [4.0, 12.0]
+    tgt_fan = [-3.0, 5.0, 13.0]
+    member = (edge, edge.line_id, src_off, tgt_off)
+
+    got = route_tapered_anchored(
+        member,
+        centerline,
+        transition_leg=3,
+        base_radius=CURVE_RADIUS,
+        src_bundle_offsets=src_fan,
+        tgt_bundle_offsets=tgt_fan,
+        normalize_exempt=False,
+    )
+
+    manual = [(s, tgt_off) for s in src_fan] + [(src_off, t) for t in tgt_fan]
+    expected = build_tapered_bundle(
+        [member],
+        centerline,
+        transition_leg=3,
+        base_radius=CURVE_RADIUS,
+        bundle_offsets=manual,
+        normalize_exempt=False,
+    )[0]
+
+    assert got.points == expected.points
+    assert got.curve_radii == expected.curve_radii


### PR DESCRIPTION
## Summary

`_route_bypass` was the one inter-section handler that reached past the `centrelines.py` abstraction layer and called `build_tapered_bundle` directly. It did so because its corner anchors come from two *independent* channel fans (the source gap's and the target gap's), paired asymmetrically so neither gap's spread pulls the other's per-corner anchor - a shape `route_tapered` cannot express, since it derives anchors from the members it routes.

This adds a `route_tapered_anchored` helper to `centrelines.py` that routes a single tapering member against two independent channel fans, assembling the paired `bundle_offsets` internally. `_route_bypass` now describes only its geometry plus the two gap fans and calls the helper, so the builder's internal input format no longer leaks into the handler.

- New `route_tapered_anchored(member, centerline, *, transition_leg, base_radius, src_bundle_offsets, tgt_bundle_offsets, ...)` in `src/nf_metro/layout/routing/centrelines.py`.
- `_route_bypass` (`inter_section_handlers.py`) routes through it; the inline `bundle_offsets` assembly and direct `build_tapered_bundle` call are removed.
- Contract test in `tests/test_bypass_centreline.py` pinning that the helper reproduces the hand-paired `bundle_offsets` for an asymmetric (2-line source gap, 3-line target gap) tapering case.

No change to bypass geometry or the per-gap offset arithmetic (the issue's non-goal): bypass route points and `curve_radii` are byte-identical across all bypass fixtures (funcprofiler_upstream, bypass_gap2_rightward_overflow, upward_bypass, fan_in_merge, bypass_fan_in_outer_slot, longread_variant_calling, differentialabundance).

Fixes #814

## Test plan
- [x] pytest passes (11649 passed; new contract test added, fails on `main` where the helper is absent)
- [x] ruff check + ruff format clean on whole repo
- [x] mypy clean
- [x] routing gate-coverage ratchet passes (no gate arms added; helper is branchless)
- [ ] Visual review of render preview
- [ ] Render-preview verdict: expected "No visual changes" (geometry byte-identical)

Generated with Claude Code