### PR TITLE
test(layout): lock TB trunk pass-through against station-as-elbow (#255)

### DIFF
--- a/examples/topologies/tb_passthrough_trunk.mmd
+++ b/examples/topologies/tb_passthrough_trunk.mmd
@@ -1,0 +1,29 @@
+%%metro title: TB pass-through trunk
+%%metro style: dark
+%%metro line: rna | RNA-seq | #1f9e89
+%%metro line: affy | Affymetrix | #e6550d
+%%metro line: mq | MaxQuant | #0570b0
+
+%%metro file: bundle_zip | ZIP | Bundle
+
+graph LR
+    subgraph analysis [Analysis]
+        align[Align]
+        call[Call]
+        align -->|rna,affy,mq| call
+    end
+
+    subgraph reporting [Reporting]
+        %%metro direction: TB
+        %%metro entry: left | rna, affy, mq
+        collect[Collect]
+        annotate[Annotate]
+        package[Package]
+        bundle_zip[ ]
+
+        collect -->|rna,affy,mq| annotate
+        annotate -->|rna,affy,mq| package
+        package -->|rna,affy,mq| bundle_zip
+    end
+
+    call -->|rna,affy,mq| collect

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -502,6 +502,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "built via `build_concentric_bundle` (#707).",
     ),
     (
+        "tb_passthrough_trunk",
+        TOPOLOGIES_DIR,
+        "A three-line bundle running straight down a linear chain of stations "
+        "in a `%%metro direction: TB` section. The trunk passes through each "
+        "station as a clean vertical column: every line holds one offset, so "
+        "no station reads as an elbow.",
+    ),
+    (
         "around_below_ep_col_gt0",
         TOPOLOGIES_DIR,
         "A two-line bundle looping around below the canvas into a non-zero-"

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -698,6 +698,57 @@ def test_straight_through_line_keeps_constant_offset(fixture, line_id):
 
 
 # ---------------------------------------------------------------------------
+# TB trunk passes through stations as a straight vertical column
+# ---------------------------------------------------------------------------
+
+# (fixture, section_id, line_id) where the named line runs straight down a
+# single base-X column inside a TB section.  Every station it touches must
+# carry one per-line offset; any variation paints the line bending in to
+# touch the station marker and back out, so the station reads as an elbow on
+# the trunk.  Vertical analogue of test_straight_through_line_keeps_constant
+# _offset above.
+_TB_STRAIGHT_THROUGH_LINES = [
+    ("topologies/tb_passthrough_trunk.mmd", "reporting", "rna"),
+    ("topologies/tb_passthrough_trunk.mmd", "reporting", "affy"),
+    ("topologies/tb_passthrough_trunk.mmd", "reporting", "mq"),
+]
+
+
+@pytest.mark.parametrize("fixture,section_id,line_id", _TB_STRAIGHT_THROUGH_LINES)
+def test_tb_straight_through_line_keeps_constant_offset(fixture, section_id, line_id):
+    """A line confined to one base-X column in a TB section carries one offset.
+
+    In a top-to-bottom section the trunk runs vertically, so a per-station
+    offset variation paints the line bending in to touch the station marker
+    and back out: the station reads as an elbow on the trunk.  The bundle
+    must pass through cleanly as a straight column.
+    """
+    graph = _layout(fixture)
+    assert graph.sections[section_id].direction == "TB", (
+        f"{fixture}: section {section_id} is not TB; test precondition fails"
+    )
+    offsets = compute_station_offsets(graph)
+    stations = [
+        sid
+        for sid in graph.stations
+        if graph.stations[sid].section_id == section_id
+        and not graph.stations[sid].is_port
+        and line_id in graph.station_lines(sid)
+    ]
+    xs = [graph.stations[sid].x for sid in stations]
+    assert max(xs) - min(xs) <= _Y_TOL, (
+        f"{fixture}: {line_id} spans columns {min(xs)}..{max(xs)}; "
+        "test precondition (single column) does not hold"
+    )
+    offs = {sid: round(offsets.get((sid, line_id), 0.0), 1) for sid in stations}
+    distinct = sorted(set(offs.values()))
+    assert len(distinct) == 1, (
+        f"{fixture}: line {line_id} runs straight down one column but its "
+        f"offset varies {distinct}; per-station offsets {offs}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Subset-carrying section anchors its bundle on its own trunk
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Issue #255 (a station-as-elbow pinch recurring in `direction: TB` sections) does **not** reproduce on current `main`. The TB routing path was reworked substantially after the April 2026 report (notably #810 rebuilding TB section corners via the shared bundle builder, and #816 subset-section trunk anchoring), and the offset-consistency gap the issue pointed at no longer manifests.

Verified by reconstructing the issue's exact topology two ways (the `differentialabundance` reporting section forced to TB, and a minimal 4-line TB pass-through): in both, each line holds a constant X across the section and internal drops stay vertical, so no station reads as an elbow.

This PR locks that behaviour so it cannot silently regress:

- **`tests/test_layout_invariants.py`**: `test_tb_straight_through_line_keeps_constant_offset`, the vertical analogue of the existing `test_straight_through_line_keeps_constant_offset`. A line confined to one base-X column in a TB section must carry a single per-station offset; any variation paints the line bending in to touch a station marker and back out.
- **`examples/topologies/tb_passthrough_trunk.mmd`**: a focused fixture, a three-line bundle running straight down a linear chain of stations in a TB section. Auto-collected by `test_topology_validation.py`.
- **`scripts/build_gallery.py`**: a gallery entry so CI's render-diff tracks the fixture.

The assertion was confirmed meaningful by injecting a divergent per-station offset and observing it trip.

Fixes #255

## Test plan
- [x] pytest passes (full suite: 12759 passed; new invariant test green and verified to fail on a simulated offset jog)
- [x] ruff format --check + ruff check + mypy clean on whole repo
- [x] Gate-coverage ratchet green (new fixture exercises already-covered paths)
- [ ] Visual review of render preview
- No runtime validator added: distinguishing a clean pass-through column from a legitimate fan-out diagonal at render time risks false positives; the parametrised invariant test plus the gallery render-diff cover silent regressions.

Generated with Claude Code