### PR TITLE
fix(routing): make route_edges placement-pure (#678)

### DIFF
--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1190,17 +1190,10 @@ def _guard_no_line_crosses_file_icon(
     if routes is None:
         from nf_metro.layout.routing import route_edges
 
-        # route_edges' diagonal-centring pass mutates Station.x in place;
-        # a guard must stay observational, so snapshot and restore X
-        # around the call (mirrors _run_pass_c_guards).
-        saved_x = {sid: s.x for sid, s in graph.stations.items()}
         try:
             routes = route_edges(graph, station_offsets=offsets)
         except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
             return
-        finally:
-            for sid, x in saved_x.items():
-                graph.stations[sid].x = x
 
     icon_boxes = _icon_obstacles_by_station(graph, THEMES["nfcore"], offsets)
     if not icon_boxes:
@@ -1274,10 +1267,10 @@ def iter_line_label_strikes(
 
     with _restoring_layout_geometry(graph):
         if routes is None:
-            from nf_metro.layout.routing import route_edges
+            from nf_metro.layout.routing import route_edges_centred
 
             try:
-                routes = route_edges(graph, station_offsets=offsets)
+                routes = route_edges_centred(graph, station_offsets=offsets)
             except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
                 return
         placements = place_labels(
@@ -1433,10 +1426,10 @@ def _guard_no_wrapped_label_trunk_strike(
 
     with _restoring_layout_geometry(graph):
         if routes is None:
-            from nf_metro.layout.routing import route_edges
+            from nf_metro.layout.routing import route_edges_centred
 
             try:
-                routes = route_edges(graph, station_offsets=offsets)
+                routes = route_edges_centred(graph, station_offsets=offsets)
             except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
                 return
         placements = place_labels(
@@ -3342,39 +3335,6 @@ def _bisection_should_run(guard_name: str, phase: str) -> bool:
         return True
 
 
-def _guard_routing_preserves_non_x(
-    graph: MetroGraph,
-    phase: str,
-    saved_xy: dict[str, tuple[float, float]],
-    saved_bbox: dict[str, tuple[float, float, float, float]],
-) -> None:
-    """Raise if a guard's ``route_edges`` call mutated anything but ``Station.x``.
-
-    ``_run_pass_c_guards`` snapshots and restores only ``Station.x`` because
-    that is the sole graph state ``route_edges`` mutates.  If a future routing
-    change starts moving ``Station.y`` or a section bbox, the X-only restore
-    would leak that mutation into later Pass C stages, silently making
-    ``validate=True`` non-idempotent again (#518).  This fails loudly instead.
-    """
-    for sid, station in graph.stations.items():
-        if abs(station.y - saved_xy[sid][1]) > 1e-6:
-            raise PhaseInvariantError(
-                f"{phase}: guard's route_edges call moved station {sid!r} in Y "
-                f"({saved_xy[sid][1]:.3f} -> {station.y:.3f}); the guard snapshot "
-                "restores X only. Extend the snapshot/restore in "
-                "_run_pass_c_guards to keep the validate flag observational."
-            )
-    for sid, sec in graph.sections.items():
-        now = (sec.bbox_x, sec.bbox_y, sec.bbox_w, sec.bbox_h)
-        if now != saved_bbox[sid]:
-            raise PhaseInvariantError(
-                f"{phase}: guard's route_edges call mutated section {sid!r} bbox "
-                f"({saved_bbox[sid]} -> {now}); the guard snapshot restores "
-                "station X only. Extend the snapshot/restore in "
-                "_run_pass_c_guards to keep the validate flag observational."
-            )
-
-
 def _run_pass_c_guards(
     graph: MetroGraph,
     phase: str,
@@ -3419,26 +3379,13 @@ def _run_pass_c_guards(
     if offsets is None:
         offsets = compute_station_offsets(graph)
     if routes is None:
-        # route_edges' diagonal-centring pass mutates Station.x in place.
-        # That is intended on the final render path (validate=False never
-        # calls this), but a guard must be observational: running it
-        # mid-pipeline would change the input to later Pass C stages.
-        # Snapshot and restore station X around the call.  The snapshot
-        # covers only X because route_edges touches no other graph state;
-        # _guard_routing_preserves_non_x verifies that contract still holds.
-        saved_xy = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
-        saved_bbox = {
-            sid: (sec.bbox_x, sec.bbox_y, sec.bbox_w, sec.bbox_h)
-            for sid, sec in graph.sections.items()
-        }
+        # route_edges is placement-pure: routing here to inspect the routes
+        # leaves graph.stations untouched, so this guard stays observational
+        # even running mid-pipeline between Pass C stages.
         try:
             routes = route_edges(graph, station_offsets=offsets)
         except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
             routes = None
-        finally:
-            _guard_routing_preserves_non_x(graph, phase, saved_xy, saved_bbox)
-            for sid, (x, _) in saved_xy.items():
-                graph.stations[sid].x = x
 
     _guard_coordinates_finite(graph, phase)
     _guard_section_bboxes_positive(graph, phase)

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -730,16 +730,10 @@ def _line_crossed_file_icon_sinks(graph: MetroGraph) -> set[str]:
     if not leaf_sinks:
         return set()
 
-    # route_edges' diagonal-centring pass mutates Station.x in place; this is
-    # a read-only probe, so snapshot and restore X around the call.
-    saved_x = {sid: s.x for sid, s in graph.stations.items()}
     try:
         routes = route_edges(graph, station_offsets=offsets)
     except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
         return set()
-    finally:
-        for sid, x in saved_x.items():
-            graph.stations[sid].x = x
 
     crossed: set[str] = set()
     for r in routes:

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -43,12 +43,12 @@ def _probe_label_placements(
     labels overlap their neighbours in a way the search should react to.
     """
     from nf_metro.layout.labels import place_labels
-    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.routing import compute_station_offsets, route_edges_centred
 
     with _restoring_layout_geometry(graph):
         try:
             offsets = compute_station_offsets(graph)
-            routes = route_edges(graph, station_offsets=offsets)
+            routes = route_edges_centred(graph, station_offsets=offsets)
             placements = place_labels(
                 graph,
                 station_offsets=offsets,

--- a/src/nf_metro/layout/routing/__init__.py
+++ b/src/nf_metro/layout/routing/__init__.py
@@ -1,17 +1,19 @@
 """Edge routing subpackage for metro map layout.
 
 Public API:
-- route_edges: Main edge routing dispatcher
+- route_edges: Main edge routing dispatcher (placement-pure)
+- route_edges_centred: route_edges + applied bubble-centring marker moves
 - RoutedPath: Routed path dataclass
 - compute_station_offsets: Per-station Y offset computation
 """
 
 from nf_metro.layout.routing.common import RoutedPath
-from nf_metro.layout.routing.core import route_edges
+from nf_metro.layout.routing.core import route_edges, route_edges_centred
 from nf_metro.layout.routing.offsets import compute_station_offsets
 
 __all__ = [
     "RoutedPath",
     "compute_station_offsets",
     "route_edges",
+    "route_edges_centred",
 ]

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -133,11 +133,19 @@ def route_edges(
     diagonal_run: float = DIAGONAL_RUN,
     curve_radius: float = CURVE_RADIUS,
     station_offsets: dict[tuple[str, str], float] | None = None,
+    station_moves: dict[str, float] | None = None,
 ) -> list[RoutedPath]:
     """Route all edges with smooth direction changes.
 
     Detects cross-row edges (large Y gap relative to X gap) and routes
     them through a vertical connector at the fold edge.
+
+    Routing is pure with respect to placement: it never moves stations.  The
+    bubble-centring pass instead emits per-station X-targets as *move
+    requests*; when ``station_moves`` is supplied it is populated with
+    ``{station_id: x}`` for the render path to apply (settling the markers on
+    their centred flats).  Callers that omit it get a route they can inspect
+    without perturbing ``graph.stations``.
     """
     if graph.line_spread is LineSpread.RAILS:
         from nf_metro.layout.routing.rail import route_rail_edges
@@ -195,7 +203,9 @@ def route_edges(
         if result is not None:
             routes.append(result)
 
-    _center_bubble_stations(routes, graph)
+    moves = _center_bubble_stations(routes, graph)
+    if station_moves is not None:
+        station_moves.update(moves)
     _spread_diagonal_bundles(routes, ctx)
     _normalize_gap_channels(routes, ctx)
     _normalize_bypass_trunks(routes, ctx)
@@ -210,4 +220,36 @@ def route_edges(
     _join_fanout_upstream_tails(routes, ctx)
     _clear_bypass_v_label_strikes(routes, ctx)
 
+    return routes
+
+
+def route_edges_centred(
+    graph: MetroGraph,
+    diagonal_run: float = DIAGONAL_RUN,
+    curve_radius: float = CURVE_RADIUS,
+    station_offsets: dict[tuple[str, str], float] | None = None,
+) -> list[RoutedPath]:
+    """Route, then settle the bubble-centred markers onto ``graph.stations``.
+
+    The drawn variant of :func:`route_edges`: it applies the centring move
+    requests so any reader of marker / label geometry after routing (the SVG
+    render, the label-overlap spacing search, the render-output strike guards)
+    sees the markers on their centred flats.  Unlike :func:`route_edges` this
+    is *not* placement-pure -- it is the single named home for that mutation.
+
+    Inside a ``_restoring_layout_geometry`` scope the move is undone on exit,
+    so a probe can inspect the drawn geometry without perturbing the settled
+    layout.  Bisection / placement guards that must read the *un-centred*
+    placement geometry call :func:`route_edges` directly instead.
+    """
+    moves: dict[str, float] = {}
+    routes = route_edges(
+        graph,
+        diagonal_run=diagonal_run,
+        curve_radius=curve_radius,
+        station_offsets=station_offsets,
+        station_moves=moves,
+    )
+    for sid, x in moves.items():
+        graph.stations[sid].x = x
     return routes

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -128,29 +128,23 @@ from nf_metro.parser.model import (
 )
 
 
-def route_edges(
+def _route_edges(
     graph: MetroGraph,
-    diagonal_run: float = DIAGONAL_RUN,
-    curve_radius: float = CURVE_RADIUS,
-    station_offsets: dict[tuple[str, str], float] | None = None,
-    station_moves: dict[str, float] | None = None,
-) -> list[RoutedPath]:
-    """Route all edges with smooth direction changes.
+    diagonal_run: float,
+    curve_radius: float,
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> tuple[list[RoutedPath], dict[str, float]]:
+    """Route all edges, returning the paths and the bubble-centring moves.
 
-    Detects cross-row edges (large Y gap relative to X gap) and routes
-    them through a vertical connector at the fold edge.
-
-    Routing is pure with respect to placement: it never moves stations.  The
-    bubble-centring pass instead emits per-station X-targets as *move
-    requests*; when ``station_moves`` is supplied it is populated with
-    ``{station_id: x}`` for the render path to apply (settling the markers on
-    their centred flats).  Callers that omit it get a route they can inspect
-    without perturbing ``graph.stations``.
+    Shared body behind :func:`route_edges` (pure) and
+    :func:`route_edges_centred` (applies the moves).  The ``moves`` are the
+    per-station X-targets the bubble-centring pass produced as ``{station_id:
+    x}`` requests; the route points are adjusted in place either way.
     """
     if graph.line_spread is LineSpread.RAILS:
         from nf_metro.layout.routing.rail import route_rail_edges
 
-        return route_rail_edges(graph)
+        return route_rail_edges(graph), {}
 
     # Per-section rail mode: route each rail section's internal edges with the
     # dedicated rail router (straight rails, no bundling) and let the normal
@@ -204,8 +198,6 @@ def route_edges(
             routes.append(result)
 
     moves = _center_bubble_stations(routes, graph)
-    if station_moves is not None:
-        station_moves.update(moves)
     _spread_diagonal_bundles(routes, ctx)
     _normalize_gap_channels(routes, ctx)
     _normalize_bypass_trunks(routes, ctx)
@@ -220,6 +212,27 @@ def route_edges(
     _join_fanout_upstream_tails(routes, ctx)
     _clear_bypass_v_label_strikes(routes, ctx)
 
+    return routes, moves
+
+
+def route_edges(
+    graph: MetroGraph,
+    diagonal_run: float = DIAGONAL_RUN,
+    curve_radius: float = CURVE_RADIUS,
+    station_offsets: dict[tuple[str, str], float] | None = None,
+) -> list[RoutedPath]:
+    """Route all edges with smooth direction changes.
+
+    Detects cross-row edges (large Y gap relative to X gap) and routes
+    them through a vertical connector at the fold edge.
+
+    Routing is pure with respect to placement: it never moves stations.  The
+    bubble-centring pass emits its per-station X-targets as move requests,
+    which this entry point discards; :func:`route_edges_centred` is the variant
+    that applies them.  Callers get a route they can inspect without perturbing
+    ``graph.stations``.
+    """
+    routes, _moves = _route_edges(graph, diagonal_run, curve_radius, station_offsets)
     return routes
 
 
@@ -242,14 +255,7 @@ def route_edges_centred(
     layout.  Bisection / placement guards that must read the *un-centred*
     placement geometry call :func:`route_edges` directly instead.
     """
-    moves: dict[str, float] = {}
-    routes = route_edges(
-        graph,
-        diagonal_run=diagonal_run,
-        curve_radius=curve_radius,
-        station_offsets=station_offsets,
-        station_moves=moves,
-    )
+    routes, moves = _route_edges(graph, diagonal_run, curve_radius, station_offsets)
     for sid, x in moves.items():
         graph.stations[sid].x = x
     return routes

--- a/src/nf_metro/layout/routing/postprocess.py
+++ b/src/nf_metro/layout/routing/postprocess.py
@@ -471,12 +471,17 @@ def _apply_station_moves(
     graph: MetroGraph,
     candidates: dict[str, _StationMoveCandidate],
     original_x: dict[str, float],
+    moves: dict[str, float],
 ) -> None:
-    """Second pass: apply station-move candidates with companion consensus.
+    """Second pass: record station-move requests with companion consensus.
 
     Only moves a station when all column companions (visible stations at
     the same original X in the same section) are also candidates.  This
     preserves column alignment when only some stations want to centre.
+
+    The X-target is recorded in ``moves`` (a request the render path applies);
+    the routes bounding the station are adjusted here, since those are routing
+    output.  ``graph.stations`` is left untouched so routing is placement-pure.
     """
     for sid, (
         new_x,
@@ -509,7 +514,7 @@ def _apply_station_moves(
                 if any(c not in candidates for c in companions):
                     continue
 
-        station.x = new_x
+        moves[sid] = new_x
         for r in in_routes:
             r.points[-1] = (new_x, r.points[-1][1])
         for r in flat_in:
@@ -524,13 +529,23 @@ def _align_uncentered_siblings(
     routes: list[RoutedPath],
     graph: MetroGraph,
     original_x: dict[str, float],
+    moves: dict[str, float],
 ) -> None:
     """Post-pass: drag unmoved stations to match their centered siblings.
 
     Groups stations by (section, original_x).  Only operates when moved
     stations disagree (spread > 1px): finds the majority X position and
     realigns outliers and unmoved stations to match.
+
+    Reads each station's settled X from ``moves`` (the requests
+    :func:`_apply_station_moves` recorded), falling back to ``original_x``;
+    its own realignments are recorded back into ``moves`` rather than written
+    to ``graph.stations``, so routing stays placement-pure.
     """
+
+    def settled_x(sid: str) -> float:
+        return moves.get(sid, original_x[sid])
+
     col_groups: dict[tuple[str | None, float], list[str]] = defaultdict(list)
     for sid, s in graph.stations.items():
         if s.is_port or s.is_hidden:
@@ -552,17 +567,17 @@ def _align_uncentered_siblings(
         moved = [
             sid
             for sid in group
-            if abs(graph.stations[sid].x - original_x[sid]) > STATION_MOVE_TOLERANCE
+            if abs(settled_x(sid) - original_x[sid]) > STATION_MOVE_TOLERANCE
         ]
         unmoved = [
             sid
             for sid in group
-            if abs(graph.stations[sid].x - original_x[sid]) <= STATION_MOVE_TOLERANCE
+            if abs(settled_x(sid) - original_x[sid]) <= STATION_MOVE_TOLERANCE
         ]
         if not moved:
             continue
 
-        moved_xs = [graph.stations[sid].x for sid in moved]
+        moved_xs = [settled_x(sid) for sid in moved]
         if max(moved_xs) - min(moved_xs) <= 1.0:
             continue
         # Moved stations disagree on target X.  Find the majority
@@ -582,8 +597,8 @@ def _align_uncentered_siblings(
         target_x = majority_x
 
         for sid in unmoved:
-            old_x = graph.stations[sid].x
-            graph.stations[sid].x = target_x
+            old_x = settled_x(sid)
+            moves[sid] = target_x
             for rp in routes_by_src.get(sid, []):
                 if abs(rp.points[0][0] - old_x) < STATION_MOVE_TOLERANCE:
                     rp.points[0] = (target_x, rp.points[0][1])
@@ -592,7 +607,9 @@ def _align_uncentered_siblings(
                     rp.points[-1] = (target_x, rp.points[-1][1])
 
 
-def _center_bubble_stations(routes: list[RoutedPath], graph: MetroGraph) -> None:
+def _center_bubble_stations(
+    routes: list[RoutedPath], graph: MetroGraph
+) -> dict[str, float]:
     """Shift diagonals so bubble stations sit centred on their flat segments.
 
     A "bubble station" branches off the trunk at a different Y, with a
@@ -606,15 +623,21 @@ def _center_bubble_stations(routes: list[RoutedPath], graph: MetroGraph) -> None
     1. **Candidate collection** - identifies stations needing centering;
        shifts simple diagonals directly, collects complex cases as
        station-move candidates.
-    2. **Station moves** - applies moves only when all column companions
+    2. **Station moves** - records moves only when all column companions
        also want to move (preserving column alignment).
     3. **Sibling alignment** - drags remaining unmoved stations to match
        the majority of their centered column group.
+
+    Route points are adjusted in place (routing output); the per-station
+    X-targets are returned as ``{station_id: x}`` move requests for the
+    render path to apply, so ``route_edges`` leaves ``graph.stations`` intact.
     """
     ctx = _build_bubble_ctx(routes, graph)
     candidates = _collect_centering_candidates(graph, ctx)
-    _apply_station_moves(graph, candidates, ctx.original_x)
-    _align_uncentered_siblings(routes, graph, ctx.original_x)
+    moves: dict[str, float] = {}
+    _apply_station_moves(graph, candidates, ctx.original_x, moves)
+    _align_uncentered_siblings(routes, graph, ctx.original_x, moves)
+    return moves
 
 
 def _clear_bypass_v_label_strikes(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -25,7 +25,11 @@ from nf_metro.layout.labels import (
     font_scale_context,
     place_labels,
 )
-from nf_metro.layout.routing import RoutedPath, compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    RoutedPath,
+    compute_station_offsets,
+    route_edges_centred,
+)
 from nf_metro.layout.routing.corners import curve_tangents, resolve_curve_radii
 from nf_metro.layout.routing.invariants import assert_render_curve_invariants
 from nf_metro.manifest import node_data_attrs
@@ -456,7 +460,7 @@ def _render_svg_scaled(
     )
 
     station_offsets = compute_station_offsets(graph)
-    routes = route_edges(graph, station_offsets=station_offsets)
+    routes = route_edges_centred(graph, station_offsets=station_offsets)
     assert_render_curve_invariants(graph, routes, station_offsets)
 
     # Compute labels early so section bbox expansions are applied

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -30,18 +30,26 @@ class TestAlignUncenteredSiblings:
         station_specs: list[tuple[str, float, float]],
         original_xs: dict[str, float],
         edge_pairs: list[tuple[str, str]] | None = None,
-    ) -> tuple[MetroGraph, list[RoutedPath], dict[str, float]]:
-        """Build a minimal graph, routes, and original_x mapping.
+    ) -> tuple[MetroGraph, list[RoutedPath], dict[str, float], dict[str, float]]:
+        """Build a minimal graph, routes, original_x and settled-move mapping.
 
-        station_specs: list of (id, x, y) tuples.
+        station_specs: list of (id, x, y) tuples, where ``x`` is the station's
+        *settled* X (the move :func:`_apply_station_moves` would have recorded).
         original_xs: mapping of station id -> original x.
         edge_pairs: optional list of (source, target) pairs for routes.
+
+        Routing is placement-pure, so the settled positions are carried in a
+        ``moves`` dict rather than written to ``graph.stations``; the returned
+        dict seeds that input the way an upstream :func:`_apply_station_moves`
+        would.
         """
         graph = MetroGraph()
+        moves: dict[str, float] = {}
         for sid, x, y in station_specs:
             graph.stations[sid] = Station(
                 id=sid, label=sid.upper(), x=x, y=y, section_id="sec1"
             )
+            moves[sid] = x
 
         routes: list[RoutedPath] = []
         if edge_pairs:
@@ -56,7 +64,7 @@ class TestAlignUncenteredSiblings:
                 )
                 routes.append(rp)
 
-        return graph, routes, original_xs
+        return graph, routes, original_xs, moves
 
     def test_majority_path_aligns_outlier(self):
         """When >50% of moved stations agree on X, outliers are realigned.
@@ -72,11 +80,11 @@ class TestAlignUncenteredSiblings:
         ]
         original_xs = {"a": 100.0, "b": 100.0, "c": 100.0, "d": 100.0}
 
-        graph, routes, ox = self._make_graph_and_routes(specs, original_xs)
-        _align_uncentered_siblings(routes, graph, ox)
+        graph, routes, ox, moves = self._make_graph_and_routes(specs, original_xs)
+        _align_uncentered_siblings(routes, graph, ox, moves)
 
         # Outlier d should be dragged to 120.0 (majority X)
-        assert abs(graph.stations["d"].x - 120.0) < 0.5
+        assert abs(moves["d"] - 120.0) < 0.5
 
     def test_tie_skips_alignment(self):
         """When no clear majority (<=50%), alignment is skipped entirely.
@@ -92,15 +100,13 @@ class TestAlignUncenteredSiblings:
         ]
         original_xs = {"a": 100.0, "b": 100.0, "c": 100.0, "d": 100.0}
 
-        graph, routes, ox = self._make_graph_and_routes(specs, original_xs)
+        graph, routes, ox, moves = self._make_graph_and_routes(specs, original_xs)
 
-        # Record positions before
-        xs_before = {sid: s.x for sid, s in graph.stations.items()}
-        _align_uncentered_siblings(routes, graph, ox)
+        moves_before = dict(moves)
+        _align_uncentered_siblings(routes, graph, ox, moves)
 
-        # No majority -> no changes
-        for sid in ("a", "b", "c", "d"):
-            assert graph.stations[sid].x == xs_before[sid]
+        # No majority -> no settled positions change
+        assert moves == moves_before
 
     def test_majority_updates_route_endpoints(self):
         """Route endpoints should be updated when stations are dragged.
@@ -124,12 +130,14 @@ class TestAlignUncenteredSiblings:
         }
         edge_pairs = [("c", "d"), ("d", "e")]
 
-        graph, routes, ox = self._make_graph_and_routes(specs, original_xs, edge_pairs)
-        _align_uncentered_siblings(routes, graph, ox)
+        graph, routes, ox, moves = self._make_graph_and_routes(
+            specs, original_xs, edge_pairs
+        )
+        _align_uncentered_siblings(routes, graph, ox, moves)
 
         # d and e should be dragged to 120.0
-        assert abs(graph.stations["d"].x - 120.0) < 0.5
-        assert abs(graph.stations["e"].x - 120.0) < 0.5
+        assert abs(moves["d"] - 120.0) < 0.5
+        assert abs(moves["e"] - 120.0) < 0.5
 
         # Route c->d: target endpoint should be updated
         cd_route = [r for r in routes if r.edge.target == "d"][0]

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -63,7 +63,11 @@ from nf_metro.layout.phases.off_track import (
     _reanchor_off_track_to_consumer,
     _section_distinct_trunk_ys,
 )
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    compute_station_offsets,
+    route_edges,
+    route_edges_centred,
+)
 from nf_metro.layout.routing.common import resolve_section
 from nf_metro.layout.routing.invariants import (
     check_bundle_order_preserved,
@@ -2015,15 +2019,15 @@ _LABEL_STRIKE_FIXTURES = _params_with_xfails(ALL_FIXTURES, _LABEL_STRIKE_DIAGONA
 def _label_glyph_strikes(fixture: str) -> list[tuple[str, str]]:
     """Return ``(station_id, line_id)`` pairs where a foreign line strikes a label.
 
-    Mirrors the renderer: ``route_edges`` mutates Station.x via diagonal
-    centring and the renderer places labels on that mutated geometry, so the
-    label glyph-ink boxes are built without restoring X.  A pair is reported
-    when a segment of a line the station does not carry (and which is not an
-    endpoint of the segment's edge) crosses the label's glyph-ink box.
+    Mirrors the renderer: ``route_edges_centred`` settles the diagonal-centred
+    markers onto the graph and the renderer places labels on that geometry, so
+    the label glyph-ink boxes are built on the centred markers.  A pair is
+    reported when a segment of a line the station does not carry (and which is
+    not an endpoint of the segment's edge) crosses the label's glyph-ink box.
     """
     graph = _layout(fixture)
     offsets = compute_station_offsets(graph)
-    routes = route_edges(graph, station_offsets=offsets)
+    routes = route_edges_centred(graph, station_offsets=offsets)
     theme = THEMES["nfcore"]
     icon_obstacles = _compute_icon_obstacles(graph, theme, offsets)
     placements = place_labels(

--- a/tests/test_legend_placement.py
+++ b/tests/test_legend_placement.py
@@ -47,7 +47,7 @@ def _place(text: str):
     graph = parse_metro_mermaid(text)
     compute_layout(graph)
     offsets = S.compute_station_offsets(graph)
-    routes = S.route_edges(graph, station_offsets=offsets)
+    routes = S.route_edges_centred(graph, station_offsets=offsets)
     max_x, max_y = S._compute_canvas_bounds(graph, routes, False)
     pos = graph.legend_position
     show_logo = bool(graph.logo_path and Path(graph.logo_path).is_file())

--- a/tests/test_route_edges_placement_pure.py
+++ b/tests/test_route_edges_placement_pure.py
@@ -1,0 +1,86 @@
+"""``route_edges`` is pure with respect to station placement (#678).
+
+Routing consumes placement and produces paths; it must not move stations.
+The bubble-centring post-pass emits its X-targets as *move requests*:
+``route_edges`` adjusts its own route points (its legitimate output) but leaves
+``graph.stations`` untouched.  The render path applies the requests explicitly
+to settle the markers; every other caller (the Pass C bisection guards, the
+label/icon strike guards, introspection tooling) ignores them and gets a route
+it can inspect without snapshotting/restoring ``Station.x`` -- closing the #518
+trap at its source.
+
+Probe: lay out each corpus fixture, then route it and assert no station's
+``(x, y)`` changed.  ``variant_calling`` is the sharpest case: its centring
+splits ``gatk``/``deepvariant`` off their shared column in the routes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conftest import content_corpus
+
+from nf_metro.convert import convert_nextflow_dag
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+CORPUS = content_corpus()
+
+
+@pytest.mark.parametrize("fixture", CORPUS, ids=[fid for fid, _, _ in CORPUS])
+def test_route_edges_does_not_move_stations(fixture):
+    fid, path, is_nextflow = fixture
+    text = path.read_text()
+    if is_nextflow:
+        text = convert_nextflow_dag(text)
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=False)
+
+    before = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+    offsets = compute_station_offsets(graph)
+    route_edges(graph, station_offsets=offsets)
+    after = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+
+    moved = [sid for sid in before if before[sid] != after[sid]]
+    sample = {
+        sid: (
+            tuple(round(v, 2) for v in before[sid]),
+            tuple(round(v, 2) for v in after[sid]),
+        )
+        for sid in moved[:8]
+    }
+    assert not moved, (
+        f"{fid}: route_edges moved {len(moved)} station(s); routing must be "
+        f"placement-pure (emit move requests, not mutate graph.stations). "
+        f"Moved (before -> after): {sample}"
+    )
+
+
+def test_route_edges_splits_variant_calling_column_only_in_routes():
+    """Centring lands in the *routes*, leaving the shared column on the graph.
+
+    ``gatk``/``deepvariant`` share a column after layout.  Routing centres each
+    onto its own diagonals (the move the render path applies), but on the
+    graph the pair must stay on their shared column: the move is a request, not
+    an in-place mutation.
+    """
+    path = Path(__file__).resolve().parent.parent / "examples" / "variant_calling.mmd"
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph, validate=False)
+
+    shared_x = graph.stations["gatk"].x
+    assert graph.stations["deepvariant"].x == pytest.approx(shared_x)
+
+    offsets = compute_station_offsets(graph)
+    route_edges(graph, station_offsets=offsets)
+
+    assert graph.stations["gatk"].x == pytest.approx(shared_x), (
+        "route_edges moved gatk off its column; the centring X must be a move "
+        "request, not an in-place mutation"
+    )
+    assert graph.stations["deepvariant"].x == pytest.approx(shared_x), (
+        "route_edges moved deepvariant off its column; the centring X must be a "
+        "move request, not an in-place mutation"
+    )


### PR DESCRIPTION
## Summary

`route_edges` no longer mutates `Station.x`. The bubble-centring post-pass adjusts its route points (routing output) but emits its per-station X-targets as *move requests*; a new `route_edges_centred` applies them. Callers split by what they need:

- **Draw/render geometry** (SVG render, the label-overlap spacing search, the render-output label/icon strike guards) use `route_edges_centred`, which settles the centred markers onto the graph.
- **Placement geometry** (the Pass C bisection guards) call the pure `route_edges` and read un-centred positions directly.

With routing observably pure, the #518 workaround is deleted at its source:

- the snapshot/restore around `route_edges` in `_run_pass_c_guards` and its `_guard_routing_preserves_non_x` backstop;
- the matching `saved_x` snapshot/restore in `_guard_no_line_crosses_file_icon` and `_line_crossed_file_icon_sinks`.

Internally a private `_route_edges` returns `(routes, moves)`; `route_edges` and `route_edges_centred` are thin wrappers over it, so the public router keeps its original signature with no out-parameter.

Gallery renders are **byte-identical across the full corpus** (147 fixtures).

This is part 1 of #678 (routing-side placement purity). Part 2 (decoupling the post-pass clobber chains via symbolic gap-relative slots) is split out to #845.

Fixes #678

## Test plan

- [x] New `tests/test_route_edges_placement_pure.py`: corpus-parametrised invariant that `route_edges` moves no station; fails on `main` (13 fixtures + the `variant_calling` column-split case), passes here.
- [x] `test_validate_flag_idempotent` (the #518 oracle) still green with the workaround removed.
- [x] Full suite: 12907 passed, 75 skipped, 6 pre-existing xfailed.
- [x] `ruff format --check` + `ruff check` + `mypy` clean on the whole repo.
- [x] Routing gate-coverage ratchet green (no new reconciliation owed).
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/846/) — verdict: no visual changes (byte-identical corpus).

Generated with Claude Code
