### PR TITLE
feat(render): responsive SVG mode — viewBox only, no fixed dimensions (#838)

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -180,6 +180,11 @@ def _resolve_theme(theme: str | None, graph: MetroGraph) -> Theme:
     default=None,
     help="Pipeline title (overrides the %%metro title: directive).",
 )
+@click.option(
+    "--responsive/--no-responsive",
+    default=False,
+    help="Emit viewBox only (no fixed width/height) for CSS-scalable embedding.",
+)
 @layout_cli_options
 def render(
     input_file: Path,
@@ -192,6 +197,7 @@ def render(
     legend: str | None,
     from_nextflow: bool,
     title: str | None,
+    responsive: bool,
     **layout_opts: object,
 ) -> None:
     """Render a Mermaid metro map definition to SVG or interactive HTML."""
@@ -240,7 +246,7 @@ def render(
     if format_ == "html":
         content = render_html(graph, theme_obj, debug=debug, embed_basename=output.name)
     else:
-        content = render_svg(graph, theme_obj, debug=debug)
+        content = render_svg(graph, theme_obj, debug=debug, responsive=responsive)
 
     output.write_text(content if content.endswith("\n") else content + "\n")
     click.echo(

--- a/src/nf_metro/manifest/produce.py
+++ b/src/nf_metro/manifest/produce.py
@@ -113,7 +113,11 @@ def manifest_metadata_svg(manifest: Mapping[str, Any]) -> str:
 
 
 def overlay_svg(
-    manifest: Mapping[str, Any], body: str = "", *, extra_attrs: str = ""
+    manifest: Mapping[str, Any],
+    body: str = "",
+    *,
+    extra_attrs: str = "",
+    responsive: bool = False,
 ) -> str:
     """An overlay ``<svg>`` sized to the manifest, to stack over the base diagram.
 
@@ -124,12 +128,20 @@ def overlay_svg(
     can't mismatch the coordinate space.  ``extra_attrs`` is verbatim attributes
     for the root element (e.g. ``'class="overlay"'`` or
     ``'style="pointer-events:none"'``).
+
+    If ``responsive`` is True the root element omits fixed ``width``/``height``
+    and adds ``preserveAspectRatio="xMinYMin meet"``, matching a responsive base
+    SVG so both layers scale identically in a host page.  The manifest's own
+    ``width``/``height`` fields are unaffected and continue to supply the
+    ``viewBox`` origin.
     """
     width, height = manifest["width"], manifest["height"]
     extra = f" {extra_attrs}" if extra_attrs else ""
+    wh = "" if responsive else f'width="{width}" height="{height}" '
+    par = ' preserveAspectRatio="xMinYMin meet"' if responsive else ""
     return (
-        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
-        f'viewBox="0 0 {width} {height}"{extra}>{body}</svg>'
+        f'<svg xmlns="http://www.w3.org/2000/svg" {wh}'
+        f'viewBox="0 0 {width} {height}"{par}{extra}>{body}</svg>'
     )
 
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 __all__ = ["apply_route_offsets", "render_svg"]
 
 import html
+import re
 import textwrap
 import warnings
 from dataclasses import replace
@@ -387,6 +388,7 @@ def render_svg(
     animate: bool | None = None,
     debug: bool = False,
     legend_position: str | None = None,
+    responsive: bool = False,
 ) -> str:
     """Render a metro map graph to an SVG string.
 
@@ -395,6 +397,11 @@ def render_svg(
 
     If ``legend_position`` is given it overrides ``graph.legend_position``
     for this render only, without mutating the graph.
+
+    If ``responsive`` is True the root ``<svg>`` element omits fixed
+    ``width``/``height`` attributes and adds
+    ``preserveAspectRatio="xMinYMin meet"``, so a host page can scale the
+    diagram with CSS (e.g. ``width: 100%; height: auto``).
     """
     if not graph.stations:
         return '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
@@ -417,6 +424,7 @@ def render_svg(
             animate=animate,
             debug=debug,
             legend_position=legend_position,
+            responsive=responsive,
         )
 
 
@@ -449,6 +457,7 @@ def _render_svg_scaled(
     animate: bool,
     debug: bool,
     legend_position: str | None,
+    responsive: bool = False,
 ) -> str:
     """Render body, run with ``theme`` fonts and label metrics already scaled."""
     effective_legend_position = (
@@ -543,7 +552,10 @@ def _render_svg_scaled(
     svg_width = width or int(auto_width)
     svg_height = height or int(auto_height)
 
-    d = draw.Drawing(svg_width, svg_height)
+    if responsive:
+        d = draw.Drawing(svg_width, svg_height, preserveAspectRatio="xMinYMin meet")
+    else:
+        d = draw.Drawing(svg_width, svg_height)
 
     # Embed the machine-readable manifest first, so the file is a durable,
     # self-describing contract regardless of what is drawn below it.
@@ -650,7 +662,21 @@ def _render_svg_scaled(
             )
         )
 
-    return d.as_svg()
+    svg = d.as_svg()
+    if responsive:
+        svg = _strip_svg_dimensions(svg)
+    return svg
+
+
+_SVG_OPEN_TAG_RE = re.compile(r"(<svg\b[^>]*?>)", re.DOTALL)
+_SVG_WH_ATTR_RE = re.compile(r'\s+(?:width|height)="[^"]*"')
+
+
+def _strip_svg_dimensions(svg: str) -> str:
+    """Remove fixed width/height attributes from the root <svg> opening tag."""
+    return _SVG_OPEN_TAG_RE.sub(
+        lambda m: _SVG_WH_ATTR_RE.sub("", m.group(1)), svg, count=1
+    )
 
 
 def _legend_overlaps_sections(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,6 +245,23 @@ def test_validate_svg_no_manifest(tmp_path):
     assert result.exit_code == 1
 
 
+def test_render_responsive_flag_omits_fixed_dimensions(tmp_path):
+    """--responsive omits fixed width/height from root <svg> element."""
+    import xml.etree.ElementTree as ET
+
+    out = tmp_path / "responsive.svg"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["render", str(RNASEQ_MMD), "-o", str(out), "--responsive"]
+    )
+    assert result.exit_code == 0, result.output
+    root = ET.fromstring(out.read_text())
+    assert root.get("width") is None
+    assert root.get("height") is None
+    assert root.get("viewBox") is not None
+    assert root.get("preserveAspectRatio") == "xMinYMin meet"
+
+
 def test_validate_svg_rejects_nonconforming(tmp_path):
     """validate-svg fails when the embedded manifest violates the schema."""
     import re

--- a/tests/test_manifest_standalone.py
+++ b/tests/test_manifest_standalone.py
@@ -121,6 +121,17 @@ def test_overlay_svg_shares_the_manifest_viewbox() -> None:
     assert layer.endswith("<circle/></svg>")
 
 
+def test_overlay_svg_responsive_omits_fixed_dimensions() -> None:
+    manifest = build_manifest_data(title=None, width=360, height=92, nodes=[])
+    layer = overlay_svg(manifest, "<circle/>", responsive=True)
+    assert 'viewBox="0 0 360 92"' in layer
+    assert 'preserveAspectRatio="xMinYMin meet"' in layer
+    assert 'width="360"' not in layer
+    assert 'height="92"' not in layer
+    assert manifest["width"] == 360
+    assert manifest["height"] == 92
+
+
 def test_matching_node_ids_is_case_insensitive_and_ordered() -> None:
     patterns = {"align": ["ALIGN.*"], "qc": ["fastqc", "multiqc"], "none": []}
     assert matching_node_ids("nfcore:rnaseq:alignhisat2", patterns) == ["align"]

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1082,3 +1082,44 @@ def test_label_halo_suppressed_when_disabled():
     ns = "{http://www.w3.org/2000/svg}"
     texts = [t for t in root.iter(f"{ns}text") if (t.text or "") == "Input"]
     assert len(texts) == 1, "halo copy should be absent when haloing is disabled"
+
+
+# ---------------------------------------------------------------------------
+# Responsive render mode
+# ---------------------------------------------------------------------------
+
+
+def _graph_for_responsive():
+    graph = parse_metro_mermaid(
+        "%%metro title: Responsive Test\n"
+        "%%metro line: main | Main | #ff0000\n"
+        "graph LR\n"
+        "    a[Start]\n"
+        "    b[End]\n"
+        "    a -->|main| b\n"
+    )
+    compute_layout(graph)
+    return graph
+
+
+def test_responsive_render_omits_fixed_dimensions():
+    svg = render_svg(_graph_for_responsive(), NFCORE_THEME, responsive=True)
+    root = ET.fromstring(svg)
+    assert root.get("width") is None, "responsive SVG must not carry a fixed width"
+    assert root.get("height") is None, "responsive SVG must not carry a fixed height"
+
+
+def test_responsive_render_has_viewbox_and_aspect_ratio():
+    svg = render_svg(_graph_for_responsive(), NFCORE_THEME, responsive=True)
+    root = ET.fromstring(svg)
+    assert root.get("viewBox") is not None, "responsive SVG must have a viewBox"
+    assert root.get("preserveAspectRatio") == "xMinYMin meet", (
+        "responsive SVG must declare preserveAspectRatio"
+    )
+
+
+def test_default_render_retains_fixed_dimensions():
+    svg = render_svg(_graph_for_responsive(), NFCORE_THEME)
+    root = ET.fromstring(svg)
+    assert root.get("width") is not None, "default SVG must carry a fixed width"
+    assert root.get("height") is not None, "default SVG must carry a fixed height"


### PR DESCRIPTION
## Summary

- Adds `--responsive/--no-responsive` flag to the `render` CLI command
- Adds `responsive: bool = False` kwarg to `render_svg()` and `overlay_svg()`
- When `responsive=True`, the root `<svg>` element carries `viewBox` + `preserveAspectRatio="xMinYMin meet"` but no fixed `width`/`height`, making the diagram scale to its CSS container
- Default output is unchanged (back-compat for existing asset pipelines)
- Manifest `width`/`height` fields are always recorded regardless of mode, so `overlay_svg()` consumers can reconstruct the coordinate space for stacked overlays
- `overlay_svg()` accepts the same `responsive=` flag so base and overlay layers share identical sizing behaviour

Fixes #838

## Test plan
- [x] `test_responsive_render_omits_fixed_dimensions` — root element has no `width`/`height`
- [x] `test_responsive_render_has_viewbox_and_aspect_ratio` — root element has `viewBox` + `preserveAspectRatio`
- [x] `test_default_render_retains_fixed_dimensions` — default mode unchanged
- [x] `test_overlay_svg_responsive_omits_fixed_dimensions` — overlay layer matches base responsive behaviour; manifest data retains intrinsic dimensions
- [x] `test_render_responsive_flag_omits_fixed_dimensions` — CLI `--responsive` flag end-to-end
- [x] Full pytest suite green (12764 passed)
- [x] ruff format + ruff check clean
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/839/) — default (fixed) renders expected unchanged; responsive mode not rendered by CI gallery (it's a new output mode, not a gallery format)

Generated with Claude Code