### PR TITLE
refactor(routing): symbolic GapSlot data structure (#845-A)

### DIFF
--- a/src/nf_metro/layout/routing/__init__.py
+++ b/src/nf_metro/layout/routing/__init__.py
@@ -4,14 +4,16 @@ Public API:
 - route_edges: Main edge routing dispatcher (placement-pure)
 - route_edges_centred: route_edges + applied bubble-centring marker moves
 - RoutedPath: Routed path dataclass
+- GapSlot: Symbolic gap-relative slot for a vertical channel run
 - compute_station_offsets: Per-station Y offset computation
 """
 
-from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.layout.routing.common import GapSlot, RoutedPath
 from nf_metro.layout.routing.core import route_edges, route_edges_centred
 from nf_metro.layout.routing.offsets import compute_station_offsets
 
 __all__ = [
+    "GapSlot",
     "RoutedPath",
     "compute_station_offsets",
     "route_edges",

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -262,6 +262,32 @@ def bundle_width(n_lines: int, offset_step: float = OFFSET_STEP) -> float:
     return max(0, n_lines - 1) * offset_step
 
 
+@dataclass(frozen=True)
+class GapSlot:
+    """A symbolic position for a vertical channel run within a gap bundle.
+
+    A handler declares *where* a vertical run intends to sit -- which line of
+    which bundle, in which inter-column corridor, travelling which way -- without
+    committing to a concrete X coordinate.  A single materialization pass later
+    resolves the slot to final geometry, replacing the compute-then-renormalize
+    chain in which handlers emit ``_get_offset`` Xs that a post-pass discards and
+    re-derives.
+
+    The corridor is the inter-column gap bounded by the adjacent grid columns
+    ``gap_lo_col`` and ``gap_hi_col`` (``gap_hi_col == gap_lo_col + 1``); the run
+    traverses grid ``row`` in ``direction`` (:attr:`Direction.U` or
+    :attr:`Direction.D`).  ``slot_index`` is this line's 0-based rank among the
+    ``n_slots`` lines sharing the same gap and direction.
+    """
+
+    gap_lo_col: int
+    gap_hi_col: int
+    row: int
+    direction: Direction
+    slot_index: int
+    n_slots: int
+
+
 @dataclass
 class RoutedPath:
     """A routed path for an edge, consisting of (x, y) waypoints."""
@@ -278,6 +304,11 @@ class RoutedPath:
     Set by wrap / around-section / TOP-entry handlers whose vertical
     channels follow a special concentric loop (all corners share one
     radius) that the standard L-shape re-stacking would break."""
+    gap_slot: GapSlot | None = None
+    """Symbolic gap-relative slot for this route's vertical channel run.
+
+    ``None`` until a handler is migrated to declare placement symbolically; the
+    materialization pass resolves a non-``None`` slot to concrete channel X."""
 
 
 def initial_fanout_descent_span(

--- a/tests/test_gap_slot.py
+++ b/tests/test_gap_slot.py
@@ -1,0 +1,64 @@
+"""The symbolic gap-slot data structure (#845).
+
+``GapSlot`` lets a handler declare *where* a vertical channel run sits in a gap
+bundle -- which line of which bundle, in which inter-column corridor, travelling
+which way -- without committing to a concrete X.  No handler emits one and no
+pass consumes one: the field is a foundation the vertical-channel migration
+builds on, so every route the corpus produces carries ``gap_slot is None``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import content_corpus
+
+from nf_metro.convert import convert_nextflow_dag
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.common import Direction, GapSlot, RoutedPath
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import Edge
+
+CORPUS = content_corpus()
+
+
+def test_gap_slot_carries_documented_fields():
+    slot = GapSlot(
+        gap_lo_col=2,
+        gap_hi_col=3,
+        row=1,
+        direction=Direction.D,
+        slot_index=1,
+        n_slots=3,
+    )
+    assert (slot.gap_lo_col, slot.gap_hi_col) == (2, 3)
+    assert slot.row == 1
+    assert slot.direction is Direction.D
+    assert (slot.slot_index, slot.n_slots) == (1, 3)
+
+
+def test_routed_path_gap_slot_defaults_to_none():
+    rp = RoutedPath(
+        edge=Edge(source="a", target="b", line_id="l1"),
+        line_id="l1",
+        points=[(0.0, 0.0), (10.0, 0.0)],
+    )
+    assert rp.gap_slot is None
+
+
+@pytest.mark.parametrize("fixture", CORPUS, ids=[fid for fid, _, _ in CORPUS])
+def test_no_handler_emits_a_gap_slot_yet(fixture):
+    fid, path, is_nextflow = fixture
+    text = path.read_text()
+    if is_nextflow:
+        text = convert_nextflow_dag(text)
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph, validate=False)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    with_slot = [r for r in routes if r.gap_slot is not None]
+    assert not with_slot, (
+        f"{fid}: {len(with_slot)} route(s) carry a gap_slot; this PR is purely "
+        f"additive -- no handler should populate it yet"
+    )


### PR DESCRIPTION
## Summary
- Add a `GapSlot` frozen dataclass to `layout/routing/common.py` describing where a vertical channel run sits in a gap bundle: the adjacent column pair (`gap_lo_col`/`gap_hi_col`), the grid `row`, the travel `direction` (reusing the existing `Direction` enum), and the line's `slot_index` within an `n_slots`-line bundle.
- Add an optional `gap_slot: GapSlot | None = None` field to `RoutedPath`.
- Export `GapSlot` from the `routing` package alongside `RoutedPath`.
- Add `tests/test_gap_slot.py`: the slot carries its documented fields, `RoutedPath.gap_slot` defaults to `None`, and no handler populates a slot across the whole fixture corpus.

No handler emits a slot and no pass consumes one, so the change is purely additive and renders are byte-identical. It is the foundation the #845-B vertical-channel and #845-D bypass-trunk migrations build on.

Fixes #848

## Test plan
- [x] pytest passes (13061 passed, including new `test_gap_slot.py`)
- [x] ruff check + ruff format clean on whole repo
- [x] mypy clean
- [ ] Render-preview verdict: expected "No visual changes" (purely additive)

Generated with Claude Code