### PR TITLE
feat(render): namespace SVG classes and add dark-mode CSS opt-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -e ".[dev]"
+      - run: pip install -e ".[dev,font]"
       - run: pytest

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -201,6 +201,27 @@ def _resolve_theme(theme: str | None, graph: MetroGraph) -> Theme:
         "Loses selectable text. Requires fonttools[woff]."
     ),
 )
+@click.option(
+    "--svg-class-prefix",
+    type=str,
+    default="",
+    help=(
+        "Prefix every SVG presentation class with this string (e.g. 'myapp' "
+        "produces 'myapp-nf-metro-station'). Use distinct prefixes for each map "
+        "on a shared page to prevent CSS collisions. Has no effect on the "
+        "interactive HTML output, which already scopes each map independently."
+    ),
+)
+@click.option(
+    "--no-dark-mode-css",
+    is_flag=True,
+    default=False,
+    help=(
+        "Suppress the prefers-color-scheme: dark <style> block. "
+        "Useful when a host page manages its own theme and the injected "
+        "media query would conflict."
+    ),
+)
 @layout_cli_options
 def render(
     input_file: Path,
@@ -216,6 +237,8 @@ def render(
     responsive: bool,
     embed_font: bool,
     text_to_paths: bool,
+    svg_class_prefix: str,
+    no_dark_mode_css: bool,
     **layout_opts: object,
 ) -> None:
     """Render a Mermaid metro map definition to SVG or interactive HTML."""
@@ -274,6 +297,8 @@ def render(
             debug=debug,
             responsive=responsive,
             font_portability=font_portability,
+            svg_class_prefix=svg_class_prefix,
+            inject_dark_mode_css=not no_dark_mode_css,
         )
 
     output.write_text(content if content.endswith("\n") else content + "\n")

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 __all__ = ["apply_route_offsets", "render_svg"]
 
+import contextvars
 import html
 import re
 import textwrap
@@ -118,6 +119,18 @@ from nf_metro.render.legend import (
 )
 from nf_metro.render.manifest import build_manifest, manifest_metadata_svg
 from nf_metro.render.style import Theme
+
+# Per-render SVG class namespace.  Set by render_svg() for the duration of one
+# render call so all helper functions pick it up without extra parameters.
+_render_class_prefix: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "_render_class_prefix", default=""
+)
+
+
+def _ns(cls: str) -> str:
+    """Apply the active render namespace prefix to an SVG class name."""
+    p = _render_class_prefix.get()
+    return f"{p}-{cls}" if p else cls
 
 
 def apply_route_offsets(
@@ -394,6 +407,8 @@ def render_svg(
     legend_position: str | None = None,
     responsive: bool = False,
     font_portability: Literal["embed", "paths"] | None = None,
+    svg_class_prefix: str = "",
+    inject_dark_mode_css: bool = True,
 ) -> str:
     """Render a metro map graph to an SVG string.
 
@@ -414,6 +429,16 @@ def render_svg(
     - ``"paths"``: converts all text to vector paths, removing font
       dependencies entirely (requires ``fontTools[woff]``).
     - ``None`` (default): bare ``font-family`` reference, resolved by the host renderer.
+
+    ``svg_class_prefix``: when non-empty, every SVG presentation class (e.g.
+    ``nf-metro-station``, ``metro-line-<id>``) is prefixed with
+    ``<svg_class_prefix>-``.  Use distinct prefixes for each map on a shared
+    page to prevent CSS collisions between maps or with host-page styles.
+    ``data-*`` attributes and manifest element ids are not affected.
+
+    ``inject_dark_mode_css``: when False, the ``prefers-color-scheme: dark``
+    ``<style>`` block is omitted.  Useful when a host page manages its own
+    theme and the injected media query would fight it.
     """
     if not graph.stations:
         return '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
@@ -426,18 +451,23 @@ def render_svg(
         animate = graph.animate
 
     scaled_theme = _scale_theme_fonts(theme, graph.font_scale)
-    with font_scale_context(graph.font_scale):
-        svg = _render_svg_scaled(
-            graph,
-            scaled_theme,
-            width=width,
-            height=height,
-            padding=padding,
-            animate=animate,
-            debug=debug,
-            legend_position=legend_position,
-            responsive=responsive,
-        )
+    token = _render_class_prefix.set(svg_class_prefix)
+    try:
+        with font_scale_context(graph.font_scale):
+            svg = _render_svg_scaled(
+                graph,
+                scaled_theme,
+                width=width,
+                height=height,
+                padding=padding,
+                animate=animate,
+                debug=debug,
+                legend_position=legend_position,
+                responsive=responsive,
+                inject_dark_mode_css=inject_dark_mode_css,
+            )
+    finally:
+        _render_class_prefix.reset(token)
 
     if font_portability == "paths":
         from nf_metro.render.font_embed import text_to_paths as _text_to_paths
@@ -482,6 +512,7 @@ def _render_svg_scaled(
     debug: bool,
     legend_position: str | None,
     responsive: bool = False,
+    inject_dark_mode_css: bool = True,
 ) -> str:
     """Render body, run with ``theme`` fonts and label metrics already scaled."""
     effective_legend_position = (
@@ -595,7 +626,9 @@ def _render_svg_scaled(
     # Dark-mode CSS for transparent-background themes so that elements
     # rendered directly on the canvas (section labels, number badges,
     # title) remain readable when the browser provides a dark background.
-    if not theme.background_color or theme.background_color == "none":
+    if inject_dark_mode_css and (
+        not theme.background_color or theme.background_color == "none"
+    ):
         _inject_dark_mode_style(d)
 
     # Background (skip for transparent themes)
@@ -617,7 +650,7 @@ def _render_svg_scaled(
                 fill=theme.title_color,
                 font_family=theme.label_font_family,
                 font_weight="bold",
-                **{"class": "nf-metro-title"},
+                **{"class": _ns("nf-metro-title")},
             )
         )
 
@@ -817,12 +850,15 @@ def _inject_dark_mode_style(d: draw.Drawing) -> None:
     media query adjusts those elements so they remain readable.  CSS rules
     override SVG presentation attributes, so we only need class selectors.
     """
-    css = textwrap.dedent("""\
-        @media (prefers-color-scheme: dark) {
-            .nf-metro-section-label { fill: #d0d0d0; }
-            .nf-metro-section-num-circle { fill: #777777; }
-            .nf-metro-title { fill: #ffffff; }
-        }
+    sl = _ns("nf-metro-section-label")
+    sc = _ns("nf-metro-section-num-circle")
+    ti = _ns("nf-metro-title")
+    css = textwrap.dedent(f"""\
+        @media (prefers-color-scheme: dark) {{
+            .{sl} {{ fill: #d0d0d0; }}
+            .{sc} {{ fill: #777777; }}
+            .{ti} {{ fill: #ffffff; }}
+        }}
     """)
     d.append(draw.Raw(f"<style>{css}</style>"))
 
@@ -858,7 +894,7 @@ def _render_first_class_sections(
                 fill=theme.section_fill,
                 stroke=theme.section_stroke,
                 stroke_width=SECTION_STROKE_WIDTH,
-                class_="nf-metro-section-box",
+                class_=_ns("nf-metro-section-box"),
                 **section_data,
             )
         )
@@ -898,7 +934,7 @@ def _render_first_class_sections(
                 circle_r,
                 fill=theme.station_stroke,
                 **{
-                    "class": "nf-metro-section-num-circle",
+                    "class": _ns("nf-metro-section-num-circle"),
                     "data-section-id": section.id,
                 },
             )
@@ -929,7 +965,10 @@ def _render_first_class_sections(
                 font_family=theme.label_font_family,
                 font_weight="bold",
                 dy=TEXT_VCENTER_DY,
-                **{"class": "nf-metro-section-label", "data-section-id": section.id},
+                **{
+                    "class": _ns("nf-metro-section-label"),
+                    "data-section-id": section.id,
+                },
             )
         )
 
@@ -963,7 +1002,7 @@ def _render_edges(
         line = graph.lines.get(route.line_id)
         color = line.color if line else FALLBACK_LINE_COLOR
         style_kw = line_style_kwargs(line.style) if line else {}
-        class_name = f"metro-line-{route.line_id}"
+        class_name = _ns(f"metro-line-{route.line_id}")
         breaks = bridges.get(id(route))
 
         if breaks:
@@ -1176,7 +1215,7 @@ def _station_data_attrs(graph: MetroGraph, station: Station) -> dict[str, str]:
     because drawsvg does not escape unknown kwargs.
     """
     data = {
-        "class_": "nf-metro-station",
+        "class_": _ns("nf-metro-station"),
         "data-station-id": station.id,
         "data-station-lines": ",".join(graph.station_lines(station.id)),
         "data-station-label": html.escape(station.label or station.id),
@@ -1271,18 +1310,21 @@ def _draw_interchange_glyph(
     _link_bar(
         (bar_half + sw) * 2,
         outline,
-        **{**station_data, "class_": "nf-metro-rail-connector"},
+        **{**station_data, "class_": _ns("nf-metro-rail-connector")},
     )
     _knobs(
         knob_r + sw,
         outline,
-        **{"class_": "nf-metro-rail-knob-outline", "data-station-id": data_station_id},
+        **{
+            "class_": _ns("nf-metro-rail-knob-outline"),
+            "data-station-id": data_station_id,
+        },
     )
     _link_bar(bar_half * 2, interior_fill)
     _knobs(
         knob_r,
         interior_fill,
-        **{"class_": "nf-metro-rail-knob", "data-station-id": data_station_id},
+        **{"class_": _ns("nf-metro-rail-knob"), "data-station-id": data_station_id},
     )
 
 
@@ -1416,7 +1458,7 @@ def _station_group_attrs(
         station.section_id if section is not None and not section.is_implicit else None
     )
     return {
-        "class_": "nf-metro-station-group",
+        "class_": _ns("nf-metro-station-group"),
         **node_data_attrs(
             id=station.id,
             x=station.x,
@@ -1905,7 +1947,7 @@ def _render_labels(
         label_data: dict[str, str] = {}
         if label.station_id and not label.station_id.startswith("__"):
             label_data["data-station-id"] = label.station_id
-            label_data["class_"] = "nf-metro-station-label"
+            label_data["class_"] = _ns("nf-metro-station-label")
 
         if label.angle:
             # Diagonal labels: anchor at the pill and rotate about
@@ -2260,7 +2302,7 @@ def _render_station_groups(
             fill="none",
             stroke_linecap="round",
             stroke_linejoin="round",
-            class_="nf-metro-group-underline",
+            class_=_ns("nf-metro-group-underline"),
         )
         bracket.M(band.x_left, band.rule_y + band.tick_dy)
         bracket.L(band.x_left, band.rule_y)
@@ -2278,7 +2320,7 @@ def _render_station_groups(
                 font_weight="bold",
                 text_anchor="middle",
                 dominant_baseline=band.baseline,
-                class_="nf-metro-group-label",
+                class_=_ns("nf-metro-group-label"),
             )
         )
 

--- a/tests/test_svg_namespace.py
+++ b/tests/test_svg_namespace.py
@@ -1,0 +1,168 @@
+"""Tests for SVG class namespacing and dark-mode CSS opt-out."""
+
+import re
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.svg import render_svg
+from nf_metro.themes import LIGHT_THEME, NFCORE_THEME
+
+_MMD = (
+    "%%metro title: Test\n"
+    "%%metro line: main | Main | #ff0000\n"
+    "graph LR\n"
+    "    subgraph s1 [Step One]\n"
+    "        a[Input]\n"
+    "    end\n"
+    "    subgraph s2 [Step Two]\n"
+    "        b[Output]\n"
+    "    end\n"
+    "    a -->|main| b\n"
+)
+
+
+def _make_graph():
+    g = parse_metro_mermaid(_MMD)
+    compute_layout(g)
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Dark-mode CSS injection
+# ---------------------------------------------------------------------------
+
+
+def test_dark_mode_css_present_for_transparent_theme_by_default():
+    """LIGHT_THEME (background_color=none) injects the dark-mode block by default."""
+    svg = render_svg(_make_graph(), LIGHT_THEME)
+    assert "prefers-color-scheme" in svg
+
+
+def test_dark_mode_css_absent_for_opaque_theme():
+    """NFCORE_THEME (opaque background) does not inject the dark-mode block."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "prefers-color-scheme" not in svg
+
+
+def test_inject_dark_mode_css_false_suppresses_block():
+    """inject_dark_mode_css=False suppresses the media query regardless of theme."""
+    svg = render_svg(_make_graph(), LIGHT_THEME, inject_dark_mode_css=False)
+    assert "prefers-color-scheme" not in svg
+
+
+def test_inject_dark_mode_css_true_matches_default():
+    """inject_dark_mode_css=True is equivalent to the default for transparent themes."""
+    svg_default = render_svg(_make_graph(), LIGHT_THEME)
+    svg_explicit = render_svg(_make_graph(), LIGHT_THEME, inject_dark_mode_css=True)
+    assert svg_default == svg_explicit
+
+
+# ---------------------------------------------------------------------------
+# SVG class namespacing
+# ---------------------------------------------------------------------------
+
+_CLASS_PATTERN = re.compile(r'class="([^"]*)"')
+_ALL_KNOWN_CLASSES = {
+    "nf-metro-title",
+    "nf-metro-section-box",
+    "nf-metro-section-num-circle",
+    "nf-metro-section-label",
+    "nf-metro-station",
+    "nf-metro-station-group",
+    "nf-metro-station-label",
+    "nf-metro-group-underline",
+    "nf-metro-group-label",
+    "nf-metro-rail-connector",
+    "nf-metro-rail-knob-outline",
+    "nf-metro-rail-knob",
+}
+
+
+def _extract_classes(svg: str) -> set[str]:
+    return {cls for m in _CLASS_PATTERN.finditer(svg) for cls in m.group(1).split()}
+
+
+def test_default_render_uses_unprefixed_classes():
+    """Without a prefix the class names must be the documented bare names."""
+    svg = render_svg(_make_graph(), LIGHT_THEME)
+    classes = _extract_classes(svg)
+    # At minimum title, section-box, section-label, station, station-label present
+    assert "nf-metro-title" in classes
+    assert "nf-metro-section-box" in classes
+    assert "nf-metro-station" in classes
+    # No class should start with an extra dash-prefix
+    assert not any(c.startswith("abc-nf-metro-") for c in classes)
+
+
+def test_svg_class_prefix_applied_to_all_classes():
+    """svg_class_prefix='abc' prepends abc- to every SVG presentation class."""
+    prefix = "abc"
+    svg = render_svg(_make_graph(), LIGHT_THEME, svg_class_prefix=prefix)
+    classes = _extract_classes(svg)
+
+    # Unprefixed presentation classes must not appear
+    assert "nf-metro-title" not in classes
+    assert "nf-metro-section-box" not in classes
+    assert "nf-metro-station" not in classes
+
+    # Prefixed versions must be present
+    assert "abc-nf-metro-title" in classes
+    assert "abc-nf-metro-section-box" in classes
+    assert "abc-nf-metro-station" in classes
+
+
+def test_svg_class_prefix_applied_to_metro_line_class():
+    """metro-line-<id> is also prefixed."""
+    prefix = "mymap"
+    svg = render_svg(_make_graph(), LIGHT_THEME, svg_class_prefix=prefix)
+    assert "mymap-metro-line-main" in svg
+    # Unprefixed form absent
+    assert 'class="metro-line-main"' not in svg
+
+
+def test_svg_class_prefix_applied_to_dark_mode_css_selectors():
+    """Dark-mode CSS selectors are also prefixed so the block scopes correctly."""
+    prefix = "ns1"
+    svg = render_svg(_make_graph(), LIGHT_THEME, svg_class_prefix=prefix)
+    assert "prefers-color-scheme" in svg
+    # Selectors in the <style> block must use the prefix
+    assert ".ns1-nf-metro-section-label" in svg
+    assert ".ns1-nf-metro-title" in svg
+    # Bare selectors must not be present in the CSS block
+    style_block = re.search(r"<style>(.*?)</style>", svg, re.DOTALL)
+    assert style_block is not None
+    css = style_block.group(1)
+    assert ".nf-metro-section-label" not in css
+    assert ".nf-metro-title" not in css
+
+
+def test_two_renders_with_different_prefixes_dont_share_presentation_classes():
+    """Demonstrates the embedding isolation property."""
+    g = _make_graph()
+    svg1 = render_svg(g, LIGHT_THEME, svg_class_prefix="map1")
+    svg2 = render_svg(g, LIGHT_THEME, svg_class_prefix="map2")
+
+    classes1 = {c for c in _extract_classes(svg1) if c.startswith("map")}
+    classes2 = {c for c in _extract_classes(svg2) if c.startswith("map")}
+
+    assert classes1
+    assert classes2
+    assert classes1.isdisjoint(classes2)
+
+
+def test_empty_prefix_is_identical_to_no_prefix():
+    """Passing svg_class_prefix='' is the same as omitting it."""
+    g = _make_graph()
+    svg_default = render_svg(g, LIGHT_THEME)
+    svg_empty = render_svg(g, LIGHT_THEME, svg_class_prefix="")
+    assert svg_default == svg_empty
+
+
+def test_manifest_ids_and_data_attrs_not_prefixed():
+    """data-node-*, data-station-id, data-schema-version are not class names
+    and must not be modified by the prefix."""
+    prefix = "scoped"
+    svg = render_svg(_make_graph(), LIGHT_THEME, svg_class_prefix=prefix)
+    assert "data-station-id" in svg
+    assert "scoped-data-station-id" not in svg
+    assert "data-section-id" in svg


### PR DESCRIPTION
## Summary

- Adds `svg_class_prefix` parameter to `render_svg()`: when non-empty, every SVG presentation class (`nf-metro-*`, `metro-line-<id>`) is prefixed with `<prefix>-`, preventing CSS collisions when multiple maps or host-page styles share a DOM. The dark-mode `<style>` block selectors are prefixed too. `data-*` attributes and the manifest element id are exempt.
- Adds `inject_dark_mode_css` parameter to `render_svg()`: when `False`, the `prefers-color-scheme: dark` block is omitted entirely, for host pages that drive their own light/dark theme.
- Both are opt-in with backward-compatible defaults (empty prefix, dark-mode CSS enabled for transparent themes). The interactive HTML output is unaffected (already scoped per-embed via `nfmm-<sid>`).
- Exposes both options via `--svg-class-prefix TEXT` and `--no-dark-mode-css` CLI flags.
- Uses a `contextvars.ContextVar` so the prefix propagates to all 13 class-emit call sites without threading it through every helper signature.

Fixes #840

## Test plan
- [x] `tests/test_svg_namespace.py` - 11 new tests covering: prefix applied to all class types including `metro-line-*`, dark-mode CSS suppressed, CSS selectors prefixed, two maps with different prefixes don't share classes, empty prefix identical to no prefix, `data-*` attrs unaffected
- [x] Full `pytest` suite: 13080 passed, 75 skipped, 6 xfailed (all pre-existing)
- [x] `ruff format --check` + `ruff check` clean on whole repo
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/856/)

Generated with Claude Code