### PR TITLE
feat(render): drive chrome colors via CSS custom properties (#841)

### DIFF
--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -38,6 +38,7 @@ from nf_metro.render.constants import (
     TEXT_VCENTER_DY,
     line_style_kwargs,
 )
+from nf_metro.render.ns import ns as _ns
 from nf_metro.render.style import Theme
 
 
@@ -309,6 +310,7 @@ def render_legend(
             rx=LEGEND_BORDER_RADIUS,
             ry=LEGEND_BORDER_RADIUS,
             fill=theme.legend_background,
+            class_=_ns("nf-metro-legend-bg"),
         )
     )
 
@@ -354,6 +356,7 @@ def render_legend(
                 fill=theme.legend_text_color,
                 font_family=theme.label_font_family,
                 dy=TEXT_VCENTER_DY,
+                class_=_ns("nf-metro-legend-text"),
             )
         )
 
@@ -425,5 +428,6 @@ def _render_marker_key(
                 fill=theme.legend_text_color,
                 font_family=theme.label_font_family,
                 dy=TEXT_VCENTER_DY,
+                class_=_ns("nf-metro-legend-text"),
             )
         )

--- a/src/nf_metro/render/ns.py
+++ b/src/nf_metro/render/ns.py
@@ -1,0 +1,29 @@
+"""SVG class-namespace utilities shared across render modules."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+from collections.abc import Generator
+
+__all__ = ["ns", "class_prefix_context"]
+
+_render_class_prefix: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "_render_class_prefix", default=""
+)
+
+
+def ns(cls: str) -> str:
+    """Apply the active render namespace prefix to an SVG class name."""
+    p = _render_class_prefix.get()
+    return f"{p}-{cls}" if p else cls
+
+
+@contextlib.contextmanager
+def class_prefix_context(prefix: str) -> Generator[None, None, None]:
+    """Context manager that sets the SVG class namespace prefix for the duration."""
+    token = _render_class_prefix.set(prefix)
+    try:
+        yield
+    finally:
+        _render_class_prefix.reset(token)

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -869,10 +869,6 @@ def _inject_chrome_css(d: draw.Drawing, theme: Theme) -> None:
             f" stroke: var(--nfm-section-stroke, {theme.section_stroke})",
         ),
         _rule("nf-metro-section-label", f"fill: var(--nfm-section-label-color, {tc})"),
-        _rule(
-            "nf-metro-section-num-circle",
-            f"fill: var(--nfm-section-label-color, {tc})",
-        ),
         _rule("nf-metro-group-label", f"fill: var(--nfm-section-label-color, {tc})"),
         _rule(
             "nf-metro-group-underline",

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 __all__ = ["apply_route_offsets", "render_svg"]
 
-import contextvars
 import html
 import re
 import textwrap
@@ -118,19 +117,9 @@ from nf_metro.render.legend import (
     render_legend,
 )
 from nf_metro.render.manifest import build_manifest, manifest_metadata_svg
+from nf_metro.render.ns import class_prefix_context
+from nf_metro.render.ns import ns as _ns
 from nf_metro.render.style import Theme
-
-# Per-render SVG class namespace.  Set by render_svg() for the duration of one
-# render call so all helper functions pick it up without extra parameters.
-_render_class_prefix: contextvars.ContextVar[str] = contextvars.ContextVar(
-    "_render_class_prefix", default=""
-)
-
-
-def _ns(cls: str) -> str:
-    """Apply the active render namespace prefix to an SVG class name."""
-    p = _render_class_prefix.get()
-    return f"{p}-{cls}" if p else cls
 
 
 def apply_route_offsets(
@@ -451,23 +440,19 @@ def render_svg(
         animate = graph.animate
 
     scaled_theme = _scale_theme_fonts(theme, graph.font_scale)
-    token = _render_class_prefix.set(svg_class_prefix)
-    try:
-        with font_scale_context(graph.font_scale):
-            svg = _render_svg_scaled(
-                graph,
-                scaled_theme,
-                width=width,
-                height=height,
-                padding=padding,
-                animate=animate,
-                debug=debug,
-                legend_position=legend_position,
-                responsive=responsive,
-                inject_dark_mode_css=inject_dark_mode_css,
-            )
-    finally:
-        _render_class_prefix.reset(token)
+    with class_prefix_context(svg_class_prefix), font_scale_context(graph.font_scale):
+        svg = _render_svg_scaled(
+            graph,
+            scaled_theme,
+            width=width,
+            height=height,
+            padding=padding,
+            animate=animate,
+            debug=debug,
+            legend_position=legend_position,
+            responsive=responsive,
+            inject_dark_mode_css=inject_dark_mode_css,
+        )
 
     if font_portability == "paths":
         from nf_metro.render.font_embed import text_to_paths as _text_to_paths
@@ -623,9 +608,14 @@ def _render_svg_scaled(
         )
         d.append(draw.Raw(manifest_metadata_svg(manifest)))
 
+    # Chrome CSS: custom properties so hosts can recolor without re-rendering.
+    # Injected before the background rect so browser parsing order is correct.
+    _inject_chrome_css(d, theme)
+
     # Dark-mode CSS for transparent-background themes so that elements
     # rendered directly on the canvas (section labels, number badges,
     # title) remain readable when the browser provides a dark background.
+    # Must follow the chrome CSS so the media-query rule wins by source order.
     if inject_dark_mode_css and (
         not theme.background_color or theme.background_color == "none"
     ):
@@ -634,7 +624,14 @@ def _render_svg_scaled(
     # Background (skip for transparent themes)
     if theme.background_color and theme.background_color != "none":
         d.append(
-            draw.Rectangle(0, 0, svg_width, svg_height, fill=theme.background_color)
+            draw.Rectangle(
+                0,
+                0,
+                svg_width,
+                svg_height,
+                fill=theme.background_color,
+                class_=_ns("nf-metro-bg"),
+            )
         )
 
     # Title / Logo (standalone logo only when not embedded in legend)
@@ -839,6 +836,58 @@ def _render_logo(
             embed=True,
         )
     )
+
+
+def _inject_chrome_css(d: draw.Drawing, theme: Theme) -> None:
+    """Inject CSS custom properties for chrome colors.
+
+    Defines ``--nfm-*`` properties on the chrome element classes so a host
+    can recolor the map's non-semantic surfaces (background, labels, section
+    boxes, legend) by setting those properties on a wrapping element.  The
+    fallback for each property is the theme's baked value.  Line/route colors
+    carry semantic meaning and remain as baked presentation attributes.
+    """
+    tc = theme.section_label_color
+
+    def _rule(cls: str, props: str) -> str:
+        return f".{_ns(cls)} {{ {props}; }}"
+
+    lines: list[str] = []
+    if theme.background_color and theme.background_color != "none":
+        lines.append(
+            _rule("nf-metro-bg", f"fill: var(--nfm-bg, {theme.background_color})")
+        )
+    lines += [
+        _rule("nf-metro-title", f"fill: var(--nfm-title-color, {theme.title_color})"),
+        _rule(
+            "nf-metro-station-label",
+            f"fill: var(--nfm-label-color, {theme.label_color})",
+        ),
+        _rule(
+            "nf-metro-section-box",
+            f"fill: var(--nfm-section-fill, {theme.section_fill});"
+            f" stroke: var(--nfm-section-stroke, {theme.section_stroke})",
+        ),
+        _rule("nf-metro-section-label", f"fill: var(--nfm-section-label-color, {tc})"),
+        _rule(
+            "nf-metro-section-num-circle",
+            f"fill: var(--nfm-section-label-color, {tc})",
+        ),
+        _rule("nf-metro-group-label", f"fill: var(--nfm-section-label-color, {tc})"),
+        _rule(
+            "nf-metro-group-underline",
+            f"stroke: var(--nfm-section-label-color, {tc})",
+        ),
+        _rule(
+            "nf-metro-legend-bg",
+            f"fill: var(--nfm-legend-bg, {theme.legend_background})",
+        ),
+        _rule(
+            "nf-metro-legend-text",
+            f"fill: var(--nfm-legend-text-color, {theme.legend_text_color})",
+        ),
+    ]
+    d.append(draw.Raw(f"<style>{chr(10).join(lines)}</style>"))
 
 
 def _inject_dark_mode_style(d: draw.Drawing) -> None:

--- a/tests/test_css_custom_properties.py
+++ b/tests/test_css_custom_properties.py
@@ -1,0 +1,180 @@
+"""Tests for CSS custom property injection for chrome color theming.
+
+Chrome colors (background, labels, section, title, legend) are driven through
+CSS custom properties so a host can recolor without re-rendering.  Line/route
+colors remain baked as presentation attributes (semantic).
+"""
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.svg import render_svg
+from nf_metro.themes import LIGHT_THEME, NFCORE_THEME
+
+_MMD = (
+    "%%metro title: Test\n"
+    "%%metro line: main | Main | #ff0000\n"
+    "%%metro line: other | Other | #00bbcc\n"
+    "graph LR\n"
+    "    subgraph s1 [Step One]\n"
+    "        a[Input]\n"
+    "    end\n"
+    "    subgraph s2 [Step Two]\n"
+    "        b[Output]\n"
+    "    end\n"
+    "    a -->|main| b\n"
+    "    a -->|other| b\n"
+)
+
+
+def _make_graph():
+    g = parse_metro_mermaid(_MMD)
+    compute_layout(g)
+    return g
+
+
+# ---------------------------------------------------------------------------
+# CSS custom property presence
+# ---------------------------------------------------------------------------
+
+
+def test_svg_contains_nfm_bg_property():
+    """SVG output should declare --nfm-bg as a CSS custom property."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "--nfm-bg" in svg
+
+
+def test_svg_contains_nfm_label_color_property():
+    """SVG output should declare --nfm-label-color for station labels."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "--nfm-label-color" in svg
+
+
+def test_svg_contains_nfm_title_color_property():
+    """SVG output should declare --nfm-title-color for the diagram title."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "--nfm-title-color" in svg
+
+
+def test_svg_contains_nfm_section_fill_property():
+    """SVG output should declare --nfm-section-fill for section boxes."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "--nfm-section-fill" in svg
+
+
+def test_svg_contains_nfm_section_stroke_property():
+    """SVG output should declare --nfm-section-stroke for section box borders."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "--nfm-section-stroke" in svg
+
+
+def test_svg_contains_nfm_section_label_color_property():
+    """SVG output should declare --nfm-section-label-color for section names."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "--nfm-section-label-color" in svg
+
+
+def test_svg_contains_nfm_legend_bg_property():
+    """SVG output should declare --nfm-legend-bg for the legend panel."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "--nfm-legend-bg" in svg
+
+
+def test_svg_contains_nfm_legend_text_color_property():
+    """SVG output should declare --nfm-legend-text-color for legend labels."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "--nfm-legend-text-color" in svg
+
+
+# ---------------------------------------------------------------------------
+# Fallback values match theme colors
+# ---------------------------------------------------------------------------
+
+
+def test_chrome_css_fallbacks_match_nfcore_theme():
+    """CSS custom property fallbacks must match the nfcore theme's baked colors."""
+    theme = NFCORE_THEME
+    svg = render_svg(_make_graph(), theme)
+    assert f"--nfm-bg, {theme.background_color}" in svg
+    assert f"--nfm-label-color, {theme.label_color}" in svg
+    assert f"--nfm-title-color, {theme.title_color}" in svg
+    assert f"--nfm-section-fill, {theme.section_fill}" in svg
+    assert f"--nfm-section-stroke, {theme.section_stroke}" in svg
+    assert f"--nfm-section-label-color, {theme.section_label_color}" in svg
+    assert f"--nfm-legend-bg, {theme.legend_background}" in svg
+    assert f"--nfm-legend-text-color, {theme.legend_text_color}" in svg
+
+
+def test_chrome_css_fallbacks_match_light_theme():
+    """CSS custom property fallbacks must match the light theme's baked colors.
+
+    The bg rule is omitted for transparent themes (background_color='none').
+    """
+    theme = LIGHT_THEME
+    svg = render_svg(_make_graph(), theme)
+    # No bg rule for transparent-background themes
+    assert "--nfm-bg" not in svg
+    assert f"--nfm-label-color, {theme.label_color}" in svg
+    assert f"--nfm-title-color, {theme.title_color}" in svg
+    assert f"--nfm-section-fill, {theme.section_fill}" in svg
+    assert f"--nfm-section-stroke, {theme.section_stroke}" in svg
+    assert f"--nfm-section-label-color, {theme.section_label_color}" in svg
+
+
+# ---------------------------------------------------------------------------
+# Line/route colors remain baked (semantic, not chrome)
+# ---------------------------------------------------------------------------
+
+
+def test_line_colors_not_in_chrome_css_vars():
+    """Line colors must NOT appear inside CSS custom property declarations."""
+    g = _make_graph()
+    svg = render_svg(g, NFCORE_THEME)
+    # CSS custom properties live in a <style> block; line colors are baked
+    # as stroke= presentation attributes on path/line elements.
+    for line in g.lines.values():
+        # The color should appear somewhere (baked), but not inside a var(...)
+        assert f"--nfm-line-{line.id}" not in svg
+        # Verify it IS baked as a presentation attribute
+        assert line.color in svg
+
+
+# ---------------------------------------------------------------------------
+# Background rect carries the chrome class
+# ---------------------------------------------------------------------------
+
+
+def test_background_rect_has_nf_metro_bg_class():
+    """The canvas background rect should carry the nf-metro-bg class."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "nf-metro-bg" in svg
+
+
+# ---------------------------------------------------------------------------
+# Class prefix propagates into chrome CSS selectors
+# ---------------------------------------------------------------------------
+
+
+def test_chrome_css_uses_namespaced_class_selectors():
+    """With svg_class_prefix, the chrome CSS selectors use the prefixed class names."""
+    svg = render_svg(_make_graph(), NFCORE_THEME, svg_class_prefix="mymap")
+    # With prefix "mymap", nf-metro-bg becomes mymap-nf-metro-bg
+    assert "mymap-nf-metro-bg" in svg
+    # The unprefixed class should not appear in the chrome CSS selectors
+    assert ".nf-metro-bg" not in svg
+
+
+# ---------------------------------------------------------------------------
+# Legend elements carry chrome classes
+# ---------------------------------------------------------------------------
+
+
+def test_legend_background_has_nf_metro_legend_bg_class():
+    """The legend background rect should carry the nf-metro-legend-bg class."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "nf-metro-legend-bg" in svg
+
+
+def test_legend_text_has_nf_metro_legend_text_class():
+    """Legend text entries should carry the nf-metro-legend-text class."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "nf-metro-legend-text" in svg

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -907,8 +907,9 @@ def test_render_group_label_caption_and_underline():
     assert "Family" in grouped_svg
     assert "nf-metro-group-label" in grouped_svg
     assert "nf-metro-group-underline" in grouped_svg
-    # The base render has neither marker.
-    assert "nf-metro-group-label" not in base_svg
+    # The base render has no group-label elements (the class may appear in the
+    # <style> block as a CSS selector, but no element should carry it).
+    assert not re.search(r'class="[^"]*nf-metro-group-label', base_svg)
 
 
 def _section_box_bottoms(svg: str) -> dict[str, float]:


### PR DESCRIPTION
## Summary

- Introduces `--nfm-*` CSS custom properties on SVG chrome element classes so hosts embedding the map can recolor the background, station labels, section boxes, title, and legend by setting those variables on a wrapping element, without re-rendering
- Line/route colors remain baked as presentation attributes (they carry semantic meaning and must not be overridable this way)
- The background `--nfm-bg` rule is suppressed entirely for transparent-background themes (e.g. the light theme where `background_color="none"`)
- Extracts the SVG class-namespace `ContextVar` and `ns()` function from `svg.py` into a new `render/ns.py` module, also adding a `class_prefix_context()` context manager; this breaks a potential circular import since `legend.py` needs `ns()` but is itself imported by `svg.py`
- Background rect, legend background rect, and legend text elements gain the appropriate chrome classes
- 15 new tests cover property presence, fallback correctness, line-color exclusion, element class membership, and prefix propagation

Fixes #841

## Test plan
- [x] 15 new tests in `tests/test_css_custom_properties.py` pass
- [x] Existing `tests/test_render.py` passes (one assertion updated to use regex so it matches only element class attributes, not the CSS selector in the `<style>` block)
- [x] `ruff format` + `ruff check` + `mypy` clean on whole repo
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/847/)

Generated with Claude Code