### PR TITLE
feat(render): bare mode — omit title and outer padding for embedding

### DIFF
--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -222,6 +222,15 @@ def _resolve_theme(theme: str | None, graph: MetroGraph) -> Theme:
         "media query would conflict."
     ),
 )
+@click.option(
+    "--bare/--no-bare",
+    default=False,
+    help=(
+        "Omit the title and outer padding so the canvas hugs the diagram "
+        "content. The attribution watermark is kept. Suitable for embedding "
+        "in a host page that supplies its own frame and heading."
+    ),
+)
 @layout_cli_options
 def render(
     input_file: Path,
@@ -239,6 +248,7 @@ def render(
     text_to_paths: bool,
     svg_class_prefix: str,
     no_dark_mode_css: bool,
+    bare: bool,
     **layout_opts: object,
 ) -> None:
     """Render a Mermaid metro map definition to SVG or interactive HTML."""
@@ -299,6 +309,7 @@ def render(
             font_portability=font_portability,
             svg_class_prefix=svg_class_prefix,
             inject_dark_mode_css=not no_dark_mode_css,
+            bare=bare,
         )
 
     output.write_text(content if content.endswith("\n") else content + "\n")

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -177,6 +177,9 @@ WATERMARK_PADDING_RATIO: float = 0.5
 WATERMARK_Y_INSET: float = 8.0
 """Y distance from bottom edge for watermark text."""
 
+WATERMARK_BARE_X_INSET: float = 8.0
+"""X distance from right/left canvas edge for watermark text in bare mode."""
+
 WATERMARK_FILL: str = "rgba(150, 150, 150, 0.6)"
 """Fill color for the muted attribution watermark."""
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -98,6 +98,7 @@ from nf_metro.render.constants import (
     TERMINUS_FONT_COLOR,
     TEXT_VCENTER_DY,
     TITLE_Y_OFFSET,
+    WATERMARK_BARE_X_INSET,
     WATERMARK_FILL,
     WATERMARK_FONT_SIZE,
     WATERMARK_PADDING_RATIO,
@@ -398,6 +399,7 @@ def render_svg(
     font_portability: Literal["embed", "paths"] | None = None,
     svg_class_prefix: str = "",
     inject_dark_mode_css: bool = True,
+    bare: bool = False,
 ) -> str:
     """Render a metro map graph to an SVG string.
 
@@ -428,6 +430,11 @@ def render_svg(
     ``inject_dark_mode_css``: when False, the ``prefers-color-scheme: dark``
     ``<style>`` block is omitted.  Useful when a host page manages its own
     theme and the injected media query would fight it.
+
+    ``bare``: when True, omits the title and outer padding so the canvas
+    hugs the diagram content.  The attribution watermark is kept.  Use for
+    embedding the SVG inside a host page that supplies its own frame and
+    heading.
     """
     if not graph.stations:
         return '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
@@ -452,6 +459,7 @@ def render_svg(
             legend_position=legend_position,
             responsive=responsive,
             inject_dark_mode_css=inject_dark_mode_css,
+            bare=bare,
         )
 
     if font_portability == "paths":
@@ -498,6 +506,7 @@ def _render_svg_scaled(
     legend_position: str | None,
     responsive: bool = False,
     inject_dark_mode_css: bool = True,
+    bare: bool = False,
 ) -> str:
     """Render body, run with ``theme`` fonts and label metrics already scaled."""
     effective_legend_position = (
@@ -583,10 +592,10 @@ def _render_svg_scaled(
         logo_y = LOGO_Y_STANDALONE
         max_x = max(max_x, logo_x + logo_w)
 
-    # Right margin: use one padding width (content origin already provides
-    # the left margin).  Bottom margin: just enough room for the watermark
-    # text below the last content element.
-    auto_width = max_x + padding
+    # Right margin: one padding width in full mode; none in bare mode so the
+    # canvas hugs the content.  Bottom margin is always just enough room for
+    # the watermark text.
+    auto_width = max_x + (0.0 if bare else padding)
     auto_height = max_y + WATERMARK_Y_INSET * 2 + WATERMARK_FONT_SIZE
 
     svg_width = width or int(auto_width)
@@ -634,22 +643,23 @@ def _render_svg_scaled(
             )
         )
 
-    # Title / Logo (standalone logo only when not embedded in legend)
-    if show_logo and not logo_in_legend:
-        _render_logo(d, graph.logo_path, logo_x, logo_y, logo_w, logo_h)
-    elif graph.title and not logo_in_legend:
-        d.append(
-            draw.Text(
-                graph.title,
-                theme.title_font_size,
-                padding,
-                TITLE_Y_OFFSET,
-                fill=theme.title_color,
-                font_family=theme.label_font_family,
-                font_weight="bold",
-                **{"class": _ns("nf-metro-title")},
+    # Title / Logo (omitted in bare mode; standalone logo only when not in legend)
+    if not bare:
+        if show_logo and not logo_in_legend:
+            _render_logo(d, graph.logo_path, logo_x, logo_y, logo_w, logo_h)
+        elif graph.title and not logo_in_legend:
+            d.append(
+                draw.Text(
+                    graph.title,
+                    theme.title_font_size,
+                    padding,
+                    TITLE_Y_OFFSET,
+                    fill=theme.title_color,
+                    font_family=theme.label_font_family,
+                    font_weight="bold",
+                    **{"class": _ns("nf-metro-title")},
+                )
             )
-        )
 
     # Sections
     if graph.sections:
@@ -691,11 +701,14 @@ def _render_svg_scaled(
         )
 
     # Attribution watermark
+    watermark_x_inset = (
+        WATERMARK_BARE_X_INSET if bare else padding * WATERMARK_PADDING_RATIO
+    )
     d.append(
         draw.Text(
             f"created with nf-metro {_version_string()}",
             WATERMARK_FONT_SIZE,
-            svg_width - padding * WATERMARK_PADDING_RATIO,
+            svg_width - watermark_x_inset,
             svg_height - WATERMARK_Y_INSET,
             fill=WATERMARK_FILL,
             font_family=theme.label_font_family,
@@ -708,7 +721,7 @@ def _render_svg_scaled(
             draw.Text(
                 graph.caption,
                 CAPTION_FONT_SIZE,
-                padding * WATERMARK_PADDING_RATIO,
+                watermark_x_inset,
                 svg_height - WATERMARK_Y_INSET,
                 fill=CAPTION_FILL,
                 font_family=theme.label_font_family,

--- a/tests/test_bare_render.py
+++ b/tests/test_bare_render.py
@@ -1,0 +1,159 @@
+"""Tests for bare render mode.
+
+Bare mode omits the title and outer padding so the SVG is a tight content
+fragment suitable for embedding.  The attribution watermark is NOT removed.
+"""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nf_metro.cli import cli
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.constants import (
+    CANVAS_PADDING,
+    WATERMARK_FONT_SIZE,
+    WATERMARK_Y_INSET,
+)
+from nf_metro.render.svg import render_svg
+from nf_metro.themes import NFCORE_THEME
+
+_TITLED_MMD = (
+    "%%metro title: My Pipeline\n"
+    "%%metro line: main | Main | #ff0000\n"
+    "graph LR\n"
+    "    a[Input] -->|main| b[Output]\n"
+)
+
+_MULTI_SECTION_MMD = Path("examples/rnaseq_sections.mmd")
+
+
+def _graph(text: str):
+    g = parse_metro_mermaid(text)
+    compute_layout(g)
+    return g
+
+
+def _title_text_elements(svg: str) -> list[ET.Element]:
+    """Return all <text> elements that carry the nf-metro-title class."""
+    root = ET.fromstring(svg)
+    return [
+        el
+        for el in root.iter("{http://www.w3.org/2000/svg}text")
+        if "nf-metro-title" in el.get("class", "")
+    ]
+
+
+def test_bare_omits_title():
+    """No title text element is rendered in bare output."""
+    g = _graph(_TITLED_MMD)
+    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    assert _title_text_elements(bare_svg) == []
+
+
+def test_full_chrome_still_has_title():
+    """Full-chrome render includes the title."""
+    g = _graph(_TITLED_MMD)
+    full_svg = render_svg(g, NFCORE_THEME)
+    assert "My Pipeline" in full_svg
+
+
+def test_bare_keeps_watermark():
+    """Watermark attribution must survive bare mode."""
+    g = _graph(_TITLED_MMD)
+    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    assert "nf-metro" in bare_svg
+
+
+def test_bare_canvas_narrower_than_full():
+    """Bare canvas must be narrower (right padding dropped)."""
+    g = _graph(_TITLED_MMD)
+    full_svg = render_svg(g, NFCORE_THEME)
+    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+
+    full_width = int(ET.fromstring(full_svg).attrib["width"])
+    bare_width = int(ET.fromstring(bare_svg).attrib["width"])
+
+    assert bare_width < full_width
+    assert full_width - bare_width == pytest.approx(CANVAS_PADDING, abs=2)
+
+
+def test_bare_canvas_narrower_multi_section():
+    """Right-padding removal holds for a multi-section diagram."""
+    if not _MULTI_SECTION_MMD.exists():
+        pytest.skip("rnaseq_sections.mmd not found")
+    g = _graph(_MULTI_SECTION_MMD.read_text())
+    full_svg = render_svg(g, NFCORE_THEME)
+    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+
+    full_width = int(ET.fromstring(full_svg).attrib["width"])
+    bare_width = int(ET.fromstring(bare_svg).attrib["width"])
+
+    assert bare_width < full_width
+
+
+def test_bare_viewbox_starts_at_origin():
+    """viewBox must begin with '0 0' so overlay alignment is preserved."""
+    g = _graph(_TITLED_MMD)
+    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    root = ET.fromstring(bare_svg)
+    vb = root.attrib.get("viewBox", "")
+    assert vb.startswith("0 0"), f"viewBox={vb!r} does not start at origin"
+
+
+def test_full_viewbox_starts_at_origin():
+    """Full-chrome viewBox must also start at origin (no regression)."""
+    g = _graph(_TITLED_MMD)
+    full_svg = render_svg(g, NFCORE_THEME)
+    root = ET.fromstring(full_svg)
+    vb = root.attrib.get("viewBox", "")
+    assert vb.startswith("0 0"), f"viewBox={vb!r} does not start at origin"
+
+
+def test_bare_height_includes_watermark():
+    """Height must accommodate the watermark even in bare mode."""
+    g = _graph(_TITLED_MMD)
+    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    h = int(ET.fromstring(bare_svg).attrib["height"])
+    assert h >= WATERMARK_Y_INSET + WATERMARK_FONT_SIZE
+
+
+def test_bare_is_valid_svg():
+    """Bare output must be well-formed XML with an svg root."""
+    g = _graph(_TITLED_MMD)
+    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    root = ET.fromstring(bare_svg)
+    assert root.tag.endswith("svg") or "svg" in root.tag
+
+
+def test_bare_cli_flag(tmp_path):
+    """--bare CLI flag produces tighter output than default."""
+    runner = CliRunner()
+    src = Path("examples/rnaseq_sections.mmd")
+    if not src.exists():
+        pytest.skip("rnaseq_sections.mmd not found")
+
+    full_out = tmp_path / "full.svg"
+    bare_out = tmp_path / "bare.svg"
+
+    result_full = runner.invoke(cli, ["render", str(src), "-o", str(full_out)])
+    assert result_full.exit_code == 0, result_full.output
+
+    result_bare = runner.invoke(
+        cli, ["render", str(src), "-o", str(bare_out), "--bare"]
+    )
+    assert result_bare.exit_code == 0, result_bare.output
+
+    full_width = int(ET.parse(full_out).getroot().attrib["width"])
+    bare_width = int(ET.parse(bare_out).getroot().attrib["width"])
+    assert bare_width < full_width
+
+
+def test_bare_no_title_class_element():
+    """No SVG element with the nf-metro-title class is drawn in bare output."""
+    g = _graph(_TITLED_MMD)
+    bare_svg = render_svg(g, NFCORE_THEME, bare=True)
+    assert _title_text_elements(bare_svg) == []


### PR DESCRIPTION
## Summary

- Adds `bare: bool = False` to `render_svg()` and a `--bare/--no-bare` CLI flag on the `render` command.
- In bare mode the title text element is suppressed and the canvas right margin drops from `CANVAS_PADDING` (60px) to zero, so the SVG canvas hugs the content extent.
- The attribution watermark is kept — bare mode is not a watermark-removal path.
- Watermark horizontal inset uses a new `WATERMARK_BARE_X_INSET` constant (8px) so it stays visually clear of the canvas edge without borrowing the vertical `WATERMARK_Y_INSET` constant.
- `viewBox` origin remains `0 0` in both modes, preserving overlay alignment.
- Default (full-chrome) output is unchanged.

Fixes #843

## Test plan
- [ ] `pytest tests/test_bare_render.py` — 11 new tests covering: title element absent, watermark present, canvas narrower by exactly `CANVAS_PADDING`, `viewBox` starts at `0 0`, valid SVG, height includes watermark, CLI `--bare` flag
- [ ] Full `pytest` passes (13 124 tests)
- [ ] `ruff check . && ruff format --check .` clean
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/860/)

Generated with Claude Code