### PR TITLE
Embedding guide for host integrators (#844) + cairosvg raster fix (#863)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,9 @@ This is the authoritative visual review and should be used for all layout or ren
 ```bash
 source ~/.local/bin/mm-activate nf-metro
 
-# Render SVG
-python -m nf_metro render examples/rnaseq_sections.mmd -o /tmp/rnaseq_sections.svg --x-spacing 60 --y-spacing 40
+# Render SVG. --no-chrome-css bakes concrete colors so cairosvg can rasterize it;
+# without it cairosvg aborts on the var() chrome custom properties.
+python -m nf_metro render examples/rnaseq_sections.mmd -o /tmp/rnaseq_sections.svg --x-spacing 60 --y-spacing 40 --no-chrome-css
 
 # Convert SVG to PNG via cairosvg (scale=2 for retina)
 python -c "import cairosvg; cairosvg.svg2png(url='/tmp/rnaseq_sections.svg', write_to='/tmp/rnaseq_sections.png', scale=2)"

--- a/README.md
+++ b/README.md
@@ -79,17 +79,32 @@ nf-metro render [OPTIONS] INPUT_FILE
 | `--height INTEGER` | auto | SVG height in pixels |
 | `--x-spacing FLOAT` | auto | Horizontal spacing between layers (widened from 60 only when wide labels would otherwise collide) |
 | `--y-spacing FLOAT` | auto | Vertical spacing between tracks (derived from the map's content so captioned icons and dense labels don't collide) |
-| `--max-layers-per-row INTEGER` | auto | Max layers before folding to next row |
+| `--fold-threshold INTEGER` | `15` | Max station-columns a section row may reach before wrapping to the next row |
 | `--animate / --no-animate` | off | Add animated balls traveling along lines |
 | `--debug / --no-debug` | off | Show debug overlay (ports, hidden stations, edge waypoints) |
 | `--logo PATH` | none | Logo image path (overrides `%%metro logo:` directive) |
-| `--line-order [definition\|span]` | from file | Line ordering strategy: `definition` preserves `.mmd` order, `span` sorts by section span (longest first) |
-| `--straight-diamonds / --no-straight-diamonds` | on | Keep top branch of diamond fork-joins on the main track. Use `--no-straight-diamonds` for symmetric fan-out. |
+| `--line-order [definition\|span]` | `definition` | Line ordering strategy: `definition` preserves `.mmd` order, `span` sorts by section span (longest first) |
+| `--diamond-style [straight\|symmetric]` | `straight` | Fork-join layout: `straight` keeps the top branch on the main track; `symmetric` fans the branches evenly |
 | `--center-ports / --no-center-ports` | off | Centre inter-section ports on the shorter of the two connected sections |
 | `--section-x-gap FLOAT` | `50` | Horizontal gap between sections |
-| `--section-y-gap FLOAT` | `40` | Vertical gap between sections |
+| `--section-y-gap FLOAT` | `50` | Vertical gap between sections |
 | `--from-nextflow` | off | Convert Nextflow `-with-dag` mermaid input before rendering |
-| `--title TEXT` | none | Pipeline title (used with `--from-nextflow`) |
+| `--title TEXT` | none | Pipeline title (overrides the `%%metro title:` directive) |
+
+#### Embedding options
+
+Flags for producing an SVG to embed in another page or application. See the
+[embedding guide](docs/embedding.md) for when to use each.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--responsive / --no-responsive` | off | Emit `viewBox` only (no fixed `width`/`height`) so the host can scale with CSS |
+| `--embed-font / --no-embed-font` | off | Inline Inter as a base64 `@font-face` so the SVG renders identically on any host |
+| `--text-to-paths / --no-text-to-paths` | off | Convert text to vector paths (no font dependency; loses selectable text; needs `fonttools[woff]`) |
+| `--bare / --no-bare` | off | Omit the title and outer padding so the canvas hugs the content (keeps the watermark) |
+| `--svg-class-prefix TEXT` | none | Prefix every SVG presentation class, so multiple maps on one page don't collide |
+| `--no-dark-mode-css` | off | Suppress the `prefers-color-scheme: dark` block when the host manages its own theme |
+| `--no-chrome-css` | off | Bake concrete chrome colors instead of `--nfm-*` `var()` (needed for raster export, e.g. cairosvg) |
 
 The `--logo` flag lets you use the same `.mmd` file with different logos for dark/light themes:
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,306 @@
+# Embedding guide
+
+!!! warning "Experimental - pre-1.0, not yet stable"
+    The embedding surface (render flags, `--nfm-*` properties, the `data-*`
+    contract, and the manifest schema) is new and still being shaped. Pin to a
+    specific nf-metro release if you depend on the exact output. The manifest
+    schema version (`MANIFEST_SCHEMA_VERSION`) and driver contract version
+    (`DRIVER_CONTRACT_VERSION`) are both `1.0`.
+
+This guide is for someone putting a rendered nf-metro map into **their own**
+page or application: a docs site, an internal dashboard, a pipeline run viewer.
+You do not need to read `src/` to follow it. It covers how to produce an
+embed-friendly file, how to size and theme it from the host page, and how to
+drive it from live state (lighting up nodes as a job runs).
+
+If you only want a picture in a README, skip to
+[Static embed](#a-static-embed). If you want a panel that reacts to a running
+pipeline, read on to [Interactive and progress embeds](#interactive-and-progress-embeds).
+
+## Choosing an output
+
+nf-metro renders two shapes, and the right one depends on what the host needs.
+
+| You want | Use | Why |
+|----------|-----|-----|
+| A static picture (thumbnail, README, slide) | `render` → **SVG** | One self-contained file; scales crisply; no scripts. |
+| A live, interactive panel (pan/zoom, line filtering, hover) | `render --format html` | A self-contained page with the driver and styling already wired. |
+| A progress overlay driven by your own app | **SVG** + the [manifest](manifest.md) | You read the embedded manifest and draw your own status layer. |
+
+The SVG carries a machine-readable [manifest](manifest.md) and a stable
+[`data-*` contract](embed.md) either way, so a static embed can later become an
+interactive one without re-rendering.
+
+## Render options for embedding
+
+These flags shape the SVG for life inside someone else's page. They apply to
+`--format svg`; the interactive HTML page already handles sizing, scoping, and
+chrome itself (see [Interactive and progress embeds](#interactive-and-progress-embeds)).
+
+### Responsive sizing - `--responsive`
+
+By default the `<svg>` carries fixed `width`/`height` attributes. With
+`--responsive` it emits **only** a `viewBox` (plus `preserveAspectRatio`), so
+the host sizes it with CSS:
+
+```bash
+nf-metro render pipeline.mmd -o pipeline.svg --responsive
+```
+
+```css
+.metro-map svg { width: 100%; height: auto; }
+```
+
+Use this for any fluid layout. The `viewBox` stays `0 0 <width> <height>`, so
+overlays built from the manifest still line up (see
+[Progress overlays](#progress-overlays)).
+
+### Font portability - `--embed-font` / `--text-to-paths`
+
+By default the SVG references a system font family, which renders differently
+(or falls back) on a host without that font. Two flags make it self-contained:
+
+| Flag | What it does | Keeps selectable text? | Trade-off |
+|------|--------------|------------------------|-----------|
+| `--embed-font` | Inlines a subset of Inter as a base64 `@font-face` block. | Yes (and `data-*` on labels). | Larger file. |
+| `--text-to-paths` | Converts every glyph to a vector `<path>`. | No. | Smallest dependency surface; needs `fonttools[woff]`. |
+
+```bash
+nf-metro render pipeline.mmd -o pipeline.svg --embed-font      # portable, still selectable
+nf-metro render pipeline.mmd -o pipeline.svg --text-to-paths   # zero font dependency
+```
+
+Prefer `--embed-font` when you want labels to stay selectable/searchable;
+`--text-to-paths` when the consumer is a strict renderer or you need pixel
+fidelity with no font handling at all.
+
+### Bare fragment - `--bare`
+
+`--bare` drops the title and the outer right padding so the canvas hugs the
+content, for a host that supplies its own frame and heading:
+
+```bash
+nf-metro render pipeline.mmd -o pipeline.svg --bare
+```
+
+The `viewBox` origin stays at `0 0` and coordinates stay absolute, so the
+[manifest](manifest.md) and any overlay still align. The attribution watermark
+is **kept** in bare mode (see [Attribution](#attribution)).
+
+### Theming from the host - `--nfm-*` properties
+
+Chrome colors (background, title, labels, section boxes, legend) are emitted as
+CSS custom properties with the theme color as the fallback, e.g.
+`fill: var(--nfm-bg, #2b2b2b)`. A host recolors the map **without re-rendering**
+by setting these on a wrapping element:
+
+```css
+.metro-map {
+  --nfm-bg: #ffffff;
+  --nfm-title-color: #222;
+  --nfm-label-color: #333;
+  --nfm-section-fill: #f4f4f4;
+  --nfm-section-stroke: #ddd;
+  --nfm-section-label-color: #555;
+  --nfm-legend-bg: #fafafa;
+  --nfm-legend-text-color: #333;
+}
+```
+
+| Property | Recolors |
+|----------|----------|
+| `--nfm-bg` | Background rectangle |
+| `--nfm-title-color` | Title text |
+| `--nfm-label-color` | Station labels |
+| `--nfm-section-fill` / `--nfm-section-stroke` | Section box fill / border |
+| `--nfm-section-label-color` | Section names and group labels |
+| `--nfm-legend-bg` / `--nfm-legend-text-color` | Legend background / text |
+
+Line and route colors are **not** recolorable - they carry meaning, so they
+stay baked as presentation attributes.
+
+### Multiple maps on one page - `--svg-class-prefix`
+
+Two inline SVGs on the same page share class names (`nf-metro-station`, …),
+so host CSS or the dark-mode block from one can bleed into the other. Give each
+a distinct prefix:
+
+```bash
+nf-metro render a.mmd -o a.svg --svg-class-prefix mapA
+nf-metro render b.mmd -o b.svg --svg-class-prefix mapB
+```
+
+`mapA-nf-metro-station`, `mapB-nf-metro-station`, and so on stay independent.
+`data-*` attributes and the manifest element id are never prefixed, so the
+[contract](embed.md) is unchanged.
+
+### Dark-mode opt-out - `--no-dark-mode-css`
+
+When a theme has a transparent background, the SVG injects a
+`@media (prefers-color-scheme: dark)` block so labels stay readable on a dark
+host page. If your host manages its own theme and that media query fights it,
+suppress it:
+
+```bash
+nf-metro render pipeline.mmd -o pipeline.svg --no-dark-mode-css
+```
+
+### Raster export (PNG) - `--no-chrome-css`
+
+The `--nfm-*` properties above use CSS `var()`, which a browser resolves but
+many rasterizers (including **cairosvg**) cannot parse - they abort on the
+`var()` token. For a PNG, either render with `--no-chrome-css` (which bakes the
+concrete theme colors and omits the `var()` block; the map looks identical, you
+just lose live host recoloring)…
+
+```bash
+nf-metro render pipeline.mmd -o pipeline.svg --no-chrome-css
+python -c "import cairosvg; cairosvg.svg2png(url='pipeline.svg', write_to='pipeline.png', scale=2)"
+```
+
+…or feed the default SVG to a CSS-custom-property-aware rasterizer
+(`resvg`, `rsvg-convert`, or headless Chromium), which honors the fallbacks.
+
+## Sizing and placement
+
+Everything in an nf-metro SVG lives in one coordinate space: `viewBox="0 0 w h"`
+with no outer transform. That is what makes the host's job simple:
+
+- **Size** the SVG with CSS (`width: 100%; height: auto`) - use `--responsive`
+  so there are no fixed dimensions to override.
+- **Stack** a base render and an overlay by giving both the **same `viewBox`**
+  and absolutely positioning them in the same box. Because coordinates are
+  absolute and share the origin, a marker the overlay draws at a node's
+  manifest `(x, y)` lands exactly on that node.
+
+```html
+<div class="metro-map" style="position: relative;">
+  <!-- base render, sized by CSS -->
+  <object data="pipeline.svg" type="image/svg+xml" style="width:100%;"></object>
+  <!-- overlay, same viewBox, on top -->
+  <svg viewBox="0 0 1509 759"
+       style="position:absolute; inset:0; width:100%; pointer-events:none;">
+    <!-- status markers at manifest coordinates -->
+  </svg>
+</div>
+```
+
+The manifest's `width`/`height` fields give the exact `viewBox` to reuse.
+
+## The embed contract
+
+The stable surface a host depends on is documented in one authoritative place
+each - this guide links to them rather than restating them:
+
+- **[Embed contract](embed.md)** - the `data-node-*` / `data-station-*` /
+  `data-section-*` attribute vocabulary and the driver API
+  (`attachMetroMap`, `highlightLine`, `selectNode`, `getManifest`, …).
+- **[Data manifest](manifest.md)** - the manifest JSON schema, its version, the
+  matching semantics (`patterns` → runtime names), and the `overlay_svg` helper.
+
+The join key across all of it is the node `id`: it equals `data-node-id` on the
+drawn element and `node.id` in the manifest JSON.
+
+## A static embed
+
+The minimum to put a map on a page. Render a portable, fluid SVG and inline it:
+
+```bash
+nf-metro render pipeline.mmd -o pipeline.svg --responsive --embed-font
+```
+
+```html
+<div class="metro-map" style="max-width: 1000px;">
+  <!-- paste the contents of pipeline.svg here, or: -->
+  <object data="pipeline.svg" type="image/svg+xml" style="width:100%;"></object>
+</div>
+```
+
+GitHub READMEs strip `<script>`, so a static SVG is the right choice there. Most
+static-site generators and wikis accept the inline SVG as-is.
+
+## Interactive and progress embeds
+
+### The self-contained interactive page
+
+`render --format html` produces a complete page - SVG, driver, and styling
+inlined, no network. Its **Embed…** modal offers an inline `<div>` snippet
+(keeps interactivity, no iframe), an iframe one-liner, and a static-SVG
+fallback. The page is already responsive and scopes each map independently, so
+the SVG-only sizing/namespacing flags above do not apply to it (the CLI warns
+if you pass them with `--format html`). Font portability **does** reach the
+inlined SVG, so an embeddable page can carry its own fonts:
+
+```bash
+nf-metro render pipeline.mmd --format html -o pipeline.html --embed-font
+```
+
+To wire the driver onto a page yourself (rather than copy the modal snippet),
+see the [driver API](embed.md#driver-api) and `nf-metro embed-script`.
+
+### Progress overlays
+
+To light up nodes as a pipeline runs, keep the base map static and redraw a
+thin **overlay** layer on each state change. The base SVG is the durable map;
+the overlay is a cheap, disposable status layer. The coordinate-space rules:
+
+- The base SVG and overlay share `viewBox="0 0 w h"` (origin `0 0`).
+- The manifest's `width`/`height` match the base render's dimensions.
+- Each node's `x`/`y`/`r` are absolute units in that space, so an overlay
+  marker at `(x, y)` lands on the node.
+
+A worked end-to-end example - read the embedded manifest, match a runtime
+process name to a node, and draw a status layer with `overlay_svg()` - is in the
+manifest tutorial:
+**[Light up a diagram as a job runs](manifest.md#tutorial-light-up-a-diagram-as-a-job-runs)**.
+
+The sketch, in Python:
+
+```python
+from nf_metro.manifest import read_manifest, match_node_ids, overlay_svg
+
+manifest = read_manifest(open("pipeline.svg").read())
+
+def status_layer(states):  # {node_id: "running" | "done" | ...}
+    colors = {"running": "#ffc23a", "done": "#2bee92", "failed": "#ff4d4d"}
+    markers = "".join(
+        f'<circle cx="{n["x"]}" cy="{n["y"]}" r="{n["r"] + 5}" fill="none" '
+        f'stroke="{colors[states[n["id"]]]}" stroke-width="3.5"/>'
+        for n in manifest["nodes"] if n["id"] in states
+    )
+    return overlay_svg(manifest, markers, extra_attrs='style="pointer-events:none"')
+
+# On each event from your runtime:
+#   ids = match_node_ids(manifest, "NFCORE_RNASEQ:RNASEQ:ALIGN_STAR_SALMON:STAR_ALIGN")
+#   update a {node_id: state} map, then re-render status_layer(states) on top.
+```
+
+For a ready-made server that does exactly this for a live Nextflow run, see
+[Live progress](live.md).
+
+## Versioning and stability
+
+The manifest schema and the driver contract are versioned independently, both
+`1.0` today:
+
+```python
+from nf_metro.manifest import MANIFEST_SCHEMA_VERSION       # "1.0"
+from nf_metro.render.driver import DRIVER_CONTRACT_VERSION  # "1.0"
+```
+
+The schema version is `major.minor`: the minor part increments for additive,
+backward-compatible changes; the major part for breaking ones. **Consumers must
+ignore unknown fields.** Stable surface (keyed to the version): the `data-*`
+attribute names, the manifest fields, the `0 0 w h` coordinate rule, and the
+driver method names. Everything else - exact pixel coordinates, internal class
+names beyond the documented ones, the layout - is internal and may change.
+Until a stability notice, pin to a specific nf-metro release.
+
+## Attribution
+
+Rendered maps carry a small `created with nf-metro` watermark in the corner. It
+stays by default, **including in `--bare` mode**. Please keep it on embedded
+maps - it is a quiet credit that helps people find the project, and keeping it
+is the easiest way to support nf-metro. There is no convenience flag to remove
+it; removal is reserved for specific functionality rather than offered as a
+toggle. This is a friendly ask, not a license restriction.

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,20 @@ Every layout/render option below also has a `%%metro` directive twin; an explici
 | `--height INTEGER` | auto | Output height in pixels |
 | `--animate / --no-animate` | off | Add animated balls traveling along lines |
 
+#### Embedding options
+
+Flags for producing an SVG to embed in another page or application. The [Embedding guide](embedding.md) explains when to use each.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--responsive / --no-responsive` | off | Emit `viewBox` only (no fixed `width`/`height`) for CSS-scalable embedding |
+| `--embed-font / --no-embed-font` | off | Inline Inter as a base64 `@font-face` so the SVG renders identically anywhere |
+| `--text-to-paths / --no-text-to-paths` | off | Convert text to vector paths (no font dependency; loses selectable text) |
+| `--bare / --no-bare` | off | Omit the title and outer padding so the canvas hugs the content (keeps the watermark) |
+| `--svg-class-prefix TEXT` | none | Prefix every SVG presentation class so multiple maps on one page don't collide |
+| `--no-dark-mode-css` | off | Suppress the `prefers-color-scheme: dark` block when the host manages its own theme |
+| `--no-chrome-css` | off | Bake concrete chrome colors instead of `--nfm-*` `var()` (needed for raster export, e.g. cairosvg) |
+
 #### Interactive HTML output
 
 `--format html` produces a self-contained `.html` file with the SVG inlined plus a small JS/CSS layer (no external dependencies, no network):
@@ -141,6 +155,10 @@ nf-metro info INPUT_FILE
 ## Writing metro maps
 
 Read the [Guide](guide.md) to learn how to write `.mmd` files, from minimal examples to multi-section pipelines with custom grid layouts.
+
+## Embedding maps in your own page
+
+Read the [Embedding guide](embedding.md) to put a rendered map into a docs site, dashboard, or app: responsive sizing, font portability, host theming, and driving a progress overlay from a running pipeline.
 
 ## Gallery
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,8 +38,10 @@ exclude_docs: |
 nav:
   - Home: index.md
   - Guide: guide.md
+  - Embedding: embedding.md
   - Live progress: live.md
   - Data manifest: manifest.md
+  - Embed contract: embed.md
   - Nextflow Import: nextflow.md
   - nf-core Pipelines: pipelines/index.md
   - Gallery: gallery/index.md

--- a/scripts/render_topologies.py
+++ b/scripts/render_topologies.py
@@ -84,7 +84,9 @@ def render_file(
     theme = THEMES[theme_name]
 
     try:
-        svg_str = render_svg(graph, theme, debug=debug)
+        # chrome_css=False bakes concrete colors so the cairosvg PNG step below
+        # works (cairosvg cannot parse the var() chrome custom properties).
+        svg_str = render_svg(graph, theme, debug=debug, chrome_css=False)
     except Exception as e:
         return name, [f"RENDER ERROR: {e}"]
 

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -223,6 +223,17 @@ def _resolve_theme(theme: str | None, graph: MetroGraph) -> Theme:
     ),
 )
 @click.option(
+    "--no-chrome-css",
+    is_flag=True,
+    default=False,
+    help=(
+        "Omit the chrome --nfm-* CSS custom-property <style> block. Colors "
+        "still render (they are baked as presentation attributes); only live "
+        "host recoloring is dropped. Use for raster export: cairosvg and "
+        "similar rasterizers cannot parse var() and fail without this."
+    ),
+)
+@click.option(
     "--bare/--no-bare",
     default=False,
     help=(
@@ -248,6 +259,7 @@ def render(
     text_to_paths: bool,
     svg_class_prefix: str,
     no_dark_mode_css: bool,
+    no_chrome_css: bool,
     bare: bool,
     **layout_opts: object,
 ) -> None:
@@ -299,7 +311,34 @@ def render(
     )
 
     if format_ == "html":
-        content = render_html(graph, theme_obj, debug=debug, embed_basename=output.name)
+        # The interactive page supplies its own responsive frame, chrome, and
+        # per-map class scoping, so the SVG-only sizing/namespacing flags have
+        # nothing to act on. Font portability and the dark-mode block do reach
+        # the inlined SVG, so they are threaded through.
+        ignored = [
+            name
+            for name, enabled in (
+                ("--responsive", responsive),
+                ("--bare", bare),
+                ("--svg-class-prefix", bool(svg_class_prefix)),
+            )
+            if enabled
+        ]
+        if ignored:
+            click.echo(
+                f"Note: {', '.join(ignored)} only affect --format svg and are "
+                "ignored for --format html (the interactive page is already "
+                "responsive and scopes each map independently).",
+                err=True,
+            )
+        content = render_html(
+            graph,
+            theme_obj,
+            debug=debug,
+            embed_basename=output.name,
+            font_portability=font_portability,
+            inject_dark_mode_css=not no_dark_mode_css,
+        )
     else:
         content = render_svg(
             graph,
@@ -309,6 +348,7 @@ def render(
             font_portability=font_portability,
             svg_class_prefix=svg_class_prefix,
             inject_dark_mode_css=not no_dark_mode_css,
+            chrome_css=not no_chrome_css,
             bare=bare,
         )
 

--- a/src/nf_metro/render/html.py
+++ b/src/nf_metro/render/html.py
@@ -7,6 +7,7 @@ import html
 import json
 from importlib.resources import files
 from string import Template
+from typing import Literal
 
 from nf_metro.parser.model import MetroGraph
 from nf_metro.render.driver import get_driver_js
@@ -34,10 +35,16 @@ def render_html(
     animate: bool | None = None,
     debug: bool = False,
     embed_basename: str = "metro_map.html",
+    font_portability: Literal["embed", "paths"] | None = None,
+    inject_dark_mode_css: bool = True,
 ) -> str:
     """Render the graph to an interactive standalone HTML page.
 
     The HTML side panel replaces the SVG legend in interactive mode.
+
+    ``font_portability`` and ``inject_dark_mode_css`` are forwarded to the
+    inlined SVG so an embeddable page can carry its own fonts and opt out of
+    the dark-mode media query.  See :func:`nf_metro.render.svg.render_svg`.
     """
     svg = render_svg(
         graph,
@@ -47,6 +54,8 @@ def render_html(
         animate=animate,
         debug=debug,
         legend_position="none",
+        font_portability=font_portability,
+        inject_dark_mode_css=inject_dark_mode_css,
     )
 
     title = graph.title or "nf-metro map"

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -399,6 +399,7 @@ def render_svg(
     font_portability: Literal["embed", "paths"] | None = None,
     svg_class_prefix: str = "",
     inject_dark_mode_css: bool = True,
+    chrome_css: bool = True,
     bare: bool = False,
 ) -> str:
     """Render a metro map graph to an SVG string.
@@ -431,6 +432,14 @@ def render_svg(
     ``<style>`` block is omitted.  Useful when a host page manages its own
     theme and the injected media query would fight it.
 
+    ``chrome_css``: when False, the chrome ``--nfm-*`` CSS custom-property
+    ``<style>`` block is omitted.  Chrome elements carry their concrete theme
+    colors as presentation attributes regardless, so both modes render the
+    same map; what False drops is a host page's ability to recolor it live
+    with ``var()``.  Set this False for raster export (e.g. cairosvg, which
+    cannot parse ``var()``) or any consumer without CSS custom-property
+    support.
+
     ``bare``: when True, omits the title and outer padding so the canvas
     hugs the diagram content.  The attribution watermark is kept.  Use for
     embedding the SVG inside a host page that supplies its own frame and
@@ -459,6 +468,7 @@ def render_svg(
             legend_position=legend_position,
             responsive=responsive,
             inject_dark_mode_css=inject_dark_mode_css,
+            chrome_css=chrome_css,
             bare=bare,
         )
 
@@ -506,6 +516,7 @@ def _render_svg_scaled(
     legend_position: str | None,
     responsive: bool = False,
     inject_dark_mode_css: bool = True,
+    chrome_css: bool = True,
     bare: bool = False,
 ) -> str:
     """Render body, run with ``theme`` fonts and label metrics already scaled."""
@@ -619,7 +630,8 @@ def _render_svg_scaled(
 
     # Chrome CSS: custom properties so hosts can recolor without re-rendering.
     # Injected before the background rect so browser parsing order is correct.
-    _inject_chrome_css(d, theme)
+    if chrome_css:
+        _inject_chrome_css(d, theme)
 
     # Dark-mode CSS for transparent-background themes so that elements
     # rendered directly on the canvas (section labels, number badges,

--- a/tests/test_css_custom_properties.py
+++ b/tests/test_css_custom_properties.py
@@ -5,6 +5,8 @@ CSS custom properties so a host can recolor without re-rendering.  Line/route
 colors remain baked as presentation attributes (semantic).
 """
 
+import pytest
+
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render.svg import render_svg
@@ -178,3 +180,36 @@ def test_legend_text_has_nf_metro_legend_text_class():
     """Legend text entries should carry the nf-metro-legend-text class."""
     svg = render_svg(_make_graph(), NFCORE_THEME)
     assert "nf-metro-legend-text" in svg
+
+
+# ---------------------------------------------------------------------------
+# chrome_css=False: concrete colors for raster export (cairosvg)
+# ---------------------------------------------------------------------------
+
+
+def test_chrome_css_false_omits_var_references():
+    """chrome_css=False emits no var() so non-CSS-custom-property renderers cope."""
+    svg = render_svg(_make_graph(), NFCORE_THEME, chrome_css=False)
+    assert "var(--nfm" not in svg
+
+
+def test_chrome_css_false_keeps_concrete_chrome_colors():
+    """Dropping the var() block leaves concrete colors baked on chrome elements."""
+    svg = render_svg(_make_graph(), NFCORE_THEME, chrome_css=False)
+    # The background rect and section boxes keep their theme fills.
+    assert f'fill="{NFCORE_THEME.background_color}"' in svg
+    assert f'fill="{NFCORE_THEME.section_fill}"' in svg
+
+
+def test_chrome_css_default_emits_var_block():
+    """The default keeps the var() block so a host can recolor the map live."""
+    svg = render_svg(_make_graph(), NFCORE_THEME)
+    assert "var(--nfm-bg" in svg
+
+
+def test_chrome_css_false_rasterizes_with_cairosvg():
+    """chrome_css=False output is consumable by cairosvg, which cannot parse var()."""
+    cairosvg = pytest.importorskip("cairosvg")
+    svg = render_svg(_make_graph(), NFCORE_THEME, chrome_css=False)
+    png = cairosvg.svg2png(bytestring=svg.encode())
+    assert png[:8] == b"\x89PNG\r\n\x1a\n"

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -141,3 +141,57 @@ def test_render_html_title_in_markup():
 
     assert graph.title
     assert graph.title in html_out
+
+
+# ---------------------------------------------------------------------------
+# Embedding flags forwarded to the inlined SVG
+# ---------------------------------------------------------------------------
+
+
+def test_render_html_forwards_font_portability_embed():
+    """font_portability='embed' inlines the webfont into the page's SVG."""
+    text = RNASEQ_MMD.read_text()
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph)
+
+    plain = render_html(graph, THEMES["nfcore"])
+    embedded = render_html(graph, THEMES["nfcore"], font_portability="embed")
+
+    assert "@font-face" not in plain
+    assert "@font-face" in embedded
+
+
+def test_render_html_embed_font_via_cli(tmp_path):
+    """render --format html --embed-font reaches the inlined SVG."""
+    out = tmp_path / "out.html"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["render", str(RNASEQ_MMD), "-o", str(out), "--format", "html", "--embed-font"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "@font-face" in out.read_text()
+
+
+def test_render_html_warns_on_svg_only_flags(tmp_path):
+    """SVG-only sizing/namespacing flags warn (not silently ignored) for html."""
+    out = tmp_path / "out.html"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            str(RNASEQ_MMD),
+            "-o",
+            str(out),
+            "--format",
+            "html",
+            "--bare",
+            "--svg-class-prefix",
+            "foo",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "--bare" in result.output
+    assert "--svg-class-prefix" in result.output
+    assert "ignored for --format html" in result.output


### PR DESCRIPTION
## Summary

Adds the integrator-facing embedding guide that #844 calls for, fixes the cairosvg breakage from #863, and smooths two UX rough edges surfaced while validating the shipped embedding features (#838-#843).

### Docs (#844)
- **`docs/embedding.md`** - an end-to-end guide for someone embedding a rendered map in their own page: the render modes for embedding (responsive, font portability, bare, `--nfm-*` chrome theming, class namespacing, dark-mode and raster opt-outs) and when to choose each; host sizing/placement against the shared `viewBox`; the progress-overlay pattern with coordinate-space rules; copy-paste static and interactive examples; versioning/stability; and a friendly "please keep the watermark" attribution request. It links to the authoritative contract references (`embed.md`, `manifest.md`) rather than duplicating them.
- Wires the guide **and the previously-orphaned `embed.md`** into the mkdocs nav; links the guide from the README and docs index.
- Refreshes the stale README CLI table: drops the removed `--max-layers-per-row` / `--straight-diamonds`, corrects the `--section-y-gap` default, and adds an Embedding options section.

### Raster export fix (#863)
- New `chrome_css` render option (`--no-chrome-css`) omits the `--nfm-*` CSS custom-property `<style>` block. Chrome elements keep their concrete theme colors as presentation attributes, so the map renders identically; only live host recoloring via `var()` is dropped. cairosvg and similar rasterizers cannot parse `var()` and abort without this.
- `scripts/render_topologies.py` and the CLAUDE.md quick-render loop now use the cairosvg-safe path, restoring local PNG export.

### HTML flag handling
- `--format html` no longer silently ignores the embedding flags: font portability and the dark-mode opt-out now thread into the inlined SVG; the SVG-only sizing/namespacing flags (`--responsive`, `--bare`, `--svg-class-prefix`) emit a clear note instead of vanishing.

Fixes #844
Fixes #863

## Test plan
- [x] `pytest` passes (13131 passed, 6 pre-existing xfails); new regression tests in `test_css_custom_properties.py` (chrome_css opt-out + cairosvg rasterization) and `test_html.py` (HTML flag threading + warning)
- [x] `ruff format --check` + `ruff check` + `mypy` clean on the whole repo
- [x] `mkdocs build` resolves all links in the new guide (pre-existing generated-asset warnings unchanged)
- [ ] Visual review of the [render preview](https://pinin4fjords.github.io/nf-metro/_pr/864/)
- [ ] Render-preview verdict captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
