### PR TITLE
refactor: consolidate the bypass-V id predicate via is_bypass_v (#699)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -277,7 +277,7 @@ from nf_metro.layout.phases.spacing import (  # noqa: F401
     _spread_bump,
     _struck_stations_and_collinear,
 )
-from nf_metro.parser.model import LineSpread, MetroGraph, Section
+from nf_metro.parser.model import LineSpread, MetroGraph, Section, is_bypass_v
 from nf_metro.parser.validate import (
     CyclicGraphError,
     find_cycle,
@@ -736,8 +736,7 @@ def _apply_label_strike_clearance(
     bypass_divergence_sources = {
         edge.source
         for edge in graph.edges
-        if edge.target.startswith("__bypass_")
-        and not edge.source.startswith("__bypass_")
+        if is_bypass_v(edge.target) and not is_bypass_v(edge.source)
     }
 
     def _issues() -> tuple[set[str], bool, set[tuple[str, str, int]]]:

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -13,7 +13,15 @@ from nf_metro.layout.constants import (
     SECTION_Y_PADDING,
     STATION_RADIUS_APPROX,
 )
-from nf_metro.parser.model import Edge, MetroGraph, Port, PortSide, Section, Station
+from nf_metro.parser.model import (
+    Edge,
+    MetroGraph,
+    Port,
+    PortSide,
+    Section,
+    Station,
+    is_bypass_v,
+)
 
 if TYPE_CHECKING:
     from nf_metro.layout.routing.common import RoutedPath
@@ -103,7 +111,7 @@ def _content_station_ys(graph: MetroGraph, section: Section) -> list[float]:
         if (
             sid in graph.stations
             and not graph.stations[sid].is_port
-            and not sid.startswith("__bypass_")
+            and not is_bypass_v(sid)
         )
     ]
 
@@ -409,7 +417,7 @@ def _max_stations_per_layer(sub: MetroGraph) -> int:
     """
     layer_ys: dict[int, set[float]] = defaultdict(set)
     for s in sub.stations.values():
-        if s.id.startswith("__bypass_"):
+        if is_bypass_v(s.id):
             continue
         layer_ys[s.layer].add(s.y)
     return max((len(ys) for ys in layer_ys.values()), default=1)
@@ -529,7 +537,7 @@ def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
             if (
                 st
                 and not st.is_port
-                and not other_id.startswith("__bypass_")
+                and not is_bypass_v(other_id)
                 and set(graph.station_lines(other_id)) == bundle
             ):
                 trunk_ys.add(round(st.y, 3))

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -25,7 +25,7 @@ from nf_metro.layout.phases.single_section import (
     _terminus_y_overhang,
     angled_label_reach,
 )
-from nf_metro.parser.model import MetroGraph, Section, Station
+from nf_metro.parser.model import MetroGraph, Section, Station, is_bypass_v
 
 
 def _predicted_bypass_bottom_in_row(
@@ -394,7 +394,7 @@ def _predict_section_content_bottom(
             if (
                 sid in graph.stations
                 and not graph.stations[sid].is_port
-                and not sid.startswith("__bypass_")
+                and not is_bypass_v(sid)
             )
         ]
     if not content_bots:
@@ -403,7 +403,7 @@ def _predict_section_content_bottom(
     bypass_max_ys = [
         graph.stations[sid].y
         for sid in section.station_ids
-        if sid in graph.stations and sid.startswith("__bypass_")
+        if sid in graph.stations and is_bypass_v(sid)
     ]
     port_max_ys = [
         graph.stations[sid].y
@@ -573,7 +573,7 @@ def _section_content_hug_top(
     bypass_min_ys = [
         graph.stations[sid].y
         for sid in section.station_ids
-        if sid in graph.stations and sid.startswith("__bypass_")
+        if sid in graph.stations and is_bypass_v(sid)
     ]
     port_min_ys = [
         graph.stations[sid].y
@@ -606,9 +606,7 @@ def _section_band_is_empty(graph: MetroGraph, section: Section) -> bool:
         st = graph.stations.get(sid)
         if st is None:
             continue
-        if (
-            st.is_port or sid.startswith("__bypass_")
-        ) and st.y < topmost - SAME_COORD_TOLERANCE:
+        if (st.is_port or is_bypass_v(sid)) and st.y < topmost - SAME_COORD_TOLERANCE:
             return False
     return True
 

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -26,7 +26,14 @@ from nf_metro.layout.phases._common import (
     _grow_section_bbox_upward,
     _set_section_bbox_top,
 )
-from nf_metro.parser.model import Edge, MetroGraph, PortSide, Section, Station
+from nf_metro.parser.model import (
+    Edge,
+    MetroGraph,
+    PortSide,
+    Section,
+    Station,
+    is_bypass_v,
+)
 
 # A producer this far below the section's top trunk row is treated as
 # sitting on a downward branch, so its off-track output drops below it
@@ -369,11 +376,11 @@ def _detect_fork_join_layers(
     making a visible-vs-owner diagonal trigger a gap while a V-only off-trunk
     peer does not.
     """
-    visible_tracks = {t for sid, t in tracks.items() if not sid.startswith("__bypass_")}
+    visible_tracks = {t for sid, t in tracks.items() if not is_bypass_v(sid)}
     is_single_track = len(visible_tracks) <= 1
 
     def _has_bypass(ids: set[str]) -> bool:
-        return any(nid.startswith("__bypass_") for nid in ids)
+        return any(is_bypass_v(nid) for nid in ids)
 
     def _bypass_aware_tracks(ids: set[str], owner_sid: str) -> set[float]:
         """Visible peer tracks plus the owner's own track, V's removed."""
@@ -382,7 +389,7 @@ def _detect_fork_join_layers(
         if owner_track is not None:
             result.add(owner_track)
         for nid in ids:
-            if nid.startswith("__bypass_"):
+            if is_bypass_v(nid):
                 continue
             t = tracks.get(nid)
             if t is not None:

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -43,7 +43,7 @@ from nf_metro.layout.phases.off_track import (
     _insert_phantom_pass_throughs,
     _space_off_track_outputs,
 )
-from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
+from nf_metro.parser.model import MetroGraph, PortSide, Section, Station, is_bypass_v
 
 
 def _align_terminus_to_upstream(graph: MetroGraph) -> None:
@@ -258,12 +258,10 @@ def _layout_single_section(
     # section edge (~CURVE_RADIUS + half a station flat) - much less
     # than the full station_y_padding (which is reserved for label
     # clearance around real stations).
-    real_for_bbox = [
-        s for s in sub.stations.values() if not s.id.startswith("__bypass_")
-    ]
+    real_for_bbox = [s for s in sub.stations.values() if not is_bypass_v(s.id)]
     if not real_for_bbox:
         real_for_bbox = list(sub.stations.values())
-    bypass_v_ys = [s.y for s in sub.stations.values() if s.id.startswith("__bypass_")]
+    bypass_v_ys = [s.y for s in sub.stations.values() if is_bypass_v(s.id)]
     xs = [s.x for s in real_for_bbox]
     ys = [s.y for s in real_for_bbox]
     extra_label_h = _multiline_label_padding(sub)
@@ -692,10 +690,10 @@ def _adjust_lr_exit_gap(
             if edge.source not in real_ids:
                 continue
             src_id = edge.source
-            if src_id.startswith("__bypass_"):
+            if is_bypass_v(src_id):
                 pred_y = None
                 for pe in graph.edges_to(src_id):
-                    if pe.source in real_ids and not pe.source.startswith("__bypass_"):
+                    if pe.source in real_ids and not is_bypass_v(pe.source):
                         ps = sub.stations.get(pe.source)
                         if ps is not None:
                             pred_y = ps.y

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import DIAGONAL_SLOPE_RATIO, MIN_STATION_FLAT_LENGTH
 from nf_metro.layout.phases._common import _restoring_layout_geometry
-from nf_metro.parser.model import MetroGraph
+from nf_metro.parser.model import MetroGraph, is_bypass_v
 
 if TYPE_CHECKING:
     from nf_metro.layout.labels import LabelOverlap, LabelPlacement
@@ -119,8 +119,8 @@ def _struck_label_station_ids(
 
     def _bypass_endpoint(r: RoutedPath) -> str | None:
         """The real station a bypass-V leg diverges from or merges at, if any."""
-        src_bypass = r.edge.source.startswith("__bypass_")
-        tgt_bypass = r.edge.target.startswith("__bypass_")
+        src_bypass = is_bypass_v(r.edge.source)
+        tgt_bypass = is_bypass_v(r.edge.target)
         if src_bypass == tgt_bypass:
             return None
         return r.edge.target if src_bypass else r.edge.source
@@ -243,8 +243,8 @@ def _bypass_v_flat_gaps_from(
     """
     gaps: set[tuple[str, int]] = set()
     for r in routes:
-        into_v = r.edge.target.startswith("__bypass_")
-        out_of_v = r.edge.source.startswith("__bypass_")
+        into_v = is_bypass_v(r.edge.target)
+        out_of_v = is_bypass_v(r.edge.source)
         if into_v == out_of_v:
             continue
         v = graph.stations.get(r.edge.target if into_v else r.edge.source)
@@ -274,10 +274,7 @@ def _bypass_v_collapsed_flat_gaps(graph: MetroGraph) -> set[tuple[str, int]]:
     geometry mutations, so this never perturbs the live layout.  See
     :func:`_bypass_v_flat_gaps_from`.
     """
-    if not any(
-        e.source.startswith("__bypass_") or e.target.startswith("__bypass_")
-        for e in graph.edges
-    ):
+    if not any(is_bypass_v(e.source) or is_bypass_v(e.target) for e in graph.edges):
         return set()
     probe = _probe_label_placements(graph, allow_hyphenation=True)
     if probe is None:

--- a/src/nf_metro/layout/routing/intra_handlers.py
+++ b/src/nf_metro/layout/routing/intra_handlers.py
@@ -48,6 +48,7 @@ from nf_metro.parser.model import (
     Edge,
     PortSide,
     Station,
+    is_bypass_v,
 )
 
 
@@ -391,13 +392,13 @@ def _route_diagonal(
     # equal V-side flat reservations so V sits at the centre of the
     # straight segment of the bypass loop.
     v_flat_half = CURVE_RADIUS + MIN_STATION_FLAT_LENGTH / 2
-    if tgt.is_hidden and edge.target.startswith("__bypass_"):
+    if tgt.is_hidden and is_bypass_v(edge.target):
         is_fork_flag = False
         is_join_flag = True
         tgt_min = v_flat_half
         if src_min + tgt_min + ctx.diagonal_run > abs(dx):
             tgt_min = MIN_STRAIGHT_EDGE
-    elif src.is_hidden and edge.source.startswith("__bypass_"):
+    elif src.is_hidden and is_bypass_v(edge.source):
         is_fork_flag = True
         is_join_flag = False
         src_min = v_flat_half

--- a/src/nf_metro/layout/routing/postprocess.py
+++ b/src/nf_metro/layout/routing/postprocess.py
@@ -26,6 +26,7 @@ from nf_metro.layout.routing.context import (
 from nf_metro.parser.model import (
     MetroGraph,
     Station,
+    is_bypass_v,
 )
 
 
@@ -69,9 +70,7 @@ def _spread_diagonal_bundles(routes: list[RoutedPath], ctx: _RoutingCtx) -> None
         # forces asymmetric clamping, producing a visible kink at V.
         # Bypass V routes are short and the perpendicular separation
         # from per-line Y offsets alone is sufficient for visibility.
-        if rp.edge.source.startswith("__bypass_") or rp.edge.target.startswith(
-            "__bypass_"
-        ):
+        if is_bypass_v(rp.edge.source) or is_bypass_v(rp.edge.target):
             continue
         if rp.edge.source in ctx.fork_stations:
             fork_groups[rp.edge.source].append(rp)
@@ -429,8 +428,7 @@ def _centering_candidate(
 
     # Guard: don't shift in convergence/divergence bundles.  Bypass V
     # helpers have no marker so the convergence-guard doesn't apply.
-    is_bypass_v = sid.startswith("__bypass_")
-    if not is_bypass_v:
+    if not is_bypass_v(sid):
         if out_rp and len(ctx.diag_in_sources.get(out_rp.edge.target, set())) > 1:
             return None
         if in_rp and len(ctx.diag_out_targets.get(in_rp.edge.source, set())) > 1:
@@ -459,7 +457,7 @@ def _collect_centering_candidates(
     for sid, station in graph.stations.items():
         if station.is_port:
             continue
-        if station.is_hidden and not sid.startswith("__bypass_"):
+        if station.is_hidden and not is_bypass_v(sid):
             continue
         candidate = _centering_candidate(graph, ctx, sid, station)
         if candidate is not None:
@@ -494,7 +492,7 @@ def _apply_station_moves(
         # Hidden bypass V helpers have no marker, so column alignment
         # with visible companions isn't a visible concern - centre them
         # without requiring companion consensus.
-        skip_companion_check = sid.startswith("__bypass_")
+        skip_companion_check = is_bypass_v(sid)
         if not skip_companion_check and abs(new_x - station.x) > STATION_MOVE_TOLERANCE:
             ox = original_x.get(sid, station.x)
             companions = []

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -37,7 +37,7 @@ from nf_metro.layout.routing.common import (
     resolve_section,
     section_exists_above_row,
 )
-from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
+from nf_metro.parser.model import MetroGraph, PortSide, Section, Station, is_bypass_v
 
 
 def _assign_grid_layout(
@@ -1287,10 +1287,10 @@ def _find_connected_internal_coord(
     )
     vals: list[float] = []
     for edge in graph.edges_from(port_id):
-        if edge.target in internal_ids and not edge.target.startswith("__bypass_"):
+        if edge.target in internal_ids and not is_bypass_v(edge.target):
             vals.append(getattr(graph.stations[edge.target], axis))
     for edge in graph.edges_to(port_id):
-        if edge.source in internal_ids and not edge.source.startswith("__bypass_"):
+        if edge.source in internal_ids and not is_bypass_v(edge.source):
             vals.append(getattr(graph.stations[edge.source], axis))
     if vals:
         return sum(vals) / len(vals)

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -117,6 +117,20 @@ class MarkerLegendEntry:
     caption: str
 
 
+BYPASS_V_PREFIX = "__bypass_"
+
+
+def is_bypass_v(station_id: str) -> bool:
+    """True if *station_id* names a hidden bypass-V helper station.
+
+    Bypass-V helpers are the routing-only nodes inserted by
+    :mod:`nf_metro.parser.resolve` to route a line around a station it does
+    not stop at.  Their ids are built with :data:`BYPASS_V_PREFIX`; this is
+    the one place the prefix is interpreted.
+    """
+    return station_id.startswith(BYPASS_V_PREFIX)
+
+
 @dataclass
 class Station:
     """A node/station in the metro map."""

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 import networkx as nx
 
 from nf_metro.parser.model import (
+    BYPASS_V_PREFIX,
     Edge,
     MetroGraph,
     Port,
@@ -299,7 +300,7 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
             )
             for pred_id, bypass_edges in bypass_by_pred.items():
                 bypass_count += 1
-                v_id = f"__bypass_{sid}_{pred_id}_{bypass_count}"
+                v_id = f"{BYPASS_V_PREFIX}{sid}_{pred_id}_{bypass_count}"
                 new_stations.append(
                     Station(
                         id=v_id,

--- a/tests/test_bypass_invariants.py
+++ b/tests/test_bypass_invariants.py
@@ -37,6 +37,7 @@ import pytest
 from nf_metro.layout.engine import _station_marker_bbox, compute_layout
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import is_bypass_v
 from nf_metro.render.svg import apply_route_offsets
 
 GUIDE = Path(__file__).resolve().parent.parent / "examples" / "guide"
@@ -133,7 +134,22 @@ _BYPASS_QUIET_FIXTURES = [
 def test_no_bypass_inserted_for_quiet_fixtures(rel_path):
     text = (Path(__file__).resolve().parent.parent / rel_path).read_text()
     graph = parse_metro_mermaid(text)
-    bypass_ids = [sid for sid in graph.stations if sid.startswith("__bypass_")]
+    bypass_ids = [sid for sid in graph.stations if is_bypass_v(sid)]
     assert bypass_ids == [], (
         f"{rel_path}: expected no bypass stations, got {bypass_ids}"
     )
+
+
+@pytest.mark.parametrize("name", _GUIDE_BYPASS_FIXTURES)
+def test_is_bypass_v_recognises_resolve_generated_helpers(name):
+    """The helper ids ``resolve`` builds are recognised by ``is_bypass_v`` and
+    carry the V's defining traits (hidden, label-less).  Pins the
+    producer/consumer pairing so renaming the prefix stays a one-site change
+    rather than silently splitting the id-builder from its predicate.
+    """
+    graph = _layout_guide(name)
+    flagged = [st for sid, st in graph.stations.items() if is_bypass_v(sid)]
+    assert flagged, f"{name}: expected at least one bypass-V helper"
+    for st in flagged:
+        assert st.is_hidden, f"{name}: {st.id!r} flagged as bypass-V but is visible"
+        assert not st.label.strip(), f"{name}: bypass-V {st.id!r} carries a label"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -11,6 +11,7 @@ from nf_metro.layout.labels import label_text_width
 from nf_metro.layout.layers import assign_layers
 from nf_metro.layout.ordering import assign_tracks
 from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import is_bypass_v
 
 
 def _patch_layout_helper(monkeypatch, name, replacement):
@@ -207,7 +208,7 @@ def test_compute_layout_rowspan_section_compacts_content():
     tall_content_top = min(
         graph.stations[sid].y
         for sid in tall.station_ids
-        if not graph.stations[sid].is_port and not sid.startswith("__bypass_")
+        if not graph.stations[sid].is_port and not is_bypass_v(sid)
     )
     assert tall.bbox_y == pytest.approx(tall_content_top - SECTION_Y_PADDING), (
         f"tall bbox_y={tall.bbox_y} should hug its content "

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -74,7 +74,14 @@ from nf_metro.layout.routing.invariants import (
     check_no_collinear_distinct_lines,
 )
 from nf_metro.parser.mermaid import parse_metro_mermaid
-from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
+from nf_metro.parser.model import (
+    BYPASS_V_PREFIX,
+    MetroGraph,
+    PortSide,
+    Section,
+    Station,
+    is_bypass_v,
+)
 from nf_metro.render.svg import (
     _compute_icon_obstacles,
     _icon_obstacles_by_station,
@@ -308,10 +315,7 @@ def _fixtures_with_bypass() -> list[str]:
             g = _layout(name)
         except Exception:
             continue
-        if any(
-            st.is_hidden and sid.startswith("__bypass_")
-            for sid, st in g.stations.items()
-        ):
+        if any(st.is_hidden and is_bypass_v(sid) for sid, st in g.stations.items()):
             out.append(name)
     return out
 
@@ -2138,8 +2142,8 @@ def _bypass_v_own_label_strikes(fixture: str) -> list[str]:
     by_station = {p.station_id: p for p in placements if p.station_id}
     struck: list[str] = []
     for r in routes:
-        src_bypass = r.edge.source.startswith("__bypass_")
-        tgt_bypass = r.edge.target.startswith("__bypass_")
+        src_bypass = is_bypass_v(r.edge.source)
+        tgt_bypass = is_bypass_v(r.edge.target)
         if src_bypass == tgt_bypass:
             continue
         endpoint = r.edge.target if src_bypass else r.edge.source
@@ -2843,7 +2847,7 @@ def test_off_track_fit_top_clamps_to_content_above_band():
         for s in section.station_ids
         if not graph.stations[s].is_port
         and not graph.stations[s].off_track
-        and not s.startswith("__bypass_")
+        and not is_bypass_v(s)
     )
     graph.stations[on_id].y = highest - 30.0  # above the off-track band
 
@@ -2928,7 +2932,7 @@ def _fit_top_section(*, content_ys, ports=(), bypass_ys=(), grid_row=0):
         )
         section.station_ids.append(sid)
     for i, y in enumerate(bypass_ys):
-        sid = f"__bypass_{i}"
+        sid = f"{BYPASS_V_PREFIX}{i}"
         graph.stations[sid] = Station(id=sid, label="", section_id="s", y=y)
         section.station_ids.append(sid)
     return graph, section
@@ -4530,9 +4534,7 @@ def test_non_consumed_lines_route_via_virtual_station(fixture):
     # would otherwise route past annotate.  After v110, those lines
     # must enter a hidden station in the same section.
     bypass_station_ids = {
-        sid
-        for sid, st in graph.stations.items()
-        if st.is_hidden and sid.startswith("__bypass_")
+        sid for sid, st in graph.stations.items() if st.is_hidden and is_bypass_v(sid)
     }
     assert bypass_station_ids, (
         f"{fixture}: expected at least one __bypass_ hidden station "
@@ -4650,9 +4652,7 @@ def test_bypass_avoids_off_track_inputs(fixture):
     # require strictly less than one full row, ie ~12 px or more.
     MIN_CLEARANCE = 12.0
     bypass_ids = [
-        sid
-        for sid, st in graph.stations.items()
-        if st.is_hidden and sid.startswith("__bypass_")
+        sid for sid, st in graph.stations.items() if st.is_hidden and is_bypass_v(sid)
     ]
     if not bypass_ids:
         pytest.skip(f"{fixture}: no bypass virtual stations")
@@ -5148,9 +5148,7 @@ def test_bypass_v_has_horizontal_segment(fixture):
     routes = route_edges(graph, station_offsets=offsets)
 
     bypass_v_ids = {
-        sid
-        for sid, st in graph.stations.items()
-        if st.is_hidden and sid.startswith("__bypass_")
+        sid for sid, st in graph.stations.items() if st.is_hidden and is_bypass_v(sid)
     }
     assert bypass_v_ids, f"{fixture}: expected at least one __bypass_ virtual station"
 
@@ -5505,7 +5503,7 @@ def test_section_bbox_top_hugs_content(fixture):
         content_top = min(
             graph.stations[sid].y
             for sid in sec.station_ids
-            if not graph.stations[sid].is_port and not sid.startswith("__bypass_")
+            if not graph.stations[sid].is_port and not is_bypass_v(sid)
         )
         gap = content_top - sec.bbox_y
         if abs(gap - SECTION_Y_PADDING) > tol:
@@ -5855,9 +5853,7 @@ def test_bypass_clearance_from_lower_section(fixture):
 
     graph = _layout(fixture)
     bypass_stations = [
-        st
-        for sid, st in graph.stations.items()
-        if st.is_hidden and sid.startswith("__bypass_")
+        st for sid, st in graph.stations.items() if st.is_hidden and is_bypass_v(sid)
     ]
     if not bypass_stations:
         pytest.skip(f"{fixture}: no bypass virtual stations")


### PR DESCRIPTION
## Summary
- Add a canonical `is_bypass_v(station_id)` predicate and `BYPASS_V_PREFIX` constant to `parser/model.py`, replacing ~30 hand-rolled `id.startswith("__bypass_")` checks across 9 `src/` files and 3 test files.
- `parser/resolve.py` builds bypass-V ids from `BYPASS_V_PREFIX`, so the `"__bypass_"` naming convention now lives in exactly one place.
- Add `test_is_bypass_v_recognises_resolve_generated_helpers` pinning the id-builder to its predicate (the helpers `resolve` creates are recognised by `is_bypass_v` and carry the V's defining traits), so a future prefix rename stays a one-site change.

Pure refactor, no behaviour change: the `"__bypass_"` literal remains only in docstrings/comments and human-facing assert messages.

Fixes #699

## Test plan
- [x] Gallery renders byte-identical before/after (156 SVGs, combined hash unchanged)
- [x] pytest passes (13436 passed, pre-existing xfails only), including the new predicate test
- [x] ruff check + ruff format clean on whole repo; mypy clean
- [x] Routing gate-coverage ratchet green (predicate-expression swap, no gate-structure change)
- [ ] Render-preview verdict: expected "No visual changes detected"