### PR TITLE
fix(layout): carry the bbox with a same-column RL perp-entry shift (#875)

### DIFF
--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -991,8 +991,6 @@ def _shift_lr_perp_entry_stations(
             continue  # gap is already sufficient
 
         # Shift internal stations away from the entry side.
-        # Stage 1.1 (_adjust_lr_entry_inset) already reserved bbox space
-        # for this shift, so no bbox expansion is needed here.
         for sid in section.station_ids:
             if sid in port_ids:
                 continue
@@ -1003,3 +1001,14 @@ def _shift_lr_perp_entry_stations(
                 s.x += shift
             else:
                 s.x -= shift
+
+        # _adjust_lr_entry_inset reserves bbox width on the right to match an
+        # LR section's rightward shift; an RL run shifts left, so extend the
+        # bbox left by the same amount to keep the trailing station inside it.
+        # Guarded to a same-column drop, where the entry port sits within the
+        # run's span (nearest_x is the run's far edge here): a cross-column
+        # port would drag the run off its own columns, an unsupported shape
+        # left to fail loudly downstream.
+        if section.direction == "RL" and min(internal_xs) <= port_x <= nearest_x:
+            section.bbox_x -= shift
+            section.bbox_w += shift

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -1,5 +1,6 @@
 """Tests for auto-layout inference logic."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -685,3 +686,51 @@ def test_folded_grid_preserves_topo_order_in_serpentine_read(fixture, threshold)
                 f"its successor {sid!r} at grid {grid[sid]} (read-rank "
                 f"{rank[sid]}) in serpentine read order"
             )
+
+
+_GRID_DIRECTIVE_RE = re.compile(r"^\s*%%metro\s+(grid|direction)\s*:", re.IGNORECASE)
+
+
+def _strip_grid_and_direction(text: str) -> str:
+    """Drop every ``%%metro grid:``/``direction:`` line so the map lays out
+    under pure auto-inference."""
+    return "\n".join(
+        line for line in text.splitlines() if not _GRID_DIRECTIVE_RE.match(line)
+    )
+
+
+@pytest.mark.parametrize("fixture", ["sarek_metro.mmd", "rnaseq_auto.mmd"])
+def test_perp_entry_run_stays_in_section_bbox(fixture):
+    """A perpendicular-entry shift keeps the run inside its section bbox (#875).
+
+    Auto-layout can place a horizontal (LR/RL) section as a run fed by a
+    same-column vertical drop, so its only port is a perpendicular TOP entry.
+    Opening the station-elbow gap shifts the run away from that port; the bbox
+    must follow on the shift side.  Stripping ``sarek_metro``'s explicit
+    ``grid:`` directives drives its ``annotation`` section into exactly this
+    state -- before the fix the leftmost station spilled past ``bbox_x`` and
+    the always-on bbox-containment guard aborted the render.  ``rnaseq_auto``
+    is a clean auto-layout that must keep passing.
+    """
+    from nf_metro.layout.constants import GUARD_TOLERANCE
+    from nf_metro.layout.engine import compute_layout
+
+    text = _strip_grid_and_direction((EXAMPLES / fixture).read_text())
+    graph = parse_metro_mermaid(text)
+    compute_layout(graph)
+
+    tol = GUARD_TOLERANCE
+    junction_ids = graph.junction_ids
+    for sid, station in graph.stations.items():
+        if station.is_port or sid in junction_ids:
+            continue
+        sec = graph.sections.get(station.section_id or "")
+        if sec is None or sec.bbox_w == 0:
+            continue
+        left = sec.bbox_x - tol
+        right = sec.bbox_x + sec.bbox_w + tol
+        assert left <= station.x <= right, (
+            f"{fixture}: station {sid!r} x={station.x:.1f} outside section "
+            f"{station.section_id!r} bbox x-range "
+            f"[{sec.bbox_x:.1f}, {sec.bbox_x + sec.bbox_w:.1f}]"
+        )


### PR DESCRIPTION
## Summary

Auto-layout could place a station outside its own section bbox, aborting the render with `PhaseInvariantError` at the `final:` stage. This fixes the same-column case (the auto-layout crash on the real shipped `sarek_metro` pipeline).

An LR/RL section whose only port is a perpendicular TOP/BOTTOM entry (a vertical drop from a section directly above) has its internal run shifted away from that port to open a station-elbow gap. The bbox reservation (`_adjust_lr_entry_inset`) widens the bbox's right edge, which matches an LR section's rightward shift but is the wrong side for an RL section, whose run shifts left. The trailing station then spilled past `bbox_x` and the always-on bbox-containment guard rejected the layout.

The fix extends the RL bbox left by the shift amount so the run stays inside it, guarded to a same-column drop (the entry port within the run's X-span). A cross-column perpendicular anchor that drags the run off its own grid columns is a distinct, unsupported shape left to fail loudly; that case (repros B1/B2 from #875) is tracked in #879.

## Diagnosis

`#875` reported three repros. They split across two placement passes:

- **Same-column** (this PR): `sarek_metro` `annotation` (RL) — `_shift_lr_perp_entry_stations` shifts the run left, bbox reserved on the wrong side.
- **Cross-column** (deferred to #879): `genomic_pipeline`/`genomeassembly` under `direction: TB` — the run/trunk is dragged toward a cross-column perpendicular anchor while the bbox stays at the section's own column. Clamping the run in-bbox only relocates the crash into the routing layer, so it needs routing-layer support for the bridged L-shape.

## Test plan

- [x] `pytest` passes (13622 passed; new `test_perp_entry_run_stays_in_section_bbox` fails on `main`, passes here)
- [x] `ruff format --check` + `ruff check` + `mypy` clean on whole repo
- [x] Runtime validator: the always-on `_guard_stations_within_bbox` is the check
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/880/)
- [ ] Render-preview verdict captured

Fixes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)
