### PR TITLE
fix(routing): clear only the source column on the cross-column perp-drop lead-in (#892)

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -167,6 +167,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_partial_branch_offset_gaps,
     _guard_perp_entry_boundary_consistent,
     _guard_perp_entry_feed_not_collinear,
+    _guard_perp_exit_over_leadin_no_overdip,
     _guard_ports_on_boundaries,
     _guard_rail_above_label_band,
     _guard_rail_one_station_per_column,
@@ -1716,6 +1717,9 @@ def _finalize_layout(
             _guard_no_stacked_elbow_graze(graph, phase, offsets=offsets, routes=routes)
             _guard_fanout_tail_join(graph, phase, offsets=offsets, routes=routes)
             _guard_perp_entry_boundary_consistent(
+                graph, phase, offsets=offsets, routes=routes
+            )
+            _guard_perp_exit_over_leadin_no_overdip(
                 graph, phase, offsets=offsets, routes=routes
             )
             _guard_inter_section_route_no_backtrack(graph, phase, routes=routes)

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -3211,6 +3211,43 @@ def _guard_perp_entry_boundary_consistent(
     raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
 
 
+def _guard_perp_exit_over_leadin_no_overdip(
+    graph: MetroGraph,
+    phase: str,
+    *,
+    offsets: dict[tuple[str, str], float] | None = None,
+    routes: list[RoutedPath] | None = None,
+) -> None:
+    """Final-phase: a cross-column perp-exit lead-in must clear only the
+    sections its exit-side down-leg actually passes under, not the row's
+    deepest section in a far column.
+
+    See
+    :func:`nf_metro.layout.routing.invariants.check_perp_exit_over_leadin_clears_only_spanned_sections`
+    for the semantic definition.
+    """
+    from nf_metro.layout.routing.invariants import (
+        check_perp_exit_over_leadin_clears_only_spanned_sections,
+    )
+
+    if routes is None:
+        from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+        if offsets is None:
+            offsets = compute_station_offsets(graph)
+        try:
+            routes = route_edges(graph, station_offsets=offsets)
+        except Exception:  # noqa: BLE001 - routing failure surfaces elsewhere
+            return
+
+    violations = check_perp_exit_over_leadin_clears_only_spanned_sections(graph, routes)
+    if not violations:
+        return
+    first = violations[0]
+    extra = f" (+{len(violations) - 1} more)" if len(violations) > 1 else ""
+    raise PhaseInvariantError(f"{phase}: {first.message()}{extra}")
+
+
 def _guard_off_track_clear_of_anchor(graph: MetroGraph, phase: str) -> None:
     """At final: every off-track station must sit at least ``GUARD_TOLERANCE``
     clear of its anchor on the expected side.

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -178,6 +178,7 @@ def header_corridor_y(
     below: bool,
     base_radius: float,
     default: float = 0.0,
+    col: int | None = None,
 ) -> float:
     """Y of an inter-row routing channel that clears a row's header band.
 
@@ -187,10 +188,14 @@ def header_corridor_y(
     occupies the gap above the row (contributing a header badge); the topmost
     row has only the canvas-top title band, so the smaller
     :data:`SECTION_ROUTE_CLEARANCE` keeps the channel from overshooting it.
+
+    When *col* is given the channel clears only that grid column's sections, so
+    a corridor leg confined to one column isn't pushed past a tall section
+    stacked in a different column of the same row.
     """
     if below:
         return (
-            row_bottom_edge(graph, row, default=default)
+            row_bottom_edge(graph, row, default=default, col=col)
             + SECTION_ROUTE_CLEARANCE
             + base_radius
         )
@@ -199,7 +204,7 @@ def header_corridor_y(
         if section_exists_above_row(graph, row)
         else SECTION_ROUTE_CLEARANCE
     )
-    return row_top_edge(graph, row, default=default) - clearance - base_radius
+    return row_top_edge(graph, row, default=default, col=col) - clearance - base_radius
 
 
 def section_exists_above_row(graph: MetroGraph, row: int) -> bool:

--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -1609,6 +1609,23 @@ def _route_perp_exit_over(
             # switch to the entry-side corridor outside the target box, then turn
             # the final perpendicular leg in from the port's own side.
             gap_x = inter_col_gap_x()
+            # The exit-side down-leg drops at the exit X and runs across only to
+            # the inter-column gap, so it need clear just the source column's
+            # sections, not the row's deepest section in a far column (which
+            # would loop the leg to the canvas bottom around a box it never
+            # passes under).
+            cy_down = (
+                header_corridor_y(
+                    graph,
+                    row,
+                    below=not is_top,
+                    base_radius=base,
+                    default=sy,
+                    col=src_sec.grid_col if src_sec is not None else None,
+                )
+                if row is not None
+                else cy_base
+            )
             cy_entry = (
                 header_corridor_y(
                     graph,
@@ -1622,8 +1639,8 @@ def _route_perp_exit_over(
             )
             centerline = [
                 (sx, sy),
-                (sx, cy_base),
-                (gap_x, cy_base),
+                (sx, cy_down),
+                (gap_x, cy_down),
                 (gap_x, cy_entry),
                 (tx, cy_entry),
                 (tx, ty),

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -2036,6 +2036,92 @@ def check_merge_branches_meet_trunk(
     return violations
 
 
+@dataclass(frozen=True)
+class PerpExitLeadInOverdip:
+    """A cross-column perp-exit lead-in clears a section it never passes under.
+
+    The exit-side down-leg of
+    :func:`~nf_metro.layout.routing.inter_section_handlers._route_perp_exit_over`'s
+    ``crosses_box`` shape drops at the exit X and runs only to the inter-column
+    gap, so it should clear just the sections under that span.  A leg seated
+    below (BOTTOM exit) or above (TOP exit) a section whose X extent it never
+    overlaps loops needlessly to the canvas edge around a box it doesn't cross.
+    """
+
+    source: str
+    target: str
+    section_id: str
+    leg_y: float
+    section_edge: float
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        return (
+            f"perp-exit lead-in {self.source!r}->{self.target!r} corridor at "
+            f"y={self.leg_y:.1f} overshoots section {self.section_id!r} "
+            f"(edge y={self.section_edge:.1f}) it never passes under"
+        )
+
+
+def check_perp_exit_over_leadin_clears_only_spanned_sections(
+    graph: MetroGraph, routes: list[RoutedPath]
+) -> list[PerpExitLeadInOverdip]:
+    """Return crosses_box perp-exit lead-ins overshooting an un-spanned section.
+
+    ``_route_perp_exit_over`` drops out of a TOP/BOTTOM exit, crosses to the
+    inter-column gap, then climbs to the entry-side corridor.  The first leg --
+    from the exit X to the gap -- need only clear the source column's sections;
+    if it dips below (BOTTOM exit) or rises above (TOP exit) a section in a
+    different column it never travels under, the route loops to the canvas edge.
+    """
+    tol = COORD_TOLERANCE
+    violations: list[PerpExitLeadInOverdip] = []
+    for r in routes:
+        src_port = graph.ports.get(r.edge.source)
+        tgt_port = graph.ports.get(r.edge.target)
+        if (
+            src_port is None
+            or tgt_port is None
+            or src_port.is_entry
+            or not tgt_port.is_entry
+            or src_port.side not in (PortSide.TOP, PortSide.BOTTOM)
+            or tgt_port.side not in (PortSide.TOP, PortSide.BOTTOM)
+            or not r.is_inter_section
+            or len(r.points) != 6
+        ):
+            continue
+        src_st = graph.stations.get(r.edge.source)
+        if src_st is None or src_st.section_id is None:
+            continue
+        src_sec = graph.sections.get(src_st.section_id)
+        if src_sec is None:
+            continue
+        (sx, _sy), (cx, cy), (gx, _gy), *_rest = r.points
+        if abs(cx - sx) > tol:  # not the exit-drop-first shape
+            continue
+        is_bottom = src_port.side == PortSide.BOTTOM
+        leg_lo, leg_hi = sorted((sx, gx))
+        for s in graph.sections.values():
+            if s.id == src_sec.id or s.grid_row != src_sec.grid_row or s.bbox_h <= 0:
+                continue
+            s_lo, s_hi = s.bbox_x, s.bbox_x + s.bbox_w
+            if leg_hi > s_lo + tol and s_hi > leg_lo + tol:
+                continue  # leg passes under this section; clearing it is expected
+            if is_bottom and cy > s.bbox_y + s.bbox_h + tol:
+                violations.append(
+                    PerpExitLeadInOverdip(
+                        r.edge.source, r.edge.target, s.id, cy, s.bbox_y + s.bbox_h
+                    )
+                )
+            elif not is_bottom and cy < s.bbox_y - tol:
+                violations.append(
+                    PerpExitLeadInOverdip(
+                        r.edge.source, r.edge.target, s.id, cy, s.bbox_y
+                    )
+                )
+    return violations
+
+
 @dataclass
 class UndeclaredGapChannel:
     """A vertical inter-section leg sits in a gap with no :class:`GapSlot`.
@@ -2336,6 +2422,7 @@ __all__ = [
     "PartialBranchGapViolation",
     "PeeloffBundleCrossing",
     "PerpEntryBoundaryViolation",
+    "PerpExitLeadInOverdip",
     "SameLineParallelRun",
     "Side",
     "StackedElbowGraze",
@@ -2353,6 +2440,7 @@ __all__ = [
     "check_no_same_line_parallel_descents",
     "check_peeloff_concentric",
     "check_perp_entry_boundary_consistent",
+    "check_perp_exit_over_leadin_clears_only_spanned_sections",
     "bypass_horizontal_targets",
     "check_stacked_elbow_clearance",
     "check_partial_branch_offset_gaps",

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -50,6 +50,7 @@ from nf_metro.layout.routing.common import (
     iter_port_peeloff_bundles,
     iter_vertical_segments,
     peeloff_target_slots,
+    resolve_section,
     tail_on_slot,
     trunk_segments_cross,
     vertical_direction,
@@ -2090,10 +2091,7 @@ def check_perp_exit_over_leadin_clears_only_spanned_sections(
             or len(r.points) != 6
         ):
             continue
-        src_st = graph.stations.get(r.edge.source)
-        if src_st is None or src_st.section_id is None:
-            continue
-        src_sec = graph.sections.get(src_st.section_id)
+        src_sec = resolve_section(graph, graph.stations.get(r.edge.source))
         if src_sec is None:
             continue
         (sx, _sy), (cx, cy), (gx, _gy), *_rest = r.points

--- a/tests/test_perp_exit_over_no_overdip.py
+++ b/tests/test_perp_exit_over_no_overdip.py
@@ -1,0 +1,98 @@
+"""The cross-column perp-drop lead-in must clear only the sections it passes
+under, not the row's deepest section in a far column.
+
+``_route_perp_exit_over``'s ``crosses_box`` branch (a BOTTOM exit feeding a
+TOP entry, or the mirror) drops out of the exit, runs across to the
+inter-column gap, then rises/descends to the entry-side corridor.  The
+exit-side down-leg travels only from the exit X to the gap, so it need clear
+just the section(s) it passes under -- the source column -- not the deepest
+section anywhere in the row.  Seating it on the whole row's bottom edge makes
+it loop to the canvas bottom around a tall section it never crosses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.common import _sections_in_row
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import PortSide
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES = REPO_ROOT / "examples"
+
+# Fixtures whose perp exit crosses to the inter-column gap to reach a
+# perpendicular entry on the far side of the target (the ``crosses_box`` lead-in).
+CROSS_COLUMN_PERP_FIXTURES = [
+    EXAMPLES / "topologies" / "cross_column_perp_drop_far_exit.mmd",
+]
+
+
+def _crosses_box_routes(graph, routes):
+    """Routes taking the ``crosses_box`` lead-in: a TOP/BOTTOM exit feeding a
+    TOP/BOTTOM entry on the far side of the target (a six-waypoint centreline
+    that drops, crosses to the gap, then climbs to the entry-side corridor)."""
+    out = []
+    for r in routes:
+        src_port = graph.ports.get(r.edge.source)
+        tgt_port = graph.ports.get(r.edge.target)
+        if (
+            src_port is not None
+            and tgt_port is not None
+            and not src_port.is_entry
+            and tgt_port.is_entry
+            and src_port.side in (PortSide.TOP, PortSide.BOTTOM)
+            and tgt_port.side in (PortSide.TOP, PortSide.BOTTOM)
+            and r.is_inter_section
+            and len(r.points) == 6
+        ):
+            out.append(r)
+    return out
+
+
+@pytest.mark.parametrize("path", CROSS_COLUMN_PERP_FIXTURES, ids=lambda p: p.stem)
+def test_perp_exit_over_leadin_does_not_dip_below_far_section(path: Path) -> None:
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+
+    crossing = _crosses_box_routes(graph, routes)
+    assert crossing, f"{path.stem}: expected a crosses_box perp-exit lead-in route"
+
+    tol = 1.0
+    for r in crossing:
+        src_sec_id = graph.stations[r.edge.source].section_id
+        src_sec = graph.sections[src_sec_id]
+        row = src_sec.grid_row
+        is_bottom = graph.ports[r.edge.source].side == PortSide.BOTTOM
+
+        # The exit-side corridor leg: the corner right after the exit and the
+        # horizontal run from it to the inter-column gap.
+        (sx, _), (cx, cy), (gx, _gy), *_ = r.points
+        assert abs(cx - sx) < tol, f"{path.stem}: first leg is not the exit drop"
+        leg_lo, leg_hi = sorted((sx, gx))
+
+        for s in _sections_in_row(graph, row):
+            if s.id == src_sec_id:
+                continue
+            s_lo, s_hi = s.bbox_x, s.bbox_x + s.bbox_w
+            if leg_hi > s_lo + tol and s_hi > leg_lo + tol:
+                continue  # the leg passes under this section; clearing it is fine
+            s_bottom = s.bbox_y + s.bbox_h
+            if is_bottom:
+                assert cy <= s_bottom + tol, (
+                    f"{path.stem}: {r.edge.source}->{r.edge.target} down-leg at "
+                    f"y={cy:.0f} dips below section {s.id} (bottom={s_bottom:.0f}) "
+                    f"it never passes under"
+                )
+            else:
+                assert cy >= s.bbox_y - tol, (
+                    f"{path.stem}: {r.edge.source}->{r.edge.target} up-leg at "
+                    f"y={cy:.0f} rises above section {s.id} (top={s.bbox_y:.0f}) "
+                    f"it never passes over"
+                )

--- a/tests/test_perp_exit_over_no_overdip.py
+++ b/tests/test_perp_exit_over_no_overdip.py
@@ -18,7 +18,9 @@ import pytest
 
 from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.routing import compute_station_offsets, route_edges
-from nf_metro.layout.routing.common import _sections_in_row
+from nf_metro.layout.routing.invariants import (
+    check_perp_exit_over_leadin_clears_only_spanned_sections,
+)
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import PortSide
 
@@ -32,11 +34,9 @@ CROSS_COLUMN_PERP_FIXTURES = [
 ]
 
 
-def _crosses_box_routes(graph, routes):
-    """Routes taking the ``crosses_box`` lead-in: a TOP/BOTTOM exit feeding a
-    TOP/BOTTOM entry on the far side of the target (a six-waypoint centreline
-    that drops, crosses to the gap, then climbs to the entry-side corridor)."""
-    out = []
+def _exercises_crosses_box(graph, routes) -> bool:
+    """True if some route takes the up-and-over lead-in: a TOP/BOTTOM exit
+    feeding a TOP/BOTTOM entry as a six-waypoint inter-section centreline."""
     for r in routes:
         src_port = graph.ports.get(r.edge.source)
         tgt_port = graph.ports.get(r.edge.target)
@@ -50,49 +50,19 @@ def _crosses_box_routes(graph, routes):
             and r.is_inter_section
             and len(r.points) == 6
         ):
-            out.append(r)
-    return out
+            return True
+    return False
 
 
 @pytest.mark.parametrize("path", CROSS_COLUMN_PERP_FIXTURES, ids=lambda p: p.stem)
 def test_perp_exit_over_leadin_does_not_dip_below_far_section(path: Path) -> None:
     graph = parse_metro_mermaid(path.read_text())
     compute_layout(graph)
-    offsets = compute_station_offsets(graph)
-    routes = route_edges(graph, station_offsets=offsets)
+    routes = route_edges(graph, station_offsets=compute_station_offsets(graph))
 
-    crossing = _crosses_box_routes(graph, routes)
-    assert crossing, f"{path.stem}: expected a crosses_box perp-exit lead-in route"
+    assert _exercises_crosses_box(graph, routes), (
+        f"{path.stem}: expected a crosses_box perp-exit lead-in route"
+    )
 
-    tol = 1.0
-    for r in crossing:
-        src_sec_id = graph.stations[r.edge.source].section_id
-        src_sec = graph.sections[src_sec_id]
-        row = src_sec.grid_row
-        is_bottom = graph.ports[r.edge.source].side == PortSide.BOTTOM
-
-        # The exit-side corridor leg: the corner right after the exit and the
-        # horizontal run from it to the inter-column gap.
-        (sx, _), (cx, cy), (gx, _gy), *_ = r.points
-        assert abs(cx - sx) < tol, f"{path.stem}: first leg is not the exit drop"
-        leg_lo, leg_hi = sorted((sx, gx))
-
-        for s in _sections_in_row(graph, row):
-            if s.id == src_sec_id:
-                continue
-            s_lo, s_hi = s.bbox_x, s.bbox_x + s.bbox_w
-            if leg_hi > s_lo + tol and s_hi > leg_lo + tol:
-                continue  # the leg passes under this section; clearing it is fine
-            s_bottom = s.bbox_y + s.bbox_h
-            if is_bottom:
-                assert cy <= s_bottom + tol, (
-                    f"{path.stem}: {r.edge.source}->{r.edge.target} down-leg at "
-                    f"y={cy:.0f} dips below section {s.id} (bottom={s_bottom:.0f}) "
-                    f"it never passes under"
-                )
-            else:
-                assert cy >= s.bbox_y - tol, (
-                    f"{path.stem}: {r.edge.source}->{r.edge.target} up-leg at "
-                    f"y={cy:.0f} rises above section {s.id} (top={s.bbox_y:.0f}) "
-                    f"it never passes over"
-                )
+    overdips = check_perp_exit_over_leadin_clears_only_spanned_sections(graph, routes)
+    assert not overdips, "\n".join(v.message() for v in overdips)


### PR DESCRIPTION
## Summary
- The `crosses_box` lead-in of `_route_perp_exit_over` (a BOTTOM exit feeding a TOP entry in another column) seated its exit-side down-leg on the whole row's bottom edge, so it dipped below the row's deepest section even though its horizontal run only travels under the short source section. On `cross_column_perp_drop_far_exit` the leg dropped to y=276 (below `qc`'s box and the lowest station) before crossing into the inter-column gap, a large gratuitous loop to the canvas bottom.
- `header_corridor_y` now accepts a `col` argument (threaded through to `row_bottom_edge`/`row_top_edge`, which already supported it), and the `crosses_box` down-leg computes its corridor Y restricted to the source column. The leg now clears only `align` (y=196), removing the loop. `cy_base` is unchanged for the non-crossing and side-entry branches.
- Adds `check_perp_exit_over_leadin_clears_only_spanned_sections` and the `_guard_perp_exit_over_leadin_no_overdip` final-phase validator: a crosses_box lead-in must not dip below (BOTTOM exit) or rise above (TOP exit) a section its exit-side leg never passes under.
- Adds an invariant test on `cross_column_perp_drop_far_exit` that calls the new check.

Fixes #892

## Test plan
- [x] pytest passes (14056 passed), including the new invariant test
- [x] ruff format + ruff check clean on whole repo; mypy clean
- [x] Runtime validator added and wired into the final-phase validate block
- [x] Routing gate-coverage ratchet green on Python 3.11 (no reconciliation owed)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/893/)

Generated with Claude Code
