### PR TITLE
fix(layout): drop the dead cross-column TB TOP-entry shift (#890)

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -449,9 +449,6 @@ TB_LINE_Y_OFFSET: float = 3.0
 ENTRY_SHIFT_TB: float = 1.0
 """Entry shift multiplier for TB sections with perpendicular entry."""
 
-ENTRY_SHIFT_TB_CROSS: float = 1.0
-"""Entry shift multiplier for TB sections with cross-column TOP entry."""
-
 ENTRY_INSET_LR: float = 0.3
 """Entry inset multiplier for LR/RL sections with perpendicular entry."""
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -183,6 +183,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_stations_in_sections,
     _guard_stations_within_bbox,
     _guard_tall_anchor_stack_well_formed,
+    _guard_tb_top_entry_drop_hugs_top,
     _guard_terminus_icons_within_bbox,
     _guard_topmost_row_top_entry_hugs_section,
     _guard_trunk_bands_crossing_optimal,
@@ -647,6 +648,7 @@ def _compute_layout_scaled(
         _guard_single_trunk_off_track_step(graph, "final")
         _guard_off_track_consumer_on_trunk(graph, "final")
         _guard_off_track_input_column_stack(graph, "final")
+        _guard_tb_top_entry_drop_hugs_top(graph, "final")
 
 
 def _apply_label_strike_clearance(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -438,12 +438,9 @@ def _tb_top_entry_drop_overshoot(
 ) -> list[tuple[str, float]]:
     """Return ``(section_id, gap)`` for TB sections whose first station sits
     further below the box top than the standard padding despite the TOP
-    entry being a clean vertical drop.
+    entry being a clean vertical drop (see :func:`_adjust_tb_entry_shifts`
+    for why such a drop is always vertical).
 
-    A TB entry port on the TOP boundary is placed on the section trunk X, so
-    the port -> first-station segment is a straight vertical drop and the
-    cross-column lead-in turns in the header corridor above the box, not
-    inside it.  Any in-section room above the first station is then unused.
     Sections with a perpendicular (LEFT/RIGHT) entry are excluded: they
     legitimately shift their stations down to clear the entry port.
     """
@@ -452,23 +449,16 @@ def _tb_top_entry_drop_overshoot(
     for sid, sec in graph.sections.items():
         if sec.direction != "TB" or sec.bbox_h == 0:
             continue
-        top_ports = [
-            graph.ports[pid]
-            for pid in sec.entry_ports
-            if pid in graph.ports and graph.ports[pid].side == PortSide.TOP
+        entry_ports = [
+            graph.ports[pid] for pid in sec.entry_ports if pid in graph.ports
         ]
+        top_ports = [p for p in entry_ports if p.side == PortSide.TOP]
         if not top_ports:
             continue
-        has_perp_entry = any(
-            graph.ports[pid].side in (PortSide.LEFT, PortSide.RIGHT)
-            for pid in sec.entry_ports
-            if pid in graph.ports
-        )
-        if has_perp_entry:
+        if any(p.side in (PortSide.LEFT, PortSide.RIGHT) for p in entry_ports):
             continue
-        # Include hidden stations: a hidden trunk-head (e.g. a fan-out hub)
-        # is what the port drops onto, so it -- not the first visible marker
-        # further down the trunk -- sets the port -> first-station distance.
+        # A hidden trunk-head (e.g. a fan-out hub) is a valid drop target, so
+        # do not filter to visible markers further down the trunk.
         body = [
             graph.stations[s]
             for s in sec.station_ids

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -22,6 +22,7 @@ from nf_metro.layout.constants import (
     ROW_BAND_SLACK,
     SAME_COORD_TOLERANCE,
     SECTION_Y_GAP,
+    SECTION_Y_PADDING,
     STATION_RADIUS_APPROX,
     X_SPACING,
 )
@@ -430,6 +431,72 @@ def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:
                 f"({sec.bbox_x:.1f}, {sec.bbox_y:.1f}, "
                 f"w={sec.bbox_w:.1f}, h={sec.bbox_h:.1f})"
             )
+
+
+def _tb_top_entry_drop_overshoot(
+    graph: MetroGraph,
+) -> list[tuple[str, float]]:
+    """Return ``(section_id, gap)`` for TB sections whose first station sits
+    further below the box top than the standard padding despite the TOP
+    entry being a clean vertical drop.
+
+    A TB entry port on the TOP boundary is placed on the section trunk X, so
+    the port -> first-station segment is a straight vertical drop and the
+    cross-column lead-in turns in the header corridor above the box, not
+    inside it.  Any in-section room above the first station is then unused.
+    Sections with a perpendicular (LEFT/RIGHT) entry are excluded: they
+    legitimately shift their stations down to clear the entry port.
+    """
+    tol = GUARD_TOLERANCE
+    offenders: list[tuple[str, float]] = []
+    for sid, sec in graph.sections.items():
+        if sec.direction != "TB" or sec.bbox_h == 0:
+            continue
+        top_ports = [
+            graph.ports[pid]
+            for pid in sec.entry_ports
+            if pid in graph.ports and graph.ports[pid].side == PortSide.TOP
+        ]
+        if not top_ports:
+            continue
+        has_perp_entry = any(
+            graph.ports[pid].side in (PortSide.LEFT, PortSide.RIGHT)
+            for pid in sec.entry_ports
+            if pid in graph.ports
+        )
+        if has_perp_entry:
+            continue
+        # Include hidden stations: a hidden trunk-head (e.g. a fan-out hub)
+        # is what the port drops onto, so it -- not the first visible marker
+        # further down the trunk -- sets the port -> first-station distance.
+        body = [
+            graph.stations[s]
+            for s in sec.station_ids
+            if s in graph.stations and not graph.stations[s].is_port
+        ]
+        if not body:
+            continue
+        first = min(body, key=lambda st: st.y)
+        port_xs = [graph.stations[p.id].x for p in top_ports if p.id in graph.stations]
+        if not any(abs(first.x - px) <= tol for px in port_xs):
+            continue
+        gap = first.y - sec.bbox_y
+        if gap > SECTION_Y_PADDING + tol:
+            offenders.append((sid, gap))
+    return offenders
+
+
+def _guard_tb_top_entry_drop_hugs_top(graph: MetroGraph, phase: str) -> None:
+    """Final: a clean TB TOP-entry drop must seat its first station at the
+    standard top padding, with no unused in-section reservation."""
+    offenders = _tb_top_entry_drop_overshoot(graph)
+    if offenders:
+        sid, gap = offenders[0]
+        raise PhaseInvariantError(
+            f"{phase}: section {sid!r} first station sits {gap:.1f}px below "
+            f"its box top despite a clean vertical TOP-entry drop "
+            f"(expected <= {SECTION_Y_PADDING:.1f})"
+        )
 
 
 def _guard_section_bboxes_positive(graph: MetroGraph, phase: str) -> None:

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -9,7 +9,6 @@ from nf_metro.layout.constants import (
     DIAGONAL_LABEL_OFFSET,
     ENTRY_SHIFT_LR,
     ENTRY_SHIFT_TB,
-    ENTRY_SHIFT_TB_CROSS,
     EXIT_GAP_MULTIPLIER,
     FONT_HEIGHT,
     ICON_CAPTION_FONT_HEIGHT,
@@ -564,12 +563,18 @@ def _adjust_tb_entry_shifts(
     graph: MetroGraph,
     y_spacing: float,
 ) -> None:
-    """Apply TB section entry shifts for perpendicular and cross-column entries."""
+    """Shift TB section stations down to clear a perpendicular entry port.
+
+    A TB TOP/BOTTOM entry port sits on the section trunk X
+    (``_assign_entry_port_position``), so its drop onto the first station is
+    a clean vertical continuation and the cross-column lead-in turns in the
+    header corridor above the box, never inside it -- no in-section room is
+    needed for it.  Only a perpendicular (LEFT/RIGHT) entry, whose port would
+    otherwise coincide with the first station, needs the stations nudged
+    down."""
     if section.direction != "TB":
         return
 
-    # Perpendicular entry: shift stations down so first station isn't
-    # at the entry port (avoiding station-as-elbow).
     has_perp_entry = any(
         graph.ports[pid].side in (PortSide.LEFT, PortSide.RIGHT)
         for pid in section.entry_ports
@@ -577,27 +582,6 @@ def _adjust_tb_entry_shifts(
     )
     if has_perp_entry:
         entry_shift = y_spacing * ENTRY_SHIFT_TB
-        for s in sub.stations.values():
-            s.y += entry_shift
-        section.bbox_h += entry_shift
-
-    # Cross-column TOP entry: shift stations down for L-shape routing room.
-    has_cross_col_top_entry = False
-    for pid in section.entry_ports:
-        port = graph.ports.get(pid)
-        if not port or port.side != PortSide.TOP:
-            continue
-        for edge in graph.edges_to(pid):
-            src = graph.stations.get(edge.source)
-            if src and src.section_id:
-                src_sec = graph.sections.get(src.section_id)
-                if src_sec and src_sec.grid_col != section.grid_col:
-                    has_cross_col_top_entry = True
-                    break
-        if has_cross_col_top_entry:
-            break
-    if has_cross_col_top_entry:
-        entry_shift = y_spacing * ENTRY_SHIFT_TB_CROSS
         for s in sub.stations.values():
             s.y += entry_shift
         section.bbox_h += entry_shift

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1111,16 +1111,9 @@ def test_diagonal_overlay_check_detects_collapse():
 def test_tb_top_entry_clean_drop_hugs_top(fixture):
     """A TB section whose TOP entry drops straight onto its first station
     must seat that station at the standard top padding, with no extra
-    reserved gap.
-
-    A TB/BT entry port on the TOP/BOTTOM boundary is placed on the section
-    trunk X (``_assign_entry_port_position``), so the port -> first-station
-    segment is always a clean vertical drop and the up-and-over lead-in
-    turns in the header corridor *above* the box, never inside it.  Reserving
-    in-section L-shape room for a cross-column source therefore only pushes
-    the first station needlessly far below the box top.  Excludes sections
-    with a perpendicular (LEFT/RIGHT) entry, which legitimately shift their
-    stations down to clear the entry port (``ENTRY_SHIFT_TB``).
+    reserved gap (see ``_adjust_tb_entry_shifts`` for why the drop is always
+    vertical).  Excludes sections with a perpendicular (LEFT/RIGHT) entry,
+    which legitimately shift their stations down to clear the entry port.
     """
     graph = _layout(fixture)
     offenders = _tb_top_entry_drop_overshoot(graph)

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -55,6 +55,7 @@ from nf_metro.layout.phases.bbox import (
     _section_content_hug_top,
     _section_fit_top,
 )
+from nf_metro.layout.phases.guards import _tb_top_entry_drop_overshoot
 from nf_metro.layout.phases.off_track import (
     _is_single_trunk_lr_section,
     _off_track_anchor_of,
@@ -1104,6 +1105,30 @@ def test_diagonal_overlay_check_detects_collapse():
         _diag("a", "c", "blue", [(0.0, 0.0), (45.0, 300.0)]),
     ]
     assert not check_no_collinear_distinct_diagonals(graph, diverging, {})
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_tb_top_entry_clean_drop_hugs_top(fixture):
+    """A TB section whose TOP entry drops straight onto its first station
+    must seat that station at the standard top padding, with no extra
+    reserved gap.
+
+    A TB/BT entry port on the TOP/BOTTOM boundary is placed on the section
+    trunk X (``_assign_entry_port_position``), so the port -> first-station
+    segment is always a clean vertical drop and the up-and-over lead-in
+    turns in the header corridor *above* the box, never inside it.  Reserving
+    in-section L-shape room for a cross-column source therefore only pushes
+    the first station needlessly far below the box top.  Excludes sections
+    with a perpendicular (LEFT/RIGHT) entry, which legitimately shift their
+    stations down to clear the entry port (``ENTRY_SHIFT_TB``).
+    """
+    graph = _layout(fixture)
+    offenders = _tb_top_entry_drop_overshoot(graph)
+    assert not offenders, "; ".join(
+        f"{sid}: first station {gap:.0f}px below box top "
+        f"(expected <= {SECTION_Y_PADDING:.0f})"
+        for sid, gap in offenders
+    )
 
 
 @pytest.mark.parametrize("fixture", ALL_FIXTURES)


### PR DESCRIPTION
## Summary

A TB section with a TOP entry fed from a different grid column shifted every internal station down by `y_spacing` (~40px) to reserve in-section L-shape routing room. That room is never used: `_assign_entry_port_position` always places a TB TOP/BOTTOM entry port on the section trunk X, so the port -> first-station segment is a clean vertical drop and the cross-column lead-in turns in the header corridor *above* the box. The shift only pushed the first station 40px below the standard top padding (90px below the box top instead of 50px).

- Remove the cross-column TOP-entry shift branch in `_adjust_tb_entry_shifts` and the now-unused `ENTRY_SHIFT_TB_CROSS` constant. The perpendicular-entry shift is unchanged.
- Add `_guard_tb_top_entry_drop_hugs_top`, run in the final validate block, asserting a clean TB TOP-entry drop seats its first station at the standard top padding.
- Add a parametrised invariant test (`test_tb_top_entry_clean_drop_hugs_top`) over the full fixture corpus.

The first station now hugs the box top with normal 50px padding and each affected section's box is 40px shorter.

Fixes #890

## Test plan
- [x] pytest passes (14200 passed; new invariant test added, fails on `main`, passes here)
- [x] ruff check + ruff format clean on whole repo; mypy clean
- [x] Runtime validator added (`_guard_tb_top_entry_drop_hugs_top`)
- [x] Coordinate-level gallery vet: exactly 3 `examples/topologies/` fixtures change (`tb_bottom_entry_flow_start`, `cross_column_perp_drop`, `cross_column_perp_drop_far_exit`), each `qc` box height 180->140 with box top unchanged; no other section in the corpus moves
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/895/)

Generated with Claude Code