### PR TITLE
feat(routing): general hanging-route guard over all routes (#883)

### DIFF
--- a/docs/dev/routing.md
+++ b/docs/dev/routing.md
@@ -78,6 +78,26 @@ offset propagation at each corner (the corner-radius helpers live in
 `check_bundle_order_preserved` (in `routing/invariants.py`) catches any
 regression where a line crosses over its bundle-mates.
 
+## Render-time guards
+
+`assert_render_curve_invariants` (in `routing/invariants.py`) runs a set of
+correctness checks on the final `route_edges` output every render -- the exact
+geometry the renderer is about to draw -- so a defective route aborts the
+render with a message naming the offending edge rather than being shipped.  It
+is always on, independent of `compute_layout`'s `validate` flag.
+
+Among these are the **endpoint guards**, which assert that a routed segment
+terminates at a real anchor rather than hanging in open space:
+
+* `check_merge_branches_meet_trunk` -- a merge feeder must land on its trunk's
+  channel (merge junctions only).
+* `check_no_hanging_routes` -- the general backstop: **every** route's two
+  endpoints must each lie within `2 * CURVE_RADIUS` of a station/port/junction
+  marker or of another route it joins (a bundle mate, a branch onto a trunk, a
+  peel-off).  Rail-mode endpoints are skipped (a rail stub terminates on its
+  rail).  This generalises the merge-only check to any route family; the
+  family-specific checks remain as sharper diagnostics.
+
 ## The descriptor catalogue (`WRAP_TABLE`)
 
 [`routing/inter_section.py`](https://github.com/pinin4fjords/nf-metro/blob/main/src/nf_metro/layout/routing/inter_section.py)

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -2037,6 +2037,109 @@ def check_merge_branches_meet_trunk(
     return violations
 
 
+# A routed endpoint farther than this from every real anchor (a station/
+# port/junction marker or another route's path) reads as a path hanging in
+# open space rather than one terminating on the structure it serves.  Two
+# corner radii of slack covers the endpoint's turn-in arc and the per-line
+# bundle offset that fans it off the marker; a genuine hang (a desynced drop
+# level, a stub that never reaches its trunk) is an order of magnitude larger.
+_HANGING_ROUTE_TOL = 2 * CURVE_RADIUS
+
+
+@dataclass(frozen=True)
+class HangingRoute:
+    """A routed path whose endpoint terminates disconnected from any anchor.
+
+    Every route must begin and end on a real anchor: a station, port, or
+    junction marker, or a point on another route it legitimately joins (a
+    bundle mate, a branch onto a trunk, a peel-off).  An endpoint farther than
+    :data:`_HANGING_ROUTE_TOL` from all of those is a stub hanging in open
+    space -- the universal symptom underneath the family-specific endpoint
+    desyncs (merge branches, rail stubs).  ``which`` names the offending end
+    (``"source"`` or ``"target"``); ``gap`` is the distance to the nearest
+    anchor.
+    """
+
+    source: str
+    target: str
+    line_id: str
+    which: str
+    endpoint: tuple[float, float]
+    gap: float
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        return (
+            f"route {self.source!r}->{self.target!r} on {self.line_id!r}: "
+            f"{self.which} endpoint "
+            f"({self.endpoint[0]:.1f},{self.endpoint[1]:.1f}) is {self.gap:.1f}px "
+            f"from the nearest station, port, junction, or joining route -- "
+            f"a path hanging in open space"
+        )
+
+
+def check_no_hanging_routes(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[HangingRoute]:
+    """Return routes whose endpoints terminate disconnected from any anchor.
+
+    The general backstop for the hanging-path defect class: it asserts the
+    property every family-specific endpoint guard encodes locally -- that a
+    routed segment terminates at a real anchor -- once, over every route.  An
+    endpoint is anchored when it lies within :data:`_HANGING_ROUTE_TOL` of a
+    station/port/junction marker (all live in ``graph.stations``, including
+    terminus/file-icon hosts) or of any *other* route's rendered path (the
+    join point of a bundle mate, a branch onto its trunk, or a peel-off).
+
+    Rail-mode endpoints are skipped: a rail stub terminates on its rail rather
+    than a marker, a distinct idiom with its own dedicated stub tracking.  This
+    complements -- and does not replace -- the precise family-specific checks
+    such as :func:`check_merge_branches_meet_trunk`; they stay as sharper
+    diagnostics.
+    """
+    anchor_xy = [(st.x, st.y) for st in graph.stations.values()]
+    rendered = [(r, _route_render_points(r, offsets)) for r in routes]
+    polylines = [(r, pts) for r, pts in rendered if len(pts) >= 2]
+
+    violations: list[HangingRoute] = []
+    for r, pts in rendered:
+        if len(pts) < 2:
+            continue
+        ends = (("source", pts[0], r.edge.source), ("target", pts[-1], r.edge.target))
+        for which, end, node in ends:
+            if graph.station_is_rail(node):
+                continue
+            d_marker = min(
+                (((end[0] - x) ** 2 + (end[1] - y) ** 2) ** 0.5 for x, y in anchor_xy),
+                default=float("inf"),
+            )
+            if d_marker <= _HANGING_ROUTE_TOL:
+                continue
+            d_join = min(
+                (
+                    _point_to_polyline_distance(end, other_pts)
+                    for other, other_pts in polylines
+                    if other is not r
+                ),
+                default=float("inf"),
+            )
+            if d_join <= _HANGING_ROUTE_TOL:
+                continue
+            violations.append(
+                HangingRoute(
+                    source=r.edge.source,
+                    target=r.edge.target,
+                    line_id=r.line_id,
+                    which=which,
+                    endpoint=end,
+                    gap=min(d_marker, d_join),
+                )
+            )
+    return violations
+
+
 @dataclass(frozen=True)
 class PerpExitLeadInOverdip:
     """A cross-column perp-exit lead-in clears a section it never passes under.
@@ -2362,6 +2465,10 @@ def assert_render_curve_invariants(
             check_merge_branches_meet_trunk(graph, routes, offsets),
         ),
         (
+            "route hanging in open space",
+            check_no_hanging_routes(graph, routes, offsets),
+        ),
+        (
             "undeclared gap channel",
             check_gap_channels_materialized(graph, routes),
         ),
@@ -2414,6 +2521,7 @@ __all__ = [
     "DiagonalOverlapViolation",
     "CurveInvariantError",
     "FanoutTailGap",
+    "HangingRoute",
     "MergeBranchHang",
     "MergePortApproachViolation",
     "NonConcentricCornerViolation",
@@ -2433,6 +2541,7 @@ __all__ = [
     "check_fanout_tail_join",
     "check_merge_branches_meet_trunk",
     "check_merge_port_approach_side",
+    "check_no_hanging_routes",
     "check_no_collinear_distinct_lines",
     "check_no_collinear_distinct_diagonals",
     "check_no_same_line_parallel_descents",

--- a/tests/test_hanging_route_invariant.py
+++ b/tests/test_hanging_route_invariant.py
@@ -1,0 +1,120 @@
+"""Tests for the general hanging-route invariant.
+
+A routed path that ends in mid-air -- disconnected from any station, port,
+junction, terminus icon, or the route it should join -- is among the worst
+final-render defects.  Family-specific guards catch it for merge feeders
+(:func:`check_merge_branches_meet_trunk`) and rail stubs, but
+:func:`check_no_hanging_routes` is the always-on backstop that asserts the
+universal property underneath all of them, over every route, regardless of
+which handler produced it.
+
+Covers:
+
+* Happy-path: every shipped example and topology fixture routes with no
+  endpoint hanging in open space.
+* Always-on: a planted hang aborts the render path through
+  :func:`assert_render_curve_invariants`, independent of ``validate``.
+* Meaningfulness: planting a hanging tail on an ordinary intra-section route
+  (outside the merge and rail families) makes the check fire, and the
+  unmutated routing does not -- so the check is not vacuous.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.invariants import (
+    CurveInvariantError,
+    assert_render_curve_invariants,
+    check_no_hanging_routes,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES = REPO_ROOT / "examples"
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = []
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    paths.extend(sorted((EXAMPLES / "topologies").glob("*.mmd")))
+    paths.extend(sorted((EXAMPLES / "guide").glob("*.mmd")))
+    paths.extend(sorted(FIXTURES.glob("*.mmd")))
+    return paths
+
+
+def _route(path: Path):
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    return graph, routes, offsets
+
+
+@pytest.mark.parametrize(
+    "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
+)
+def test_no_hanging_routes_in_gallery(path: Path) -> None:
+    """Every shipped fixture routes with no endpoint hanging in open space."""
+    graph, routes, offsets = _route(path)
+    violations = check_no_hanging_routes(graph, routes, offsets)
+    assert not violations, "\n".join(v.message() for v in violations)
+
+
+def _plant_hanging_tail(graph, routes):
+    """Replace an ordinary (non-rail, non-merge) route's target endpoint with a
+    point far out in open space, returning the index of the mutated route.
+
+    Picks a route whose target is a real station rather than a merge junction so
+    the planted hang is outside the merge and rail families the dedicated guards
+    already cover.
+    """
+    for i, r in enumerate(routes):
+        if graph.station_is_rail(r.edge.source) or graph.station_is_rail(r.edge.target):
+            continue
+        if r.edge.target in graph.junction_ids:
+            continue
+        if len(r.points) < 2:
+            continue
+        far = (r.points[-1][0] + 1000.0, r.points[-1][1] + 1000.0)
+        routes[i] = dataclasses.replace(
+            r, points=[*r.points[:-1], far], offsets_applied=True
+        )
+        return i
+    raise AssertionError("no ordinary route available to plant a hanging tail")
+
+
+def test_planted_hanging_tail_is_caught() -> None:
+    """Shoving an ordinary route's endpoint into open space makes the check fire,
+    naming that route -- and the unmutated routing does not.  Proves the check
+    is neither vacuous nor a false-positive on the clean render."""
+    graph, routes, offsets = _route(FIXTURES / "rnaseq_sections.mmd")
+    assert not check_no_hanging_routes(graph, routes, offsets)
+
+    idx = _plant_hanging_tail(graph, routes)
+    planted = routes[idx]
+    violations = check_no_hanging_routes(graph, routes, offsets)
+    assert any(
+        v.source == planted.edge.source
+        and v.target == planted.edge.target
+        and v.which == "target"
+        for v in violations
+    ), "expected the planted hanging tail to be reported"
+
+
+def test_planted_hanging_tail_aborts_render_path() -> None:
+    """The guard runs on the always-on render path: a planted hang raises
+    ``CurveInvariantError`` even though ``compute_layout``'s ``validate`` block
+    is not involved."""
+    graph, routes, offsets = _route(FIXTURES / "rnaseq_sections.mmd")
+    assert_render_curve_invariants(graph, routes, offsets)  # clean: no raise
+
+    _plant_hanging_tail(graph, routes)
+    with pytest.raises(CurveInvariantError, match="hanging in open space"):
+        assert_render_curve_invariants(graph, routes, offsets)


### PR DESCRIPTION
## Summary

Adds `check_no_hanging_routes`, a single always-on render-time invariant that asserts the universal property underneath every family-specific endpoint check: *every routed segment terminates at a real anchor.*

- For every `RoutedPath`, both endpoints must lie within `2 * CURVE_RADIUS` of a real anchor: a station / port / junction marker (all live in `graph.stations`, including terminus / file-icon hosts) or a point on another route it joins (a bundle mate, a branch onto a trunk, a peel-off).
- An endpoint matching none of those is a `HangingRoute` violation.
- Rail-mode endpoints are skipped (a rail stub terminates on its rail, a distinct idiom).
- Wired into `assert_render_curve_invariants`, so it runs on every render independent of `compute_layout`'s `validate` flag.

This generalises the merge-only `check_merge_branches_meet_trunk` to any route family, so a hanging path produced by an unguarded handler (an inter-section bypass, an off-track output, a fold tail) can no longer reach a final render unflagged. The family-specific checks remain as sharper diagnostics.

The tolerance is the merge guard's own `2 * CURVE_RADIUS`: across the whole corpus the worst legitimate non-rail endpoint gap is 16px (a wide bundle's outermost line fanned off its marker), while a genuine hang is hundreds of px, so the two separate cleanly.

Documented in the routing guard inventory (`docs/dev/routing.md`).

Fixes #883

## Test plan
- [x] `tests/test_hanging_route_invariant.py`: corpus-green across all examples/topologies/fixtures; a planted hanging tail on an ordinary intra-section route (outside the merge/rail families) is caught and aborts the render path via `assert_render_curve_invariants`; the unmutated routing is clean (non-vacuous).
- [x] Full suite green (14214 passed, 0 failures, no xfail flips).
- [x] `ruff format --check` + `ruff check` + `mypy` clean on the whole repo.
- [x] Routing gate-coverage ratchet green under Python 3.11.
- [ ] Render-preview verdict (expected: no visual changes; this is a guard-only addition with no geometry change).

Generated with Claude Code