### PR TITLE
feat(render): opt-in static directional flow chevrons (#725)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ nf-metro render [OPTIONS] INPUT_FILE
 | `--y-spacing FLOAT` | auto | Vertical spacing between tracks (derived from the map's content so captioned icons and dense labels don't collide) |
 | `--fold-threshold INTEGER` | `15` | Max station-columns a section row may reach before wrapping to the next row |
 | `--animate / --no-animate` | off | Add animated balls traveling along lines |
+| `--directional / --no-directional` | off | Draw static chevrons along each route pointing in the flow direction (source to target) |
 | `--debug / --no-debug` | off | Show debug overlay (ports, hidden stations, edge waypoints) |
 | `--logo PATH` | none | Logo image path (overrides `%%metro logo:` directive) |
 | `--line-order [definition\|span]` | `definition` | Line ordering strategy: `definition` preserves `.mmd` order, `span` sorts by section span (longest first) |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -529,6 +529,7 @@ These go at the top of the file, before `graph LR`.
 | `%%metro width: <pixels>` | Output width in pixels (default: auto from content) |
 | `%%metro height: <pixels>` | Output height in pixels (default: auto from content) |
 | `%%metro animate: true` | Add animated balls traveling along the metro lines |
+| `%%metro directional: true` | Draw static chevrons along each route pointing in the flow direction (source to target). Off by default; CLI equivalent `--directional`. Marker size, spacing, opacity, and colour are theme knobs (`directional_marker_*`). |
 | `%%metro file: <station> \| <label> [\| <name>] [\| banner]` | Mark a station as a file terminus with a document icon. Optional `name` renders as a caption below the icon; optional `banner` draws the label on a dark strip across the icon. |
 | `%%metro files: <station> \| <label> [\| <name>] [\| banner]` | Mark a station with a stacked-documents icon (e.g. paired files). Optional `name` caption; optional `banner` strip. |
 | `%%metro dir: <station> \| <label> [\| <name>]` | Mark a station with a folder icon (e.g. output directory). Optional `name` caption. |

--- a/examples/directional_flow.mmd
+++ b/examples/directional_flow.mmd
@@ -1,0 +1,25 @@
+%%metro title: Directional Flow
+%%metro style: dark
+%%metro directional: true
+%%metro line: dna | DNA variants | #E64A19
+%%metro line: rna | RNA expression | #1E88E5
+
+graph LR
+    reads[Reads]
+    trim[Trim]
+    align[Align]
+    snv[Call SNVs]
+    sv[Call SVs]
+    merge[Merge calls]
+    quant[Quantify]
+    report[Report]
+
+    reads -->|dna| trim
+    trim -->|dna| align
+    align -->|dna| snv
+    align -->|dna| sv
+    snv -->|dna| merge
+    sv -->|dna| merge
+    merge -->|dna| report
+    reads -->|rna| quant
+    quant -->|rna| report

--- a/examples/directional_flow.mmd
+++ b/examples/directional_flow.mmd
@@ -3,23 +3,30 @@
 %%metro directional: true
 %%metro line: dna | DNA variants | #E64A19
 %%metro line: rna | RNA expression | #1E88E5
+%%metro line: meth | Methylation | #43A047
 
 graph LR
     reads[Reads]
+    qc[QC]
     trim[Trim]
     align[Align]
-    snv[Call SNVs]
-    sv[Call SVs]
-    merge[Merge calls]
+    callvar[Call variants]
     quant[Quantify]
+    methcall[Call methylation]
     report[Report]
 
-    reads -->|dna| trim
+    reads -->|dna| qc
+    reads -->|rna| qc
+    reads -->|meth| qc
+    qc -->|dna| trim
+    qc -->|rna| trim
+    qc -->|meth| trim
     trim -->|dna| align
-    align -->|dna| snv
-    align -->|dna| sv
-    snv -->|dna| merge
-    sv -->|dna| merge
-    merge -->|dna| report
-    reads -->|rna| quant
+    trim -->|rna| align
+    trim -->|meth| align
+    align -->|dna| callvar
+    align -->|rna| quant
+    align -->|meth| methcall
+    callvar -->|dna| report
     quant -->|rna| report
+    methcall -->|meth| report

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -47,6 +47,15 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "Minimal two-line pipeline with no sections.",
     ),
     (
+        "directional_flow",
+        EXAMPLES_DIR,
+        "Opt-in static flow chevrons via `%%metro directional: true` (CLI: "
+        "`--directional`): periodic open chevrons ride each route pointing "
+        "source to target, making fan-out and merge direction legible without "
+        "the animated `--animate` balls. Marker size, spacing, opacity, and "
+        "colour are `Theme` knobs.",
+    ),
+    (
         "line_spread",
         EXAMPLES_DIR,
         "Demonstrates the `%%metro line_spread:` axis with one per-section "

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -51,9 +51,10 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         EXAMPLES_DIR,
         "Opt-in static flow chevrons via `%%metro directional: true` (CLI: "
         "`--directional`): periodic open chevrons ride each route pointing "
-        "source to target, making fan-out and merge direction legible without "
-        "the animated `--animate` balls. Marker size, spacing, opacity, and "
-        "colour are `Theme` knobs.",
+        "source to target. A three-line bundled trunk fans out to per-line "
+        "analyses and converges again, so the chevrons make bundle, fan-out, "
+        "and merge direction legible without the animated `--animate` balls. "
+        "Marker size, spacing, opacity, and colour are `Theme` knobs.",
     ),
     (
         "line_spread",

--- a/src/nf_metro/options.py
+++ b/src/nf_metro/options.py
@@ -203,6 +203,12 @@ LAYOUT_OPTIONS: tuple[LayoutOption, ...] = (
         help="Add animated balls traveling along the metro lines.",
     ),
     LayoutOption(
+        name="directional",
+        kind="bool",
+        help="Draw static chevrons along each route pointing in the flow "
+        "direction (source to target). Off by default.",
+    ),
+    LayoutOption(
         name="manifest",
         attr="embed_manifest",
         kind="bool",

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -368,6 +368,7 @@ class MetroGraph:
     width: int | None = None
     height: int | None = None
     animate: bool = False
+    directional: bool = False
     embed_manifest: bool = True
     # Max station-columns a section row may reach before the auto-layout wraps
     # it onto the next row. None falls back to 15; raise it to keep a long

--- a/src/nf_metro/render/style.py
+++ b/src/nf_metro/render/style.py
@@ -49,6 +49,12 @@ class Theme:
     animation_ball_stroke_width: float = 1.0
     animation_balls_per_line: int = 1
     animation_speed: float = 80.0  # pixels per second
+    # Static directional chevrons (--directional). Kept transit-restrained:
+    # a wide spacing so most routes show only a few markers.
+    directional_marker_size: float = 4.0  # arm half-length and half-width, px
+    directional_marker_spacing: float = 64.0  # px
+    directional_marker_opacity: float = 0.75
+    directional_marker_color: str = ""  # empty = inherit the line colour
     # Terminus (file icon) settings
     terminus_width: float = TERMINUS_WIDTH
     terminus_height: float = 2 * ICON_HALF_HEIGHT

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 __all__ = ["apply_route_offsets", "render_svg"]
 
 import html
+import math
 import re
 import textwrap
 import warnings
@@ -680,6 +681,10 @@ def _render_svg_scaled(
     # Draw edges (lines) behind stations
     _render_edges(d, graph, routes, station_offsets, theme)
 
+    # Directional chevrons ride on top of the lines but behind stations.
+    if graph.directional:
+        _render_directional_markers(d, graph, routes, station_offsets, theme)
+
     # Animation (after edges, before stations so balls travel behind station markers)
     if animate:
         from nf_metro.render.animate import render_animation
@@ -1121,6 +1126,121 @@ def _render_edges(
 
             path.L(*pts[-1])
             d.append(path)
+
+
+def _render_directional_markers(
+    d: draw.Drawing,
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    station_offsets: dict[tuple[str, str], float],
+    theme: Theme,
+) -> None:
+    """Draw static chevrons along each route, pointing source to target.
+
+    The flow direction is the order of the routed point sequence, so each
+    chevron simply rides the polyline at the local segment direction. Markers
+    are spaced by arc length and kept sparse and subtle by default, in the
+    spirit of a one-way transit line's direction-of-travel arrows.
+    """
+    size = theme.directional_marker_size
+    spacing = max(theme.directional_marker_spacing, 1.0)
+    opacity = theme.directional_marker_opacity
+    # A route shorter than one chevron carries no useful direction cue.
+    min_length = 2 * size
+    stroke_width = max(theme.line_width * 0.5, 1.0)
+
+    for route in routes:
+        pts = apply_route_offsets(route, station_offsets)
+        if len(pts) < 2:
+            continue
+        line = graph.lines.get(route.line_id)
+        color = theme.directional_marker_color or (
+            line.color if line else FALLBACK_LINE_COLOR
+        )
+        class_name = _ns(f"metro-direction-{route.line_id}")
+        for point, heading in _chevron_samples(pts, spacing, min_length):
+            _draw_chevron(
+                d,
+                point,
+                heading,
+                color,
+                size,
+                stroke_width,
+                opacity,
+                class_name,
+                route.line_id,
+            )
+
+
+def _chevron_samples(
+    pts: list[tuple[float, float]], spacing: float, min_length: float
+) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+    """Sample (point, unit-heading) pairs evenly along a polyline.
+
+    Chevrons are centred on the polyline so a route reads symmetrically. A
+    route between ``min_length`` and ``spacing`` in length carries a single
+    chevron at its midpoint.
+    """
+    segments = [
+        (a, b, length)
+        for a, b in zip(pts, pts[1:])
+        if (length := math.hypot(b[0] - a[0], b[1] - a[1])) > 0
+    ]
+    total = sum(length for _, _, length in segments)
+    if total < min_length:
+        return []
+
+    count = max(1, int(total // spacing))
+    start = (total - (count - 1) * spacing) / 2
+
+    samples: list[tuple[tuple[float, float], tuple[float, float]]] = []
+    targets = [start + i * spacing for i in range(count)]
+    travelled = 0.0
+    ti = 0
+    for (ax, ay), (bx, by), length in segments:
+        ux, uy = (bx - ax) / length, (by - ay) / length
+        while ti < len(targets) and targets[ti] <= travelled + length:
+            offset = targets[ti] - travelled
+            samples.append(((ax + ux * offset, ay + uy * offset), (ux, uy)))
+            ti += 1
+        travelled += length
+    return samples
+
+
+def _draw_chevron(
+    d: draw.Drawing,
+    point: tuple[float, float],
+    heading: tuple[float, float],
+    color: str,
+    size: float,
+    stroke_width: float,
+    opacity: float,
+    class_name: str,
+    line_id: str,
+) -> None:
+    """Draw one open ``>`` chevron centred at *point*, apex along *heading*."""
+    px, py = point
+    ux, uy = heading
+    perp = (-uy, ux)
+    apex = (px + ux * size, py + uy * size)
+    back = (px - ux * size, py - uy * size)
+    wing1 = (back[0] + perp[0] * size, back[1] + perp[1] * size)
+    wing2 = (back[0] - perp[0] * size, back[1] - perp[1] * size)
+
+    path = draw.Path(
+        stroke=color,
+        stroke_width=stroke_width,
+        fill="none",
+        stroke_linecap="round",
+        stroke_linejoin="round",
+        opacity=opacity,
+        class_=class_name,
+        **{"data-line-id": line_id},
+    )
+    path.M(*wing1)
+    path.L(*apex)
+    path.L(*wing2)
+    d.append(path)
 
 
 def _curve_tangents(

--- a/tests/test_directional_markers.py
+++ b/tests/test_directional_markers.py
@@ -1,0 +1,97 @@
+"""Tests for static directional chevrons (``--directional``)."""
+
+import pathlib
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges_centred
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.svg import (
+    _chevron_samples,
+    apply_route_offsets,
+    render_svg,
+)
+from nf_metro.themes import NFCORE_THEME
+
+EXAMPLES_DIR = pathlib.Path(__file__).parent.parent / "examples"
+
+DIRECTION_FIXTURES = [
+    "simple_pipeline",
+    "rnaseq_auto",
+    "genomic_pipeline",
+    "longread_variant_calling",
+]
+
+
+def _laid_out(stem: str):
+    graph = parse_metro_mermaid((EXAMPLES_DIR / f"{stem}.mmd").read_text())
+    compute_layout(graph)
+    return graph
+
+
+def _render(stem: str, *, directional: bool) -> str:
+    graph = _laid_out(stem)
+    graph.directional = directional
+    return render_svg(graph, NFCORE_THEME)
+
+
+def test_directional_off_by_default_emits_no_chevrons():
+    svg = _render("simple_pipeline", directional=False)
+    assert "metro-direction-" not in svg
+
+
+@pytest.mark.parametrize("stem", DIRECTION_FIXTURES)
+def test_directional_flag_emits_chevrons(stem):
+    svg = _render(stem, directional=True)
+    assert "metro-direction-" in svg
+
+
+@pytest.mark.parametrize("stem", DIRECTION_FIXTURES)
+def test_chevron_headings_point_downstream(stem):
+    """Every chevron must point from the route's source toward its target.
+
+    Direction is read from the routed point order, so a chevron heading on any
+    segment should agree with that segment's own source-to-target travel.
+    """
+    graph = _laid_out(stem)
+    station_offsets = compute_station_offsets(graph)
+    routes = route_edges_centred(graph, station_offsets=station_offsets)
+
+    spacing = NFCORE_THEME.directional_marker_spacing
+    min_length = 2 * NFCORE_THEME.directional_marker_size
+
+    checked = 0
+    for route in routes:
+        pts = apply_route_offsets(route, station_offsets)
+        for point, heading in _chevron_samples(pts, spacing, min_length):
+            assert _heading_is_forward_on_polyline(pts, point, heading)
+            checked += 1
+
+    assert checked > 0, f"{stem} produced no chevrons to check"
+
+
+def _heading_is_forward_on_polyline(pts, point, heading, tol=0.5):
+    """A chevron heading must run forward along a segment it lies on.
+
+    The point can coincide with a corner vertex shared by two segments; the
+    heading is forward-valid if it points in the source-to-target direction of
+    either adjoining segment. A reversed heading matches neither.
+    """
+    px, py = point
+    ux, uy = heading
+    for (ax, ay), (bx, by) in zip(pts, pts[1:]):
+        seg_len_sq = (bx - ax) ** 2 + (by - ay) ** 2
+        if seg_len_sq == 0:
+            continue
+        t = ((px - ax) * (bx - ax) + (py - ay) * (by - ay)) / seg_len_sq
+        if not -0.01 <= t <= 1.01:
+            continue
+        cx, cy = ax + t * (bx - ax), ay + t * (by - ay)
+        if abs(cx - px) >= tol or abs(cy - py) >= tol:
+            continue
+        seg_len = seg_len_sq**0.5
+        forward = ((bx - ax) * ux + (by - ay) * uy) / seg_len
+        if forward > 0.999:
+            return True
+    return False


### PR DESCRIPTION
## Summary

Adds an opt-in, static way to show flow direction along routes, resolving #725. The existing `--animate` balls were the only directional cue; this adds a render-layer chevron overlay that needs no motion and no layout change.

- **`--directional` CLI flag** and matching **`%%metro directional: true`** directive (registered once in `LAYOUT_OPTIONS`), off by default, writing to `MetroGraph.directional`.
- Periodic **open `>` chevrons** ride each routed polyline at the local segment heading, always pointing source -> target. They are spaced by arc length and centred per route; a route between one chevron's length and the spacing gets a single midpoint chevron.
- Deliberately **transit-restrained**: a wide default spacing so most routes show only a few markers, in the spirit of a one-way loop line's direction-of-travel arrows rather than a dense debug overlay.
- **Theme knobs**: `directional_marker_size`, `directional_marker_spacing`, `directional_marker_opacity`, `directional_marker_color` (empty inherits the line colour).
- New **`directional_flow`** gallery example (a DNA-variant diamond plus a parallel RNA line converging at Report) so the feature gets visual review and CI render-diff coverage; guide, README CLI table, and `%%metro` directive table updated.
- **Tests**: parametrised over four fixtures - chevrons are emitted only when enabled, and every chevron heading is forward-parallel to a segment it lies on (catches a reversed-direction regression).

No runtime layout validator was added: directionality is a render-layer property derived from the routed point order (the same order the whole engine depends on), not a layout invariant that `compute_layout` could regress silently.

Fixes #725

## Test plan
- [x] `pytest` passes (incl. new `tests/test_directional_markers.py`, 9 cases)
- [x] `ruff check` + `ruff format --check` clean on whole repo
- [x] `mypy` clean
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/901/) - new `directional_flow` example shows the chevrons; existing examples unchanged (feature is off by default)
- [ ] Render-preview verdict captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
