### PR TITLE
docs(examples): enable directional chevrons on three gallery maps

### DIFF
--- a/examples/cross_track_interchange.mmd
+++ b/examples/cross_track_interchange.mmd
@@ -1,5 +1,6 @@
 %%metro title: Cross-track interchange
 %%metro style: dark
+%%metro directional: true
 %%metro legend: br
 %%metro line: tumor | Tumor | #d62728
 %%metro line: normal | Normal | #0570b0

--- a/examples/longread_variant_calling.mmd
+++ b/examples/longread_variant_calling.mmd
@@ -1,5 +1,6 @@
 %%metro title: Long-read Variant Calling
 %%metro style: dark
+%%metro directional: true
 %%metro files: fastq_in | FASTQ
 %%metro files: bam_in | BAM
 %%metro files: ubam_in | uBAM

--- a/examples/tb_file_termini.mmd
+++ b/examples/tb_file_termini.mmd
@@ -1,5 +1,6 @@
 %%metro title: TB section file outputs
 %%metro style: dark
+%%metro directional: true
 %%metro line: rna | RNA-seq | #1f9e89
 %%metro line: dna | Variant | #2c7fb8
 %%metro file: report_html | HTML | Report


### PR DESCRIPTION
Turns on `%%metro directional: true` for the three gallery examples where flow direction is genuinely ambiguous from the layout alone, which is where the opt-in chevrons (#725) earn their keep.

| Example | Why it benefits |
| --- | --- |
| `cross_track_interchange` | Lines converge, cross at an interchange, then pinch into a fan-in. Chevrons make the direction into the merge points clear. |
| `longread_variant_calling` | Boustrophedon layout wraps across nine sections, so spatial position does not imply flow order. Arrows show which way the long inter-section bypasses run. |
| `tb_file_termini` | A top-to-bottom reporting section where the vertical drop to the file outputs reads equally well up or down without arrows. |

Render-only change: the directive only enables the static chevrons; layout is untouched. Verified each map renders cleanly with the chevrons driven by the directive (not the CLI flag).

Examples deliberately left off: `genomic_pipeline` (dense vertical caller fan makes chevrons busy) and `differentialabundance` (already visually dense).

🤖 Generated with [Claude Code](https://claude.com/claude-code)