### PR TITLE
feat(layout): reorder an interleaving lane out of an interchange bar span (#779)

### DIFF
--- a/examples/topologies/README.md
+++ b/examples/topologies/README.md
@@ -31,6 +31,7 @@ Each fixture is tagged with the layout class(es) it primarily exercises. Use thi
 | `trunk_through_fan.mmd` | trunk bundle entering and exiting a section that has an internal fork-join diamond |
 | `terminal_symmetric_fan.mmd` | two-line bundle fanning out to three terminal nodes in a reporting section (no inter-terminal edges) |
 | `multi_line_bundle.mmd` | dense bundle / tall station pills |
+| `interchange_lane_reorder.mmd` | auto-interchange / interleaving-lane reorder (issue #779) |
 | `mismatched_tracks.mmd` | per-line track mismatch between sections |
 | `mixed_bundle_column.mmd` | mixed-cardinality fan-out into stacked column |
 | `mixed_port_sides.mmd` | multi-side exit ports (RIGHT + BOTTOM) |

--- a/examples/topologies/interchange_lane_reorder.mmd
+++ b/examples/topologies/interchange_lane_reorder.mmd
@@ -1,0 +1,23 @@
+%%metro title: Interchange lane reorder
+%%metro style: dark
+%%metro line: top | Top | #d62728
+%%metro line: mid | Mid | #2db572
+%%metro line: bot | Bot | #f5c542
+
+graph LR
+    subgraph s [Parallel lanes]
+        top_in[ ]
+        mid_in[ ]
+        bot_in[ ]
+        hub[Shared step]
+        mid_step[Mid step]
+        top_out[ ]
+        mid_out[ ]
+        bot_out[ ]
+        top_in -->|top| hub
+        bot_in -->|bot| hub
+        mid_in -->|mid| mid_step
+        hub -->|top| top_out
+        hub -->|bot| bot_out
+        mid_step -->|mid| mid_out
+    end

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -294,6 +294,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
     ),
     # --- Multi-line bundles ---
     (
+        "interchange_lane_reorder",
+        TOPOLOGIES_DIR,
+        "Two lanes share one step while a third lane is declared between them. "
+        "Auto-layout reorders the interleaving lane to an outer track so the "
+        "two members become adjacent and infer a clean interchange, instead of "
+        "abstaining (issue #779).",
+    ),
+    (
         "multi_line_bundle",
         TOPOLOGIES_DIR,
         "Six lines travelling through the same three-section chain.",

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -14,6 +14,7 @@ __all__ = ["infer_section_layout", "infer_interchanges", "detect_serpentine_runs
 from collections import defaultdict, deque
 from collections.abc import Set as AbstractSet
 
+from nf_metro.layout.layers import assign_layers
 from nf_metro.parser.model import Interchange, MetroGraph, PortSide, SectionDAG
 
 
@@ -33,11 +34,13 @@ def infer_interchanges(graph: MetroGraph) -> None:
     explicit ``%%metro interchange:`` directive (or nothing).  Author-written
     interchanges are left untouched.
     """
-    explicit = {ic.node_id for ic in graph.interchanges}
+    explicit = [ic.node_id for ic in graph.interchanges]
+    explicit_set = set(explicit)
+    candidates: list[str] = []
     for sid, st in list(graph.stations.items()):
         if st.is_port or st.interchange_id is not None or st.is_terminus:
             continue
-        if sid in explicit:
+        if sid in explicit_set:
             continue
         # Rail sections already lay every line on its own rail and draw shared
         # stops as interchanges, so one here is redundant and would clash with
@@ -46,10 +49,56 @@ def infer_interchanges(graph: MetroGraph) -> None:
             continue
         if not _is_parallel_lane_hub(graph, sid):
             continue
-        if not _rails_span_is_clear(graph, sid):
-            continue
+        candidates.append(sid)
+
+    order = list(graph.lines.keys())
+
+    # Author-pinned interchanges must keep their span clear under any reorder we
+    # try; collect them so a track shuffle for an inferred hub can never push a
+    # non-member rail under an explicit bar.
+    committed = list(explicit)
+    inferred: list[str] = []
+    pending: list[str] = []
+    for sid in candidates:
+        if _rails_span_is_clear(graph, sid, order):
+            committed.append(sid)
+            inferred.append(sid)
+        else:
+            pending.append(sid)
+
+    # A straddle is an artifact of lane order, which is free unless the author
+    # fixed it with %%metro line_order:.  For each abstaining hub, try to pull
+    # its member lines into a contiguous block (the minimal disturbance that
+    # clears the bar) and keep the reorder only if every already-committed
+    # interchange -- explicit or inferred -- stays clear under it.
+    if pending and graph.line_order == "definition":
+        layers = assign_layers(graph)
+        for sid in pending:
+            # Line order only governs the bar span when every member rail runs
+            # straight through the hub.  A member line that enters or leaves via
+            # a long edge (a neighbour more than one layer away) slopes off its
+            # base track, so a contiguous lane order would not actually close the
+            # bar -- reordering would only manufacture a straddle the runtime
+            # check then trips on.  Skip those; abstaining stays correct.
+            if not _member_lines_pass_straight(graph, sid, layers):
+                continue
+            new_order = _cluster_member_lines(graph, sid, order)
+            if new_order is None or not _rails_span_is_clear(graph, sid, new_order):
+                continue
+            if not all(
+                _rails_span_is_clear(graph, other, new_order) for other in committed
+            ):
+                continue
+            order = new_order
+            committed.append(sid)
+            inferred.append(sid)
+
+    if order != list(graph.lines.keys()):
+        graph.lines = {lid: graph.lines[lid] for lid in order}
+
+    for sid in inferred:
         lines = graph.station_lines(sid)
-        ordered = [lid for lid in graph.lines if lid in lines]
+        ordered = [lid for lid in order if lid in lines]
         graph.interchanges.append(
             Interchange(node_id=sid, rails=[[lid] for lid in ordered], inferred=True)
         )
@@ -87,14 +136,15 @@ def _is_parallel_lane_hub(graph: MetroGraph, sid: str) -> bool:
     return len(preds) == len(lines) and len(succs) == len(lines)
 
 
-def _rails_span_is_clear(graph: MetroGraph, sid: str) -> bool:
+def _rails_span_is_clear(graph: MetroGraph, sid: str, order: list[str]) -> bool:
     """True when the interchange's rails would form a contiguous track block.
 
     The connector bar spans from the topmost member rail to the bottommost, so
     if a non-member line's rail falls between them its stations sit under the
-    bar (a station-as-elbow violation).  Track order follows line-definition
-    order within a section, so require the member lines to be a contiguous run
-    among the section's lines -- no other line interleaved.
+    bar (a station-as-elbow violation).  Track order follows *order* (the line
+    ordering tracks will be assigned from) within a section, so require the
+    member lines to be a contiguous run among the section's lines -- no other
+    line interleaved.
     """
     section_id = graph.stations[sid].section_id
     section = graph.sections.get(section_id) if section_id is not None else None
@@ -106,9 +156,54 @@ def _rails_span_is_clear(graph: MetroGraph, sid: str) -> bool:
         if (m := graph.stations.get(mid)) is not None and not m.is_port
         for lid in graph.station_lines(mid)
     }
-    section_order = [lid for lid in graph.lines if lid in present]
+    section_order = [lid for lid in order if lid in present]
     member_idx = sorted(section_order.index(lid) for lid in graph.station_lines(sid))
     return member_idx == list(range(member_idx[0], member_idx[-1] + 1))
+
+
+def _member_lines_pass_straight(
+    graph: MetroGraph, sid: str, layers: dict[str, int]
+) -> bool:
+    """True when every line through *sid* enters and leaves at adjacent layers.
+
+    A parallel-lane hub's rails only sit on their line base tracks -- the
+    assumption :func:`_rails_span_is_clear` makes when it reads lane order as
+    track order -- while each line runs as a straight horizontal segment past
+    the hub.  A line whose predecessor or successor is more than one layer away
+    travels a sloping long edge instead, dragging its rail off that track, so
+    lane order then fails to predict the real bar span.
+    """
+    hub_layer = layers.get(sid)
+    if hub_layer is None:
+        return False
+    for lid in graph.station_lines(sid):
+        for e in graph.edges_to(sid):
+            if e.line_id == lid and layers.get(e.source) != hub_layer - 1:
+                return False
+        for e in graph.edges_from(sid):
+            if e.line_id == lid and layers.get(e.target) != hub_layer + 1:
+                return False
+    return True
+
+
+def _cluster_member_lines(
+    graph: MetroGraph, sid: str, order: list[str]
+) -> list[str] | None:
+    """Return *order* with *sid*'s member lines pulled into a contiguous block.
+
+    The block keeps the members' relative order and is seated where the first
+    member currently sits, so every non-member lane keeps its relative position
+    (the smallest reshuffle that closes the straddle).  Returns ``None`` when
+    the node carries fewer than two lines (nothing to bridge).
+    """
+    members = graph.station_lines(sid)
+    member_block = [lid for lid in order if lid in members]
+    if len(member_block) < 2:
+        return None
+    first_idx = order.index(member_block[0])
+    rest = [lid for lid in order if lid not in members]
+    n_before = sum(1 for lid in order[:first_idx] if lid not in members)
+    return rest[:n_before] + member_block + rest[n_before:]
 
 
 def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> None:

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -138,6 +138,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _guard_inter_section_route_no_backtrack,
     _guard_inter_section_route_no_full_width_backtrack,
     _guard_inter_section_routes_in_row_band,
+    _guard_interchange_bar_clears_non_members,
     _guard_merge_port_approach_side,
     _guard_merge_port_outgoing_side_preserved,
     _guard_no_artefactual_counter_flow,
@@ -649,6 +650,7 @@ def _compute_layout_scaled(
         _guard_single_trunk_off_track_step(graph, "final")
         _guard_off_track_consumer_on_trunk(graph, "final")
         _guard_off_track_input_column_stack(graph, "final")
+        _guard_interchange_bar_clears_non_members(graph, "final")
         _guard_tb_top_entry_drop_hugs_top(graph, "final")
 
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -412,6 +412,35 @@ def _guard_rail_one_station_per_column(graph: MetroGraph, phase: str) -> None:
                 )
 
 
+def _guard_interchange_bar_clears_non_members(graph: MetroGraph, phase: str) -> None:
+    """An interchange connector bar must not cross a non-member station.
+
+    The bar runs vertically between the top and bottom member rails at the
+    interchange column; any other station sharing that column within the span
+    would be cut by the bar (a station-as-elbow violation).  Auto-detection
+    abstains or reorders to avoid this, but the seating is geometry-dependent,
+    so verify the settled layout directly.
+    """
+    tol = GUARD_TOLERANCE
+    for ic in graph.interchanges:
+        member_ids = set(ic.member_ids)
+        members = [graph.stations[m] for m in ic.member_ids if m in graph.stations]
+        if len(members) < 2:
+            continue
+        x = members[0].x
+        ys = [m.y for m in members]
+        lo, hi = min(ys), max(ys)
+        for s in graph.stations.values():
+            if s.is_port or s.id in member_ids:
+                continue
+            if abs(s.x - x) < tol and lo - tol < s.y < hi + tol:
+                raise PhaseInvariantError(
+                    f"{phase}: interchange {ic.node_id!r} bar (x={x:.1f}, "
+                    f"y {lo:.1f}..{hi:.1f}) spans non-member station {s.id!r} "
+                    f"at ({s.x:.1f}, {s.y:.1f})"
+                )
+
+
 def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:
     """After Stage 3.1+: ports must sit on their section's bounding box edge."""
     tolerance = GUARD_TOLERANCE

--- a/tests/test_interchange.py
+++ b/tests/test_interchange.py
@@ -12,6 +12,10 @@ import pytest
 
 from nf_metro.layout.constants import SAME_COORD_TOLERANCE
 from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.phases.guards import (
+    PhaseInvariantError,
+    _guard_interchange_bar_clears_non_members,
+)
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.render import render_svg
 from nf_metro.themes import THEMES
@@ -149,12 +153,70 @@ def test_example_fixture_renders_with_inferred_and_explicit_agreeing():
     assert {c.node_id for c in g_auto.interchanges if c.inferred} == {"markduplicates"}
 
 
-def test_auto_detection_abstains_when_bar_would_span_a_third_lane():
+# Two parallel lanes (top/bot) sharing one step, with a third lane (mid)
+# declared between them so its track interleaves the would-be bar span.  Every
+# lane runs straight through (neighbours one layer away), so the straddle is a
+# pure lane-order artifact the reorder can lift.
+_REORDERABLE = (
+    "%%metro line: top | Top | #d62728\n"
+    "%%metro line: mid | Mid | #2db572\n"
+    "%%metro line: bot | Bot | #f5c542\n"
+    "{directive}"
+    "graph LR\n"
+    "    subgraph s [S]\n"
+    "        top_in[ ]\n        mid_in[ ]\n        bot_in[ ]\n"
+    "        hub[Hub]\n        mid_step[Mid]\n"
+    "        top_out[ ]\n        mid_out[ ]\n        bot_out[ ]\n"
+    "        top_in -->|top| hub\n        bot_in -->|bot| hub\n"
+    "        mid_in -->|mid| mid_step\n"
+    "        hub -->|top| top_out\n        hub -->|bot| bot_out\n"
+    "        mid_step -->|mid| mid_out\n"
+    "    end\n"
+)
+
+
+def test_auto_detection_abstains_when_a_diverging_member_cannot_be_un_straddled():
     """longread's samtools_merge carries ubam+bam, but the fastq lane's track
-    sits between them; a bridge there would draw its bar over cat_fastq.  The
-    clearance rule must keep auto-detection from inferring it."""
+    sits between them.  The bam member leaves on a long edge (to a station two
+    layers downstream), so its rail slopes off its base track -- no lane order
+    can make the two member rails adjacent, and reordering would only manufacture
+    a straddle over cat_fastq.  Auto-detection must keep abstaining there."""
     g = parse_metro_mermaid((EXAMPLES / "longread_variant_calling.mmd").read_text())
     assert "samtools_merge" not in {c.node_id for c in g.interchanges}
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        _REORDERABLE.format(directive=""),
+        (EXAMPLES / "topologies" / "interchange_lane_reorder.mmd").read_text(),
+    ],
+    ids=["inline", "fixture"],
+)
+def test_auto_detection_reorders_interleaving_lane_out_of_bar_span(src):
+    """An interleaving non-member lane is reordered to an outer track so the two
+    member rails become adjacent and the bar infers cleanly, instead of
+    abstaining.  The interleaving lane's station must then sit clear of the bar."""
+    g = parse_metro_mermaid(src)
+    assert "hub" in {c.node_id for c in g.interchanges}
+    compute_layout(g)
+    ic = next(c for c in g.interchanges if c.node_id == "hub")
+    members = [g.stations[m] for m in ic.member_ids]
+    x = members[0].x
+    ys = [m.y for m in members]
+    lo, hi = min(ys), max(ys)
+    mid_step = g.stations["mid_step"]
+    assert abs(mid_step.x - x) < SAME_COORD_TOLERANCE
+    assert not (lo - SAME_COORD_TOLERANCE < mid_step.y < hi + SAME_COORD_TOLERANCE)
+
+
+def test_reorder_respects_explicit_line_order_directive():
+    """An explicit ``%%metro line_order:`` directive is the author's choice and
+    must win: the reorder that would un-straddle the bar is not applied, so the
+    hub abstains rather than silently overriding the requested track order."""
+    g = parse_metro_mermaid(_REORDERABLE.format(directive="%%metro line_order: span\n"))
+    assert list(g.lines.keys()) == ["top", "mid", "bot"]
+    assert "hub" not in {c.node_id for c in g.interchanges}
 
 
 def test_directive_bundles_multiple_lines_on_one_rail():
@@ -200,25 +262,23 @@ def test_marked_interchange_renders_as_a_tinted_interchange():
 def test_interchange_bar_never_spans_a_non_member_station(fixture):
     """An interchange connector bar runs between its top and bottom member
     rails; no other station may sit within that span at the bar's column, or
-    the bar would visibly cut through that station's marker."""
+    the bar would visibly cut through that station's marker.  This is exactly
+    the always-on guard's contract, so exercise it directly over the corpus."""
     g = parse_metro_mermaid(fixture.read_text())
     compute_layout(g)
-    for ic in g.interchanges:
-        members = [g.stations[m] for m in ic.member_ids if m in g.stations]
-        if len(members) < 2:
-            continue
-        x = members[0].x
-        ys = [m.y for m in members]
-        lo, hi = min(ys), max(ys)
-        for s in g.stations.values():
-            if s.is_port or s.id in ic.member_ids:
-                continue
-            spans = (
-                abs(s.x - x) < SAME_COORD_TOLERANCE
-                and lo - SAME_COORD_TOLERANCE < s.y < hi + SAME_COORD_TOLERANCE
-            )
-            assert not spans, (
-                f"{fixture.name}: interchange {ic.node_id!r} bar (x={x:.0f}, "
-                f"y {lo:.0f}..{hi:.0f}) spans station {s.id!r} at "
-                f"({s.x:.0f}, {s.y:.0f})"
-            )
+    _guard_interchange_bar_clears_non_members(g, fixture.name)
+
+
+def test_runtime_guard_flags_an_interchange_bar_over_a_non_member(monkeypatch):
+    """The always-on guard raises when a bar straddles a non-member station.
+
+    Forcing the lane reorder past its straight-through gate seats longread's
+    samtools_merge bar across cat_fastq; the guard must catch that geometry
+    rather than letting the broken bar render."""
+    import nf_metro.layout.auto_layout as al
+
+    monkeypatch.setattr(al, "_member_lines_pass_straight", lambda *a, **k: True)
+    g = parse_metro_mermaid((EXAMPLES / "longread_variant_calling.mmd").read_text())
+    compute_layout(g, validate=False)
+    with pytest.raises(PhaseInvariantError, match="spans non-member station"):
+        _guard_interchange_bar_clears_non_members(g, "final")


### PR DESCRIPTION
## Summary

Auto-interchange detection used to abstain whenever a non-member lane's track fell between an interchange's member rails, because the connector bar there would cut across that lane's station. That straddle is usually an artifact of lane order, which is a free layout choice, so the inference now tries to lift it before giving up.

Before abstaining on an interleaved hub, `infer_interchanges` pulls the member lines into a contiguous block (the minimal reshuffle that closes the bar) and keeps the reorder only when:

- the line order is the default (an explicit `%%metro line_order:` directive always wins),
- every member line passes straight through the hub (a member leaving on a long edge slopes off its base track, so lane order would not predict the real bar span), and
- every already-committed interchange, explicit or inferred, stays clear under the new order.

A new always-on guard (`_guard_interchange_bar_clears_non_members`) verifies the settled geometry on every render, so a mis-seated bar fails loudly instead of shipping a bar drawn over a station.

`longread_variant_calling` (the issue's motivating case) keeps abstaining at `samtools_merge`: its `bam` member leaves on a long edge to a station two layers downstream, so its rail slopes off the trunk and no lane order can make the two member rails adjacent. This is the issue's documented-decision acceptance path rather than the clean-interchange path.

## Changes

- `layout/auto_layout.py`: lane-reorder attempt in `infer_interchanges`; new `_member_lines_pass_straight` and `_cluster_member_lines`; `_rails_span_is_clear` now scores a candidate line order.
- `layout/phases/guards.py` + `layout/engine.py`: new runtime guard `_guard_interchange_bar_clears_non_members`, wired into the final validate block.
- `examples/topologies/interchange_lane_reorder.mmd` (+ gallery entry + README row): a clean parallel-lane hub with an interleaving lane that the reorder lifts into a clean interchange.
- `tests/test_interchange.py`: positive reorder test (inline + fixture), explicit-`line_order`-wins test, runtime-guard test; the corpus invariant test now calls the guard directly.

Fixes #779. Follow-up to #778.

## Test plan
- [x] pytest passes (15131 passed), including new invariant tests
- [x] ruff check + ruff format clean on whole repo; mypy clean
- [x] Runtime validator added and verified to fire on a forced straddle
- [ ] Visual review of render preview
- [ ] Render-preview verdict captured

Generated with Claude Code