### PR TITLE
feat(live): selectable status-overlay styles for the live progress page

### DIFF
--- a/docs/live.md
+++ b/docs/live.md
@@ -104,8 +104,32 @@ blank map.
 |--------|---------|
 | `--port` | Port to listen on (default 8080). |
 | `--host` | Interface to bind. Default `127.0.0.1` (local only); use `0.0.0.0` to accept connections from other hosts. |
-| `--theme` | Theme name (`nfcore`, `light`). |
+| `--theme` | Theme name (`nfcore`, `light`, `seqera`). The page chrome (background, text) follows the theme, so a light theme gives a light page. |
+| `--overlay` | Status-overlay style: `ring` (default), `pulse`, `dot`, or `led`. Sets the style shown until a viewer picks another. |
 | `--token` | If set, `/events` POSTs must supply `?token=...` or an `X-Metro-Token` header. |
+
+### Overlay styles
+
+The status overlay - how a station shows pending / queued / running / done /
+failed - has a few looks, picked in the page's **Style** menu (the choice is
+remembered per browser) or set as the page default with `--overlay`. Every mark
+takes the station's own marker shape: a circle for a single-line stop, a capsule
+spanning the bundle for an interchange.
+
+- **`ring`** (default) - a bold outline hugging each station, leaving the marker
+  visible underneath; the dash marches around it while running. Clean and
+  professional; the recommended look for a light page or embedding in Seqera
+  Platform.
+- **`pulse`** - a crisp status mark filling the station with a radar ripple
+  while running.
+- **`dot`** - a flat status mark that gently breathes while running, no glow.
+  The most minimal option.
+- **`led`** - glowing neon marks that pulse while running; reads best on the
+  dark `nfcore` theme.
+
+All styles are driven entirely client-side from the same status data, so
+switching style never re-renders the map. Animations respect
+`prefers-reduced-motion`.
 
 ### Endpoints
 

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -18,6 +18,7 @@ from nf_metro.layout import (
     PhaseInvariantError,
     compute_layout,
 )
+from nf_metro.live.server import DEFAULT_OVERLAY, OVERLAY_STYLES
 from nf_metro.options import LAYOUT_OPTIONS, LayoutOption
 from nf_metro.parser import (
     ERROR,
@@ -539,6 +540,13 @@ def explain(
 )
 @click.option("--theme", type=str, default=None, help="Theme name (nfcore, light).")
 @click.option(
+    "--overlay",
+    type=click.Choice(OVERLAY_STYLES),
+    default=DEFAULT_OVERLAY,
+    show_default=True,
+    help="Status-overlay style shown until a viewer picks another in the page.",
+)
+@click.option(
     "--token",
     default=None,
     help="If set, /events POSTs must supply ?token=... or an X-Metro-Token header.",
@@ -565,6 +573,7 @@ def serve(
     port: int,
     host: str,
     theme: str | None,
+    overlay: str,
     token: str | None,
     open_browser: bool,
     shutdown_after_complete: bool,
@@ -611,7 +620,9 @@ def serve(
             err=True,
         )
 
-    httpd = serve_map(graph, theme_obj, host=host, port=port, token=token)
+    httpd = serve_map(
+        graph, theme_obj, host=host, port=port, token=token, overlay=overlay
+    )
     # Local subprocesses post to a concrete loopback address, not 0.0.0.0.
     run_host = "127.0.0.1" if host == "0.0.0.0" else host
     page_url = f"http://{run_host}:{port}/"
@@ -649,12 +660,21 @@ def serve(
 )
 @click.option("--theme", type=str, default="nfcore", help="Theme name (nfcore, light).")
 @click.option(
+    "--overlay",
+    type=click.Choice(OVERLAY_STYLES),
+    default=DEFAULT_OVERLAY,
+    show_default=True,
+    help="Status-overlay style shown until a viewer picks another in the page.",
+)
+@click.option(
     "--token",
     default=None,
     help="If set, POSTs to /maps and /r/*/events must supply ?token=... "
     "or an X-Metro-Token header.",
 )
-def serve_multi_cmd(port: int, host: str, theme: str, token: str | None) -> None:
+def serve_multi_cmd(
+    port: int, host: str, theme: str, overlay: str, token: str | None
+) -> None:
     """Run a persistent live server many pipelines can report into. [experimental]
 
     Unlike `serve` (one map), this starts with no map. A pipeline registers its
@@ -680,7 +700,9 @@ def serve_multi_cmd(port: int, host: str, theme: str, token: str | None) -> None
             "use --token to restrict POSTs.",
             err=True,
         )
-    httpd = serve_multi(THEMES[theme], host=host, port=port, token=token)
+    httpd = serve_multi(
+        THEMES[theme], host=host, port=port, token=token, overlay=overlay
+    )
     display_host = "localhost" if host == "127.0.0.1" else host
     click.echo("nf-metro live progress - persistent server (experimental)")
     click.echo("")

--- a/src/nf_metro/live/server.py
+++ b/src/nf_metro/live/server.py
@@ -23,21 +23,101 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, TypedDict
 
 from nf_metro.layout import compute_layout
+from nf_metro.layout.routing.offsets import compute_station_offsets
 from nf_metro.live.mapping import stations_for_process
 from nf_metro.parser import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph
 from nf_metro.render import render_svg
 from nf_metro.render.style import Theme
+from nf_metro.render.svg import station_marker_box
 
 SVG_DIM_RE = re.compile(r'<svg[^>]*?\bwidth="([\d.]+)"[^>]*?\bheight="([\d.]+)"')
 
+# Overlay styles, in the order they appear in the page's style picker. Each is a
+# self-contained look painted on the same status overlay; the run only ever
+# reports states (pending/queued/running/done/failed), so switching style is
+# purely a client-side CSS swap and the map never re-renders.
+OVERLAY_STYLES: tuple[str, ...] = ("ring", "pulse", "dot", "led")
+OVERLAY_LABELS: dict[str, str] = {
+    "ring": "Ring",
+    "pulse": "Pulse",
+    "dot": "Status dot",
+    "led": "Neon LED",
+}
+DEFAULT_OVERLAY = "ring"
+
+
+def _is_light_bg(color: str) -> bool:
+    """Whether a theme's background reads as light, so the page chrome can match.
+
+    Transparent backgrounds (``none``) are treated as light: those themes are
+    drawn for placement on a light host page.
+    """
+    c = color.strip().lower()
+    if c in ("", "none", "transparent"):
+        return True
+    if c.startswith("#") and len(c) in (4, 7):
+        if len(c) == 4:
+            c = "#" + "".join(ch * 2 for ch in c[1:])
+        r, g, b = (int(c[i : i + 2], 16) for i in (1, 3, 5))
+        return 0.299 * r + 0.587 * g + 0.114 * b > 140
+    return False
+
+
+# Page chrome and status palette, per page scheme. Light values are tuned for a
+# Seqera Platform / light-mode host (e.g. embedding in a light dashboard).
+_CHROME: dict[str, dict[str, str]] = {
+    "dark": {
+        "bg": "#0b1021",
+        "fg": "#e6e9f0",
+        "muted": "#8ea0c8",
+        "border": "#222a44",
+        "hover": "#141a30",
+        "field-bg": "#141a30",
+        "field-border": "#2a3656",
+    },
+    "light": {
+        "bg": "#f8f9fa",
+        "fg": "#242424",
+        "muted": "#6c757d",
+        "border": "#dee2e6",
+        "hover": "#f1f3f5",
+        "field-bg": "#ffffff",
+        "field-border": "#ced4da",
+    },
+}
+_STATE_COLORS: dict[str, dict[str, str]] = {
+    "dark": {
+        "pending": "#3a4a6b",
+        "queued": "#ffb020",
+        "running": "#ffc23a",
+        "done": "#2bee92",
+        "failed": "#ff4d4d",
+    },
+    "light": {
+        "pending": "#adb5bd",
+        "queued": "#f59f00",
+        "running": "#f08c00",
+        "done": "#2f9e44",
+        "failed": "#e03131",
+    },
+}
+
 
 class StationGeom(TypedDict):
-    """An overlaid station: its id and its centre in SVG pixel space."""
+    """An overlaid station: its id and its drawn marker box in SVG pixel space.
+
+    ``x``/``y`` are the marker centre; ``w``/``h``/``rx`` describe the pill so an
+    overlay mark takes the same shape (a circle for one line, a capsule spanning
+    the bundle for several).
+    """
 
     id: str
     x: float
     y: float
+    w: float
+    h: float
+    rx: float
 
 
 class MapModel:
@@ -45,6 +125,7 @@ class MapModel:
 
     def __init__(self, graph: MetroGraph, theme: Theme) -> None:
         self.mapping = graph.process_mapping
+        self.is_light = _is_light_bg(theme.background_color)
         svg = render_svg(graph, theme)
         self.svg_body = re.sub(r"^<\?xml[^>]*\?>\s*", "", svg)
 
@@ -52,11 +133,22 @@ class MapModel:
         self.width = float(dim.group(1)) if dim else float(graph.width or 1000)
         self.height = float(dim.group(2)) if dim else float(graph.height or 600)
 
-        self.stations: list[StationGeom] = [
-            {"id": s.id, "x": round(s.x, 1), "y": round(s.y, 1)}
-            for s in graph.stations.values()
-            if not s.is_port and s.id in self.mapping
-        ]
+        offsets = compute_station_offsets(graph)
+        self.stations: list[StationGeom] = []
+        for s in graph.stations.values():
+            if s.is_port or s.id not in self.mapping:
+                continue
+            cx, cy, w, h, rx = station_marker_box(graph, theme, s, offsets)
+            self.stations.append(
+                {
+                    "id": s.id,
+                    "x": round(cx, 1),
+                    "y": round(cy, 1),
+                    "w": round(w, 1),
+                    "h": round(h, 1),
+                    "rx": round(rx, 1),
+                }
+            )
 
     def stations_for_process(self, process: str) -> list[str]:
         return stations_for_process(process, self.mapping)
@@ -163,26 +255,192 @@ class ProgressState:
             q.put(msg)
 
 
-def build_page(model: MapModel, stream_url: str = "/stream") -> str:
-    halos = "\n".join(
-        f'<g class="halo pending" id="halo-{html.escape(st["id"])}">'
-        f'<circle class="led" cx="{st["x"]}" cy="{st["y"]}" r="7"/>'
-        f"</g>"
-        for st in model.stations
+# How far the ring style's outline sits outside the station's own marker.
+_RING_GAP = 3.5
+
+
+def _ov_rect(cls: str, bx: float, by: float, bw: float, bh: float, brx: float) -> str:
+    return (
+        f'<rect class="{cls}" x="{round(bx, 1)}" y="{round(by, 1)}" '
+        f'width="{round(bw, 1)}" height="{round(bh, 1)}" '
+        f'rx="{round(brx, 1)}" ry="{round(brx, 1)}"/>'
     )
-    overlay = (
+
+
+def _halo_svg(st: StationGeom) -> str:
+    """The status overlay for one station: ripple, ring, and dot marks.
+
+    Each mark takes the station's own pill shape (circle / capsule) and size, so
+    a dot fills the marker and a ring hugs it. The ring is inflated by
+    ``_RING_GAP`` so it sits just outside the drawn marker.
+    """
+    w, h, rx = st["w"], st["h"], st["rx"]
+    x, y = st["x"] - w / 2, st["y"] - h / 2
+    g = _RING_GAP
+    return (
+        f'<g class="halo pending" id="halo-{html.escape(st["id"])}">'
+        + _ov_rect("ov-ripple", x, y, w, h, rx)
+        + _ov_rect("ov-ring", x - g, y - g, w + 2 * g, h + 2 * g, rx + g)
+        + _ov_rect("ov-dot", x, y, w, h, rx)
+        + "</g>"
+    )
+
+
+def _root_vars(scheme: str) -> str:
+    """The ``:root`` custom properties driving page chrome and status colours."""
+    lines = [f"  color-scheme: {scheme};"]
+    lines += [f"  --{k}: {v};" for k, v in _CHROME[scheme].items()]
+    lines += [f"  --st-{k}: {v};" for k, v in _STATE_COLORS[scheme].items()]
+    return ":root {\n" + "\n".join(lines) + "\n}\n"
+
+
+def build_page(
+    model: MapModel, stream_url: str = "/stream", overlay: str = DEFAULT_OVERLAY
+) -> str:
+    if overlay not in OVERLAY_STYLES:
+        overlay = DEFAULT_OVERLAY
+    halos = "\n".join(_halo_svg(st) for st in model.stations)
+    overlay_svg = (
         f'<svg class="overlay" width="{model.width}" height="{model.height}" '
         f'viewBox="0 0 {model.width} {model.height}" '
         f'xmlns="http://www.w3.org/2000/svg">{halos}</svg>'
     )
-    return PAGE_TEMPLATE.format(
-        width=model.width,
-        height=model.height,
-        base_svg=model.svg_body,
-        overlay=overlay,
-        stream_url=stream_url,
+    scheme = "light" if model.is_light else "dark"
+    css = _root_vars(scheme) + _LAYOUT_CSS + _OVERLAY_CSS
+    options = "".join(
+        f'<option value="{v}"{" selected" if v == overlay else ""}>'
+        f"{html.escape(OVERLAY_LABELS[v])}</option>"
+        for v in OVERLAY_STYLES
+    )
+    script = _SCRIPT.replace("%STREAM_URL%", stream_url)
+    return (
+        PAGE_TEMPLATE.replace("%CSS%", css)
+        .replace("%OPTIONS%", options)
+        .replace("%OVERLAY%", overlay)
+        .replace("%WIDTH%", str(model.width))
+        .replace("%HEIGHT%", str(model.height))
+        .replace("%SCRIPT%", script)
+        .replace("%BASE_SVG%", model.svg_body)
+        .replace("%OVERLAY_SVG%", overlay_svg)
     )
 
+
+_LAYOUT_CSS = """
+  body { margin: 0; background: var(--bg); color: var(--fg);
+         font-family: -apple-system, "Segoe UI", Roboto, Inter, sans-serif; }
+  header { display: flex; align-items: center; gap: 1.25rem;
+           padding: 0.6rem 1rem; border-bottom: 1px solid var(--border); }
+  #run { font-size: 0.95rem; }
+  #run b { color: var(--muted); font-weight: 600; }
+  .controls { display: flex; align-items: center; gap: 1.25rem; margin-left: auto; }
+  .style-picker { display: inline-flex; align-items: center; gap: 0.4rem;
+                  font-size: 0.8rem; color: var(--muted); }
+  .style-picker select { font: inherit; color: var(--fg); background: var(--field-bg);
+         border: 1px solid var(--field-border); border-radius: 6px;
+         padding: 0.15rem 0.4rem; }
+  .legend { display: flex; gap: 1rem; font-size: 0.8rem; }
+  .legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
+  .legend i { width: 12px; height: 12px; border-radius: 50%;
+              border: 2px solid; display: inline-block; }
+  .stage { overflow: auto; padding: 1rem; }
+  .wrap { position: relative; }
+  .wrap > svg { position: absolute; top: 0; left: 0; }
+"""
+
+# Every style paints the same overlay DOM (a ripple, a ring, and a dot per
+# station), each shaped like the station's own marker. A style opts in to the
+# sub-marks it uses; the halo group carries the current status colour in --c,
+# which the picked style reads. The running animations are shape-agnostic (they
+# scale, breathe, or march the dash) so they read correctly on a capsule as well
+# as a circle.
+_OVERLAY_CSS = """
+  .overlay { pointer-events: none; }
+  .overlay rect { transform-box: fill-box; transform-origin: center; }
+  .ov-dot, .ov-ring, .ov-ripple { transition: fill .3s, stroke .3s, opacity .3s;
+         display: none; }
+  .halo.pending { --c: var(--st-pending); }
+  .halo.queued  { --c: var(--st-queued); }
+  .halo.running { --c: var(--st-running); }
+  .halo.done    { --c: var(--st-done); }
+  .halo.failed  { --c: var(--st-failed); }
+
+  /* ring: an outline hugging the station; the dash marches around while running */
+  [data-overlay="ring"] .ov-ring {
+         display: inline; fill: none; stroke: var(--c); stroke-width: 3.5;
+         stroke-linecap: round; }
+  [data-overlay="ring"] .halo.pending .ov-ring { opacity: .35; }
+  [data-overlay="ring"] .halo.queued  .ov-ring { opacity: .6; stroke-dasharray: 2 6; }
+  [data-overlay="ring"] .halo.running .ov-ring {
+         stroke-dasharray: 11 9; animation: ov-march .7s linear infinite; }
+
+  /* pulse: a crisp status dot with a radar ripple while active */
+  [data-overlay="pulse"] .ov-dot { display: inline; fill: var(--c); }
+  [data-overlay="pulse"] .halo.pending .ov-dot { opacity: .3; }
+  [data-overlay="pulse"] .halo.queued  .ov-dot { opacity: .65; }
+  [data-overlay="pulse"] .halo.running .ov-ripple,
+  [data-overlay="pulse"] .halo.failed  .ov-ripple {
+         display: inline; fill: var(--c); animation: ov-ripple 1.6s ease-out infinite; }
+
+  /* dot: a flat status dot that breathes while running, no glow */
+  [data-overlay="dot"] .ov-dot { display: inline; fill: var(--c); }
+  [data-overlay="dot"] .halo.pending .ov-dot { opacity: .3; }
+  [data-overlay="dot"] .halo.queued  .ov-dot { opacity: .6; }
+  [data-overlay="dot"] .halo.running .ov-dot {
+         animation: ov-breathe 1.5s ease-in-out infinite; }
+
+  /* led: the original neon glow */
+  [data-overlay="led"] .ov-dot { display: inline; fill: var(--c);
+         filter: drop-shadow(0 0 4px var(--c)) drop-shadow(0 0 10px var(--c)); }
+  [data-overlay="led"] .halo.pending .ov-dot { opacity: .45; }
+  [data-overlay="led"] .halo.queued  .ov-dot { opacity: .7; }
+  [data-overlay="led"] .halo.running .ov-dot {
+         animation: ov-led-pulse 1.1s ease-in-out infinite; }
+  [data-overlay="led"] .halo.failed  .ov-dot {
+         animation: ov-led-pulse .7s ease-in-out infinite; }
+
+  @keyframes ov-march { to { stroke-dashoffset: -20; } }
+  @keyframes ov-ripple { from { transform: scale(1); opacity: .55; }
+                         to   { transform: scale(3.2); opacity: 0; } }
+  @keyframes ov-breathe { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+  @keyframes ov-led-pulse {
+    0%,100% { transform: scale(1);
+      filter: drop-shadow(0 0 4px var(--c)) drop-shadow(0 0 9px var(--c)); }
+    50%     { transform: scale(1.35);
+      filter: drop-shadow(0 0 7px var(--c)) drop-shadow(0 0 18px var(--c)); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ov-dot, .ov-ring, .ov-ripple { animation: none !important; }
+    [data-overlay="pulse"] .halo.running .ov-ripple,
+    [data-overlay="pulse"] .halo.failed  .ov-ripple { display: none; }
+  }
+"""
+
+_SCRIPT = """<script>
+  const wrap = document.querySelector('.wrap');
+  const picker = document.getElementById('overlay-style');
+  const STORE = 'nf-metro-overlay';
+  const saved = localStorage.getItem(STORE);
+  if (saved && [...picker.options].some(o => o.value === saved)) {
+    picker.value = saved;
+    wrap.setAttribute('data-overlay', saved);
+  }
+  picker.addEventListener('change', () => {
+    wrap.setAttribute('data-overlay', picker.value);
+    localStorage.setItem(STORE, picker.value);
+  });
+  const es = new EventSource('%STREAM_URL%');
+  es.onmessage = (e) => {
+    const data = JSON.parse(e.data);
+    document.getElementById('run-name').textContent =
+        data.run.name || 'waiting for events';
+    document.getElementById('run-state').textContent = data.run.state;
+    for (const [sid, s] of Object.entries(data.stations)) {
+      const g = document.getElementById('halo-' + sid);
+      if (g) g.setAttribute('class', 'halo ' + s.state);
+    }
+  };
+</script>"""
 
 PAGE_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
@@ -190,64 +448,30 @@ PAGE_TEMPLATE = """<!DOCTYPE html>
 <meta charset="utf-8"/>
 <title>nf-metro live</title>
 <style>
-  :root {{ color-scheme: dark; }}
-  body {{ margin: 0; background: #0b1021; color: #e6e9f0;
-         font-family: -apple-system, Segoe UI, Roboto, sans-serif; }}
-  header {{ display: flex; align-items: center; gap: 1.5rem;
-           padding: 0.6rem 1rem; border-bottom: 1px solid #222a44; }}
-  #run {{ font-size: 0.95rem; }}
-  #run b {{ color: #8ea0c8; font-weight: 600; }}
-  .legend {{ display: flex; gap: 1rem; margin-left: auto; font-size: 0.8rem; }}
-  .legend span {{ display: inline-flex; align-items: center; gap: 0.35rem; }}
-  .legend i {{ width: 12px; height: 12px; border-radius: 50%;
-              border: 2px solid; display: inline-block; }}
-  .stage {{ overflow: auto; padding: 1rem; }}
-  .wrap {{ position: relative; width: {width}px; height: {height}px; }}
-  .wrap > svg {{ position: absolute; top: 0; left: 0; }}
-  .overlay {{ pointer-events: none; }}
-  .led {{ --c: #3a4a6b; fill: var(--c); transform-box: fill-box;
-         transform-origin: center; transition: fill 0.3s, opacity 0.3s;
-         filter: drop-shadow(0 0 4px var(--c)) drop-shadow(0 0 10px var(--c)); }}
-  .halo.pending .led {{ --c: #2a3656; opacity: 0.45; }}
-  .halo.queued  .led {{ --c: #ffb020; opacity: 0.7; }}
-  .halo.running .led {{ --c: #ffc23a; animation: led-pulse 1.1s ease-in-out infinite; }}
-  .halo.done    .led {{ --c: #2bee92; }}
-  .halo.failed  .led {{ --c: #ff4d4d; animation: led-pulse 0.7s ease-in-out infinite; }}
-  @keyframes led-pulse {{
-    0%,100% {{ transform: scale(1);
-      filter: drop-shadow(0 0 4px var(--c)) drop-shadow(0 0 9px var(--c)); }}
-    50%     {{ transform: scale(1.35);
-      filter: drop-shadow(0 0 7px var(--c)) drop-shadow(0 0 18px var(--c)); }}
-  }}
+%CSS%
 </style>
 </head>
 <body>
 <header>
   <div id="run">Run: <b id="run-name">waiting for events</b> &middot;
        <span id="run-state">idle</span></div>
-  <div class="legend">
-    <span><i style="border-color:#ffc23a"></i>running</span>
-    <span><i style="border-color:#2bee92"></i>done</span>
-    <span><i style="border-color:#ff4d4d"></i>failed</span>
+  <div class="controls">
+    <label class="style-picker">Style
+      <select id="overlay-style">%OPTIONS%</select>
+    </label>
+    <div class="legend">
+      <span><i style="border-color:var(--st-running)"></i>running</span>
+      <span><i style="border-color:var(--st-done)"></i>done</span>
+      <span><i style="border-color:var(--st-failed)"></i>failed</span>
+    </div>
   </div>
 </header>
-<div class="stage"><div class="wrap">
-  {base_svg}
-  {overlay}
+<div class="stage"><div class="wrap" data-overlay="%OVERLAY%"
+     style="width:%WIDTH%px;height:%HEIGHT%px">
+  %BASE_SVG%
+  %OVERLAY_SVG%
 </div></div>
-<script>
-  const es = new EventSource('{stream_url}');
-  es.onmessage = (e) => {{
-    const data = JSON.parse(e.data);
-    document.getElementById('run-name').textContent =
-        data.run.name || 'waiting for events';
-    document.getElementById('run-state').textContent = data.run.state;
-    for (const [sid, s] of Object.entries(data.stations)) {{
-      const g = document.getElementById('halo-' + sid);
-      if (g) g.setAttribute('class', 'halo ' + s.state);
-    }}
-  }};
-</script>
+%SCRIPT%
 </body>
 </html>"""
 
@@ -308,13 +532,17 @@ def _sse_response(handler: BaseHTTPRequestHandler, state: ProgressState) -> None
 
 
 def make_handler(
-    model: MapModel, state: ProgressState, token: str | None
+    model: MapModel,
+    state: ProgressState,
+    token: str | None,
+    overlay: str = DEFAULT_OVERLAY,
 ) -> type[BaseHTTPRequestHandler]:
     class Handler(_QuietHandler):
         def do_GET(self) -> None:
             path = urllib.parse.urlparse(self.path).path
             if path == "/":
-                _send_body(self, 200, build_page(model), "text/html; charset=utf-8")
+                page = build_page(model, overlay=overlay)
+                _send_body(self, 200, page, "text/html; charset=utf-8")
             elif path == "/state":
                 _send_body(self, 200, json.dumps(state.snapshot()), "application/json")
             elif path == "/stream":
@@ -354,15 +582,17 @@ def serve(
     host: str = "127.0.0.1",
     port: int = 8080,
     token: str | None = None,
+    overlay: str = DEFAULT_OVERLAY,
 ) -> MetroServer:
     """Build the model and return a serving ``MetroServer``.
 
     The caller drives the server (``serve_forever``); separating construction
-    makes the handler and state testable without binding a socket.
+    makes the handler and state testable without binding a socket. ``overlay``
+    is the status-overlay style shown until a viewer picks another in the page.
     """
     model = MapModel(graph, theme)
     state = ProgressState(model)
-    httpd = MetroServer((host, port), make_handler(model, state, token))
+    httpd = MetroServer((host, port), make_handler(model, state, token, overlay))
     httpd.state = state
     return httpd
 
@@ -375,9 +605,13 @@ class RunRegistry:
     weblog events drive. Many pipelines can report into one server.
     """
 
-    def __init__(self, theme: Theme, max_runs: int = 100) -> None:
+    def __init__(
+        self, theme: Theme, max_runs: int = 100, overlay: str = DEFAULT_OVERLAY
+    ) -> None:
         self.theme = theme
         self.max_runs = max_runs
+        self.overlay = overlay if overlay in OVERLAY_STYLES else DEFAULT_OVERLAY
+        self.is_light = _is_light_bg(theme.background_color)
         self.lock = threading.Lock()
         self.runs: dict[str, dict[str, Any]] = {}
 
@@ -434,8 +668,31 @@ def build_index(registry: RunRegistry) -> str:
     )
     if not rows:
         rows = '<p class="empty">No runs yet. Point a pipeline at this server.</p>'
-    return INDEX_TEMPLATE.format(rows=rows)
+    scheme = "light" if registry.is_light else "dark"
+    return INDEX_TEMPLATE.replace("%CSS%", _root_vars(scheme) + _INDEX_CSS).replace(
+        "%ROWS%", rows
+    )
 
+
+_INDEX_CSS = """
+  body { margin: 0; background: var(--bg); color: var(--fg);
+         font-family: -apple-system, "Segoe UI", Roboto, Inter, sans-serif; }
+  header { padding: 0.8rem 1rem; border-bottom: 1px solid var(--border);
+           font-weight: 600; }
+  .runs { display: flex; flex-direction: column; gap: 0.5rem; padding: 1rem;
+          max-width: 720px; }
+  .run { display: flex; justify-content: space-between; align-items: center;
+         padding: 0.7rem 1rem; border: 1px solid var(--border); border-radius: 8px;
+         text-decoration: none; color: var(--fg); border-left-width: 4px; }
+  .run:hover { background: var(--hover); }
+  .run.running  { border-left-color: var(--st-running); }
+  .run.complete { border-left-color: var(--st-done); }
+  .run.error    { border-left-color: var(--st-failed); }
+  .run.idle     { border-left-color: var(--st-pending); }
+  .name { font-weight: 600; }
+  .meta { font-size: 0.8rem; color: var(--muted); }
+  .empty { padding: 1rem; color: var(--muted); }
+"""
 
 INDEX_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
@@ -444,28 +701,13 @@ INDEX_TEMPLATE = """<!DOCTYPE html>
 <meta http-equiv="refresh" content="3"/>
 <title>nf-metro live</title>
 <style>
-  body {{ margin: 0; background: #0b1021; color: #e6e9f0;
-         font-family: -apple-system, Segoe UI, Roboto, sans-serif; }}
-  header {{ padding: 0.8rem 1rem; border-bottom: 1px solid #222a44; font-weight: 600; }}
-  .runs {{ display: flex; flex-direction: column; gap: 0.5rem; padding: 1rem;
-          max-width: 720px; }}
-  .run {{ display: flex; justify-content: space-between; align-items: center;
-         padding: 0.7rem 1rem; border: 1px solid #222a44; border-radius: 8px;
-         text-decoration: none; color: #e6e9f0; border-left-width: 4px; }}
-  .run:hover {{ background: #141a30; }}
-  .run.running {{ border-left-color: #ffc23a; }}
-  .run.complete {{ border-left-color: #2bee92; }}
-  .run.error {{ border-left-color: #ff4d4d; }}
-  .run.idle {{ border-left-color: #3a4a6b; }}
-  .name {{ font-weight: 600; }}
-  .meta {{ font-size: 0.8rem; color: #8ea0c8; }}
-  .empty {{ padding: 1rem; color: #8ea0c8; }}
+%CSS%
 </style>
 </head>
 <body>
 <header>nf-metro live &middot; runs</header>
 <div class="runs">
-{rows}
+%ROWS%
 </div>
 </body>
 </html>"""
@@ -499,7 +741,11 @@ def make_multi_handler(
             kind = m.group(2)
             state: ProgressState = run["state"]
             if kind is None:
-                page = build_page(run["model"], stream_url=f"/r/{m.group(1)}/stream")
+                page = build_page(
+                    run["model"],
+                    stream_url=f"/r/{m.group(1)}/stream",
+                    overlay=registry.overlay,
+                )
                 _send_body(self, 200, page, "text/html; charset=utf-8")
             elif kind == "state":
                 _send_body(self, 200, json.dumps(state.snapshot()), "application/json")
@@ -553,9 +799,10 @@ def serve_multi(
     host: str = "127.0.0.1",
     port: int = 8080,
     token: str | None = None,
+    overlay: str = DEFAULT_OVERLAY,
 ) -> ThreadingHTTPServer:
     """A persistent multi-run server: pipelines POST their .mmd to ``/maps``."""
-    registry = RunRegistry(theme)
+    registry = RunRegistry(theme, overlay=overlay)
     return ThreadingHTTPServer((host, port), make_multi_handler(registry, token))
 
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1224,6 +1224,43 @@ def _pill_box(
     return cx - w / 2, cy - h / 2, w, h
 
 
+def station_marker_box(
+    graph: MetroGraph,
+    theme: Theme,
+    station: Station,
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> tuple[float, float, float, float, float]:
+    """The drawn marker's bounding box as ``(cx, cy, w, h, rx)``.
+
+    Mirrors the bundle-span / orientation logic of :func:`_render_station_into`
+    and defers to :func:`_pill_box` for the box itself, so an overlay can place
+    a shape that matches a station's pill (a circle for one line, a capsule
+    spanning the bundle for several) without re-running the renderer. Glyph
+    stations (rail interchanges, explicit markers) fall back to the same
+    bundle-span box, a reasonable footprint for those too.
+    """
+    r = theme.station_radius
+    is_tb_vert = bool(
+        station.section_id
+        and (sec := graph.sections.get(station.section_id))
+        and sec.direction == "TB"
+    )
+    if station.rail_top_y is not None and station.rail_bottom_y is not None:
+        used = station.rail_used_ys or [station.y]
+        min_off, max_off = min(used) - station.y, max(used) - station.y
+    elif station_offsets and not graph.station_is_rail(station.id):
+        offs = [
+            station_offsets.get((station.id, lid), 0.0)
+            for lid in graph.station_lines(station.id)
+        ]
+        min_off, max_off = (min(offs), max(offs)) if offs else (0.0, 0.0)
+    else:
+        min_off = max_off = 0.0
+
+    x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb_vert)
+    return x + w / 2, y + h / 2, w, h, r
+
+
 def _append_terminus_icons(
     d: draw.Drawing,
     station: Station,

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -11,8 +11,11 @@ import pytest
 from nf_metro.layout import compute_layout
 from nf_metro.live import server as server_mod
 from nf_metro.live.server import (
+    DEFAULT_OVERLAY,
+    OVERLAY_STYLES,
     MapModel,
     ProgressState,
+    _is_light_bg,
     _weblog_command,
     build_page,
     run_lifecycle,
@@ -31,12 +34,16 @@ MMD = (
 )
 
 
-def _model() -> MapModel:
+def _graph():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         graph = parse_metro_mermaid(MMD)
     compute_layout(graph)
-    return MapModel(graph, THEMES["nfcore"])
+    return graph
+
+
+def _model() -> MapModel:
+    return MapModel(_graph(), THEMES["nfcore"])
 
 
 def _ev(event, task_id, process, status=""):
@@ -66,6 +73,34 @@ def test_state_machine_queued_running_done():
     assert trim["state"] == "done" and trim["done"] == 2 and trim["total"] == 2
 
 
+def test_completed_station_stays_done_for_rest_of_run():
+    # A station that finishes must not "un-green" as other stations progress;
+    # a successful run ends with every station that ran in the done state.
+    state = ProgressState(_model())
+    state.ingest({"event": "started", "runName": "r"})
+    state.ingest(_ev("process_submitted", 1, "TRIMGALORE", "SUBMITTED"))
+    state.ingest(_ev("process_started", 1, "TRIMGALORE", "RUNNING"))
+    state.ingest(_ev("process_completed", 1, "TRIMGALORE", "COMPLETED"))
+    assert state.snapshot()["stations"]["trim"]["state"] == "done"
+
+    # qc is submitted, runs, and completes; trim stays done throughout.
+    state.ingest(_ev("process_submitted", 2, "FASTQC", "SUBMITTED"))
+    assert state.snapshot()["stations"]["trim"]["state"] == "done"
+    state.ingest(_ev("process_started", 2, "FASTQC", "RUNNING"))
+    assert state.snapshot()["stations"]["trim"]["state"] == "done"
+    state.ingest(_ev("process_completed", 2, "FASTQC", "COMPLETED"))
+    snap = state.snapshot()["stations"]
+    assert snap["trim"]["state"] == "done" and snap["qc"]["state"] == "done"
+
+
+def test_only_a_new_run_resets_a_done_station():
+    state = ProgressState(_model())
+    state.ingest(_ev("process_completed", 1, "TRIMGALORE", "COMPLETED"))
+    assert state.snapshot()["stations"]["trim"]["state"] == "done"
+    state.ingest({"event": "started", "runName": "r2"})
+    assert state.snapshot()["stations"]["trim"]["state"] == "pending"
+
+
 def test_state_machine_failure():
     state = ProgressState(_model())
     state.ingest(_ev("process_started", 1, "TRIMGALORE", "RUNNING"))
@@ -91,6 +126,81 @@ def test_build_page_contains_halo_ids():
     page = build_page(_model())
     assert 'id="halo-trim"' in page and 'id="halo-qc"' in page
     assert 'id="halo-input"' not in page
+
+
+def test_each_halo_carries_the_shared_overlay_marks():
+    page = build_page(_model())
+    # One DOM serves every style: a ripple, a ring, and a dot per station.
+    for cls in ("ov-ripple", "ov-ring", "ov-dot"):
+        assert page.count(f'class="{cls}"') == 2  # trim + qc
+
+
+def test_overlay_marks_match_the_drawn_station_pill():
+    import re
+
+    from nf_metro.layout.routing.offsets import compute_station_offsets
+    from nf_metro.render.svg import station_marker_box
+
+    graph = _graph()
+    offsets = compute_station_offsets(graph)
+    model = MapModel(graph, THEMES["nfcore"])
+    page = build_page(model)
+    for st in model.stations:
+        cx, cy, w, h, rx = station_marker_box(
+            graph, THEMES["nfcore"], graph.stations[st["id"]], offsets
+        )
+        # The dot rect is the marker box exactly (within rounding).
+        assert st["w"] == round(w, 1) and st["h"] == round(h, 1)
+        m = re.search(
+            rf'id="halo-{st["id"]}">.*?class="ov-dot" x="([\d.-]+)" y="([\d.-]+)" '
+            rf'width="([\d.-]+)" height="([\d.-]+)"',
+            page,
+        )
+        assert m, f"no ov-dot rect for {st['id']}"
+        assert abs(float(m.group(3)) - round(w, 1)) < 0.2
+        assert abs(float(m.group(4)) - round(h, 1)) < 0.2
+
+
+def test_page_offers_every_overlay_style():
+    page = build_page(_model())
+    assert 'id="overlay-style"' in page
+    for style in OVERLAY_STYLES:
+        assert f'value="{style}"' in page
+
+
+def test_default_overlay_is_selected_and_applied():
+    page = build_page(_model())
+    assert f'data-overlay="{DEFAULT_OVERLAY}"' in page
+    assert f'<option value="{DEFAULT_OVERLAY}" selected>' in page
+
+
+def test_explicit_overlay_drives_the_initial_style():
+    page = build_page(_model(), overlay="pulse")
+    assert 'data-overlay="pulse"' in page
+    assert '<option value="pulse" selected>' in page
+    assert "pulse" != DEFAULT_OVERLAY  # exercises the non-default path
+
+
+def test_unknown_overlay_falls_back_to_default():
+    page = build_page(_model(), overlay="bogus")
+    assert f'data-overlay="{DEFAULT_OVERLAY}"' in page
+
+
+def test_dark_theme_page_uses_dark_chrome():
+    page = build_page(MapModel(_graph(), THEMES["nfcore"]))
+    assert "color-scheme: dark" in page
+
+
+def test_light_theme_page_uses_light_chrome():
+    page = build_page(MapModel(_graph(), THEMES["seqera"]))
+    assert "color-scheme: light" in page
+    assert "--bg: #f8f9fa" in page
+
+
+def test_is_light_bg_classifies_themes():
+    assert _is_light_bg("#f8f9fa") is True
+    assert _is_light_bg("none") is True
+    assert _is_light_bg("#2b2b2b") is False
 
 
 @pytest.mark.parametrize("token", [None, "sekret"])
@@ -249,7 +359,8 @@ def test_serve_cli_wires_launch_and_prints_url(monkeypatch, tmp_path):
     )
     calls = {}
 
-    def fake_serve_map(graph, theme, host=None, port=None, token=None):
+    def fake_serve_map(graph, theme, host=None, port=None, token=None, overlay=None):
+        calls["overlay"] = overlay
         return object()
 
     def fake_lifecycle(httpd, page_url, events_url, **kw):
@@ -260,14 +371,37 @@ def test_serve_cli_wires_launch_and_prints_url(monkeypatch, tmp_path):
 
     result = CliRunner().invoke(
         cli_mod.cli,
-        ["serve", str(mmd), "--port", "9999", "--open", "--", "nextflow", "run", "p"],
+        [
+            "serve",
+            str(mmd),
+            "--port",
+            "9999",
+            "--overlay",
+            "ring",
+            "--open",
+            "--",
+            "nextflow",
+            "run",
+            "p",
+        ],
     )
     assert result.exit_code == 0, result.output
     assert calls["launch_cmd"] == ("nextflow", "run", "p")
     assert calls["open_browser"] is True
+    assert calls["overlay"] == "ring"
     assert calls["page_url"] == "http://127.0.0.1:9999/"
     assert calls["events_url"] == "http://127.0.0.1:9999/events"
     assert "▶ Open: http://127.0.0.1:9999/" in result.output
+
+
+def test_serve_rejects_unknown_overlay():
+    from click.testing import CliRunner
+
+    from nf_metro import cli as cli_mod
+
+    result = CliRunner().invoke(cli_mod.cli, ["serve", "x.mmd", "--overlay", "nope"])
+    assert result.exit_code != 0
+    assert "nope" in result.output
 
 
 def test_registry_register_and_listing():


### PR DESCRIPTION
## Summary

The `nf-metro serve` live-progress overlay was a single hardcoded neon-LED look on a fixed dark page. This adds a choice of overlay styles, defaults to a clean one, and makes the page chrome follow the map theme so the page suits a light host such as Seqera Platform.

## What changed

**Four overlay styles** (the choice is purely client-side; the map never re-renders when you switch):

| Style | Look | Best for |
|---|---|---|
| `ring` (default) | bold outline hugging the station; dash marches around while running | light mode / Seqera; status reads separately from line colours |
| `pulse` | status mark filling the station with a radar ripple while running | a more prominent "live" look |
| `dot` | flat status mark, gentle breathe while running | minimal |
| `led` | the original neon glow | the dark `nfcore` theme |

- **Picker + default.** A **Style** menu on the page switches styles live and remembers the choice per browser. `nf-metro serve` and `nf-metro serve-multi` take `--overlay ring|pulse|dot|led` to set the page default.
- **Marks match the station shape.** Each mark takes the station's own drawn marker shape and size — a circle for a single-line stop, a capsule spanning the bundle for a multi-line/interchange station. A new `station_marker_box()` helper in `render/svg.py` shares the renderer's exact `_pill_box` geometry, so the overlay and the drawn pill cannot drift (locked by a test).
- **Theme-aware page chrome.** The page background, text, and the `serve-multi` dashboard now follow the theme's background (light theme → light page); status colours are tuned for white backgrounds. `color-scheme` is set accordingly.
- **Animations.** Running animations are shape-agnostic (the ring marches its dash rather than rotating an arc, which would visibly spin a capsule) and respect `prefers-reduced-motion`.

## Behaviour notes

- A completed station stays `done` for the rest of a run; the `done`/`failed` task sets are only cleared by a new run's `started` event. A successful run therefore ends with every station that ran in the done (green) state. Locked by `test_completed_station_stays_done_for_rest_of_run` and `test_only_a_new_run_resets_a_done_station`.

## Tests & docs

- New tests in `tests/test_live_server.py` cover the style picker, default/explicit/invalid overlay handling, light/dark chrome, overlay-mark-to-pill geometry, the CLI `--overlay` flag, and the done-state guarantees.
- `docs/live.md` documents the styles, the picker, and the `--overlay` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)