### PR TITLE
fix(layout): widen a tight section to clear a wide bypassed-label rake (#700)

### DIFF
--- a/examples/topologies/bypass_label_rake_wide.mmd
+++ b/examples/topologies/bypass_label_rake_wide.mmd
@@ -1,0 +1,31 @@
+%%metro title: Bypass V Past An Extra-Wide Label
+%%metro style: dark
+%%metro line: dna | DNA | #e63946
+%%metro line: rna | RNA | #0570b0
+%%metro line: prot | Protein | #2db572
+
+graph LR
+    subgraph input [Input]
+        fetch[Fetch Data]
+        validate[Validate]
+        fetch -->|dna,rna,prot| validate
+    end
+
+    subgraph processing [Processing]
+        branch[Branch]
+        align[Alignment]
+        quant[Quantification And Expression Estimation Module]
+        search[Database Search]
+        branch -->|dna,rna| align
+        branch -->|prot| search
+        align -->|rna| quant
+    end
+
+    subgraph reporting [Reporting]
+        multiqc[MultiQC]
+    end
+
+    validate -->|dna,rna,prot| branch
+    align -->|dna| multiqc
+    quant -->|rna| multiqc
+    search -->|prot| multiqc

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -380,6 +380,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "left edge (`_clear_bypass_v_label_strikes`).",
     ),
     (
+        "bypass_label_rake_wide",
+        TOPOLOGIES_DIR,
+        "An extra-wide bypassed-station label the router cannot seat the V's "
+        "flat-run corner clear of: the strike-clearance loop pushes the bypassed "
+        "node out by whole grid columns until the dip clears the glyphs, widening "
+        "rather than relying on the router's partial corner-seating (issue #700).",
+    ),
+    (
         "bypass_v_tight",
         TOPOLOGIES_DIR,
         "An intra-section bypass V at a tight column pitch: without room for a "

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -197,6 +197,7 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     _run_pass_c_guards,
     _section_lacks_flow_aligned_port,
     inter_section_route_backtrack_legs,
+    iter_line_label_strikes,
 )
 from nf_metro.layout.phases.junctions import (  # noqa: F401
     _junction_incoming_line_count,
@@ -656,6 +657,78 @@ def _compute_layout_scaled(
         _guard_tb_top_entry_drop_hugs_top(graph, "final")
 
 
+def _bypass_label_rakes(graph: MetroGraph) -> set[str]:
+    # Stations whose name label a bypass-V leg crosses, per the guard's strike
+    # definition: it counts a leg's crossing of the station the V routes around
+    # but exempts the leg's own diverging/merging endpoint, isolating the
+    # bypassed-middle rake the gap lever relocates.
+    return {
+        s.station_id
+        for s in iter_line_label_strikes(graph)
+        if is_bypass_v(s.src) or is_bypass_v(s.tgt)
+    }
+
+
+def _clear_bypass_label_rakes(
+    graph: MetroGraph,
+    *,
+    issues: Callable[[], tuple[set[str], bool, set[tuple[str, str, int]]]],
+    adjust: Callable[[tuple[str, str, int], int], None],
+    lever_value: Callable[[tuple[str, str, int]], int],
+    growable_target: Callable[[str], tuple[Section, int] | None],
+    relay: Callable[..., None],
+    reseat: Callable[[], None],
+) -> None:
+    """Push a bypassed node out by whole grid columns to clear a wide-label rake.
+
+    Separate from the fan/convergence loop in ``_apply_label_strike_clearance``
+    because it grows the gap before the *bypassed* node's layer (lengthening the
+    V's leg) rather than a struck station's own runway, and because its probe
+    must read the router's flat-run seating (obstacle boxes kept current by
+    ``reseat``) so it fires only for a rake the router could not seat clear.  The
+    seated boxes are local: the entry value is restored before returning, so the
+    fan/convergence loop reasons about unseated routes.
+    """
+    if not any(
+        v.is_hidden and v.bypasses_station_id is not None
+        for v in graph.stations.values()
+    ):
+        return
+    entry_obstacles = dict(graph.bypass_label_obstacles)
+    graph.bypass_label_obstacles = _bypass_label_obstacles(graph)
+    rake_levers = {
+        ("gap", target[0].id, target[1])
+        for sid in _bypass_label_rakes(graph)
+        if (target := growable_target(sid)) is not None
+    }
+    struck_pre, collinear_pre, _ = issues() if rake_levers else (set(), False, ())
+    if not rake_levers or collinear_pre:
+        graph.bypass_label_obstacles = entry_obstacles
+        return
+    for _ in range(_MAX_SPREAD_ITERS):
+        for lever in rake_levers:
+            adjust(lever, 1)
+        reseat()
+        struck_now, collinear, _ = issues()
+        if collinear:
+            for lever in rake_levers:
+                adjust(lever, -1)
+            break
+        # Done once no rake remains and the shift added no new strike (struck_now
+        # is a subset of the pre-shift strikes); a residual the gaps cannot clear
+        # rolls back wholesale for the guard backstop.
+        if not _bypass_label_rakes(graph) and struck_now <= struck_pre:
+            break
+    else:
+        for lever in rake_levers:
+            while lever_value(lever) > 0:
+                adjust(lever, -1)
+    # The grow steps re-laid against seated boxes; settle the chosen levers
+    # against the restored (unseated) boxes the next loop expects.
+    graph.bypass_label_obstacles = entry_obstacles
+    relay()
+
+
 def _apply_label_strike_clearance(
     graph: MetroGraph,
     *,
@@ -690,7 +763,11 @@ def _apply_label_strike_clearance(
     back, so the loop never ships a layout worse than it found.
     """
 
-    def _relay() -> None:
+    def _relay(*, validate_layout: bool = False) -> None:
+        # Growth/shrink steps re-lay unvalidated: an intermediate lever width can
+        # carry a transient strike or overlap that a later column clears.  The
+        # settled layout is re-laid once with ``validate_layout`` so the caller's
+        # stage-boundary checks run on the result the phase ships.
         _layout_once(
             graph,
             x_spacing=x_spacing,
@@ -701,8 +778,14 @@ def _apply_label_strike_clearance(
             section_y_padding=section_y_padding,
             section_x_gap=section_x_gap,
             section_y_gap=section_y_gap,
-            validate=validate,
+            validate=validate_layout,
         )
+
+    def _reseat() -> None:
+        # Refresh the obstacle boxes after re-laying so the rake probe's routes
+        # carry the router's flat-run seating against the current geometry.
+        _relay()
+        graph.bypass_label_obstacles = _bypass_label_obstacles(graph)
 
     def _growable_target(station_id: str) -> tuple[Section, int] | None:
         st = graph.stations.get(station_id)
@@ -752,6 +835,16 @@ def _apply_label_strike_clearance(
         struck_, collinear_, flat_gaps_ = _label_clearance_issues(graph)
         flat_levers_ = {("gap", sid, layer) for sid, layer in flat_gaps_}
         return struck_, collinear_, flat_levers_
+
+    _clear_bypass_label_rakes(
+        graph,
+        issues=_issues,
+        adjust=_adjust,
+        lever_value=_lever_value,
+        growable_target=_growable_target,
+        relay=_relay,
+        reseat=_reseat,
+    )
 
     struck, _, flat_levers = _issues()
     count = len(struck) + len(flat_levers)
@@ -814,7 +907,7 @@ def _apply_label_strike_clearance(
                 if still_struck or collinear or still_flat:
                     _adjust(lever, 1)
                     break
-        _relay()
+        _relay(validate_layout=validate)
 
 
 def _retrofit_section_rails_phase(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -2447,6 +2447,41 @@ def test_no_diagonal_strikes_label(fixture, x_spacing):
     assert not collinear, f"{fixture} @ x_spacing={x_spacing}: collinear overlay"
 
 
+_BYPASS_LABEL_RAKE_CASES = [
+    "topologies/bypass_label_rake.mmd",
+    "topologies/bypass_label_rake_left.mmd",
+    "topologies/bypass_label_rake_wide.mmd",
+    "guide/06a_without_hidden.mmd",
+    "guide/06b_with_hidden.mmd",
+]
+
+
+@pytest.mark.parametrize("fixture", _BYPASS_LABEL_RAKE_CASES)
+def test_bypass_v_clears_wide_bypassed_label(fixture):
+    """A bypass V never rakes the label of the station it routes around.
+
+    The V's lead-in descent (or lead-out climb) can cross the bypassed station's
+    name when that label is wide enough to reach past the V's column.  The router
+    seats the V's flat-run corners clear where it can; a section too cramped to
+    fit the corner outside the label leaves a residual the strike-clearance loop
+    resolves by pushing the bypassed node out by whole grid columns.  Uses the
+    runtime guard's own strike definition, which counts a bypass-V crossing of a
+    bypassed-middle label.
+    """
+    from nf_metro.layout.phases.guards import iter_line_label_strikes
+
+    graph = _layout(fixture)
+    strikes = [
+        s
+        for s in iter_line_label_strikes(graph)
+        if is_bypass_v(s.src) or is_bypass_v(s.tgt)
+    ]
+    assert not strikes, (
+        f"{fixture}: bypass V rakes a bypassed-station label: "
+        + ", ".join(f"{s.line_id} -> {s.station_id}" for s in strikes)
+    )
+
+
 def test_label_strike_guard_catches_a_strike():
     """The runtime guard fires on a genuine glyph strike and clears a graze.
 


### PR DESCRIPTION
## Summary

A bypass V routing around a station whose name label is wider than the router can seat the V's flat-run corner clear of left a residual strike through that label. `#632` lengthens the V's flat run in the router to clear it, but that clearance is partial when the section is too cramped for the corner to seat outside the label, leaving only `_guard_no_line_strikes_label` as a backstop (which fails the render).

This adds a strike-clearance **pre-pass** that pushes the bypassed node out by whole grid columns until the V's leg clears the label, widening rather than relying on the router's partial corner-seating. This is the node-spacing lever `#688`/`#697` introduced for a collapsed flat, extended to fire on a wide-label rake.

Key properties:
- The pre-pass detects rakes via the guard's own strike definition (`iter_line_label_strikes`), which counts a bypass-V leg crossing the station it routes around but exempts the leg's own diverging/merging endpoint (the fan/runway loop's concern).
- It probes against the router's flat-run seating, so it fires **only** for a rake the router could not seat clear; the seated obstacle boxes are local to the pre-pass and the entry value is restored before the fan/convergence loop, which reasons about unseated routes.
- The gap is grown (clearing any fan strike the shift induces on a neighbour) until no rake remains and no new strike persists, rolling back wholesale if the gaps cannot clear it so an unreachable case is left for the guard backstop.
- Exploratory re-lays in the clearance loop no longer validate mid-step; the settled layout is validated as before.

New regression fixture `bypass_label_rake_wide.mmd` (gallery + parametrized invariant test). Across the full corpus, only this new fixture's geometry changes; all 167 existing fixtures are byte-identical.

Fixes #700

## Test plan
- [x] `pytest` passes, including the new `test_bypass_v_clears_wide_bypassed_label` (parametrized over the wide fixture + existing bypass fixtures) and the full invariant/topology suites
- [x] `ruff format --check`, `ruff check`, and `mypy` clean on the whole repo
- [x] Routing gate-coverage ratchet green (under Python 3.11)
- [x] Backstop `_guard_no_line_strikes_label` retained
- [ ] Visual review of the render preview
- [ ] Render-preview verdict (expected: no visual changes to existing fixtures; new `bypass_label_rake_wide` tile only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)