### PR TITLE
refactor(layout): AxisFrame primitive + no-new-TB-branches ratchet (#916)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -71,6 +71,32 @@ Stages split into three regimes:
 3. **Post-Stage-3.1**: ports sit on bbox edges (validated by
    `_guard_ports_on_boundaries`).
 
+## Axis vocabulary (TB policy)
+
+TB sections run the identical LR machinery and swap axes only at coordinate
+assignment (`single_section.py`). Every heuristic written against the LR
+*interpretation* of `x`/`y` (horizontal trunks, layers spread along X, lines
+stacked along Y) is wrong-by-default for TB, and the historical fix was to
+hand-write a one-off `if direction == "TB"` mirror per heuristic. That count
+only grew.
+
+The sanctioned alternative is the `AxisFrame` primitive in `geometry.py`:
+`AxisFrame.for_direction(direction, x_spacing, y_spacing)` returns the
+**primary** axis (the layer/flow axis: X for LR/RL, Y for TB) and the
+**secondary** axis (the track axis: Y for LR/RL, X for TB), each carrying its
+`step` and `get`/`set` accessors, plus `primary_sign` (`-1` for RL, which runs
+the LR primary axis reversed). A heuristic expressed against primary/secondary
+instead of raw `x`/`y` has a TB path that is *the same code* as its LR path, so
+it needs no branch.
+
+**Policy:** no new one-off TB branches. A heuristic that needs TB awareness is
+the trigger to convert it to the axis vocabulary, not to add another branch.
+This is machine-enforced by `tests/test_tb_branch_ratchet.py`, which counts
+`"TB"` literals / `.TB` attribute accesses across the layout package and fails
+CI if the total rises above its baseline (mirroring the corner-radius and
+gate-coverage ratchets). Migrating a heuristic onto `AxisFrame` removes its
+branch and lowers the count; lower the baseline in the same change to lock it in.
+
 ## Validate-mode guards
 
 `compute_layout(validate=True)` runs these guards at fixed checkpoints:

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -4,6 +4,50 @@ from __future__ import annotations
 
 import bisect
 from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class _HasXY(Protocol):
+    x: float
+    y: float
+
+
+@dataclass(frozen=True)
+class Axis:
+    """A coordinate axis (``"x"`` or ``"y"``) and its spacing unit."""
+
+    name: str
+    step: float
+
+    def get(self, station: _HasXY) -> float:
+        return getattr(station, self.name)
+
+    def set(self, station: _HasXY, value: float) -> None:
+        setattr(station, self.name, value)
+
+
+@dataclass(frozen=True)
+class AxisFrame:
+    """A section's layer (``primary``) and track (``secondary``) axes.
+
+    LR/RL place layers along X and stack lines along Y; TB transposes the two.
+    ``primary_sign`` is ``-1`` for RL, which runs the primary axis in reverse (as
+    ``single_section._mirror_rl`` does by hand), else ``+1``.
+    """
+
+    primary: Axis
+    secondary: Axis
+    primary_sign: float
+
+    @classmethod
+    def for_direction(
+        cls, direction: str, x_spacing: float, y_spacing: float
+    ) -> AxisFrame:
+        if direction == "TB":
+            return cls(Axis("y", y_spacing), Axis("x", x_spacing), 1.0)
+        sign = -1.0 if direction == "RL" else 1.0
+        return cls(Axis("x", x_spacing), Axis("y", y_spacing), sign)
 
 
 def segment_intersects_quad(

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -28,6 +28,7 @@ from nf_metro.layout.constants import (
     TERMINUS_ICON_CLEARANCE_V,
     TERMINUS_WIDTH,
 )
+from nf_metro.layout.geometry import AxisFrame
 from nf_metro.layout.labels import (
     _label_text_height,
     active_font_scale,
@@ -328,10 +329,8 @@ def _resolve_station_collisions(
     such collisions and shifts the later-defined station along the section's
     secondary axis by one spacing unit, repeating until the cell is unique.
     """
-    if section.direction == "TB":
-        primary, secondary, primary_step, step = "y", "x", y_spacing, x_spacing
-    else:
-        primary, secondary, primary_step, step = "x", "y", x_spacing, y_spacing
+    frame = AxisFrame.for_direction(section.direction, x_spacing, y_spacing)
+    primary, secondary = frame.primary, frame.secondary
 
     EPS = SAME_COORD_TOLERANCE
     # Off-track stations carry a placeholder Y here (the off-track lift in
@@ -349,10 +348,10 @@ def _resolve_station_collisions(
     # row for TB).  Use the primary-axis step size; the bucket spans a
     # half-step either side of a layer centre so off-grid layer_extra
     # offsets stay in the same bucket as their layer peers.
-    primary_step_norm = max(primary_step, 1.0)
+    primary_step_norm = max(primary.step, 1.0)
     by_primary: dict[float, list[Station]] = {}
     for s in real:
-        bucket = round(getattr(s, primary) / primary_step_norm)
+        bucket = round(primary.get(s) / primary_step_norm)
         by_primary.setdefault(bucket, []).append(s)
 
     # Stable tiebreaker so the earlier-defined station keeps its slot
@@ -362,14 +361,14 @@ def _resolve_station_collisions(
     for stations in by_primary.values():
         if len(stations) < 2:
             continue
-        stations.sort(key=lambda s: (getattr(s, secondary), order.get(s.id, 0)))
+        stations.sort(key=lambda s: (secondary.get(s), order.get(s.id, 0)))
         used: list[float] = []
         for s in stations:
-            pos = getattr(s, secondary)
-            while any(abs(pos - u) < step - EPS for u in used):
-                pos += step
-            if pos != getattr(s, secondary):
-                setattr(s, secondary, pos)
+            pos = secondary.get(s)
+            while any(abs(pos - u) < secondary.step - EPS for u in used):
+                pos += secondary.step
+            if pos != secondary.get(s):
+                secondary.set(s, pos)
             used.append(pos)
 
 

--- a/tests/test_axis_frame.py
+++ b/tests/test_axis_frame.py
@@ -1,0 +1,57 @@
+"""Unit tests for the ``AxisFrame`` axis-vocabulary primitive."""
+
+from __future__ import annotations
+
+import pytest
+
+from nf_metro.layout.geometry import AxisFrame
+from nf_metro.parser.model import Station
+
+X_SPACING = 60.0
+Y_SPACING = 40.0
+
+
+def _station() -> Station:
+    return Station(id="s", label="S")
+
+
+def test_lr_primary_is_x_secondary_is_y() -> None:
+    frame = AxisFrame.for_direction("LR", X_SPACING, Y_SPACING)
+    assert frame.primary.name == "x"
+    assert frame.secondary.name == "y"
+    assert frame.primary.step == X_SPACING
+    assert frame.secondary.step == Y_SPACING
+    assert frame.primary_sign == 1.0
+
+
+def test_tb_transposes_axes() -> None:
+    frame = AxisFrame.for_direction("TB", X_SPACING, Y_SPACING)
+    assert frame.primary.name == "y"
+    assert frame.secondary.name == "x"
+    assert frame.primary.step == Y_SPACING
+    assert frame.secondary.step == X_SPACING
+    assert frame.primary_sign == 1.0
+
+
+def test_rl_shares_lr_axes_but_reverses_primary_sign() -> None:
+    frame = AxisFrame.for_direction("RL", X_SPACING, Y_SPACING)
+    assert frame.primary.name == "x"
+    assert frame.secondary.name == "y"
+    assert frame.primary_sign == -1.0
+
+
+@pytest.mark.parametrize("direction", ["LR", "RL", "TB"])
+def test_accessors_read_and_write_named_coordinate(direction: str) -> None:
+    frame = AxisFrame.for_direction(direction, X_SPACING, Y_SPACING)
+    station = _station()
+    station.x = 11.0
+    station.y = 22.0
+
+    frame.primary.set(station, 5.0)
+    frame.secondary.set(station, 7.0)
+
+    assert frame.primary.get(station) == 5.0
+    assert frame.secondary.get(station) == 7.0
+    assert {frame.primary.name, frame.secondary.name} == {"x", "y"}
+    assert getattr(station, frame.primary.name) == 5.0
+    assert getattr(station, frame.secondary.name) == 7.0

--- a/tests/test_tb_branch_ratchet.py
+++ b/tests/test_tb_branch_ratchet.py
@@ -1,0 +1,67 @@
+"""Ratchet on one-off TB branches in the layout package (policy in CONTRACT.md).
+
+Counts ``"TB"`` literals and ``.TB`` attribute accesses across
+``src/nf_metro/layout/`` and fails if the total rises above the baseline. A
+heuristic needing TB awareness should migrate onto the ``AxisFrame`` primitive
+(``layout/geometry.py``) rather than add another ``direction == "TB"`` branch.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_LAYOUT_DIR = Path(__file__).resolve().parents[1] / "src/nf_metro/layout"
+
+# Lower this (never raise it) when a heuristic migrates onto AxisFrame.
+_BASELINE_TB_BRANCHES = 45
+
+
+def _count_in_file(path: Path) -> int:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and node.value == "TB":
+            count += 1
+        elif isinstance(node, ast.Attribute) and node.attr == "TB":
+            count += 1
+    return count
+
+
+def count_tb_branches() -> dict[str, int]:
+    """Map each layout module (relative path) to its TB-reference count."""
+    return {
+        str(path.relative_to(_LAYOUT_DIR)): n
+        for path in sorted(_LAYOUT_DIR.rglob("*.py"))
+        if (n := _count_in_file(path))
+    }
+
+
+def test_no_new_tb_branches() -> None:
+    per_file = count_tb_branches()
+    total = sum(per_file.values())
+
+    # Guard against the counter silently matching nothing (modules moved, AST
+    # walk broken): the engine genuinely carries dozens of TB references today.
+    assert total >= 20, (
+        f"expected many TB references, found {total} - the counter may be "
+        "broken or the layout package restructured"
+    )
+
+    breakdown = "\n  ".join(f"{n:>3}  {name}" for name, n in per_file.items())
+    assert total <= _BASELINE_TB_BRANCHES, (
+        f"TB-branch count rose to {total} (baseline {_BASELINE_TB_BRANCHES}).\n"
+        "A heuristic needing TB awareness is the trigger to convert it to the "
+        "AxisFrame primary/secondary vocabulary (layout/geometry.py), not to add "
+        f'another one-off `direction == "TB"` branch (CONTRACT.md).\n  {breakdown}'
+    )
+
+
+def test_baseline_is_current() -> None:
+    """Baseline equals the live count, so headroom can't accumulate after a drop."""
+    total = sum(count_tb_branches().values())
+    assert total == _BASELINE_TB_BRANCHES, (
+        f"TB-branch count is {total} but the baseline is {_BASELINE_TB_BRANCHES}. "
+        "If you migrated a heuristic onto AxisFrame (count dropped), lower the "
+        "baseline to match; if the count rose, see test_no_new_tb_branches."
+    )


### PR DESCRIPTION
## Summary
- New `AxisFrame` primitive in `layout/geometry.py`. `AxisFrame.for_direction(direction, x_spacing, y_spacing)` returns the **primary** (layer/flow) and **secondary** (track) axes - each an `Axis` carrying its `step` and `get`/`set` accessors - plus `primary_sign` (`-1` for RL, whose primary axis runs reversed, else `+1`).
- `_resolve_station_collisions` (the embryonic `(primary, secondary, primary_step, step)` tuple's only consumer) re-expressed on `AxisFrame`. Byte-identical: all 192 gallery/topology/example renders hash unchanged.
- `tests/test_tb_branch_ratchet.py`: AST-counts `"TB"` literals and `.TB` attribute accesses across `src/nf_metro/layout/` and fails CI if the total rises above its baseline (45), mirroring the corner-radius / gate-coverage ratchets. A companion test keeps the baseline equal to the live count so headroom can't accumulate after a migration drops it.
- `tests/test_axis_frame.py`: unit coverage of the primitive (LR/RL/TB axis assignment, `primary_sign`, accessors).
- `CONTRACT.md`: records the policy - no new one-off TB branches; a heuristic needing TB awareness is the trigger to convert it to the axis vocabulary.

Foundation for the #682 heuristic migration; unblocks the migration children (C, D, E).

Fixes #916

## Test plan
- [x] pytest passes (incl. new ratchet + unit tests); ratchet verified to fail when a TB literal is injected
- [x] ruff format + ruff check clean on whole repo; mypy clean
- [x] Byte-identical gallery oracle (192 renders, hashes unchanged)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/924/) - expect "No visual changes detected"

Generated with Claude Code
