### PR TITLE
refactor(routing): unify the offset regime behind a named enum + one applier (#920)

### DIFF
--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -1873,6 +1873,26 @@ def _grow_section_for_box(
         sec.bbox_h = (y_max + margin) - sec.bbox_y
 
 
+def _route_endpoints_with_offsets(
+    route: "RoutedPath",
+    station_offsets: dict[tuple[str, str], float] | None,
+) -> list[tuple[float, float]]:
+    """A route's points with the render-time endpoint separation applied.
+
+    Label-strike tests care only about each segment's orientation, so this
+    shifts just the endpoints (the renderer's full per-line offsetting also
+    moves interior channel points).  A baked route's points are returned as
+    routed.  Reuses the renderer's offsetting so the two stay in lockstep.
+    """
+    pts = list(route.points)
+    if station_offsets and pts:
+        from nf_metro.layout.routing.common import apply_route_offsets
+
+        shifted = apply_route_offsets(route, station_offsets)
+        pts[0], pts[-1] = shifted[0], shifted[-1]
+    return pts
+
+
 def _avoid_diagonal_routes(
     placements: list[LabelPlacement],
     graph: MetroGraph,
@@ -1890,12 +1910,7 @@ def _avoid_diagonal_routes(
     """
     diag: list[tuple[float, float, float, float]] = []
     for route in routes:
-        pts = list(route.points)
-        if station_offsets and not route.offsets_applied and pts:
-            so = station_offsets.get((route.edge.source, route.line_id), 0.0)
-            to = station_offsets.get((route.edge.target, route.line_id), 0.0)
-            pts[0] = (pts[0][0], pts[0][1] + so)
-            pts[-1] = (pts[-1][0], pts[-1][1] + to)
+        pts = _route_endpoints_with_offsets(route, station_offsets)
         for i in range(len(pts) - 1):
             (x1, y1), (x2, y2) = pts[i], pts[i + 1]
             dx, dy = x2 - x1, y2 - y1
@@ -1967,12 +1982,7 @@ def _foreign_route_segments(
     """
     segs: list[tuple[str, str, str, float, float, float, float]] = []
     for route in routes:
-        pts = list(route.points)
-        if station_offsets and not route.offsets_applied and pts:
-            so = station_offsets.get((route.edge.source, route.line_id), 0.0)
-            to = station_offsets.get((route.edge.target, route.line_id), 0.0)
-            pts[0] = (pts[0][0], pts[0][1] + so)
-            pts[-1] = (pts[-1][0], pts[-1][1] + to)
+        pts = _route_endpoints_with_offsets(route, station_offsets)
         for (x1, y1), (x2, y2) in zip(pts, pts[1:]):
             is_diagonal = abs(y2 - y1) >= max(abs(x2 - x1), 1.0) * DIAGONAL_SLOPE_RATIO
             if is_diagonal != diagonal:

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -316,7 +316,7 @@ def routes_through_unrelated_sections(
     """
     from nf_metro.layout.geometry import segment_intersects_bbox
     from nf_metro.layout.routing import compute_station_offsets, route_edges
-    from nf_metro.render.svg import apply_route_offsets
+    from nf_metro.layout.routing.common import apply_route_offsets
 
     if offsets is None:
         offsets = compute_station_offsets(graph)

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1257,7 +1257,7 @@ def _guard_no_line_crosses_non_consumer(
     sharing its trunk-Y row with a busier sibling whose inbound
     bundle traverses the sparse consumer's column.
     """
-    from nf_metro.render.svg import apply_route_offsets
+    from nf_metro.layout.routing.common import apply_route_offsets
 
     if offsets is None:
         from nf_metro.layout.routing import compute_station_offsets
@@ -1323,7 +1323,8 @@ def _guard_no_line_crosses_file_icon(
     one belonging to a line the icon's station also carries, since a
     different edge of that line is still raking the artefact.
     """
-    from nf_metro.render.svg import _icon_obstacles_by_station, apply_route_offsets
+    from nf_metro.layout.routing.common import apply_route_offsets
+    from nf_metro.render.svg import _icon_obstacles_by_station
     from nf_metro.themes import THEMES
 
     if offsets is None:
@@ -1437,7 +1438,7 @@ def iter_opposing_line_overlaps(
     lines sharing a channel are carried on their own offset slots, not on the
     same track.
     """
-    from nf_metro.render.svg import apply_route_offsets
+    from nf_metro.layout.routing.common import apply_route_offsets
 
     if offsets is None:
         from nf_metro.layout.routing import compute_station_offsets
@@ -1542,7 +1543,8 @@ def iter_line_label_strikes(
         place_labels,
         segment_strikes_label,
     )
-    from nf_metro.render.svg import _compute_icon_obstacles, apply_route_offsets
+    from nf_metro.layout.routing.common import apply_route_offsets
+    from nf_metro.render.svg import _compute_icon_obstacles
     from nf_metro.themes import THEMES
 
     if offsets is None:
@@ -1750,7 +1752,7 @@ def _guard_off_track_output_clears_non_producer(
     closes the gap by checking the output route against same-section trunk
     markers regardless of line membership, exempting only the producer.
     """
-    from nf_metro.render.svg import apply_route_offsets
+    from nf_metro.layout.routing.common import apply_route_offsets
 
     producer_of = {
         off_id: anchor_id

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -720,8 +720,12 @@ def _line_crossed_file_icon_sinks(graph: MetroGraph) -> set[str]:
     already sits clear is never lifted.
     """
     from nf_metro.layout.geometry import segment_intersects_bbox
-    from nf_metro.layout.routing import compute_station_offsets, route_edges
-    from nf_metro.render.svg import _icon_obstacles_by_station, apply_route_offsets
+    from nf_metro.layout.routing import (
+        apply_route_offsets,
+        compute_station_offsets,
+        route_edges,
+    )
+    from nf_metro.render.svg import _icon_obstacles_by_station
     from nf_metro.themes import THEMES
 
     offsets = compute_station_offsets(graph)

--- a/src/nf_metro/layout/phases/spacing.py
+++ b/src/nf_metro/layout/phases/spacing.py
@@ -111,7 +111,7 @@ def _struck_label_station_ids(
     ``relocatable_for`` below).
     """
     from nf_metro.layout.labels import segment_strikes_label
-    from nf_metro.render.svg import apply_route_offsets
+    from nf_metro.layout.routing.common import apply_route_offsets
 
     def _off_track(node_id: str) -> bool:
         st = graph.stations.get(node_id)

--- a/src/nf_metro/layout/routing/__init__.py
+++ b/src/nf_metro/layout/routing/__init__.py
@@ -4,17 +4,26 @@ Public API:
 - route_edges: Main edge routing dispatcher (placement-pure)
 - route_edges_centred: route_edges + applied bubble-centring marker moves
 - RoutedPath: Routed path dataclass
+- OffsetRegime: Which line-separation regime a route is in
+- apply_route_offsets: A route's final render geometry, separation applied
 - GapSlot: Symbolic gap-relative slot for a vertical channel run
 - compute_station_offsets: Per-station Y offset computation
 """
 
-from nf_metro.layout.routing.common import GapSlot, RoutedPath
+from nf_metro.layout.routing.common import (
+    GapSlot,
+    OffsetRegime,
+    RoutedPath,
+    apply_route_offsets,
+)
 from nf_metro.layout.routing.core import route_edges, route_edges_centred
 from nf_metro.layout.routing.offsets import compute_station_offsets
 
 __all__ = [
     "GapSlot",
+    "OffsetRegime",
     "RoutedPath",
+    "apply_route_offsets",
     "compute_station_offsets",
     "route_edges",
     "route_edges_centred",

--- a/src/nf_metro/layout/routing/bundle.py
+++ b/src/nf_metro/layout/routing/bundle.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from nf_metro.layout.constants import COORD_TOLERANCE
-from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.layout.routing.common import OffsetRegime, RoutedPath
 from nf_metro.layout.routing.corners import reference_anchored_radius
 from nf_metro.parser.model import Edge
 
@@ -104,8 +104,8 @@ def build_concentric_bundle(
     Returns
     -------
     One :class:`RoutedPath` per member, each a parallel offset of *centerline*
-    with concentric corner radii.  ``offsets_applied`` is set: the per-line
-    offset is baked into the points, not left to the renderer's heuristic.
+    with concentric corner radii.  Each is :attr:`OffsetRegime.BAKED`: the
+    per-line offset is in the points, not left to the renderer's heuristic.
     """
     n_legs = len(centerline) - 1
     if n_legs < 1:
@@ -357,7 +357,7 @@ def _fan_bundle(
                 is_inter_section=is_inter_section,
                 curve_radii=radii or None,
                 normalize_exempt=normalize_exempt,
-                offsets_applied=True,
+                offset_regime=OffsetRegime.BAKED,
             )
         )
     return routes

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -25,6 +25,27 @@ from nf_metro.layout.constants import (
 from nf_metro.parser.model import Edge, MetroGraph, PortSide, Section, Station
 
 
+class OffsetRegime(Enum):
+    """When a route's parallel-line separations are applied.
+
+    A diagram routes lines on two separation regimes, and any pass reasoning
+    about spacing must know which one a given route is in:
+
+    ``DEFERRED``
+        The stored points sit on the trunk centreline; the per-line separation
+        is applied at render by :func:`apply_route_offsets` as a lateral (Y)
+        shift of the endpoints.  The default for plain LR/RL runs.
+    ``BAKED``
+        The stored points already carry the separation -- a TB X-stagger, a
+        rail's per-line Y, or a bundle's concentric corner fan -- because it is
+        geometry a uniform endpoint Y-shift cannot express.  Render-time
+        offsetting is skipped so the separation is not applied twice.
+    """
+
+    DEFERRED = "deferred"
+    BAKED = "baked"
+
+
 class Direction(Enum):
     """Cardinal travel direction for a horizontal or vertical run."""
 
@@ -448,7 +469,8 @@ class RoutedPath:
     points: list[tuple[float, float]]
     is_inter_section: bool = False
     curve_radii: list[float] | None = None
-    offsets_applied: bool = False
+    offset_regime: OffsetRegime = OffsetRegime.DEFERRED
+    """Which separation regime this route is in (see :class:`OffsetRegime`)."""
     normalize_exempt: bool = False
     """Skip this route in the gap-channel normalization post-pass.
 
@@ -506,6 +528,43 @@ class RoutedPath:
         trunk's direction and band rank from the routed geometry.
         """
         self.trunk_slot = TrunkSlot(gap_upper_row=gap_upper_row)
+
+
+def apply_route_offsets(
+    route: RoutedPath,
+    station_offsets: dict[tuple[str, str], float],
+) -> list[tuple[float, float]]:
+    """The route's final render geometry, with its line separation applied.
+
+    The single place a route's stored points become drawable coordinates, so
+    every spacing-aware pass (the renderer, the label-strike search, the render
+    invariants) reads one regime-aware result instead of re-deriving it.
+
+    A :attr:`~OffsetRegime.BAKED` route already carries its separation, so its
+    points are returned verbatim.  A :attr:`~OffsetRegime.DEFERRED` route is
+    shifted in Y: the source-side waypoints by the source offset, the
+    target-side by the target offset, each interior point assigned to whichever
+    end it is closer to.
+    """
+    if route.offset_regime is OffsetRegime.BAKED:
+        return list(route.points)
+
+    src_off = station_offsets.get((route.edge.source, route.line_id), 0.0)
+    tgt_off = station_offsets.get((route.edge.target, route.line_id), 0.0)
+    orig_sy = route.points[0][1]
+    orig_ty = route.points[-1][1]
+    last = len(route.points) - 1
+    pts: list[tuple[float, float]] = []
+    for i, (x, y) in enumerate(route.points):
+        if i == 0:
+            pts.append((x, y + src_off))
+        elif i == last:
+            pts.append((x, y + tgt_off))
+        elif abs(y - orig_sy) <= abs(y - orig_ty):
+            pts.append((x, y + src_off))
+        else:
+            pts.append((x, y + tgt_off))
+    return pts
 
 
 def initial_fanout_descent_span(

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -44,8 +44,10 @@ from nf_metro.layout.constants import (
 from nf_metro.layout.phases.guards import GuardSpec
 from nf_metro.layout.routing.common import (
     Direction,
+    OffsetRegime,
     RoutedPath,
     _vert_horiz_cross,
+    apply_route_offsets,
     gap_lo_for_x,
     horizontal_direction,
     initial_fanout_descent_span,
@@ -323,7 +325,7 @@ def _per_line_drop_x(
         if rp is None:
             continue
         x = _vertical_x_at_station(
-            _route_render_points(rp, offsets), station, at_end=at_end
+            apply_route_offsets(rp, offsets), station, at_end=at_end
         )
         if x is None:
             continue
@@ -1065,30 +1067,6 @@ def _axis_aligned(
     return None, 0.0
 
 
-def _route_render_points(
-    rp: RoutedPath, offsets: dict[tuple[str, str], float]
-) -> list[tuple[float, float]]:
-    """Final render geometry for a route (mirrors render.apply_route_offsets)."""
-    if rp.offsets_applied:
-        return list(rp.points)
-    src_off = offsets.get((rp.edge.source, rp.line_id), 0.0)
-    tgt_off = offsets.get((rp.edge.target, rp.line_id), 0.0)
-    orig_sy = rp.points[0][1]
-    orig_ty = rp.points[-1][1]
-    out: list[tuple[float, float]] = []
-    last = len(rp.points) - 1
-    for k, (x, y) in enumerate(rp.points):
-        if k == 0:
-            out.append((x, y + src_off))
-        elif k == last:
-            out.append((x, y + tgt_off))
-        elif abs(y - orig_sy) <= abs(y - orig_ty):
-            out.append((x, y + src_off))
-        else:
-            out.append((x, y + tgt_off))
-    return out
-
-
 def _collinear_overlay_violations(
     routes: list[RoutedPath],
     offsets: dict[tuple[str, str], float],
@@ -1111,7 +1089,7 @@ def _collinear_overlay_violations(
     for rp in routes:
         if rp.is_inter_section != inter_section:
             continue
-        pts = _route_render_points(rp, offsets)
+        pts = apply_route_offsets(rp, offsets)
         edge = (rp.edge.source, rp.edge.target)
         for p1, p2 in zip(pts, pts[1:]):
             axis, coord = _axis_aligned(p1, p2)
@@ -1263,7 +1241,7 @@ def _diagonal_segments(
     rp: RoutedPath, offsets: dict[tuple[str, str], float]
 ) -> list[_Seg]:
     """Final-render diagonal segments of *rp* (both axes change appreciably)."""
-    pts = _route_render_points(rp, offsets)
+    pts = apply_route_offsets(rp, offsets)
     out: list[_Seg] = []
     for p1, p2 in zip(pts, pts[1:]):
         if (
@@ -1479,7 +1457,7 @@ def check_no_same_line_parallel_descents(
     for rp in routes:
         if not rp.is_inter_section:
             continue
-        pts = _route_render_points(rp, offsets)
+        pts = apply_route_offsets(rp, offsets)
         edge = (rp.edge.source, rp.edge.target)
         for p1, p2 in zip(pts, pts[1:]):
             axis, coord = _axis_aligned(p1, p2)
@@ -1869,7 +1847,7 @@ def check_stacked_elbow_clearance(
     for rp in routes:
         if not rp.is_inter_section:
             continue
-        pts = _route_render_points(rp, offsets)
+        pts = apply_route_offsets(rp, offsets)
         edge = (rp.edge.source, rp.edge.target)
         for p1, p2 in zip(pts, pts[1:]):
             axis, coord = _axis_aligned(p1, p2)
@@ -2012,7 +1990,7 @@ def check_concentric_bundle_corners(
     for (src_id, tgt_id), bundle in bundles.items():
         if len(bundle) < 2:
             continue
-        rendered = [(r, _route_render_points(r, offsets)) for r in bundle]
+        rendered = [(r, apply_route_offsets(r, offsets)) for r in bundle]
         radii = {id(r): _resolved_corner_radii(r, pts) for r, pts in rendered}
         for ai in range(len(rendered)):
             ra, pa = rendered[ai]
@@ -2296,7 +2274,7 @@ def check_merge_branches_meet_trunk(
         for e in feeders:
             r = by_key.get((e.source, e.target, e.line_id))
             if r is not None and len(r.points) >= 2:
-                polylines.append((e, _route_render_points(r, offsets)))
+                polylines.append((e, apply_route_offsets(r, offsets)))
         for edge, pts in polylines:
             end = pts[-1]
             d_merge = ((end[0] - merge_st.x) ** 2 + (end[1] - merge_st.y) ** 2) ** 0.5
@@ -2388,7 +2366,7 @@ def check_no_hanging_routes(
     diagnostics.
     """
     anchor_xy = [(st.x, st.y) for st in graph.stations.values()]
-    rendered = [(r, _route_render_points(r, offsets)) for r in routes]
+    rendered = [(r, apply_route_offsets(r, offsets)) for r in routes]
     polylines = [(r, pts) for r, pts in rendered if len(pts) >= 2]
 
     violations: list[HangingRoute] = []
@@ -2423,6 +2401,84 @@ def check_no_hanging_routes(
                     which=which,
                     endpoint=end,
                     gap=min(d_marker, d_join),
+                )
+            )
+    return violations
+
+
+_LATERAL_OFFSET_TOL = 1.0
+
+
+@dataclass(frozen=True)
+class RegimeOffsetMisapplied:
+    """A deferred route's endpoint separation would shift it along its travel.
+
+    A :attr:`~nf_metro.layout.routing.common.OffsetRegime.DEFERRED` route's
+    line separation is applied at render as a Y-shift of its endpoints, which
+    only reads as a lateral separation when the terminal segment is horizontal
+    (the run travels in X).  A deferred route whose terminal segment is
+    vertical carries a non-zero endpoint offset that the renderer would apply
+    *along* the line's own travel rather than across it -- the route belongs in
+    the :attr:`~nf_metro.layout.routing.common.OffsetRegime.BAKED` regime
+    (a TB / rail / bundle path that pre-bakes its separation) but was left
+    deferred.  This is the latent two-regimes defect made loud.
+    """
+
+    source: str
+    target: str
+    line_id: str
+    which: str
+    offset: float
+    segment: tuple[tuple[float, float], tuple[float, float]]
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        (x1, y1), (x2, y2) = self.segment
+        return (
+            f"deferred route {self.source!r}->{self.target!r} on "
+            f"{self.line_id!r}: {self.which} offset {self.offset:.1f}px applies "
+            f"along a non-horizontal terminal segment "
+            f"(({x1:.1f},{y1:.1f})->({x2:.1f},{y2:.1f})); the route must be "
+            f"OffsetRegime.BAKED, not DEFERRED"
+        )
+
+
+def check_deferred_offsets_apply_laterally(
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+) -> list[RegimeOffsetMisapplied]:
+    """Flag deferred routes whose endpoint separation is not a lateral shift.
+
+    The render-time offset regime (:func:`apply_route_offsets`) shifts a
+    deferred route's endpoints in Y; that is a clean per-line separation only
+    when the terminal segment runs horizontally.  A deferred route with a
+    non-zero endpoint offset on a vertical terminal segment would be
+    mis-separated -- the structural signature of a route left in the wrong
+    regime -- so it must instead bake its separation
+    (:attr:`~nf_metro.layout.routing.common.OffsetRegime.BAKED`).
+    """
+    violations: list[RegimeOffsetMisapplied] = []
+    for r in routes:
+        if r.offset_regime is not OffsetRegime.DEFERRED or len(r.points) < 2:
+            continue
+        ends = (
+            ("source", r.edge.source, r.points[0], r.points[1]),
+            ("target", r.edge.target, r.points[-1], r.points[-2]),
+        )
+        for which, node, end, neighbour in ends:
+            off = offsets.get((node, r.line_id), 0.0)
+            if abs(off) <= _LATERAL_OFFSET_TOL:
+                continue
+            if abs(end[1] - neighbour[1]) <= _LATERAL_OFFSET_TOL:
+                continue  # terminal segment is horizontal: shift is lateral
+            violations.append(
+                RegimeOffsetMisapplied(
+                    source=r.edge.source,
+                    target=r.edge.target,
+                    line_id=r.line_id,
+                    which=which,
+                    offset=off,
+                    segment=(end, neighbour),
                 )
             )
     return violations
@@ -2916,6 +2972,10 @@ def assert_render_curve_invariants(
             check_no_hanging_routes(graph, routes, offsets),
         ),
         (
+            "deferred route offset applied along travel",
+            check_deferred_offsets_apply_laterally(routes, offsets),
+        ),
+        (
             "bottommost-row climb dives below clear corridor",
             check_bottom_row_climb_stays_at_row_level(graph, routes),
         ),
@@ -3012,6 +3072,7 @@ CHECK_REGISTRY: tuple[GuardSpec, ...] = (
     _check_spec(check_no_same_line_parallel_descents, "A"),
     _check_spec(check_merge_branches_meet_trunk, "A"),
     _check_spec(check_no_hanging_routes, "A"),
+    _check_spec(check_deferred_offsets_apply_laterally, "A"),
     _check_spec(check_bottom_row_climb_stays_at_row_level, "A"),
     _check_spec(check_gap_channels_materialized, "A"),
     _check_spec(check_trunks_declared, "A"),
@@ -3050,6 +3111,7 @@ __all__ = [
     "PeeloffBundleCrossing",
     "PerpEntryBoundaryViolation",
     "PerpExitLeadInOverdip",
+    "RegimeOffsetMisapplied",
     "RightEntryNeedlessDive",
     "SameLineParallelRun",
     "Side",
@@ -3061,6 +3123,7 @@ __all__ = [
     "check_gap_channels_materialized",
     "check_trunks_declared",
     "check_concentric_bundle_corners",
+    "check_deferred_offsets_apply_laterally",
     "check_fanout_tail_join",
     "check_no_distinct_line_fanout_crossing",
     "check_merge_branches_meet_trunk",

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -2406,6 +2406,9 @@ def check_no_hanging_routes(
     return violations
 
 
+# px: doubles as the floor below which an endpoint offset is negligible and the
+# slack within which a terminal segment counts as horizontal (so its Y-shift is
+# a lateral separation rather than an along-travel displacement).
 _LATERAL_OFFSET_TOL = 1.0
 
 

--- a/src/nf_metro/layout/routing/postprocess.py
+++ b/src/nf_metro/layout/routing/postprocess.py
@@ -21,6 +21,7 @@ from nf_metro.layout.geometry import segment_intersects_bbox
 from nf_metro.layout.routing.common import (
     OffsetRegime,
     RoutedPath,
+    apply_route_offsets,
 )
 from nf_metro.layout.routing.context import (
     _RoutingCtx,
@@ -796,8 +797,6 @@ def _clear_bypass_v_label_strikes(routes: list[RoutedPath], ctx: _RoutingCtx) ->
     obstacles = ctx.graph.bypass_label_obstacles
     if not obstacles or ctx.station_offsets is None:
         return
-
-    from nf_metro.render.svg import apply_route_offsets
 
     legs_by_v: dict[str, list[RoutedPath]] = defaultdict(list)
     for r in routes:

--- a/src/nf_metro/layout/routing/postprocess.py
+++ b/src/nf_metro/layout/routing/postprocess.py
@@ -19,6 +19,7 @@ from nf_metro.layout.constants import (
 )
 from nf_metro.layout.geometry import segment_intersects_bbox
 from nf_metro.layout.routing.common import (
+    OffsetRegime,
     RoutedPath,
 )
 from nf_metro.layout.routing.context import (
@@ -76,7 +77,7 @@ def _spread_diagonal_bundles(routes: list[RoutedPath], ctx: _RoutingCtx) -> None
     fork_groups: dict[str, list[RoutedPath]] = defaultdict(list)
     join_groups: dict[str, list[RoutedPath]] = defaultdict(list)
     for rp in routes:
-        if not _is_diagonal_route(rp) or rp.offsets_applied:
+        if not _is_diagonal_route(rp) or rp.offset_regime is OffsetRegime.BAKED:
             continue
         if rp.edge.source in ctx.fork_stations:
             fork_groups[rp.edge.source].append(rp)
@@ -236,14 +237,15 @@ def _apply_diagonal_spread(
     rep = group[0]
     # Baked routes carry their offset along X already, so the complementary
     # spread runs along Y; render-time routes are the mirror image.
-    ai = 1 if rep.offsets_applied else 0
+    baked = rep.offset_regime is OffsetRegime.BAKED
+    ai = 1 if baked else 0
     bi = 1 - ai
     d_a = rep.points[2][ai] - rep.points[1][ai]
     d_b = rep.points[2][bi] - rep.points[1][bi]
     sign = 1.0 if d_a >= 0 else -1.0
     hypot = math.hypot(d_a, d_b)
 
-    if rep.offsets_applied:
+    if baked:
         deltas = _baked_spread_deltas(group, offsets, center, d_a, d_b, hypot, bi)
     else:
         # A Y-only offset under-separates a diagonal: its perpendicular component

--- a/src/nf_metro/layout/routing/rail.py
+++ b/src/nf_metro/layout/routing/rail.py
@@ -24,7 +24,7 @@ from nf_metro.layout.constants import (
     RAIL_TERMINUS_FAN_LEAD,
 )
 from nf_metro.layout.routing.bundle import build_tapered_bundle
-from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.layout.routing.common import OffsetRegime, RoutedPath
 from nf_metro.parser.model import Edge, MetroGraph, Station
 
 
@@ -275,7 +275,7 @@ def route_rail_edges(
                 edge=edge,
                 line_id=edge.line_id,
                 points=points,
-                offsets_applied=True,
+                offset_regime=OffsetRegime.BAKED,
             )
         )
     return routes

--- a/src/nf_metro/layout/routing/tb_handlers.py
+++ b/src/nf_metro/layout/routing/tb_handlers.py
@@ -18,6 +18,7 @@ from nf_metro.layout.routing.centrelines import (
     gather_member_edges,
 )
 from nf_metro.layout.routing.common import (
+    OffsetRegime,
     RoutedPath,
 )
 from nf_metro.layout.routing.context import (
@@ -82,7 +83,7 @@ def _route_tb_internal(
         edge=edge,
         line_id=edge.line_id,
         points=[(sx, sy), (tx, ty)],
-        offsets_applied=True,
+        offset_regime=OffsetRegime.BAKED,
     )
 
 
@@ -158,7 +159,7 @@ def _route_tb_diagonal(
         edge=edge,
         line_id=edge.line_id,
         points=[(sx, sy), (sx, diag_start_y), (tx, diag_end_y), (tx, ty)],
-        offsets_applied=True,
+        offset_regime=OffsetRegime.BAKED,
     )
 
 
@@ -371,7 +372,7 @@ def _route_perp_entry(
             edge=edge,
             line_id=edge.line_id,
             points=[(x, sy), (x, tgt.y)],
-            offsets_applied=True,
+            offset_regime=OffsetRegime.BAKED,
         )
 
     _members, line_ids, edge_by_line = gather_member_edges(graph, edge)

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -30,6 +30,7 @@ from nf_metro.layout.labels import (
 )
 from nf_metro.layout.routing import (
     RoutedPath,
+    apply_route_offsets,
     compute_station_offsets,
     route_edges_centred,
 )
@@ -126,38 +127,6 @@ from nf_metro.render.section_header import (
     resolve_all_section_headers,
 )
 from nf_metro.render.style import Theme
-
-
-def apply_route_offsets(
-    route: RoutedPath,
-    station_offsets: dict[tuple[str, str], float],
-) -> list[tuple[float, float]]:
-    """Apply per-line Y offsets to a route's waypoints.
-
-    If the route already has offsets applied (e.g. TB section routes),
-    returns a copy of its points unchanged. Otherwise, shifts source-side
-    waypoints by the source offset and target-side waypoints by the target
-    offset, with intermediate points assigned to whichever end is closer.
-    """
-    if route.offsets_applied:
-        return list(route.points)
-
-    src_off = station_offsets.get((route.edge.source, route.line_id), 0.0)
-    tgt_off = station_offsets.get((route.edge.target, route.line_id), 0.0)
-
-    orig_sy = route.points[0][1]
-    orig_ty = route.points[-1][1]
-    pts: list[tuple[float, float]] = []
-    for i, (x, y) in enumerate(route.points):
-        if i == 0:
-            pts.append((x, y + src_off))
-        elif i == len(route.points) - 1:
-            pts.append((x, y + tgt_off))
-        elif abs(y - orig_sy) <= abs(y - orig_ty):
-            pts.append((x, y + src_off))
-        else:
-            pts.append((x, y + tgt_off))
-    return pts
 
 
 def _compute_canvas_bounds(

--- a/tests/test_bundle_order_invariant.py
+++ b/tests/test_bundle_order_invariant.py
@@ -15,7 +15,11 @@ from pathlib import Path
 import pytest
 
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.common import Direction, RoutedPath
 from nf_metro.layout.routing.invariants import (
     BundleOrderViolation,
@@ -248,7 +252,7 @@ def _synthetic_route(line_id: str, points: list[tuple[float, float]]) -> RoutedP
         line_id=line_id,
         points=points,
         is_inter_section=True,
-        offsets_applied=True,
+        offset_regime=OffsetRegime.BAKED,
     )
 
 

--- a/tests/test_bypass_centreline.py
+++ b/tests/test_bypass_centreline.py
@@ -21,7 +21,11 @@ import pytest
 
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.bundle import build_tapered_bundle
 from nf_metro.layout.routing.centrelines import route_tapered_anchored
 from nf_metro.layout.routing.invariants import (
@@ -96,7 +100,7 @@ def test_bypass_routes_are_offset_baked(path: Path) -> None:
     _graph, _offsets, routes = _route(path)
     bypasses = _bypass_routes(routes)
     assert bypasses, f"{path.stem}: expected at least one U-shaped bypass route"
-    assert all(r.offsets_applied for r in bypasses)
+    assert all(r.offset_regime is OffsetRegime.BAKED for r in bypasses)
 
 
 def test_single_line_bypass_descent_turns_tight() -> None:

--- a/tests/test_centreline_inter_section.py
+++ b/tests/test_centreline_inter_section.py
@@ -4,13 +4,13 @@ The straight, L-shape, single-corner and vertical-drop inter-section handlers
 construct their routes by describing a centreline and fanning it with
 ``build_concentric_bundle`` (``layout/routing/centrelines.py``) rather than
 assembling per-line ``points`` / ``curve_radii`` by hand.  A bundle built that
-way is offset-baked (``offsets_applied``) and correct by construction -- its
-corners stay concentric and its lines keep a constant side-of-travel order.
+way is offset-baked (:attr:`OffsetRegime.BAKED`) and correct by construction --
+its corners stay concentric and its lines keep a constant side-of-travel order.
 
 These tests pin that on the fixtures that exercise each shape: a regression to
-a hand-rolled, render-time-offset path would drop ``offsets_applied`` on the
-multi-line inter-section bundles, and a flat or mis-signed radius would trip the
-render-path curve guard.
+a hand-rolled, render-time-offset path would leave the multi-line inter-section
+bundles :attr:`OffsetRegime.DEFERRED`, and a flat or mis-signed radius would
+trip the render-path curve guard.
 """
 
 from __future__ import annotations
@@ -20,7 +20,11 @@ from pathlib import Path
 import pytest
 
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.invariants import (
     assert_render_curve_invariants,
     check_bundle_order_preserved,
@@ -76,4 +80,6 @@ def test_multi_line_inter_section_bundles_are_offset_baked(path: Path) -> None:
             bundles.setdefault((r.edge.source, r.edge.target), []).append(r)
     multiline = {k: v for k, v in bundles.items() if len({r.line_id for r in v}) > 1}
     assert multiline, f"{path.stem}: expected a multi-line inter-section bundle"
-    assert all(r.offsets_applied for rs in multiline.values() for r in rs)
+    assert all(
+        r.offset_regime is OffsetRegime.BAKED for rs in multiline.values() for r in rs
+    )

--- a/tests/test_coincide_track_radii.py
+++ b/tests/test_coincide_track_radii.py
@@ -36,7 +36,11 @@ import pytest
 import nf_metro.layout.routing.normalize as normalize
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.common import RoutedPath
 from nf_metro.layout.routing.corners import concentric_corner_radius_at
 from nf_metro.layout.routing.normalize import _set_vchannel_x, _VChannel
@@ -127,7 +131,7 @@ def test_set_vchannel_x_rederives_flanking_corners_from_waypoints() -> None:
         line_id="l",
         points=points,
         is_inter_section=True,
-        offsets_applied=True,
+        offset_regime=OffsetRegime.BAKED,
         curve_radii=[19.0, 19.0],
     )
     channel = _VChannel(route=route, idx=1, x=50.0, y_lo=0.0, y_hi=100.0, down=True)

--- a/tests/test_concentric_bundle_corners.py
+++ b/tests/test_concentric_bundle_corners.py
@@ -19,7 +19,11 @@ from pathlib import Path
 import pytest
 
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.common import RoutedPath
 from nf_metro.layout.routing.invariants import check_concentric_bundle_corners
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -78,7 +82,7 @@ def _route(
         line_id=line_id,
         points=points,
         is_inter_section=True,
-        offsets_applied=True,
+        offset_regime=OffsetRegime.BAKED,
         curve_radii=radii,
     )
 

--- a/tests/test_entry_wrap_centreline.py
+++ b/tests/test_entry_wrap_centreline.py
@@ -21,7 +21,11 @@ import pytest
 
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.invariants import (
     assert_render_curve_invariants,
     check_bundle_order_preserved,
@@ -109,4 +113,4 @@ def test_entry_wrap_routes_are_offset_baked(path: Path) -> None:
     graph, _offsets, routes = _route(path)
     wraps = _wrap_routes(graph, routes)
     assert wraps, f"{path.stem}: expected at least one entry-wrap route"
-    assert all(r.offsets_applied for r in wraps)
+    assert all(r.offset_regime is OffsetRegime.BAKED for r in wraps)

--- a/tests/test_hanging_route_invariant.py
+++ b/tests/test_hanging_route_invariant.py
@@ -27,7 +27,11 @@ from pathlib import Path
 import pytest
 
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.invariants import (
     CurveInvariantError,
     assert_render_curve_invariants,
@@ -84,7 +88,7 @@ def _plant_hanging_tail(graph, routes):
             continue
         far = (r.points[-1][0] + 1000.0, r.points[-1][1] + 1000.0)
         routes[i] = dataclasses.replace(
-            r, points=[*r.points[:-1], far], offsets_applied=True
+            r, points=[*r.points[:-1], far], offset_regime=OffsetRegime.BAKED
         )
         return i
     raise AssertionError("no ordinary route available to plant a hanging tail")

--- a/tests/test_intra_perp_exit_centreline.py
+++ b/tests/test_intra_perp_exit_centreline.py
@@ -24,7 +24,11 @@ import pytest
 
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.context import _build_routing_context
 from nf_metro.layout.routing.intra_handlers import _route_intra_section
 from nf_metro.layout.routing.invariants import (
@@ -159,4 +163,4 @@ def test_intra_perp_exit_natural_render_is_clean(path: Path) -> None:
     arm_targets = {t for (_s, t) in _arm_groups(graph)}
     arm_routes = [r for r in routes if r.edge.target in arm_targets]
     assert arm_routes, f"{path.stem}: expected routed perp-exit arm edges"
-    assert all(r.offsets_applied for r in arm_routes)
+    assert all(r.offset_regime is OffsetRegime.BAKED for r in arm_routes)

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -8,6 +8,7 @@ from nf_metro.layout.labels import (
     _avoid_diagonal_routes,
     _compute_port_label_preference,
 )
+from nf_metro.layout.routing.common import OffsetRegime
 from nf_metro.parser.model import Edge, MetroGraph, Port, PortSide, Station
 
 
@@ -147,7 +148,7 @@ class _FakeRoute:
     edge: _FakeEdge = field(default_factory=_FakeEdge)
     line_id: str = "L1"
     points: list = field(default_factory=list)
-    offsets_applied: bool = True
+    offset_regime: OffsetRegime = OffsetRegime.BAKED
 
 
 class TestSegmentIntersectsBbox:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -70,6 +70,7 @@ from nf_metro.layout.phases.off_track import (
     _section_distinct_trunk_ys,
 )
 from nf_metro.layout.routing import (
+    OffsetRegime,
     compute_station_offsets,
     route_edges,
     route_edges_centred,
@@ -1113,7 +1114,7 @@ def test_intra_section_collinear_check_detects_overlay():
             line_id=line,
             points=[(0.0, 100.0), (200.0, 100.0)],
             is_inter_section=False,
-            offsets_applied=True,
+            offset_regime=OffsetRegime.BAKED,
         )
 
     graph = SimpleNamespace(stations={})  # no endpoints => no convergence excuse
@@ -1167,7 +1168,7 @@ def test_diagonal_overlay_check_detects_collapse():
             line_id=line,
             points=pts,
             is_inter_section=False,
-            offsets_applied=True,
+            offset_regime=OffsetRegime.BAKED,
         )
 
     graph = SimpleNamespace(stations={})
@@ -1246,7 +1247,7 @@ def test_stacked_elbow_check_detects_graze():
             line_id=line,
             points=[(x, y_lo), (x, y_hi)],
             is_inter_section=True,
-            offsets_applied=True,
+            offset_regime=OffsetRegime.BAKED,
         )
 
     # A deep descent landing at y=100 and a shallow descent leaving it, 6px

--- a/tests/test_offset_regime.py
+++ b/tests/test_offset_regime.py
@@ -1,0 +1,165 @@
+"""Tests for the unified offset regime.
+
+A routed path carries its parallel-line separation in one of two regimes
+(:class:`OffsetRegime`): ``DEFERRED`` routes leave it to the renderer, which
+shifts their endpoints in Y; ``BAKED`` routes already carry it in their points
+(a TB X-stagger, a rail per-line Y, a bundle's concentric fan).  Mixing the two
+is the §4.8 fragility: every spacing-aware pass must know which regime a route
+is in.
+
+Covers:
+
+* ``apply_route_offsets`` is the single regime-aware applier: it shifts a
+  deferred route's endpoints and returns a baked route's points verbatim.
+* Happy-path: every shipped fixture's deferred routes apply their separation
+  laterally (no deferred route carries an offset along a vertical terminal
+  segment).
+* Always-on + meaningfulness: a deferred route planted with a non-zero offset
+  on a vertical terminal segment is caught by the check and aborts the render
+  path, while the clean routing does not.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    apply_route_offsets,
+    compute_station_offsets,
+    route_edges,
+)
+from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.layout.routing.invariants import (
+    CurveInvariantError,
+    assert_render_curve_invariants,
+    check_deferred_offsets_apply_laterally,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import Edge
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES = REPO_ROOT / "examples"
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = []
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    paths.extend(sorted((EXAMPLES / "topologies").glob("*.mmd")))
+    paths.extend(sorted((EXAMPLES / "guide").glob("*.mmd")))
+    paths.extend(sorted(FIXTURES.glob("*.mmd")))
+    return paths
+
+
+def _route(path: Path):
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    return graph, routes, offsets
+
+
+def _edge() -> Edge:
+    return Edge(source="a", target="b", line_id="L")
+
+
+def test_apply_route_offsets_shifts_deferred_endpoints() -> None:
+    """A deferred route's endpoints shift by their station offset; interior
+    points go to whichever end they are nearer."""
+    route = RoutedPath(
+        edge=_edge(),
+        line_id="L",
+        points=[(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)],
+        offset_regime=OffsetRegime.DEFERRED,
+    )
+    offsets = {("a", "L"): 5.0, ("b", "L"): -3.0}
+    assert apply_route_offsets(route, offsets) == [
+        (0.0, 5.0),
+        (50.0, 5.0),  # nearer the source end
+        (100.0, -3.0),
+    ]
+
+
+def test_apply_route_offsets_returns_baked_points_verbatim() -> None:
+    """A baked route already carries its separation, so its points are
+    returned verbatim and any offset entry is ignored."""
+    points = [(0.0, 0.0), (0.0, 100.0)]
+    route = RoutedPath(
+        edge=_edge(),
+        line_id="L",
+        points=list(points),
+        offset_regime=OffsetRegime.BAKED,
+    )
+    offsets = {("a", "L"): 5.0, ("b", "L"): -3.0}
+    assert apply_route_offsets(route, offsets) == points
+
+
+def test_default_regime_is_deferred() -> None:
+    """A route with no regime declared defers its offset to render time."""
+    assert (
+        RoutedPath(
+            edge=_edge(), line_id="L", points=[(0.0, 0.0), (1.0, 0.0)]
+        ).offset_regime
+        is OffsetRegime.DEFERRED
+    )
+
+
+@pytest.mark.parametrize(
+    "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
+)
+def test_deferred_offsets_apply_laterally_in_gallery(path: Path) -> None:
+    """No shipped fixture defers an offset onto a vertical terminal segment."""
+    _graph, routes, offsets = _route(path)
+    violations = check_deferred_offsets_apply_laterally(routes, offsets)
+    assert not violations, "\n".join(v.message() for v in violations)
+
+
+def _plant_vertical_deferred_offset(routes, offsets):
+    """Force a deferred route's last segment vertical and give its target a
+    non-zero offset, so the render-time Y-shift would run along the line's own
+    travel.  Returns the mutated route's index."""
+    for i, r in enumerate(routes):
+        if r.offset_regime is not OffsetRegime.DEFERRED or len(r.points) < 2:
+            continue
+        x, y = r.points[-1]
+        # A clean vertical terminal segment whose endpoint stays put (so the
+        # endpoint remains anchored and only the regime check fires).
+        routes[i] = dataclasses.replace(r, points=[(x, y - 50.0), (x, y)])
+        offsets[(r.edge.target, r.line_id)] = 8.0
+        return i
+    raise AssertionError("no deferred route available to plant on")
+
+
+def test_planted_vertical_deferred_offset_is_caught() -> None:
+    """A deferred route with an offset on a vertical terminal segment is
+    reported, and the unmutated routing is not -- the check is neither vacuous
+    nor a false positive on the clean render."""
+    _graph, routes, offsets = _route(FIXTURES / "rnaseq_sections.mmd")
+    assert not check_deferred_offsets_apply_laterally(routes, offsets)
+
+    idx = _plant_vertical_deferred_offset(routes, offsets)
+    planted = routes[idx]
+    violations = check_deferred_offsets_apply_laterally(routes, offsets)
+    assert any(
+        v.source == planted.edge.source
+        and v.target == planted.edge.target
+        and v.which == "target"
+        for v in violations
+    ), "expected the planted vertical deferred offset to be reported"
+
+
+def test_planted_vertical_deferred_offset_aborts_render_path() -> None:
+    """The check runs on the always-on render path: the planted route aborts
+    with ``CurveInvariantError`` independent of ``compute_layout``'s validate
+    block."""
+    graph, routes, offsets = _route(FIXTURES / "rnaseq_sections.mmd")
+    assert_render_curve_invariants(graph, routes, offsets)  # clean: no raise
+
+    _plant_vertical_deferred_offset(routes, offsets)
+    with pytest.raises(CurveInvariantError, match="deferred route offset"):
+        assert_render_curve_invariants(graph, routes, offsets)

--- a/tests/test_perp_exit_over_centreline.py
+++ b/tests/test_perp_exit_over_centreline.py
@@ -20,7 +20,11 @@ import pytest
 
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.invariants import (
     assert_render_curve_invariants,
     check_bundle_order_preserved,
@@ -107,4 +111,4 @@ def test_perp_exit_over_routes_are_offset_baked(path: Path) -> None:
     graph, _offsets, routes = _route(path)
     over = _over_routes(graph, routes)
     assert over, f"{path.stem}: expected at least one up-and-over perp-exit route"
-    assert all(r.offsets_applied for r in over)
+    assert all(r.offset_regime is OffsetRegime.BAKED for r in over)

--- a/tests/test_rail_offtrack_centreline.py
+++ b/tests/test_rail_offtrack_centreline.py
@@ -28,7 +28,11 @@ import pytest
 
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.invariants import assert_render_curve_invariants
 from nf_metro.parser.mermaid import parse_metro_mermaid
 
@@ -106,4 +110,6 @@ def test_rail_offtrack_render_is_clean(stem: str) -> None:
     assert_render_curve_invariants(graph, routes, offsets)
     bundles = _offtrack_elbow_bundles(graph, routes)
     assert bundles, f"{stem}: expected routed off-track elbow edges"
-    assert all(r.offsets_applied for v in bundles.values() for r in v)
+    assert all(
+        r.offset_regime is OffsetRegime.BAKED for v in bundles.values() for r in v
+    )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import pytest
 
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.parser.mermaid import parse_metro_mermaid
 
 
@@ -410,4 +414,4 @@ def test_around_and_corridor_routes_built_from_centreline(fixture, handler):
             f"expected 4 derived corner radii, got {r.curve_radii}"
         )
         assert all(c > 0 for c in r.curve_radii)
-        assert r.offsets_applied
+        assert r.offset_regime is OffsetRegime.BAKED

--- a/tests/test_tapered_bundle.py
+++ b/tests/test_tapered_bundle.py
@@ -23,7 +23,11 @@ import pytest
 
 from nf_metro.layout.constants import COORD_TOLERANCE
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.bundle import (
     build_concentric_bundle,
     build_tapered_bundle,
@@ -65,7 +69,7 @@ def test_tapered_rigid_matches_concentric() -> None:
         assert t.line_id == r.line_id
         assert t.points == r.points
         assert t.curve_radii == r.curve_radii
-        assert t.offsets_applied == r.offsets_applied
+        assert t.offset_regime is r.offset_regime
 
 
 def test_tapered_lands_on_both_offsets() -> None:
@@ -95,7 +99,7 @@ def test_tapered_lands_on_both_offsets() -> None:
     assert by_line["std"].points[1][0] == pytest.approx(20.0 - 1.5)
     assert by_line["leg"].points[1][0] == pytest.approx(20.0 + 1.5)
     # Baked, so the renderer must not re-apply or deform.
-    assert all(r.offsets_applied for r in routes)
+    assert all(r.offset_regime is OffsetRegime.BAKED for r in routes)
     assert all(r.normalize_exempt for r in routes)
 
 

--- a/tests/test_tb_handler_centreline.py
+++ b/tests/test_tb_handler_centreline.py
@@ -28,7 +28,11 @@ import pytest
 
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.context import _build_routing_context
 from nf_metro.layout.routing.invariants import (
     assert_render_curve_invariants,
@@ -215,4 +219,4 @@ def test_tb_corner_natural_render_is_clean(family, finder, stem) -> None:
     arm_targets = {t for (_s, t) in finder(graph)}
     arm_routes = [r for r in routes if r.edge.target in arm_targets]
     assert arm_routes, f"{stem}: expected routed {family} arm edges"
-    assert all(r.offsets_applied for r in arm_routes)
+    assert all(r.offset_regime is OffsetRegime.BAKED for r in arm_routes)

--- a/tests/test_top_entry_staircase.py
+++ b/tests/test_top_entry_staircase.py
@@ -11,8 +11,9 @@ that construction, across every fixture whose routing reaches the handler:
   radius that nests non-concentrically and pinches the bundle);
 * co-travelling lines keep a constant side-of-travel order (no flip/crossing);
 * the always-on render-path guard accepts the routes;
-* each staircase route bakes its per-line offset (``offsets_applied``), the
-  signature of a builder-fanned bundle rather than a renderer-offset one.
+* each staircase route bakes its per-line offset
+  (:attr:`OffsetRegime.BAKED`), the signature of a builder-fanned bundle
+  rather than a renderer-offset one.
 
 See issue #793.
 """
@@ -24,7 +25,11 @@ from pathlib import Path
 import pytest
 
 from nf_metro.layout.engine import compute_layout
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    OffsetRegime,
+    compute_station_offsets,
+    route_edges,
+)
 from nf_metro.layout.routing.invariants import (
     assert_render_curve_invariants,
     check_bundle_order_preserved,
@@ -81,14 +86,14 @@ def test_top_entry_routes_are_builder_fanned(rel: str) -> None:
     """Each staircase route bakes its offset, as a centreline-built bundle does.
 
     A bundle fanned by the centreline builder bakes each line's per-line offset
-    into its points (``offsets_applied``); a route that defers the offset to the
-    renderer leaves the flag unset.
+    into its points (:attr:`OffsetRegime.BAKED`); a route that defers the offset
+    to the renderer stays :attr:`OffsetRegime.DEFERRED`.
     """
     graph, _offsets, routes = _routed(rel)
     staircases = _top_entry_routes(graph, routes)
     assert staircases, f"{rel}: expected at least one TOP-entry route"
     for rp in staircases:
-        assert rp.offsets_applied, (
+        assert rp.offset_regime is OffsetRegime.BAKED, (
             f"{rel}: {rp.line_id} {rp.edge.source}->{rp.edge.target} "
             "TOP-entry route did not bake its offset (not builder-fanned)"
         )


### PR DESCRIPTION
## Summary

Addresses the **offsets-regime** half of #920 (the second of the two §4.8 fragility mechanisms; child of #682). The handler-collapse half is a deliberate follow-up.

A diagram routes parallel-line separations under two regimes: LR/RL routes defer them to render time (a Y-shift of the endpoints), while TB / rail / bundle routes bake them into their points at construction (an X-stagger, a per-line rail Y, or a concentric corner fan a uniform Y-shift cannot express). Every spacing-aware pass had to know which regime a route was in, and the regime was carried by an opaque `RoutedPath.offsets_applied` boolean with the render-time application logic duplicated across the renderer and the invariants.

This PR:

- Replaces `offsets_applied: bool` with an explicit `OffsetRegime` enum (`DEFERRED` / `BAKED`) that names *why* a route pre-baked its separation. The 6 baking sites (tb_handlers, rail, bundle) and every consumer read the named regime.
- Collapses the duplicated render-time applier onto one canonical `apply_route_offsets` in `routing/common.py`. The renderer, the always-on render invariants, and the label-strike search all reuse it instead of re-deriving the Y-shift; the duplicate `_route_render_points` in invariants is removed. Layout-layer call sites import it from its canonical home rather than reaching up into `render.svg`.
- Adds an always-on guard `check_deferred_offsets_apply_laterally`: a deferred route whose endpoint offset would apply *along* a vertical terminal segment is a route left in the wrong regime, and now aborts the render path naming the edge. Validated false-positive-free across the whole corpus (3338 deferred routes, 0 violations).

Full unification onto a single render-time regime is not achievable (bundle/rail geometry cannot be expressed as a per-endpoint Y-shift), so the enum + single applier + assertion is the regime-uniformity this half can deliver.

Render output is **byte-identical** across all 157 gallery + topology fixtures.

Fixes the offsets-regime portion of #920.

## Test plan
- [x] `pytest` passes (16953 passed; new `tests/test_offset_regime.py` covers the applier, the gallery property, and a planted wrong-regime route caught on the always-on path)
- [x] `ruff check` + `ruff format --check` clean on whole repo
- [x] `mypy` clean
- [x] Routing gate-coverage ratchet green (py3.11)
- [x] Runtime validator added (`check_deferred_offsets_apply_laterally`, Tier A)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/937/) — expected verdict: no visual changes (byte-identical locally)

Generated with Claude Code
