### PR TITLE
refactor(routing): collapse LR/TB centreline construction onto axis-generic builders (#920)

### DIFF
--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -73,6 +73,71 @@ def lanes_run_along_y(direction: str) -> bool:
     return AxisFrame.axes_for_direction(direction)[1] == "y"
 
 
+Point = tuple[float, float]
+
+
+def axis_point(primary_axis: str, primary: float, secondary: float) -> Point:
+    """Assemble an ``(x, y)`` point from a ``(primary, secondary)`` coordinate pair.
+
+    *primary_axis* is the flow-axis name (``"x"`` for LR/RL, ``"y"`` for TB/BT)
+    from :meth:`AxisFrame.axes_for_direction`; *secondary* lands on the other
+    axis.  The inverse of :func:`axis_split`.
+    """
+    return (primary, secondary) if primary_axis == "x" else (secondary, primary)
+
+
+def axis_split(primary_axis: str, point: Point) -> Point:
+    """Decompose an ``(x, y)`` point into its ``(primary, secondary)`` coordinates.
+
+    The inverse of :func:`axis_point`.
+    """
+    px, py = point
+    return (px, py) if primary_axis == "x" else (py, px)
+
+
+def single_corner_centreline(
+    direction: str, src: Point, tgt: Point, *, flow_first: bool
+) -> list[Point]:
+    """Three-point centreline turning one right-angle corner from *src* to *tgt*.
+
+    The two legs run along a section's flow (primary) and lane (secondary) axes.
+    With *flow_first* the first leg runs along the flow axis to the target's flow
+    coordinate, then turns onto the lane axis into the port -- the exit-port
+    shape (an LR/RL trunk run then perpendicular rise, a TB drop then run out to
+    a side port).  Without it the legs swap order, lane axis first then flow --
+    the lane-axis entry shape (a TB side-port run in then drop onto the trunk).
+    """
+    primary_axis, _secondary_axis = AxisFrame.axes_for_direction(direction)
+    src_primary, src_secondary = axis_split(primary_axis, src)
+    tgt_primary, tgt_secondary = axis_split(primary_axis, tgt)
+    if flow_first:
+        corner = axis_point(primary_axis, tgt_primary, src_secondary)
+    else:
+        corner = axis_point(primary_axis, src_primary, tgt_secondary)
+    return [src, corner, tgt]
+
+
+def diagonal_centreline(
+    direction: str, src: Point, tgt: Point, primary_start: float, primary_end: float
+) -> list[Point]:
+    """Four-point centreline: a flow-axis run, a 45-degree diagonal, a flow-axis run.
+
+    *primary_start* and *primary_end* are the flow-axis coordinates where the
+    diagonal begins and ends (from ``_compute_diagonal_placement``).  The first
+    straight run carries the source's lane coordinate, the second the target's,
+    so the line steps from one lane to the other across the diagonal.
+    """
+    primary_axis, _secondary_axis = AxisFrame.axes_for_direction(direction)
+    _src_primary, src_secondary = axis_split(primary_axis, src)
+    _tgt_primary, tgt_secondary = axis_split(primary_axis, tgt)
+    return [
+        src,
+        axis_point(primary_axis, primary_start, src_secondary),
+        axis_point(primary_axis, primary_end, tgt_secondary),
+        tgt,
+    ]
+
+
 def segment_intersects_quad(
     x1: float,
     y1: float,

--- a/src/nf_metro/layout/routing/intra_handlers.py
+++ b/src/nf_metro/layout/routing/intra_handlers.py
@@ -22,6 +22,10 @@ from nf_metro.layout.constants import (
     MIN_STRAIGHT_EDGE,
     MIN_STRAIGHT_PORT,
 )
+from nf_metro.layout.geometry import (
+    diagonal_centreline,
+    single_corner_centreline,
+)
 from nf_metro.layout.labels import (
     label_text_width,
 )
@@ -130,7 +134,9 @@ def _route_entry_runway(
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[(sx, sy), (diag_start_x, sy), (diag_end_x, ty), (tx, ty)],
+        points=diagonal_centreline(
+            section.direction, (sx, sy), (tx, ty), diag_start_x, diag_end_x
+        ),
     )
 
 
@@ -190,13 +196,22 @@ def _route_perp_exit(
         return RoutedPath(
             edge=edge,
             line_id=edge.line_id,
-            points=[(src.x, src.y), (tgt.x, src.y), (tgt.x, tgt.y)],
+            points=single_corner_centreline(
+                src_section.direction, (src.x, src.y), (tgt.x, tgt.y), flow_first=True
+            ),
         )
-    return _route_perp_exit_bundle(edge, src, tgt, tgt_port.side, ctx)
+    return _route_perp_exit_bundle(
+        edge, src, tgt, tgt_port.side, ctx, src_section.direction
+    )
 
 
 def _route_perp_exit_bundle(
-    edge: Edge, src: Station, tgt: Station, side: PortSide, ctx: _RoutingCtx
+    edge: Edge,
+    src: Station,
+    tgt: Station,
+    side: PortSide,
+    ctx: _RoutingCtx,
+    direction: str,
 ) -> RoutedPath | None:
     """Fan a co-travelling perpendicular-exit bundle along one turning centreline.
 
@@ -234,7 +249,7 @@ def _route_perp_exit_bundle(
 
     routes = build_tapered_bundle(
         [(edge, edge.line_id, source_offset(edge.line_id), exit_offset(edge.line_id))],
-        [(sx, sy), (tx, sy), (tx, ty)],
+        single_corner_centreline(direction, (sx, sy), (tx, ty), flow_first=True),
         transition_leg=1,
         base_radius=ctx.curve_radius,
         bundle_offsets=[(source_offset(lid), exit_offset(lid)) for lid in line_ids],
@@ -415,8 +430,12 @@ def _route_diagonal(
         is_join_flag,
     )
 
+    section = ctx.graph.sections.get(src.section_id or "")
+    direction = section.direction if section else "LR"
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[(sx, sy), (diag_start_x, sy), (diag_end_x, ty), (tx, ty)],
+        points=diagonal_centreline(
+            direction, (sx, sy), (tx, ty), diag_start_x, diag_end_x
+        ),
     )

--- a/src/nf_metro/layout/routing/tb_handlers.py
+++ b/src/nf_metro/layout/routing/tb_handlers.py
@@ -152,9 +152,10 @@ def _route_tb_diagonal(
 ) -> RoutedPath:
     """Route TB edges with vertical runs and a 45-degree diagonal transition.
 
-    The transpose of ``_route_diagonal``'s horizontal-run shape: the diagonal is
-    placed along the flow axis (Y for TB) by the shared ``_compute_diagonal_placement``
-    and laid out by the shared :func:`~nf_metro.layout.geometry.diagonal_centreline`.
+    The flow-axis sibling of ``_route_diagonal``: the diagonal is placed along
+    the flow axis (Y for TB) by the shared ``_compute_diagonal_placement`` and
+    laid out by :func:`~nf_metro.layout.geometry.diagonal_centreline`, which maps
+    the flow-axis run back to vertical legs for a vertical-flow *direction*.
     """
     diag_start_y, diag_end_y = _compute_diagonal_placement(
         sy,
@@ -419,6 +420,11 @@ def _route_perp_entry_l_shape(
 
     The centreline references the port X; each line fans by its drop channel on
     the vertical leg and by its target-station Y offset on the turn-in leg.
+
+    The drop is vertical-first because the entry port is TOP/BOTTOM, regardless
+    of the target section's flow axis -- so this is a direct V-H build, not the
+    flow-relative ``single_corner_centreline`` (which would invert the leg order
+    for a horizontal-flow target).
     """
     sx, sy = src.x, src.y
     tx, ty = tgt.x, tgt.y

--- a/src/nf_metro/layout/routing/tb_handlers.py
+++ b/src/nf_metro/layout/routing/tb_handlers.py
@@ -10,6 +10,10 @@ from nf_metro.layout.constants import (
     COORD_TOLERANCE,
     MIN_STRAIGHT_EDGE,
 )
+from nf_metro.layout.geometry import (
+    diagonal_centreline,
+    single_corner_centreline,
+)
 from nf_metro.layout.routing.bundle import (
     build_offset_bundle,
     build_tapered_bundle,
@@ -76,7 +80,8 @@ def _route_tb_internal(
 
     # Different X tracks: route with vertical runs + 45-degree diagonal
     if abs(dx) >= COORD_TOLERANCE:
-        return _route_tb_diagonal(edge, sx, sy, tx, ty, ctx)
+        direction = graph.sections[src_sec].direction
+        return _route_tb_diagonal(edge, sx, sy, tx, ty, ctx, direction)
 
     # Same track: straight vertical drop
     return RoutedPath(
@@ -143,8 +148,14 @@ def _route_tb_diagonal(
     tx: float,
     ty: float,
     ctx: _RoutingCtx,
+    direction: str,
 ) -> RoutedPath:
-    """Route TB edges with vertical runs and a 45-degree diagonal transition."""
+    """Route TB edges with vertical runs and a 45-degree diagonal transition.
+
+    The transpose of ``_route_diagonal``'s horizontal-run shape: the diagonal is
+    placed along the flow axis (Y for TB) by the shared ``_compute_diagonal_placement``
+    and laid out by the shared :func:`~nf_metro.layout.geometry.diagonal_centreline`.
+    """
     diag_start_y, diag_end_y = _compute_diagonal_placement(
         sy,
         ty,
@@ -158,7 +169,9 @@ def _route_tb_diagonal(
     return RoutedPath(
         edge=edge,
         line_id=edge.line_id,
-        points=[(sx, sy), (sx, diag_start_y), (tx, diag_end_y), (tx, ty)],
+        points=diagonal_centreline(
+            direction, (sx, sy), (tx, ty), diag_start_y, diag_end_y
+        ),
         offset_regime=OffsetRegime.BAKED,
     )
 
@@ -251,7 +264,12 @@ def _route_tb_lr_exit(
     return _route_single_corner(
         edge,
         ctx,
-        [(src.x, src.y), (src.x, tgt.y), (tgt.x, tgt.y)],
+        single_corner_centreline(
+            graph.sections[src.section_id].direction,
+            (src.x, src.y),
+            (tgt.x, tgt.y),
+            flow_first=True,
+        ),
         line_ids,
         source_offset,
         target_offset,
@@ -297,7 +315,12 @@ def _route_tb_lr_entry(
     return _route_single_corner(
         edge,
         ctx,
-        [(src.x, src.y), (tgt.x, src.y), (tgt.x, tgt.y)],
+        single_corner_centreline(
+            graph.sections[src.section_id].direction,
+            (src.x, src.y),
+            (tgt.x, tgt.y),
+            flow_first=False,
+        ),
         line_ids,
         source_offset,
         target_offset,

--- a/tests/test_axis_centrelines.py
+++ b/tests/test_axis_centrelines.py
@@ -1,0 +1,152 @@
+"""Axis-generic centreline builders and the routing handlers that share them.
+
+The single-corner and diagonal centrelines an LR/RL handler builds are the
+transpose of the ones a TB handler builds.  ``geometry.single_corner_centreline``
+and ``geometry.diagonal_centreline`` express that transpose once; these tests pin
+the transpose contract and assert the LR and TB handlers both delegate to it.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout import geometry
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+TOPO = Path(__file__).parent.parent / "examples" / "topologies"
+
+SRC: geometry.Point = (0.0, 0.0)
+TGT: geometry.Point = (10.0, 5.0)
+
+
+def _layout(name: str) -> None:
+    graph = parse_metro_mermaid((TOPO / name).read_text())
+    compute_layout(graph)
+
+
+def _spy(monkeypatch: pytest.MonkeyPatch, modpath: str, fname: str) -> list[dict]:
+    """Wrap ``modpath.fname`` so each call's kwargs are recorded; return the log."""
+    mod = importlib.import_module(modpath)
+    real = getattr(mod, fname)
+    calls: list[dict] = []
+
+    def wrapper(*args, **kwargs):
+        result = real(*args, **kwargs)
+        calls.append(kwargs)
+        return result
+
+    monkeypatch.setattr(mod, fname, wrapper)
+    return calls
+
+
+def test_single_corner_centreline_exit_transposes_by_axis() -> None:
+    assert geometry.single_corner_centreline("LR", SRC, TGT, flow_first=True) == [
+        (0.0, 0.0),
+        (10.0, 0.0),
+        (10.0, 5.0),
+    ]
+    assert geometry.single_corner_centreline("TB", SRC, TGT, flow_first=True) == [
+        (0.0, 0.0),
+        (0.0, 5.0),
+        (10.0, 5.0),
+    ]
+
+
+def test_single_corner_centreline_entry_swaps_leg_order() -> None:
+    # flow_first=False turns on the lane axis first; for TB that is the X leg,
+    # for LR the Y leg -- the exact transpose of the flow_first=True corner.
+    assert geometry.single_corner_centreline("TB", SRC, TGT, flow_first=False) == [
+        (0.0, 0.0),
+        (10.0, 0.0),
+        (10.0, 5.0),
+    ]
+    assert geometry.single_corner_centreline("LR", SRC, TGT, flow_first=False) == [
+        (0.0, 0.0),
+        (0.0, 5.0),
+        (10.0, 5.0),
+    ]
+
+
+def test_diagonal_centreline_transposes_by_axis() -> None:
+    assert geometry.diagonal_centreline("LR", SRC, TGT, 3.0, 7.0) == [
+        (0.0, 0.0),
+        (3.0, 0.0),
+        (7.0, 5.0),
+        (10.0, 5.0),
+    ]
+    assert geometry.diagonal_centreline("TB", SRC, TGT, 3.0, 7.0) == [
+        (0.0, 0.0),
+        (0.0, 3.0),
+        (10.0, 7.0),
+        (10.0, 5.0),
+    ]
+
+
+def test_rl_shares_lr_orientation() -> None:
+    # RL and LR share the X primary axis (RL flips only the primary sign, at
+    # placement time), so the centreline builders produce the same shape.
+    assert geometry.single_corner_centreline(
+        "RL", SRC, TGT, flow_first=True
+    ) == geometry.single_corner_centreline("LR", SRC, TGT, flow_first=True)
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_axis_point_split_roundtrip(axis: str) -> None:
+    assert geometry.axis_split(axis, geometry.axis_point(axis, 3.0, 4.0)) == (3.0, 4.0)
+
+
+@pytest.mark.parametrize("fixture", ["tb_lr_exit_left.mmd", "tb_lr_exit_right.mmd"])
+def test_tb_lr_exit_routes_through_shared_corner_builder(
+    monkeypatch: pytest.MonkeyPatch, fixture: str
+) -> None:
+    calls = _spy(
+        monkeypatch, "nf_metro.layout.routing.tb_handlers", "single_corner_centreline"
+    )
+    _layout(fixture)
+    assert any(kw.get("flow_first") is True for kw in calls)
+
+
+def test_tb_lr_entry_routes_through_shared_corner_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _spy(
+        monkeypatch, "nf_metro.layout.routing.tb_handlers", "single_corner_centreline"
+    )
+    _layout("tb_right_entry_stack.mmd")
+    assert any(kw.get("flow_first") is False for kw in calls)
+
+
+def test_lr_perp_exit_routes_through_shared_corner_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _spy(
+        monkeypatch,
+        "nf_metro.layout.routing.intra_handlers",
+        "single_corner_centreline",
+    )
+    _layout("lr_perp_top_exit_side_entry.mmd")
+    assert any(kw.get("flow_first") is True for kw in calls)
+
+
+def test_tb_diagonal_routes_through_shared_diagonal_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _spy(
+        monkeypatch, "nf_metro.layout.routing.tb_handlers", "diagonal_centreline"
+    )
+    _layout("tb_internal_diagonal.mmd")
+    assert calls
+
+
+def test_lr_diagonal_routes_through_shared_diagonal_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _spy(
+        monkeypatch, "nf_metro.layout.routing.intra_handlers", "diagonal_centreline"
+    )
+    _layout("bypass_v_tight.mmd")
+    assert calls


### PR DESCRIPTION
## Summary

Half B of #920 (the handler-collapse half; Half A, the offsets regime, merged in #937). The LR/RL and TB routing handlers built their single-corner and diagonal centrelines as hand-written, transposed point lists. This expresses the transpose once and routes both axes through it.

- New axis-generic builders in `layout/geometry.py`, driven by `AxisFrame.axes_for_direction`: `single_corner_centreline(direction, src, tgt, *, flow_first)` and `diagonal_centreline(direction, src, tgt, primary_start, primary_end)`, plus the `axis_point` / `axis_split` orientation primitives and a `Point` alias.
- Routed through the shared builders: the LR perpendicular-exit (single + bundle), the LR diagonal fall-through and entry-runway, and the TB side-exit, side-entry, and diagonal handlers. Exit shapes pass `flow_first=True`; the TB lane-axis entry passes `flow_first=False`.
- The builders are spacing-free (routing carries no `x_spacing`/`y_spacing`), so they take a direction and resolve orientation rather than a fully-stepped `AxisFrame`.

### Deliberately left direct (documented)

These are direction-specific bundle ordering, not coordinate-axis swaps, so collapsing them would be contortion:

- The offset / reversal conventions (`_tb_x_offset`, `_perp_riser_lateral`, `reversed_offset`) and `reversal.py`'s `detect_reversed_sections` — ordering semantics with no LR transpose.
- `inter_section_handlers._route_tb_bottom_exit` — TB-specific inter-section geometry.
- The TOP/BOTTOM perp-*entry* V-H drop (`_route_perp_entry_l_shape` / `_route_perp_entry_from_corridor`): its leg order is fixed by the port side, not the section flow axis, so it stays a direct build (routing it through the flow-relative builder would invert the legs for a horizontal-flow target).

The handler functions themselves stay separate; only their centreline geometry is shared.

Fixes #920.

## Test plan
- [x] New `tests/test_axis_centrelines.py`: pins the transpose contract for both axes and asserts the LR and TB handlers delegate to the shared builders (fails on the pre-collapse tree).
- [x] Full suite green (16965 passed); routing-gate-coverage and TB-branch ratchets unchanged (no `if`/`while` added or rewritten in `layout/routing/`).
- [x] `ruff format --check`, `ruff check`, `mypy` clean on the whole repo.
- [x] Byte-identical gallery oracle: all 137 example + topology renders md5-identical to `main`.
- [ ] Render-preview verdict (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)