### PR TITLE
feat(render): validate render geometry from the drawn SVG (#679)

### DIFF
--- a/docs/dev/render.md
+++ b/docs/dev/render.md
@@ -113,6 +113,30 @@ so that existing `nf_metro.render.manifest` import paths keep working.
 `manifest_metadata_svg(graph)` returns the raw SVG `<metadata>` XML string
 for cases where the caller assembles the SVG element manually.
 
+## Render-geometry validation (`validate.py`)
+
+The layout guards and routing invariants validate geometry *before* the
+render-time regimes run — the per-line offsets `apply_route_offsets` applies,
+the multi-line label Y-shifts, and the wrapped-label lift. The picture the
+user sees only exists in the emitted SVG, so a class of defect (a line drawn
+through a label only after the offsets shift it) is invisible to them.
+
+`validate_render(svg)` closes that gap from the other side. It reads the
+finished artifact back into geometry — node markers from the embedded
+manifest, route polylines from the drawn `<path data-line-id>` ink (splitting
+at each `M` so a bridge-hop gap is a real break, and collapsing each smoothing
+`Q` to its corner), and label ink boxes from the drawn `<text>` ink — then
+runs render-geometry checks on what was drawn. The label-strike check reuses
+the authoritative `segment_strikes_label` predicate at the label's drawn font
+scale, so a finding means the rendered image is wrong, not that a
+re-derivation diverged. It needs only the SVG string, so it validates a
+produced file (in CI, or via `validate-svg --geometry`) and behind
+`render --validate` without re-running layout.
+
+The marker-crossing and offset-pitch separation checks the same direction
+calls for are tracked separately: they fire on accepted idioms (rail
+interchanges; diagonal bundles) that the bare manifest cannot yet distinguish.
+
 ## Animation (`animate.py`)
 
 `render_animation(d, graph, routes, station_offsets, theme)` appends
@@ -146,6 +170,7 @@ selectable via `%%metro style: <key>` or `--style`.
 | `bridges.py` | `compute_bridges` — detects genuine non-merging crossings and returns `BridgeBreak` gap spans; drawing is in `svg.py` |
 | `html.py` | `render_html` — standalone HTML page and inline embed snippet around the SVG |
 | `manifest.py` | nf-metro adapter for the embedded-manifest standard; `build_manifest`, `manifest_metadata_svg` |
+| `validate.py` | `validate_render` — render-geometry guards that read the drawn SVG (markers, route ink, label ink) as their own oracle |
 | `animate.py` | `render_animation` — animated balls via `<animateMotion>` |
 | `style.py` | `Theme` dataclass |
 | `legend.py` | `render_legend`, `compute_legend_dimensions` |

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -30,7 +30,7 @@ from nf_metro.parser import (
 )
 from nf_metro.parser.directives import apply_legend_directive
 from nf_metro.parser.model import LineSpread, MetroGraph
-from nf_metro.render import render_svg
+from nf_metro.render import render_svg, validate_render
 from nf_metro.render.html import render_html
 from nf_metro.render.style import Theme
 from nf_metro.themes import THEMES
@@ -246,6 +246,17 @@ def _resolve_theme(theme: str | None, graph: MetroGraph) -> Theme:
         "in a host page that supplies its own frame and heading."
     ),
 )
+@click.option(
+    "--validate",
+    "validate_geometry",
+    is_flag=True,
+    default=False,
+    help=(
+        "After rendering, run the render-geometry guards on the produced SVG "
+        "(the picture as drawn, including render-time offsets and label "
+        "lifts) and fail if any defect is found. SVG output only."
+    ),
+)
 @layout_cli_options
 def render(
     input_file: Path,
@@ -265,6 +276,7 @@ def render(
     no_dark_mode_css: bool,
     no_chrome_css: bool,
     bare: bool,
+    validate_geometry: bool,
     **layout_opts: object,
 ) -> None:
     """Render a Mermaid metro map definition to SVG or interactive HTML."""
@@ -363,6 +375,17 @@ def render(
             )
     except PhaseInvariantError as e:
         raise click.ClickException(str(e))
+
+    if validate_geometry:
+        if format_ == "html":
+            raise click.ClickException("--validate applies to --format svg only.")
+        findings = validate_render(content)
+        if findings:
+            detail = "\n".join(f"  - {f.message}" for f in findings)
+            raise click.ClickException(
+                f"render-geometry validation found {len(findings)} "
+                f"defect(s) in the drawn SVG:\n{detail}"
+            )
 
     output.write_text(content if content.endswith("\n") else content + "\n")
     click.echo(
@@ -867,8 +890,22 @@ def check_mapping_cmd(
 
 @cli.command(name="validate-svg")
 @click.argument("svg_file", type=click.Path(exists=True, path_type=Path))
-def validate_svg_cmd(svg_file: Path) -> None:
-    """Validate an SVG's embedded manifest against the manifest JSON Schema."""
+@click.option(
+    "--geometry",
+    is_flag=True,
+    default=False,
+    help=(
+        "Also run the render-geometry guards on the drawn ink (the picture as "
+        "rendered, including render-time offsets and label lifts), not just the "
+        "manifest schema."
+    ),
+)
+def validate_svg_cmd(svg_file: Path, geometry: bool) -> None:
+    """Validate an SVG's embedded manifest against the manifest JSON Schema.
+
+    With ``--geometry`` it additionally runs the render-geometry guards on the
+    drawn ink and reports any defect.
+    """
     from nf_metro.render import manifest_schema, read_manifest
 
     try:
@@ -878,7 +915,8 @@ def validate_svg_cmd(svg_file: Path) -> None:
             "validate-svg needs the jsonschema package: pip install jsonschema"
         )
 
-    manifest = read_manifest(svg_file.read_text())
+    svg = svg_file.read_text()
+    manifest = read_manifest(svg)
     if manifest is None:
         click.echo(f"{svg_file}: no diagram manifest embedded", err=True)
         raise SystemExit(1)
@@ -891,9 +929,20 @@ def validate_svg_cmd(svg_file: Path) -> None:
         click.echo(f"  at {where}: {e.message}", err=True)
         raise SystemExit(1)
 
+    if geometry:
+        findings = validate_render(svg)
+        if findings:
+            click.echo(
+                f"{svg_file}: {len(findings)} render-geometry defect(s)", err=True
+            )
+            for finding in findings:
+                click.echo(f"  - {finding.message}", err=True)
+            raise SystemExit(1)
+
     click.echo(
         f"Valid: {len(manifest.get('nodes', []))} nodes, "
         f"schema version {manifest.get('version')}"
+        + (", render geometry clean" if geometry else "")
     )
 
 

--- a/src/nf_metro/render/__init__.py
+++ b/src/nf_metro/render/__init__.py
@@ -16,8 +16,11 @@ from nf_metro.render.manifest import (
     read_manifest,
 )
 from nf_metro.render.svg import render_svg
+from nf_metro.render.validate import RenderFinding, validate_render
 
 __all__ = [
+    "RenderFinding",
+    "validate_render",
     "MANIFEST_ELEMENT_ID",
     "MANIFEST_SCHEMA_VERSION",
     "build_manifest",

--- a/src/nf_metro/render/validate.py
+++ b/src/nf_metro/render/validate.py
@@ -1,0 +1,255 @@
+"""Render-geometry guards that read the rendered SVG as their own oracle.
+
+The layout guards in :mod:`nf_metro.layout.phases.guards` and the routing
+invariants validate geometry *before* the render-time regimes run -- the
+per-line offsets applied by :func:`~nf_metro.render.svg.apply_route_offsets`,
+the multi-line label Y-shifts, and the wrapped-label lift off foreign trunks.
+The picture the user actually sees only exists in the emitted SVG.
+
+:func:`validate_render` closes that gap from the other side: it parses the
+finished artifact back into node markers (from the embedded manifest), route
+polylines (from the drawn ``<path data-line-id>`` ink), and label ink boxes
+(from the drawn ``<text>`` ink), then runs render-geometry checks on what was
+drawn.  Because the predicate is the project's authoritative one
+(:func:`~nf_metro.layout.labels.segment_strikes_label`) applied to the parsed
+ink, a finding means the rendered image is wrong, not that a re-derivation
+diverged.
+
+The checks are decoupled from the engine: they need only the SVG string, so
+they validate a produced file in CI or standalone without re-running layout,
+and they see the render-only geometry the pre-render guards cannot.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, NamedTuple
+
+from nf_metro.layout.constants import LABEL_FONT_SIZE, LABEL_LINE_HEIGHT
+from nf_metro.layout.labels import (
+    LabelPlacement,
+    font_scale_context,
+    segment_strikes_label,
+)
+from nf_metro.manifest import read_manifest
+
+# The defect family of a finding; one per render-geometry check.
+LABEL_STRIKE = "label-strike"
+
+
+class RenderFinding(NamedTuple):
+    """One render-geometry defect read back out of the drawn SVG.
+
+    Captured from the rendered ink (after the offset and label-lift regimes),
+    so a finding is a real visual defect in the user's output.  ``segment`` is
+    the drawn line segment ``((x1, y1), (x2, y2))`` that triggered it.
+    """
+
+    kind: str
+    line_id: str
+    station_id: str
+    message: str
+    segment: tuple[tuple[float, float], tuple[float, float]]
+
+
+class _Label(NamedTuple):
+    placement: LabelPlacement
+    font_size: float
+
+
+# A single route renders as one element per metro line; ``metro-direction-*``
+# chevrons (the optional directional markers) also carry ``data-line-id`` but
+# are not the route, so the route class substring gates them out.
+_ROUTE_CLASS = "metro-line-"
+_NUM = re.compile(r"-?\d+(?:\.\d+)?")
+_ELEMENT = re.compile(r"<(path|line)\b([^>]*?)/?>", re.DOTALL)
+_TEXT = re.compile(r"<text\b([^>]*?)>(.*?)</text>", re.DOTALL)
+_TSPAN = re.compile(r"<tspan\b[^>]*>(.*?)</tspan>", re.DOTALL)
+_TAG = re.compile(r"<[^>]+>")
+
+
+def _attr(attrs: str, name: str, default: str | None = None) -> str | None:
+    match = re.search(rf'\b{name}="([^"]*)"', attrs)
+    return match.group(1) if match else default
+
+
+def parse_route_polylines(
+    svg: str,
+) -> list[tuple[str, list[list[tuple[float, float]]]]]:
+    """Reconstruct each drawn route's polylines from the SVG ink.
+
+    Returns ``(line_id, subpaths)`` per drawn route element, where each subpath
+    is a list of ``(x, y)`` vertices.  A route splits into several subpaths at
+    every ``M`` after the first, so a bridged edge's hop gap is a real break
+    rather than a phantom segment spanning it.  Each smoothing ``Q`` is
+    collapsed back to its corner (the control point), which is the exact
+    pre-smoothing vertex, so the polyline equals the logical routed path.
+    """
+    routes: list[tuple[str, list[list[tuple[float, float]]]]] = []
+    for tag, attrs in _ELEMENT.findall(svg):
+        cls = _attr(attrs, "class") or ""
+        if _ROUTE_CLASS not in cls:
+            continue
+        line_id = _attr(attrs, "data-line-id") or ""
+        if tag == "line":
+            x1, y1, x2, y2 = (
+                float(_attr(attrs, k) or 0.0) for k in ("x1", "y1", "x2", "y2")
+            )
+            routes.append((line_id, [[(x1, y1), (x2, y2)]]))
+            continue
+        d = _attr(attrs, "d") or ""
+        subpaths: list[list[tuple[float, float]]] = []
+        current: list[tuple[float, float]] = []
+        for cmd, body in re.findall(r"([MLQ])([^MLQ]*)", d):
+            nums = [float(n) for n in _NUM.findall(body)]
+            if cmd == "M":
+                if current:
+                    subpaths.append(current)
+                current = [(nums[0], nums[1])]
+            elif cmd == "L":
+                current.append((nums[0], nums[1]))
+            elif cmd == "Q":
+                if current:
+                    current.pop()
+                current.append((nums[0], nums[1]))
+        if current:
+            subpaths.append(current)
+        routes.append((line_id, subpaths))
+    return routes
+
+
+def parse_station_labels(svg: str) -> list[_Label]:
+    """Reconstruct station-label ink placements from the drawn ``<text>`` ink.
+
+    Inverts :func:`~nf_metro.render.svg._render_labels`' emission: the
+    ``dominant-baseline`` attribute names the side (``auto`` above, ``hanging``
+    below, ``central`` centred), the multi-line block's anchor Y is recovered
+    from the per-line ``dy`` stacking the renderer applied, and a ``rotate``
+    transform restores the diagonal angle.  The resulting
+    :class:`~nf_metro.layout.labels.LabelPlacement` feeds the authoritative
+    glyph-ink predicates so the box matches what was drawn.
+    """
+    labels: list[_Label] = []
+    for attrs, body in _TEXT.findall(svg):
+        station_id = _attr(attrs, "data-station-id")
+        cls = _attr(attrs, "class") or ""
+        if station_id is None or "station-label" not in cls:
+            continue
+        spans = _TSPAN.findall(body)
+        text = (
+            "\n".join(_TAG.sub("", s) for s in spans) if spans else _TAG.sub("", body)
+        )
+        text = text.strip("\n")
+        x = float(_attr(attrs, "x") or 0.0)
+        y = float(_attr(attrs, "y") or 0.0)
+        font_size = float(_attr(attrs, "font-size") or LABEL_FONT_SIZE)
+        anchor = _attr(attrs, "text-anchor") or "start"
+        baseline = _attr(attrs, "dominant-baseline") or ""
+        rotate = re.search(r"rotate\(([-\d.]+)", attrs)
+        angle = float(rotate.group(1)) if rotate else 0.0
+
+        # A rotated label is emitted at its anchor already; only the upright
+        # baselines carry the multi-line Y stacking that has to be undone.
+        n_lines = text.count("\n") + 1
+        line_spacing = font_size * LABEL_LINE_HEIGHT
+        above = False
+        dominant = ""
+        if not angle:
+            if baseline == "auto":
+                above = True
+                y += (n_lines - 1) * line_spacing
+            elif baseline == "central":
+                dominant = "central"
+                y += (n_lines - 1) * line_spacing / 2
+            elif baseline and baseline != "hanging":
+                dominant = baseline
+
+        labels.append(
+            _Label(
+                LabelPlacement(
+                    station_id=station_id,
+                    text=text,
+                    x=x,
+                    y=y,
+                    above=above,
+                    angle=angle,
+                    text_anchor=anchor,
+                    dominant_baseline=dominant,
+                ),
+                font_size,
+            )
+        )
+    return labels
+
+
+def _nodes_by_id(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {node["id"]: node for node in manifest.get("nodes", [])}
+
+
+def check_label_strikes(
+    svg: str,
+    manifest: dict[str, Any],
+    routes: list[tuple[str, list[list[tuple[float, float]]]]],
+) -> list[RenderFinding]:
+    """A drawn route segment striking through a station name's glyph ink.
+
+    A line painting over a label reads as a strike-through, and a pixel oracle
+    false-negatives on it because the line covers the text.  A segment is exempt
+    when its line is one the labelled station carries (the
+    manifest ``groups``, which subsumes the case of the station being that
+    edge's own endpoint).  Uses the authoritative glyph-ink footprint at the
+    label's drawn font scale, so it fires only on the inked glyphs, not the
+    reserved margin around them.
+    """
+    nodes = _nodes_by_id(manifest)
+    findings: list[RenderFinding] = []
+    for placement, font_size in parse_station_labels(svg):
+        node = nodes.get(placement.station_id)
+        if node is None:
+            continue
+        carried = set(node.get("groups", ()))
+        scale = font_size / LABEL_FONT_SIZE
+        with font_scale_context(scale):
+            for line_id, subpaths in routes:
+                if line_id in carried:
+                    continue
+                for subpath in subpaths:
+                    hit = _first_striking_segment(subpath, placement)
+                    if hit is not None:
+                        findings.append(
+                            RenderFinding(
+                                LABEL_STRIKE,
+                                line_id,
+                                placement.station_id,
+                                f"line {line_id!r} strikes through the label of "
+                                f"{placement.station_id!r} ({placement.text!r})",
+                                hit,
+                            )
+                        )
+                        break
+    return findings
+
+
+def _first_striking_segment(
+    subpath: list[tuple[float, float]], placement: LabelPlacement
+) -> tuple[tuple[float, float], tuple[float, float]] | None:
+    for i in range(len(subpath) - 1):
+        (x1, y1), (x2, y2) = subpath[i], subpath[i + 1]
+        if segment_strikes_label(x1, y1, x2, y2, placement):
+            return ((x1, y1), (x2, y2))
+    return None
+
+
+def validate_render(svg: str) -> list[RenderFinding]:
+    """Run the render-geometry guards on a rendered SVG and return findings.
+
+    Reads the embedded manifest for node identities and parses the drawn route
+    and label ink, then checks for label strikes on the geometry as drawn.
+    Returns an empty list for a clean render, or when the SVG carries no
+    manifest (nothing addressable to validate).
+    """
+    manifest = read_manifest(svg)
+    if manifest is None:
+        return []
+    routes = parse_route_polylines(svg)
+    return check_label_strikes(svg, manifest, routes)

--- a/tests/test_render_validate.py
+++ b/tests/test_render_validate.py
@@ -1,0 +1,186 @@
+"""Render-geometry validation reads the drawn SVG as its own oracle (#679).
+
+:func:`~nf_metro.render.validate.validate_render` parses a rendered SVG back
+into node markers (embedded manifest), route polylines (drawn ``<path>`` ink),
+and label ink boxes (drawn ``<text>`` ink) and checks the picture as drawn --
+the geometry the pre-render layout guards never see, including render-time
+offsets and the wrapped-label lift.
+
+These tests pin that the clean gallery corpus has zero label strikes, that an
+injected strike is caught and an exempt (carried-line) overlap is not, and that
+the SVG parser recovers smoothing corners exactly and breaks at bridge-hop gaps
+rather than spanning them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
+from nf_metro.render import render_svg, validate_render
+from nf_metro.render.manifest import read_manifest
+from nf_metro.render.validate import (
+    LABEL_STRIKE,
+    parse_route_polylines,
+    parse_station_labels,
+)
+from nf_metro.themes import THEMES
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+TOPOLOGIES = EXAMPLES / "topologies"
+
+
+def _renderable_corpus() -> tuple[list[str], dict[str, MetroGraph]]:
+    """Collect renderable fixtures and their laid-out graphs in one pass.
+
+    Filtering at import time keeps the parametrization to fixtures that
+    actually render (a newly-broken one drops out, caught by the count guard);
+    caching the laid-out graph lets each test render without a second layout.
+    """
+    names: list[str] = []
+    graphs: dict[str, MetroGraph] = {}
+    for path in sorted(EXAMPLES.glob("*.mmd")) + sorted(TOPOLOGIES.glob("*.mmd")):
+        try:
+            graph = parse_metro_mermaid(path.read_text())
+            compute_layout(graph)
+        except Exception:  # noqa: BLE001 - unrenderable fixtures are not our subject
+            continue
+        rel = path.relative_to(EXAMPLES).as_posix()
+        names.append(rel)
+        graphs[rel] = graph
+    return names, graphs
+
+
+CORPUS, _LAID_OUT = _renderable_corpus()
+
+
+def _render(rel_name: str) -> str:
+    graph = _LAID_OUT[rel_name]
+    theme_name = graph.style if graph.style in THEMES else "nfcore"
+    return render_svg(graph, THEMES[theme_name])
+
+
+@pytest.mark.parametrize("name", CORPUS)
+def test_clean_corpus_has_no_label_strike(name: str) -> None:
+    """No gallery render draws a line through a non-consumer station's label."""
+    findings = validate_render(_render(name))
+    strikes = [f for f in findings if f.kind == LABEL_STRIKE]
+    assert not strikes, f"{name}: {[f.message for f in strikes]}"
+
+
+def _a_foreign_label(svg: str) -> tuple[str, float, float, str]:
+    """A station label plus a line that station does not carry.
+
+    Returns ``(station_id, label_x, label_y, foreign_line_id)`` for a label
+    whose station omits at least one defined line, so a segment drawn across it
+    is an unambiguous strike by a non-consumer.
+    """
+    manifest = read_manifest(svg)
+    nodes = {n["id"]: n for n in manifest["nodes"]}
+    all_lines = [grp["id"] for grp in manifest["groups"]]
+    for placement, _font_size in parse_station_labels(svg):
+        node = nodes.get(placement.station_id)
+        if node is None:
+            continue
+        foreign = [lid for lid in all_lines if lid not in node.get("groups", ())]
+        if foreign:
+            return placement.station_id, placement.x, placement.y, foreign[0]
+    raise AssertionError("no label with a non-consumer line found")
+
+
+def _inject_segment(
+    svg: str, line_id: str, p1: tuple[float, float], p2: tuple[float, float]
+) -> str:
+    seg = (
+        f'<path d="M{p1[0]},{p1[1]} L{p2[0]},{p2[1]}" '
+        f'class="metro-line-{line_id}" data-line-id="{line_id}" />'
+    )
+    return svg.replace("</svg>", seg + "</svg>")
+
+
+def test_validate_render_flags_injected_strike() -> None:
+    """A foreign line drawn through a label's centre is reported as a strike."""
+    svg = _render("rnaseq_sections.mmd")
+    station_id, x, y, foreign = _a_foreign_label(svg)
+    struck = _inject_segment(svg, foreign, (x - 40, y), (x + 40, y))
+
+    findings = validate_render(struck)
+    strikes = [f for f in findings if f.kind == LABEL_STRIKE]
+    assert len(strikes) == 1
+    assert strikes[0].line_id == foreign
+    assert strikes[0].station_id == station_id
+
+
+def test_carried_line_overlap_is_exempt() -> None:
+    """A line the labelled station carries is not a strike (it owns that name)."""
+    svg = _render("rnaseq_sections.mmd")
+    manifest = read_manifest(svg)
+    nodes = {n["id"]: n for n in manifest["nodes"]}
+    placement = next(
+        pl for pl, _ in parse_station_labels(svg) if nodes[pl.station_id].get("groups")
+    )
+    carried = nodes[placement.station_id]["groups"][0]
+    over = _inject_segment(
+        svg,
+        carried,
+        (placement.x - 40, placement.y),
+        (placement.x + 40, placement.y),
+    )
+    assert not validate_render(over)
+
+
+def test_no_manifest_yields_no_findings() -> None:
+    """An SVG without an embedded manifest has nothing addressable to validate."""
+    plain = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0,0 L9,9"/></svg>'
+    assert validate_render(plain) == []
+
+
+def test_parser_collapses_smoothing_curve_to_its_corner() -> None:
+    """A ``Q`` smoothing arc is read back as its sharp corner (control point)."""
+    svg = (
+        '<path d="M0,0 L40,0 Q50,0,50,10 L50,50" '
+        'class="metro-line-x" data-line-id="x" />'
+    )
+    (line_id, subpaths) = parse_route_polylines(svg)[0]
+    assert line_id == "x"
+    assert subpaths == [[(0.0, 0.0), (50.0, 0.0), (50.0, 50.0)]]
+
+
+def test_parser_breaks_at_bridge_hop_gap() -> None:
+    """A second ``M`` (a bridge hop) starts a new subpath, never a span across."""
+    svg = '<path d="M0,0 L40,0 M60,0 L100,0" class="metro-line-x" data-line-id="x" />'
+    (_, subpaths) = parse_route_polylines(svg)[0]
+    assert subpaths == [[(0.0, 0.0), (40.0, 0.0)], [(60.0, 0.0), (100.0, 0.0)]]
+
+
+def test_directional_chevrons_are_not_parsed_as_routes() -> None:
+    """``metro-direction-*`` chevrons carry ``data-line-id`` but are not routes."""
+    svg = (
+        '<path d="M0,0 L9,9" class="metro-line-x" data-line-id="x" />'
+        '<path d="M3,3 L6,6" class="metro-direction-x" data-line-id="x" />'
+    )
+    parsed = parse_route_polylines(svg)
+    assert [line_id for line_id, _ in parsed] == ["x"]
+
+
+@pytest.mark.parametrize(
+    "name", ["differentialabundance_default.mmd", "genomic_pipeline.mmd"]
+)
+def test_real_render_routes_split_on_bridge_gaps(name: str) -> None:
+    """A real render with bridged edges yields multi-subpath routes, none empty."""
+    if name not in CORPUS:
+        pytest.skip(f"{name} not in renderable corpus")
+    routes = parse_route_polylines(_render(name))
+    assert routes
+    assert all(sub for _, subs in routes for sub in subs)
+    assert any(len(subs) > 1 for _, subs in routes)
+
+
+def test_corpus_is_nonempty() -> None:
+    """The corpus parametrization actually collected fixtures (guards a silent
+    empty-glob that would make the regression lock vacuous)."""
+    assert len(CORPUS) > 30


### PR DESCRIPTION
## Summary

Adds `validate_render(svg)`: a render-geometry oracle that reads the **finished SVG** back into geometry and checks the picture *as drawn*. This is a new guard family, distinct from the layout guards and routing invariants, which all validate geometry *before* the render-time regimes run (the per-line offsets `apply_route_offsets` applies, multi-line label Y-shifts, the wrapped-label lift) and so cannot see what the user actually sees.

- **`src/nf_metro/render/validate.py`** parses the artifact back into:
  - node markers, from the embedded manifest;
  - route polylines, from the drawn `<path data-line-id>` ink (split into subpaths at each `M` so a bridge-hop gap is a real break, with each smoothing `Q` collapsed to its exact corner — directional `metro-direction-*` chevrons are excluded);
  - label ink boxes, from the drawn `<text>` ink (inverting the renderer's baseline/`dy`/`rotate` emission).
  - The **label-strike** check reuses the authoritative `segment_strikes_label` predicate at the label's drawn font scale, so a finding means the rendered image is wrong, not that a re-derivation diverged.
- **Decoupled from the engine** — needs only the SVG string, so it validates a produced file standalone. Surfaced behind `render --validate` and `validate-svg --geometry`; the parametrised corpus test is the CI gate.
- **No render-path change**: `validate_render` is opt-in and never called from `render_svg`, so the gallery renders byte-identically to `main`.

### Scope

The label-strike guard is shipped here: it is false-positive-clean across the 137-fixture example corpus, and the entire visual-strike guard family is currently Tier-B and runs nowhere on the render path, so this is the only cheap render-time / standalone catch for it.

The other two checks the #679 direction names are deferred to **#942**, because each fires on an accepted idiom the bare manifest cannot yet distinguish:
- **marker-crossing** (breeze-past): accurate, but its corpus hits are all **rail interchange** stations where a line passing through is the intended idiom, and the manifest carries no rail flag to exempt them;
- **offset-pitch separation** (#663 class): a fixed perpendicular threshold false-positives on diagonal bundles (4px vertical pitch = ~2.8px perpendicular); a correct version needs a pitch-aware oracle and adjudication of borderline gallery cases.

Closes #679. Defers the remaining two guards to #942.

## Test plan
- [x] `pytest` passes (new `tests/test_render_validate.py`: corpus-wide strike-free lock, injected-strike detection, carried-line exemption, parser corner/bridge-gap/chevron behaviour). Pre-existing `test_font_portability` failures are env-only (missing `fontTools[woff]`), pass once installed.
- [x] `ruff check` + `ruff format --check` + `mypy` clean on the whole repo
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/944/)
- [ ] Render-preview verdict: expected **No visual changes** (`render_svg` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
