### PR TITLE
feat(render): rail-aware marker-cross + offset-pitch separation guards (#942)

### DIFF
--- a/docs/dev/render.md
+++ b/docs/dev/render.md
@@ -126,16 +126,28 @@ finished artifact back into geometry — node markers from the embedded
 manifest, route polylines from the drawn `<path data-line-id>` ink (splitting
 at each `M` so a bridge-hop gap is a real break, and collapsing each smoothing
 `Q` to its corner), and label ink boxes from the drawn `<text>` ink — then
-runs render-geometry checks on what was drawn. The label-strike check reuses
-the authoritative `segment_strikes_label` predicate at the label's drawn font
-scale, so a finding means the rendered image is wrong, not that a
-re-derivation diverged. It needs only the SVG string, so it validates a
-produced file (in CI, or via `validate-svg --geometry`) and behind
-`render --validate` without re-running layout.
+runs render-geometry checks on what was drawn. Three checks run:
 
-The marker-crossing and offset-pitch separation checks the same direction
-calls for are tracked separately: they fire on accepted idioms (rail
-interchanges; diagonal bundles) that the bare manifest cannot yet distinguish.
+- **label-strike** reuses the authoritative `segment_strikes_label` predicate
+  at the label's drawn font scale, so a finding means the rendered image is
+  wrong, not that a re-derivation diverged.
+- **marker-cross** flags a route segment through a non-consumer station's
+  marker (a line the station carries, via the manifest `groups`, is exempt).
+  Rail-interchange stations are exempt too — a line threading an interchange
+  knob is the intended rail idiom — and their ids are read back from the drawn
+  `...-rail-...` markers, since the manifest carries no rail flag.
+- **offset-collapse** flags two distinct lines drawn flush where the offset
+  regime assigned them a full `OFFSET_STEP` apart. Two lines on the same
+  assigned slot draw flush by design (a shared-trunk bundle), so the check
+  compares the drawn gap against the gap the regime *assigned*, not a constant.
+
+label-strike and marker-cross are pure artifact oracles (the SVG string is
+enough), so they run on a produced file in CI, via `validate-svg --geometry`,
+and behind `render --validate`. offset-collapse needs the engine's assigned
+offsets to tell an intended same-slot bundle from a real merge, so
+`validate_render(svg, *, graph=...)` runs it only when the laid-out graph is
+supplied — the `render --validate` path and the CI corpus test, not the
+standalone SVG path.
 
 ## Animation (`animate.py`)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,16 @@ The page supports drag-to-pan, scroll-to-zoom, station hover tooltips, and a cli
 
 The **Embed&hellip;** button opens a panel with copyable inline-HTML, iframe, and static-SVG snippets. The [Embedding guide](embedding.md) explains when to reach for each, plus responsive sizing, font portability, host theming, and progress overlays.
 
+#### Validating the rendered geometry
+
+Pass `--validate` to check the *drawn* SVG after rendering and fail (non-zero exit) if a route is drawn through a station's label or marker, or two distinct lines collapse into one stroke where they should run parallel. This reads the geometry as it ends up on the page (after the per-line offsets and label shifts the layout applies), catching defects the pre-render checks cannot see:
+
+```bash
+nf-metro render pipeline.mmd -o pipeline.svg --validate
+```
+
+To run the same geometry checks on an already-rendered SVG, use [`nf-metro validate-svg --geometry`](manifest.md#manifest-schema).
+
 ### `nf-metro convert`
 
 Convert a Nextflow `-with-dag` mermaid file to nf-metro format.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -141,6 +141,15 @@ nf-metro validate-svg pipeline.svg
 (`validate-svg` uses `jsonschema`; install it with `pip install jsonschema` if it
 isn't already present.)
 
+Add `--geometry` to also check the *drawn* picture, not just the schema: it flags
+a route drawn through a station's label or marker (rail interchanges excepted).
+The offset-collapse check (distinct lines merging into one stroke) needs the
+engine's assigned offsets, so it runs only via [`render --validate`](index.md#validating-the-rendered-geometry).
+
+```bash
+nf-metro validate-svg pipeline.svg --geometry
+```
+
 In another language, extract the `<metadata id="diagram-manifest">` JSON the same
 way and feed it, with the shipped `schema.json`, to any standard JSON Schema
 validator.

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -379,7 +379,7 @@ def render(
     if validate_geometry:
         if format_ == "html":
             raise click.ClickException("--validate applies to --format svg only.")
-        findings = validate_render(content)
+        findings = validate_render(content, graph=graph)
         if findings:
             detail = "\n".join(f"  - {f.message}" for f in findings)
             raise click.ClickException(
@@ -895,16 +895,17 @@ def check_mapping_cmd(
     is_flag=True,
     default=False,
     help=(
-        "Also run the render-geometry guards on the drawn ink (the picture as "
-        "rendered, including render-time offsets and label lifts), not just the "
-        "manifest schema."
+        "Also run the artifact-only render-geometry guards on the drawn ink "
+        "(label strikes and non-consumer marker crossings), not just the "
+        "manifest schema. The offset-collapse check needs the engine's assigned "
+        "offsets and runs only via 'render --validate'."
     ),
 )
 def validate_svg_cmd(svg_file: Path, geometry: bool) -> None:
     """Validate an SVG's embedded manifest against the manifest JSON Schema.
 
-    With ``--geometry`` it additionally runs the render-geometry guards on the
-    drawn ink and reports any defect.
+    With ``--geometry`` it additionally runs the artifact-only render-geometry
+    guards on the drawn ink and reports any defect.
     """
     from nf_metro.render import manifest_schema, read_manifest
 

--- a/src/nf_metro/render/validate.py
+++ b/src/nf_metro/render/validate.py
@@ -145,6 +145,18 @@ def parse_route_polylines(
     return routes
 
 
+def drawn_segments(
+    routes: list[tuple[str, _Subpaths]],
+) -> list[tuple[str, _Point, _Point]]:
+    """Flatten parsed route subpaths into ``(line_id, p1, p2)`` drawn segments."""
+    return [
+        (line_id, subpath[i], subpath[i + 1])
+        for line_id, subpaths in routes
+        for subpath in subpaths
+        for i in range(len(subpath) - 1)
+    ]
+
+
 def parse_station_labels(svg: str) -> list[_Label]:
     """Reconstruct station-label ink placements from the drawn ``<text>`` ink.
 
@@ -369,22 +381,16 @@ def check_offset_collapse(
     expected = _expected_line_segments(graph)
     if not expected:
         return []
-    drawn = [
-        (line_id, subpath[i], subpath[i + 1])
-        for line_id, subpaths in routes
-        for subpath in subpaths
-        for i in range(len(subpath) - 1)
-    ]
+    drawn = drawn_segments(routes)
     findings: list[RenderFinding] = []
     seen: set[tuple[str, str, int, int]] = set()
     for i, (line_a, a1, a2) in enumerate(drawn):
         for line_b, b1, b2 in drawn[i + 1 :]:
             if line_b == line_a:
                 continue
-            run = _flush_run((a1, a2), (b1, b2))
-            if run is None:
+            midpoint = _flush_run((a1, a2), (b1, b2))
+            if midpoint is None:
                 continue
-            midpoint = run
             anchor = _nearest_vertex(expected.get(line_a, ()), midpoint)
             if anchor is None:
                 continue

--- a/src/nf_metro/render/validate.py
+++ b/src/nf_metro/render/validate.py
@@ -15,17 +15,27 @@ drawn.  Because the predicate is the project's authoritative one
 ink, a finding means the rendered image is wrong, not that a re-derivation
 diverged.
 
-The checks are decoupled from the engine: they need only the SVG string, so
-they validate a produced file in CI or standalone without re-running layout,
-and they see the render-only geometry the pre-render guards cannot.
+Three checks run on the drawn ink.  The **label-strike** and **marker-cross**
+checks are pure artifact oracles -- they need only the SVG string, so they
+validate a produced file standalone without re-running layout.  The
+**offset-collapse** check is offset-pitch-aware: telling an acceptable
+same-slot bundle (distinct lines the regime put on one offset, drawn flush by
+design) from a real collapse (lines the regime spread apart, drawn flush)
+needs the assigned offsets, which the bare artifact cannot supply.  It
+therefore runs only when the laid-out ``graph`` is passed alongside the SVG;
+the standalone path runs the two artifact-only checks.
+
+All three see the render-only geometry (the offset regime, label Y-shifts, the
+wrapped-label lift) that the pre-render layout guards never observe.
 """
 
 from __future__ import annotations
 
 import re
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
-from nf_metro.layout.constants import LABEL_FONT_SIZE, LABEL_LINE_HEIGHT
+from nf_metro.layout.constants import LABEL_FONT_SIZE, LABEL_LINE_HEIGHT, OFFSET_STEP
+from nf_metro.layout.geometry import segment_intersects_bbox
 from nf_metro.layout.labels import (
     LabelPlacement,
     font_scale_context,
@@ -33,8 +43,25 @@ from nf_metro.layout.labels import (
 )
 from nf_metro.manifest import read_manifest
 
+if TYPE_CHECKING:
+    from nf_metro.parser.model import MetroGraph
+
 # The defect family of a finding; one per render-geometry check.
 LABEL_STRIKE = "label-strike"
+MARKER_CROSS = "marker-cross"
+OFFSET_COLLAPSE = "offset-collapse"
+
+# A drawn run shorter than this reads as a corner nub, not a parallel stretch;
+# two lines closer than ``_FLUSH_TOL`` perpendicular read as a single stroke.
+_RUN_MIN = 8.0
+_FLUSH_TOL = 1.5
+# A pair the offset regime spread by a full step (allowing diagonal foreshorten
+# and rounding) is meant to read as two lines; drawn flush, it has collapsed.
+_PITCH_MIN = OFFSET_STEP - 0.5
+
+_Point = tuple[float, float]
+_Segment = tuple[_Point, _Point]
+_Subpaths = list[list[_Point]]
 
 
 class RenderFinding(NamedTuple):
@@ -186,6 +213,33 @@ def _nodes_by_id(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {node["id"]: node for node in manifest.get("nodes", [])}
 
 
+# Rail-mode markers (knob, knob outline, connector bar) all carry both an
+# ``...-rail-...`` class and the station id; a line threading an interchange
+# knob is the intended rail idiom, so the station id signals a marker-cross
+# exemption straight from the artifact (the manifest carries no rail flag).
+_RAIL_MARKER = re.compile(r"<\w+\b[^>]*?\brail\b[^>]*?/?>", re.DOTALL)
+
+
+def parse_rail_station_ids(svg: str) -> set[str]:
+    """Recover the set of rail-station ids from the drawn rail markers.
+
+    A line passing through a rail interchange's knob is the deliberate rail
+    idiom (the same reason the hanging-route guard skips rail endpoints), so
+    :func:`check_marker_crossings` reads these ids back from the SVG to exempt
+    rail stations without a manifest schema addition.
+    """
+    ids: set[str] = set()
+    for match in _RAIL_MARKER.finditer(svg):
+        element = match.group(0)
+        cls = _attr(element, "class") or ""
+        if "rail" not in cls:
+            continue
+        sid = _attr(element, "data-station-id")
+        if sid is not None:
+            ids.add(sid)
+    return ids
+
+
 def check_label_strikes(
     svg: str,
     manifest: dict[str, Any],
@@ -240,16 +294,223 @@ def _first_striking_segment(
     return None
 
 
-def validate_render(svg: str) -> list[RenderFinding]:
+def check_marker_crossings(
+    svg: str,
+    manifest: dict[str, Any],
+    routes: list[tuple[str, _Subpaths]],
+) -> list[RenderFinding]:
+    """A drawn route segment passing through a non-consumer station's marker.
+
+    A line raking across a station marker reads as the route running through
+    that station, so it must touch only the markers of stations that carry it.
+    A segment is exempt when its line is one the marker's station carries (the
+    manifest ``groups``, which subsumes the station being that edge's own
+    endpoint).  Rail-interchange stations are exempt too: a line threading an
+    interchange knob is the intended rail idiom, and their ids are read back
+    from the drawn rail markers.  The render-side companion to the layout
+    guard ``_guard_no_line_crosses_non_consumer``, read from the artifact so
+    it also catches any marker crossing introduced after the offset regime.
+    """
+    nodes = _nodes_by_id(manifest)
+    rail = parse_rail_station_ids(svg)
+    findings: list[RenderFinding] = []
+    for line_id, subpaths in routes:
+        for sid, node in nodes.items():
+            if sid in rail or line_id in node.get("groups", ()):
+                continue
+            radius = node.get("r", 0.0)
+            bbox = (
+                node["x"] - radius,
+                node["y"] - radius,
+                node["x"] + radius,
+                node["y"] + radius,
+            )
+            hit = _first_crossing_segment(subpaths, bbox)
+            if hit is not None:
+                findings.append(
+                    RenderFinding(
+                        MARKER_CROSS,
+                        line_id,
+                        sid,
+                        f"line {line_id!r} crosses the marker of non-consumer "
+                        f"station {sid!r}",
+                        hit,
+                    )
+                )
+    return findings
+
+
+def _first_crossing_segment(
+    subpaths: _Subpaths, bbox: tuple[float, float, float, float]
+) -> _Segment | None:
+    for subpath in subpaths:
+        for i in range(len(subpath) - 1):
+            (x1, y1), (x2, y2) = subpath[i], subpath[i + 1]
+            if segment_intersects_bbox(x1, y1, x2, y2, bbox):
+                return ((x1, y1), (x2, y2))
+    return None
+
+
+def check_offset_collapse(
+    graph: MetroGraph,
+    routes: list[tuple[str, _Subpaths]],
+) -> list[RenderFinding]:
+    """Distinct lines drawn flush where the offset regime spread them apart.
+
+    Two lines the regime assigned the same offset slot legitimately draw flush
+    (a shared-trunk bundle), so a bare perpendicular-distance floor cannot
+    distinguish that from a real collapse.  This compares the *drawn* gap on a
+    shared run against the gap the offset regime *assigned* the pair there: a
+    pair drawn flush whose assigned gap is at least one offset step has
+    collapsed into a single stroke.  The assigned geometry comes from the
+    engine, the drawn geometry from the artifact, so a finding is a real
+    render-time merge, not a re-derivation mismatch.
+    """
+    expected = _expected_line_segments(graph)
+    if not expected:
+        return []
+    drawn = [
+        (line_id, subpath[i], subpath[i + 1])
+        for line_id, subpaths in routes
+        for subpath in subpaths
+        for i in range(len(subpath) - 1)
+    ]
+    findings: list[RenderFinding] = []
+    seen: set[tuple[str, str, int, int]] = set()
+    for i, (line_a, a1, a2) in enumerate(drawn):
+        for line_b, b1, b2 in drawn[i + 1 :]:
+            if line_b == line_a:
+                continue
+            run = _flush_run((a1, a2), (b1, b2))
+            if run is None:
+                continue
+            midpoint = run
+            anchor = _nearest_vertex(expected.get(line_a, ()), midpoint)
+            if anchor is None:
+                continue
+            assigned = _perp_gap(anchor, expected.get(line_b, ()))
+            if assigned is None or assigned < _PITCH_MIN:
+                continue
+            pair = tuple(sorted((line_a, line_b)))
+            key = (pair[0], pair[1], round(midpoint[0]), round(midpoint[1]))
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                RenderFinding(
+                    OFFSET_COLLAPSE,
+                    line_a,
+                    "",
+                    f"lines {pair[0]!r} and {pair[1]!r} draw flush near "
+                    f"({midpoint[0]:.1f},{midpoint[1]:.1f}) but the offset regime "
+                    f"spread them by {assigned:.1f}px",
+                    (a1, a2),
+                )
+            )
+    return findings
+
+
+def _expected_line_segments(graph: MetroGraph) -> dict[str, list[_Segment]]:
+    """The post-offset routed segments the engine assigns, grouped by line."""
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+    from nf_metro.layout.routing.common import apply_route_offsets
+
+    offsets = compute_station_offsets(graph)
+    try:
+        routes = route_edges(graph, station_offsets=offsets)
+    except Exception:  # noqa: BLE001 - routing failure surfaces on the render path
+        return {}
+    segments: dict[str, list[_Segment]] = {}
+    for routed in routes:
+        pts = apply_route_offsets(routed, offsets)
+        line = segments.setdefault(routed.line_id, [])
+        for i in range(len(pts) - 1):
+            line.append((pts[i], pts[i + 1]))
+    return segments
+
+
+def _flush_run(a: _Segment, b: _Segment) -> _Point | None:
+    """Midpoint of the stretch where *a* and *b* run collinear and flush.
+
+    ``None`` unless the two segments are parallel, perpendicular-closer than
+    ``_FLUSH_TOL``, and overlap for at least ``_RUN_MIN`` along their shared
+    direction (so a mere corner touch never counts).
+    """
+    (ax1, ay1), (ax2, ay2) = a
+    ux, uy = ax2 - ax1, ay2 - ay1
+    length = (ux * ux + uy * uy) ** 0.5
+    if length < _RUN_MIN:
+        return None
+    ux, uy = ux / length, uy / length
+    (bx1, by1), (bx2, by2) = b
+    if abs((bx2 - bx1) * uy - (by2 - by1) * ux) > 1e-3 * length:
+        return None
+    if abs((bx1 - ax1) * (-uy) + (by1 - ay1) * ux) >= _FLUSH_TOL:
+        return None
+    t0 = (bx1 - ax1) * ux + (by1 - ay1) * uy
+    t1 = (bx2 - ax1) * ux + (by2 - ay1) * uy
+    lo = max(0.0, min(t0, t1))
+    hi = min(length, max(t0, t1))
+    if hi - lo < _RUN_MIN:
+        return None
+    mid = (lo + hi) / 2
+    return (ax1 + ux * mid, ay1 + uy * mid)
+
+
+def _nearest_vertex(
+    segments: tuple[_Segment, ...] | list[_Segment], point: _Point
+) -> _Point | None:
+    best: _Point | None = None
+    best_d = 0.0
+    for (x1, y1), (x2, y2) in segments:
+        for vx, vy in ((x1, y1), (x2, y2)):
+            d = (vx - point[0]) ** 2 + (vy - point[1]) ** 2
+            if best is None or d < best_d:
+                best, best_d = (vx, vy), d
+    return best
+
+
+def _perp_gap(
+    point: _Point, segments: tuple[_Segment, ...] | list[_Segment]
+) -> float | None:
+    """Shortest distance from *point* to any segment it projects onto."""
+    best: float | None = None
+    px, py = point
+    for (x1, y1), (x2, y2) in segments:
+        dx, dy = x2 - x1, y2 - y1
+        length_sq = dx * dx + dy * dy
+        if length_sq < 1e-9:
+            continue
+        t = ((px - x1) * dx + (py - y1) * dy) / length_sq
+        if t < -0.05 or t > 1.05:
+            continue
+        cx, cy = x1 + t * dx, y1 + t * dy
+        d = ((px - cx) ** 2 + (py - cy) ** 2) ** 0.5
+        if best is None or d < best:
+            best = d
+    return best
+
+
+def validate_render(
+    svg: str, *, graph: MetroGraph | None = None
+) -> list[RenderFinding]:
     """Run the render-geometry guards on a rendered SVG and return findings.
 
     Reads the embedded manifest for node identities and parses the drawn route
-    and label ink, then checks for label strikes on the geometry as drawn.
-    Returns an empty list for a clean render, or when the SVG carries no
-    manifest (nothing addressable to validate).
+    and label ink, then checks the geometry as drawn for label strikes and
+    non-consumer marker crossings (both pure artifact oracles).  When the
+    laid-out *graph* is supplied it additionally checks for offset-pitch
+    collapse, which needs the engine's assigned offsets to tell an intended
+    same-slot bundle from a real merge.  Returns an empty list for a clean
+    render, or when the SVG carries no manifest (nothing addressable to
+    validate).
     """
     manifest = read_manifest(svg)
     if manifest is None:
         return []
     routes = parse_route_polylines(svg)
-    return check_label_strikes(svg, manifest, routes)
+    findings = check_label_strikes(svg, manifest, routes)
+    findings += check_marker_crossings(svg, manifest, routes)
+    if graph is not None:
+        findings += check_offset_collapse(graph, routes)
+    return findings

--- a/tests/test_render_validate.py
+++ b/tests/test_render_validate.py
@@ -6,10 +6,11 @@ and label ink boxes (drawn ``<text>`` ink) and checks the picture as drawn --
 the geometry the pre-render layout guards never see, including render-time
 offsets and the wrapped-label lift.
 
-These tests pin that the clean gallery corpus has zero label strikes, that an
-injected strike is caught and an exempt (carried-line) overlap is not, and that
-the SVG parser recovers smoothing corners exactly and breaks at bridge-hop gaps
-rather than spanning them.
+These tests pin that the clean gallery corpus has zero label strikes, marker
+crossings, and offset-collapses; that an injected defect of each kind is caught
+while its accepted idiom (a carried-line overlap, a rail interchange, a
+same-slot bundle) is not; and that the SVG parser recovers smoothing corners
+exactly and breaks at bridge-hop gaps rather than spanning them.
 """
 
 from __future__ import annotations
@@ -25,6 +26,10 @@ from nf_metro.render import render_svg, validate_render
 from nf_metro.render.manifest import read_manifest
 from nf_metro.render.validate import (
     LABEL_STRIKE,
+    MARKER_CROSS,
+    OFFSET_COLLAPSE,
+    check_marker_crossings,
+    parse_rail_station_ids,
     parse_route_polylines,
     parse_station_labels,
 )
@@ -70,6 +75,30 @@ def test_clean_corpus_has_no_label_strike(name: str) -> None:
     findings = validate_render(_render(name))
     strikes = [f for f in findings if f.kind == LABEL_STRIKE]
     assert not strikes, f"{name}: {[f.message for f in strikes]}"
+
+
+@pytest.mark.parametrize("name", CORPUS)
+def test_clean_corpus_has_no_marker_cross(name: str) -> None:
+    """No gallery render rakes a line through a non-consumer station marker.
+
+    The two corpus crossings are rail interchanges (the intended idiom); the
+    guard exempts them by reading the rail markers back from the SVG.
+    """
+    findings = validate_render(_render(name))
+    crossings = [f for f in findings if f.kind == MARKER_CROSS]
+    assert not crossings, f"{name}: {[f.message for f in crossings]}"
+
+
+@pytest.mark.parametrize("name", CORPUS)
+def test_clean_corpus_has_no_offset_collapse(name: str) -> None:
+    """No gallery render draws an offset-spread line pair flush into one stroke.
+
+    Passing the laid-out graph enables the offset-pitch-aware check; a clean
+    corpus has only same-slot bundles, which it does not flag.
+    """
+    findings = validate_render(_render(name), graph=_LAID_OUT[name])
+    collapses = [f for f in findings if f.kind == OFFSET_COLLAPSE]
+    assert not collapses, f"{name}: {[f.message for f in collapses]}"
 
 
 def _a_foreign_label(svg: str) -> tuple[str, float, float, str]:
@@ -184,3 +213,123 @@ def test_corpus_is_nonempty() -> None:
     """The corpus parametrization actually collected fixtures (guards a silent
     empty-glob that would make the regression lock vacuous)."""
     assert len(CORPUS) > 30
+
+
+@pytest.mark.parametrize("name", ["line_spread.mmd", "sarek_metro.mmd"])
+def test_rail_interchange_crossing_is_exempt_yet_detectable(name: str) -> None:
+    """A line through a rail interchange knob is exempt, not a marker cross.
+
+    Bypassing the rail exemption surfaces the same crossing, so the clean
+    result is the exemption working, not the check missing the geometry.
+    """
+    if name not in CORPUS:
+        pytest.skip(f"{name} not in renderable corpus")
+    svg = _render(name)
+    manifest = read_manifest(svg)
+    routes = parse_route_polylines(svg)
+
+    assert not check_marker_crossings(svg, manifest, routes)
+
+    rails = parse_rail_station_ids(svg)
+    assert rails, f"{name} has no rail markers to exempt"
+    svg_no_rail = svg
+    for sid in rails:
+        svg_no_rail = svg_no_rail.replace(
+            f'data-station-id="{sid}"', "data-station-id="
+        )
+    unexempted = check_marker_crossings(svg_no_rail, manifest, routes)
+    struck = {f.station_id for f in unexempted}
+    assert struck & rails, f"{name}: rail exemption masked nothing real"
+
+
+def test_injected_marker_cross_through_non_consumer_is_caught() -> None:
+    """A foreign line drawn over a non-rail station marker is a marker cross."""
+    svg = _render("rnaseq_sections.mmd")
+    manifest = read_manifest(svg)
+    rails = parse_rail_station_ids(svg)
+    all_lines = [grp["id"] for grp in manifest["groups"]]
+    node, foreign = next(
+        (n, lid)
+        for n in manifest["nodes"]
+        if n["id"] not in rails and n.get("groups")
+        for lid in all_lines
+        if lid not in n["groups"]
+    )
+    r = node.get("r", 5.0)
+    struck = _inject_segment(
+        svg, foreign, (node["x"] - r, node["y"]), (node["x"] + r, node["y"])
+    )
+    crossings = [
+        f
+        for f in validate_render(struck)
+        if f.kind == MARKER_CROSS and f.station_id == node["id"]
+    ]
+    assert len(crossings) == 1
+    assert crossings[0].line_id == foreign
+
+
+def _parallel_drawn_pair(svg: str) -> tuple[str, str, float, float, float, float]:
+    """A distinct horizontal line pair one offset step apart on a shared x-run.
+
+    Returns ``(line_a, line_b, y_a, y_b, x_lo, x_hi)``; raises if none exists.
+    """
+    segs = [
+        (lid, sub[i], sub[i + 1])
+        for lid, subs in parse_route_polylines(svg)
+        for sub in subs
+        for i in range(len(sub) - 1)
+    ]
+    for i, (la, a1, a2) in enumerate(segs):
+        if abs(a1[1] - a2[1]) > 0.1 or abs(a2[0] - a1[0]) < 24:
+            continue
+        for lb, b1, b2 in segs[i + 1 :]:
+            if lb == la or abs(b1[1] - b2[1]) > 0.1:
+                continue
+            if not 3.4 <= abs(b1[1] - a1[1]) <= 4.6:
+                continue
+            x_lo = max(min(a1[0], a2[0]), min(b1[0], b2[0]))
+            x_hi = min(max(a1[0], a2[0]), max(b1[0], b2[0]))
+            if x_hi - x_lo >= 24:
+                return la, lb, a1[1], b1[1], x_lo, x_hi
+    raise AssertionError("no offset-step-separated horizontal pair found")
+
+
+def test_offset_collapse_caught_when_spread_pair_drawn_flush() -> None:
+    """An offset-spread pair drawn onto one Y collapses into a single stroke."""
+    svg = _render("genomic_pipeline.mmd")
+    graph = _LAID_OUT["genomic_pipeline.mmd"]
+    clean = validate_render(svg, graph=graph)
+    assert not [f for f in clean if f.kind == OFFSET_COLLAPSE]
+
+    line_a, line_b, _y_a, y_b, x_lo, x_hi = _parallel_drawn_pair(svg)
+    merged = _inject_segment(svg, line_a, (x_lo + 2, y_b), (x_hi - 2, y_b))
+    collapses = [
+        f for f in validate_render(merged, graph=graph) if f.kind == OFFSET_COLLAPSE
+    ]
+    assert collapses
+    assert {line_a, line_b} == set(collapses[0].message.split("'")[1::2][:2])
+
+
+def test_same_slot_bundle_is_not_offset_collapse() -> None:
+    """Distinct lines the regime put on one slot draw flush without a finding."""
+    name = "topologies/funcprofiler_upstream.mmd"
+    if name not in CORPUS:
+        pytest.skip(f"{name} not in renderable corpus")
+    from nf_metro.render.validate import _flush_run
+
+    svg = _render(name)
+    segs = [
+        (lid, sub[i], sub[i + 1])
+        for lid, subs in parse_route_polylines(svg)
+        for sub in subs
+        for i in range(len(sub) - 1)
+    ]
+    flush = any(
+        la != lb and _flush_run((a1, a2), (b1, b2)) is not None
+        for i, (la, a1, a2) in enumerate(segs)
+        for lb, b1, b2 in segs[i + 1 :]
+    )
+    assert flush, "fixture no longer exercises a same-slot flush bundle"
+
+    findings = validate_render(svg, graph=_LAID_OUT[name])
+    assert not [f for f in findings if f.kind == OFFSET_COLLAPSE]

--- a/tests/test_render_validate.py
+++ b/tests/test_render_validate.py
@@ -29,6 +29,7 @@ from nf_metro.render.validate import (
     MARKER_CROSS,
     OFFSET_COLLAPSE,
     check_marker_crossings,
+    drawn_segments,
     parse_rail_station_ids,
     parse_route_polylines,
     parse_station_labels,
@@ -273,12 +274,7 @@ def _parallel_drawn_pair(svg: str) -> tuple[str, str, float, float, float, float
 
     Returns ``(line_a, line_b, y_a, y_b, x_lo, x_hi)``; raises if none exists.
     """
-    segs = [
-        (lid, sub[i], sub[i + 1])
-        for lid, subs in parse_route_polylines(svg)
-        for sub in subs
-        for i in range(len(sub) - 1)
-    ]
+    segs = drawn_segments(parse_route_polylines(svg))
     for i, (la, a1, a2) in enumerate(segs):
         if abs(a1[1] - a2[1]) > 0.1 or abs(a2[0] - a1[0]) < 24:
             continue
@@ -307,7 +303,9 @@ def test_offset_collapse_caught_when_spread_pair_drawn_flush() -> None:
         f for f in validate_render(merged, graph=graph) if f.kind == OFFSET_COLLAPSE
     ]
     assert collapses
-    assert {line_a, line_b} == set(collapses[0].message.split("'")[1::2][:2])
+    assert collapses[0].line_id in {line_a, line_b}
+    assert f"'{line_a}'" in collapses[0].message
+    assert f"'{line_b}'" in collapses[0].message
 
 
 def test_same_slot_bundle_is_not_offset_collapse() -> None:
@@ -318,12 +316,7 @@ def test_same_slot_bundle_is_not_offset_collapse() -> None:
     from nf_metro.render.validate import _flush_run
 
     svg = _render(name)
-    segs = [
-        (lid, sub[i], sub[i + 1])
-        for lid, subs in parse_route_polylines(svg)
-        for sub in subs
-        for i in range(len(sub) - 1)
-    ]
+    segs = drawn_segments(parse_route_polylines(svg))
     flush = any(
         la != lb and _flush_run((a1, a2), (b1, b2)) is not None
         for i, (la, a1, a2) in enumerate(segs)


### PR DESCRIPTION
## Summary

Completes the render-geometry oracle (#679) by adding the two deferred guards to `src/nf_metro/render/validate.py`, each alongside the shipping `label-strike` check:

- **Marker-cross** (`marker-cross`): flags a drawn route segment passing through a non-consumer station's marker. Lines the station carries (manifest `groups`, which subsumes edge endpoints) are exempt. Rail-interchange stations are exempt too: a line threading an interchange knob is the intended rail idiom (the same reason #743's hanging-route guard skips rail endpoints). Rail-station ids are read back from the drawn rail markers (`...-rail-...` class + `data-station-id`), so no manifest schema addition is needed. This is the render-side companion to the layout guard `_guard_no_line_crosses_non_consumer`. Pure artifact oracle.
- **Offset-collapse** (`offset-collapse`): flags distinct lines drawn flush where the offset regime spread them apart. A bare perpendicular-distance floor cannot tell an acceptable same-slot bundle (distinct lines the regime put on one offset, drawn flush by design) from a real collapse, so the check is offset-pitch-aware: it compares the *drawn* gap on a shared run against the gap the engine's offsets *assigned* the pair there, flagging only a flush pair whose assigned gap is at least one `OFFSET_STEP`. This needs the engine's assigned offsets, so it runs when the laid-out `graph` is passed to `validate_render`.

`validate_render(svg, *, graph=None)` runs the two artifact-only checks always; offset-collapse additionally when `graph` is supplied. Wiring:

- `render --validate` passes the laid-out graph, so all three checks run.
- `validate-svg --geometry` (standalone, SVG only) runs the two artifact-only checks; its help text notes offset-collapse needs the engine.
- The 137-fixture corpus test in `tests/test_render_validate.py` is the CI gate for all three.

Adjudication of the cases #679 flagged: the only flush distinct-line pairs in the shipping gallery (`funcprofiler_upstream`, `multiqc`/`humann3`) are assigned the **same** offset slot (pitch 0), so the offset-pitch-aware check reports nothing on them. Both corpus marker crossings (`line_spread` `r_filter`, `sarek_metro` `strelka2`) are rail interchanges, now exempt. Both guards are FP-clean across all 137 fixtures.

The guards are not added to the always-on `render_svg` path, so the gallery render is byte-identical (no visual changes).

Fixes #942

## Test plan
- [x] pytest passes (full suite: 17574 passed; new invariant tests in `tests/test_render_validate.py`)
- [x] ruff check + ruff format clean on whole repo; mypy clean
- [x] Each guard verified non-vacuous: rail exemption is load-bearing (bypassing it re-surfaces the crossing), and an injected defect of each kind is caught
- [x] Routing gate-coverage ratchet unaffected (no `if`/`while` changes in `layout/routing/`)
- [ ] Render-preview verdict: expected "No visual changes detected" (guards are opt-in, not in `render_svg`)
