### PR TITLE
docs: sync CLI/directive reference and packaging metadata for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ nf-metro render [OPTIONS] INPUT_FILE
 |--------|---------|-------------|
 | `-o`, `--output PATH` | `<input>.<format>` | Output file path |
 | `--format [svg\|html]` | `svg` | Output format: `svg` or interactive `html` |
-| `--theme [nfcore\|light]` | `nfcore` | Visual theme |
+| `--theme [nfcore\|light\|seqera]` | from `style:`, else `nfcore` | Visual theme |
+| `--legend TEXT` | auto | Legend+logo position (keyword, `keyword \| canvas`, `keyword \| dx,dy`, or `x,y`) |
+| `--line-spread [bundle\|centered\|rails]` | `bundle` | How lines sharing a station relate vertically |
 | `--width INTEGER` | auto | SVG width in pixels |
 | `--height INTEGER` | auto | SVG height in pixels |
 | `--x-spacing FLOAT` | auto | Horizontal spacing between layers (widened from 60 only when wide labels would otherwise collide) |
@@ -88,8 +90,15 @@ nf-metro render [OPTIONS] INPUT_FILE
 | `--line-order [definition\|span]` | `definition` | Line ordering strategy: `definition` preserves `.mmd` order, `span` sorts by section span (longest first) |
 | `--diamond-style [straight\|symmetric]` | `straight` | Fork-join layout: `straight` keeps the top branch on the main track; `symmetric` fans the branches evenly |
 | `--center-ports / --no-center-ports` | off | Centre inter-section ports on the shorter of the two connected sections |
+| `--compact-offsets / --no-compact-offsets` | off | Size each station only for the lines actually passing through it |
 | `--section-x-gap FLOAT` | `50` | Horizontal gap between sections |
 | `--section-y-gap FLOAT` | `50` | Vertical gap between sections |
+| `--label-angle FLOAT` | theme default | Station-label angle in degrees |
+| `--font-scale FLOAT` | `1.0` | Scale text and the label metrics that drive layout spacing |
+| `--logo-scale FLOAT` | `1.0` | Scale the logo within the legend |
+| `--legend-min-height FLOAT` | `0` | Minimum legend content height in pixels |
+| `--legend-logo-gap FLOAT` | auto | Gap between the logo and the legend entries |
+| `--validate` | off | Run the render-geometry oracle over the drawn SVG and report violations |
 | `--from-nextflow` | off | Convert Nextflow `-with-dag` mermaid input before rendering |
 | `--title TEXT` | none | Pipeline title (overrides the `%%metro title:` directive) |
 
@@ -371,6 +380,13 @@ These are automatically rewritten into port-to-port connections with junction st
 | `%%metro entry: <side> \| <lines>` | Section | Entry port hint |
 | `%%metro exit: <side> \| <lines>` | Section | Exit port hint |
 | `%%metro direction: <dir>` | Section | Flow direction: `LR`, `RL`, `TB` |
+
+## Python API
+
+nf-metro is a command-line tool. Its Python modules are importable, but the internal
+API (parser, layout engine, renderer) is not part of the public, semver-stable surface
+and may change between releases without notice. Drive nf-metro through the `nf-metro`
+CLI (or `python -m nf_metro`) for stable behaviour.
 
 ## License
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -510,6 +510,7 @@ These go at the top of the file, before `graph LR`.
 | Directive | Description |
 |-----------|-------------|
 | `%%metro title: <text>` | Map title |
+| `%%metro caption: <text>` | Free-text caption or attribution line rendered bottom-left of the map (e.g. `Adapted from Author et al., Journal (Year)`). |
 | `%%metro logo: <path>` | Logo image, bundled into the legend (or top-left if there is no legend). |
 | `%%metro logo_scale: <factor>` | Scale the logo within the legend block (`1.0` = default auto-size). Values above 1 grow the legend box to contain the logo. |
 | `%%metro style: <name>` | Theme: `dark` (default, the nfcore theme) or `light`. Selects the render theme unless `--theme` is passed. |
@@ -541,6 +542,7 @@ These go at the top of the file, before `graph LR`.
 | `%%metro interchange: <node> \| <rail-1 lines> \| <rail-2 lines> [\| ...]` | Render a shared step as a cross-track interchange instead of a convergence point (see below). Each pipe-group is one rail (comma-separated lines bundle on it). Auto-layout infers this for fully-parallel lanes, so the directive is only needed to pin a grouping. |
 | `%%metro legend_min_height: <pixels>` | Minimum legend content height in pixels (useful for single-line maps where the logo would otherwise be tiny) |
 | `%%metro process: <station> \| <regex>` | _Experimental._ Tie a station to the Nextflow process(es) it represents, for live progress (see [Live progress](live.md)). The regex matches the fully-qualified process name; repeat the directive to attach several patterns to one station. Pure metadata - it never affects the rendered map. |
+| `%%metro manifest: <bool>` | Embed the machine-readable data manifest (the `<metadata>` block and per-node `data-node-*` attributes) in the SVG. On by default; `%%metro manifest: false` (or `--no-manifest`) emits the drawn map only. |
 
 **Compact offsets.** By default, each line reserves a fixed vertical slot across the whole map based on its declaration order. If you define three lines, every station that carries even one of them is sized to fit all three. This keeps bundles visually consistent but wastes space when most stations only carry one or two lines.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,20 @@ description = "Generate metro-map-style SVG diagrams from Mermaid graph definiti
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
+authors = [{ name = "Jonathan Manning", email = "jonathan.manning@seqera.io" }]
+maintainers = [{ name = "Jonathan Manning", email = "jonathan.manning@seqera.io" }]
+keywords = [
+    "nextflow",
+    "nf-core",
+    "bioinformatics",
+    "visualization",
+    "metro-map",
+    "mermaid",
+    "svg",
+    "pipeline",
+    "workflow",
+    "diagram",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
Part of the 1.0.0 readiness sweep: the low-risk doc/metadata fixes that can land independently. See the umbrella issue for the full checklist.

## What this does

- **README CLI reference** — sync with the shipped feature set: add the `seqera` theme and the `--legend`, `--line-spread`, `--compact-offsets`, `--label-angle`, `--font-scale`, `--logo-scale`, `--legend-min-height`, `--legend-logo-gap`, and `--validate` options. The README table had drifted behind `docs/index.md`.
- **README Python API note** — state that nf-metro is CLI-first and its internal modules are not a semver-stable public surface.
- **`docs/guide.md` directive table** — add the `%%metro caption:` and `%%metro manifest:` directives, which were implemented but undocumented.
- **`pyproject.toml`** — add `authors`, `maintainers`, and `keywords` for a credible PyPI listing.

Docs and packaging metadata only; no code or behaviour change. The `Development Status` classifier bump and the `0.7.2 → 1.0.0` version bump are deliberately left for the release-tag commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)