### PR TITLE
chore: gitignore local working notes and generated assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,14 @@ docs/gallery/index.md
 .claude/scheduled_tasks.lock
 .claude/worktrees/
 .coverage
+
+# Local working notes and generated assets (not committed)
+AUTO_LAYOUT_FINDINGS.md
+BLOG_NOTES.md
+COST_SAVINGS.md
+LAYOUT_ENGINE_ASSESSMENT.md
+SPEC_FACTORING_RESEARCH.md
+blog_drafts/
+nf_metro_live_led.gif
+proposal_review_summary.txt
+scripts/optimize_layout.py


### PR DESCRIPTION
## Summary

- Adds 9 entries to `.gitignore` covering local working notes, blog drafts, generated assets, and dev scripts that were sitting in the repo root as untracked files
- Keeps the files accessible locally while ensuring they never accidentally get committed

Fixes #963

## Test plan
- [ ] `git status` shows a clean working tree after applying (no stray untracked files)
- [ ] Visual review: no gallery changes expected (`.gitignore`-only diff)

Generated with Claude Code