### PR TITLE
feat(playground): report a bug as a prefilled GitHub issue

### DIFF
--- a/docs/playground/app.js
+++ b/docs/playground/app.js
@@ -3,6 +3,8 @@
 // Pinned so the install path is reproducible; bump deliberately.
 const PYODIDE_VERSION = "v0.27.2";
 
+const REPO = "pinin4fjords/nf-metro";
+
 const SEED = `%%metro title: Example Pipeline
 %%metro line: qc | QC | #2dd4bf
 %%metro line: main | Main | #c792ea
@@ -51,6 +53,7 @@ const el = (id) => document.getElementById(id);
 let editor = null;
 let pyRender = null;
 let lastSvg = "";
+let nfMetroVersion = "";
 
 /* ------------------------------- editor -------------------------------- */
 
@@ -118,6 +121,7 @@ async function boot() {
     await micropip.install(await resolveWheel());
     pyodide.runPython(PY_GLUE);
     pyRender = pyodide.globals.get("nfm_render");
+    nfMetroVersion = pyodide.runPython("import nf_metro; nf_metro.__version__");
     el("boot").classList.add("hidden");
     doRender();
     // Readiness means the runtime is up, independent of whether the first
@@ -347,16 +351,90 @@ function loadFromHash() {
   }
 }
 
-async function shareLink() {
+function shareUrl() {
   const hash = "#mmd=" + encodeURIComponent(b64urlEncode(editor.getValue()));
-  history.replaceState(null, "", location.pathname + location.search + hash);
-  const full = location.href;
+  return location.origin + location.pathname + location.search + hash;
+}
+
+async function shareLink() {
+  const url = shareUrl();
+  history.replaceState(null, "", url);
   try {
-    await navigator.clipboard.writeText(full);
+    await navigator.clipboard.writeText(url);
     toast("Share link copied to clipboard");
   } catch (_) {
     toast("Share link is in the address bar");
   }
+}
+
+/* ----------------------------- bug report ----------------------------- */
+
+function buildIssueUrl(explanation) {
+  const opts = currentOptions();
+  const mmd = editor.getValue();
+  const MAX = 6000;
+  const mmdBlock =
+    mmd.length > MAX
+      ? mmd.slice(0, MAX) + "\n... (truncated; full map in the reproduce link)"
+      : mmd;
+  const lo = opts.layout_options;
+  const body = `## What's wrong
+
+${explanation}
+
+## Map source
+
+\`\`\`
+${mmdBlock}
+\`\`\`
+
+## Reproduce
+
+[Open this map in the playground](${shareUrl()})
+
+## Environment
+
+- nf-metro: ${nfMetroVersion || "unknown"}
+- theme: ${opts.theme}
+- animate: ${lo.animate}
+- directional: ${lo.directional}
+- x-spacing: ${lo.x_spacing ?? "auto"}
+- y-spacing: ${lo.y_spacing ?? "auto"}
+- page: ${location.href.split("#")[0]}
+- user agent: ${navigator.userAgent}
+`;
+  const firstLine = explanation.trim().split("\n")[0].slice(0, 70);
+  const params = new URLSearchParams({
+    title: `[playground] ${firstLine}`,
+    body,
+    labels: "playground",
+  });
+  return `https://github.com/${REPO}/issues/new?${params.toString()}`;
+}
+
+function openReport() {
+  el("report-text").value = "";
+  el("report-submit").disabled = true;
+  el("report-modal").classList.remove("hidden");
+  el("report-text").focus();
+}
+
+function closeReport() {
+  el("report-modal").classList.add("hidden");
+}
+
+function submitReport() {
+  const explanation = el("report-text").value.trim();
+  if (!explanation) {
+    el("report-text").focus();
+    return;
+  }
+  const url = buildIssueUrl(explanation);
+  // Exposed so the e2e suite can assert the prefilled issue without
+  // navigating to github.com.
+  window.__nfMetroLastIssueUrl = url;
+  window.open(url, "_blank", "noopener");
+  closeReport();
 }
 
 /* -------------------------------- utils -------------------------------- */
@@ -386,6 +464,21 @@ function wireControls() {
   el("btn-svg").addEventListener("click", exportSvg);
   el("btn-png").addEventListener("click", exportPng);
   el("btn-share").addEventListener("click", shareLink);
+
+  el("btn-report").addEventListener("click", openReport);
+  el("report-cancel").addEventListener("click", closeReport);
+  el("report-submit").addEventListener("click", submitReport);
+  el("report-text").addEventListener("input", (e) => {
+    el("report-submit").disabled = e.target.value.trim() === "";
+  });
+  el("report-modal").addEventListener("click", (e) => {
+    if (e.target === el("report-modal")) closeReport();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !el("report-modal").classList.contains("hidden")) {
+      closeReport();
+    }
+  });
 }
 
 initEditor();

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -11,6 +11,7 @@
 <body>
   <header id="bar">
     <div class="brand">nf-metro <span class="muted">playground</span> <span class="beta">beta</span></div>
+    <button id="btn-report" class="report-btn" title="Report a bug with this map">Report a bug</button>
   </header>
 
   <main id="split">
@@ -60,6 +61,24 @@
   </main>
 
   <div id="toast" class="hidden"></div>
+
+  <div id="report-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="report-title">
+    <div class="modal">
+      <h2 id="report-title">Report a bug</h2>
+      <p class="muted small">
+        This opens a pre-filled GitHub issue in a new tab with your current map,
+        options, and description. You review and submit it there (a GitHub
+        account and sign-in are required).
+      </p>
+      <label for="report-text">What's wrong? <span class="req">required</span></label>
+      <textarea id="report-text" rows="5"
+        placeholder="What did you expect, and what happened instead?"></textarea>
+      <div class="modal-actions">
+        <button id="report-cancel" class="ghost">Cancel</button>
+        <button id="report-submit" disabled>Open GitHub issue</button>
+      </div>
+    </div>
+  </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/mode/simple.min.js"></script>

--- a/docs/playground/style.css
+++ b/docs/playground/style.css
@@ -244,6 +244,65 @@ button:disabled { opacity: 0.45; cursor: not-allowed; }
   z-index: 20;
 }
 
+.report-btn {
+  margin-left: auto;
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.report-btn:hover { border-color: var(--danger); background: var(--danger-bg); }
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 6, 10, 0.66);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 30;
+}
+.modal {
+  width: min(560px, 100%);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px 22px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+.modal h2 { margin: 0 0 8px; font-size: 17px; }
+.modal p { margin: 0 0 14px; }
+.modal label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+  color: var(--text);
+}
+.modal label .req {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--danger);
+}
+.modal textarea {
+  width: 100%;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+  font: inherit;
+  font-size: 13px;
+  resize: vertical;
+}
+.modal textarea:focus { outline: none; border-color: var(--accent); }
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 16px;
+}
+.modal-actions button.ghost { color: var(--muted); }
+
 @media (max-width: 720px) {
   #split { grid-template-columns: 1fr; grid-template-rows: 1fr 1fr; }
   #editor-pane { border-right: none; border-bottom: 1px solid var(--border); }

--- a/docs/playground/tests/playground.spec.js
+++ b/docs/playground/tests/playground.spec.js
@@ -127,6 +127,36 @@ test("SVG and PNG export produce non-empty downloads", async () => {
   expect(stat.size).toBeGreaterThan(0);
 });
 
+test("bug report builds a prefilled GitHub issue with the map and explanation", async () => {
+  await page.evaluate(() => {
+    window.__nfMetro.setValue(
+      "%%metro line: q | Q | #abc\ngraph LR\n  uniquenode[Unique] -->|q| other[Other]\n"
+    );
+    // Prevent the real github.com tab from opening during the test.
+    window.open = () => null;
+  });
+
+  await page.locator("#btn-report").click();
+  await expect(page.locator("#report-modal")).toBeVisible();
+  // The explanation is mandatory: submit stays disabled until it's filled.
+  await expect(page.locator("#report-submit")).toBeDisabled();
+
+  await page.locator("#report-text").fill("Edge renders backwards from uniquenode");
+  await expect(page.locator("#report-submit")).toBeEnabled();
+  await page.locator("#report-submit").click();
+
+  await expect(page.locator("#report-modal")).toBeHidden();
+  const issueUrl = await page.evaluate(() => window.__nfMetroLastIssueUrl);
+  const u = new URL(issueUrl);
+  expect(u.host).toBe("github.com");
+  expect(u.pathname).toBe("/pinin4fjords/nf-metro/issues/new");
+  expect(u.searchParams.get("labels")).toBe("playground");
+  const body = u.searchParams.get("body");
+  expect(body).toContain("Edge renders backwards from uniquenode");
+  expect(body).toContain("uniquenode[Unique]");
+  expect(body).toContain("#mmd=");
+});
+
 test("share link round-trips the editor content", async () => {
   const source = await page.evaluate(() => {
     const v = "%%metro line: z | Z | #0af\ngraph LR\n  s1[S1] -->|z| s2[S2]\n";


### PR DESCRIPTION
## What this adds

A **"Report a bug"** button in the playground that turns the current map into a prefilled GitHub issue.

Clicking it opens a small modal asking for a **mandatory** description of what's wrong (the submit button stays disabled until it's filled). On submit, it opens a prefilled GitHub **New issue** page in a new tab, populated with:

- the description
- the current map source (fenced; truncated past 6000 chars, with the full map preserved via the reproduce link)
- a **reproduce link** (the playground share URL, which encodes the map in the fragment)
- environment details: nf-metro version, theme, animate/directional, spacing, page URL, user agent
- the `playground` label

## Why a prefilled issue rather than direct creation

The playground is a static, zero-backend page. Creating issues programmatically would require a server endpoint or an embedded GitHub token, neither of which is acceptable for a static site. Opening a prefilled `issues/new` URL keeps the zero-backend property; the user reviews and submits the issue on GitHub (sign-in required). Labels are applied for users with triage permission and ignored otherwise.

## Testing

A new Playwright case drives the flow end to end: opens the modal, asserts the submit button is disabled until the description is filled, submits, and verifies the resulting `github.com/.../issues/new` URL carries the `playground` label, the description, the map source, and the reproduce link. `window.open` is stubbed in the test so no real tab is launched. Full suite: 11/11 e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
