### PR TITLE
feat(playground): load any bundled example from a dropdown

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,9 @@ jobs:
           WHEEL=$(basename docs/playground/wheels/*.whl)
           printf '{"wheel": "%s"}\n' "$WHEEL" > docs/playground/wheels/index.json
 
+      - name: Build playground example manifest
+        run: python scripts/build_playground_examples.py
+
       - name: Configure git for mike
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/playground-e2e.yml
+++ b/.github/workflows/playground-e2e.yml
@@ -26,6 +26,9 @@ jobs:
           WHEEL=$(basename docs/playground/wheels/*.whl)
           printf '{"wheel": "%s"}\n' "$WHEEL" > docs/playground/wheels/index.json
 
+      - name: Build playground example manifest
+        run: python scripts/build_playground_examples.py
+
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ docs/gallery/index.md
 # Playground dev wheel (CI- or locally-built; never committed)
 docs/playground/wheels/
 
+# Playground example manifest (built by scripts/build_playground_examples.py)
+docs/playground/examples.json
+
 # Playwright local artifacts
 docs/playground/tests/node_modules/
 docs/playground/tests/test-results/

--- a/docs/playground/app.js
+++ b/docs/playground/app.js
@@ -54,6 +54,7 @@ let editor = null;
 let pyRender = null;
 let lastSvg = "";
 let nfMetroVersion = "";
+const examples = {};
 
 /* ------------------------------- editor -------------------------------- */
 
@@ -456,7 +457,38 @@ function toast(msg) {
   toastTimer = setTimeout(() => t.classList.add("hidden"), 1800);
 }
 
+/* ------------------------------ examples ------------------------------ */
+
+async function loadExamples() {
+  let entries;
+  try {
+    const resp = await fetch("examples.json", { cache: "no-store" });
+    if (!resp.ok) return;
+    entries = await resp.json();
+  } catch (_) {
+    return; // no manifest shipped; the starter remains available
+  }
+  const group = el("example-group");
+  entries.forEach(({ name, mmd }) => {
+    examples[name] = mmd;
+    const opt = document.createElement("option");
+    opt.value = name;
+    opt.textContent = name;
+    group.append(opt);
+  });
+}
+
+function loadExample(value) {
+  if (!value) return;
+  const mmd = value === "__seed__" ? SEED : examples[value];
+  if (mmd != null) editor.setValue(mmd);
+  // The dropdown is an action menu, not a state mirror: reset to the
+  // placeholder so re-picking the same entry fires `change` again.
+  el("example-select").value = "";
+}
+
 function wireControls() {
+  el("example-select").addEventListener("change", (e) => loadExample(e.target.value));
   ["opt-theme", "opt-animate", "opt-directional", "opt-x-spacing", "opt-y-spacing"].forEach(
     (id) => el(id).addEventListener("change", doRender)
   );
@@ -483,4 +515,5 @@ function wireControls() {
 
 initEditor();
 wireControls();
+loadExamples();
 boot();

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -17,6 +17,14 @@
   <main id="split">
     <section id="editor-pane">
       <div class="pane-toolbar">
+        <label>Load
+          <select id="example-select">
+            <option value="" selected>example…</option>
+            <option value="__seed__">Starter pipeline</option>
+            <optgroup id="example-group" label="Examples"></optgroup>
+          </select>
+        </label>
+        <span class="sep"></span>
         <span class="group-label">Insert</span>
         <button id="btn-section" title="Insert a section block">+ Section</button>
         <button id="btn-line" title="Insert a line definition">+ Line</button>

--- a/docs/playground/tests/playground.spec.js
+++ b/docs/playground/tests/playground.spec.js
@@ -127,6 +127,28 @@ test("SVG and PNG export produce non-empty downloads", async () => {
   expect(stat.size).toBeGreaterThan(0);
 });
 
+test("example dropdown loads a chosen example and renders it", async () => {
+  const select = page.locator("#example-select");
+  // Manifest populated the dropdown beyond the placeholder + starter.
+  expect(await select.locator("option").count()).toBeGreaterThan(2);
+
+  await select.selectOption("rnaseq_auto");
+  await expect
+    .poll(async () => page.evaluate(() => window.__nfMetro.getValue()))
+    .toContain("graph");
+  await expect
+    .poll(async () => page.locator("#preview [data-line-id]").count())
+    .toBeGreaterThan(0);
+  // Action menu resets to its placeholder after loading.
+  await expect(select).toHaveValue("");
+
+  // The starter entry is always available even without the manifest.
+  await select.selectOption("__seed__");
+  await expect
+    .poll(async () => page.evaluate(() => window.__nfMetro.getValue()))
+    .toContain("Example Pipeline");
+});
+
 test("bug report builds a prefilled GitHub issue with the map and explanation", async () => {
   await page.evaluate(() => {
     window.__nfMetro.setValue(

--- a/scripts/build_playground_examples.py
+++ b/scripts/build_playground_examples.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Generate the playground's example manifest from ``examples/*.mmd``.
+
+The browser playground is a static page, so it cannot read the repo's
+``examples/`` directory directly. This writes their contents to
+``docs/playground/examples.json`` (a list of ``{"name", "mmd"}``) for the
+"load example" dropdown to fetch. Run it before building/serving the
+playground; the output is git-ignored and regenerated in CI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = ROOT / "examples"
+OUTPUT = ROOT / "docs" / "playground" / "examples.json"
+
+
+def main() -> None:
+    entries = [
+        {"name": path.stem, "mmd": path.read_text()}
+        for path in sorted(EXAMPLES_DIR.glob("*.mmd"))
+    ]
+    OUTPUT.write_text(json.dumps(entries, indent=2) + "\n")
+    print(f"wrote {len(entries)} examples -> {OUTPUT.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this adds

A **"Load example"** dropdown in the editor toolbar that lets users start from any of the curated pipeline maps instead of the toy starter. Selecting an entry loads its source into the editor and re-renders; the dropdown acts as an action menu (it resets to its placeholder after loading, so re-picking the same entry works).

It offers:
- **Starter pipeline** (the built-in seed), always available
- every map in `examples/*.mmd` (33 maps: rnaseq, differentialabundance, epitopeprediction, hlatyping, genome assembly, and the topology/feature demos)

## How the static page gets the examples

The examples live in `examples/` at the repo root, which a static page can't read. A small build step (`scripts/build_playground_examples.py`) writes their contents to `docs/playground/examples.json`, which the page fetches at load. The manifest is generated in the docs and e2e workflows and is git-ignored, mirroring the dev-wheel pattern. If the manifest is absent, the dropdown still offers the starter and the playground works.

All 33 examples were verified to render through the browser path (missing logo files are skipped and `file:` icons are built-in, so none error).

## Testing

A new Playwright case selects `rnaseq_auto` from the dropdown, asserts the editor content and a rendered map update, that the menu resets to its placeholder, and that the starter entry reloads the seed. Full suite: 12/12 e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
