### PR TITLE
test: lock fold-induced layout defects (#672, #989, #990)

### DIFF
--- a/examples/regressions/rnaseq_auto_fold1.mmd
+++ b/examples/regressions/rnaseq_auto_fold1.mmd
@@ -1,0 +1,96 @@
+%%metro title: nf-core/rnaseq (folded, --fold-threshold 1)
+%%metro style: dark
+%%metro fold_threshold: 1
+%%metro line: star_rsem | Aligner: STAR, Quantification: RSEM | #0570b0
+%%metro line: star_salmon | Aligner: STAR, Quantification: Salmon (default) | #2db572
+%%metro line: hisat2 | Aligner: HISAT2, Quantification: None | #f5c542
+%%metro line: pseudo_salmon | Pseudo-aligner: Salmon, Quantification: Salmon | #e63946
+%%metro line: pseudo_kallisto | Pseudo-aligner: Kallisto, Quantification: Kallisto | #7b2d3b
+%%metro legend: bl
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        cat_fastq[cat fastq]
+        fastqc_raw[FastQC]
+        infer_strandedness[infer strandedness]
+        umi_tools_extract[UMI-tools extract]
+        fastp[FastP]
+        trimgalore[Trim Galore!]
+        fastqc_trimmed[FastQC]
+        bbsplit[BBSplit]
+        sortmerna[SortMeRNA]
+
+        cat_fastq -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| fastqc_raw
+        fastqc_raw -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| infer_strandedness
+        infer_strandedness -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| umi_tools_extract
+
+        umi_tools_extract -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| fastp
+        umi_tools_extract -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| trimgalore
+        fastp -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| fastqc_trimmed
+        trimgalore -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| fastqc_trimmed
+
+        fastqc_trimmed -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| bbsplit
+        bbsplit -->|star_salmon,star_rsem,hisat2,pseudo_salmon,pseudo_kallisto| sortmerna
+    end
+
+    subgraph genome_align [Genome alignment & quantification]
+        star[STAR]
+        hisat2_align[HISAT2]
+        rsem[RSEM]
+        salmon_quant[Salmon]
+        umi_tools_dedup[UMI-tools dedup]
+
+        star -->|star_rsem| rsem
+        star -->|star_salmon| umi_tools_dedup
+        umi_tools_dedup -->|star_salmon| salmon_quant
+        hisat2_align -->|hisat2| umi_tools_dedup
+    end
+
+    subgraph postprocessing [Post-processing]
+        samtools[SAMtools]
+        picard[Picard]
+        bedtools[BEDTools]
+        bedgraph[bedGraphToBigWig]
+        stringtie[StringTie]
+
+        samtools -->|star_salmon,star_rsem,hisat2| picard
+        picard -->|star_salmon,star_rsem,hisat2| bedtools
+        bedtools -->|star_salmon,star_rsem,hisat2| bedgraph
+        bedgraph -->|star_salmon,star_rsem,hisat2| stringtie
+    end
+
+    subgraph pseudo_align [Pseudo-alignment & quantification]
+        salmon_pseudo[Salmon]
+        kallisto[Kallisto]
+        multiqc_pseudo[MultiQC]
+
+        salmon_pseudo -->|pseudo_salmon| multiqc_pseudo
+        kallisto -->|pseudo_kallisto| multiqc_pseudo
+    end
+
+    subgraph qc_report [Quality control & reporting]
+        rseqc[RSeQC]
+        preseq[Preseq]
+        qualimap[Qualimap]
+        dupradar[dupRadar]
+        deseq2_pca[DESeq2 PCA]
+        kraken2[Kraken2/Bracken]
+        multiqc_final[MultiQC]
+
+        rseqc -->|star_salmon,star_rsem,hisat2| preseq
+        preseq -->|star_salmon,star_rsem,hisat2| qualimap
+        qualimap -->|star_salmon,star_rsem,hisat2| dupradar
+        dupradar -->|star_salmon,star_rsem,hisat2| deseq2_pca
+        deseq2_pca -->|star_salmon,star_rsem,hisat2| kraken2
+        kraken2 -->|star_salmon,star_rsem,hisat2| multiqc_final
+    end
+
+    %% Inter-section edges
+    sortmerna -->|star_salmon,star_rsem| star
+    sortmerna -->|hisat2| hisat2_align
+    sortmerna -->|pseudo_salmon| salmon_pseudo
+    sortmerna -->|pseudo_kallisto| kallisto
+    salmon_quant -->|star_salmon| samtools
+    rsem -->|star_rsem| samtools
+    umi_tools_dedup -->|hisat2| samtools
+    stringtie -->|star_salmon,star_rsem,hisat2| rseqc

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -87,6 +87,15 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "showing how explicit directives can fine-tune placement.",
     ),
     (
+        "rnaseq_auto_fold1",
+        EXAMPLES_DIR / "regressions",
+        "The auto-layout pipeline pinned to `%%metro fold_threshold: 1` (maximal "
+        "folding). Regression fixture for known layout defects under aggressive "
+        "folding: fan-in station-as-elbow + crossing (#672), space-wasting "
+        "section placement and intra-section column gaps (#989), and a "
+        "non-consumer breeze-through (#990).",
+    ),
+    (
         "genomic_pipeline",
         EXAMPLES_DIR,
         "Multi-section genomic variant-calling pipeline: same-direction sections "

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -23,6 +23,7 @@ from layout_validator import (
     check_route_segment_crossings,
     check_section_overlap,
     check_single_segment_diagonals,
+    check_station_as_elbow,
     check_station_containment,
     validate_layout,
 )
@@ -333,6 +334,64 @@ class TestVariantCallingDefects:
     def test_no_route_segment_crossings(self, graph):
         v = check_route_segment_crossings(graph)
         assert not v, "\n".join(vi.message for vi in v)
+
+
+# --- rnaseq_auto under aggressive folding (#672, #989, #990) ---
+#
+# `rnaseq_auto_fold1.mmd` is `rnaseq_auto.mmd` pinned to
+# `%%metro fold_threshold: 1`, so it folds maximally at the default flags
+# and reproduces three known layout defects that only surface under heavy
+# folding. Each is locked with a strict xfail keyed to its tracking issue;
+# when an engine fix lands the matching xfail flips to XPASS and reds CI,
+# prompting the marker removal.
+
+RNASEQ_AUTO_FOLD1_FILE = EXAMPLES_DIR / "regressions" / "rnaseq_auto_fold1.mmd"
+
+
+class TestRnaseqAutoFold1Defects:
+    """Lock known fold-induced layout defects in the rnaseq_auto pipeline."""
+
+    @pytest.fixture
+    def graph(self):
+        # max_station_columns=None honours the fixture's own
+        # `%%metro fold_threshold: 1` directive instead of the default 15.
+        return _load_and_layout(RNASEQ_AUTO_FOLD1_FILE, max_station_columns=None)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="fan-in station-as-elbow under fold (TB section, side entry on "
+        "the trunk row); tracked in #672",
+    )
+    def test_no_station_as_elbow(self, graph):
+        errors = [
+            v for v in check_station_as_elbow(graph) if v.severity == Severity.ERROR
+        ]
+        assert not errors, "\n".join(v.message for v in errors)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="space-wasting placement / intra-section column gaps under "
+        "fold; tracked in #989",
+    )
+    def test_no_excessive_column_gaps(self, graph):
+        v = check_excessive_column_gaps(graph)
+        assert not v, "\n".join(vi.message for vi in v)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="non-consumer line breezes through downstream markers under "
+        "fold instead of bypassing; tracked in #990",
+    )
+    def test_no_breeze_through_markers(self, graph):
+        from nf_metro.render import render_svg
+        from nf_metro.render.validate import validate_render
+        from nf_metro.themes import THEMES
+
+        svg = render_svg(graph, THEMES["nfcore"])
+        crosses = [
+            v for v in validate_render(svg, graph=graph) if "non-consumer" in v.message
+        ]
+        assert not crosses, "\n".join(v.message for v in crosses)
 
 
 # --- #420: single-line linear chains must stay axis-aligned ---


### PR DESCRIPTION
## Summary

Adds a regression lock (no engine fix) for three layout defects that only surface under aggressive folding, all observed on `examples/rnaseq_auto.mmd --fold-threshold 1`.

- Adds `examples/regressions/rnaseq_auto_fold1.mmd`: `rnaseq_auto` pinned to `%%metro fold_threshold: 1`, so it folds maximally at the default flags.
- Adds a gallery entry for it, so CI's render-diff tracks the folded render going forward.
- Adds `TestRnaseqAutoFold1Defects` with one strict xfail per defect, each keyed to its tracking issue:
  - `test_no_station_as_elbow` -> #672 (fan-in station-as-elbow + descent crossing in `pseudo_align`)
  - `test_no_excessive_column_gaps` -> #989 (space-wasting placement / intra-section column gaps)
  - `test_no_breeze_through_markers` -> #990 (non-consumer line drawn through downstream markers instead of bypassing)

When an engine fix lands, the matching xfail flips to XPASS and reds CI, prompting the marker removal.

## Why `examples/regressions/`

`compute_layout(validate=True)` deliberately raises a `PhaseInvariantError` on this fixture (the Stage 6.14 non-consumer-marker-cross guard catches the #672 defect). The validated content corpus globs `examples/*.mmd`, `examples/topologies/`, `examples/guide/` and `tests/fixtures/` (all non-recursive) and expects `validate=True` to succeed, so the fixture lives in a sibling `examples/regressions/` directory to stay out of those globs. The dedicated test class loads it honouring the fold directive (`max_station_columns=None`).

## Test plan

- [x] `pytest` passes: 19329 passed, 9 xfailed (the 3 new locks included), 0 failed
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] New fixture renders cleanly via the default render path (the gallery render)
- [ ] Render preview: confirms the new `rnaseq_auto_fold1` gallery render; no existing gallery example changes

Relates to #672, #989, #990 (regression lock only; no fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
