### PR TITLE
feat(playground): full render-diff example set, grouped in the dropdown

### DIFF
--- a/.github/workflows/playground-e2e.yml
+++ b/.github/workflows/playground-e2e.yml
@@ -26,6 +26,9 @@ jobs:
           WHEEL=$(basename docs/playground/wheels/*.whl)
           printf '{"wheel": "%s"}\n' "$WHEEL" > docs/playground/wheels/index.json
 
+      - name: Install nf-metro (the manifest generator imports build_gallery)
+        run: pip install -e .
+
       - name: Build playground example manifest
         run: python scripts/build_playground_examples.py
 

--- a/docs/playground/app.js
+++ b/docs/playground/app.js
@@ -460,21 +460,26 @@ function toast(msg) {
 /* ------------------------------ examples ------------------------------ */
 
 async function loadExamples() {
-  let entries;
+  let groups;
   try {
     const resp = await fetch("examples.json", { cache: "no-store" });
     if (!resp.ok) return;
-    entries = await resp.json();
+    groups = await resp.json();
   } catch (_) {
     return; // no manifest shipped; the starter remains available
   }
-  const group = el("example-group");
-  entries.forEach(({ name, mmd }) => {
-    examples[name] = mmd;
-    const opt = document.createElement("option");
-    opt.value = name;
-    opt.textContent = name;
-    group.append(opt);
+  const select = el("example-select");
+  groups.forEach(({ label, entries }) => {
+    const optgroup = document.createElement("optgroup");
+    optgroup.label = label;
+    entries.forEach(({ name, mmd }) => {
+      examples[name] = mmd;
+      const opt = document.createElement("option");
+      opt.value = name;
+      opt.textContent = name;
+      optgroup.append(opt);
+    });
+    select.append(optgroup);
   });
 }
 

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -21,7 +21,6 @@
           <select id="example-select">
             <option value="" selected>example…</option>
             <option value="__seed__">Starter pipeline</option>
-            <optgroup id="example-group" label="Examples"></optgroup>
           </select>
         </label>
         <span class="sep"></span>

--- a/docs/playground/tests/playground.spec.js
+++ b/docs/playground/tests/playground.spec.js
@@ -131,6 +131,8 @@ test("example dropdown loads a chosen example and renders it", async () => {
   const select = page.locator("#example-select");
   // Manifest populated the dropdown beyond the placeholder + starter.
   expect(await select.locator("option").count()).toBeGreaterThan(2);
+  // Entries are grouped into multiple <optgroup>s.
+  expect(await select.locator("optgroup").count()).toBeGreaterThan(1);
 
   await select.selectOption("rnaseq_auto");
   await expect
@@ -141,6 +143,12 @@ test("example dropdown loads a chosen example and renders it", async () => {
     .toBeGreaterThan(0);
   // Action menu resets to its placeholder after loading.
   await expect(select).toHaveValue("");
+
+  // A topology fixture (only in the render diff, not examples/*.mmd) loads too.
+  await select.selectOption("single_section");
+  await expect
+    .poll(async () => page.evaluate(() => window.__nfMetro.getValue()))
+    .toContain("graph");
 
   // The starter entry is always available even without the manifest.
   await select.selectOption("__seed__");

--- a/scripts/build_playground_examples.py
+++ b/scripts/build_playground_examples.py
@@ -1,30 +1,93 @@
 #!/usr/bin/env python3
-"""Generate the playground's example manifest from ``examples/*.mmd``.
+"""Generate the playground's grouped example manifest.
 
-The browser playground is a static page, so it cannot read the repo's
-``examples/`` directory directly. This writes their contents to
-``docs/playground/examples.json`` (a list of ``{"name", "mmd"}``) for the
-"load example" dropdown to fetch. Run it before building/serving the
-playground; the output is git-ignored and regenerated in CI.
+The browser playground is a static page, so it cannot read the repo's example
+maps directly. This writes their contents to ``docs/playground/examples.json``
+(an ordered list of ``{"label", "entries": [{"name", "mmd"}]}`` groups) for the
+"load example" dropdown to fetch.
+
+The set and grouping mirror the gallery / PR render-diff: it reuses
+``build_gallery``'s curated, ordered entries and its ``CATEGORY_HEADERS`` so the
+dropdown stays in lockstep with what the render diff shows. Run it before
+building/serving the playground; the output is git-ignored and regenerated in
+CI.
 """
 
 from __future__ import annotations
 
 import json
+import re
+import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
-EXAMPLES_DIR = ROOT / "examples"
+SCRIPTS_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPTS_DIR.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_gallery as gallery  # noqa: E402  (path set above)
+
 OUTPUT = ROOT / "docs" / "playground" / "examples.json"
+
+# Mirrors render_test_fixtures() in build_gallery.py.
+TEST_FIXTURE_STEMS = ("multiline_labels", "rnaseq_simple", "genomeassembly_organellar")
+
+_DIVIDER_RE = re.compile(r"^\s*#\s*-{2,}\s*(.+?)\s*-{2,}\s*$")
+_STEM_RE = re.compile(r'^\s*"([A-Za-z0-9_]+)"\s*,\s*$')
+
+
+def gallery_categories() -> dict[str, str]:
+    """Map each gallery stem to its ``# --- ... ---`` divider in build_gallery.
+
+    ``CATEGORY_HEADERS`` only marks 7 coarse sections, collapsing ~90 entries
+    into "Fold Topologies". The source's divider comments carry the finer
+    taxonomy the maintainer actually uses, so the dropdown reads those.
+    """
+    stems = {stem for stem, _dir, _desc in gallery.GALLERY_ENTRIES}
+    category: dict[str, str] = {}
+    current = "Gallery"
+    for line in Path(gallery.__file__).read_text().splitlines():
+        divider = _DIVIDER_RE.match(line)
+        if divider:
+            current = divider.group(1)
+            continue
+        stem = _STEM_RE.match(line)
+        if stem and stem.group(1) in stems:
+            category.setdefault(stem.group(1), current)
+    return category
 
 
 def main() -> None:
-    entries = [
-        {"name": path.stem, "mmd": path.read_text()}
-        for path in sorted(EXAMPLES_DIR.glob("*.mmd"))
-    ]
-    OUTPUT.write_text(json.dumps(entries, indent=2) + "\n")
-    print(f"wrote {len(entries)} examples -> {OUTPUT.relative_to(ROOT)}")
+    groups: list[dict] = []
+    by_label: dict[str, list] = {}
+    seen: set[str] = set()
+
+    def add(label: str, name: str, path: Path) -> None:
+        if name in seen or not path.exists():
+            return
+        seen.add(name)
+        if label not in by_label:
+            by_label[label] = []
+            groups.append({"label": label, "entries": by_label[label]})
+        by_label[label].append({"name": name, "mmd": path.read_text()})
+
+    # Gallery: main examples + topologies, grouped by the source's dividers.
+    categories = gallery_categories()
+    for stem, source_dir, _description in gallery.GALLERY_ENTRIES:
+        add(categories.get(stem, "Gallery"), stem, source_dir / f"{stem}.mmd")
+
+    for path in sorted(gallery.GUIDE_DIR.glob("*.mmd")):
+        add("Guide", path.stem, path)
+
+    for stem in TEST_FIXTURE_STEMS:
+        add("Test fixtures", stem, gallery.TEST_FIXTURES_DIR / f"{stem}.mmd")
+
+    # Nextflow `-with-dag` inputs are intentionally excluded: they are raw
+    # mermaid, not metro maps, and only render via --from-nextflow conversion.
+
+    OUTPUT.write_text(json.dumps(groups, indent=2) + "\n")
+    total = sum(len(g["entries"]) for g in groups)
+    rel = OUTPUT.relative_to(ROOT)
+    print(f"wrote {total} examples in {len(groups)} groups -> {rel}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this adds

Expands the playground's **"Load example"** dropdown so it offers every map the gallery / PR render diff renders, **grouped** into `<optgroup>`s instead of one flat list.

Previously the dropdown only carried `examples/*.mmd` (33 maps). It now includes the full render-diff set (146 maps): the main examples, all topology stress fixtures, the guide snippets, and the test fixtures, organised into 16 groups (Main examples, Simple topologies, Fan-out and fan-in, Offset and bypass, Routing-gate coverage, and so on).

## How the set and grouping stay in lockstep with the render diff

`scripts/build_playground_examples.py` now reuses `build_gallery`'s curated, ordered `GALLERY_ENTRIES` (the same list the gallery and render diff render) and derives the group labels from that file's `# --- ... ---` section dividers, which carry a finer taxonomy than the 7 coarse `CATEGORY_HEADERS`. The manifest is the grouped form `[{label, entries: [{name, mmd}]}]`, written to the git-ignored `docs/playground/examples.json` and regenerated in CI.

Nextflow `-with-dag` inputs are intentionally excluded: they are raw mermaid, not metro maps, and only render via `--from-nextflow` conversion.

## Notes

- All 146 maps were verified to render through the browser path with no errors.
- The dropdown stays an action menu (resets to its placeholder after loading, so re-picking the same entry works).

## Testing

The Playwright case now also asserts the dropdown is split into multiple `<optgroup>`s and that a topology fixture (`single_section`, which only appears in the render diff, not in `examples/*.mmd`) loads and renders. Full suite: 12/12 e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
