### PR TITLE
feat(playground): source-of-truth layout/style controls + debug toggle (fixes #994)

### DIFF
--- a/docs/playground/app.js
+++ b/docs/playground/app.js
@@ -42,6 +42,7 @@ def nfm_render(mmd, opts_json):
             theme=opts.get("theme") or None,
             responsive=True,
             embed_font=True,
+            debug=bool(opts.get("debug")),
             layout_options=layout,
         )
         return json.dumps({"ok": True, "svg": svg})
@@ -136,21 +137,15 @@ async function boot() {
 
 /* -------------------------------- render ------------------------------- */
 
-function numOrNull(id) {
-  const v = el(id).value.trim();
-  if (v === "") return null;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : null;
-}
-
 function currentOptions() {
+  // Layout/style directives live in the source (parsed on render); only the
+  // preview-overlay toggles are passed as render overrides here.
   return {
-    theme: el("opt-theme").value,
+    theme: themeKeyFromSource(),
+    debug: el("opt-debug").checked,
     layout_options: {
       animate: el("opt-animate").checked,
       directional: el("opt-directional").checked,
-      x_spacing: numOrNull("opt-x-spacing"),
-      y_spacing: numOrNull("opt-y-spacing"),
     },
   };
 }
@@ -185,6 +180,90 @@ function doRender() {
     showError(res.error);
   }
   refreshLineColors();
+  syncDirectiveControls();
+}
+
+/* ------------------------- directive controls ------------------------- */
+
+// Controls that change the map's layout or styling are source-of-truth: each
+// writes a `%%metro <key>:` directive into the editor and is synced back from
+// it, so the change is saved with the map and travels with export/share. (The
+// animate/chevrons/debug toggles are preview overlays handled separately.)
+
+// directive key for the theme; values are friendly aliases (dark == nfcore).
+const THEME_KEYS = ["nfcore", "light"];
+const THEME_STYLE_TOKEN = { nfcore: "dark", light: "light" };
+const STYLE_ALIASES = { dark: "nfcore" };
+
+// [control id, directive key, kind]
+const DIRECTIVE_CONTROLS = [
+  ["opt-line-spread", "line_spread", "choice"],
+  ["opt-diamond-style", "diamond_style", "choice"],
+  ["opt-line-order", "line_order", "choice"],
+  ["opt-center-ports", "center_ports", "bool"],
+  ["opt-compact-offsets", "compact_offsets", "bool"],
+  ["opt-font-scale", "font_scale", "number"],
+  ["opt-fold-threshold", "fold_threshold", "number"],
+  ["opt-x-spacing", "x_spacing", "number"],
+  ["opt-y-spacing", "y_spacing", "number"],
+];
+
+function readDirective(key) {
+  const m = editor.getValue().match(new RegExp(`^\\s*%%metro\\s+${key}:\\s*(.+?)\\s*$`, "m"));
+  return m ? m[1] : null;
+}
+
+// value === null removes the directive line; otherwise it is set (inserted
+// after a %%metro title: line if present, else at the top - directives must
+// precede the graph block).
+function setDirective(key, value) {
+  const lines = editor.getValue().split("\n");
+  const idx = lines.findIndex((l) => new RegExp(`^\\s*%%metro\\s+${key}:`).test(l));
+  if (value === null) {
+    if (idx >= 0) editor.replaceRange("", { line: idx, ch: 0 }, { line: idx + 1, ch: 0 });
+  } else if (idx >= 0) {
+    const updated = lines[idx].replace(new RegExp(`(%%metro\\s+${key}:\\s*).*`), `$1${value}`);
+    editor.replaceRange(updated, { line: idx, ch: 0 }, { line: idx, ch: lines[idx].length });
+  } else {
+    const titleIdx = lines.findIndex((l) => /^\s*%%metro\s+title:/.test(l));
+    const at = titleIdx >= 0 ? titleIdx + 1 : 0;
+    editor.replaceRange(`%%metro ${key}: ${value}\n`, { line: at, ch: 0 });
+  }
+}
+
+function applyDirectiveControl(id, key, kind) {
+  const control = el(id);
+  let value;
+  if (kind === "bool") {
+    value = control.checked ? "true" : null;
+  } else {
+    const raw = control.value.trim();
+    value = raw === "" ? null : raw;
+  }
+  setDirective(key, value);
+  doRender();
+}
+
+function themeKeyFromSource() {
+  const value = (readDirective("style") || "").toLowerCase();
+  const key = STYLE_ALIASES[value] || value;
+  return THEME_KEYS.includes(key) ? key : "nfcore";
+}
+
+function setThemeDirective(themeKey) {
+  setDirective("style", THEME_STYLE_TOKEN[themeKey] || themeKey);
+  doRender();
+}
+
+const _TRUE = new Set(["true", "yes", "1"]);
+
+function syncDirectiveControls() {
+  el("opt-theme").value = themeKeyFromSource();
+  for (const [id, key, kind] of DIRECTIVE_CONTROLS) {
+    const value = readDirective(key);
+    if (kind === "bool") el(id).checked = _TRUE.has((value || "").toLowerCase());
+    else el(id).value = value ?? "";
+  }
 }
 
 /* ----------------------------- line colors ---------------------------- */
@@ -397,10 +476,9 @@ ${mmdBlock}
 
 - nf-metro: ${nfMetroVersion || "unknown"}
 - theme: ${opts.theme}
+- debug: ${opts.debug}
 - animate: ${lo.animate}
 - directional: ${lo.directional}
-- x-spacing: ${lo.x_spacing ?? "auto"}
-- y-spacing: ${lo.y_spacing ?? "auto"}
 - page: ${location.href.split("#")[0]}
 - user agent: ${navigator.userAgent}
 `;
@@ -494,8 +572,12 @@ function loadExample(value) {
 
 function wireControls() {
   el("example-select").addEventListener("change", (e) => loadExample(e.target.value));
-  ["opt-theme", "opt-animate", "opt-directional", "opt-x-spacing", "opt-y-spacing"].forEach(
-    (id) => el(id).addEventListener("change", doRender)
+  el("opt-theme").addEventListener("change", (e) => setThemeDirective(e.target.value));
+  DIRECTIVE_CONTROLS.forEach(([id, key, kind]) =>
+    el(id).addEventListener("change", () => applyDirectiveControl(id, key, kind))
+  );
+  ["opt-animate", "opt-directional", "opt-debug"].forEach((id) =>
+    el(id).addEventListener("change", doRender)
   );
   Object.keys(SNIPPETS).forEach((id) => el(id).addEventListener("click", () => insertSnippet(id)));
   el("btn-svg").addEventListener("click", exportSvg);

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -46,6 +46,39 @@
         </label>
         <label class="check"><input type="checkbox" id="opt-animate" /> Animate</label>
         <label class="check"><input type="checkbox" id="opt-directional" /> Chevrons</label>
+        <label class="check"><input type="checkbox" id="opt-debug" /> Debug</label>
+        <span class="sep"></span>
+        <span class="group-label">Layout</span>
+        <label>Line spread
+          <select id="opt-line-spread">
+            <option value="">auto</option>
+            <option value="bundle">bundle</option>
+            <option value="centered">centered</option>
+            <option value="rails">rails</option>
+          </select>
+        </label>
+        <label>Diamonds
+          <select id="opt-diamond-style">
+            <option value="">auto</option>
+            <option value="straight">straight</option>
+            <option value="symmetric">symmetric</option>
+          </select>
+        </label>
+        <label>Line order
+          <select id="opt-line-order">
+            <option value="">auto</option>
+            <option value="definition">definition</option>
+            <option value="span">span</option>
+          </select>
+        </label>
+        <label class="check"><input type="checkbox" id="opt-center-ports" /> Centre ports</label>
+        <label class="check"><input type="checkbox" id="opt-compact-offsets" /> Compact offsets</label>
+        <label>Font scale
+          <input type="number" id="opt-font-scale" min="0.1" step="0.1" placeholder="1.0" />
+        </label>
+        <label>Fold cols
+          <input type="number" id="opt-fold-threshold" min="1" step="1" placeholder="auto" />
+        </label>
         <label>X-spacing
           <input type="number" id="opt-x-spacing" min="1" step="10" placeholder="auto" />
         </label>

--- a/docs/playground/tests/playground.spec.js
+++ b/docs/playground/tests/playground.spec.js
@@ -57,13 +57,81 @@ test("directional toggle adds chevron markers", async () => {
   await page.locator("#opt-directional").uncheck();
 });
 
-test("theme switch changes the rendered output", async () => {
+test("theme dropdown writes the %%metro style directive and re-renders", async () => {
+  await page.evaluate(() =>
+    window.__nfMetro.setValue("%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n")
+  );
   const before = await page.locator("#preview").innerHTML();
+
   await page.locator("#opt-theme").selectOption("light");
   await expect
-    .poll(async () => page.locator("#preview").innerHTML())
-    .not.toBe(before);
+    .poll(async () => page.evaluate(() => window.__nfMetro.getValue()))
+    .toContain("%%metro style: light");
+  await expect.poll(async () => page.locator("#preview").innerHTML()).not.toBe(before);
+
   await page.locator("#opt-theme").selectOption("nfcore");
+  await expect
+    .poll(async () => page.evaluate(() => window.__nfMetro.getValue()))
+    .toContain("%%metro style: dark");
+});
+
+test("theme dropdown syncs from the source style directive", async () => {
+  await page.evaluate(() =>
+    window.__nfMetro.setValue(
+      "%%metro style: light\n%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n"
+    )
+  );
+  await expect(page.locator("#opt-theme")).toHaveValue("light");
+});
+
+test("debug toggle adds the debug overlay", async () => {
+  // A sectioned map has ports/waypoints for the overlay to draw.
+  await page.evaluate(() =>
+    window.__nfMetro.setValue(
+      "%%metro line: a | A | #f00\ngraph LR\n" +
+        "  subgraph s1 [One]\n    n1[N1]\n  end\n" +
+        "  subgraph s2 [Two]\n    n2[N2]\n  end\n" +
+        "  n1 -->|a| n2\n"
+    )
+  );
+  const before = await page.locator("#preview").innerHTML();
+  await page.locator("#opt-debug").check();
+  await expect.poll(async () => page.locator("#preview").innerHTML()).not.toBe(before);
+  await page.locator("#opt-debug").uncheck();
+});
+
+test("layout controls write %%metro directives and sync from source", async () => {
+  const getValue = () => page.evaluate(() => window.__nfMetro.getValue());
+  await page.evaluate(() =>
+    window.__nfMetro.setValue("%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n")
+  );
+
+  // choice -> writes directive, then "auto" removes it
+  await page.locator("#opt-line-spread").selectOption("rails");
+  await expect.poll(getValue).toContain("%%metro line_spread: rails");
+  await page.locator("#opt-line-spread").selectOption("");
+  await expect.poll(getValue).not.toContain("line_spread");
+
+  // bool -> writes true, unchecking removes it
+  await page.locator("#opt-center-ports").check();
+  await expect.poll(getValue).toContain("%%metro center_ports: true");
+  await page.locator("#opt-center-ports").uncheck();
+  await expect.poll(getValue).not.toContain("center_ports");
+
+  // number -> writes the value and re-renders
+  await page.locator("#opt-font-scale").fill("1.5");
+  await page.locator("#opt-font-scale").blur();
+  await expect.poll(getValue).toContain("%%metro font_scale: 1.5");
+
+  // controls sync FROM a source directive
+  await page.evaluate(() =>
+    window.__nfMetro.setValue(
+      "%%metro line_spread: centered\n%%metro center_ports: true\n" +
+        "%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n"
+    )
+  );
+  await expect(page.locator("#opt-line-spread")).toHaveValue("centered");
+  await expect(page.locator("#opt-center-ports")).toBeChecked();
 });
 
 test("snippet button inserts valid boilerplate and still renders", async () => {


### PR DESCRIPTION
## Summary

Make the playground's layout/style controls source-of-truth, fixing #994 and adding the requested extra options.

- **Fix #994**: changing **Theme** now rewrites the `%%metro style:` directive in the editor (was render-only), and the dropdown syncs from the source, so loading a map/example/shared-link reflects its style. (Inverse bug fixed too.)
- **Generalised** to a directive-binding system. These controls now write their `%%metro` directive and sync from it, so a control change is saved with the map and travels with export/share:
  - `line_spread` (bundle / centered / rails)
  - `diamond_style` (straight / symmetric)
  - `line_order` (definition / span)
  - `center_ports`, `compact_offsets`
  - `font_scale`, `fold_threshold`
  - `x_spacing`, `y_spacing` (migrated from render-override to source for consistency)
- **New Debug overlay toggle** (ports, hidden stations, edge waypoints) - a preview-only control, since `debug` has no directive.
- **Animate** and **Chevrons** remain preview-only overlays (they don't change the base layout).

The conceptual line: controls that change the map's layout or styling write a `%%metro` directive into the source; animate/chevrons/debug are preview overlays that don't.

## Test plan
- [x] Playwright e2e: 15/15 pass, including the theme directive write + sync, the debug overlay, and the generic directive controls (choice/bool/number write + removal + sync-from-source)
- [x] All directive values verified to parse and apply through `render_string`
- [x] No Python changed; ruff/mypy unaffected
- [ ] Visual review of the render preview

Fixes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)
