### PR TITLE
fix(render): draw debug row grid through bundled markers (#589)

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -9,6 +9,7 @@ import math
 import re
 import textwrap
 import warnings
+from collections.abc import Iterable
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, Literal, NamedTuple
@@ -19,7 +20,6 @@ from nf_metro.layout.constants import (
     LABEL_LINE_HEIGHT,
     OFFTRACK_TERMINUS_NUB_CLEARANCE,
     SAME_COORD_TOLERANCE,
-    Y_SPACING,
 )
 from nf_metro.layout.geometry import segment_intersects_bbox
 from nf_metro.layout.labels import (
@@ -2715,21 +2715,39 @@ def _compute_col_boundary_xs(
     return result
 
 
+def _row_grid_anchor_ys(graph: MetroGraph, station_ids: Iterable[str]) -> list[float]:
+    """The distinct placement-row Ys among the given stations.
+
+    A station is positioned by ``station.y`` -- the row anchor (the offset-0
+    slot, the top of the bundle), not the centre of its rendered pill, which is
+    offset downward by the bundle mid.  The debug grid marks these anchors so a
+    line shows where the engine placed a row; same-row stations share their
+    anchor and collapse to one line, while a station the engine drifted onto a
+    slightly different Y splits off its own line.  Hidden stations (bypass
+    junctions and the like) occupy real rows too, so they anchor a line; only
+    ports, which ride a neighbouring station's row, are skipped.
+    """
+    return sorted(
+        {
+            round(st.y, 1)
+            for sid in station_ids
+            if (st := graph.stations.get(sid)) and not st.is_port
+        }
+    )
+
+
 def _draw_debug_y_grid(
     d: draw.Drawing,
     *,
     x_start: float,
     x_end: float,
-    base_y: float,
-    slot_spacing: float,
-    n_slots: int,
+    row_ys: list[float],
     label: str,
     debug_font: str,
     debug_font_size: float,
 ) -> None:
-    """Draw horizontal grid-slot lines, labelling the topmost one."""
-    for i in range(n_slots):
-        y = base_y + i * slot_spacing
+    """Draw one horizontal line per row Y, labelling the topmost one."""
+    for i, y in enumerate(row_ys):
         d.append(
             draw.Line(
                 x_start,
@@ -2879,40 +2897,27 @@ def _render_debug_overlay(
                 )
             )
 
-    # Horizontal grid-slot lines. Multi-section row groups use the shared
-    # slot spacing from _align_row_y_grids; every other section falls back to
-    # the global Y pitch so single-section diagrams still show their grid.
-    grid_info = graph._row_y_grid_info
+    # Horizontal row lines at each section's placement-row anchors (the distinct
+    # station.y values, see _row_grid_anchor_ys). Multi-section row bands share
+    # one full-width set of lines; every other section draws its own.
     grouped_sec_ids: set[str] = set()
-    for row, info in grid_info.items():
-        slot_spacing = info["slot_spacing"]
-        sec_ids = info["section_ids"]
-        ref_secs = [graph.sections[sid] for sid in sec_ids if sid in graph.sections]
+    for row, info in graph._row_y_grid_info.items():
+        ref_secs = [
+            graph.sections[sid] for sid in info["section_ids"] if sid in graph.sections
+        ]
         if not ref_secs:
             continue
         grouped_sec_ids.update(s.id for s in ref_secs)
-        all_station_ys: list[float] = []
-        for sec in ref_secs:
-            for sid in sec.station_ids:
-                st = graph.stations.get(sid)
-                if st and not st.is_port:
-                    all_station_ys.append(st.y)
-        if not all_station_ys:
-            continue
-        base_y = min(all_station_ys)
-        max_y = max(all_station_ys)
-        n_slots = (
-            int(round((max_y - base_y) / slot_spacing)) + 1 if slot_spacing > 0 else 1
+        row_ys = _row_grid_anchor_ys(
+            graph, (sid for sec in ref_secs for sid in sec.station_ids)
         )
-        x_start = min(s.bbox_x for s in ref_secs) - 10
-        x_end = max(s.bbox_x + s.bbox_w for s in ref_secs) + 10
+        if not row_ys:
+            continue
         _draw_debug_y_grid(
             d,
-            x_start=x_start,
-            x_end=x_end,
-            base_y=base_y,
-            slot_spacing=slot_spacing,
-            n_slots=n_slots,
+            x_start=min(s.bbox_x for s in ref_secs) - 10,
+            x_end=max(s.bbox_x + s.bbox_w for s in ref_secs) + 10,
+            row_ys=row_ys,
             label=f"row {row} grid",
             debug_font=debug_font,
             debug_font_size=debug_font_size,
@@ -2921,24 +2926,14 @@ def _render_debug_overlay(
     for sec in sections:
         if sec.id in grouped_sec_ids:
             continue
-        sec_ys = [
-            st.y
-            for sid in sec.station_ids
-            for st in (graph.stations.get(sid),)
-            if st and not st.is_port
-        ]
-        if not sec_ys:
+        row_ys = _row_grid_anchor_ys(graph, sec.station_ids)
+        if not row_ys:
             continue
-        base_y = min(sec_ys)
-        max_y = max(sec_ys)
-        n_slots = int(round((max_y - base_y) / Y_SPACING)) + 1
         _draw_debug_y_grid(
             d,
             x_start=sec.bbox_x - 10,
             x_end=sec.bbox_x + sec.bbox_w + 10,
-            base_y=base_y,
-            slot_spacing=Y_SPACING,
-            n_slots=n_slots,
+            row_ys=row_ys,
             label=f"row {sec.grid_row} grid",
             debug_font=debug_font,
             debug_font_size=debug_font_size,

--- a/tests/test_debug_row_grid.py
+++ b/tests/test_debug_row_grid.py
@@ -1,0 +1,108 @@
+"""The debug row grid must mark placement-row anchors, not an assumed pitch (#589).
+
+A station is positioned by ``station.y`` -- the row anchor (the offset-0 slot,
+the top of its line bundle), not the centre of its rendered pill, which is
+offset downward by the bundle mid.  The ``--debug`` row grid exists to show
+where the engine placed each row, so every line must sit on a real ``station.y``
+and every occupied row must have one.  Drawing an inferred uniform pitch instead
+let lines drift off the anchors -- missing real rows and adding phantom lines
+where no station sits.  These tests pin each line to an actual anchor.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.render.constants import DEBUG_ROW_GRID_COLOR
+from nf_metro.render.svg import compute_station_offsets, render_svg, station_marker_box
+from nf_metro.themes import NFCORE_THEME
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+
+# Fixtures whose rows are not on a single uniform pitch, so an inferred-pitch
+# grid drifts off the anchors -- the condition that motivated #589.
+# bypass_label_rake_wide pins a row anchored only by a hidden bypass junction:
+# its line must survive (an inferred pitch dropped that lowest row).
+GRID_FIXTURES = [
+    "differentialabundance.mmd",
+    "differentialabundance_default.mmd",
+    "diagonal_labels.mmd",
+    "sarek_metro.mmd",
+    "topologies/bypass_label_rake_wide.mmd",
+]
+
+EPS = 0.5
+
+
+def _laid_out(name: str):
+    graph = parse_metro_mermaid((EXAMPLES_DIR / name).read_text())
+    compute_layout(graph)
+    return graph
+
+
+def _row_grid_line_ys(svg: str) -> list[float]:
+    """Y of every horizontal debug row-grid line (drawsvg emits Line as path)."""
+    rgb = DEBUG_ROW_GRID_COLOR.split("(")[1].rsplit(",", 1)[0]
+    ys: list[float] = []
+    for d, stroke in re.findall(r'<path d="([^"]+)" stroke="([^"]+)"', svg):
+        if rgb not in stroke:
+            continue
+        m = re.fullmatch(r"M[\d.]+,([\d.]+) L[\d.]+,([\d.]+)", d)
+        if m and abs(float(m.group(1)) - float(m.group(2))) < EPS:
+            ys.append(float(m.group(1)))
+    return ys
+
+
+def _anchor_ys(graph) -> set[float]:
+    return {round(st.y, 1) for st in graph.stations.values() if not st.is_port}
+
+
+@pytest.mark.parametrize("fixture", GRID_FIXTURES)
+def test_debug_row_grid_marks_placement_anchors(fixture):
+    """Every occupied row has a grid line on its anchor, and no grid line sits
+    where no station is placed."""
+    graph = _laid_out(fixture)
+    svg = render_svg(graph, NFCORE_THEME, debug=True, chrome_css=False)
+    grid_ys = _row_grid_line_ys(svg)
+    assert grid_ys, "debug render drew no row-grid lines"
+    anchors = _anchor_ys(graph)
+
+    for a in anchors:
+        assert any(abs(a - g) <= EPS for g in grid_ys), (
+            f"{fixture}: row anchor y={a} has no grid line; "
+            f"lines={sorted(set(grid_ys))}"
+        )
+    for g in grid_ys:
+        assert any(abs(a - g) <= EPS for a in anchors), (
+            f"{fixture}: grid line y={g} sits at no station anchor {sorted(anchors)}"
+        )
+
+
+def test_debug_grid_sits_at_anchor_not_pill_centre():
+    """The headline #589 case: the nine bundled qc_report stations share one
+    anchor line at station.y, and their pills hang below it (centre != anchor)."""
+    graph = _laid_out("rnaseq_sections_manual.mmd")
+    svg = render_svg(graph, NFCORE_THEME, debug=True, chrome_css=False)
+    grid_ys = _row_grid_line_ys(svg)
+    offsets = compute_station_offsets(graph)
+
+    qc = [
+        st
+        for st in graph.stations.values()
+        if st.section_id == "qc_report" and not st.is_port and not st.is_hidden
+    ]
+    trunk_y = min(st.y for st in qc)
+    trunk = [st for st in qc if abs(st.y - trunk_y) < EPS]
+    assert len(trunk) > 1, "expected a bundled trunk row in qc_report"
+
+    grid_at = [g for g in grid_ys if abs(g - trunk_y) <= EPS]
+    assert grid_at, f"no grid line at the qc_report anchor y={trunk_y}"
+
+    for st in trunk:
+        _cx, cy, _w, _h, _r = station_marker_box(graph, NFCORE_THEME, st, offsets)
+        # The bundle offset puts the drawn pill centre below its anchor line.
+        assert cy > trunk_y + EPS
+        assert not any(abs(cy - g) <= EPS for g in grid_at)


### PR DESCRIPTION
## Summary

The `--debug` row grid is meant to show where the engine placed each row, so a reviewer can spot a station that drifted off its row. It inferred a uniform row pitch (`base_y + i*slot_spacing`, or `+i*Y_SPACING` in the single-section fallback) and drew lines on that lattice. Where a section's rows are not evenly pitched, the lattice drifts off the real rows: it misses some anchors and draws phantom lines where no station sits.

This draws one line per distinct `station.y` instead, the placement anchor (the offset-0 slot, the top of the line bundle). Same-row stations share their anchor and collapse to one line; a station the engine drifted onto a different Y splits off its own line, which is the signal the grid exists to surface. Hidden stations (bypass junctions and the like) occupy real rows too, so they anchor a line; only ports, which ride a neighbouring station's row, are skipped.

A station is positioned by its anchor `station.y`, not the centre of its rendered pill. Bundled pills are drawn centred on their own sub-bundle and so hang below the anchor line by their bundle mid; that is expected (the line marks the top of the row), not a misplacement.

`_draw_debug_y_grid` now takes an explicit `row_ys` list, fed by the new `_row_grid_anchor_ys` helper.

Debug-overlay only; normal (non-debug) renders are byte-identical. Verified across the corpus: the grid never drops a line that sits on a real (visible or hidden) station row; it only removes the assumed-pitch phantom slots and adds lines where the lattice missed an anchor.

Fixes #589

## Test plan
- [x] New test `tests/test_debug_row_grid.py`: every occupied row (including hidden bypass rows, e.g. `bypass_label_rake_wide`) has a grid line on its anchor and no line sits where no station is placed; plus a headline `qc_report` case pinning "line at the anchor, pills hang below" so the centre-based approach can't be reintroduced. The drift fixtures fail on `main`, pass here.
- [x] Full suite green (19450 passed); no guard/golden changes
- [x] ruff check + ruff format clean; mypy clean
- [x] Render-preview verdict: deltas present (the gallery renders with `--debug`). Every delta is debug row-grid lines moving onto the placement anchors on fixtures whose rows are unevenly pitched. Verified by diffing before/after debug SVGs: only `rgba(80,255,180)` grid-line paths differ, and no real (station-bearing) row line is dropped; zero station/route/label/section ink changed.

Generated with Claude Code
