### PR TITLE
feat(playground): tuck advanced layout options behind a disclosure

### DIFF
--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -46,52 +46,59 @@
           </select>
         </label>
         <label class="check"><input type="checkbox" id="opt-animate" /> Animate</label>
-        <label class="check"><input type="checkbox" id="opt-directional" /> Chevrons</label>
-        <label class="check"><input type="checkbox" id="opt-debug" /> Debug</label>
-        <span class="sep"></span>
-        <span class="group-label">Layout</span>
-        <label>Line spread
-          <select id="opt-line-spread">
-            <option value="">auto</option>
-            <option value="bundle">bundle</option>
-            <option value="centered">centered</option>
-            <option value="rails">rails</option>
-          </select>
-        </label>
-        <label>Diamonds
-          <select id="opt-diamond-style">
-            <option value="">auto</option>
-            <option value="straight">straight</option>
-            <option value="symmetric">symmetric</option>
-          </select>
-        </label>
-        <label>Line order
-          <select id="opt-line-order">
-            <option value="">auto</option>
-            <option value="definition">definition</option>
-            <option value="span">span</option>
-          </select>
-        </label>
-        <label class="check"><input type="checkbox" id="opt-center-ports" /> Centre ports</label>
-        <label class="check"><input type="checkbox" id="opt-compact-offsets" /> Compact offsets</label>
-        <label>Font scale
-          <input type="number" id="opt-font-scale" min="0.1" step="0.1" placeholder="1.0" />
-        </label>
-        <label>Fold cols
-          <input type="number" id="opt-fold-threshold" min="1" step="1" placeholder="auto" />
-        </label>
-        <label>X-spacing
-          <input type="number" id="opt-x-spacing" min="1" step="10" placeholder="auto" />
-        </label>
-        <label>Y-spacing
-          <input type="number" id="opt-y-spacing" min="1" step="10" placeholder="auto" />
-        </label>
         <span class="sep"></span>
         <span class="group-label">Export</span>
         <button id="btn-svg">SVG</button>
         <button id="btn-png">PNG</button>
         <button id="btn-share">Share link</button>
       </div>
+
+      <details id="advanced" class="advanced">
+        <summary>Advanced options</summary>
+        <div class="pane-toolbar advanced-controls">
+          <label class="check"><input type="checkbox" id="opt-directional" /> Chevrons</label>
+          <label class="check"><input type="checkbox" id="opt-debug" /> Debug</label>
+          <span class="sep"></span>
+          <span class="group-label">Layout</span>
+          <label>Line spread
+            <select id="opt-line-spread">
+              <option value="">auto</option>
+              <option value="bundle">bundle</option>
+              <option value="centered">centered</option>
+              <option value="rails">rails</option>
+            </select>
+          </label>
+          <label>Diamonds
+            <select id="opt-diamond-style">
+              <option value="">auto</option>
+              <option value="straight">straight</option>
+              <option value="symmetric">symmetric</option>
+            </select>
+          </label>
+          <label>Line order
+            <select id="opt-line-order">
+              <option value="">auto</option>
+              <option value="definition">definition</option>
+              <option value="span">span</option>
+            </select>
+          </label>
+          <label class="check"><input type="checkbox" id="opt-center-ports" /> Centre ports</label>
+          <label class="check"><input type="checkbox" id="opt-compact-offsets" /> Compact offsets</label>
+          <label>Font scale
+            <input type="number" id="opt-font-scale" min="0.1" step="0.1" placeholder="1.0" />
+          </label>
+          <label>Fold cols
+            <input type="number" id="opt-fold-threshold" min="1" step="1" placeholder="auto" />
+          </label>
+          <label>X-spacing
+            <input type="number" id="opt-x-spacing" min="1" step="10" placeholder="auto" />
+          </label>
+          <label>Y-spacing
+            <input type="number" id="opt-y-spacing" min="1" step="10" placeholder="auto" />
+          </label>
+        </div>
+      </details>
+
       <div id="preview"></div>
       <div id="boot" class="overlay">
         <div class="spinner"></div>

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -46,6 +46,9 @@
           </select>
         </label>
         <label class="check"><input type="checkbox" id="opt-animate" /> Animate</label>
+        <label class="check"><input type="checkbox" id="opt-directional" /> Chevrons</label>
+        <label class="check"><input type="checkbox" id="opt-debug" /> Debug</label>
+        <label class="check"><input type="checkbox" id="opt-center-ports" /> Centre ports</label>
         <span class="sep"></span>
         <span class="group-label">Export</span>
         <button id="btn-svg">SVG</button>
@@ -56,9 +59,6 @@
       <details id="advanced" class="advanced">
         <summary>Advanced options</summary>
         <div class="pane-toolbar advanced-controls">
-          <label class="check"><input type="checkbox" id="opt-directional" /> Chevrons</label>
-          <label class="check"><input type="checkbox" id="opt-debug" /> Debug</label>
-          <span class="sep"></span>
           <span class="group-label">Layout</span>
           <label>Line spread
             <select id="opt-line-spread">
@@ -82,7 +82,6 @@
               <option value="span">span</option>
             </select>
           </label>
-          <label class="check"><input type="checkbox" id="opt-center-ports" /> Centre ports</label>
           <label class="check"><input type="checkbox" id="opt-compact-offsets" /> Compact offsets</label>
           <label>Font scale
             <input type="number" id="opt-font-scale" min="0.1" step="0.1" placeholder="1.0" />

--- a/docs/playground/style.css
+++ b/docs/playground/style.css
@@ -74,6 +74,29 @@ body {
 }
 .pane-toolbar label.check { gap: 5px; }
 
+.advanced { border-bottom: 1px solid var(--border); }
+.advanced > summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  padding: 7px 12px;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--panel);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.advanced > summary::-webkit-details-marker { display: none; }
+.advanced > summary::before {
+  content: "▸";
+  font-size: 10px;
+  transition: transform 0.12s ease;
+}
+.advanced[open] > summary::before { transform: rotate(90deg); }
+.advanced > summary:hover { color: var(--text); }
+.advanced .advanced-controls { border-bottom: none; }
+
 .swatches {
   display: flex;
   align-items: center;

--- a/docs/playground/tests/playground.spec.js
+++ b/docs/playground/tests/playground.spec.js
@@ -12,6 +12,13 @@ async function waitReady(p) {
   });
 }
 
+// Advanced controls live in a collapsed <details>; open it before driving them.
+async function openAdvanced() {
+  await page.evaluate(() => {
+    document.getElementById("advanced").open = true;
+  });
+}
+
 test.beforeAll(async ({ browser }) => {
   page = await browser.newPage();
   await page.goto("/index.html");
@@ -48,7 +55,18 @@ test("animate toggle adds motion elements", async () => {
   await expect(page.locator("#preview animateMotion")).toHaveCount(0);
 });
 
+test("advanced options are collapsed by default and toggle open", async () => {
+  // Progressive disclosure: power-user knobs are hidden until requested.
+  await expect(page.locator("#advanced")).not.toHaveAttribute("open", /.*/);
+  await expect(page.locator("#opt-line-spread")).toBeHidden();
+  await page.locator("#advanced > summary").click();
+  await expect(page.locator("#opt-line-spread")).toBeVisible();
+  await page.locator("#advanced > summary").click();
+  await expect(page.locator("#opt-line-spread")).toBeHidden();
+});
+
 test("directional toggle adds chevron markers", async () => {
+  await openAdvanced();
   await expect(page.locator('#preview [class*="metro-direction"]')).toHaveCount(0);
   await page.locator("#opt-directional").check();
   expect(
@@ -85,6 +103,7 @@ test("theme dropdown syncs from the source style directive", async () => {
 });
 
 test("debug toggle adds the debug overlay", async () => {
+  await openAdvanced();
   // A sectioned map has ports/waypoints for the overlay to draw.
   await page.evaluate(() =>
     window.__nfMetro.setValue(
@@ -101,6 +120,7 @@ test("debug toggle adds the debug overlay", async () => {
 });
 
 test("layout controls write %%metro directives and sync from source", async () => {
+  await openAdvanced();
   const getValue = () => page.evaluate(() => window.__nfMetro.getValue());
   await page.evaluate(() =>
     window.__nfMetro.setValue("%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n")

--- a/docs/playground/tests/playground.spec.js
+++ b/docs/playground/tests/playground.spec.js
@@ -66,7 +66,6 @@ test("advanced options are collapsed by default and toggle open", async () => {
 });
 
 test("directional toggle adds chevron markers", async () => {
-  await openAdvanced();
   await expect(page.locator('#preview [class*="metro-direction"]')).toHaveCount(0);
   await page.locator("#opt-directional").check();
   expect(
@@ -103,7 +102,6 @@ test("theme dropdown syncs from the source style directive", async () => {
 });
 
 test("debug toggle adds the debug overlay", async () => {
-  await openAdvanced();
   // A sectioned map has ports/waypoints for the overlay to draw.
   await page.evaluate(() =>
     window.__nfMetro.setValue(


### PR DESCRIPTION
## Summary

Apply progressive disclosure to the playground's preview toolbar so the default view isn't overwhelming.

- **Primary row (always visible)**: Theme, Animate, Chevrons, Debug, Centre ports, and Export (SVG / PNG / Share).
- **"Advanced options" panel (collapsed by default)**: the remaining layout knobs - line spread, diamonds, line order, compact offsets, font scale, fold cols, x/y-spacing.

Implemented with a native `<details>`/`<summary>` disclosure - accessible (keyboard + screen-reader), zero JavaScript, with a rotating caret. The controls keep their IDs and behaviour; they're just tucked away until requested.

## Test plan
- [x] Playwright e2e: 17/17 pass, including a test asserting the panel is collapsed by default and toggles open/closed
- [x] No Python changed; ruff/mypy unaffected
- [ ] Visual review of the render preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
