### PR TITLE
feat(playground): zoom controls on the preview

### DIFF
--- a/docs/playground/app.js
+++ b/docs/playground/app.js
@@ -203,12 +203,61 @@ function doRender() {
     showError(null);
     lastSvg = res.svg;
     el("preview").innerHTML = res.svg;
+    applyZoom();
   } else {
     // Keep the last good render visible; just report the problem.
     showError(res.error);
   }
   refreshLineColors();
   syncDirectiveControls();
+}
+
+/* --------------------------------- zoom -------------------------------- */
+
+// null = fit-to-view (responsive); a number is a scale factor on the SVG's
+// intrinsic (viewBox) size. Re-applied after every render since the <svg> is
+// replaced.
+let zoomFactor = null;
+const ZOOM_STEP = 1.25;
+const ZOOM_MIN = 0.1;
+const ZOOM_MAX = 8;
+
+function viewBoxWidth(svg) {
+  const m = (svg.getAttribute("viewBox") || "").match(/[-\d.]+ [-\d.]+ ([-\d.]+) [-\d.]+/);
+  return m ? parseFloat(m[1]) : svg.getBoundingClientRect().width;
+}
+
+function applyZoom() {
+  const svg = el("preview").querySelector("svg");
+  if (!svg) return;
+  el("preview").classList.toggle("zoomed", zoomFactor !== null);
+  if (zoomFactor === null) {
+    svg.style.maxWidth = "100%";
+    svg.style.width = "";
+    svg.style.height = "";
+  } else {
+    svg.style.maxWidth = "none";
+    svg.style.width = viewBoxWidth(svg) * zoomFactor + "px";
+    svg.style.height = "auto";
+  }
+}
+
+function currentScale() {
+  const svg = el("preview").querySelector("svg");
+  if (!svg) return 1;
+  return svg.getBoundingClientRect().width / viewBoxWidth(svg);
+}
+
+function zoomBy(step) {
+  // Starting from fit, continue smoothly from the currently displayed scale.
+  const base = zoomFactor === null ? currentScale() : zoomFactor;
+  zoomFactor = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, base * step));
+  applyZoom();
+}
+
+function zoomFit() {
+  zoomFactor = null;
+  applyZoom();
 }
 
 /* ------------------------- directive controls ------------------------- */
@@ -643,6 +692,10 @@ function wireControls() {
   el("btn-svg").addEventListener("click", exportSvg);
   el("btn-png").addEventListener("click", exportPng);
   el("btn-share").addEventListener("click", shareLink);
+
+  el("zoom-in").addEventListener("click", () => zoomBy(ZOOM_STEP));
+  el("zoom-out").addEventListener("click", () => zoomBy(1 / ZOOM_STEP));
+  el("zoom-fit").addEventListener("click", zoomFit);
 
   el("btn-report").addEventListener("click", openReport);
   el("report-cancel").addEventListener("click", closeReport);

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -93,6 +93,11 @@
         <button id="btn-share">Share link</button>
       </div>
       <div id="preview"></div>
+      <div id="zoom-controls">
+        <button id="zoom-out" title="Zoom out" aria-label="Zoom out">&minus;</button>
+        <button id="zoom-fit" title="Fit to view" aria-label="Fit to view">Fit</button>
+        <button id="zoom-in" title="Zoom in" aria-label="Zoom in">+</button>
+      </div>
       <div id="boot" class="overlay">
         <div class="spinner"></div>
         <p id="boot-msg">Starting Python runtime…</p>

--- a/docs/playground/style.css
+++ b/docs/playground/style.css
@@ -201,7 +201,37 @@ button:disabled { opacity: 0.45; cursor: not-allowed; }
   align-items: flex-start;
   justify-content: center;
 }
-#preview svg { max-width: 100%; height: auto; }
+/* When zoomed past the viewport, left-align so the start stays scrollable. */
+#preview.zoomed { justify-content: flex-start; }
+/* flex-shrink:0 so an explicit zoom width isn't shrunk back to the container. */
+#preview svg { max-width: 100%; height: auto; flex-shrink: 0; }
+
+#zoom-controls {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  gap: 1px;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  z-index: 5;
+}
+#zoom-controls button {
+  border: none;
+  border-radius: 0;
+  background: var(--panel-2);
+  color: var(--text);
+  min-width: 34px;
+  height: 30px;
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+#zoom-controls button#zoom-fit { font-size: 12px; }
+#zoom-controls button:hover { background: var(--accent-press); color: #02120f; }
 
 .overlay {
   position: absolute;

--- a/docs/playground/tests/playground.spec.js
+++ b/docs/playground/tests/playground.spec.js
@@ -214,6 +214,25 @@ test("SVG and PNG export produce non-empty downloads", async () => {
   expect(stat.size).toBeGreaterThan(0);
 });
 
+test("zoom controls scale the preview and Fit resets", async () => {
+  await page.evaluate(() =>
+    window.__nfMetro.setValue("%%metro line: a | A | #f00\ngraph LR\n  zn1[ZN1] -->|a| zn2[ZN2]\n")
+  );
+  await expect(page.locator('#preview [data-station-id="zn1"]').first()).toBeVisible();
+
+  const svgWidth = () =>
+    page.locator("#preview svg").evaluate((s) => s.getBoundingClientRect().width);
+  const fitWidth = await svgWidth();
+
+  await page.locator("#zoom-in").click();
+  await expect.poll(svgWidth).toBeGreaterThan(fitWidth + 1);
+  await expect(page.locator("#preview")).toHaveClass(/zoomed/);
+
+  await page.locator("#zoom-fit").click();
+  await expect(page.locator("#preview")).not.toHaveClass(/zoomed/);
+  await expect.poll(svgWidth).toBeLessThanOrEqual(fitWidth + 1);
+});
+
 test("example dropdown loads a chosen example and renders it", async () => {
   const select = page.locator("#example-select");
   // Manifest populated the dropdown beyond the placeholder + starter.


### PR DESCRIPTION
## Summary

Add zoom controls to the playground preview - useful for large maps that get shrunk to fit.

- A floating cluster (**−**, **Fit**, **+**) in the bottom-right of the preview pane.
- **+ / −** scale the rendered SVG by a factor on its intrinsic (viewBox) size; the pane scrolls when the map is larger than the viewport (left-aligned so the start stays reachable).
- **Fit** returns to the default responsive fit-to-view.
- Zoom continues smoothly from the currently displayed scale, is clamped (0.1x-8x), and is re-applied after each render.

## Test plan
- [x] Playwright e2e: 17/17 pass, including a new test that zooms in (SVG width grows, pane gains `.zoomed`) and Fit resets it
- [x] No Python changed; ruff/mypy unaffected
- [ ] Visual review of the render preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
