### PR TITLE
fix(layout): exempt rail-interchange bridge-overs from the breeze guard

### DIFF
--- a/src/nf_metro/layout/geometric_bypass.py
+++ b/src/nf_metro/layout/geometric_bypass.py
@@ -27,7 +27,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from nf_metro.layout.geometry import BBoxXIndex, segment_intersects_bbox
-from nf_metro.layout.phases._common import _station_marker_bbox
+from nf_metro.layout.phases._common import _station_marker_bbox, marker_cross_exempt
 from nf_metro.parser.model import (
     BYPASS_V_PREFIX,
     Edge,
@@ -110,6 +110,8 @@ def _evaluate(graph: MetroGraph, *, with_quality: bool = True) -> _LayoutEval:
     boxes: list[tuple[str, tuple[float, float, float, float]]] = []
     station_lines: dict[str, set[str]] = {}
     for sid in graph.stations:
+        if marker_cross_exempt(graph, sid):
+            continue
         bbox = _station_marker_bbox(graph, sid, offsets=offsets)
         if bbox is None:
             continue

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -201,6 +201,19 @@ def _station_marker_bbox(
     return (st.x - radius, cy - half_h, st.x + radius, cy + half_h)
 
 
+def marker_cross_exempt(graph: MetroGraph, sid: str) -> bool:
+    """True when a non-consumer line crossing ``sid``'s marker is no defect.
+
+    A rail-mode section lays its lines on fixed parallel rails; a line whose
+    route skips an interchange runs along its rail through the interchange's
+    column and threads its knob.  That is the deliberate rail idiom, not a
+    breeze-past, so the marker-cross checks exempt it - matching the render-side
+    ``check_marker_crossings`` exemption (#942), which reads the same fact back
+    from the drawn rail markers.
+    """
+    return graph.station_is_rail(sid)
+
+
 def first_vertical_leg_x(points: list[tuple[float, float]]) -> float | None:
     """X of the first (near-)vertical leg of *points*.
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -45,6 +45,7 @@ from nf_metro.layout.phases._common import (
     flow_exit_carrier_anchor,
     is_loop_side_branch_station,
     iter_sole_trunk_continuations,
+    marker_cross_exempt,
     routes_through_unrelated_sections,
 )
 from nf_metro.layout.phases.bbox import _section_fit_top
@@ -1372,6 +1373,8 @@ def _guard_no_line_crosses_non_consumer(
     boxes: list[tuple[str, tuple[float, float, float, float]]] = []
     station_lines_cache: dict[str, set[str]] = {}
     for sid in graph.stations:
+        if marker_cross_exempt(graph, sid):
+            continue
         bbox = _station_marker_bbox(graph, sid, offsets=offsets)
         if bbox is None:
             continue

--- a/tests/data/guard_golden_baseline.json
+++ b/tests/data/guard_golden_baseline.json
@@ -5194,10 +5194,7 @@
     ]
   },
   "examples/line_spread.mmd": {
-    "raised": [
-      "PhaseInvariantError",
-      "after final: line 'rna' on edge 'r_call' -> 'r_annotate' crosses non-consumer station 'r_filter' marker bbox (903.0,155.0)-(913.0,169.0); segment (832.0,160.0)->(984.0,160.0)"
-    ],
+    "raised": null,
     "trace": [
       "_guard_no_same_row_backward_feed|None",
       "_guard_no_mixed_entry_directions|None",
@@ -5387,12 +5384,7 @@
       "_guard_off_track_consumer_on_trunk|final",
       "_guard_off_track_input_column_stack|final",
       "_guard_interchange_bar_clears_non_members|final",
-      "_guard_tb_top_entry_drop_hugs_top|final",
-      "_guard_no_same_row_backward_feed|None",
-      "_guard_no_mixed_entry_directions|None",
-      "_guard_no_same_row_backward_feed|None",
-      "_guard_no_mixed_entry_directions|None",
-      "_guard_no_line_crosses_non_consumer|after final"
+      "_guard_tb_top_entry_drop_hugs_top|final"
     ]
   },
   "examples/longread_variant_calling.mmd": {
@@ -7168,10 +7160,7 @@
     ]
   },
   "examples/sarek_metro.mmd": {
-    "raised": [
-      "PhaseInvariantError",
-      "after final: line 'tumor_only' on edge 'mutect2' -> 'indexcov' crosses non-consumer station 'strelka2' marker bbox (641.8,660.8)-(651.8,678.8); segment (595.3,664.8)->(698.3,664.8)"
-    ],
+    "raised": null,
     "trace": [
       "_guard_no_same_row_backward_feed|None",
       "_guard_no_mixed_entry_directions|None",
@@ -7365,12 +7354,7 @@
       "_guard_off_track_consumer_on_trunk|final",
       "_guard_off_track_input_column_stack|final",
       "_guard_interchange_bar_clears_non_members|final",
-      "_guard_tb_top_entry_drop_hugs_top|final",
-      "_guard_no_same_row_backward_feed|None",
-      "_guard_no_mixed_entry_directions|None",
-      "_guard_no_same_row_backward_feed|None",
-      "_guard_no_mixed_entry_directions|None",
-      "_guard_no_line_crosses_non_consumer|after final"
+      "_guard_tb_top_entry_drop_hugs_top|final"
     ]
   },
   "examples/simple_pipeline.mmd": {
@@ -35806,13 +35790,8 @@
     "trace": []
   },
   "tests/fixtures/rail_marker_subset_interchange.mmd": {
-    "raised": [
-      "PhaseInvariantError",
-      "after final: line 'line_b' on edge 'src_b' -> 'sink_b' crosses non-consumer station 'hub' marker bbox (305.0,226.0)-(315.0,236.0); segment (190.0,231.0)->(430.0,231.0)"
-    ],
-    "trace": [
-      "_guard_no_line_crosses_non_consumer|after final"
-    ]
+    "raised": null,
+    "trace": []
   },
   "tests/fixtures/rail_pitch_vs_labels.mmd": {
     "raised": null,

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from nf_metro.layout import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
-from nf_metro.parser.model import LineSpread
+from nf_metro.parser.model import LineSpread, is_bypass_v
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
 
@@ -1600,3 +1602,34 @@ def test_rail_one_per_column_guard_catches_a_collision():
 
     with pytest.raises(PhaseInvariantError, match="one station per column"):
         _guard_rail_one_station_per_column(graph, "test")
+
+
+@pytest.mark.parametrize(
+    "fixture,crossed_id",
+    [
+        (EXAMPLES / "line_spread.mmd", "r_filter"),
+        (EXAMPLES / "sarek_metro.mmd", "strelka2"),
+        (FIXTURES / "rail_marker_subset_interchange.mmd", None),
+    ],
+    ids=["line_spread", "sarek_metro", "rail_marker_subset"],
+)
+def test_rail_bridge_over_interchange_validates_clean(fixture, crossed_id):
+    """A line whose route skips a rail interchange threads its knob rather than
+    stopping - the deliberate rail idiom, not a breeze-past.  Full-validation
+    layout must not trip the non-consumer marker-cross guard, and the geometric
+    bypass must not bow such a crossing (a bow cannot move a line off its fixed
+    rail; the helper lands collinear and changes nothing)."""
+    from test_bypass_invariants import _nonconsumer_crossings
+
+    graph = parse_metro_mermaid(fixture.read_text())
+    compute_layout(graph, validate=True)
+
+    assert not [sid for sid in graph.stations if is_bypass_v(sid)], (
+        f"{fixture.name}: a rail-interchange crossing must not get a bypass-V"
+    )
+    if crossed_id is not None:
+        assert graph.station_is_rail(crossed_id)
+        assert _nonconsumer_crossings(graph, only_station=crossed_id), (
+            f"{fixture.name}: expected a line to thread {crossed_id!r}'s marker "
+            f"so the rail-idiom exemption is load-bearing"
+        )


### PR DESCRIPTION
## Summary

A line whose route skips a rail-mode interchange runs along its fixed rail through the interchange's column and threads its knob. That is the deliberate rail idiom (a partial interchange where the line bridges over rather than stopping), not a breeze-past defect.

Two checks disagreed about this:

- The render-side `check_marker_crossings` (#942) already exempts rail stations, so the rendered SVGs are clean.
- The layout-time `_guard_no_line_crosses_non_consumer` did not, so `sarek_metro.mmd` and `line_spread.mmd` failed full validation and only shipped because `render` runs with `validate=False`.

The geometry-aware bypass pass (#999) tried to bow these crossings with a `__bypass_` helper, but on a fixed rail the helper lands collinear with the line and removes no ink, so the only-if-improves gate reverted it on every layout. (The fold-back the issue describes does not actually occur; the revert is because the breeze count never drops.)

This change adds a shared `marker_cross_exempt(graph, sid)` helper (`graph.station_is_rail`) and applies it in both the layout breeze guard and the geometric-bypass crossing detection, aligning the layout side with the render side. A rail-interchange crossing is no longer treated as a defect or a bow candidate.

- Renders are byte-identical (verified on `sarek_metro.mmd` and `line_spread.mmd`).
- The three affected rail fixtures (`sarek_metro`, `line_spread`, `rail_marker_subset_interchange`) now pass full validation and lay out in a single pass instead of attempting-and-reverting a bypass.
- Guard-trace golden baseline updated: the three fixtures flip from a `_guard_no_line_crosses_non_consumer` raise to a clean trace (the reverse of the #999 deferral growth).

Fixes #1000

## Test plan
- [x] New parametrized invariant test `test_rail_bridge_over_interchange_validates_clean` over the three rail fixtures; verified it fails on `main` and passes with the fix
- [x] Full `pytest` passes (19543 passed, 6 pre-existing xfails)
- [x] `ruff check` + `ruff format --check` clean
- [x] Renders byte-identical for the affected fixtures
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/1003/)
