### PR TITLE
feat(layout): formalize the inter-phase state protocol (#673)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -208,6 +208,36 @@ captured once right before the consumer, rather than from live geometry. The
 reference equals the live geometry at capture time, so the property was added
 with no change to any render.
 
+## Inter-phase state protocol
+
+Some stages hand intermediate results to later stages through private
+`graph._*` fields rather than through station coordinates. These channels are
+declared as data in [`phase_state.py`](phase_state.py) (`PHASE_FIELD_REGISTRY`),
+which records each field's writer stage, its reader stages, and why it exists;
+`tests/test_phase_state_registry.py` keeps that registry in sync with the
+dataclass fields, the engine stage list, and this document.
+
+Fields whose reader genuinely depends on the writer having run call
+`require_phase_field` just before the read, which raises `PhaseInvariantError`
+under `validate=True` when the writer stage has not completed in the current
+pass:
+
+- `graph._row_y_grid_info` - written by Stage 1.2 (`_align_row_y_grids`); read
+  by the grid-group port snap (Stage 4.2-4.4), fan re-centre (6.3/6.7), and
+  grid snap (6.4).
+- `graph.half_grid_station_ids` - written by Stage 6.3 (`center_ports` only);
+  read by the Stage 6.4 grid snap, which must skip these half-pitch stations.
+- `graph._consumers_grid_snapped` - set right after the Stage 6.4 snap; the
+  Stage 6.6 off-track reanchor carries its own always-on guard on it.
+
+The remaining channels tolerate an unwritten value by design (their read sites
+fall back to live geometry or a `None`/empty default), so they are documented in
+the registry but carry no runtime check: `graph._struct_height_below_top`
+(snapshotted after 6.15a, read by the 6.13 cascade), `graph._placement_ref_y` /
+`graph._placement_ref_bbox_top` (frozen before 6.1/6.11, read via `_ref_y` /
+`_ref_bbox_top`), and `graph._base_y_spacing` (recorded before the spread loop
+when `y_spacing` is auto-resolved).
+
 ## Stage overview
 
 The pipeline groups into six stages aligned with the coord-regime

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -1008,6 +1008,7 @@ def _snap(graph: MetroGraph, phase_id: str) -> None:
     graph so the per-stage call sites stay signature-free; when disabled
     this is a single attribute read plus an early return.
     """
+    graph._stages_completed.append(phase_id)
     capture_phase_snapshot(
         graph, phase_id, getattr(graph, "_phase_snapshots_enabled", False)
     )
@@ -1192,6 +1193,11 @@ def _compute_section_layout(
     # On-track consumers are not yet grid-snapped; the off-track reanchor
     # (Stage 6.6 / 6.8) refuses to run until Stage 6.4 sets this True.
     graph._consumers_grid_snapped = False
+    # Fresh inter-phase bookkeeping for this pass: _snap appends each stage id
+    # to _stages_completed, and phase_state's write-before-read checks consult
+    # both this list and _validate_active.
+    graph._stages_completed = []
+    graph._validate_active = validate
 
     # ---- Stage 1 - Section construction (local coords) ------------------
     # Lay out each section internally, snap row Y grids, place sections on

--- a/src/nf_metro/layout/phase_state.py
+++ b/src/nf_metro/layout/phase_state.py
@@ -1,0 +1,199 @@
+"""The inter-phase state protocol: declared ``graph._*`` channels.
+
+The section-layout pipeline (``layout/engine.py``) is a long sequence of
+numbered stages that hand intermediate results to each other through private
+fields stashed on the :class:`~nf_metro.parser.model.MetroGraph`.  Left as bare
+attribute pokes, those fields form an undocumented protocol that only holds
+while stage ordering never changes: a reader stage silently sees a stale or
+default value if its writer stage is reordered away or skipped.
+
+This module makes that protocol explicit data:
+
+* :data:`CANONICAL_STAGE_ORDER` is the single ordered list of section-layout
+  stage ids (mirrored by the engine's ``_snap`` checkpoints).
+* :data:`PHASE_FIELD_REGISTRY` declares every inter-phase field with its writer
+  stage, the stages that read it, and *why* it exists.
+* :func:`require_phase_field`, called just before a read, enforces
+  write-before-read for the fields whose reader genuinely depends on the writer
+  having run, raising :class:`PhaseInvariantError` under ``validate=True`` --
+  generalising the hand-written ``graph._consumers_grid_snapped`` guard.
+
+The registry is kept in sync with the dataclass fields, the engine stage list,
+and ``CONTRACT.md`` by ``tests/test_phase_state_registry.py``, so a new bare
+poke or a drifted document reds CI rather than rotting silently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nf_metro.parser.model import MetroGraph
+
+# Writer marker for a field populated before Stage 1.1 (i.e. during spacing
+# resolution in ``compute_layout``, before the stage pipeline begins).
+PRE_LAYOUT = "pre-layout"
+
+# Section-layout stage ids in execution order.  Mirrors the ``_snap(graph, ...)``
+# checkpoints in ``engine._compute_section_layout`` and its Pass C helpers;
+# ``test_phase_state_registry`` asserts the two stay identical.  Note ``6.15a``
+# runs before ``6.15``.
+CANONICAL_STAGE_ORDER: tuple[str, ...] = (
+    "1.1", "1.2", "1.3", "1.4", "1.5",
+    "2.1",
+    "3.1", "3.2", "3.3", "3.4", "3.5",
+    "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10",
+    "5.1", "5.2", "5.3", "5.4", "5.5",
+    "6.1", "6.2", "6.3", "6.4", "6.5", "6.6", "6.7", "6.8", "6.9", "6.10",
+    "6.11", "6.12", "6.13", "6.14", "6.15a", "6.15", "6.16",
+)  # fmt: skip
+
+
+class FieldEnforcement(Enum):
+    """How strongly :func:`read_phase_field` polices a declared field.
+
+    ``REQUIRE_WRITER`` -- the reader trusts data the writer stage produces, so
+    reading before that stage has run is a bug; raise under ``validate=True``.
+
+    ``FALLBACK`` -- the read site is designed to tolerate the unwritten
+    (default/empty/``None``) value, so an early or absent read is harmless.  The
+    field is registered for documentation and drift-detection only; no runtime
+    check fires.
+    """
+
+    REQUIRE_WRITER = "require_writer"
+    FALLBACK = "fallback"
+
+
+@dataclass(frozen=True)
+class PhaseFieldSpec:
+    """One inter-phase ``graph._*`` field, declared as data.
+
+    ``writer_stage`` / ``reader_stages`` are ids from :data:`CANONICAL_STAGE_ORDER`
+    (``writer_stage`` may also be :data:`PRE_LAYOUT`).  ``run_condition_attr``, when
+    set, names a truthy ``MetroGraph`` attribute that gates whether the writer
+    stage runs at all; a ``REQUIRE_WRITER`` check is skipped when it is falsy, so a
+    conditionally-skipped writer does not trip a false positive.
+    """
+
+    name: str
+    writer_stage: str
+    reader_stages: tuple[str, ...]
+    enforcement: FieldEnforcement
+    why: str
+    run_condition_attr: str | None = None
+
+
+PHASE_FIELD_REGISTRY: dict[str, PhaseFieldSpec] = {
+    "_row_y_grid_info": PhaseFieldSpec(
+        name="_row_y_grid_info",
+        writer_stage="1.2",
+        reader_stages=("4.2", "6.3", "6.4"),
+        enforcement=FieldEnforcement.REQUIRE_WRITER,
+        why=(
+            "row-grid metadata from Stage 1.2's _align_row_y_grids; the grid-group "
+            "port snap, fan re-centre, and grid snap read it to group same-row "
+            "sections onto a shared pitch"
+        ),
+    ),
+    "half_grid_station_ids": PhaseFieldSpec(
+        name="half_grid_station_ids",
+        writer_stage="6.3",
+        reader_stages=("6.4",),
+        enforcement=FieldEnforcement.REQUIRE_WRITER,
+        why=(
+            "2-branch symfan stations Stage 6.3 places at half-pitch; Stage 6.4's "
+            "grid snap must skip them or it snaps their intentional half-grid Y to "
+            "the full grid"
+        ),
+        run_condition_attr="center_ports",
+    ),
+    "_consumers_grid_snapped": PhaseFieldSpec(
+        name="_consumers_grid_snapped",
+        writer_stage="6.4",
+        reader_stages=("6.6",),
+        enforcement=FieldEnforcement.REQUIRE_WRITER,
+        why=(
+            "readiness flag set right after the Stage 6.4 snap so the off-track "
+            "reanchor re-pins against final consumer Ys; _reanchor_off_track_to_"
+            "consumer carries its own always-on guard on this field"
+        ),
+    ),
+    "_struct_height_below_top": PhaseFieldSpec(
+        name="_struct_height_below_top",
+        writer_stage="6.15a",
+        reader_stages=("6.13",),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "settled structural extents snapshotted after Stage 6.15a; the Stage "
+            "6.13 inter-row cascade reads it for fidelity checks and falls back to "
+            "live bbox heights when the snapshot is empty (default before 6.15a)"
+        ),
+    ),
+    "_placement_ref_y": PhaseFieldSpec(
+        name="_placement_ref_y",
+        writer_stage="6.1",
+        reader_stages=("6.1", "6.2", "6.11"),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "station Ys frozen by _snapshot_placement_refs before Stages 6.1/6.2 "
+            "(re-taken before 6.11); _ref_y reads it and falls back to the live Y "
+            "for any station the snapshot does not cover"
+        ),
+    ),
+    "_placement_ref_bbox_top": PhaseFieldSpec(
+        name="_placement_ref_bbox_top",
+        writer_stage="6.1",
+        reader_stages=("6.1", "6.2", "6.11"),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "section bbox tops frozen alongside _placement_ref_y; _ref_bbox_top "
+            "reads it and falls back to the live top for any section the snapshot "
+            "does not cover"
+        ),
+    ),
+    "_base_y_spacing": PhaseFieldSpec(
+        name="_base_y_spacing",
+        writer_stage=PRE_LAYOUT,
+        reader_stages=("5.2", "6.6"),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "content pitch recorded before the spread loop widens y_spacing, and "
+            "only when y_spacing is auto-resolved; single-trunk off-track lift and "
+            "rail layout read it with a None/getattr fallback when it is unset"
+        ),
+    ),
+}
+
+
+def require_phase_field(graph: "MetroGraph", name: str) -> None:
+    """Assert ``graph.<name>`` is safe to read, enforcing write-before-read.
+
+    Call this immediately before reading a declared field.  For a
+    :attr:`FieldEnforcement.REQUIRE_WRITER` field, raises
+    :class:`PhaseInvariantError` when the field's writer stage has not yet run in
+    the current pass -- but only while ``graph._validate_active`` is set, and only
+    when the field's ``run_condition_attr`` (if any) is truthy.  On the production
+    (``validate=False``) path this is a registry lookup plus a flag check.
+    """
+    spec = PHASE_FIELD_REGISTRY[name]
+    if (
+        spec.enforcement is FieldEnforcement.REQUIRE_WRITER
+        and getattr(graph, "_validate_active", False)
+        and (
+            spec.run_condition_attr is None
+            or getattr(graph, spec.run_condition_attr, False)
+        )
+        and spec.writer_stage not in graph._stages_completed
+    ):
+        # Local import: PhaseInvariantError lives in phases.guards, which imports
+        # heavily from the layout package; importing it at module load would risk
+        # a cycle.
+        from nf_metro.layout.phases.guards import PhaseInvariantError
+
+        raise PhaseInvariantError(
+            f"{name} read before its writer Stage {spec.writer_stage} ran "
+            f"(completed stages: {graph._stages_completed}); {spec.why}"
+        )

--- a/src/nf_metro/layout/phase_state.py
+++ b/src/nf_metro/layout/phase_state.py
@@ -52,7 +52,7 @@ CANONICAL_STAGE_ORDER: tuple[str, ...] = (
 
 
 class FieldEnforcement(Enum):
-    """How strongly :func:`read_phase_field` polices a declared field.
+    """How strongly :func:`require_phase_field` polices a declared field.
 
     ``REQUIRE_WRITER`` -- the reader trusts data the writer stage produces, so
     reading before that stage has run is a bug; raise under ``validate=True``.

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -14,6 +14,7 @@ from nf_metro.layout.constants import (
     STATION_RADIUS_APPROX,
 )
 from nf_metro.layout.geometry import lanes_run_along_y
+from nf_metro.layout.phase_state import require_phase_field
 from nf_metro.parser.model import (
     Edge,
     MetroGraph,
@@ -452,6 +453,7 @@ def is_loop_side_branch_station(graph: MetroGraph, sid: str) -> bool:
 
 def _grid_group_section_ids(graph: MetroGraph) -> set[str]:
     """Return the set of section IDs that participated in grid alignment."""
+    require_phase_field(graph, "_row_y_grid_info")
     grid_info = graph._row_y_grid_info
     result: set[str] = set()
     for info in grid_info.values():

--- a/src/nf_metro/layout/phases/fan_bundles.py
+++ b/src/nf_metro/layout/phases/fan_bundles.py
@@ -8,6 +8,7 @@ from nf_metro.layout.constants import (
     SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
 )
+from nf_metro.layout.phase_state import require_phase_field
 from nf_metro.layout.phases._common import (
     _fan_offsets,
     _grid_group_section_ids,
@@ -533,6 +534,7 @@ def _section_row_pitch(graph: MetroGraph, section_id: str, default: float) -> fl
     leave re-fanned stations a fraction of a slot off the trunk line.
     Falls back to ``default`` for sections not in a multi-section row.
     """
+    require_phase_field(graph, "_row_y_grid_info")
     grid_info = graph._row_y_grid_info
     for info in grid_info.values():
         if section_id in info["section_ids"]:

--- a/src/nf_metro/layout/phases/grid_snap.py
+++ b/src/nf_metro/layout/phases/grid_snap.py
@@ -8,6 +8,7 @@ from nf_metro.layout.constants import (
     CANVAS_GRID_SHIFT_THRESHOLD,
 )
 from nf_metro.layout.geometry import lanes_run_along_y
+from nf_metro.layout.phase_state import require_phase_field
 from nf_metro.layout.phases.bbox import _min_section_bbox_top
 from nf_metro.layout.phases.canvas import _translate_graph_y
 from nf_metro.layout.phases.fan_bundles import _convergence_source_ys
@@ -67,6 +68,7 @@ def _snap_all_y_to_grid(graph: MetroGraph, y_spacing: float) -> None:
     # as non-chain so the target column still centres correctly.
     groups: dict[object, tuple[float, list[str]]] = {}
     grouped_ids: set[str] = set()
+    require_phase_field(graph, "_row_y_grid_info")
     for row, info in (graph._row_y_grid_info or {}).items():
         pitch = info.get("slot_spacing", y_spacing)
         sec_ids = list(info.get("section_ids", []))
@@ -99,6 +101,7 @@ def _group_grid_origin(
     """
     residues: Counter[float] = Counter()
     per_section_ports: dict[str, set[str]] = {}
+    require_phase_field(graph, "half_grid_station_ids")
     half_grid_ids = graph.half_grid_station_ids
     for sec_id in sec_ids:
         section = graph.sections.get(sec_id)
@@ -137,6 +140,7 @@ def _snap_group_to_grid(
     if origin_info is None:
         return
     origin_r, per_section_ports = origin_info
+    require_phase_field(graph, "half_grid_station_ids")
     half_grid_ids = graph.half_grid_station_ids
 
     # Independent snapping can round two same-column stations onto one slot;
@@ -226,6 +230,7 @@ def _snap_canvas_y_to_grid(
     """
     if y_spacing <= 0 or not graph.sections:
         return
+    require_phase_field(graph, "half_grid_station_ids")
     half_grid_ids = graph.half_grid_station_ids
     convergence_sources = _convergence_source_ys(graph)
     residues: Counter[float] = Counter()

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -510,6 +510,17 @@ class MetroGraph:
     # step uses this base pitch so a widened pitch doesn't strand the icon far
     # above the trunk.  None until compute_layout records it.
     _base_y_spacing: float | None = field(default=None, repr=False)
+    # Ordered ids of the layout stages that have completed in the current
+    # positioning pass (appended by the engine's per-stage ``_snap`` hook,
+    # reset at the start of each pass).  Backs the inter-phase write-before-read
+    # checks in ``layout/phase_state.py``: a reader can assert its writer stage
+    # is already in this list before trusting a declared ``graph._*`` field.
+    _stages_completed: list[str] = field(default_factory=list, repr=False)
+    # True while a positioning pass runs under ``validate=True``.  The
+    # phase-state accessors self-gate on it so the write-before-read checks
+    # add nothing on the production (``validate=False``) path and stay reachable
+    # from readers that don't carry the ``validate`` flag in their signature.
+    _validate_active: bool = field(default=False, repr=False)
 
     def _invalidate_edge_caches(self) -> None:
         """Reset caches that depend on the edge list."""

--- a/tests/test_phase_state_registry.py
+++ b/tests/test_phase_state_registry.py
@@ -1,0 +1,283 @@
+"""Keep the inter-phase state protocol (``layout/phase_state.py``) honest.
+
+The registry declares every ``graph._*`` field a layout stage writes for a
+later stage to read. These tests pin it against the three things it must not
+drift from:
+
+* the ``MetroGraph`` dataclass fields it names,
+* the engine's ``_snap`` stage checkpoints (``CANONICAL_STAGE_ORDER``), and
+* ``CONTRACT.md``,
+
+and they fail when a new bare cross-phase ``graph._*`` poke is introduced
+without being declared, so the protocol can't grow an undocumented member.
+A behavioural test pins the write-before-read enforcement itself.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.phase_state import (
+    CANONICAL_STAGE_ORDER,
+    PHASE_FIELD_REGISTRY,
+    PRE_LAYOUT,
+    FieldEnforcement,
+    require_phase_field,
+)
+from nf_metro.layout.phases.guards import (
+    _PASS_C_BISECTION_ORDER,
+    PhaseInvariantError,
+)
+from nf_metro.parser.model import MetroGraph
+
+REPO = Path(__file__).resolve().parent.parent
+LAYOUT_DIR = REPO / "src" / "nf_metro" / "layout"
+ENGINE = LAYOUT_DIR / "engine.py"
+CONTRACT = LAYOUT_DIR / "CONTRACT.md"
+
+# Cross-phase ``graph._*`` channels that are deliberately NOT part of the
+# inter-phase positioning protocol, so they are not in PHASE_FIELD_REGISTRY:
+#   - _stages_completed / _validate_active: the enforcement mechanism itself.
+#   - _defer_breeze_guard: a pass-control flag toggled by compute_layout.
+#   - _explicit_directions: parse/auto-layout metadata, read by a guard.
+#   - _rail_y: rail-mode router metadata, not section positioning.
+#   - _cross_column_perp_bridges: a routing-invariant relaxation flag.
+_NON_PROTOCOL_CROSS_PHASE = {
+    "_stages_completed",
+    "_validate_active",
+    "_defer_breeze_guard",
+    "_explicit_directions",
+    "_rail_y",
+    "_cross_column_perp_bridges",
+}
+
+_COMMENT = re.compile(r"#.*$", re.MULTILINE)
+_SNAP_ID = re.compile(r'_snap\(graph,\s*"([^"]+)"\)')
+_STAGE_ID = re.compile(r"^\d+\.\d+[a-z]?$")
+_GRAPH_ATTR = re.compile(r"\bgraph\.([A-Za-z_][A-Za-z0-9_]*)")
+_GRAPH_WRITE = re.compile(
+    r"\bgraph\.([A-Za-z_][A-Za-z0-9_]*)\s*"
+    r"(?:=[^=]|\.(?:append|extend|update|add|clear|pop|setdefault|discard)\b|\[)"
+)
+
+
+def _strip_comments(text: str) -> str:
+    return _COMMENT.sub("", text)
+
+
+# --- registry <-> dataclass -------------------------------------------------
+
+
+def test_registry_keys_match_spec_names():
+    for name, spec in PHASE_FIELD_REGISTRY.items():
+        assert spec.name == name, f"{name!r} keyed under a different spec.name"
+
+
+@pytest.mark.parametrize("name", sorted(PHASE_FIELD_REGISTRY))
+def test_registered_field_is_a_repr_false_dataclass_field(name):
+    """Every declared channel is a real MetroGraph field hidden from repr."""
+    fields = {f.name: f for f in dataclasses.fields(MetroGraph)}
+    assert name in fields, f"{name!r} is in the registry but not a MetroGraph field"
+    assert fields[name].repr is False, (
+        f"{name!r} is an inter-phase channel and should be declared repr=False"
+    )
+
+
+# --- stage-id validity and ordering ----------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(PHASE_FIELD_REGISTRY))
+def test_writer_and_reader_stages_are_known(name):
+    spec = PHASE_FIELD_REGISTRY[name]
+    assert (
+        spec.writer_stage in CANONICAL_STAGE_ORDER or spec.writer_stage == PRE_LAYOUT
+    ), f"{name}: writer_stage {spec.writer_stage!r} is not a known stage"
+    for r in spec.reader_stages:
+        assert r in CANONICAL_STAGE_ORDER, (
+            f"{name}: reader_stage {r!r} is not in CANONICAL_STAGE_ORDER"
+        )
+
+
+@pytest.mark.parametrize("name", sorted(PHASE_FIELD_REGISTRY))
+def test_require_writer_fields_have_writer_before_readers(name):
+    """A gated field's writer must precede every reader in pipeline order.
+
+    Skipped for FALLBACK fields, whose readers may legitimately run before the
+    writer (e.g. _struct_height_below_top is read at 6.13 and snapshotted at
+    6.15a) precisely because the read tolerates the unwritten value.
+    """
+    spec = PHASE_FIELD_REGISTRY[name]
+    if spec.enforcement is not FieldEnforcement.REQUIRE_WRITER:
+        pytest.skip("FALLBACK field: write-before-read ordering not required")
+    if spec.writer_stage == PRE_LAYOUT:
+        return
+    w = CANONICAL_STAGE_ORDER.index(spec.writer_stage)
+    for r in spec.reader_stages:
+        assert w < CANONICAL_STAGE_ORDER.index(r), (
+            f"{name}: writer Stage {spec.writer_stage} does not precede "
+            f"reader Stage {r}"
+        )
+
+
+@pytest.mark.parametrize("name", sorted(PHASE_FIELD_REGISTRY))
+def test_run_condition_attr_is_a_graph_field(name):
+    spec = PHASE_FIELD_REGISTRY[name]
+    if spec.run_condition_attr is None:
+        return
+    field_names = {f.name for f in dataclasses.fields(MetroGraph)}
+    assert spec.run_condition_attr in field_names, (
+        f"{name}: run_condition_attr {spec.run_condition_attr!r} is not a "
+        f"MetroGraph field"
+    )
+
+
+# --- CANONICAL_STAGE_ORDER <-> engine --------------------------------------
+
+
+def test_canonical_stage_order_matches_engine_snap_calls():
+    """The stage list equals the engine's stage-id ``_snap`` checkpoints."""
+    text = _strip_comments(ENGINE.read_text())
+    snap_ids = _SNAP_ID.findall(text)
+    stage_ids = tuple(s for s in snap_ids if _STAGE_ID.match(s))
+    assert stage_ids == CANONICAL_STAGE_ORDER, (
+        "CANONICAL_STAGE_ORDER drifted from engine _snap() checkpoints:\n"
+        f"  engine: {stage_ids}\n  canonical: {CANONICAL_STAGE_ORDER}"
+    )
+
+
+def test_pass_c_bisection_order_is_a_subsequence():
+    """The Pass C checkpoint stages are an ordered subset of the full list."""
+    pass_c = [p.replace("after Stage ", "") for p in _PASS_C_BISECTION_ORDER]
+    it = iter(CANONICAL_STAGE_ORDER)
+    for stage in pass_c:
+        assert stage in it, (
+            f"Pass C checkpoint {stage!r} is out of order or absent from "
+            f"CANONICAL_STAGE_ORDER"
+        )
+
+
+# --- no unregistered cross-phase poke --------------------------------------
+
+
+def _cross_phase_underscore_attrs() -> set[str]:
+    """``graph._*`` attrs written in one layout module and read in another."""
+    writers: dict[str, set[str]] = {}
+    readers: dict[str, set[str]] = {}
+    for path in LAYOUT_DIR.rglob("*.py"):
+        if path.name == "phase_state.py":
+            continue  # the registry/helper module, not a phase
+        text = _strip_comments(path.read_text())
+        mod = str(path.relative_to(LAYOUT_DIR))
+        for m in _GRAPH_WRITE.finditer(text):
+            writers.setdefault(m.group(1), set()).add(mod)
+        for m in _GRAPH_ATTR.finditer(text):
+            readers.setdefault(m.group(1), set()).add(mod)
+    cross: set[str] = set()
+    for attr, ws in writers.items():
+        if not attr.startswith("_"):
+            continue
+        if readers.get(attr, set()) - ws:  # read somewhere it isn't written
+            cross.add(attr)
+    return cross
+
+
+def test_no_unregistered_cross_phase_channel():
+    """A new cross-phase ``graph._*`` poke must be registered or allowlisted."""
+    cross = _cross_phase_underscore_attrs()
+    unaccounted = cross - set(PHASE_FIELD_REGISTRY) - _NON_PROTOCOL_CROSS_PHASE
+    assert not unaccounted, (
+        "These graph._* fields are written in one layout module and read in "
+        "another but are neither in PHASE_FIELD_REGISTRY nor allowlisted as "
+        f"non-protocol state: {sorted(unaccounted)}. Declare them in "
+        "phase_state.py (preferred) or add to _NON_PROTOCOL_CROSS_PHASE."
+    )
+
+
+# --- CONTRACT.md sync ------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(PHASE_FIELD_REGISTRY))
+def test_registered_field_documented_in_contract(name):
+    assert name in CONTRACT.read_text(), (
+        f"{name!r} is in PHASE_FIELD_REGISTRY but not documented in CONTRACT.md"
+    )
+
+
+# --- enforcement behaviour -------------------------------------------------
+
+
+def _require_writer_field() -> str:
+    for name, spec in PHASE_FIELD_REGISTRY.items():
+        if (
+            spec.enforcement is FieldEnforcement.REQUIRE_WRITER
+            and spec.run_condition_attr is None
+            and spec.writer_stage != PRE_LAYOUT
+        ):
+            return name
+    raise AssertionError("expected at least one unconditional REQUIRE_WRITER field")
+
+
+def test_read_before_writer_raises_under_validation():
+    name = _require_writer_field()
+    graph = MetroGraph()
+    graph._validate_active = True
+    graph._stages_completed = []  # writer stage has not run
+    with pytest.raises(PhaseInvariantError):
+        require_phase_field(graph, name)
+
+
+def test_read_after_writer_does_not_raise():
+    name = _require_writer_field()
+    spec = PHASE_FIELD_REGISTRY[name]
+    graph = MetroGraph()
+    graph._validate_active = True
+    graph._stages_completed = [spec.writer_stage]
+    require_phase_field(graph, name)  # no raise
+
+
+def test_no_enforcement_when_validate_inactive():
+    name = _require_writer_field()
+    graph = MetroGraph()
+    graph._validate_active = False
+    graph._stages_completed = []
+    require_phase_field(graph, name)  # no raise
+
+
+def test_run_condition_skips_check_when_falsy():
+    """A conditionally-skipped writer does not trip a false positive."""
+    conditional = [
+        n
+        for n, s in PHASE_FIELD_REGISTRY.items()
+        if s.enforcement is FieldEnforcement.REQUIRE_WRITER
+        and s.run_condition_attr is not None
+    ]
+    if not conditional:
+        pytest.skip("no conditionally-gated REQUIRE_WRITER field")
+    name = conditional[0]
+    spec = PHASE_FIELD_REGISTRY[name]
+    graph = MetroGraph()
+    graph._validate_active = True
+    graph._stages_completed = []
+    setattr(graph, spec.run_condition_attr, False)
+    require_phase_field(graph, name)  # writer not expected to have run -> no raise
+    setattr(graph, spec.run_condition_attr, True)
+    with pytest.raises(PhaseInvariantError):
+        require_phase_field(graph, name)
+
+
+def test_fallback_field_never_raises():
+    fallback = [
+        n
+        for n, s in PHASE_FIELD_REGISTRY.items()
+        if s.enforcement is FieldEnforcement.FALLBACK
+    ]
+    assert fallback, "expected at least one FALLBACK field"
+    graph = MetroGraph()
+    graph._validate_active = True
+    graph._stages_completed = []
+    for name in fallback:
+        require_phase_field(graph, name)  # no raise regardless of stage state


### PR DESCRIPTION
## Summary

Formalises the previously-undocumented protocol by which layout stages hand
intermediate results to each other through private `graph._*` fields.

- Adds `src/nf_metro/layout/phase_state.py`: a `PhaseFieldSpec` registry
  (`PHASE_FIELD_REGISTRY`) declaring each inter-phase field with its writer
  stage, reader stages, and rationale, plus `CANONICAL_STAGE_ORDER` (the single
  ordered list of section-layout stage ids).
- `require_phase_field(graph, name)` enforces write-before-read under
  `validate=True`, raising `PhaseInvariantError` when a field is read before its
  writer stage has run — generalising the hand-written `_consumers_grid_snapped`
  guard. Fields whose reads tolerate an unwritten value (fall back to live
  geometry / `None` / empty) are registered as `FALLBACK` and documented without
  a runtime check. Conditionally-written fields carry a `run_condition_attr`
  (e.g. `half_grid_station_ids` gates on `center_ports`) so a skipped writer
  does not trip a false positive.
- The engine records completed stages per pass: `_snap` appends each stage id to
  `graph._stages_completed`, reset at the start of each `_compute_section_layout`
  pass, where `_validate_active` is also set.
- Migrates the in-layout reads of `_row_y_grid_info` and `half_grid_station_ids`
  to call `require_phase_field` immediately before the read.
- Documents the protocol in a new "Inter-phase state protocol" section of
  `CONTRACT.md`.
- `tests/test_phase_state_registry.py` keeps the registry in sync with the
  `MetroGraph` dataclass fields, the engine `_snap` stage list, and
  `CONTRACT.md`, and fails when a new bare cross-phase `graph._*` poke is
  introduced without being registered (or explicitly allowlisted as
  non-protocol state). It also pins the write-before-read enforcement behaviour.

No geometry change: `validate=True` adds checks only and the production
(`validate=False`) path is a registry lookup plus a flag check. Gallery renders
are byte-identical before and after.

Fixes #673

## Test plan

- [x] `pytest` passes, including the new `tests/test_phase_state_registry.py`
- [x] `ruff check` + `ruff format --check` clean on `src/` and `tests/`
- [x] `mypy` clean on the changed modules
- [x] Gallery renders byte-identical vs base (no geometry change)
- [ ] Render-preview verdict on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
