### PR TITLE
perf(playground): cache layout graph + async loading indicator

### DIFF
--- a/docs/playground/app.js
+++ b/docs/playground/app.js
@@ -48,22 +48,55 @@ const SAMPLE_NEXTFLOW_DAG = `flowchart TB
 
 // Glue defined inside the Pyodide runtime: returns a JSON envelope so a render
 // error surfaces as data rather than a thrown PythonError to unwind in JS.
+//
+// Layout cache: parse+compute_layout is expensive (~200-500ms). We cache the
+// settled MetroGraph keyed on (normalised mmd + geometry options). Theme,
+// debug, animate, and directional are render-only - they don't affect station
+// coordinates, so changing them skips layout and only re-runs render_svg.
+// The style: directive is stripped before hashing so toggling theme (which
+// writes %%metro style: into the editor) doesn't bust the geometry cache.
 const PY_GLUE = `
+import hashlib
 import json
-from nf_metro.api import render_string
+import re as _re
+from nf_metro.api import prepare_graph, resolve_theme
 from nf_metro.convert import convert_nextflow_dag
+from nf_metro.render import render_svg
+
+_cached_graph = None
+_cached_key = None
+_RENDER_ONLY = frozenset({"animate", "directional"})
+_STYLE_RE = _re.compile(r"^\\s*%%metro\\s+style:.*$", _re.MULTILINE)
 
 def nfm_render(mmd, opts_json):
+    global _cached_graph, _cached_key
     opts = json.loads(opts_json)
-    layout = {k: v for k, v in (opts.get("layout_options") or {}).items() if v is not None}
+    all_layout = {k: v for k, v in (opts.get("layout_options") or {}).items() if v is not None}
+
+    layout_geom = {k: v for k, v in all_layout.items() if k not in _RENDER_ONLY}
+    render_only = {k: v for k, v in all_layout.items() if k in _RENDER_ONLY}
+
+    mmd_norm = _STYLE_RE.sub("", mmd).strip()
+    cache_key = hashlib.md5((mmd_norm + "\\x00" + json.dumps(layout_geom, sort_keys=True)).encode()).hexdigest()
+
     try:
-        svg = render_string(
-            mmd,
-            theme=opts.get("theme") or None,
-            responsive=True,
-            embed_font=True,
+        if cache_key != _cached_key:
+            graph = prepare_graph(mmd, layout_options=layout_geom)
+            _cached_graph = graph
+            _cached_key = cache_key
+        else:
+            graph = _cached_graph
+
+        for k, v in render_only.items():
+            setattr(graph, k, bool(v))
+
+        theme_obj = resolve_theme(opts.get("theme") or None, graph)
+        svg = render_svg(
+            graph,
+            theme_obj,
             debug=bool(opts.get("debug")),
-            layout_options=layout,
+            responsive=True,
+            font_portability="embed",
         )
         return json.dumps({"ok": True, "svg": svg})
     except Exception as e:
@@ -207,26 +240,36 @@ function showError(msg) {
 
 function doRender() {
   if (!pyRender) return;
+  // Snapshot inputs before the setTimeout so we render the state at the moment
+  // doRender fired, not what the editor contains when the callback runs.
   const mmd = editor.getValue();
-  let res;
-  try {
-    res = JSON.parse(pyRender(mmd, JSON.stringify(currentOptions())));
-  } catch (err) {
-    showError("Render runtime error: " + err);
-    return;
-  }
-  if (res.ok) {
-    showError(null);
-    lastSvg = res.svg;
-    el("preview").innerHTML = res.svg;
-    applyZoom();
-  } else {
-    // Keep the last good render visible; just report the problem.
-    showError(res.error);
-  }
-  refreshLineColors();
-  syncDirectiveControls();
-  reapplySelection();
+  const optsJson = JSON.stringify(currentOptions());
+  // Mark the preview as rendering and yield one paint cycle so the browser can
+  // show the dimmed state before the synchronous Python call blocks the thread.
+  el("preview").classList.add("rendering");
+  setTimeout(() => {
+    let res;
+    try {
+      res = JSON.parse(pyRender(mmd, optsJson));
+    } catch (err) {
+      el("preview").classList.remove("rendering");
+      showError("Render runtime error: " + err);
+      return;
+    }
+    el("preview").classList.remove("rendering");
+    if (res.ok) {
+      showError(null);
+      lastSvg = res.svg;
+      el("preview").innerHTML = res.svg;
+      applyZoom();
+    } else {
+      // Keep the last good render visible; just report the problem.
+      showError(res.error);
+    }
+    refreshLineColors();
+    syncDirectiveControls();
+    reapplySelection();
+  }, 0);
 }
 
 /* --------------------------------- zoom -------------------------------- */

--- a/docs/playground/style.css
+++ b/docs/playground/style.css
@@ -228,6 +228,9 @@ button:disabled { opacity: 0.45; cursor: not-allowed; }
 #preview.zoomed { justify-content: flex-start; }
 /* flex-shrink:0 so an explicit zoom width isn't shrunk back to the container. */
 #preview svg { max-width: 100%; height: auto; flex-shrink: 0; }
+/* Dim the preview while the Python renderer is running. The class is set just
+   before a setTimeout(0) so the browser gets one paint cycle to show it. */
+#preview.rendering { opacity: 0.45; cursor: wait; }
 
 #zoom-controls {
   position: absolute;

--- a/docs/playground/tests/playground.spec.js
+++ b/docs/playground/tests/playground.spec.js
@@ -68,9 +68,9 @@ test("advanced options are collapsed by default and toggle open", async () => {
 test("directional toggle adds chevron markers", async () => {
   await expect(page.locator('#preview [class*="metro-direction"]')).toHaveCount(0);
   await page.locator("#opt-directional").check();
-  expect(
-    await page.locator('#preview [class*="metro-direction"]').count()
-  ).toBeGreaterThan(0);
+  await expect
+    .poll(async () => page.locator('#preview [class*="metro-direction"]').count())
+    .toBeGreaterThan(0);
   await page.locator("#opt-directional").uncheck();
 });
 


### PR DESCRIPTION
## Summary

Three targeted changes to reduce playground render lag:

- **Layout cache**: `parse_metro_mermaid` + `compute_layout` is the expensive step (~200-500ms). The settled `MetroGraph` is now cached keyed on normalised source text + geometry options. Toggling theme, debug, animate, or directional skips layout entirely and only re-runs `render_svg` (~50ms). The `%%metro style:` directive is stripped before hashing so a theme toggle (which writes that directive into the editor) doesn't bust the geometry cache.

- **Render-only option bypass**: `animate` and `directional` don't affect station coordinates (not read anywhere in `layout/`). They're applied directly to the cached graph before each `render_svg` call, so any toggle of those checkboxes is always a layout cache hit.

- **Async `doRender` with loading indicator**: `pyRender()` blocks the browser thread. Moving it inside `setTimeout(0)` gives the browser one paint cycle to dim the preview (`opacity: 0.45`, `cursor: wait`) before the thread locks. On cache hits the dim is barely perceptible; on full re-layouts the user sees immediate feedback that something is happening.

The directional-toggle Playwright test used a non-retrying `count()` assertion that races with the now-async `doRender`; updated to `expect.poll()` to match the pattern already used by the animate test.

## Test plan

- [ ] Playwright playground tests pass (directional test in particular)
- [ ] Toggle theme back and forth - should be near-instant (only `render_svg` runs)
- [ ] Toggle debug - should be near-instant
- [ ] Toggle animate - should be near-instant (cache hit, layout skipped)
- [ ] Toggle directional - should be near-instant
- [ ] Edit source text - should still trigger a full re-layout as before
- [ ] Preview dims briefly while rendering then shows new output

🤖 Generated with [Claude Code](https://claude.com/claude-code)