### PR TITLE
feat(layout): AxisFrame lane sign + lane accessors (inert primitive) (#1029)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -89,6 +89,26 @@ the LR primary axis reversed). A heuristic expressed against primary/secondary
 instead of raw `x`/`y` has a TB path that is *the same code* as its LR path, so
 it needs no branch.
 
+**Lane sign (`secondary_sign`).** A transpose is a reflection: it flips
+chirality, so a TB path written as an axis swap diverges from LR in behaviour,
+not just orientation. The cure is a true 90-degree rotation, which a transpose
+is not. `AxisFrame.secondary_sign` carries the lane fan direction: a 90-degree-CW
+rotation maps LR's screen-down lane (`+Y`) to screen-left (`-X`), so TB is `-1`;
+LR/RL are `+1` (RL reverses only the primary) and BT's `+1` is reserved for true
+BT support (inert until then). The **sanctioned offset->coordinate path** applies
+this sign at the *draw accessor*, never to a stored offset, which stays positive:
+
+- `geometry.station_lane_coord(frame, station, offset)` -> `station.y + offset`
+  (LR), `station.x - offset` (TB): the screen coordinate of a positive lane
+  offset from a station.
+- `geometry.lane_delta(frame, offset)` -> `secondary_sign * offset`: the signed
+  secondary-axis displacement for a positive offset, station-free.
+- `geometry.lane_delta_to_normal_offset(lane_delta, travel)` bridges a lane delta
+  to the bundle builder's right-normal offset (`routing.bundle._right_normal`),
+  the sole point where the lane-sign and builder-normal conventions meet. The
+  builder itself fans purely geometrically along `_right_normal` of travel and is
+  not per-axis; rotation lives *above* it, in this offset->coordinate mapping.
+
 **Policy:** no new one-off TB branches. A heuristic that needs TB awareness is
 the trigger to convert it to the axis vocabulary, not to add another branch.
 This is machine-enforced by `tests/test_tb_branch_ratchet.py`, which counts

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import bisect
+import math
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Protocol
@@ -34,11 +35,19 @@ class AxisFrame:
     LR/RL place layers along X and stack lines along Y; TB transposes the two.
     ``primary_sign`` is ``-1`` for RL, which runs the primary axis in reverse
     (mirrored by ``single_section._mirror_primary``), else ``+1``.
+
+    ``secondary_sign`` is the lane fan direction.  A 90-degree-CW rotation maps
+    LR's screen-down lane (+Y) to screen-left (-X), so TB fans lanes to -X
+    (``-1``).  LR/RL keep ``+1`` (RL reverses only the primary); BT's ``+1`` is
+    reserved for true BT support and is never read on a behavioural path until
+    then.  The sign is applied at the draw accessor (:func:`station_lane_coord`,
+    :func:`lane_delta`), never to a stored offset, which stays positive.
     """
 
     primary: Axis
     secondary: Axis
     primary_sign: float
+    secondary_sign: float
 
     @staticmethod
     def axes_for_direction(direction: str) -> tuple[str, str]:
@@ -58,7 +67,15 @@ class AxisFrame:
         primary, secondary = cls.axes_for_direction(direction)
         step = {"x": x_spacing, "y": y_spacing}
         sign = -1.0 if direction == "RL" else 1.0
-        return cls(Axis(primary, step[primary]), Axis(secondary, step[secondary]), sign)
+        # A 90-degree-CW rotation fans a vertical flow's lanes to -X; BT's +1 is
+        # the inert exception reserved for true BT support.
+        secondary_sign = -1.0 if secondary == "x" and direction != "BT" else 1.0
+        return cls(
+            Axis(primary, step[primary]),
+            Axis(secondary, step[secondary]),
+            sign,
+            secondary_sign,
+        )
 
 
 def lanes_run_along_y(direction: str) -> bool:
@@ -93,6 +110,50 @@ def axis_split(primary_axis: str, point: Point) -> Point:
     """
     px, py = point
     return (px, py) if primary_axis == "x" else (py, px)
+
+
+def station_lane_coord(frame: AxisFrame, station: _HasXY, offset: float) -> float:
+    """Screen coordinate of a positive lane *offset* from *station* on its lane axis.
+
+    ``station.y + offset`` for LR/RL; ``station.x - offset`` for TB.  The lane
+    sign (:attr:`AxisFrame.secondary_sign`) lives here, at the draw accessor, so
+    stored offsets stay positive and a section plots as a true rotation of LR.
+    """
+    return frame.secondary.get(station) + frame.secondary_sign * offset
+
+
+def lane_delta(frame: AxisFrame, offset: float) -> float:
+    """Signed secondary-axis displacement for a positive lane *offset*.
+
+    ``+offset`` for LR/RL, ``-offset`` for TB -- the lane-sign image of *offset*
+    on the screen axis the lines stack along, without reference to a station.
+    """
+    return frame.secondary_sign * offset
+
+
+def lane_delta_to_normal_offset(delta: float, travel: Point) -> float:
+    """Map a lane-axis delta to the bundle builder's right-normal offset.
+
+    ``routing.bundle.build_concentric_bundle`` fans members along the right-hand
+    normal of travel (``(-ty, tx)`` in screen coords, Y growing downward) and
+    expects positive offsets.  A *delta* from :func:`lane_delta` lives on the
+    secondary (lane) screen axis -- Y for a horizontal flow, X for a vertical
+    one -- so projecting it onto the unit right-normal of *travel* restates it in
+    the builder's convention; for axis-aligned travel it is a +/-1 sign lookup.
+    This is the sole point where the lane-sign and builder-normal conventions
+    meet (used by the perpendicular turn-in corner hybrid site).
+    """
+    tx, ty = travel
+    length = math.hypot(tx, ty)
+    if length == 0.0:
+        return delta
+    nx, ny = -ty / length, tx / length
+    # The call site's travel is axis-aligned, so the lane delta sits wholly on
+    # the screen axis perpendicular to travel: Y for horizontal flow, X for
+    # vertical.  Project that displacement onto the unit right-normal.
+    travels_horizontally = abs(tx) >= abs(ty)
+    dx, dy = (0.0, delta) if travels_horizontally else (delta, 0.0)
+    return dx * nx + dy * ny
 
 
 def single_corner_centreline(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1089,7 +1089,7 @@ def _guard_terminus_icons_within_bbox(graph: MetroGraph, phase: str) -> None:
     """
     tol = 1.0
     for section in graph.sections.values():
-        if section.bbox_h <= 0 or section.direction not in ("TB", "BT"):
+        if section.bbox_h <= 0 or lanes_run_along_y(section.direction):
             continue
         top = section.bbox_y
         bottom = section.bbox_y + section.bbox_h

--- a/tests/test_axis_frame.py
+++ b/tests/test_axis_frame.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from nf_metro.layout.geometry import AxisFrame, lanes_run_along_y
+from nf_metro.layout.geometry import (
+    AxisFrame,
+    lane_delta,
+    lane_delta_to_normal_offset,
+    lanes_run_along_y,
+    station_lane_coord,
+)
 from nf_metro.parser.model import Station
 
 X_SPACING = 60.0
@@ -66,6 +72,68 @@ def test_lanes_run_along_y_tracks_secondary_axis(direction: str, on_y: bool) -> 
     # A section's lines stack on its secondary axis; the row passes only own
     # the Y (lane) axis, so they include exactly the lanes-on-Y directions.
     assert lanes_run_along_y(direction) is on_y
+
+
+@pytest.mark.parametrize(
+    "direction, expected",
+    [("LR", 1.0), ("RL", 1.0), ("TB", -1.0), ("BT", 1.0)],
+)
+def test_secondary_sign_fans_tb_lanes_opposite_lr(
+    direction: str, expected: float
+) -> None:
+    # A 90-degree-CW rotation maps LR's +Y lane to -X, so TB alone fans to -X;
+    # RL reverses only the primary, and BT keeps the inert +1 reserved for
+    # true BT support.
+    assert AxisFrame.for_direction(direction, X_SPACING, Y_SPACING).secondary_sign == (
+        expected
+    )
+
+
+@pytest.mark.parametrize("offset", [0.0, 4.0, 12.5])
+@pytest.mark.parametrize("direction", ["LR", "RL", "TB", "BT"])
+def test_station_lane_coord_applies_sign_at_draw_accessor(
+    direction: str, offset: float
+) -> None:
+    frame = AxisFrame.for_direction(direction, X_SPACING, Y_SPACING)
+    station = _station()
+    station.x = 100.0
+    station.y = 200.0
+
+    coord = station_lane_coord(frame, station, offset)
+
+    base = frame.secondary.get(station)
+    assert coord == base + frame.secondary_sign * offset
+    # A positive offset moves a TB lane to a smaller X (screen-left), the
+    # rotation image of LR moving it to a larger Y.
+    if direction == "TB":
+        assert coord == station.x - offset
+    elif frame.secondary.name == "y":
+        assert coord == station.y + offset
+
+
+@pytest.mark.parametrize("offset", [4.0, 12.5])
+@pytest.mark.parametrize("direction, travel", [("LR", (1.0, 0.0)), ("TB", (0.0, 1.0))])
+def test_lane_delta_round_trips_to_positive_builder_offset(
+    direction: str, travel: tuple[float, float], offset: float
+) -> None:
+    # The bundle builder fans along the right-normal of travel and expects
+    # positive offsets.  LR and TB are the same forward flow rotated 90 degrees,
+    # so a positive lane offset maps back to the same positive builder offset for
+    # both -- TB's -1 lane sign and its rotated travel cancel.  This is why the
+    # stored offset never negates.
+    frame = AxisFrame.for_direction(direction, X_SPACING, Y_SPACING)
+    delta = lane_delta(frame, offset)
+    assert delta == frame.secondary_sign * offset
+
+    normal_offset = lane_delta_to_normal_offset(delta, travel)
+    assert normal_offset == pytest.approx(offset)
+
+
+def test_lane_delta_to_normal_offset_is_sign_lookup_for_axis_aligned_travel() -> None:
+    # For axis-aligned travel the projection collapses to a +/-1 sign lookup,
+    # invariant to the leg's length.
+    assert lane_delta_to_normal_offset(5.0, (3.0, 0.0)) == pytest.approx(5.0)
+    assert lane_delta_to_normal_offset(5.0, (0.0, 7.0)) == pytest.approx(-5.0)
 
 
 @pytest.mark.parametrize("direction", ["LR", "RL", "TB"])

--- a/tests/test_tb_branch_ratchet.py
+++ b/tests/test_tb_branch_ratchet.py
@@ -14,7 +14,7 @@ from pathlib import Path
 _LAYOUT_DIR = Path(__file__).resolve().parents[1] / "src/nf_metro/layout"
 
 # Lower this (never raise it) when a heuristic migrates onto AxisFrame.
-_BASELINE_TB_BRANCHES = 35
+_BASELINE_TB_BRANCHES = 34
 
 
 def _count_in_file(path: Path) -> int:


### PR DESCRIPTION
## Summary

Step 1 of the rotation-unification series (#1029). Lays the foundation for plotting LR/RL/TB/BT sections with one logic that differs only by a true 90-degree rotation, replacing TB's chirality-flipping axis transpose.

- Adds `secondary_sign` to `AxisFrame` (`geometry.py`): the lane fan direction. A 90-degree-CW rotation maps LR's screen-down lane (+Y) to screen-left (-X), so TB is `-1`; LR/RL are `+1` (RL reverses only the primary); BT's `+1` is reserved for true BT support and is never read on a behavioural path until then.
- Adds the lane accessors `station_lane_coord`, `lane_delta`, and `lane_delta_to_normal_offset` (`geometry.py`): the sanctioned path mapping a positive stored offset to a screen coordinate. The lane sign is applied at the draw accessor, never to a stored offset, so stored offsets stay positive.
- Migrates the terminus-icon bbox guard (`phases/guards.py`) off `direction not in ("TB", "BT")` onto `lanes_run_along_y`, lowering the TB-branch ratchet 35 -> 34.
- Documents `secondary_sign` and the lane accessors as the sanctioned offset-to-coordinate path in `CONTRACT.md`.
- Adds `AxisFrame` tests covering the sign, the accessors, and the lane-delta/builder-normal round trip.

The step is inert: the new accessors have no production caller yet, and the migrated predicate is logically identical for every direction string. The gallery render is byte-identical to `main` (verified by rendering all 166 examples with the migrated predicate and with the original `not in ("TB", "BT")` form: identical SHA-256).

Fixes #1029

## Test plan
- [x] `pytest` passes including the new `AxisFrame` accessor tests and `test_tb_branch_ratchet` green at baseline 34
- [x] `ruff check` + `ruff format --check` clean on the whole repo
- [x] Byte-identical gallery render confirmed locally
- [ ] Render-preview verdict (CI): expecting "No visual changes detected"

Generated with Claude Code
