### PR TITLE
fix(layout): reserve upright label/icon spacing via the AxisFrame (#1043)

### DIFF
--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -90,6 +90,17 @@ def lanes_run_along_y(direction: str) -> bool:
     return AxisFrame.axes_for_direction(direction)[1] == "y"
 
 
+def lanes_run_along_x(direction: str) -> bool:
+    """``True`` when a section stacks its lines (the secondary/lane axis) on X.
+
+    The complement of :func:`lanes_run_along_y`: a vertical flow (TB/BT) runs
+    its trunk down Y and separates lines along X, so its labels sit beside the
+    pill and its file icons march along Y.  The positive way to ask "is this a
+    vertical flow" without a bare ``direction == "TB"`` branch.
+    """
+    return AxisFrame.axes_for_direction(direction)[1] == "x"
+
+
 Point = tuple[float, float]
 
 

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -50,7 +50,7 @@ from nf_metro.layout.constants import (
     X_SPACING,
 )
 from nf_metro.layout.geometry import (
-    lanes_run_along_y,
+    lanes_run_along_x,
     segment_intersects_bbox,
     segment_intersects_quad,
 )
@@ -1294,14 +1294,13 @@ def _build_label_ctx(
 def _places_label_beside_pill(graph: MetroGraph, station: Station) -> bool:
     """Whether the station's label sits beside its pill (vertical-flow section).
 
-    A vertical flow (TB/BT) stacks lines along X and runs the trunk down Y, so
-    its labels go to the side rather than above/below.  Horizontal flows place
-    labels above/below and take the alternating/angled paths instead.
+    A vertical flow (TB/BT) runs its trunk down Y and stacks lines along X, so
+    its label sits to the side instead of above/below.
     """
     if not station.section_id:
         return False
     sec = graph.sections.get(station.section_id)
-    return bool(sec and not lanes_run_along_y(sec.direction))
+    return bool(sec and lanes_run_along_x(sec.direction))
 
 
 def _place_station_label(

--- a/src/nf_metro/layout/labels.py
+++ b/src/nf_metro/layout/labels.py
@@ -49,7 +49,11 @@ from nf_metro.layout.constants import (
     TB_PILL_EDGE_OFFSET,
     X_SPACING,
 )
-from nf_metro.layout.geometry import segment_intersects_bbox, segment_intersects_quad
+from nf_metro.layout.geometry import (
+    lanes_run_along_y,
+    segment_intersects_bbox,
+    segment_intersects_quad,
+)
 from nf_metro.parser.model import MetroGraph
 
 if TYPE_CHECKING:
@@ -1287,12 +1291,17 @@ def _build_label_ctx(
     return ctx, sorted_stations
 
 
-def _is_tb_section(graph: MetroGraph, station: Station) -> bool:
-    """Whether the station belongs to a TB (top-to-bottom) section."""
+def _places_label_beside_pill(graph: MetroGraph, station: Station) -> bool:
+    """Whether the station's label sits beside its pill (vertical-flow section).
+
+    A vertical flow (TB/BT) stacks lines along X and runs the trunk down Y, so
+    its labels go to the side rather than above/below.  Horizontal flows place
+    labels above/below and take the alternating/angled paths instead.
+    """
     if not station.section_id:
         return False
     sec = graph.sections.get(station.section_id)
-    return bool(sec and sec.direction == "TB")
+    return bool(sec and not lanes_run_along_y(sec.direction))
 
 
 def _place_station_label(
@@ -1308,7 +1317,7 @@ def _place_station_label(
     if rail_panel is not None:
         min_off, max_off = rail_panel
 
-    if _is_tb_section(graph, station):
+    if _places_label_beside_pill(graph, station):
         return _place_tb_label(ctx, station, placements)
     rail_side = _rail_label_side(graph, station)
     if ctx.label_angle:

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -28,7 +28,12 @@ from nf_metro.layout.constants import (
     TERMINUS_ICON_CLEARANCE_V,
     TERMINUS_WIDTH,
 )
-from nf_metro.layout.geometry import Axis, AxisFrame, lanes_run_along_y
+from nf_metro.layout.geometry import (
+    Axis,
+    AxisFrame,
+    lanes_run_along_x,
+    lanes_run_along_y,
+)
 from nf_metro.layout.labels import (
     _label_text_height,
     active_font_scale,
@@ -612,7 +617,7 @@ def _adjust_lr_entry_inset(
     x_spacing: float,
 ) -> None:
     """LR/RL sections: add extra bbox width when entry has curves."""
-    if not lanes_run_along_y(section.direction):
+    if lanes_run_along_x(section.direction):
         return
 
     has_perp_entry = any(
@@ -666,7 +671,7 @@ def _adjust_lr_exit_gap(
     share the same Y, lines exit straight horizontally and no extra space
     is needed.
     """
-    if not lanes_run_along_y(section.direction):
+    if lanes_run_along_x(section.direction):
         return
 
     flow_exit_side = PortSide.RIGHT if section.direction == "LR" else PortSide.LEFT
@@ -895,7 +900,7 @@ def _adjust_terminus_icon_clearance(
     padding doesn't leave enough room, grow the bbox on the affected side.
     """
     section_dir = section.direction or "LR"
-    icons_march_on_y = not lanes_run_along_y(section_dir)
+    icons_march_on_y = lanes_run_along_x(section_dir)
 
     for station in sub.stations.values():
         if not station.is_terminus:

--- a/src/nf_metro/layout/phases/single_section.py
+++ b/src/nf_metro/layout/phases/single_section.py
@@ -28,7 +28,7 @@ from nf_metro.layout.constants import (
     TERMINUS_ICON_CLEARANCE_V,
     TERMINUS_WIDTH,
 )
-from nf_metro.layout.geometry import Axis, AxisFrame
+from nf_metro.layout.geometry import Axis, AxisFrame, lanes_run_along_y
 from nf_metro.layout.labels import (
     _label_text_height,
     active_font_scale,
@@ -547,11 +547,15 @@ def _adjust_tb_labels(
     section: Section,
     graph: MetroGraph,
 ) -> None:
-    """TB sections: expand bbox and shift stations right so labels fit.
+    """Vertical-flow sections: expand bbox and shift stations along the lane
+    axis so side-placed labels fit.
 
-    Labels extend leftward from the station (text_anchor=end).
+    A vertical flow (TB/BT) stacks its lines along X and places labels beside
+    the pill (extending leftward, ``text_anchor=end``), so the lane-axis (X)
+    extent must be reserved.  Horizontal flows place labels above/below and
+    reserve no extra X here.
     """
-    if section.direction != "TB":
+    if lanes_run_along_y(section.direction):
         return
 
     xs = [s.x for s in sub.stations.values()]
@@ -608,7 +612,7 @@ def _adjust_lr_entry_inset(
     x_spacing: float,
 ) -> None:
     """LR/RL sections: add extra bbox width when entry has curves."""
-    if section.direction not in ("LR", "RL"):
+    if not lanes_run_along_y(section.direction):
         return
 
     has_perp_entry = any(
@@ -662,7 +666,7 @@ def _adjust_lr_exit_gap(
     share the same Y, lines exit straight horizontally and no extra space
     is needed.
     """
-    if section.direction not in ("LR", "RL"):
+    if not lanes_run_along_y(section.direction):
         return
 
     flow_exit_side = PortSide.RIGHT if section.direction == "LR" else PortSide.LEFT
@@ -867,7 +871,7 @@ def _terminus_y_overhang(
     sections (whose icons extend horizontally), so content-extent callers
     stay byte-identical there.
     """
-    if not station.is_terminus or section_dir not in ("TB", "BT"):
+    if not station.is_terminus or lanes_run_along_y(section_dir):
         return 0.0, 0.0
     is_source = not graph.edges_to(station.id)
     extent = _terminus_icon_clearance_vertical(
@@ -891,7 +895,7 @@ def _adjust_terminus_icon_clearance(
     padding doesn't leave enough room, grow the bbox on the affected side.
     """
     section_dir = section.direction or "LR"
-    is_tb = section_dir in ("TB", "BT")
+    icons_march_on_y = not lanes_run_along_y(section_dir)
 
     for station in sub.stations.values():
         if not station.is_terminus:
@@ -901,7 +905,7 @@ def _adjust_terminus_icon_clearance(
         is_source = not graph.edges_to(station.id)
         extends_forward = _terminus_icons_extend_forward(is_source, section_dir)
 
-        if is_tb:
+        if icons_march_on_y:
             needed = _terminus_icon_clearance_vertical(n_icons, station.terminus_names)
             if extends_forward:  # icons below the station
                 clearance = section.bbox_y + section.bbox_h - station.y

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -21,7 +21,7 @@ from nf_metro.layout.constants import (
     OFFTRACK_TERMINUS_NUB_CLEARANCE,
     SAME_COORD_TOLERANCE,
 )
-from nf_metro.layout.geometry import lanes_run_along_y, segment_intersects_bbox
+from nf_metro.layout.geometry import lanes_run_along_x, segment_intersects_bbox
 from nf_metro.layout.labels import (
     LabelPlacement,
     _label_bbox,
@@ -1828,7 +1828,7 @@ def _render_station_into(
     is_tb_vert = False
     if station.section_id:
         sec = graph.sections.get(station.section_id)
-        if sec and not lanes_run_along_y(sec.direction):
+        if sec and lanes_run_along_x(sec.direction):
             is_tb_vert = True
 
     # A rail station is pinned to its rail Y; the parallel-line bundle
@@ -1940,7 +1940,7 @@ def _terminus_icon_centers(
     sources in the reverse; RL/BT mirror that so icons always point to
     the outside of the diagram.
     """
-    is_tb = not lanes_run_along_y(section_dir)
+    is_vertical_flow = lanes_run_along_x(section_dir)
     # A rail-mode off-track input parks above the rails and feeds straight down
     # into its consumer's rail (see routing/rail.py), so its icon sits directly
     # on the station coordinate (centred on the drop X) rather than marching
@@ -1955,7 +1955,7 @@ def _terminus_icon_centers(
     centers: list[tuple[float, float]] = []
     for i in range(n):
         flow = sign * (first_offset + i * step)
-        if is_tb:
+        if is_vertical_flow:
             centers.append((station.x + bundle_center, station.y + flow))
         else:
             centers.append((station.x + flow, station.y + bundle_center))
@@ -1983,13 +1983,13 @@ def _render_terminus_icons(
     # Detect if station is a source (no incoming edges) or sink.
     is_source = not graph.edges_to(station.id)
     section_dir = section.direction if section else "LR"
-    is_tb = not lanes_run_along_y(section_dir)
+    is_vertical_flow = lanes_run_along_x(section_dir)
     # Gap between the station pill and the first icon, plus the icon's own
     # half-extent along the flow axis (width for LR/RL, height for TB/BT).
     icon_gap = r + ICON_STATION_GAP
     icon_half_w = theme.terminus_width / 2
     icon_half_h = theme.terminus_height / 2
-    icon_half_flow = icon_half_h if is_tb else icon_half_w
+    icon_half_flow = icon_half_h if is_vertical_flow else icon_half_w
 
     bundle_center = (min_off + max_off) / 2
 
@@ -2004,7 +2004,7 @@ def _render_terminus_icons(
     # LR/RL march icons along X, so widen the step when adjacent captions
     # would overlap.  TB/BT stack icons along Y, where icon height (plus a
     # caption row, when present) sets the spacing.
-    if is_tb:
+    if is_vertical_flow:
         caption_room = caption_font_size + ICON_NAME_GAP if any(names) else 0.0
         icon_step = theme.terminus_height + ICON_INTER_GAP + caption_room
     else:
@@ -2053,11 +2053,11 @@ def _render_terminus_icons(
 
         # Clamp to stay within the section bbox, on whichever axis the
         # icons march along.
-        if section and is_tb and section.bbox_h > 0:
+        if section and is_vertical_flow and section.bbox_h > 0:
             top = section.bbox_y + icon_half_h + ICON_BBOX_MARGIN
             bottom = section.bbox_y + section.bbox_h - icon_half_h - ICON_BBOX_MARGIN
             icon_cy = max(top, min(icon_cy, bottom))
-        elif section and not is_tb and section.bbox_w > 0:
+        elif section and not is_vertical_flow and section.bbox_w > 0:
             icon_right = (
                 section.bbox_x + section.bbox_w - icon_half_w - ICON_BBOX_MARGIN
             )
@@ -2256,11 +2256,11 @@ def _station_marker_extent(
     clear the actual rendered marker, including the per-line offset spread.
     """
     r = theme.station_radius
-    is_tb = False
+    is_vertical_flow = False
     if station.section_id:
         sec = graph.sections.get(station.section_id)
-        if sec and not lanes_run_along_y(sec.direction):
-            is_tb = True
+        if sec and lanes_run_along_x(sec.direction):
+            is_vertical_flow = True
 
     line_offsets = [
         station_offsets.get((station.id, lid), 0.0)
@@ -2269,7 +2269,7 @@ def _station_marker_extent(
     min_off = min(line_offsets) if line_offsets else 0.0
     max_off = max(line_offsets) if line_offsets else 0.0
 
-    x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb)
+    x, y, w, h = _pill_box(station, r, min_off, max_off, is_vertical_flow)
     return (x, x + w, y, y + h)
 
 
@@ -2508,8 +2508,8 @@ def _reserve_rail_space_for_termini(graph: MetroGraph, theme: Theme) -> None:
         name_widths = [
             len(nm) * caption_font_size * 0.55 if nm else 0.0 for nm in names
         ]
-        is_tb = not lanes_run_along_y(sec.direction)
-        if is_tb:
+        is_vertical_flow = lanes_run_along_x(sec.direction)
+        if is_vertical_flow:
             step = theme.terminus_height + ICON_INTER_GAP
             half_flow = hh
         else:

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -21,7 +21,7 @@ from nf_metro.layout.constants import (
     OFFTRACK_TERMINUS_NUB_CLEARANCE,
     SAME_COORD_TOLERANCE,
 )
-from nf_metro.layout.geometry import segment_intersects_bbox
+from nf_metro.layout.geometry import lanes_run_along_y, segment_intersects_bbox
 from nf_metro.layout.labels import (
     LabelPlacement,
     _label_bbox,
@@ -1824,11 +1824,11 @@ def _render_station_into(
         )
         return
 
-    # Determine if this is a TB vertical station (rotated pill)
+    # A vertical-flow (TB/BT) station draws a horizontal (rotated) pill.
     is_tb_vert = False
     if station.section_id:
         sec = graph.sections.get(station.section_id)
-        if sec and sec.direction == "TB":
+        if sec and not lanes_run_along_y(sec.direction):
             is_tb_vert = True
 
     # A rail station is pinned to its rail Y; the parallel-line bundle
@@ -1940,7 +1940,7 @@ def _terminus_icon_centers(
     sources in the reverse; RL/BT mirror that so icons always point to
     the outside of the diagram.
     """
-    is_tb = section_dir in ("TB", "BT")
+    is_tb = not lanes_run_along_y(section_dir)
     # A rail-mode off-track input parks above the rails and feeds straight down
     # into its consumer's rail (see routing/rail.py), so its icon sits directly
     # on the station coordinate (centred on the drop X) rather than marching
@@ -1983,7 +1983,7 @@ def _render_terminus_icons(
     # Detect if station is a source (no incoming edges) or sink.
     is_source = not graph.edges_to(station.id)
     section_dir = section.direction if section else "LR"
-    is_tb = section_dir in ("TB", "BT")
+    is_tb = not lanes_run_along_y(section_dir)
     # Gap between the station pill and the first icon, plus the icon's own
     # half-extent along the flow axis (width for LR/RL, height for TB/BT).
     icon_gap = r + ICON_STATION_GAP
@@ -2259,7 +2259,7 @@ def _station_marker_extent(
     is_tb = False
     if station.section_id:
         sec = graph.sections.get(station.section_id)
-        if sec and sec.direction == "TB":
+        if sec and not lanes_run_along_y(sec.direction):
             is_tb = True
 
     line_offsets = [
@@ -2508,7 +2508,7 @@ def _reserve_rail_space_for_termini(graph: MetroGraph, theme: Theme) -> None:
         name_widths = [
             len(nm) * caption_font_size * 0.55 if nm else 0.0 for nm in names
         ]
-        is_tb = sec.direction in ("TB", "BT")
+        is_tb = not lanes_run_along_y(sec.direction)
         if is_tb:
             step = theme.terminus_height + ICON_INTER_GAP
             half_flow = hh

--- a/tests/test_tb_branch_ratchet.py
+++ b/tests/test_tb_branch_ratchet.py
@@ -14,7 +14,7 @@ from pathlib import Path
 _LAYOUT_DIR = Path(__file__).resolve().parents[1] / "src/nf_metro/layout"
 
 # Lower this (never raise it) when a heuristic migrates onto AxisFrame.
-_BASELINE_TB_BRANCHES = 34
+_BASELINE_TB_BRANCHES = 30
 
 
 def _count_in_file(path: Path) -> int:

--- a/tests/test_upright_spacing_frame.py
+++ b/tests/test_upright_spacing_frame.py
@@ -1,0 +1,82 @@
+"""Upright label/icon spacing is reserved per the section's AxisFrame.
+
+Labels and file icons never rotate, but a rotated section changes which axis
+must reserve room around them.  A vertical-flow section (TB *and* BT) stacks its
+lines along X and places labels beside the pill, so it reserves lane-axis (X)
+extent; a horizontal-flow section reserves Y.  These tests pin that the
+reservation is driven by the frame, so BT behaves identically to TB rather than
+falling through a bare ``direction == "TB"`` branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nf_metro.layout.phases.single_section import (
+    _adjust_tb_labels,
+    _terminus_y_overhang,
+)
+from nf_metro.parser.model import MetroGraph, Section, Station
+
+
+def _vertical_section(direction: str) -> tuple[MetroGraph, Section]:
+    """A minimal vertical-flow section with two labelled stations on one column."""
+    graph = MetroGraph()
+    section = Section(id="sec", name="Sec", direction=direction)
+    section.bbox_x = 0.0
+    section.bbox_y = 0.0
+    section.bbox_w = 60.0
+    section.bbox_h = 200.0
+    graph.sections["sec"] = section
+    for i, label in enumerate(("AlphaStationName", "BetaStationName")):
+        station = Station(id=f"s{i}", label=label, section_id="sec")
+        station.x = 30.0
+        station.y = 40.0 + i * 40.0
+        graph.add_station(station)
+        section.station_ids.append(station.id)
+    return graph, section
+
+
+@pytest.mark.parametrize("direction", ["TB", "BT"])
+def test_vertical_flow_reserves_lane_axis_for_side_labels(direction: str) -> None:
+    graph, section = _vertical_section(direction)
+    width_before = section.bbox_w
+    x_before = [s.x for s in graph.stations.values()]
+
+    _adjust_tb_labels(graph, section, graph)
+
+    assert section.bbox_w > width_before, (
+        f"{direction} section reserved no X extent for its side-placed labels"
+    )
+    assert [s.x for s in graph.stations.values()] != x_before, (
+        f"{direction} section did not shift stations to clear the label extent"
+    )
+
+
+def test_tb_and_bt_reserve_identical_label_extent() -> None:
+    tb_graph, tb_section = _vertical_section("TB")
+    bt_graph, bt_section = _vertical_section("BT")
+
+    _adjust_tb_labels(tb_graph, tb_section, tb_graph)
+    _adjust_tb_labels(bt_graph, bt_section, bt_graph)
+
+    assert tb_section.bbox_w == bt_section.bbox_w
+    assert [s.x for s in tb_graph.stations.values()] == [
+        s.x for s in bt_graph.stations.values()
+    ]
+
+
+@pytest.mark.parametrize("direction", ["TB", "BT"])
+def test_vertical_flow_terminus_icons_overhang_on_flow_axis(direction: str) -> None:
+    graph = MetroGraph()
+    section = Section(id="sec", name="Sec", direction=direction)
+    graph.sections["sec"] = section
+    sink = Station(id="t", label="Out", section_id="sec")
+    sink.terminus_labels = ["bam"]
+    graph.add_station(sink)
+    section.station_ids.append(sink.id)
+
+    above, below = _terminus_y_overhang(sink, direction, graph)
+    assert (above, below) != (0.0, 0.0), (
+        f"{direction} terminus reserved no flow-axis (Y) overhang for its icons"
+    )


### PR DESCRIPTION
## Summary

Part of the rotation-unification series. #1041 made the graph **geometry** a pure rotation across LR/RL/TB via `AxisFrame`; this handles the **upright layer** (labels, file icons, captions never rotate, but a rotated section changes which axis must reserve room around them).

- Express the direction-sensitive spacing reservation through the `AxisFrame` lane axis (`lanes_run_along_y` / new `lanes_run_along_x`) instead of bare `"TB"` / `("LR","RL")` literals:
  - `single_section`: `_adjust_tb_labels`, `_adjust_lr_entry_inset`, `_adjust_lr_exit_gap`, `_terminus_y_overhang`, `_adjust_terminus_icon_clearance`.
  - `labels`: `_is_tb_section` -> `_places_label_beside_pill` (frame-based).
  - `render/svg`: pill-orientation and terminus-icon march/clamp read the frame; the bare `is_tb` flags (which already covered BT) renamed to `is_vertical_flow`.
- A vertical flow (TB **and** BT) now reserves the same lane-axis (X) extent for its side-placed labels and marches its file icons along Y, rather than BT falling through a `"TB"`-only branch and clipping.
- Add `lanes_run_along_x` as the positive complement of `lanes_run_along_y` so vertical-flow guards read affirmatively.
- Lower the TB-branch ratchet baseline 34 -> 30 (four `"TB"` literals removed; verified under Python 3.11).

Text/icon **orientation** stays a deliberate upright pass and is not folded into `lane_x` (geometry only).

BT is not authorable today (directives accept only LR/RL/TB) and is never inferred, so the gallery geometry is **byte-identical**; the BT spacing is locked by unit tests that construct a BT section directly.

Fixes #1043

## Test plan
- [x] pytest passes (20495 passed; +5 new tests in `tests/test_upright_spacing_frame.py`, which fail on `main` for the BT cases)
- [x] ruff check + ruff format clean on whole repo; mypy clean
- [x] TB renders byte-identical vs `origin/main` (`rnaseq_sections`, `tb_file_termini`)
- [x] TB-branch ratchet regenerated under Python 3.11 (34 -> 30)
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/1050/)
- [x] Render-preview verdict: **no visual changes detected** (geometry byte-identical, as intended)

Generated with Claude Code

