### PR TITLE
fix(layout): TB BOTTOM-only exit reserves excessive space below last station

### DIFF
--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -578,6 +578,14 @@ GALLERY_ENTRIES: list[tuple[str, Path, str]] = [
         "trailing station stays contained (issue #1057).",
     ),
     (
+        "tb_column_continuation_two_lines",
+        TOPOLOGIES_DIR,
+        "A TB section with a two-line BOTTOM exit continuing straight down into "
+        "the TB section below. The exit port seats close to the last station "
+        "with normal section padding rather than the doubled gap the fold-span "
+        "extension would add (issue #1062).",
+    ),
+    (
         "bypass_gap2_rightward_overflow",
         TOPOLOGIES_DIR,
         "A seven-line rightward bypass whose gap-2 bundle right edge overflows "

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -316,6 +316,14 @@ def _apply_tb_fold_spans(
         next_row = row + 1
         if next_row not in row_offsets:
             continue
+        # A BOTTOM-only exit routes straight down; no sideways fold routing
+        # through the inter-row gap, so no fold-span extension is needed.
+        _exit_sides = {s for s, _ in section.exit_hints}
+        if PortSide.BOTTOM in _exit_sides and not _exit_sides & {
+            PortSide.LEFT,
+            PortSide.RIGHT,
+        }:
+            continue
         section.bbox_h += section_y_gap
         tb_bottom = row_offsets[row] + section.bbox_h
         next_row_bottom = row_offsets[next_row] + row_heights[next_row]

--- a/tests/test_tb_bottom_exit_spacing_invariant.py
+++ b/tests/test_tb_bottom_exit_spacing_invariant.py
@@ -1,0 +1,67 @@
+"""Invariant: TB sections with BOTTOM-only exits keep normal padding below last station.
+
+A TB section whose only exit is BOTTOM exits straight down into the section
+below; it does not fold sideways through the inter-row gap.  The fold-span
+extension in _apply_tb_fold_spans must therefore not grow its bbox_h, so the
+space below the last internal station stays close to the normal SECTION_Y_PADDING
+rather than doubling it (issue #1062).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.constants import SECTION_Y_PADDING, Y_SPACING
+from nf_metro.layout.engine import compute_layout
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import PortSide
+
+TOPOLOGIES_DIR = Path(__file__).parent.parent / "examples" / "topologies"
+
+# Fixtures with a TB section that has only a BOTTOM exit and a LR/RL section
+# below in the same column.  The gap below the last internal station should be
+# SECTION_Y_PADDING, not the doubled value produced by the fold-span extension.
+FIXTURES = [
+    "lr_top_entry_cross_column",
+    "tb_column_continuation_two_lines",
+]
+
+# Upper bound: SECTION_Y_PADDING plus one full y_spacing to absorb any
+# legitimate label or entry-shift padding without catching the bug (which
+# adds a full section_y_gap ≈ SECTION_Y_PADDING on top of the natural height).
+_GAP_CEILING = SECTION_Y_PADDING + Y_SPACING
+
+
+@pytest.mark.parametrize("stem", FIXTURES)
+def test_tb_bottom_exit_section_gap(stem: str) -> None:
+    graph = parse_metro_mermaid((TOPOLOGIES_DIR / f"{stem}.mmd").read_text())
+    compute_layout(graph)
+
+    for sec in graph.sections.values():
+        if sec.direction != "TB":
+            continue
+        exit_sides = {s for s, _ in sec.exit_hints}
+        if PortSide.BOTTOM not in exit_sides:
+            continue
+        if exit_sides & {PortSide.LEFT, PortSide.RIGHT}:
+            continue
+
+        internal_ys = [
+            graph.stations[sid].y
+            for sid in sec.station_ids
+            if sid in graph.stations and not graph.stations[sid].is_port
+        ]
+        if not internal_ys:
+            continue
+
+        last_y = max(internal_ys)
+        bbox_bottom = sec.bbox_y + sec.bbox_h
+        gap = bbox_bottom - last_y
+
+        assert gap <= _GAP_CEILING, (
+            f"Section '{sec.id}' in {stem}: gap below last station is {gap:.0f}px "
+            f"(last_y={last_y:.0f}, bbox_bottom={bbox_bottom:.0f}), "
+            f"expected ≤ {_GAP_CEILING:.0f}px"
+        )


### PR DESCRIPTION
## Summary

- `_apply_tb_fold_spans` in `section_placement.py` unconditionally added `section_y_gap` (~50px) to a TB section's `bbox_h` whenever the section had a next row, intended to leave room for sideways fold routing through the inter-row gap.
- A TB section whose only exit is BOTTOM exits straight down — it does not fold sideways — so the extension was wasteful: the BOTTOM port ended up ~100px below the last station instead of the normal ~50px section padding.
- Fixed with a guard: skip the extension when the section's `exit_hints` are all `PortSide.BOTTOM` (no LEFT/RIGHT fold exits).
- Added `test_tb_bottom_exit_section_gap` parametrized over `lr_top_entry_cross_column` and `tb_column_continuation_two_lines`; both fixtures' `_GAP_CEILING` check fails on `main` and passes with the fix.
- Added `tb_column_continuation_two_lines` to the gallery.

Fixes #1062

## Test plan

- [x] `pytest tests/test_tb_bottom_exit_spacing_invariant.py` passes (2 parametrized cases)
- [x] Full `pytest` passes (21218 tests, 0 failures, 6 known xfails unchanged)
- [x] Routing gate coverage ratchet clean (19 tests pass)
- [x] Pre-commit hooks clean (ruff, mypy, whitespace)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/1063/)

Generated with Claude Code