### PR TITLE
docs(live): document one-liner serve pattern and missing flags

### DIFF
--- a/docs/live.md
+++ b/docs/live.md
@@ -85,14 +85,28 @@ so it's the mode for iterating on a single pipeline - re-run and watch the same
 page - and it's the server the plugin's managed mode spawns. For many pipelines
 or runs side by side, use the dashboard in §2b instead.
 
+### One-liner (recommended)
+
+Pass the Nextflow command after `--` and `serve` handles everything: it wires
+`-with-weblog` automatically, opens your browser, and shuts itself down when the
+run finishes.
+
 ```bash
-nf-metro serve path/to/map.mmd --port 8080
+nf-metro serve path/to/map.mmd --open --shutdown-after-complete -- \
+    nextflow run my/pipeline
 ```
 
-Then open <http://localhost:8080/> and start the pipeline with its weblog
-pointed at the server:
+### Two-shell alternative
+
+If you prefer to keep the server and the pipeline in separate terminals (useful
+when iterating across many re-runs with the server left running):
 
 ```bash
+# shell 1 - the live server
+nf-metro serve path/to/map.mmd --port 8080
+# open http://localhost:8080/
+
+# shell 2 - the pipeline
 nextflow run my/pipeline -with-weblog http://localhost:8080/events
 ```
 
@@ -106,6 +120,9 @@ blank map.
 | `--host` | Interface to bind. Default `127.0.0.1` (local only); use `0.0.0.0` to accept connections from other hosts. |
 | `--theme` | Theme name (`nfcore`, `light`, `seqera`). The page chrome (background, text) follows the theme, so a light theme gives a light page. |
 | `--overlay` | Status-overlay style: `ring` (default), `pulse`, `dot`, or `led`. Sets the style shown until a viewer picks another. |
+| `--open` | Open the live page in the default browser when the server starts. |
+| `--shutdown-after-complete` | Stop the server shortly after the run's `completed` or `error` event (or after the launched command exits). |
+| `--shutdown-grace` | Seconds to keep the map up after the run finishes before shutting down (used with `--shutdown-after-complete`; default 5). |
 | `--token` | If set, `/events` POSTs must supply `?token=...` or an `X-Metro-Token` header. |
 
 ### Overlay styles
@@ -330,4 +347,14 @@ but are not treated as failures since they may be intentional.
 The repository ships a self-contained demo under
 [`examples/live/`](https://github.com/pinin4fjords/nf-metro/tree/main/examples/live):
 a toy workflow whose processes only `sleep`, a mapped map, and a process list
-for `check-mapping`. See its `README.md` to run it end to end.
+for `check-mapping`. From the repo root:
+
+```bash
+nf-metro serve examples/live/pipeline.mmd --open --shutdown-after-complete -- \
+    nextflow run examples/live/workflow/main.nf \
+              -c examples/live/workflow/nextflow.config
+```
+
+Three coloured lines fan out after Trim Galore, run in parallel, then converge
+at MultiQC. The browser opens automatically and the server stops when the
+pipeline finishes.

--- a/examples/live/README.md
+++ b/examples/live/README.md
@@ -1,8 +1,5 @@
 # Live progress demo
 
-> **Experimental.** The `%%metro process:` directive and the `nf-metro serve` /
-> `check-mapping` commands may change without notice.
-
 Light up a metro map in real time as a Nextflow pipeline runs - no Seqera
 Platform, no plugin. Stock Nextflow `-with-weblog` posts task events to
 `nf-metro serve`, which draws a status overlay on top of the static map:
@@ -25,21 +22,34 @@ nextflow run --with-weblog ──HTTP──> nf-metro serve ──SSE──> bro
 
 ## Run it
 
-Two shells. The server needs nf-metro installed; the pipeline needs Nextflow.
+From the repo root (nf-metro and Nextflow both on PATH):
 
 ```bash
-# Shell 1 - the live server
+nf-metro serve examples/live/pipeline.mmd --open --shutdown-after-complete -- \
+    nextflow run examples/live/workflow/main.nf \
+              -c examples/live/workflow/nextflow.config
+```
+
+`serve` wires `-with-weblog` automatically, opens your browser, and shuts the
+server down when the pipeline finishes.
+
+Watch the map: Trim Galore fills first, the three lines fan out and run in
+parallel, then MultiQC lights up as everything converges.
+
+### Two-shell alternative
+
+If you want to keep the server alive across multiple re-runs:
+
+```bash
+# shell 1 - the live server
 nf-metro serve examples/live/pipeline.mmd --port 8080
 # open http://localhost:8080/
 
-# Shell 2 - the pipeline (no Docker; processes only sleep)
+# shell 2 - the pipeline (no Docker; processes only sleep)
 nextflow run examples/live/workflow/main.nf \
   -c examples/live/workflow/nextflow.config \
   -with-weblog http://localhost:8080/events
 ```
-
-Watch the map: Trim Galore fills first, the three lines fan out and run in
-parallel, then MultiQC lights up as everything converges.
 
 ## Check the mapping stays honest
 


### PR DESCRIPTION
## Summary

- Adds the `-- nextflow run ...` integrated launch pattern to `docs/live.md` and `examples/live/README.md` — one command wires `-with-weblog`, opens the browser, and shuts the server down when the run finishes; this was the most impactful undocumented feature
- Adds the missing `--open`, `--shutdown-after-complete`, and `--shutdown-grace` flags to the serve options table in `docs/live.md`
- Drops the stale "Experimental" warning from `examples/live/README.md` (the feature has been stable since 1.0)
- Updates the "Try it" section in `docs/live.md` to use the one-liner directly rather than just pointing at the example README

## Test plan

- [ ] Verify the one-liner command in the updated `examples/live/README.md` runs correctly from the repo root
- [ ] Check rendered docs look correct on the live site after merge