### PR TITLE
feat(serve): accept rendered SVG with embedded manifest as input

### DIFF
--- a/docs/live.md
+++ b/docs/live.md
@@ -85,6 +85,24 @@ so it's the mode for iterating on a single pipeline - re-run and watch the same
 page - and it's the server the plugin's managed mode spawns. For many pipelines
 or runs side by side, use the dashboard in §2b instead.
 
+`serve` accepts two input formats:
+
+- **`.mmd`** - the source file; `serve` renders and lays out the map on startup.
+  Use this during map development, since changing the file and restarting
+  immediately reflects the update.
+- **`.svg`** - a pre-rendered SVG with its embedded manifest (the default output
+  of `nf-metro render`). `serve` reads station geometry and the process mapping
+  directly from the manifest - no re-render, no Python graph. Use this when you
+  have committed the SVG to a repo and want to serve it without the source, or
+  when you want layout to be stable across restarts regardless of any tool
+  version change. The `--theme` option has no effect in this mode (the SVG is
+  already drawn).
+
+!!! tip "SVG must carry a manifest"
+    The SVG path requires the manifest embedded in the file. `nf-metro render`
+    embeds it by default. If you opted out with `--no-manifest`, re-render
+    without that flag before serving.
+
 ### One-liner (recommended)
 
 Pass the Nextflow command after `--` and `serve` handles everything: it wires
@@ -92,7 +110,12 @@ Pass the Nextflow command after `--` and `serve` handles everything: it wires
 run finishes.
 
 ```bash
+# from a source file
 nf-metro serve path/to/map.mmd --open --shutdown-after-complete -- \
+    nextflow run my/pipeline
+
+# from a pre-rendered SVG
+nf-metro serve path/to/map.svg --open --shutdown-after-complete -- \
     nextflow run my/pipeline
 ```
 
@@ -102,7 +125,7 @@ If you prefer to keep the server and the pipeline in separate terminals (useful
 when iterating across many re-runs with the server left running):
 
 ```bash
-# shell 1 - the live server
+# shell 1 - the live server (either input format works)
 nf-metro serve path/to/map.mmd --port 8080
 # open http://localhost:8080/
 

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -631,32 +631,52 @@ def serve(
     map; only mapped stations change state. Use `nf-metro check-mapping` to
     verify the mapping covers the pipeline.
     """
-    from nf_metro.live.server import run_lifecycle
+    from nf_metro.live.server import MapModel, run_lifecycle, serve_model
     from nf_metro.live.server import serve as serve_map
 
-    try:
-        graph = parse_metro_mermaid(input_file.read_text())
-        compute_layout(graph)
-    except (ValueError, PhaseInvariantError) as e:
-        raise click.ClickException(str(e))
+    if input_file.suffix.lower() == ".svg":
+        try:
+            model = MapModel.from_svg(input_file.read_text())
+        except ValueError as e:
+            raise click.ClickException(str(e))
+        mapped = sorted(model.mapping)
+        if not mapped:
+            click.echo(
+                "Warning: SVG manifest has no process patterns; "
+                "no station will update.",
+                err=True,
+            )
+        if host == "0.0.0.0":  # noqa: S104 - explicit opt-in, warned
+            click.echo(
+                "Binding 0.0.0.0: reachable from other hosts; "
+                "use --token to restrict /events.",
+                err=True,
+            )
+        httpd = serve_model(model, host=host, port=port, token=token, overlay=overlay)
+    else:
+        try:
+            graph = parse_metro_mermaid(input_file.read_text())
+            compute_layout(graph)
+        except (ValueError, PhaseInvariantError) as e:
+            raise click.ClickException(str(e))
 
-    theme_obj = resolve_theme(theme, graph)
-    mapped = sorted(graph.process_mapping)
-    if not mapped:
-        click.echo(
-            "Warning: no %%metro process: directives; no station will update.",
-            err=True,
-        )
-    if host == "0.0.0.0":  # noqa: S104 - explicit opt-in, warned
-        click.echo(
-            "Binding 0.0.0.0: reachable from other hosts; "
-            "use --token to restrict /events.",
-            err=True,
-        )
+        theme_obj = resolve_theme(theme, graph)
+        mapped = sorted(graph.process_mapping)
+        if not mapped:
+            click.echo(
+                "Warning: no %%metro process: directives; no station will update.",
+                err=True,
+            )
+        if host == "0.0.0.0":  # noqa: S104 - explicit opt-in, warned
+            click.echo(
+                "Binding 0.0.0.0: reachable from other hosts; "
+                "use --token to restrict /events.",
+                err=True,
+            )
 
-    httpd = serve_map(
-        graph, theme_obj, host=host, port=port, token=token, overlay=overlay
-    )
+        httpd = serve_map(
+            graph, theme_obj, host=host, port=port, token=token, overlay=overlay
+        )
     # Local subprocesses post to a concrete loopback address, not 0.0.0.0.
     run_host = "127.0.0.1" if host == "0.0.0.0" else host
     page_url = f"http://{run_host}:{port}/"

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -646,12 +646,6 @@ def serve(
                 "no station will update.",
                 err=True,
             )
-        if host == "0.0.0.0":  # noqa: S104 - explicit opt-in, warned
-            click.echo(
-                "Binding 0.0.0.0: reachable from other hosts; "
-                "use --token to restrict /events.",
-                err=True,
-            )
         httpd = serve_model(model, host=host, port=port, token=token, overlay=overlay)
     else:
         try:
@@ -667,15 +661,14 @@ def serve(
                 "Warning: no %%metro process: directives; no station will update.",
                 err=True,
             )
-        if host == "0.0.0.0":  # noqa: S104 - explicit opt-in, warned
-            click.echo(
-                "Binding 0.0.0.0: reachable from other hosts; "
-                "use --token to restrict /events.",
-                err=True,
-            )
-
         httpd = serve_map(
             graph, theme_obj, host=host, port=port, token=token, overlay=overlay
+        )
+    if host == "0.0.0.0":  # noqa: S104 - explicit opt-in, warned
+        click.echo(
+            "Binding 0.0.0.0: reachable from other hosts; "
+            "use --token to restrict /events.",
+            err=True,
         )
     # Local subprocesses post to a concrete loopback address, not 0.0.0.0.
     run_host = "127.0.0.1" if host == "0.0.0.0" else host

--- a/src/nf_metro/live/server.py
+++ b/src/nf_metro/live/server.py
@@ -26,6 +26,7 @@ from nf_metro.layout import compute_layout
 from nf_metro.layout.routing.offsets import compute_station_offsets
 from nf_metro.layout.routing.reversal import tb_positive_fan_sections
 from nf_metro.live.mapping import stations_for_process
+from nf_metro.manifest.read import read_manifest
 from nf_metro.parser import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph
 from nf_metro.render import render_svg
@@ -153,6 +154,52 @@ class MapModel:
                     "rx": round(rx, 1),
                 }
             )
+
+    @classmethod
+    def from_svg(cls, svg_text: str, is_light: bool = False) -> "MapModel":
+        """Build a MapModel from a rendered SVG with an embedded manifest.
+
+        Reads geometry and process-mapping from the ``<metadata id="diagram-manifest">``
+        block rather than re-rendering, so a pre-rendered SVG can drive the live
+        server without the source ``.mmd`` file.  Raises ``ValueError`` if the
+        SVG carries no manifest.
+        """
+        manifest = read_manifest(svg_text)
+        if manifest is None:
+            raise ValueError(
+                "serve: SVG has no embedded manifest; "
+                "render with --manifest (the default)"
+            )
+        model = cls.__new__(cls)
+        model.svg_body = re.sub(r"^<\?xml[^>]*\?>\s*", "", svg_text)
+        model.width = float(manifest.get("width", 1000))
+        model.height = float(manifest.get("height", 600))
+        model.is_light = is_light
+        model.mapping = {
+            node["id"]: node.get("patterns", [])
+            for node in manifest.get("nodes", [])
+            if node.get("patterns")
+        }
+        model.stations = []
+        for node in manifest.get("nodes", []):
+            node_id = node["id"]
+            if node_id not in model.mapping:
+                continue
+            r = float(node.get("r", 8))
+            w = float(node.get("w", r * 2))
+            h = float(node.get("h", r * 2))
+            rx = float(node.get("rx", r))
+            model.stations.append(
+                {
+                    "id": node_id,
+                    "x": float(node["x"]),
+                    "y": float(node["y"]),
+                    "w": w,
+                    "h": h,
+                    "rx": rx,
+                }
+            )
+        return model
 
     def stations_for_process(self, process: str) -> list[str]:
         return stations_for_process(process, self.mapping)
@@ -588,13 +635,34 @@ def serve(
     token: str | None = None,
     overlay: str = DEFAULT_OVERLAY,
 ) -> MetroServer:
-    """Build the model and return a serving ``MetroServer``.
+    """Build the model from a graph+theme and return a serving ``MetroServer``.
 
     The caller drives the server (``serve_forever``); separating construction
     makes the handler and state testable without binding a socket. ``overlay``
     is the status-overlay style shown until a viewer picks another in the page.
     """
-    model = MapModel(graph, theme)
+    return serve_model(
+        MapModel(graph, theme),
+        host=host,
+        port=port,
+        token=token,
+        overlay=overlay,
+    )
+
+
+def serve_model(
+    model: MapModel,
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    token: str | None = None,
+    overlay: str = DEFAULT_OVERLAY,
+) -> MetroServer:
+    """Return a serving ``MetroServer`` from a pre-built ``MapModel``.
+
+    Allows callers that already hold a model (e.g. loaded from an SVG) to skip
+    the render step.  The caller drives the server lifecycle via
+    :func:`run_lifecycle`.
+    """
     state = ProgressState(model)
     httpd = MetroServer((host, port), make_handler(model, state, token, overlay))
     httpd.state = state

--- a/src/nf_metro/live/server.py
+++ b/src/nf_metro/live/server.py
@@ -122,6 +122,10 @@ class StationGeom(TypedDict):
     rx: float
 
 
+def _strip_xml_decl(svg: str) -> str:
+    return re.sub(r"^<\?xml[^>]*\?>\s*", "", svg)
+
+
 class MapModel:
     """Static map: SVG body, canvas size, overlay station geometry, mapping."""
 
@@ -129,7 +133,7 @@ class MapModel:
         self.mapping = graph.process_mapping
         self.is_light = _is_light_bg(theme.background_color)
         svg = render_svg(graph, theme)
-        self.svg_body = re.sub(r"^<\?xml[^>]*\?>\s*", "", svg)
+        self.svg_body = _strip_xml_decl(svg)
 
         dim = SVG_DIM_RE.search(svg)
         self.width = float(dim.group(1)) if dim else float(graph.width or 1000)
@@ -171,34 +175,28 @@ class MapModel:
                 "render with --manifest (the default)"
             )
         model = cls.__new__(cls)
-        model.svg_body = re.sub(r"^<\?xml[^>]*\?>\s*", "", svg_text)
+        model.svg_body = _strip_xml_decl(svg_text)
         model.width = float(manifest.get("width", 1000))
         model.height = float(manifest.get("height", 600))
         model.is_light = is_light
-        model.mapping = {
-            node["id"]: node.get("patterns", [])
-            for node in manifest.get("nodes", [])
-            if node.get("patterns")
-        }
+        model.mapping = {}
         model.stations = []
         for node in manifest.get("nodes", []):
             node_id = node["id"]
-            if node_id not in model.mapping:
-                continue
-            r = float(node.get("r", 8))
-            w = float(node.get("w", r * 2))
-            h = float(node.get("h", r * 2))
-            rx = float(node.get("rx", r))
-            model.stations.append(
-                {
-                    "id": node_id,
-                    "x": float(node["x"]),
-                    "y": float(node["y"]),
-                    "w": w,
-                    "h": h,
-                    "rx": rx,
-                }
-            )
+            patterns = node.get("patterns", [])
+            if patterns:
+                model.mapping[node_id] = patterns
+                r = float(node.get("r", 8))
+                model.stations.append(
+                    {
+                        "id": node_id,
+                        "x": float(node["x"]),
+                        "y": float(node["y"]),
+                        "w": float(node.get("w", r * 2)),
+                        "h": float(node.get("h", r * 2)),
+                        "rx": float(node.get("rx", r)),
+                    }
+                )
         return model
 
     def stations_for_process(self, process: str) -> list[str]:

--- a/src/nf_metro/manifest/produce.py
+++ b/src/nf_metro/manifest/produce.py
@@ -39,8 +39,10 @@ def build_manifest_data(
         nodes: The addressable nodes. Each is a mapping with required ``id``,
             ``x``, ``y``, ``r`` and optional ``label`` (defaults to ``id``),
             ``groups`` (ids of any groups the node belongs to), ``region`` (one
-            containing region id), and ``patterns`` (the regexes the node
-            matches). Coordinates are rounded here, so pass raw values.
+            containing region id), ``patterns`` (the regexes the node
+            matches), and ``w``/``h``/``rx`` (marker pill dimensions, emitted
+            when present so an overlay can reproduce the exact shape).
+            Coordinates are rounded here, so pass raw values.
         groups: Optional multi-membership categories; each a mapping with
             ``id``, ``label``, ``color``.
         regions: Optional single-membership containers; each a mapping with
@@ -85,6 +87,9 @@ def _node_entry(node: Mapping[str, Any]) -> dict[str, Any]:
     }
     if node.get("region"):
         entry["region"] = node["region"]
+    for key in ("w", "h", "rx"):
+        if node.get(key) is not None:
+            entry[key] = _round1(node[key])
     return entry
 
 
@@ -170,14 +175,19 @@ def node_data_attrs(
     r: float,
     groups: Sequence[str] = (),
     region: str | None = None,
+    w: float | None = None,
+    h: float | None = None,
+    rx: float | None = None,
 ) -> dict[str, Any]:
     """The ``data-node-*`` attribute set for one node's element.
 
     The DOM-addressable mirror of a manifest node: ``data-node-id`` is the join
     key (equals the manifest ``id``) and the geometry attributes mirror the
     manifest's ``x``/``y``/``r`` (rounded to 1dp), so a consumer can position
-    against either half interchangeably.  Returned as a plain dict so a producer
-    can spread it onto whatever element it draws.
+    against either half interchangeably.  When the marker box dimensions are
+    known, ``w``/``h``/``rx`` are also emitted so an overlay can reproduce the
+    exact pill shape without re-rendering.  Returned as a plain dict so a
+    producer can spread it onto whatever element it draws.
     """
     attrs: dict[str, Any] = {
         "data-node-id": id,
@@ -188,4 +198,10 @@ def node_data_attrs(
     }
     if region:
         attrs["data-node-region"] = region
+    if w is not None:
+        attrs["data-node-w"] = _round1(w)
+    if h is not None:
+        attrs["data-node-h"] = _round1(h)
+    if rx is not None:
+        attrs["data-node-rx"] = _round1(rx)
     return attrs

--- a/src/nf_metro/manifest/schema.json
+++ b/src/nf_metro/manifest/schema.json
@@ -77,6 +77,9 @@
           "x": { "type": "number", "description": "Centre x, absolute SVG user units." },
           "y": { "type": "number", "description": "Centre y, absolute SVG user units." },
           "r": { "type": "number", "description": "Nominal marker radius." },
+          "w": { "type": "number", "description": "Marker pill width (SVG user units)." },
+          "h": { "type": "number", "description": "Marker pill height (SVG user units)." },
+          "rx": { "type": "number", "description": "Marker pill corner radius." },
           "groups": {
             "type": "array",
             "items": { "type": "string" },

--- a/src/nf_metro/render/manifest.py
+++ b/src/nf_metro/render/manifest.py
@@ -54,6 +54,7 @@ def build_manifest(
     width: int,
     height: int,
     station_radius: float,
+    extra_node_data: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the manifest dict from the graph the renderer just laid out.
 
@@ -65,8 +66,11 @@ def build_manifest(
     (``graph.stations[].x/.y`` and ``graph.process_mapping``) so the embedded
     data cannot drift from the live behaviour.  ``width`` and ``height`` are the
     final canvas dimensions; ``station_radius`` is the single nominal marker
-    radius (an overlay needs a point and a radius, not the per-station pill
-    geometry).
+    radius.
+
+    ``extra_node_data`` is an optional mapping from station id to additional
+    fields (e.g. ``w``, ``h``, ``rx`` pill dimensions computed by the renderer)
+    that are merged into each node entry before serialisation.
 
     Ports and hidden nodes are excluded.  Every other station is included --
     unmapped ones simply carry an empty ``patterns`` list -- so the manifest is
@@ -90,6 +94,8 @@ def build_manifest(
         }
         if station.section_id in real_sections:
             entry["region"] = station.section_id
+        if extra_node_data and station.id in extra_node_data:
+            entry.update(extra_node_data[station.id])
         nodes.append(entry)
 
     return build_manifest_data(

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -615,24 +615,25 @@ def _render_svg_scaled(
     else:
         d = draw.Drawing(svg_width, svg_height)
 
+    positive_fan = tb_positive_fan_sections(graph)
+
     # Embed the machine-readable manifest first, so the file is a durable,
     # self-describing contract regardless of what is drawn below it.
     if graph.embed_manifest:
-        _pf = tb_positive_fan_sections(graph)
-        _boxes: dict[str, dict[str, float]] = {}
-        for _s in graph.stations.values():
-            if _s.is_port or _s.is_hidden:
+        boxes: dict[str, dict[str, float]] = {}
+        for s in graph.stations.values():
+            if s.is_port or s.is_hidden:
                 continue
-            _cx, _cy, _w, _h, _rx = station_marker_box(
-                graph, theme, _s, station_offsets, _pf
+            cx, cy, w, h, rx = station_marker_box(
+                graph, theme, s, station_offsets, positive_fan
             )
-            _boxes[_s.id] = {"x": _cx, "y": _cy, "w": _w, "h": _h, "rx": _rx}
+            boxes[s.id] = {"x": cx, "y": cy, "w": w, "h": h, "rx": rx}
         manifest = build_manifest(
             graph,
             width=svg_width,
             height=svg_height,
             station_radius=theme.station_radius,
-            extra_node_data=_boxes,
+            extra_node_data=boxes,
         )
         d.append(draw.Raw(manifest_metadata_svg(manifest)))
 
@@ -699,7 +700,7 @@ def _render_svg_scaled(
         render_animation(d, graph, routes, station_offsets, theme)
 
     # Draw stations (all circles, skip ports)
-    _render_stations(d, graph, theme, station_offsets)
+    _render_stations(d, graph, theme, station_offsets, positive_fan)
 
     # Draw labels
     _render_labels(d, labels, theme)
@@ -1752,6 +1753,7 @@ def _render_stations(
     graph: MetroGraph,
     theme: Theme,
     station_offsets: dict[tuple[str, str], float] | None = None,
+    positive_fan: set[str] | None = None,
 ) -> None:
     """Render stations as pill shapes.
 
@@ -1765,7 +1767,8 @@ def _render_stations(
     addressable element; with ``--no-manifest`` the glyphs are drawn directly
     with no wrapper. Skips port stations (is_port=True).
     """
-    positive_fan = tb_positive_fan_sections(graph)
+    if positive_fan is None:
+        positive_fan = tb_positive_fan_sections(graph)
     for station in graph.stations.values():
         if station.is_port or station.is_hidden:
             continue

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1690,7 +1690,11 @@ def _draw_blank_terminus_nub(
 
 
 def _station_group_attrs(
-    graph: MetroGraph, theme: Theme, station: Station
+    graph: MetroGraph,
+    theme: Theme,
+    station: Station,
+    station_offsets: dict[tuple[str, str], float] | None = None,
+    positive_fan: set[str] | None = None,
 ) -> dict[str, Any]:
     """Attributes for a station's wrapping ``<g>`` element.
 
@@ -1700,12 +1704,21 @@ def _station_group_attrs(
     ``id`` in the embedded manifest.  The geometry attributes mirror the
     manifest's ``x``/``y``/``r`` (absolute SVG user units, rounded to 1dp) so an
     overlay can position against either half interchangeably.  A metro line is a
-    manifest group and a section is a manifest region.
+    manifest group and a section is a manifest region.  When ``station_offsets``
+    is supplied the full pill box (``w``/``h``/``rx``) is also emitted so an
+    overlay can reproduce the exact marker shape.
     """
     section = graph.sections.get(station.section_id) if station.section_id else None
     section_id = (
         station.section_id if section is not None and not section.is_implicit else None
     )
+    w: float | None = None
+    h: float | None = None
+    rx: float | None = None
+    if station_offsets is not None:
+        _, _, w, h, rx = station_marker_box(
+            graph, theme, station, station_offsets, positive_fan
+        )
     return {
         "class_": _ns("nf-metro-station-group"),
         **node_data_attrs(
@@ -1715,6 +1728,9 @@ def _station_group_attrs(
             r=theme.station_radius,
             groups=graph.station_lines(station.id),
             region=section_id,
+            w=w,
+            h=h,
+            rx=rx,
         ),
     }
 
@@ -1742,7 +1758,10 @@ def _render_stations(
         if station.is_port or station.is_hidden:
             continue
         if graph.embed_manifest:
-            g = draw.Group(**_station_group_attrs(graph, theme, station))
+            attrs = _station_group_attrs(
+                graph, theme, station, station_offsets, positive_fan
+            )
+            g = draw.Group(**attrs)
             _render_station_into(
                 g, graph, theme, station, station_offsets, positive_fan
             )

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -618,11 +618,21 @@ def _render_svg_scaled(
     # Embed the machine-readable manifest first, so the file is a durable,
     # self-describing contract regardless of what is drawn below it.
     if graph.embed_manifest:
+        _pf = tb_positive_fan_sections(graph)
+        _boxes: dict[str, dict[str, float]] = {}
+        for _s in graph.stations.values():
+            if _s.is_port or _s.is_hidden:
+                continue
+            _, _, _w, _h, _rx = station_marker_box(
+                graph, theme, _s, station_offsets, _pf
+            )
+            _boxes[_s.id] = {"w": _w, "h": _h, "rx": _rx}
         manifest = build_manifest(
             graph,
             width=svg_width,
             height=svg_height,
             station_radius=theme.station_radius,
+            extra_node_data=_boxes,
         )
         d.append(draw.Raw(manifest_metadata_svg(manifest)))
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -623,10 +623,10 @@ def _render_svg_scaled(
         for _s in graph.stations.values():
             if _s.is_port or _s.is_hidden:
                 continue
-            _, _, _w, _h, _rx = station_marker_box(
+            _cx, _cy, _w, _h, _rx = station_marker_box(
                 graph, theme, _s, station_offsets, _pf
             )
-            _boxes[_s.id] = {"w": _w, "h": _h, "rx": _rx}
+            _boxes[_s.id] = {"x": _cx, "y": _cy, "w": _w, "h": _h, "rx": _rx}
         manifest = build_manifest(
             graph,
             width=svg_width,
@@ -1722,19 +1722,21 @@ def _station_group_attrs(
     section_id = (
         station.section_id if section is not None and not section.is_implicit else None
     )
+    cx: float = station.x
+    cy: float = station.y
     w: float | None = None
     h: float | None = None
     rx: float | None = None
     if station_offsets is not None:
-        _, _, w, h, rx = station_marker_box(
+        cx, cy, w, h, rx = station_marker_box(
             graph, theme, station, station_offsets, positive_fan
         )
     return {
         "class_": _ns("nf-metro-station-group"),
         **node_data_attrs(
             id=station.id,
-            x=station.x,
-            y=station.y,
+            x=cx,
+            y=cy,
             r=theme.station_radius,
             groups=graph.station_lines(station.id),
             region=section_id,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,6 +18,7 @@ import jsonschema
 import pytest
 from conftest import compute_corpus_layout, content_corpus, parse_and_layout
 
+from nf_metro.layout.routing.offsets import compute_station_offsets
 from nf_metro.live.mapping import stations_for_process
 from nf_metro.render.manifest import (
     MANIFEST_SCHEMA_VERSION,
@@ -25,7 +26,7 @@ from nf_metro.render.manifest import (
     match_node_ids,
     read_manifest,
 )
-from nf_metro.render.svg import render_svg
+from nf_metro.render.svg import render_svg, station_marker_box
 from nf_metro.themes import NFCORE_THEME
 
 # A small map with sections, multiple lines, and a process mapping so every
@@ -130,10 +131,12 @@ def test_nodes_coords_and_patterns_match_graph() -> None:
     }
     assert set(by_id) == expected
 
+    offsets = compute_station_offsets(graph)
     for sid, entry in by_id.items():
         st = graph.stations[sid]
-        assert entry["x"] == round(st.x, 1)
-        assert entry["y"] == round(st.y, 1)
+        cx, cy, _, _, _ = station_marker_box(graph, NFCORE_THEME, st, offsets)
+        assert entry["x"] == round(cx, 1)
+        assert entry["y"] == round(cy, 1)
         assert entry["r"] == round(NFCORE_THEME.station_radius, 1)
         assert entry["groups"] == graph.station_lines(sid)
         assert entry["patterns"] == graph.process_mapping.get(sid, [])


### PR DESCRIPTION
## Summary

- `nf-metro serve` now accepts a `.svg` file in addition to `.mmd`. The SVG must carry an embedded manifest (produced by default rendering); the manifest's station geometry and process patterns drive the live server without the source `.mmd` file.
- Manifest nodes gain optional `w`/`h`/`rx` pill-box fields in both the JSON block and `data-node-w/h/rx` DOM attributes on the station group element, so an overlay can reproduce the exact marker shape.
- `MapModel.from_svg()` classmethod reads the manifest and builds the model; falls back to `2*r` for `w`/`h` when absent (older SVGs stay readable).
- `serve_model()` function lets callers with a pre-built `MapModel` skip the render step; `serve()` is refactored to delegate to it.

## Test plan

- [ ] `nf-metro render examples/rnaseq_sections.mmd -o /tmp/map.svg` then `nf-metro serve /tmp/map.svg --open` opens the live page
- [ ] Stations with `%%metro process:` directives light up when Nextflow events arrive
- [ ] `nf-metro serve examples/rnaseq_sections.mmd` (`.mmd` path) still works unchanged
- [ ] `nf-metro serve /tmp/no-manifest.svg` produces a clear error ("SVG has no embedded manifest")
- [ ] CI render previews pass (manifest roundtrip tests cover the new fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)