### PR TITLE
ci(docs): build the docs site on Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
       # --- Build the Astro / Starlight site ---
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: website/package-lock.json
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
       # --- Build the Astro / Starlight site ---
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: website/package-lock.json
 


### PR DESCRIPTION
The Astro/Starlight docs deploy (PR #1089) failed on merge:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Astro 7 requires Node >=22.12, but `.github/workflows/docs.yml` pinned `setup-node` to Node 20, so `astro build` aborted before anything was published. It only surfaced on merge because the deploy runs on push to `main`/release, not on PRs. The failed run aborted before any `git push`, so `gh-pages` was untouched.

This bumps the deploy (the only workflow that builds the Astro site) to **Node 24**, the current active LTS. Validated locally: a full `astro build` on Node 24.18.0 completes clean (49 pages, pagefind + sitemap fine).

Merging this and letting the deploy re-run will publish the site to `/dev/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)