### PR TITLE
ci(docs): push gh-pages by commit ref, not branch name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -132,5 +132,5 @@ jobs:
             echo "No changes to publish."
           else
             git commit -m "docs: deploy ${VERSION} (${GITHUB_SHA::8})"
-            git push origin gh-pages
+            git push origin HEAD:gh-pages
           fi


### PR DESCRIPTION
Follow-up to #1092. With Node 24 the docs build now succeeds, so the deploy reached its final step and failed there:

```
error: src refspec gh-pages does not match any
error: failed to push some refs to '...'
```

The publish step checks out gh-pages in a **detached-HEAD** worktree (`git worktree add gh-pages origin/gh-pages`), so `git push origin gh-pages` has no local branch of that name to push. Switching to `git push origin HEAD:gh-pages` pushes the commit directly to the remote branch - works for both the detached existing-branch path and the `--orphan -b gh-pages` first-deploy path, and it's a fast-forward (no force).

The failed push left `gh-pages` untouched (still `81fe95dd`). Merging this and re-running the deploy should publish `/dev/` and finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)