### PR TITLE
feat(themes): separate brand and mode as independent axes

### DIFF
--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -25,7 +25,7 @@ from nf_metro.parser.model import LineSpread, MetroGraph
 from nf_metro.render import render_svg
 from nf_metro.render.html import render_html
 from nf_metro.render.style import Theme
-from nf_metro.themes import THEMES
+from nf_metro.themes import THEME_FAMILIES, THEMES
 
 # `style: dark` predates theme names; alias it onto the nfcore theme.
 _STYLE_THEME_ALIASES = {"dark": "nfcore"}
@@ -45,12 +45,35 @@ def apply_layout_overrides(graph: MetroGraph, opts: Mapping[str, object]) -> Non
             setattr(graph, opt.target_attr, value)
 
 
-def resolve_theme(theme: str | None, graph: MetroGraph) -> Theme:
-    """Pick the theme: an explicit name wins over the ``style:`` directive."""
-    if theme is not None:
-        return THEMES[theme]
-    name = graph.style.strip().lower()
-    return THEMES.get(_STYLE_THEME_ALIASES.get(name, name), THEMES["nfcore"])
+def resolve_theme(
+    theme: str | None, graph: MetroGraph, mode: str | None = None
+) -> Theme:
+    """Resolve the final theme from brand and mode axes independently.
+
+    Resolution order for the brand (palette/identity):
+      1. Explicit ``theme`` argument (``--theme`` CLI flag).
+      2. ``%%metro style:`` directive on the graph (or ``dark`` alias → ``nfcore``).
+
+    Resolution order for the mode (light/dark):
+      1. Explicit ``mode`` argument (``--mode`` CLI flag).
+      2. ``%%metro mode:`` directive on the graph.
+
+    When a mode is explicitly set and the brand belongs to a theme family
+    (``THEME_FAMILIES``), the family variant for that mode is returned so that
+    brand and mode are fully independent axes. When no mode is set, the brand
+    name is looked up directly in ``THEMES`` (preserving all existing defaults).
+    """
+    brand = theme or _STYLE_THEME_ALIASES.get(
+        graph.style.strip().lower(), graph.style.strip().lower()
+    )
+    resolved_mode = (mode or graph.mode).strip().lower() or None
+
+    if resolved_mode and brand in THEME_FAMILIES:
+        family = THEME_FAMILIES[brand]
+        if resolved_mode in family:
+            return family[resolved_mode]
+
+    return THEMES.get(brand, THEMES["nfcore"])
 
 
 def prepare_graph(
@@ -108,6 +131,7 @@ def render_string(
     text: str,
     *,
     theme: str | None = None,
+    mode: str | None = None,
     output_format: Literal["svg", "html"] = "svg",
     from_nextflow: bool = False,
     title: str | None = None,
@@ -140,7 +164,7 @@ def render_string(
         legend=legend,
         layout_options=layout_options,
     )
-    theme_obj = resolve_theme(theme, graph)
+    theme_obj = resolve_theme(theme, graph, mode=mode)
     font_portability: Literal["embed", "paths"] | None = (
         "paths" if text_to_paths else "embed" if embed_font else None
     )

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -116,7 +116,15 @@ def _echo_issues(
     "--theme",
     type=click.Choice(list(THEMES.keys())),
     default=None,
-    help="Visual theme (default: from the %%metro style: directive, else nfcore).",
+    help="Visual theme brand "
+    "(default: from the %%metro style: directive, else nfcore).",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["light", "dark"]),
+    default=None,
+    help="Light/dark mode, independent of the theme brand "
+    "(default: from the %%metro mode: directive, else the theme's built-in default).",
 )
 @click.option(
     "--debug/--no-debug",
@@ -236,6 +244,7 @@ def render(
     output: Path | None,
     format_: str,
     theme: str | None,
+    mode: str | None,
     debug: bool,
     logo: Path | None,
     line_spread: str | None,
@@ -274,7 +283,7 @@ def render(
     ) as e:
         raise click.ClickException(str(e))
 
-    theme_obj = resolve_theme(theme, graph)
+    theme_obj = resolve_theme(theme, graph, mode=mode)
 
     if output is None:
         output = input_file.with_suffix(f".{format_}")
@@ -572,7 +581,15 @@ def explain(
     help="Interface to bind. Default 127.0.0.1 (local only); "
     "use 0.0.0.0 to accept connections from other hosts.",
 )
-@click.option("--theme", type=str, default=None, help="Theme name (nfcore, light).")
+@click.option(
+    "--theme", type=str, default=None, help="Theme brand name (nfcore, seqera)."
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["light", "dark"]),
+    default=None,
+    help="Light/dark mode, independent of the theme brand.",
+)
 @click.option(
     "--overlay",
     type=click.Choice(OVERLAY_STYLES),
@@ -607,6 +624,7 @@ def serve(
     port: int,
     host: str,
     theme: str | None,
+    mode: str | None,
     overlay: str,
     token: str | None,
     open_browser: bool,
@@ -654,7 +672,7 @@ def serve(
         except (ValueError, PhaseInvariantError) as e:
             raise click.ClickException(str(e))
 
-        theme_obj = resolve_theme(theme, graph)
+        theme_obj = resolve_theme(theme, graph, mode=mode)
         mapped = sorted(graph.process_mapping)
         if not mapped:
             click.echo(

--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -60,6 +60,17 @@ def _dir_style(value: str, graph: MetroGraph) -> None:
     graph.style = value
 
 
+_VALID_MODES = {"light", "dark"}
+
+
+def _dir_mode(value: str, graph: MetroGraph) -> None:
+    normalised = value.strip().lower()
+    if normalised not in _VALID_MODES:
+        _warn_malformed("mode", value, "/".join(sorted(_VALID_MODES)))
+        return
+    graph.mode = normalised
+
+
 def _dir_logo(value: str, graph: MetroGraph) -> None:
     graph.logo_path = value
 
@@ -483,6 +494,7 @@ _GLOBAL_DIRECTIVE_HANDLERS.update(
     {
         "title": _dir_title,
         "style": _dir_style,
+        "mode": _dir_mode,
         "logo": _dir_logo,
         "line": _dir_line,
         "off_track": _dir_off_track,

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -347,6 +347,7 @@ class MetroGraph:
     title: str = ""
     caption: str = ""
     style: str = "dark"
+    mode: str = ""
     lines: dict[str, MetroLine] = field(default_factory=dict)
     stations: dict[str, Station] = field(default_factory=dict)
     edges: list[Edge] = field(default_factory=list)

--- a/src/nf_metro/themes/__init__.py
+++ b/src/nf_metro/themes/__init__.py
@@ -1,13 +1,34 @@
 """Theme definitions for metro maps."""
 
+from nf_metro.render.style import Theme
 from nf_metro.themes.light import LIGHT_THEME
 from nf_metro.themes.nfcore import NFCORE_THEME
+from nf_metro.themes.nfcore_light import NFCORE_LIGHT_THEME
 from nf_metro.themes.seqera import SEQERA_THEME
+from nf_metro.themes.seqera_dark import SEQERA_DARK_THEME
 
 THEMES = {
     "nfcore": NFCORE_THEME,
     "light": LIGHT_THEME,
     "seqera": SEQERA_THEME,
+    "nfcore-light": NFCORE_LIGHT_THEME,
+    "seqera-dark": SEQERA_DARK_THEME,
 }
 
-__all__ = ["THEMES", "NFCORE_THEME", "LIGHT_THEME", "SEQERA_THEME"]
+# Maps brand name -> mode -> Theme. Used when both a brand and a mode are
+# resolved independently (via ``%%metro mode:`` or ``--mode``). Brand choice
+# has no bearing on which mode is used; mode is a completely separate axis.
+THEME_FAMILIES: dict[str, dict[str, Theme]] = {
+    "nfcore": {"dark": NFCORE_THEME, "light": NFCORE_LIGHT_THEME},
+    "seqera": {"light": SEQERA_THEME, "dark": SEQERA_DARK_THEME},
+}
+
+__all__ = [
+    "THEME_FAMILIES",
+    "THEMES",
+    "LIGHT_THEME",
+    "NFCORE_LIGHT_THEME",
+    "NFCORE_THEME",
+    "SEQERA_DARK_THEME",
+    "SEQERA_THEME",
+]

--- a/src/nf_metro/themes/nfcore_light.py
+++ b/src/nf_metro/themes/nfcore_light.py
@@ -1,0 +1,25 @@
+"""nf-core light theme — solid-background counterpart of the dark nfcore theme."""
+
+from nf_metro.render.style import Theme
+
+NFCORE_LIGHT_THEME = Theme(
+    name="nfcore-light",
+    background_color="#f5f5f5",
+    station_fill="#ffffff",
+    station_stroke="#333333",
+    station_stroke_width=1.5,
+    line_width=3.0,
+    label_color="#333333",
+    label_font_family="'Helvetica Neue', Helvetica, Arial, sans-serif",
+    label_font_size=13.0,
+    label_font_weight="bold",
+    title_color="#111111",
+    title_font_size=24.0,
+    section_fill="#ededed",
+    section_stroke="#e6e6e6",
+    section_label_color="#666666",
+    section_label_font_size=16.0,
+    legend_background="rgba(255, 255, 255, 0.8)",
+    legend_text_color="#333333",
+    legend_font_size=14.0,
+)

--- a/src/nf_metro/themes/seqera_dark.py
+++ b/src/nf_metro/themes/seqera_dark.py
@@ -1,0 +1,38 @@
+"""Seqera Platform dark theme.
+
+Colors derived from the Seqera design system, dark-mode counterpart of seqera.py:
+
+  $app-brand-seqera: #160F26   - Seqera brand deep navy (background base)
+  Darkened neutrals stepping from the brand navy.
+
+Font: Inter Variable - matching the light seqera theme.
+"""
+
+from nf_metro.render.style import Theme
+
+SEQERA_DARK_THEME = Theme(
+    name="seqera-dark",
+    background_color="#1a1625",
+    station_fill="#2d273c",
+    station_stroke="#7b6ea6",
+    station_stroke_width=2.0,
+    line_width=4.0,
+    label_color="#e0d9f7",
+    label_font_family=(
+        "'Inter Variable', Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    ),
+    label_font_size=14.0,
+    label_font_weight="600",
+    title_color="#f0ecff",
+    title_font_size=26.0,
+    section_fill="#231e30",
+    section_stroke="#3d3650",
+    section_label_color="#9d94b8",
+    section_label_font_size=17.0,
+    legend_background="rgba(0, 0, 0, 0.4)",
+    legend_text_color="#e0d9f7",
+    legend_font_size=16.0,
+    animation_ball_color="#2d273c",
+    animation_ball_stroke="#7b6ea6",
+    animation_ball_stroke_width=1.5,
+)

--- a/tests/test_theme_mode_axis.py
+++ b/tests/test_theme_mode_axis.py
@@ -1,0 +1,181 @@
+"""Tests for the independent theme (brand) and mode (light/dark) axes."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from nf_metro.api import resolve_theme
+from nf_metro.parser import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
+from nf_metro.themes import (
+    NFCORE_LIGHT_THEME,
+    SEQERA_DARK_THEME,
+    THEME_FAMILIES,
+    THEMES,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_MMD = """\
+%%metro line: l1 | Line 1 | #ff0000
+graph LR
+    subgraph s1 [S1]
+        %%metro entry: left | l1
+        %%metro exit: right | l1
+        a[A]
+        a -->|l1| b[B]
+    end
+"""
+
+
+def _graph(**overrides: str) -> MetroGraph:
+    g = MetroGraph()
+    for k, v in overrides.items():
+        setattr(g, k, v)
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Style-only resolution (no explicit mode)
+# ---------------------------------------------------------------------------
+
+
+def test_default_resolves_to_nfcore_dark() -> None:
+    assert resolve_theme(None, _graph()).name == "nfcore"
+
+
+def test_style_dark_alias_resolves_to_nfcore() -> None:
+    assert resolve_theme(None, _graph(style="dark")).name == "nfcore"
+
+
+def test_style_nfcore_resolves_to_nfcore_dark() -> None:
+    assert resolve_theme(None, _graph(style="nfcore")).name == "nfcore"
+
+
+def test_style_seqera_resolves_to_seqera_light() -> None:
+    assert resolve_theme(None, _graph(style="seqera")).name == "seqera"
+
+
+def test_style_light_resolves_to_transparent_light() -> None:
+    assert resolve_theme(None, _graph(style="light")).name == "light"
+
+
+def test_explicit_theme_arg_overrides_directive() -> None:
+    g = _graph(style="seqera")
+    assert resolve_theme("nfcore", g).name == "nfcore"
+
+
+# ---------------------------------------------------------------------------
+# Mode is independent of brand: mixing them works as expected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "brand, mode, expected",
+    [
+        ("nfcore", "dark", "nfcore"),
+        ("nfcore", "light", "nfcore-light"),
+        ("seqera", "light", "seqera"),
+        ("seqera", "dark", "seqera-dark"),
+    ],
+)
+def test_brand_mode_combinations(brand: str, mode: str, expected: str) -> None:
+    """Brand and mode are resolved independently for every (brand, mode) pair."""
+    g = _graph(style=brand)
+    assert resolve_theme(None, g, mode=mode).name == expected
+
+
+def test_explicit_theme_arg_with_mode() -> None:
+    g = _graph()
+    assert resolve_theme("nfcore", g, mode="light").name == "nfcore-light"
+    assert resolve_theme("seqera", g, mode="dark").name == "seqera-dark"
+
+
+def test_mode_directive_on_graph() -> None:
+    g = _graph(style="nfcore", mode="light")
+    assert resolve_theme(None, g).name == "nfcore-light"
+
+
+def test_cli_mode_beats_directive_mode() -> None:
+    g = _graph(style="nfcore", mode="light")
+    assert resolve_theme(None, g, mode="dark").name == "nfcore"
+
+
+def test_nfcore_brand_does_not_force_dark() -> None:
+    """Choosing the nfcore brand should not lock in dark mode."""
+    g = _graph(style="nfcore", mode="light")
+    theme = resolve_theme(None, g)
+    assert theme.name == "nfcore-light"
+    assert "#f5f5f5" in theme.background_color  # solid, not dark
+
+
+def test_seqera_brand_does_not_force_light() -> None:
+    """Choosing the seqera brand should not lock in light mode."""
+    g = _graph(style="seqera", mode="dark")
+    theme = resolve_theme(None, g)
+    assert theme.name == "seqera-dark"
+    assert "#1a1625" in theme.background_color  # dark, not light
+
+
+# ---------------------------------------------------------------------------
+# New theme objects exist and have sensible properties
+# ---------------------------------------------------------------------------
+
+
+def test_nfcore_light_has_solid_background() -> None:
+    assert NFCORE_LIGHT_THEME.background_color not in ("none", "", "transparent")
+    assert NFCORE_LIGHT_THEME.background_color.startswith("#")
+
+
+def test_seqera_dark_has_dark_background() -> None:
+    assert SEQERA_DARK_THEME.background_color.startswith("#")
+    assert SEQERA_DARK_THEME.background_color != THEMES["seqera"].background_color
+
+
+def test_theme_families_cover_both_modes() -> None:
+    for brand, family in THEME_FAMILIES.items():
+        assert "light" in family, f"{brand} missing light variant"
+        assert "dark" in family, f"{brand} missing dark variant"
+        assert family["light"].name != family["dark"].name
+
+
+def test_new_themes_in_themes_dict() -> None:
+    assert "nfcore-light" in THEMES
+    assert "seqera-dark" in THEMES
+
+
+# ---------------------------------------------------------------------------
+# %%metro mode: directive
+# ---------------------------------------------------------------------------
+
+
+def test_mode_directive_parsed() -> None:
+    mmd = "%%metro mode: light\n" + _MINIMAL_MMD
+    g = parse_metro_mermaid(mmd)
+    assert g.mode == "light"
+
+
+def test_mode_directive_dark() -> None:
+    mmd = "%%metro mode: dark\n" + _MINIMAL_MMD
+    g = parse_metro_mermaid(mmd)
+    assert g.mode == "dark"
+
+
+def test_mode_directive_invalid_warns_and_ignores() -> None:
+    mmd = "%%metro mode: vivid\n" + _MINIMAL_MMD
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        g = parse_metro_mermaid(mmd)
+    assert g.mode == ""
+    assert any("mode" in str(w.message).lower() for w in caught)
+
+
+def test_mode_directive_end_to_end() -> None:
+    """%%metro mode: light + style: nfcore resolves to nfcore-light."""
+    mmd = "%%metro style: nfcore\n%%metro mode: light\n" + _MINIMAL_MMD
+    g = parse_metro_mermaid(mmd)
+    assert resolve_theme(None, g).name == "nfcore-light"


### PR DESCRIPTION
## Summary

- Adds `%%metro mode: light|dark` directive and `--mode light|dark` CLI flag so theme brand and display mode are fully independent axes
- `%%metro style: nfcore` picks the nf-core brand palette; `%%metro mode: light` picks light mode - neither axis constrains the other
- Adds two new theme variants: `nfcore-light` (solid `#f5f5f5` background, dark labels) and `seqera-dark` (dark `#1a1625` background, light labels)
- `THEME_FAMILIES` maps each brand name to its `{light, dark}` pair; `resolve_theme()` uses this when a mode is explicitly set, falls back to `THEMES` lookup when mode is unset (preserving all existing defaults)
- `--theme` and `%%metro style:` continue to work exactly as before with no mode specified; `style: dark` alias still maps to nfcore

## Key behaviours

| Input | Result |
|---|---|
| `%%metro style: nfcore` (no mode) | nfcore dark (unchanged) |
| `%%metro style: nfcore` + `%%metro mode: light` | nfcore-light |
| `%%metro style: seqera` (no mode) | seqera light (unchanged) |
| `%%metro style: seqera` + `%%metro mode: dark` | seqera-dark |
| `--theme nfcore --mode light` | nfcore-light |
| `style: dark` (legacy alias) | nfcore dark (unchanged) |

Closes #1095

## Test plan
- [ ] `tests/test_theme_mode_axis.py` (23 tests) covers all resolution paths, directive parsing, invalid mode warning, and brand-independence assertions
- [ ] ruff check + format clean
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/1096/)

Generated with Claude Code