### PR TITLE
docs(live): add metro language to bare code fences

### DIFF
--- a/docs/live.md
+++ b/docs/live.md
@@ -73,7 +73,7 @@ Set `%%metro auto_process: true` (or pass `--auto-process`) and each station
 with no explicit directive gets its own id as a default pattern, anchored to the
 final segment of the process name:
 
-```
+```metro
 %%metro auto_process: true
 ```
 
@@ -101,7 +101,7 @@ regexes. Set `%%metro process_scope:` (or pass `--process-scope`) to the shared
 prefix and each `process:` value becomes the **tail** under that scope, joined
 as `<scope>:<tail>` and matched **literally**:
 
-```
+```metro
 %%metro process_scope: NFCORE_RNASEQ:RNASEQ
 %%metro auto_process: true
 


### PR DESCRIPTION
Two code blocks in `docs/live.md` were using bare triple-backtick fences
(no language tag), so they rendered as plain `plaintext`/`text` — no
syntax highlighting on the `%%metro` directives inside them.

- Under **"Skip the boilerplate with `auto_process`"**: single-line
  `%%metro auto_process: true` block
- Under **"Factor out the shared prefix with `process_scope`"**: the six-line
  example block

Both changed from bare ` ``` ` to ` ```metro `.

No other bare opening fences exist across the docs tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)