### PR TITLE
ci(docs): copy shared assets to gh-pages root for stable URLs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -125,6 +125,14 @@ jobs:
           </html>
           HTML
 
+          # Copy shared static assets that live.md references with a
+          # version-independent /nf-metro/assets/ URL. They are built into
+          # dist/assets/ (from website/public/assets/) but deployed there only
+          # under the versioned directory; copying them here makes the stable
+          # root URL work across all versions.
+          mkdir -p gh-pages/assets
+          cp website/dist/assets/live_demo.mp4 gh-pages/assets/ 2>/dev/null || true
+
           touch gh-pages/.nojekyll
           cd gh-pages
           git add -A


### PR DESCRIPTION
`docs/live.md` embeds a video with a hardcoded version-independent URL:

```html
<video src="/nf-metro/assets/live_demo.mp4">
```

The file (`website/public/assets/live_demo.mp4`, 94 KB) is copied to
`dist/assets/` during the Astro build and then deployed to
`gh-pages/dev/assets/live_demo.mp4` — but the reference expects it at
`gh-pages/assets/live_demo.mp4` (root, no version prefix), which
nothing was writing to. Result: the video 404s on the live site.

Fix: after each versioned build, copy the file from `website/dist/assets/`
to `gh-pages/assets/` so the stable URL resolves correctly across all
versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)