### PR TITLE
docs(live): fix video URL to use relative path

### DIFF
--- a/docs/live.md
+++ b/docs/live.md
@@ -29,9 +29,9 @@ re-flows as state changes.
 
 <video controls autoplay loop muted playsinline
        style="width: 100%; max-width: 760px; border-radius: 6px"
-       src="/nf-metro/assets/live_demo.mp4">
+       src="../assets/live_demo.mp4">
 Your browser can't play the embedded video -
-<a href="/nf-metro/assets/live_demo.mp4">download it here</a>.
+<a href="../assets/live_demo.mp4">download it here</a>.
 </video>
 
 _A pipeline run lighting up the map in real time._


### PR DESCRIPTION
The `<video>` in `docs/live.md` was using `/nf-metro/assets/live_demo.mp4` — a hardcoded root-level path that was never written to. The file actually lives in `website/public/assets/` and gets deployed to `<version>/assets/` (e.g. `dev/assets/`).

Changing to `../assets/live_demo.mp4` (relative) resolves to the correct versioned path for any version the page is served from, with no deploy workflow changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)