### PR TITLE
docs(search): tune Pagefind for gallery pages and exclude playground

### DIFF
--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -1428,12 +1428,17 @@ def _details_code(identifier: str, source_label: str) -> list[str]:
     ]
 
 
-def mdx_page(title: str, imports: list[str], body: list[str]) -> list[str]:
+def mdx_page(
+    title: str, imports: list[str], body: list[str], description: str = ""
+) -> list[str]:
     """Assemble an .mdx page: frontmatter, the <Code> import + per-example raw
     imports (deduped, order-preserved), then the body lines."""
+    fm: list[str] = [f"title: {title}"]
+    if description:
+        fm.append(f"description: {description}")
     return [
         "---",
-        f"title: {title}",
+        *fm,
         "---",
         "",
         'import { Code } from "@astrojs/starlight/components";',
@@ -1551,7 +1556,17 @@ def build_gallery() -> None:
         lines.append("**Rendered output:**\n")
         lines.extend(_inline_svg(svg_id))
 
-    gallery_md = "\n".join(mdx_page("Gallery", imports, lines))
+    gallery_md = "\n".join(
+        mdx_page(
+            "Gallery",
+            imports,
+            lines,
+            description=(
+                "Rendered examples covering fan-outs, folds, diamonds, and realistic "
+                "bioinformatics workflows - each with CLI command and Mermaid source."
+            ),
+        )
+    )
     gallery_path = GALLERY_DIR / "index.mdx"
     gallery_path.write_text(gallery_md)
     print(f"\nGallery written to {gallery_path}")
@@ -1652,7 +1667,17 @@ def build_pipelines_page() -> None:
         lines.extend(_inline_svg(svg_id))
         lines.extend(_details_code(identifier, source_label))
 
-    pipelines_md = "\n".join(mdx_page("nf-core pipelines", imports, lines))
+    pipelines_md = "\n".join(
+        mdx_page(
+            "nf-core pipelines",
+            imports,
+            lines,
+            description=(
+                "Real-world nf-core pipelines rendered as metro-style SVG diagrams "
+                "using nf-metro, maintained alongside their source."
+            ),
+        )
+    )
     pipelines_path = PIPELINES_DIR / "index.mdx"
     pipelines_path.write_text(pipelines_md)
     print(f"\nPipelines page written to {pipelines_path}")

--- a/website/public/playground/index.html
+++ b/website/public/playground/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-pagefind-ignore>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary

- Add `data-pagefind-ignore` to the playground HTML's `<html>` element to exclude the standalone playground app from the Pagefind index. The playground is a static JavaScript app whose button labels and UI strings would otherwise appear as noise in search results.
- Add `description:` frontmatter to generated gallery and pipeline MDX pages (via `scripts/build_gallery.py`). Starlight uses the description as the search result snippet; without it, Pagefind falls back to raw page text.
- Update `mdx_page()` to accept an optional `description` parameter with backward-compatible default.

Audit findings (everything else already working):
- Pagefind is enabled by default (Starlight 0.41.1 + pagefind 1.5.2 in lock file).
- Gallery/pipeline pages are built by `build_gallery.py` before `npm run build` in the CI workflow, so they are present when Pagefind crawls.
- SVG content is referenced as `<img>` elements, not inline XML, so SVG markup does not pollute the index.
- Home page already carries `pagefind: false` in its frontmatter.

Fixes #1107

## Test plan
- [ ] ruff check + ruff format clean on `scripts/build_gallery.py`
- [ ] `mdx_page()` without `description` still produces valid frontmatter (backward-compatible)
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/1111/) — docs-only change, no visual impact expected

Generated with Claude Code