### PR TITLE
fix(render): mode-adaptive marker-glyph stroke via CSS custom property

### DIFF
--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -438,6 +438,7 @@ def _render_marker_key(
     swatch_cx = left_x + LEGEND_SWATCH_WIDTH / 2
     r = LEGEND_MARKER_RADIUS
     stroke = marker_stroke_color(theme)
+    stroke_cls = _ns("nf-metro-marker-stroke")
     for i, entry in enumerate(graph.marker_legend):
         entry_y = top_y + i * line_height + line_height / 2
         fill = marker_fill_color(entry.style.fill, theme)
@@ -450,6 +451,7 @@ def _render_marker_key(
                     fill=fill,
                     stroke=stroke,
                     stroke_width=theme.station_stroke_width,
+                    class_=stroke_cls,
                 )
             )
         else:
@@ -470,6 +472,7 @@ def _render_marker_key(
                     fill=fill,
                     stroke=stroke,
                     stroke_width=theme.station_stroke_width,
+                    class_=stroke_cls,
                 )
             )
         d.append(

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1040,12 +1040,11 @@ def _inject_chrome_css(d: draw.Drawing, theme: Theme) -> None:
     pair = mode_pair(theme)
     light, dark = pair if pair is not None else (theme, theme)
 
+    def _adapt(light_val: str, dark_val: str) -> str:
+        return light_val if light is dark else f"light-dark({light_val}, {dark_val})"
+
     def _prop(var: str, attr: str) -> str:
-        light_val, dark_val = getattr(light, attr), getattr(dark, attr)
-        fallback = (
-            light_val if light is dark else f"light-dark({light_val}, {dark_val})"
-        )
-        return f"var({var}, {fallback})"
+        return f"var({var}, {_adapt(getattr(light, attr), getattr(dark, attr))})"
 
     def _rule(cls: str, props: str) -> str:
         return f".{_ns(cls)} {{ {props}; }}"
@@ -1090,13 +1089,22 @@ def _inject_chrome_css(d: draw.Drawing, theme: Theme) -> None:
             f"fill: {_prop('--nfm-map-legend-text-color', 'legend_text_color')}",
         ),
     ]
+    _ms_adapt = _adapt(
+        light.marker_stroke or light.station_stroke,
+        dark.marker_stroke or dark.station_stroke,
+    )
+    lines.append(
+        _rule(
+            "nf-metro-marker-stroke",
+            f"stroke: var(--nfm-map-marker-stroke, {_ms_adapt})",
+        )
+    )
     # The label halo is a knockout of the background, so it tracks --nfm-map-bg
     # and must flip with the mode too; otherwise a dark-baked halo blots out
     # labels in light mode. Disabled-halo themes draw no halo, so emit nothing.
     halo_light, halo_dark = _label_halo_color(light), _label_halo_color(dark)
     if halo_light is not None and halo_dark is not None:
-        halo = halo_light if light is dark else f"light-dark({halo_light}, {halo_dark})"
-        halo_val = f"var(--nfm-map-bg, {halo})"
+        halo_val = f"var(--nfm-map-bg, {_adapt(halo_light, halo_dark)})"
         lines.append(
             _rule("nf-metro-label-halo", f"fill: {halo_val}; stroke: {halo_val}")
         )
@@ -1631,6 +1639,10 @@ def _render_marker_station(
     )
     x, y, w, h = _pill_box(station, r, min_off, max_off, is_tb_vert, flow_len=flow_len)
     rx = marker_corner_radius(marker.shape, r)
+    marker_data = {
+        **station_data,
+        "class_": f"{station_data['class_']} {_ns('nf-metro-marker-stroke')}",
+    }
     d.append(
         draw.Rectangle(
             x,
@@ -1642,7 +1654,7 @@ def _render_marker_station(
             fill=marker_fill_color(marker.fill, theme),
             stroke=marker_stroke_color(theme),
             stroke_width=theme.station_stroke_width,
-            **station_data,
+            **marker_data,
         )
     )
 

--- a/tests/test_css_custom_properties.py
+++ b/tests/test_css_custom_properties.py
@@ -58,6 +58,7 @@ def _make_graph():
         "--nfm-map-section-label-color",
         "--nfm-map-legend-bg",
         "--nfm-map-legend-text-color",
+        "--nfm-map-marker-stroke",
     ],
 )
 def test_svg_declares_chrome_property(prop):
@@ -201,3 +202,69 @@ def test_chrome_css_false_rasterizes_with_cairosvg():
     svg = render_svg(_make_graph(), NFCORE_THEME, chrome_css=False)
     png = cairosvg.svg2png(bytestring=svg.encode())
     assert png[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+# ---------------------------------------------------------------------------
+# Marker stroke CSS custom property
+# ---------------------------------------------------------------------------
+
+_MARKER_MMD = (
+    "%%metro title: Marker test\n"
+    "%%metro line: main | Main | #ff0000\n"
+    "%%metro marker: a | square, solid\n"
+    "%%metro marker: b | circle, open\n"
+    "%%metro marker_legend: square, solid | Mandatory\n"
+    "%%metro marker_legend: circle, open | Optional\n"
+    "graph LR\n"
+    "    subgraph s1 [Section]\n"
+    "        a[Node A]\n"
+    "        b[Node B]\n"
+    "        a -->|main| b\n"
+    "    end\n"
+)
+
+
+def _make_marker_graph():
+    g = parse_metro_mermaid(_MARKER_MMD)
+    compute_layout(g)
+    return g
+
+
+def test_marker_stroke_css_property_declared():
+    """``--nfm-map-marker-stroke`` must appear in the chrome CSS block."""
+    svg = render_svg(_make_marker_graph(), NFCORE_THEME)
+    assert "--nfm-map-marker-stroke" in svg
+
+
+def test_marker_stroke_class_on_marker_elements():
+    """Marker glyphs carry the ``nf-metro-marker-stroke`` class so the CSS var applies.
+
+    The baked hex remains as a presentation-attribute fallback for cairosvg; the CSS
+    class rule overrides it in-browser (CSS stylesheet > presentation attributes).
+    """
+    svg = render_svg(_make_marker_graph(), NFCORE_THEME)
+    assert "nf-metro-marker-stroke" in svg
+    assert "var(--nfm-map-marker-stroke" in svg
+
+
+def test_marker_stroke_fallback_is_light_dark_of_both_palettes():
+    """The --nfm-map-marker-stroke fallback pairs light and dark values."""
+    svg = render_svg(_make_marker_graph(), NFCORE_THEME)
+    light_val = NFCORE_LIGHT_THEME.marker_stroke or NFCORE_LIGHT_THEME.station_stroke
+    dark_val = NFCORE_DARK_THEME.marker_stroke or NFCORE_DARK_THEME.station_stroke
+    assert f"--nfm-map-marker-stroke, light-dark({light_val}, {dark_val})" in svg
+
+
+def test_marker_stroke_class_in_legend_swatches():
+    """Legend marker swatches carry the ``nf-metro-marker-stroke`` class too."""
+    svg = render_svg(_make_marker_graph(), NFCORE_THEME)
+    # CSS rule + at least one station marker + at least one legend swatch
+    count = svg.count("nf-metro-marker-stroke")
+    assert count >= 3, f"Expected ≥3 occurrences (rule + station + swatch), got {count}"
+
+
+def test_chrome_css_false_marker_stroke_is_concrete():
+    """chrome_css=False keeps the baked marker stroke for cairosvg rasterisation."""
+    svg = render_svg(_make_marker_graph(), NFCORE_THEME, chrome_css=False)
+    assert "var(--nfm-map-marker-stroke" not in svg
+    assert 'stroke="' in svg

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1458,7 +1458,7 @@ def test_single_rail_marker_glyph_seats_on_its_rail():
 
     glyph_cy = None
     for el in root.iter():
-        if el.attrib.get("class") != "nf-metro-station":
+        if "nf-metro-station" not in (el.attrib.get("class") or ""):
             continue
         if el.attrib.get("data-station-id") != "haplo":
             continue

--- a/tests/test_svg_namespace.py
+++ b/tests/test_svg_namespace.py
@@ -70,6 +70,7 @@ _ALL_KNOWN_CLASSES = {
     "nf-metro-station",
     "nf-metro-station-group",
     "nf-metro-station-label",
+    "nf-metro-marker-stroke",
     "nf-metro-group-underline",
     "nf-metro-group-label",
     "nf-metro-rail-connector",


### PR DESCRIPTION
## Summary

- Adds `--nfm-map-marker-stroke` CSS custom property to the chrome CSS block, with a `light-dark(<light>, <dark>)` fallback derived from the theme's mode pair
- Adds the `nf-metro-marker-stroke` CSS class to station marker glyphs (`_render_marker_station`) and legend swatch shapes (`_render_marker_key`) so the CSS rule overrides the baked presentation attribute in-browser
- The baked `stroke=` presentation attribute is kept as a fallback for `chrome_css=False` (cairosvg rasterisation), so PNG export is unaffected
- Extracts a `_adapt(light_val, dark_val)` closure in `_inject_chrome_css` to unify the `light is dark` ternary previously duplicated across `_prop` and the halo block
- Updates the `test_svg_declares_chrome_property` parametrize list to cover `--nfm-map-marker-stroke`; adds a dedicated test section with fixtures exercising the marker stroke class, fallback correctness, legend swatch coverage, and `chrome_css=False` passthrough
- Fixes a pre-existing exact class-string match in `test_rail_mode.py` that broke when marker elements gained a second CSS class

Fixes #1112

## Test plan
- [x] pytest passes (new tests in `test_css_custom_properties.py`)
- [x] ruff check + ruff format clean
- [x] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/1120/)
- [ ] Render-preview verdict: pending CI

Generated with Claude Code