### PR TITLE
feat(playground): service-worker cache for Pyodide runtime and wheel

### DIFF
--- a/website/playground-tests/playground.spec.js
+++ b/website/playground-tests/playground.spec.js
@@ -30,9 +30,7 @@ test.afterAll(async () => {
 });
 
 test("service worker precaches pyodide.js during install", async () => {
-  // The SW precaches pyodide.js in its install event so subsequent navigations
-  // serve it from cache. By the time Pyodide has fully booted, the SW install
-  // has long since completed.
+  // By the time Pyodide has fully booted, the SW install has long since completed.
   const cached = await page.evaluate(async () => {
     const keys = await caches.keys();
     const name = keys.find((k) => k.startsWith("nfm-playground-"));

--- a/website/playground-tests/playground.spec.js
+++ b/website/playground-tests/playground.spec.js
@@ -29,6 +29,21 @@ test.afterAll(async () => {
   await page.close();
 });
 
+test("service worker precaches pyodide.js during install", async () => {
+  // The SW precaches pyodide.js in its install event so subsequent navigations
+  // serve it from cache. By the time Pyodide has fully booted, the SW install
+  // has long since completed.
+  const cached = await page.evaluate(async () => {
+    const keys = await caches.keys();
+    const name = keys.find((k) => k.startsWith("nfm-playground-"));
+    if (!name) return false;
+    const cache = await caches.open(name);
+    const entries = await cache.keys();
+    return entries.some((req) => req.url.includes("pyodide.js"));
+  });
+  expect(cached).toBe(true);
+});
+
 test("boots and renders the seed map", async () => {
   await expect(page.locator("#preview svg")).toHaveCount(1);
   expect(await page.locator("#preview [data-line-id]").count()).toBeGreaterThan(

--- a/website/public/playground/harness.html
+++ b/website/public/playground/harness.html
@@ -335,5 +335,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/mode/simple.min.js"></script>
     <script src="https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"></script>
     <script src="app.js"></script>
+    <script>
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("sw.js").catch(() => {});
+      }
+    </script>
   </body>
 </html>

--- a/website/public/playground/sw.js
+++ b/website/public/playground/sw.js
@@ -8,30 +8,23 @@ const PYODIDE_BASE = `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full/`
 const CACHE_NAME = `nfm-playground-${PYODIDE_VERSION}`;
 
 function shouldCache(url) {
-  // Cache Pyodide CDN assets and the local wheel file.
-  // wheels/index.json is always fetched fresh by app.js (cache: "no-store")
-  // so we leave it out of the SW cache entirely.
+  // wheels/index.json is fetched with cache: "no-store" by app.js for wheel
+  // discovery, so exclude it; .whl files are content-addressed and safe to cache.
   if (url.startsWith(PYODIDE_BASE)) return true;
-  try {
-    const path = new URL(url).pathname;
-    if (/\/wheels\/[^/]+\.whl$/.test(path)) return true;
-  } catch (_) {}
-  return false;
+  return /\/wheels\/[^/]+\.whl$/.test(url);
 }
 
 self.addEventListener("install", (event) => {
-  // Activate immediately without waiting for existing clients to close.
   self.skipWaiting();
-  // Precache the Pyodide entry script so the next navigation serves it from
-  // the SW cache without a CDN round-trip. The WASM and other large assets are
-  // cached on their first fetch once the SW is controlling the page.
+  // WASM and other large assets are lazily cached on first fetch once the SW
+  // controls the page; only the entry script is precached here.
   event.waitUntil(
     (async () => {
       const cache = await caches.open(CACHE_NAME);
       try {
         await cache.add(`${PYODIDE_BASE}pyodide.js`);
       } catch (_) {
-        // Don't fail install when the CDN is unreachable (offline / first-visit).
+        // Don't fail install when the CDN is unreachable.
       }
     })(),
   );
@@ -46,8 +39,6 @@ self.addEventListener("activate", (event) => {
           .filter((k) => k.startsWith("nfm-playground-") && k !== CACHE_NAME)
           .map((k) => caches.delete(k)),
       );
-      // Take control of all open clients so the cache is active on first
-      // load without requiring a page reload.
       await self.clients.claim();
     })(),
   );
@@ -60,11 +51,11 @@ self.addEventListener("fetch", (event) => {
   event.respondWith(
     (async () => {
       const cache = await caches.open(CACHE_NAME);
-      const cached = await cache.match(event.request);
+      const cached = await cache.match(url);
       if (cached) return cached;
       const response = await fetch(event.request);
       if (response.ok) {
-        cache.put(event.request, response.clone());
+        cache.put(url, response.clone());
       }
       return response;
     })(),

--- a/website/public/playground/sw.js
+++ b/website/public/playground/sw.js
@@ -1,0 +1,72 @@
+"use strict";
+
+// Keep in sync with PYODIDE_VERSION in app.js. Bumping this constant
+// changes the cache name, which causes the activate handler to evict all
+// assets from the previous version.
+const PYODIDE_VERSION = "v0.27.2";
+const PYODIDE_BASE = `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full/`;
+const CACHE_NAME = `nfm-playground-${PYODIDE_VERSION}`;
+
+function shouldCache(url) {
+  // Cache Pyodide CDN assets and the local wheel file.
+  // wheels/index.json is always fetched fresh by app.js (cache: "no-store")
+  // so we leave it out of the SW cache entirely.
+  if (url.startsWith(PYODIDE_BASE)) return true;
+  try {
+    const path = new URL(url).pathname;
+    if (/\/wheels\/[^/]+\.whl$/.test(path)) return true;
+  } catch (_) {}
+  return false;
+}
+
+self.addEventListener("install", (event) => {
+  // Activate immediately without waiting for existing clients to close.
+  self.skipWaiting();
+  // Precache the Pyodide entry script so the next navigation serves it from
+  // the SW cache without a CDN round-trip. The WASM and other large assets are
+  // cached on their first fetch once the SW is controlling the page.
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      try {
+        await cache.add(`${PYODIDE_BASE}pyodide.js`);
+      } catch (_) {
+        // Don't fail install when the CDN is unreachable (offline / first-visit).
+      }
+    })(),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((k) => k.startsWith("nfm-playground-") && k !== CACHE_NAME)
+          .map((k) => caches.delete(k)),
+      );
+      // Take control of all open clients so the cache is active on first
+      // load without requiring a page reload.
+      await self.clients.claim();
+    })(),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const url = event.request.url;
+  if (!shouldCache(url)) return;
+
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(event.request);
+      if (cached) return cached;
+      const response = await fetch(event.request);
+      if (response.ok) {
+        cache.put(event.request, response.clone());
+      }
+      return response;
+    })(),
+  );
+});

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -353,6 +353,11 @@ import { base } from "../site";
     the page URL (/playground/) just as they did with the old index.html.
   -->
   <script is:inline src={`${base}playground/app.js`}></script>
+  <script is:inline define:vars={{ swUrl: `${base}playground/sw.js` }}>
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register(swUrl).catch(() => {});
+    }
+  </script>
 </StarlightPage>
 
 <style is:global>


### PR DESCRIPTION
## Summary

- Adds `website/public/playground/sw.js`: a service worker that uses a cache-first strategy for the Pyodide CDN runtime (`cdn.jsdelivr.net/pyodide/v0.27.2/full/`) and the local nf-metro wheel (`wheels/*.whl`), making repeat playground visits near-instant and hardening the flaky-network story.
- Cache name is keyed on `PYODIDE_VERSION`; bumping that constant (in both `sw.js` and `app.js`) evicts all stale Pyodide assets on the next SW activation, providing automatic cache busting when the runtime is upgraded.
- Wheel entries are content-addressed (filename changes per deploy), so old wheel entries become unreachable automatically when a new wheel is published, without requiring a version bump.
- `wheels/index.json` is explicitly excluded from SW caching: `app.js` already fetches it with `cache: "no-store"` for wheel-name discovery, and intercepting it would mask fresh wheel deployments.
- `pyodide.js` is precached in the SW install event so the first navigation after SW installation serves it from cache.
- `skipWaiting()` + `clients.claim()` for immediate activation without requiring a page reload.
- Old `nfm-playground-*` caches are evicted on activate.
- SW is registered with a path-relative URL in both `playground.astro` and `harness.html`, so production (`/nf-metro/playground/`) and PR-preview (`/_pr/N/playground/`) scopes are disjoint and cannot hijack each other.
- Adds a Playwright test asserting that `pyodide.js` is in the SW cache after the install event completes.

Fixes #1121

## Test plan

- [x] All 36 Playwright e2e tests pass (including the new SW cache test)
- [x] `pytest` passes (23376 passed, no regressions)
- [x] ruff check + format clean
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/1122/) (no layout changes expected)

Generated with Claude Code