### PR TITLE
feat(docs): add Metro clean prop; use for hero map

### DIFF
--- a/website/src/components/Metro.astro
+++ b/website/src/components/Metro.astro
@@ -11,6 +11,10 @@ import ZoomableSVG from "@components/ZoomableSVG.astro";
 // section state is "open" (shown, expanded), "collapsed" (shown, folded), or
 // false (hidden).
 //
+// `clean` bypasses all sections and outputs just the inline SVG wrapped in
+// ZoomableSVG - for embedding directly in a hero or other contexts that need
+// the map without any <details> chrome. Ignores purpose/mmd/command/render.
+//
 // The rendered SVG arrives through the `?metro` Vite plugin as an imported
 // module string. Importing it (rather than rendering to a runtime string and
 // using set:html) is what lets its `light-dark()` chrome follow the page theme
@@ -36,6 +40,9 @@ interface Props {
   fromNextflow?: boolean;
   // <Code> title for the source block; defaults to the src path.
   title?: string;
+  // Output only the inline SVG (in a ZoomableSVG); no <details> chrome.
+  // Ignores purpose/mmd/command/render. For hero and embed contexts.
+  clean?: boolean;
 }
 
 const PURPOSES: Record<
@@ -56,12 +63,13 @@ const {
   debug = false,
   fromNextflow = false,
   title,
+  clean = false,
 } = Astro.props;
 
 const preset = PURPOSES[purpose];
-const mmdState = mmd ?? preset.mmd;
-const commandState = command ?? preset.command;
-const renderState = render ?? preset.render;
+const mmdState = clean ? false : (mmd ?? preset.mmd);
+const commandState = clean ? false : (command ?? preset.command);
+const renderState = clean ? "open" : (render ?? preset.render);
 
 if (fromNextflow && debug) {
   // No combined `?metro&nextflow&debug` glob exists; fail loudly rather than
@@ -144,34 +152,42 @@ const cliCommand =
 const codeTitle = title ?? src;
 ---
 
-<div class="metro">
-  {
-    mmdState !== false && (
-      <details class="metro-part" open={mmdState === "open"}>
-        <summary>Mermaid source</summary>
-        <Code code={source} lang="metro" title={codeTitle} />
-      </details>
-    )
-  }
-  {
-    commandState !== false && (
-      <details class="metro-part" open={commandState === "open"}>
-        <summary>CLI command</summary>
-        <Code code={cliCommand} lang="bash" />
-      </details>
-    )
-  }
-  {
-    renderState !== false && (
-      <details class="metro-part metro-render" open={renderState === "open"}>
-        <summary>Rendered map</summary>
-        <ZoomableSVG>
-          <Fragment set:html={svg} />
-        </ZoomableSVG>
-      </details>
-    )
-  }
-</div>
+{
+  clean ? (
+    <ZoomableSVG>
+      <Fragment set:html={svg} />
+    </ZoomableSVG>
+  ) : (
+    <div class="metro">
+      {
+        mmdState !== false && (
+          <details class="metro-part" open={mmdState === "open"}>
+            <summary>Mermaid source</summary>
+            <Code code={source} lang="metro" title={codeTitle} />
+          </details>
+        )
+      }
+      {
+        commandState !== false && (
+          <details class="metro-part" open={commandState === "open"}>
+            <summary>CLI command</summary>
+            <Code code={cliCommand} lang="bash" />
+          </details>
+        )
+      }
+      {
+        renderState !== false && (
+          <details class="metro-part metro-render" open={renderState === "open"}>
+            <summary>Rendered map</summary>
+            <ZoomableSVG>
+              <Fragment set:html={svg} />
+            </ZoomableSVG>
+          </details>
+        )
+      }
+    </div>
+  )
+}
 
 <style>
   /* The three sections inherit Starlight's native <details> styling (the

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -8,9 +8,7 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { Icon } from "@astrojs/starlight/components";
 import Logo from "../assets/logo.svg";
 import { base, GITHUB_URL } from "../site";
-// Generated render (scripts/build_gallery.py); lives in docs/assets/renders/ and
-// is reached via the content symlink (src/content/docs -> ../../docs). Astro bundles it.
-import heroMap from "../content/docs/assets/renders/rnaseq_auto.svg";
+import Metro from "../components/Metro.astro";
 ---
 
 <StarlightPage
@@ -47,12 +45,7 @@ import heroMap from "../content/docs/assets/renders/rnaseq_auto.svg";
         </a>
       </div>
       <figure class="hero-map">
-        <img
-          src={heroMap.src}
-          width={heroMap.width}
-          height={heroMap.height}
-          alt="nf-core/rnaseq rendered as an nf-metro map"
-        />
+        <Metro src="examples/rnaseq_auto.mmd" clean />
       </figure>
     </section>
 

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -404,7 +404,11 @@ nav.sidebar a[aria-current="page"]:hover {
   background: var(--nfm-surface);
   box-shadow: 0 25px 50px -22px rgba(32, 22, 55, 0.25);
 }
-.home .hero-map img {
+.home .hero-map .zoomable-svg {
+  display: block;
+  line-height: 0;
+}
+.home .hero-map svg {
   display: block;
   width: 100%;
   height: auto;


### PR DESCRIPTION
## Summary

- Adds a `clean` boolean prop to `<Metro>` that outputs just the inline SVG wrapped in `ZoomableSVG`, skipping all `<details>` source/command/render chrome. Intended for embedding maps directly in a hero section or other page contexts that don't want the collapsible UI.
- Uses `<Metro src="examples/rnaseq_auto.mmd" clean />` on the home page to replace the static pre-generated hero image with a live-rendered inline SVG.
- The hero SVG now adapts to the site's dark/light toggle via `light-dark()` - the previous `<img>` was baked to one palette.
- Removes the dependency on `docs/assets/renders/rnaseq_auto.svg` being present for the home page to render correctly.
- CSS updated: `.home .hero-map img` → `.home .hero-map .zoomable-svg` + `.home .hero-map svg` to handle the new inline SVG structure.

## Test plan

- [ ] Visit the home page in both light and dark mode - hero map should switch palettes with the theme toggle
- [ ] Hover over the hero map - zoom icon should appear (click-to-zoom via ZoomableSVG)
- [ ] Confirm the rest of the page (install, quick start, explore cards) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)