### PR TITLE
docs: apply Expressive Code terminal frames, file titles, diff/line markers

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ nf-metro ships four commands - `render`, `convert`, `validate`, and `info`. This
 
 Render a Mermaid metro map definition to SVG or interactive HTML.
 
-```bash
+```bash frame="terminal"
 nf-metro render [OPTIONS] INPUT_FILE
 ```
 
@@ -62,7 +62,7 @@ Flags for producing an SVG to embed in another page or application. The [Embeddi
 
 `--format html` produces a self-contained `.html` file with the SVG inlined plus a small JS/CSS layer (no external dependencies, no network):
 
-```bash
+```bash frame="terminal"
 nf-metro render pipeline.mmd --format html -o pipeline.html
 ```
 
@@ -74,7 +74,7 @@ The **Embed&hellip;** button opens a panel with copyable inline-HTML, iframe, an
 
 Pass `--validate` to check the _drawn_ SVG after rendering and fail (non-zero exit) if a route is drawn through a station's label or marker, or two distinct lines collapse into one stroke where they should run parallel. This reads the geometry as it ends up on the page (after the per-line offsets and label shifts the layout applies), catching defects the pre-render checks cannot see:
 
-```bash
+```bash frame="terminal"
 nf-metro render pipeline.mmd -o pipeline.svg --validate
 ```
 
@@ -84,7 +84,7 @@ To run the same geometry checks on an already-rendered SVG, use [`nf-metro valid
 
 Convert a Nextflow `-with-dag` mermaid file to nf-metro format.
 
-```bash
+```bash frame="terminal"
 nf-metro convert [OPTIONS] INPUT_FILE
 ```
 
@@ -99,7 +99,7 @@ See [Importing from Nextflow](/nf-metro/nextflow/) for details and examples.
 
 Check a `.mmd` file for errors without producing output.
 
-```bash
+```bash frame="terminal"
 nf-metro validate INPUT_FILE
 ```
 
@@ -107,6 +107,6 @@ nf-metro validate INPUT_FILE
 
 Print a summary of the parsed map: sections, lines, stations, and edges.
 
-```bash
+```bash frame="terminal"
 nf-metro info INPUT_FILE
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,7 +6,7 @@ How to set up nf-metro for development, run the same checks CI runs, and get a c
 
 ## Setup
 
-```bash
+```bash frame="terminal"
 git clone https://github.com/pinin4fjords/nf-metro
 cd nf-metro
 pip install -e ".[dev]"
@@ -16,7 +16,7 @@ Required Python: 3.10+. Dependencies: `click`, `drawsvg`, `networkx`, `pillow`. 
 
 ## Running checks
 
-```bash
+```bash frame="terminal"
 # All tests
 pytest
 
@@ -51,7 +51,7 @@ The topology suite parametrizes over every `.mmd` in `examples/topologies/` and 
 
 Docs pages render metro maps live from their committed `.mmd` source with the `<Metro>` component - there is nothing to pre-render or commit. In an `.mdx` page, import it once and point `src` at a repo-relative path:
 
-```mdx
+```mdx title="docs/mypage.mdx"
 import Metro from "@components/Metro.astro";
 
 <Metro src="examples/guide/01_minimal.mmd" />
@@ -65,7 +65,7 @@ That shows the Mermaid source, the CLI command, and the rendered map as three to
 | `showcase`        | collapsed | collapsed | open |
 | `reference`       | collapsed | open      | open |
 
-```mdx
+```mdx title="docs/mypage.mdx"
 {/* map only, no source block */}
 
 <Metro src="examples/rnaseq_auto.mmd" mmd={false} />
@@ -89,7 +89,7 @@ The page must be `.mdx` (not `.md`). Plain ` ```metro ` fences are untouched - u
 
 When you find a bug that will take time to fix, don't ignore it. Write a test for the _correct_ behaviour and mark it `xfail`:
 
-```python
+```python title="tests/test_example.py"
 @pytest.mark.xfail(strict=True, reason="issue #NNN: what should happen")
 def test_something():
     ...
@@ -107,7 +107,7 @@ Automated geometry checks verify the coordinates are correct; they can't verify 
 
 **Locally:** render individual examples directly:
 
-```bash
+```bash frame="terminal"
 # Activate the nf-metro dev environment if using micromamba
 source ~/.local/bin/mm-activate nf-metro
 

--- a/docs/dev/guard_tiers.md
+++ b/docs/dev/guard_tiers.md
@@ -101,7 +101,7 @@ an always-on check, and every issue-pinned guard records its issue and a
 the final geometry. Mean microseconds-per-fixture below are from that run;
 regenerate with:
 
-```bash
+```bash frame="terminal"
 python scripts/guard_cost_audit.py --json /tmp/guard_cost.json
 ```
 

--- a/docs/dev/parser.md
+++ b/docs/dev/parser.md
@@ -44,7 +44,7 @@ The work splits in two:
 
 `.mmd` files use a subset of Mermaid `graph LR` syntax:
 
-```metro
+```metro title="example.mmd"
 %%metro title: Pipeline Name
 %%metro line: line_id | Display Name | #hexcolor | style
 
@@ -87,7 +87,7 @@ a library do the recognising. nf-metro uses [`lark`](https://lark-parser.readthe
 for this. The grammar lives as a string in `grammar.py` (`_GRAMMAR`),
 and reads roughly:
 
-```lark
+```lark title="src/nf_metro/parser/grammar.py"
 node:  NAME SHAPE?
 edge:  NAME SHAPE? ARROW EDGELABEL? NAME SHAPE?
 
@@ -236,7 +236,7 @@ separate `validate` phase, `nf_metro.parser.validate.validate_graph`.
 The unrecognised-line case is handled in the grammar by a low-priority
 catch-all:
 
-```lark
+```lark title="src/nf_metro/parser/grammar.py"
 JUNK.-10: /[^\n]+/
 ```
 

--- a/docs/dev/routing_gate_triage.md
+++ b/docs/dev/routing_gate_triage.md
@@ -91,7 +91,7 @@ filed bug, or one not yet classified. A campaign is not done while any arm is
    fixture to a shared triage JSON.
 5. **Human visual verdict before PR-open.** Build the review page and get a
    verdict on _every_ new fixture:
-   ```bash
+   ```bash frame="terminal"
    source ~/.local/bin/mm-activate nf-metro && export PYTHONPATH="$PWD/src"
    python .claude/skills/nf-metro-layout-triage/build_review.py --worktree "$PWD" \
        --output-dir /tmp/gate-triage-out --violations /tmp/gate-triage-<module>.json

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -8,7 +8,7 @@ The test suite has four complementary validation layers, each checking a
 different artifact at a different point in the pipeline. Run everything
 with `pytest`; run one file or test with the usual selectors:
 
-```bash
+```bash frame="terminal"
 pytest                                   # all tests
 pytest tests/test_topology_validation.py # one file
 pytest tests/test_parser.py::test_parse_title
@@ -85,7 +85,7 @@ gallery (no diff page). The preview is published at
 To reproduce locally, render the gallery on each branch into separate
 directories and run the diff script the same way:
 
-```bash
+```bash frame="terminal"
 python scripts/build_gallery.py            # writes docs/assets/renders/*.svg
 python scripts/build_render_diff.py /tmp/base /tmp/pr /tmp/diff_site
 ```

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -178,7 +178,7 @@ Here is a pipeline with a visible `branch` station that serves only as a fork po
 
 The "Branch" station is real in the graph but meaningless in the pipeline. Renaming it to `_branch` hides it:
 
-```metro
+```metro ins={2,5,6,9}
     subgraph processing [Processing]
         _branch
         align[Alignment]
@@ -263,7 +263,7 @@ With `%%metro compact_offsets: true`, stations are only as wide as the lines act
 
 **Off-track inputs.** Pipelines often have reference or auxiliary inputs (a FASTA, a GTF, a known-variants VCF) that feed _into_ a processing step partway through a section rather than flowing along the main route. By default such an input station would claim a line-track slot on the trunk, pushing the layout around. List its station ID in `%%metro off_track:` and nf-metro lifts it above the section's main track, dropping it down into its consumer:
 
-```metro
+```metro {3}
 %%metro file: ref_in | FASTA | Reference
 %%metro file: gtf_in | GTF | Annotation
 %%metro off_track: ref_in, gtf_in
@@ -273,7 +273,7 @@ This pairs naturally with the `file:` / `files:` / `dir:` icon directives - the 
 
 **Off-track outputs.** The same directive works for file _artefacts_ written part-way through a section (a `bam`/`cram` dumped after a mapping step, say). A producer-fed sink - a station with an incoming edge from an on-track step and no on-track consumer - is anchored above its **producer** rather than the section top, so the artefact hangs off the trunk right where it is written:
 
-```metro
+```metro {2}
 %%metro file: bam_mapped | BAM
 %%metro off_track: bam_mapped
 ```
@@ -294,7 +294,7 @@ The bare directive sets the graph-wide default:
 
 Append `| <section>, ...` to override individual sections, so one map can mix modes - a `bundle` trunk feeding a `rails` analysis panel, say:
 
-```metro
+```metro {2}
 %%metro line_spread: centered
 %%metro line_spread: rails | pathways
 ```
@@ -414,7 +414,7 @@ glyph is the correct rendering.
 
 Add `--debug` to any render command to overlay layout internals on the diagram:
 
-```bash
+```bash frame="terminal"
 nf-metro render --debug pipeline.mmd -o debug.svg
 ```
 

--- a/docs/releases/0.1.mdx
+++ b/docs/releases/0.1.mdx
@@ -27,7 +27,7 @@ For cases where the inferred layout doesn't match your intent, explicit grid pos
 
 `--animate` adds travelling balls that follow each metro line from source to destination:
 
-```bash
+```bash frame="terminal"
 nf-metro render mypipeline.mmd --animate -o pipeline.svg
 ```
 

--- a/docs/releases/0.4.0.mdx
+++ b/docs/releases/0.4.0.mdx
@@ -11,7 +11,7 @@ _2026-02-19_ · [GitHub release](https://github.com/pinin4fjords/nf-metro/releas
 
 nf-metro can now import Mermaid files produced by Nextflow's `--with-dag` flag directly, without manual editing. The importer detects unsupported DAG constructs and reports them clearly.
 
-```bash
+```bash frame="terminal"
 nextflow run mypipeline.nf --with-dag dag.mmd
 nf-metro render dag.mmd -o pipeline.svg
 ```

--- a/docs/releases/0.7.0.md
+++ b/docs/releases/0.7.0.md
@@ -25,7 +25,7 @@ A big one: 228 commits since 0.6.1. Existing `.mmd` files render with no changes
 
 Lines can be **dashed** or **dotted** to indicate optional or conditional routes. Add a fourth field to `%%metro line:`:
 
-```metro
+```metro ins={1-2}
 %%metro line: qc | Quality Control | #2196F3 | dashed
 %%metro line: optional | Optional path | #ff8800 | dotted
 ```


### PR DESCRIPTION
## Summary

- **Terminal frames** (`frame="terminal"`) added to all shell code blocks across `docs/cli.md`, `docs/contributing.md`, `docs/guide.mdx`, and the `docs/dev/` and `docs/releases/` pages that had plain `bash` fences - gives every command block the macOS-style terminal title bar and darker background
- **File name titles** on: the Lark grammar excerpts in `docs/dev/parser.md` (`lark title="src/nf_metro/parser/grammar.py"`), the xfail example in `docs/contributing.md` (`python title="tests/test_example.py"`), and both `<Metro>` import blocks (`mdx title="docs/mypage.mdx"`)
- **Diff `ins` markers** on the hidden-station rename block in `docs/guide.mdx` (highlights the `_branch` lines being added) and the dashed/dotted line directive examples in `docs/releases/0.7.0.md` (marks both new directive lines green)
- **Line highlights** (`{n}`) on the `off_track` directive examples in `docs/guide.mdx` (draws attention to the `%%metro off_track:` line) and on the per-section `line_spread` override example (highlights the `| pathways` override syntax)

No `ec.config.mjs` changes needed - all four features are native EC capabilities activated purely through code fence attributes.

Fixes #1130

## Test plan
- [ ] Visual review of [render preview](https://pinin4fjords.github.io/nf-metro/_pr/1135/) - docs-only change so no SVG diffs expected
- [ ] Render-preview verdict: No visual changes

Generated with Claude Code