### PR TITLE
ci: fix playground-e2e missing pyyaml dependency

### DIFF
--- a/.github/workflows/playground-e2e.yml
+++ b/.github/workflows/playground-e2e.yml
@@ -29,7 +29,7 @@ jobs:
           printf '{"wheel": "%s"}\n' "$WHEEL" > website/public/playground/wheels/index.json
 
       - name: Install nf-metro (the manifest generator imports build_gallery)
-        run: pip install -e .
+        run: pip install -e ".[docs]"
 
       - name: Build playground example manifest
         run: python scripts/build_playground_examples.py


### PR DESCRIPTION
## Summary

The `playground-e2e` job installs nf-metro with `pip install -e .` (no extras), then runs `scripts/build_playground_examples.py`, which imports `build_gallery`. `build_gallery` reads `scripts/gallery.yaml` via `pyyaml`, but `pyyaml` ships only in the `docs` extra, so the manifest step aborts with:

```
ModuleNotFoundError: No module named 'yaml'
```

This installs the `docs` extra (`cairosvg` + `pyyaml`) in that step so the import resolves.

## Test plan
- [ ] The `e2e` job's "Build playground example manifest" step completes instead of failing on the yaml import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)