### PR TITLE
fix(routing): nest the folded merge-into-top-entry corner concentrically (#1142)

### DIFF
--- a/src/nf_metro/layout/routing/perp.py
+++ b/src/nf_metro/layout/routing/perp.py
@@ -69,13 +69,21 @@ def _perp_entry_crossing_x(
 
     The inter-section approach lands, and the intra-section drop departs, at
     this one X so the line passes straight through the boundary rather than
-    converging on the port marker and re-fanning.  It is the marker X offset by
-    the line's inter-section feeder bundle index times the offset step, fanned
-    to the side the feeder approaches from (:func:`_feeder_fan_sign`): the
-    reference feeder (index 0, e.g. a column-aligned vertical drop) sits on the
-    marker, later-index lines fan one consistent side.  Returns ``None`` when no
-    bundled inter-section feeder reaches the port for this line (nothing to
-    align a crossing X to).
+    converging on the port marker and re-fanning.
+
+    A vertical-flow (TB/BT) feeder drops on its section lane -- the exact X
+    :func:`inter_section_handlers._route_tb_bottom_exit` lands at,
+    ``port_x + _tb_x_offset(feeder, line)`` -- so the crossing tracks that lane.
+    The per-line lane width (one offset step per distinct line) is narrower than
+    the feeder's index in the *whole* cross-boundary bundle, which counts every
+    converging feeder's every line: anchoring on the bundle index instead would
+    splay the few descending lines across the wider fan and straddle the target
+    station, pinching the drop's turn-in corner.
+
+    For any other feeder the crossing falls back to the marker X offset by the
+    feeder's bundle index times the offset step, fanned to the side the feeder
+    approaches from (:func:`_feeder_fan_sign`).  Returns ``None`` when no bundled
+    inter-section feeder reaches the port for this line (nothing to align to).
     """
     feeders = [
         (info[0], edge.source)
@@ -87,7 +95,19 @@ def _perp_entry_crossing_x(
     if not feeders:
         return None
     max_index, source = max(feeders)
-    return port_x + _feeder_fan_sign(ctx, source) * max_index * ctx.offset_step
+    feeder_st = ctx.graph.stations.get(source)
+    feeder_sec = (
+        ctx.graph.sections.get(feeder_st.section_id)
+        if feeder_st and feeder_st.section_id
+        else None
+    )
+    if feeder_sec is not None and lanes_run_along_x(feeder_sec.direction):
+        # The feeder's own per-line lane width (one step per distinct line),
+        # equivalent to _tb_x_offset once the lane sign is applied below.
+        fan = _get_offset(ctx, source, line_id)
+    else:
+        fan = max_index * ctx.offset_step
+    return port_x + _feeder_fan_sign(ctx, source) * fan
 
 
 def _perp_riser_lateral(

--- a/src/nf_metro/layout/routing/perp.py
+++ b/src/nf_metro/layout/routing/perp.py
@@ -22,9 +22,10 @@ identical lateral for a given line and side.
 ``_perp_entry_crossing_x`` expresses the matching X for the *aligned* case: the
 single X at which a bundled inter-section feeder and its intra-section drop both
 cross the port, so the line passes straight through the boundary instead of
-converging on the marker and re-fanning.  It fans to the side the feeder
-approaches from (``_feeder_fan_sign``) so the crossing tracks a ``-x`` downward
-(TB) feeder and its ``+x`` upward (BT) image alike.
+converging on the marker and re-fanning.  It tracks the feeder's own section
+lane (``_tb_x_offset``) for a vertical-flow feeder -- a ``-x`` downward (TB)
+drop and its ``+x`` upward (BT) image alike -- and the ``-x`` up-and-over riser
+side for any other feeder.
 """
 
 from __future__ import annotations
@@ -34,32 +35,12 @@ from nf_metro.layout.routing.context import (
     _get_offset,
     _max_offset_at,
     _RoutingCtx,
-    _section_lane_frame,
+    _tb_x_offset,
 )
 from nf_metro.layout.routing.corners import reversed_offset
 from nf_metro.parser.model import (
     PortSide,
 )
-
-
-def _feeder_fan_sign(ctx: _RoutingCtx, source_id: str) -> float:
-    """Lateral fan sign of the inter-section feeder leaving *source_id*.
-
-    A vertical-flow (TB/BT) feeder rides its section's lane, so it fans to the
-    side its :attr:`~AxisFrame.secondary_sign` names: a downward TB feeder to
-    ``-x``, its upward BT image to ``+x``.  A horizontal feeder reaching the
-    drop instead arrives via the up-and-over riser, whose reference leg fans to
-    ``-x`` (the legacy left-fan).
-    """
-    station = ctx.graph.stations.get(source_id)
-    section = (
-        ctx.graph.sections.get(station.section_id)
-        if station and station.section_id
-        else None
-    )
-    if section is not None and lanes_run_along_x(section.direction):
-        return _section_lane_frame(ctx.graph, section, ctx.positive_fan).secondary_sign
-    return -1.0
 
 
 def _perp_entry_crossing_x(
@@ -71,19 +52,19 @@ def _perp_entry_crossing_x(
     this one X so the line passes straight through the boundary rather than
     converging on the port marker and re-fanning.
 
-    A vertical-flow (TB/BT) feeder drops on its section lane -- the exact X
+    A vertical-flow (TB/BT) feeder drops on its own section lane -- the exact X
     :func:`inter_section_handlers._route_tb_bottom_exit` lands at,
-    ``port_x + _tb_x_offset(feeder, line)`` -- so the crossing tracks that lane.
-    The per-line lane width (one offset step per distinct line) is narrower than
-    the feeder's index in the *whole* cross-boundary bundle, which counts every
+    :func:`context._tb_x_offset` -- so the crossing tracks that lane.  Its
+    per-line lane width (one offset step per distinct line) is narrower than the
+    feeder's index in the *whole* cross-boundary bundle, which counts every
     converging feeder's every line: anchoring on the bundle index instead would
     splay the few descending lines across the wider fan and straddle the target
     station, pinching the drop's turn-in corner.
 
-    For any other feeder the crossing falls back to the marker X offset by the
-    feeder's bundle index times the offset step, fanned to the side the feeder
-    approaches from (:func:`_feeder_fan_sign`).  Returns ``None`` when no bundled
-    inter-section feeder reaches the port for this line (nothing to align to).
+    Any other feeder reaches the drop via the up-and-over riser, whose reference
+    leg fans to ``-x``, so its crossing offsets the marker by the feeder's bundle
+    index on that side.  Returns ``None`` when no bundled inter-section feeder
+    reaches the port for this line (nothing to align to).
     """
     feeders = [
         (info[0], edge.source)
@@ -96,18 +77,11 @@ def _perp_entry_crossing_x(
         return None
     max_index, source = max(feeders)
     feeder_st = ctx.graph.stations.get(source)
-    feeder_sec = (
-        ctx.graph.sections.get(feeder_st.section_id)
-        if feeder_st and feeder_st.section_id
-        else None
-    )
+    section_id = feeder_st.section_id if feeder_st else None
+    feeder_sec = ctx.graph.sections.get(section_id) if section_id else None
     if feeder_sec is not None and lanes_run_along_x(feeder_sec.direction):
-        # The feeder's own per-line lane width (one step per distinct line),
-        # equivalent to _tb_x_offset once the lane sign is applied below.
-        fan = _get_offset(ctx, source, line_id)
-    else:
-        fan = max_index * ctx.offset_step
-    return port_x + _feeder_fan_sign(ctx, source) * fan
+        return port_x + _tb_x_offset(ctx, source, line_id, section_id)
+    return port_x - max_index * ctx.offset_step
 
 
 def _perp_riser_lateral(

--- a/tests/test_fold_merge_top_entry_concentric.py
+++ b/tests/test_fold_merge_top_entry_concentric.py
@@ -1,0 +1,112 @@
+"""Merge bundle dropping into a folded sink's TOP-entry port (#1142).
+
+When ``fold_threshold`` relocates a convergence sink onto a lower row, the
+sink is fed through a TOP entry port: the converging branches' bundle descends
+the inter-row corridor, crosses the boundary, and turns into the merge station.
+
+The per-line drop must cross the boundary on the *feeder's section lane* -- the
+exact X ``inter_section_handlers._route_tb_bottom_exit`` lands at -- so two
+things hold:
+
+* the inter-section approach and the intra-section drop meet at one coordinate
+  per line (no sideways jog at the port boundary), and
+* the descending lines all sit on the turn-out side of the merge station, so
+  the drop->turn corner nests concentrically instead of straddling the station
+  and pinching through the bend.
+
+Anchoring the drop on each line's index in the *whole* cross-boundary bundle
+(every converging feeder's every line) instead would splay the few descending
+lines past the feeder lane (a jog at the port) and straddle the merge station
+(a non-concentric corner).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import (
+    compute_station_offsets,
+    route_edges_centred,
+)
+from nf_metro.layout.routing.invariants import (
+    assert_render_curve_invariants,
+    check_bundle_order_preserved,
+    check_concentric_bundle_corners,
+    check_seam_segments_meet_at_port,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+TOPOLOGIES_DIR = Path(__file__).parent.parent / "examples" / "topologies"
+
+# ``shared_sink_parallel`` is a three-branch parallel fan into one sink. A
+# tightened fold relocates the sink onto a lower row, where it is fed through a
+# TOP entry port -- the geometry that exercised the bug. The bug shows at every
+# fold that relocates the sink, so exercise a range to guard the whole band.
+BASE_FIXTURE = "shared_sink_parallel"
+# Folds 1-3 relocate the sink to a TOP-entry merge (the bug geometry); 4+ leave
+# it a side entry. ``test_folded_sink_is_fed_through_top_entry`` guards the band.
+FOLDS = [1, 2, 3]
+
+
+def _folded_text(fold: int) -> str:
+    text = (TOPOLOGIES_DIR / f"{BASE_FIXTURE}.mmd").read_text()
+    return text.replace("graph LR", f"%%metro fold_threshold: {fold}\ngraph LR", 1)
+
+
+def _route_at_fold(fold: int):
+    graph = parse_metro_mermaid(_folded_text(fold))
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges_centred(graph, station_offsets=offsets)
+    return graph, routes, offsets
+
+
+@pytest.mark.parametrize("fold", FOLDS)
+def test_folded_sink_top_entry_merge_corner_is_concentric(fold: int) -> None:
+    graph, routes, offsets = _route_at_fold(fold)
+
+    pinches = check_concentric_bundle_corners(graph, routes, offsets)
+    assert not pinches, "\n".join(v.message() for v in pinches)
+
+    flips = check_bundle_order_preserved(routes)
+    assert not flips, "\n".join(v.message() for v in flips)
+
+
+@pytest.mark.parametrize("fold", FOLDS)
+def test_folded_sink_top_entry_drop_meets_feeder_at_port(fold: int) -> None:
+    graph, routes, offsets = _route_at_fold(fold)
+
+    gaps = check_seam_segments_meet_at_port(graph, routes, offsets)
+    assert not gaps, "\n".join(g.message() for g in gaps)
+
+
+@pytest.mark.parametrize("fold", FOLDS)
+def test_folded_sink_is_fed_through_top_entry(fold: int) -> None:
+    """The fold relocates the sink so it is fed through a TOP entry port.
+
+    Guards that the parametrised folds actually exercise the merge-into-top-entry
+    geometry rather than silently passing on a layout where the sink stays a
+    side entry (which would make the corner assertions vacuous).
+    """
+    graph, _routes, _offsets = _route_at_fold(fold)
+    sink_top_entries = [
+        pid
+        for pid, port in graph.ports.items()
+        if port.section_id == "sink" and port.is_entry and "entry_top" in pid
+    ]
+    assert sink_top_entries, f"fold {fold}: sink not fed through a TOP entry"
+
+
+@pytest.mark.parametrize("fold", FOLDS)
+def test_folded_sink_render_passes_curve_self_check(fold: int) -> None:
+    """The render-time curve self-check passes on the folded layout.
+
+    ``assert_render_curve_invariants`` is the backstop that aborts the render
+    when a bundle curve is defective; it must not fire for the folded sink's
+    merge corner.
+    """
+    graph, routes, offsets = _route_at_fold(fold)
+    assert_render_curve_invariants(graph, routes, offsets)

--- a/tests/test_fold_merge_top_entry_concentric.py
+++ b/tests/test_fold_merge_top_entry_concentric.py
@@ -18,6 +18,12 @@ Anchoring the drop on each line's index in the *whole* cross-boundary bundle
 (every converging feeder's every line) instead would splay the few descending
 lines past the feeder lane (a jog at the port) and straddle the merge station
 (a non-concentric corner).
+
+The fold directive is injected at test time rather than shipped as a fixture:
+the folded ``shared_sink_parallel`` also stacks its branches in one column, so a
+separate, unfixed defect (feeders routing through the intervening branch boxes,
+#1148) would fail the corpus-wide invariant tests on a committed fixture. This
+test scopes itself to the corner/seam geometry, which is exercised regardless.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

A multi-line bundle merging into a section that `fold_threshold` relocates onto a lower row enters through a TOP entry port: the converging branches' bundle descends the inter-row corridor, crosses the boundary, and turns into the merge station.

`_perp_entry_crossing_x` anchored each line's drop on its index in the *whole* cross-boundary bundle (every converging feeder's every line). That index is wider than the few distinct lines actually descending, so the drop fan splayed past the feeder's section lane and straddled the merge station, with two consequences:

- the inter-section approach and the intra-section drop parted at the port boundary (a sideways jog), and
- the drop->turn corner could not nest concentrically — the bundle pinched through the bend (the abort #1142 reports).

This anchors a vertical-flow feeder's crossing on its own section lane instead (`_tb_x_offset`, the exact X `_route_tb_bottom_exit` lands at), so the line passes straight through the boundary and the merge corner nests concentrically.

A follow-up refactor drops the now-redundant `_feeder_fan_sign` helper: its sole caller no longer hands it a vertical-flow feeder, leaving it a constant for every other case.

Fixes #1142.

## Scope notes

- The fix is confined to the folded merge-into-top-entry geometry; **no existing gallery render changes** (verified byte-for-byte against `main`).
- The folded `shared_sink_parallel` fixture also stacks its branches in one column, so its feeders route through the intervening branch boxes — a separate, pre-existing defect filed as #1148. That is why the regression test injects the fold directive at test time rather than committing the folded fixture (which would fail the corpus-wide route-through invariants). The corner/seam geometry this PR fixes is exercised regardless.

## Test plan

- [x] New regression test `tests/test_fold_merge_top_entry_concentric.py` (concentric corner, port-seam continuity, render-time curve self-check, across folds 1-3) — fails on the prior logic (2 non-concentric + 3 seam violations), passes now
- [x] Full suite green (23510 passed); routing gate-coverage ratchet green under CPython 3.11
- [x] `ruff check` + `ruff format --check` + `mypy` clean on `src/ tests/`
- [ ] Render preview verdict
