### PR TITLE
docs: add beta badge to Playground sidebar entry

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -177,8 +177,9 @@ export default defineConfig({
             { label: "Gallery", link: "/gallery/" },
             { label: "nf-core pipelines", link: "/pipelines/" },
             {
-              label: "Playground (beta)",
+              label: "Playground",
               link: "/playground/",
+              badge: { text: "beta", variant: "caution" },
               // data-astro-reload forces a full navigation so the CDN scripts
               // (CodeMirror, Pyodide) and app.js re-initialise from scratch
               // instead of being skipped by Astro's ClientRouter.


### PR DESCRIPTION
## Summary

- Moves "beta" from the label text to a Starlight `badge` on the Playground sidebar item, so it renders as a visual chip rather than plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)