### PR TITLE
ci(docs): install [docs] extra so pyyaml is available for build_gallery

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install nf-metro (gallery generator + wheel build)
-        run: pip install -e "." build
+        run: pip install -e ".[docs]" build
 
       # --- Generate dynamic content into the Astro project ---
       - name: Build playground wheel


### PR DESCRIPTION
## Summary

- Fixes `ModuleNotFoundError: No module named 'yaml'` in the deploy workflow
- `build_gallery.py` and `build_playground_examples.py` both import `pyyaml`, which lives in the `[docs]` optional dependency group (alongside `cairosvg`)
- The deploy workflow was installing with `pip install -e "." build` (bare), so `pyyaml` was never installed
- One-character fix: add `[docs]` extra to the install step, matching what the playground-e2e workflow already does (fixed in 9da69c2e)

## Test plan

- [ ] CI passes on this PR
- [ ] Docs deploy workflow completes past the "Build playground example manifest" and "Build gallery + pipelines" steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)