### PR TITLE
fix(docs): rebase internal links to the build base so link validation works on every deploy

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -1,0 +1,48 @@
+name: Docs link check
+
+# Builds the Astro site on pull requests so starlight-links-validator runs and
+# fails the PR on a broken internal link, rather than only surfacing it when the
+# post-merge deploy (docs.yml) builds and fails.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "website/**"
+      - "examples/**"
+      - "scripts/build_gallery.py"
+      - "scripts/gallery.yaml"
+      - ".github/workflows/docs-links.yml"
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install nf-metro (gallery generator + render CLI)
+        run: pip install -e ".[docs]"
+
+      - name: Build gallery + pipelines content
+        run: python scripts/build_gallery.py
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install npm dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Build site (runs starlight-links-validator)
+        working-directory: website
+        run: npm run build

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -8,6 +8,7 @@ import sitemap from "@astrojs/sitemap";
 import mermaid from "astro-mermaid";
 import { metroVitePlugin } from "./src/lib/render-metro.mjs";
 import { starlightGitFix } from "./src/lib/starlight-git-fix.mjs";
+import { remarkRebaseLinks } from "./src/lib/rebase-links.mjs";
 import { GITHUB_URL, PAGES_ORIGIN } from "./src/repo";
 
 // Expressive Code options (custom grammars + the color-chips plugin) live in
@@ -80,6 +81,9 @@ function buildReleasesSidebar() {
 export default defineConfig({
   site,
   base,
+  markdown: {
+    remarkPlugins: [[remarkRebaseLinks, { base }]],
+  },
   vite: {
     // Renders `<path>.mmd?metro` imports to inline SVG via the nf-metro CLI.
     plugins: [starlightGitFix(), metroVitePlugin()],
@@ -128,21 +132,18 @@ export default defineConfig({
     starlight({
       plugins: [
         starlightLinksValidator({
-          // Docs use /nf-metro/ (production-base) absolute links. Versioned
-          // builds (dev, releases) use a different base, so those same pages
-          // sit under a different prefix and the validator cannot find them.
-          // Skipping cross-base links here is safe: the release/production
-          // build (base="/nf-metro/") validates them normally.
-          // gallery/ and pipelines/ are custom Astro routes (not Starlight
-          // content entries) so the validator can never resolve them.
-          // releases/ are frozen versioned deploys on gh-pages; not present
-          // in the current Astro build.
-          // live_demo.mp4 is a public/ static asset, not a navigable page.
+          // Docs author internal links with the production `/nf-metro/` base;
+          // remarkRebaseLinks rewrites that prefix to the active build base
+          // before this validator runs, so cross-references validate against
+          // real pages on every base. Only links the validator structurally
+          // cannot resolve are excluded:
+          // - gallery/ and pipelines/ are custom Astro routes, not Starlight
+          //   content entries, so the validator can only see them as opaque
+          //   custom pages.
+          // - live_demo.mp4 is a public/ static asset, not a navigable page.
           exclude: ({ link }) =>
-            (link.startsWith("/nf-metro/") && !link.startsWith(base)) ||
-            link.startsWith("/nf-metro/gallery") ||
-            link.startsWith("/nf-metro/pipelines") ||
-            link.startsWith("/nf-metro/releases") ||
+            link.startsWith(`${base}gallery`) ||
+            link.startsWith(`${base}pipelines`) ||
             link === "../assets/live_demo.mp4",
         }),
       ],

--- a/website/src/lib/rebase-links.mjs
+++ b/website/src/lib/rebase-links.mjs
@@ -1,0 +1,42 @@
+import { visit } from "unist-util-visit";
+
+const PROD_BASE = "/nf-metro/";
+
+/**
+ * Rewrite production-base internal links to the build's actual base.
+ *
+ * Docs are authored with absolute `/nf-metro/<slug>` links - readable and
+ * stable regardless of where a build is deployed. Versioned deploys set a
+ * different base (e.g. `/nf-metro/dev/`, `/nf-metro/0.7.2/`), so the same page
+ * lives under that prefix instead. This rewrites the authored prefix to the
+ * active base so links resolve at runtime on every deploy, and so the links
+ * validator (a rehype pass, which runs after this remark pass) sees the
+ * resolved URL and validates it against real pages.
+ *
+ * @param {string} base The Astro `base`, always ending in `/`.
+ */
+export function remarkRebaseLinks({ base }) {
+  if (base === PROD_BASE) return () => {};
+
+  const rebase = (url) =>
+    typeof url === "string" && url.startsWith(PROD_BASE)
+      ? base + url.slice(PROD_BASE.length)
+      : url;
+
+  return (tree) => {
+    visit(tree, (node) => {
+      if (node.type === "link") {
+        node.url = rebase(node.url);
+      } else if (
+        node.type === "mdxJsxFlowElement" ||
+        node.type === "mdxJsxTextElement"
+      ) {
+        for (const attr of node.attributes ?? []) {
+          if (attr.type === "mdxJsxAttribute" && attr.name === "href") {
+            attr.value = rebase(attr.value);
+          }
+        }
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Problem

The docs deploy was failing link validation ([example run](https://github.com/pinin4fjords/nf-metro/actions/runs/28328998454/job/83923818553)): `Found 29 invalid links`.

Docs author internal links with the fixed production base `/nf-metro/<slug>`, but versioned deploys build each site with a **different** base via `DOCS_BASE` (`/nf-metro/dev/` on main push, `/nf-metro/latest/` and `/nf-metro/<version>/` on release). `starlight-links-validator` resolves absolute links against `base + pathname`, so on those builds the authored links point at pages that do not exist.

This was also a latent **runtime** bug, not just a validator complaint: the same links 404 on every versioned deploy, since pages never live at a bare `/nf-metro/<slug>`. Prior attempts excluded the cross-base links from validation, which silenced the check without fixing the links (and still failed, because the `dev/`-prefixed links coincidentally matched the dev base prefix).

## Fix

A small remark plugin (`website/src/lib/rebase-links.mjs`) rewrites the authored `/nf-metro/` prefix to the active build base. It runs before the validator's rehype pass, so:

- Links resolve to the correct URL at runtime on **every** base.
- The validator sees the resolved URLs and validates them against real pages.

The exclusion list drops the cross-base hack and is reduced to only what the validator structurally cannot resolve: the `gallery/` and `pipelines/` custom Astro routes, and the `live_demo.mp4` static asset. The `releases/` pages are real content entries and now validate.

No doc files change; they keep their readable absolute links.

Verified `npm run build` is clean (`All internal links are valid`) at `/nf-metro/`, `/nf-metro/dev/`, and `/nf-metro/<version>/`.

## PR-time validation

Adds `.github/workflows/docs-links.yml`, which builds the site on PRs that touch docs or the site so a broken internal link fails the PR rather than only surfacing on the post-merge deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)