### PR TITLE
feat(docs): render maps inline on gallery and pipelines index pages

### DIFF
--- a/website/src/pages/gallery/index.astro
+++ b/website/src/pages/gallery/index.astro
@@ -13,6 +13,16 @@ for (const entry of entries) {
   if (!byCategory.has(cat)) byCategory.set(cat, []);
   byCategory.get(cat)!.push(entry);
 }
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+const headings = Array.from(byCategory.keys()).map((cat) => ({
+  depth: 2,
+  slug: slugify(cat),
+  text: cat,
+}));
 ---
 
 <StarlightPage
@@ -21,11 +31,12 @@ for (const entry of entries) {
     description:
       "Rendered examples covering fan-outs, folds, diamonds, and realistic bioinformatics workflows.",
     template: "doc",
-    tableOfContents: false,
+    tableOfContents: true,
     pagefind: true,
     prev: false,
     next: false,
   }}
+  headings={headings}
 >
   <p>
     Examples covering the full range of layout patterns.
@@ -34,7 +45,7 @@ for (const entry of entries) {
   {
     Array.from(byCategory.entries()).map(([category, items]) => (
       <section class="nfm-gallery-section">
-        <h2>{category}</h2>
+        <h2 id={slugify(category)}>{category}</h2>
         {items.map((entry) => (
           <div class="nfm-gallery-entry">
             <h3>

--- a/website/src/pages/gallery/index.astro
+++ b/website/src/pages/gallery/index.astro
@@ -1,6 +1,7 @@
 ---
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { getCollection } from "astro:content";
+import Metro from "@components/Metro.astro";
 import { base } from "../../site";
 
 const entries = await getCollection("gallery");
@@ -27,24 +28,22 @@ for (const entry of entries) {
   }}
 >
   <p>
-    Examples covering the full range of layout patterns. Click any entry to see
-    the rendered map, Mermaid source, and CLI command.
+    Examples covering the full range of layout patterns.
   </p>
 
   {
     Array.from(byCategory.entries()).map(([category, items]) => (
       <section class="nfm-gallery-section">
         <h2>{category}</h2>
-        <ul class="nfm-gallery-grid">
-          {items.map((entry) => (
-            <li>
-              <a href={`${base}gallery/${entry.id}/`}>
-                <strong>{entry.data.title}</strong>
-                <span>{entry.data.description}</span>
-              </a>
-            </li>
-          ))}
-        </ul>
+        {items.map((entry) => (
+          <div class="nfm-gallery-entry">
+            <h3>
+              <a href={`${base}gallery/${entry.id}/`}>{entry.data.title}</a>
+            </h3>
+            <p class="nfm-entry-desc">{entry.data.description}</p>
+            <Metro src={entry.data.src} purpose="showcase" />
+          </div>
+        ))}
       </section>
     ))
   }
@@ -59,49 +58,30 @@ for (const entry of entries) {
     font-size: var(--sl-text-h4);
     border-bottom: 1px solid var(--sl-color-hairline);
     padding-bottom: 0.4rem;
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
   }
 
-  .nfm-gallery-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
-    gap: 0.75rem;
-    list-style: none;
-    padding: 0;
-    margin: 0;
+  .nfm-gallery-entry {
+    margin-bottom: 2.5rem;
   }
 
-  .nfm-gallery-grid li a {
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-    padding: 0.75rem 1rem;
-    border: 1px solid var(--sl-color-hairline);
-    border-radius: 6px;
-    text-decoration: none;
-    color: inherit;
-    background: var(--sl-color-bg);
-    transition: border-color 0.12s ease, background 0.12s ease;
+  .nfm-gallery-entry h3 {
+    font-size: var(--sl-text-h5);
+    margin-bottom: 0.25rem;
   }
 
-  .nfm-gallery-grid li a:hover {
-    border-color: var(--sl-color-accent);
-    background: var(--sl-color-bg-nav);
-  }
-
-  .nfm-gallery-grid li a strong {
-    font-size: 0.875rem;
+  .nfm-gallery-entry h3 a {
     color: var(--sl-color-text-accent);
-    font-family: var(--sl-font-mono, monospace);
+    text-decoration: none;
   }
 
-  .nfm-gallery-grid li a span {
-    font-size: 0.8rem;
+  .nfm-gallery-entry h3 a:hover {
+    text-decoration: underline;
+  }
+
+  .nfm-entry-desc {
+    font-size: 0.85rem;
     color: var(--sl-color-gray-3);
-    line-height: 1.4;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+    margin-bottom: 0.75rem;
   }
 </style>

--- a/website/src/pages/pipelines/index.astro
+++ b/website/src/pages/pipelines/index.astro
@@ -1,6 +1,7 @@
 ---
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { getCollection } from "astro:content";
+import Metro from "@components/Metro.astro";
 import { base } from "../../site";
 
 const entries = await getCollection("pipelines");
@@ -26,56 +27,46 @@ const entries = await getCollection("pipelines");
     <a href={`${base}guide/`}>Guide</a> for how to write your own.
   </p>
 
-  <ul class="nfm-pipeline-list">
-    {
-      entries.map((entry) => (
-        <li>
-          <a href={`${base}pipelines/${entry.id}/`}>
-            <strong>{entry.data.title}</strong>
-            <span>{entry.data.description}</span>
-          </a>
-        </li>
-      ))
-    }
-  </ul>
+  {
+    entries.map((entry) => (
+      <div class="nfm-pipeline-entry">
+        <h2>
+          <a href={`${base}pipelines/${entry.id}/`}>{entry.data.title}</a>
+        </h2>
+        <p class="nfm-entry-desc">
+          {entry.data.description}{" "}
+          <a href={entry.data.repo_url} target="_blank" rel="noopener">GitHub</a>
+        </p>
+        <Metro src={entry.data.src} purpose="showcase" />
+      </div>
+    ))
+  }
 </StarlightPage>
 
 <style>
-  .nfm-pipeline-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    list-style: none;
-    padding: 0;
-    margin-block: 1.5rem;
+  .nfm-pipeline-entry {
+    margin-bottom: 3rem;
   }
 
-  .nfm-pipeline-list li a {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-    padding: 0.85rem 1rem;
-    border: 1px solid var(--sl-color-hairline);
-    border-radius: 6px;
-    text-decoration: none;
-    color: inherit;
-    background: var(--sl-color-bg);
-    transition: border-color 0.12s ease, background 0.12s ease;
+  .nfm-pipeline-entry h2 {
+    font-size: var(--sl-text-h4);
+    border-bottom: 1px solid var(--sl-color-hairline);
+    padding-bottom: 0.4rem;
+    margin-bottom: 0.5rem;
   }
 
-  .nfm-pipeline-list li a:hover {
-    border-color: var(--sl-color-accent);
-    background: var(--sl-color-bg-nav);
-  }
-
-  .nfm-pipeline-list li a strong {
-    font-size: 0.9rem;
+  .nfm-pipeline-entry h2 a {
     color: var(--sl-color-text-accent);
+    text-decoration: none;
   }
 
-  .nfm-pipeline-list li a span {
-    font-size: 0.82rem;
+  .nfm-pipeline-entry h2 a:hover {
+    text-decoration: underline;
+  }
+
+  .nfm-entry-desc {
+    font-size: 0.85rem;
     color: var(--sl-color-gray-3);
-    line-height: 1.4;
+    margin-bottom: 0.75rem;
   }
 </style>

--- a/website/src/pages/pipelines/index.astro
+++ b/website/src/pages/pipelines/index.astro
@@ -5,6 +5,16 @@ import Metro from "@components/Metro.astro";
 import { base } from "../../site";
 
 const entries = await getCollection("pipelines");
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+const headings = entries.map((entry) => ({
+  depth: 2,
+  slug: slugify(entry.data.title),
+  text: entry.data.title,
+}));
 ---
 
 <StarlightPage
@@ -13,11 +23,12 @@ const entries = await getCollection("pipelines");
     description:
       "Real-world nf-core pipelines rendered as metro-style SVG diagrams using nf-metro.",
     template: "doc",
-    tableOfContents: false,
+    tableOfContents: true,
     pagefind: true,
     prev: false,
     next: false,
   }}
+  headings={headings}
 >
   <p>
     Real-world pipelines rendered with nf-metro. See the{" "}
@@ -30,7 +41,7 @@ const entries = await getCollection("pipelines");
   {
     entries.map((entry) => (
       <div class="nfm-pipeline-entry">
-        <h2>
+        <h2 id={slugify(entry.data.title)}>
           <a href={`${base}pipelines/${entry.id}/`}>{entry.data.title}</a>
         </h2>
         <p class="nfm-entry-desc">


### PR DESCRIPTION
## Summary

- Gallery and pipelines index pages now render maps inline with `<Metro purpose="showcase">` instead of text-only tile grids
- Gallery groups by category with `<h2>` section headings; each entry heading links to its dedicated page
- Pipelines lists each pipeline with its render, description, and GitHub link
- Both pages pass explicit `headings` to `<StarlightPage>` and carry matching `id` attributes on `<h2>` elements so Starlight's right-hand ToC panel works