### PR TITLE
fix(gallery): preserve gallery.yaml category order on the gallery page

### DIFF
--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -200,6 +200,7 @@ def build_gallery_manifest() -> None:
         entries.append(
             {
                 "id": stem,
+                "order": len(entries),
                 "title": clean_name(stem),
                 "src": metro_src(stem, source_dir),
                 "description": description,

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -5,6 +5,7 @@ import { file } from "astro/loaders";
 import { z } from "astro:content";
 
 const gallerySchema = z.object({
+  order: z.number(),
   title: z.string(),
   src: z.string(),
   description: z.string(),

--- a/website/src/pages/gallery/index.astro
+++ b/website/src/pages/gallery/index.astro
@@ -4,9 +4,10 @@ import { getCollection } from "astro:content";
 import Metro from "@components/Metro.astro";
 import { base } from "../../site";
 
-const entries = await getCollection("gallery");
+const allEntries = await getCollection("gallery");
+const entries = allEntries.sort((a, b) => a.data.order - b.data.order);
 
-// Group entries by category, preserving insertion order.
+// Group entries by category, preserving gallery.yaml insertion order.
 const byCategory = new Map<string, typeof entries>();
 for (const entry of entries) {
   const cat = entry.data.category;


### PR DESCRIPTION
## Summary

- `getCollection()` sorts entries alphabetically by ID, discarding the insertion order from `gallery.json`
- Fix: emit an `order` integer index into each `gallery.json` entry (`build_gallery.py`), add it to the Zod schema (`content.config.ts`), and sort by it before grouping in the gallery index page

The three changed lines:
1. `build_gallery.py` — adds `"order": len(entries)` to each emitted JSON entry
2. `content.config.ts` — adds `order: z.number()` to `gallerySchema`
3. `gallery/index.astro` — sorts by `a.data.order - b.data.order` before the grouping loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)