### PR TITLE
fix: make convergence-split section placement deterministic (hash-seed independent)

### DIFF
--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -798,8 +798,17 @@ def _detect_convergence_split(
     if not convergence_sid:
         return None
 
-    # Return set: convergence + transitive successors
-    return_set = {convergence_sid} | _transitive_successors(convergence_sid, successors)
+    # Return set: convergence + transitive successors. Migration below tests
+    # membership against this frozen base, never the set it is growing, so a
+    # section's inclusion never depends on the order a companion happened to be
+    # visited in -- the migration loops are fed from ``col_assign``, whose key
+    # order in the engine derives from a BFS over set-valued successor maps and
+    # so varies with ``PYTHONHASHSEED``.  Order-dependent membership made the
+    # whole grid placement non-deterministic across hash seeds.
+    base_return_set = frozenset(
+        {convergence_sid} | _transitive_successors(convergence_sid, successors)
+    )
+    return_set = set(base_return_set)
 
     # Companion migration: sections that feed ONLY into the return set
     # AND share a direct predecessor with the convergence section.
@@ -809,11 +818,11 @@ def _detect_convergence_split(
     # bypass A->D, sec_c feeds sec_d but sec_c's predecessor sec_b does
     # NOT directly feed sec_d).
     convergence_preds = predecessors.get(convergence_sid, set())
-    for sid in list(col_assign.keys()):
-        if sid in return_set:
+    for sid in sorted(col_assign):
+        if sid in base_return_set:
             continue
         sid_succs = successors.get(sid, set())
-        if not sid_succs or not sid_succs.issubset(return_set):
+        if not sid_succs or not sid_succs.issubset(base_return_set):
             continue
         # Check: does this section share a predecessor with the convergence?
         sid_preds = predecessors.get(sid, set())
@@ -826,17 +835,17 @@ def _detect_convergence_split(
     # pulled onto the return row. Leaving it stacked forces an extra spine
     # row occupied by a single small section, with a large empty band beside
     # it (issue #484: tr_calling stacked under small_variants).
-    for sid in list(col_assign.keys()):
-        if sid in return_set:
+    for sid in sorted(col_assign):
+        if sid in base_return_set:
             continue
         sid_succs = successors.get(sid, set())
-        if not sid_succs or not sid_succs.issubset(return_set):
+        if not sid_succs or not sid_succs.issubset(base_return_set):
             continue
         topo_col = col_assign[sid]
         has_spine_sibling = any(
             other != sid
             and col_assign.get(other) == topo_col
-            and other not in return_set
+            and other not in base_return_set
             for other in col_groups.get(topo_col, [])
         )
         if has_spine_sibling:

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -798,17 +798,24 @@ def _detect_convergence_split(
     if not convergence_sid:
         return None
 
-    # Return set: convergence + transitive successors. Migration below tests
-    # membership against this frozen base, never the set it is growing, so a
-    # section's inclusion never depends on the order a companion happened to be
-    # visited in -- the migration loops are fed from ``col_assign``, whose key
-    # order in the engine derives from a BFS over set-valued successor maps and
-    # so varies with ``PYTHONHASHSEED``.  Order-dependent membership made the
-    # whole grid placement non-deterministic across hash seeds.
+    # Migration below tests membership against this frozen base, never the set
+    # it is growing: ``col_assign``'s key order derives from a BFS over
+    # set-valued successor maps and so varies with ``PYTHONHASHSEED``, so an
+    # order-dependent inclusion would make grid placement hash-seed dependent.
     base_return_set = frozenset(
         {convergence_sid} | _transitive_successors(convergence_sid, successors)
     )
     return_set = set(base_return_set)
+
+    # Both migrations only ever pull in a section that feeds ONLY into the base
+    # return set; they differ in the second test they then apply.
+    candidates = [
+        sid
+        for sid in sorted(col_assign)
+        if sid not in base_return_set
+        and successors.get(sid, set())
+        and successors[sid].issubset(base_return_set)
+    ]
 
     # Companion migration: sections that feed ONLY into the return set
     # AND share a direct predecessor with the convergence section.
@@ -818,15 +825,8 @@ def _detect_convergence_split(
     # bypass A->D, sec_c feeds sec_d but sec_c's predecessor sec_b does
     # NOT directly feed sec_d).
     convergence_preds = predecessors.get(convergence_sid, set())
-    for sid in sorted(col_assign):
-        if sid in base_return_set:
-            continue
-        sid_succs = successors.get(sid, set())
-        if not sid_succs or not sid_succs.issubset(base_return_set):
-            continue
-        # Check: does this section share a predecessor with the convergence?
-        sid_preds = predecessors.get(sid, set())
-        if sid_preds & convergence_preds:
+    for sid in candidates:
+        if predecessors.get(sid, set()) & convergence_preds:
             return_set.add(sid)
 
     # Stacked-sibling migration: a section that feeds ONLY into the return
@@ -835,12 +835,7 @@ def _detect_convergence_split(
     # pulled onto the return row. Leaving it stacked forces an extra spine
     # row occupied by a single small section, with a large empty band beside
     # it (issue #484: tr_calling stacked under small_variants).
-    for sid in sorted(col_assign):
-        if sid in base_return_set:
-            continue
-        sid_succs = successors.get(sid, set())
-        if not sid_succs or not sid_succs.issubset(base_return_set):
-            continue
+    for sid in candidates:
         topo_col = col_assign[sid]
         has_spine_sibling = any(
             other != sid

--- a/tests/test_placement_determinism.py
+++ b/tests/test_placement_determinism.py
@@ -1,0 +1,82 @@
+"""Section placement must be a deterministic function of graph structure.
+
+Auto-layout's convergence-based row split (``_detect_convergence_split``) feeds
+its companion/stacked-sibling migration loops from ``col_assign``, whose key
+order in the real engine comes from a BFS over set-valued successor maps -- and
+set iteration order varies with ``PYTHONHASHSEED``.  If a migration loop tests
+membership against the *growing* return set, whether a section is pulled onto
+the return row can cascade off the order its companion happened to be visited
+in, making the whole grid placement hash-seed dependent (observed on
+``genomeassembly`` under a lowered ``fold_threshold``: the same input flips
+between a backward-feed abort and a route-through-box).
+
+The result must depend only on structure, never on iteration order.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from nf_metro.layout.auto_layout import _detect_convergence_split
+
+
+def _reorder(d: dict, order: list[str]) -> dict:
+    """A dict with the same items, re-inserted in ``order`` (rest appended)."""
+    rest = [k for k in d if k not in order]
+    return {k: d[k] for k in [*order, *rest]}
+
+
+# A convergence sink ``C`` (preds spanning cols 0 and 2) with a tail ``G``.
+# ``P`` is a genuine companion (feeds only into {C,G}, shares pred ``A``).
+# ``Q`` feeds only into ``P`` -- it can be reached as a companion ONLY by
+# cascading off ``P`` already being in the return set, so an order-dependent
+# loop includes it for some visit orders and not others.
+_CASCADE_SUCC = {
+    "A": {"C", "P", "Q"},
+    "M": {"C"},
+    "Q": {"P"},
+    "P": {"C"},
+    "C": {"G"},
+    "G": set(),
+}
+_CASCADE_COL = {"A": 0, "M": 0, "Q": 1, "P": 2, "C": 3, "G": 4}
+
+
+def _predecessors(succ: dict[str, set[str]]) -> dict[str, set[str]]:
+    pred: dict[str, set[str]] = {k: set() for k in succ}
+    for s, tgts in succ.items():
+        for t in tgts:
+            pred.setdefault(t, set()).add(s)
+    return pred
+
+
+def _col_groups(col: dict[str, int]) -> dict[int, list[str]]:
+    groups: dict[int, list[str]] = {}
+    for sid, c in col.items():
+        groups.setdefault(c, []).append(sid)
+    return groups
+
+
+_SECTIONS = sorted(_CASCADE_COL)
+
+
+@pytest.mark.parametrize(
+    "order", [list(p) for p in itertools.permutations(_SECTIONS)][:24]
+)
+def test_convergence_split_is_order_independent(order):
+    """``_detect_convergence_split`` returns the same set under any key order."""
+    pred = _predecessors(_CASCADE_SUCC)
+    groups = _col_groups(_CASCADE_COL)
+
+    baseline = _detect_convergence_split(
+        _reorder(_CASCADE_COL, _SECTIONS), groups, _CASCADE_SUCC, pred
+    )
+    permuted = _detect_convergence_split(
+        _reorder(_CASCADE_COL, order), groups, _CASCADE_SUCC, pred
+    )
+    assert permuted == baseline, (
+        f"return set depends on col_assign key order: {order} -> {permuted} "
+        f"vs canonical {baseline}"
+    )

--- a/tests/test_placement_determinism.py
+++ b/tests/test_placement_determinism.py
@@ -62,9 +62,28 @@ def _col_groups(col: dict[str, int]) -> dict[int, list[str]]:
 _SECTIONS = sorted(_CASCADE_COL)
 
 
-@pytest.mark.parametrize(
-    "order", [list(p) for p in itertools.permutations(_SECTIONS)][:24]
-)
+_PERMUTATIONS = list(itertools.islice(itertools.permutations(_SECTIONS), 24))
+
+
+def test_convergence_split_excludes_cascade_only_companion():
+    """A companion reachable only via another companion stays off the return row.
+
+    ``Q`` feeds only into ``P`` (itself only a companion), so it qualifies for
+    the return row solely by cascading off ``P``'s inclusion -- the membership
+    test must read the frozen base, where ``P`` is absent, and leave ``Q`` out.
+    """
+    result = _detect_convergence_split(
+        _CASCADE_COL,
+        _col_groups(_CASCADE_COL),
+        _CASCADE_SUCC,
+        _predecessors(_CASCADE_SUCC),
+    )
+    assert result is not None
+    assert "Q" not in result
+    assert {"C", "G", "P"} <= result
+
+
+@pytest.mark.parametrize("order", _PERMUTATIONS)
 def test_convergence_split_is_order_independent(order):
     """``_detect_convergence_split`` returns the same set under any key order."""
     pred = _predecessors(_CASCADE_SUCC)


### PR DESCRIPTION
## Summary

Make auto-layout's section placement a deterministic function of graph structure. `_detect_convergence_split`'s companion and stacked-sibling migration loops tested `issubset` against the return set they were growing, while iterating `col_assign` keys whose order derives from a BFS over set-valued successor maps. Set iteration varies with `PYTHONHASHSEED`, so whether a section was pulled onto the return row could cascade off the order a companion happened to be visited in - making the whole grid placement hash-seed dependent.

`examples/genomeassembly.mmd` under a lowered `fold_threshold` was the clearest victim: across hash seeds it flipped between a `BackwardFlowError` abort, a route-through-box, and a clean placement.

The fix tests migration membership against a frozen snapshot of the base return set (convergence section + its transitive successors) and iterates in sorted order, so a section's inclusion depends only on structure. The two migrations now share one candidate list, so they can't drift apart on the "feeds only into the base" predicate.

Fixes #1168. First step toward #1085 (the by-construction placement/port-side objective): layout guarantees can't be reasoned about while placement output depends on the hash seed. The remaining #1085 residual on `genomeassembly` (authored ports facing away from connecting sections under fold, plus a layered routing fold-back) is tracked in #1167.

## Test plan
- [x] New `tests/test_placement_determinism.py`: order-independence (24 permutations) + a value assertion pinning the canonical result. Fails on `main`, passes here.
- [x] `genomeassembly` fold=5 placement now identical across `PYTHONHASHSEED` 1-6.
- [x] Full suite: 24139 passed, 0 failed, no golden/ratchet edits.
- [x] `ruff check` + `ruff format --check` + `mypy` clean repo-wide.
- [ ] Render-preview verdict (expect "No visual changes": the fix only changes which of two non-deterministic outcomes is chosen on aggressive-fold inputs; default-fold gallery is untouched).

Generated with Claude Code
