### PR TITLE
fix(playground): add missing Copy source button to Astro page

### DIFF
--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -104,6 +104,7 @@ import { base } from "../site";
           <button id="btn-svg">SVG</button>
           <button id="btn-png">PNG</button>
           <button id="btn-share">Share link</button>
+          <button id="btn-copy-source">Copy source</button>
           <button
             id="btn-report"
             class="report-btn"


### PR DESCRIPTION
## Summary

The deployed playground (`https://seqeralabs.github.io/nf-metro/dev/playground/`) hangs forever on "Starting Python runtime…" — the Python runtime never starts and no map renders.

**Cause:** #1175 added a "Copy source" button and wired its click handler in `app.js`:

```js
el("btn-copy-source").addEventListener("click", copySource);
```

The matching `<button id="btn-copy-source">` was added to the standalone test harness (`website/public/playground/harness.html`) but not to the deployed Astro page (`website/src/pages/playground.astro`). On that page `el("btn-copy-source")` is `null`, so the unguarded `addEventListener` throws during init and aborts `app.js` before `boot()` runs. The "Starting Python runtime…" text is the static HTML placeholder; the runtime never actually boots.

This PR adds the button to the Export toolbar, mirroring the harness.

## Verification

Reproduced against the exact live production page:

- **Before:** stuck; console error `Cannot read properties of null (reading 'addEventListener')`.
- **After:** no error; runtime boots and a map renders in ~3s.

Also cross-checked every DOM id `app.js` references against the Astro page — `btn-copy-source` was the only unguarded element missing (`btn-theme` is guarded with `if (btn)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)