### PR TITLE
fix(playground): point bug-report link at seqeralabs/nf-metro

### DIFF
--- a/website/playground-tests/playground.spec.js
+++ b/website/playground-tests/playground.spec.js
@@ -386,7 +386,7 @@ test("bug report builds a prefilled GitHub issue with the map and explanation", 
   const issueUrl = await page.evaluate(() => window.__nfMetroLastIssueUrl);
   const u = new URL(issueUrl);
   expect(u.host).toBe("github.com");
-  expect(u.pathname).toBe("/pinin4fjords/nf-metro/issues/new");
+  expect(u.pathname).toBe("/seqeralabs/nf-metro/issues/new");
   expect(u.searchParams.get("labels")).toBe("playground");
   const body = u.searchParams.get("body");
   expect(body).toContain("Edge renders backwards from uniquenode");

--- a/website/public/playground/app.js
+++ b/website/public/playground/app.js
@@ -3,7 +3,7 @@
 // Pinned so the install path is reproducible; bump deliberately.
 const PYODIDE_VERSION = "v0.27.2";
 
-const REPO = "pinin4fjords/nf-metro";
+const REPO = "seqeralabs/nf-metro";
 
 const SEED = `%%metro title: Example Pipeline
 %%metro line: qc | QC | #2dd4bf


### PR DESCRIPTION
## Summary

The playground "Report a bug" feature builds its pre-filled GitHub issue URL from the `REPO` constant in `website/public/playground/app.js`, which still pointed at the pre-transfer owner `pinin4fjords/nf-metro`. As a result, bug reports submitted from the playground opened against the old repository.

The #1174 org-transfer cleanup updated `website/src/repo.ts` but missed this standalone playground JS (it isn't part of the TS build). This updates the `REPO` constant and the matching e2e assertion to `seqeralabs/nf-metro`.

## Test plan
- [ ] Playground "Report a bug" opens an issue against `github.com/seqeralabs/nf-metro/issues/new`
- [ ] Playground e2e (`playground.spec.js`) passes with the updated path assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)