### PR TITLE
fix(render): gate fold-induced opposing-line fold-backs as FoldThresholdError (#1187)

### DIFF
--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -31,6 +31,7 @@ from nf_metro.layout.labels import (
 from nf_metro.layout.phases.guards import (
     FoldThresholdError,
     assert_render_layout_invariants,
+    iter_opposing_line_overlaps,
 )
 from nf_metro.layout.routing import (
     RoutedPath,
@@ -465,6 +466,11 @@ def render_svg(
                 raise reframed from exc
             raise
 
+    if _fold_back_under_compression(graph):
+        reframed = _fold_threshold_error(graph)
+        if reframed is not None:
+            raise reframed
+
     if font_portability == "paths":
         from nf_metro.render.font_embed import text_to_paths as _text_to_paths
 
@@ -498,6 +504,25 @@ def _fold_threshold_error(graph: MetroGraph) -> FoldThresholdError | None:
         f"bundle curves. Raise --fold-threshold (or the %%metro fold_threshold "
         f"directive), or remove it to render at the default width."
     )
+
+
+def _fold_back_under_compression(graph: MetroGraph) -> bool:
+    """True when a fold-compressed grid leaves a line folding back over itself.
+
+    A too-small fold can collapse an inter-section fan onto a single row where a
+    line runs out along a track and straight back along it.  The doubled-back
+    legs draw collinear on the trunk, so no curve self-check fires and the map
+    renders silently tangled (a station in the overlap is read out of flow
+    order).  Detecting it here lets the render chokepoint reframe the tangle as
+    a :class:`FoldThresholdError`, the same authoring error a fold-induced curve
+    abort raises, instead of emitting the tangled map.
+
+    Guarded on ``_fold_compressed_sections`` so the default (un-folded) render
+    pays nothing: at the natural width the set is empty and this short-circuits.
+    """
+    if not graph._fold_compressed_sections:
+        return False
+    return any(iter_opposing_line_overlaps(graph))
 
 
 def _scale_theme_fonts(theme: Theme, scale: float) -> Theme:

--- a/tests/test_convergence_sink_port_side.py
+++ b/tests/test_convergence_sink_port_side.py
@@ -19,10 +19,14 @@ from pathlib import Path
 
 import pytest
 
+from nf_metro.api import prepare_graph
+from nf_metro.layout import FoldThresholdError
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import PortSide
 from nf_metro.parser.resolve import _expected_flow_side
+from nf_metro.render import render_svg
+from nf_metro.themes import THEMES
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
 
@@ -79,13 +83,22 @@ def _layout(name: str, fold: int, *, validate: bool = False):
     return graph
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="inter-section assemblies fan tangle under fold over-compression (#1187)",
-)
 @pytest.mark.parametrize("fold", [3, 5, 7, 9, 11])
-def test_genomeassembly_renders_clean_under_lowered_fold(fold: int) -> None:
-    _layout("genomeassembly", fold, validate=True)
+def test_genomeassembly_gates_lowered_fold_as_authoring_error(fold: int) -> None:
+    """Under a lowered fold the 5-section grid over-compresses (all 5 relocate),
+    collapsing the inter-section ``assemblies`` fan onto a single row where the
+    line folds back over its own track.  The doubled-back legs draw collinear on
+    the trunk, so the render emits no curve self-check and would otherwise show a
+    silently-tangled map; the render gate surfaces it as a clean
+    :class:`FoldThresholdError` instead (#1187).
+    """
+    graph = prepare_graph(
+        (EXAMPLES / "genomeassembly.mmd").read_text(),
+        layout_options={"fold_threshold": fold},
+    )
+    with pytest.raises(FoldThresholdError) as exc:
+        render_svg(graph, THEMES["nfcore"])
+    assert "fold" in str(exc.value).lower()
 
 
 def test_genomeassembly_sink_exit_and_entry_face_inward() -> None:


### PR DESCRIPTION
## Summary

A `fold_threshold` below a map's natural width can over-compress the section grid so an inter-section fan collapses onto one row, where a line runs out along a track and straight back over it. The doubled-back legs draw collinear on the trunk, so no curve self-check fires: the existing `FoldThresholdError` gate (which only catches `CurveInvariantError`/`SectionHeaderClashError`) misses it, and the map renders **silently tangled**. `examples/genomeassembly.mmd` at `fold_threshold` 3-11 is the real-pipeline case (5/5 sections relocate — the #1088 collapsed-geometry signature).

This extends the render-time gate: after a successful render, when the grid was fold-compressed (`_fold_compressed_sections` non-empty) and a line folds back over its own track (`iter_opposing_line_overlaps`), it raises the same `FoldThresholdError` authoring error a fold-induced curve abort raises, rather than emitting a tangled map. The default (un-folded) render short-circuits on the empty `_fold_compressed_sections` set and pays nothing; previously-fixed fold-compressible fixtures that render clean (section_diamond, shared_sink_parallel, epitopeprediction) are unaffected (they have no fold-back).

Per the #1088 oracle, genomeassembly's 5/5-section relocation is genuine over-compression, not a sound layout with a fixable routing defect, so the gate (the issue's option 2) is the correct outcome rather than a deep fan-routing fix.

Fixes #1187

## Changes

- `render/svg.py`: new `_fold_back_under_compression` helper; `render_svg` raises `FoldThresholdError` when it returns true.
- `tests/test_convergence_sink_port_side.py`: retargets the strict-xfail `test_genomeassembly_renders_clean_under_lowered_fold` (which encoded the routing-fix premise) to a positive `test_genomeassembly_gates_lowered_fold_as_authoring_error` asserting the clean gate error across folds 3-11.

## Test plan
- [x] pytest passes (25000 passed, 6 pre-existing xfails); retargeted gate test fails without the fix, passes with it
- [x] ruff check + ruff format --check + mypy clean (whole repo)
- [x] Gate-coverage ratchet untouched (no `layout/routing/` change); 3.11 ratchet tests pass
- [ ] Visual review of render preview (genomeassembly renders at default fold in the gallery — unaffected; fold path raises rather than renders)

Generated with Claude Code