### PR TITLE
chore: release 1.0.0

### DIFF
--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -5,50 +5,40 @@ slug: releases/1.0.0
 
 _2026-06-30_ · [GitHub release](https://github.com/seqeralabs/nf-metro/releases/tag/1.0.0) · [Diff](https://github.com/seqeralabs/nf-metro/compare/0.7.2...1.0.0)
 
-Major milestone release and first release under the [seqeralabs](https://github.com/seqeralabs/nf-metro) GitHub organisation. 300+ commits since 0.7.2. Existing `.mmd` files render identically.
+Major milestone release and first release under the [seqeralabs](https://github.com/seqeralabs/nf-metro) GitHub organisation. 300+ commits since 0.7.2. The `.mmd` input format is backward compatible - existing files render without edits (many will look better thanks to the routing work below).
 
 ## All four flow directions
 
 nf-metro now supports all four Mermaid graph directions: `LR`, `RL`, `TB`, and `BT`. Previously only `LR` and `TB` were supported; `RL` and `BT` are their respective mirrors, with full routing vocabulary for fold sections, bypass-V, convergence sinks, and perpendicular entries.
 
-## Layout and routing fixes
+## Routing engine
 
-The majority of the code change in this release is engine work. Key areas:
+The majority of the code change in this release is engine work, and most of it is structural rather than a list of isolated fixes. Three large programs ran across the cycle, then a focused fold-routing sprint closed it out.
 
-**Fold routing**
+**Centreline-builder unification.** Edge routing was consolidated onto a single centreline builder that owns corner anchoring and tapering for every route family - entry-wrap, perpendicular-exit up-and-over, U-shaped bypass, TOP-entry staircase, fan L-shapes, and inter-section bundles. What used to be scattered per-case path construction now flows through one declarative inter-section dispatch table and one builder, so curves are correct by construction rather than patched after the fact (#791-#814, plus the #845 symbolic gap-slot model).
 
-Folded sections (where a line wraps across a column boundary) saw the most work:
+**Direction-agnostic layout (AxisFrame).** Layout heuristics that were written against hardcoded `"TB"` string checks were migrated to an `AxisFrame` abstraction with lane accessors and a single offset-regime applier, and the core handlers adopted a `Direction` enum. This is what made the new `RL` and `BT` directions tractable: every routing handler now operates on one canonical orientation, and the per-direction special cases were retired. The `LR`/`TB` rotation model was extended so `RL` and `BT` are derived by mirroring at the seam-classifier layer (#918-#922, #1029-#1049).
 
-- Perpendicular-entry fan line-crossing on folded sections: distinct lines now slot onto parallel approach channels rather than overlapping (#1144).
+**Robustness hardening.** A gate-arm triage pass gave every un-exercised branch in the layout and routing modules a verdict - reachable (with a new fixture), defensive, or a filed bug - and the inter-phase state shared between layout stages was formalised into an explicit protocol. A guard registry with a cost audit and golden baseline now reds CI the moment a layout regresses (#687, #673, #921).
+
+**Fold-threshold routing.** Folded sections (where a line wraps across a column boundary) got the most targeted-fix work, late in the cycle. The keystone: fold-back routes that cannot be drawn cleanly now raise a `FoldThresholdError` and are treated as an authoring constraint rather than emitting broken geometry (#1088). On top of that gate:
+
+- Perpendicular-entry fans slot onto parallel approach channels by feeder order instead of overlapping (#1144).
 - Folded LEFT-exit staircase bundle ordering and concentric nesting (#1143, #1161).
 - Folded bbox bottom aligns to the target section's settled content bottom, not its live bounding box, preventing balance drift on tall fold targets (#1162).
 - Tight 1-row folds no longer leave a visible run-out stub on the bypass-V (#1177).
 - Same-side cul-de-sac entry re-anchors the interior-consumer port instead of routing around it, removing a whole class of U-route generation (#1182).
-- Fold-induced opposing-line fold-backs now raise `FoldThresholdError` rather than producing visually broken routes, treating them as an authoring constraint (#1187).
-- Convergence-sink ports facing the wrong section after fold relocation (#1167).
-- Disconnected components now renormalise grid rows after stacking, preventing section overlap (#1164).
+- Opposing-line fold-backs under fold compression raise `FoldThresholdError` rather than tangling (#1187).
+- Convergence-sink ports no longer face the wrong section after fold relocation (#1167).
+- Disconnected components renormalise grid rows after stacking, preventing section overlap (#1164).
+- Corridor-fed single-line sections re-centre instead of drifting off-trunk (#1173); same-column RIGHT-entry corridor descent no longer jogs before dropping (#1178).
+- TB-section bypass-V seats on the line's lane-side grid column, not a fixed offset (#1163); the post-bypass settling pass runs in both validate modes (#1171); convergence-split placement is deterministic across runs (#1168).
 
-**Perpendicular entry and corridor routing**
-
-- Corridor-fed single-line sections were drifting off-trunk; re-centred and guarded against drift (#1173).
-- Same-column RIGHT-entry corridor descent no longer jogs horizontally before dropping (#1178).
-- Folded perp-entry fan slotting uses feeder approach order to prevent line crossings (#1144).
-
-**Bypass and convergence**
-
-- Post-bypass settling pass now runs in both validate modes, fixing a class of validate-vs-render discrepancy (#1171).
-- TB-section bypass-V now seats on the line's lane-side grid column, not a fixed offset (#1163).
-- Convergence-split section placement is now deterministic across runs (#1168).
-
-**Symmetric diamonds and spacing**
+**Spacing and symmetry.**
 
 - Symmetric 2-way diamonds compact to half pitch through the grid-snap, halving wasted horizontal space (#1076).
-- Upright (TB/BT) label and icon spacing now derives from the AxisFrame rather than hardcoded `"TB"` string checks (#1043).
-- Light theme line width corrected to match `OFFSET_STEP` (was 4 px, now 3 px) (#1073).
-
-**TB/BT rotation unification**
-
-The `LR`/`TB` rotation model was extended to cover all four directions. `RL` and `BT` are derived by mirroring the corresponding forward direction at the seam classifier layer, so all routing handlers operate on a single canonical orientation and the per-direction special cases were removed.
+- Upright (TB/BT) label and icon spacing derives from the `AxisFrame` rather than hardcoded `"TB"` checks (#1043).
+- Light theme line width corrected to match `OFFSET_STEP` (4 px -> 3 px) (#1073).
 
 ## CSS offset-path animations
 
@@ -63,12 +53,25 @@ Brand (`nfcore`, `seqera`) and display mode (`light`, `dark`) are now independen
 A stable Python API:
 
 ```python
-from nf_metro import render_graph, RenderConfig
+from nf_metro.api import render_string, RenderConfig
 
-svg = render_graph(graph_text, RenderConfig(theme="nfcore", mode="dark"))
+svg = render_string(
+    graph_text,
+    theme="nfcore",
+    mode="dark",
+    config=RenderConfig(embed_font=True, responsive=True),
+)
 ```
 
-`RenderConfig` is a typed dataclass covering all CLI flags. The `render-many` CLI command enables batch rendering with the full option set; it strips the XML prolog so output is safe to inline in HTML.
+`render_string` is the one-call entry point. `RenderConfig` is a typed dataclass bundling the render-side output options (font embedding, responsive viewBox, class prefixes, color-scheme handling) for callers who prefer a config object over keyword arguments. The `render-many` CLI command batch-renders a JSON manifest of jobs in a single process, amortising interpreter and import startup across the whole corpus.
+
+## Embedded data manifest
+
+Every render now carries a machine-readable JSON manifest - station visual centres, pill dimensions, and line metadata - factored into a dependency-free `nf_metro.manifest` package and documented as a standard. This is what lets `nf-metro serve` accept a previously rendered SVG as input, and it gives host systems a stable way to map screen coordinates back to graph elements (#623).
+
+## Font portability
+
+Renders can embed the Inter font or convert text to vector paths, so maps display identically whether or not the host has the font installed - important for SVGs that travel into PDFs, slides, and other documents (#839).
 
 ## Live workflow visualisation (`nf-metro serve`)
 
@@ -87,7 +90,7 @@ Rebuilt in [Astro](https://astro.build/) / [Starlight](https://starlight.astro.b
 
 ## CI
 
-- 3-way parallel test split with `pytest-split`, roughly halving CI wall-clock time.
-- Python 3.10 dropped; minimum is now Python 3.11.
+- 3-way parallel test split with `pytest-split` to cut CI wall-clock time.
+- Python 3.10 dropped (EOL); minimum is now Python 3.11.
 - All GitHub Actions refs pinned to full commit SHAs (seqeralabs org policy).
 - Incremental render-diff: PR previews only re-render changed fixtures.

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -7,53 +7,60 @@ _2026-06-30_ · [GitHub release](https://github.com/seqeralabs/nf-metro/releases
 
 Major milestone release and first release under the [seqeralabs](https://github.com/seqeralabs/nf-metro) GitHub organisation. 300+ commits since 0.7.2. Existing `.mmd` files render identically.
 
-## New documentation site
-
-The docs are rebuilt in [Astro](https://astro.build/) with the [Starlight](https://starlight.astro.build/) framework and a Seqera-branded theme, replacing MkDocs-Material:
-
-- **Live metro maps embedded in docs** - every `.mmd` snippet renders live at build time via a Vite plugin; no pre-baked PNGs.
-- **`<Metro>` authoring component** - a three-panel toggle (source, CLI command, map) for self-documenting examples.
-- **Zoomable SVG lightbox** - click any map to pan and zoom.
-- **Versioned docs with in-page version switcher** - each release deploys its own snapshot.
-- **Full-text search** via Pagefind.
-- **Color-chip swatches** in code blocks, Expressive Code formatting, link validation in CI, sitemap, and `lastUpdated` timestamps.
-
-## Interactive browser playground
-
-A browser-based `.mmd` editor powered by [Pyodide](https://pyodide.org/) runs the full Python nf-metro engine client-side:
-
-- Load any bundled example from a dropdown, or import a Nextflow `-with-dag` Mermaid file directly.
-- Graphical topology editing writes back to the `.mmd` source.
-- Zoom controls, debug overlay, brand/mode toggles, and a prefilled bug-report link.
-- Share any diagram via a URL (gzip-compressed so larger diagrams fit).
-- The Pyodide runtime and nf-metro wheel cache on first load via a service worker; subsequent opens are instant.
-
-## Live workflow visualisation (`nf-metro serve`)
-
-`nf-metro serve` connects to a running Nextflow workflow and renders it as a live metro map in the browser, updating as processes start and finish.
-
-Two new options since the initial implementation:
-
-- **SVG input** - pass a previously rendered SVG (with embedded manifest) instead of a `.mmd` source file.
-- **`auto_process` mapping** - `%%metro auto_process: true` and `process_scope:` collapse a Nextflow DAG into a lean process-level map automatically.
-
 ## All four flow directions
 
-nf-metro now supports all four Mermaid flow directions: `LR`, `RL`, `TB`, and `BT`.
+nf-metro now supports all four Mermaid graph directions: `LR`, `RL`, `TB`, and `BT`. Previously only `LR` and `TB` were supported; `RL` and `BT` are their respective mirrors, with full routing vocabulary for fold sections, bypass-V, convergence sinks, and perpendicular entries.
 
-`graph BT` (bottom-to-top) mirrors `TB`: folded sections stack upward, exit ports emerge from the top, and inter-section seams are horizontal. `graph RL` mirrors `LR` with the full routing vocabulary.
+## Layout and routing fixes
 
-## Light and dark as independent axes
+The majority of the code change in this release is engine work. Key areas:
 
-Brand (`nfcore`, `seqera`) and display mode (`light`, `dark`) are now independent. A single rendered SVG carries both palettes via CSS `light-dark()` and adapts to the viewer's `color-scheme` automatically. Logo assets also adapt: the correct light or dark variant is picked without extra directives.
+**Fold routing**
+
+Folded sections (where a line wraps across a column boundary) saw the most work:
+
+- Perpendicular-entry fan line-crossing on folded sections: distinct lines now slot onto parallel approach channels rather than overlapping (#1144).
+- Folded LEFT-exit staircase bundle ordering and concentric nesting (#1143, #1161).
+- Folded bbox bottom aligns to the target section's settled content bottom, not its live bounding box, preventing balance drift on tall fold targets (#1162).
+- Tight 1-row folds no longer leave a visible run-out stub on the bypass-V (#1177).
+- Same-side cul-de-sac entry re-anchors the interior-consumer port instead of routing around it, removing a whole class of U-route generation (#1182).
+- Fold-induced opposing-line fold-backs now raise `FoldThresholdError` rather than producing visually broken routes, treating them as an authoring constraint (#1187).
+- Convergence-sink ports facing the wrong section after fold relocation (#1167).
+- Disconnected components now renormalise grid rows after stacking, preventing section overlap (#1164).
+
+**Perpendicular entry and corridor routing**
+
+- Corridor-fed single-line sections were drifting off-trunk; re-centred and guarded against drift (#1173).
+- Same-column RIGHT-entry corridor descent no longer jogs horizontally before dropping (#1178).
+- Folded perp-entry fan slotting uses feeder approach order to prevent line crossings (#1144).
+
+**Bypass and convergence**
+
+- Post-bypass settling pass now runs in both validate modes, fixing a class of validate-vs-render discrepancy (#1171).
+- TB-section bypass-V now seats on the line's lane-side grid column, not a fixed offset (#1163).
+- Convergence-split section placement is now deterministic across runs (#1168).
+
+**Symmetric diamonds and spacing**
+
+- Symmetric 2-way diamonds compact to half pitch through the grid-snap, halving wasted horizontal space (#1076).
+- Upright (TB/BT) label and icon spacing now derives from the AxisFrame rather than hardcoded `"TB"` string checks (#1043).
+- Light theme line width corrected to match `OFFSET_STEP` (was 4 px, now 3 px) (#1073).
+
+**TB/BT rotation unification**
+
+The `LR`/`TB` rotation model was extended to cover all four directions. `RL` and `BT` are derived by mirroring the corresponding forward direction at the seam classifier layer, so all routing handlers operate on a single canonical orientation and the per-direction special cases were removed.
 
 ## CSS offset-path animations
 
-Ball animations switch from SMIL `<animateMotion>` to CSS `offset-path`, fixing animation in browsers with SMIL disabled and removing a class of SVG-in-HTML embedding issues.
+Ball animations switch from SMIL `<animateMotion>` to CSS `offset-path`. SMIL is disabled in some host environments and causes SVG-in-HTML embedding issues; `offset-path` works reliably across all modern browsers.
 
-## Render API
+## Light and dark as independent axes
 
-A stable Python API is available:
+Brand (`nfcore`, `seqera`) and display mode (`light`, `dark`) are now independent. A single rendered SVG carries both palettes via CSS `light-dark()` and adapts to the viewer's `color-scheme` automatically. Logo assets also adapt per `color-scheme` with no extra directives required.
+
+## Render API and render-many
+
+A stable Python API:
 
 ```python
 from nf_metro import render_graph, RenderConfig
@@ -61,22 +68,26 @@ from nf_metro import render_graph, RenderConfig
 svg = render_graph(graph_text, RenderConfig(theme="nfcore", mode="dark"))
 ```
 
-`RenderConfig` is a typed dataclass covering all CLI flags. The `render-many` CLI command enables batch rendering with the full option set (used internally for the docs build).
+`RenderConfig` is a typed dataclass covering all CLI flags. The `render-many` CLI command enables batch rendering with the full option set; it strips the XML prolog so output is safe to inline in HTML.
 
-## CI and test improvements
+## Live workflow visualisation (`nf-metro serve`)
 
-- **3-way parallel test split** with `pytest-split`, roughly halving wall-clock test time.
-- **Python 3.10 dropped** - minimum is now Python 3.11.
-- **pip caching** on lint and test jobs.
-- **All GitHub Actions refs pinned to full commit SHAs** (seqeralabs org policy).
-- **Incremental render-diff** - PR previews only re-render changed fixtures.
+`nf-metro serve` connects to a running Nextflow workflow and renders a live metro map in the browser, updating as processes progress. New in this release:
 
-## Layout and routing fixes
+- **SVG input** - accepts a previously rendered SVG (with embedded manifest) instead of a `.mmd` source.
+- **`auto_process` mapping** - `%%metro auto_process: true` and `process_scope:` collapse a Nextflow DAG into a lean process-level map automatically.
 
-Key areas fixed since 0.7.2:
+## Interactive browser playground
 
-- **Fold routing** - perp-entry fan line-crossing (#1144), folded LEFT-exit staircase ordering (#1143/#1161), folded bbox bottom alignment (#1162), tight 1-row fold bypass run-out (#1177), same-side cul-de-sac re-anchor (#1182), fold-induced opposing-line fold-backs gated as authoring errors (#1187).
-- **Convergence and bypass** - corridor-fed single-line re-centering (#1173), same-column RIGHT-entry corridor descent (#1178), fold-relocated convergence-sink port facing (#1167), disconnected-component grid-row renormalisation (#1164).
-- **Symmetric diamonds** - half-pitch compact layout (#1076).
-- **Upright label/icon spacing** via AxisFrame (#1043).
-- **Light theme line width** corrected to match `OFFSET_STEP` (#1073).
+A browser-based editor powered by [Pyodide](https://pyodide.org/) runs the full Python engine client-side - edit `.mmd` source, see the map update live. Features: example dropdown, Nextflow DAG import, graphical topology editing, zoom controls, brand/mode toggles, gzip-compressed share URLs, and a service-worker cache so the Pyodide runtime loads instantly after the first visit.
+
+## New documentation site
+
+Rebuilt in [Astro](https://astro.build/) / [Starlight](https://starlight.astro.build/) with a Seqera-branded theme, replacing MkDocs-Material. Metro maps render live at build time; the `<Metro>` component presents source, CLI command, and rendered map as a three-panel toggle. Versioned docs with an in-page version switcher, Pagefind full-text search, ZoomableSVG lightbox, color-chip swatches in code blocks, and link validation in CI.
+
+## CI
+
+- 3-way parallel test split with `pytest-split`, roughly halving CI wall-clock time.
+- Python 3.10 dropped; minimum is now Python 3.11.
+- All GitHub Actions refs pinned to full commit SHAs (seqeralabs org policy).
+- Incremental render-diff: PR previews only re-render changed fixtures.

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -5,61 +5,55 @@ slug: releases/1.0.0
 
 _2026-06-30_ · [GitHub release](https://github.com/seqeralabs/nf-metro/releases/tag/1.0.0) · [Diff](https://github.com/seqeralabs/nf-metro/compare/0.7.2...1.0.0)
 
-Major milestone release. 300+ commits since 0.7.2, marking the project's move to the [seqeralabs](https://github.com/seqeralabs/nf-metro) GitHub organisation and a stable public API. Existing `.mmd` files render identically - all changes are additive or internal.
+Major milestone release and first release under the [seqeralabs](https://github.com/seqeralabs/nf-metro) GitHub organisation. 300+ commits since 0.7.2. Existing `.mmd` files render identically.
 
 ## New documentation site
 
-The docs are rebuilt from scratch in [Astro](https://astro.build/) with the [Starlight](https://starlight.astro.build/) framework and a Seqera-branded theme. Highlights:
+The docs are rebuilt in [Astro](https://astro.build/) with the [Starlight](https://starlight.astro.build/) framework and a Seqera-branded theme, replacing MkDocs-Material:
 
-- **Live metro maps embedded in docs** - every `.mmd` snippet in the guides renders live at build time via a Vite plugin; no pre-baked PNGs needed.
-- **`<Metro>` authoring component** - a three-panel toggle (source, CLI command, map) makes `.mmd` examples self-documenting.
-- **Zoomable SVG lightbox** - click any map in the docs to open a pan-and-zoom lightbox.
-- **Versioned docs with in-page version switcher** - each GitHub Release deploys its own snapshot; the switcher lets readers jump between versions.
-- **Full-text search** - Pagefind index, tuned for gallery pages.
-- **Color-chip swatches** - `%%metro` color hex codes render as inline swatches in code blocks.
-- **Expressive Code** - terminal frames, diff markers, and line highlights throughout.
-- **Link validation** in CI - broken internal links fail the build.
-- **Sitemap** and `lastUpdated` timestamps on every page.
+- **Live metro maps embedded in docs** - every `.mmd` snippet renders live at build time via a Vite plugin; no pre-baked PNGs.
+- **`<Metro>` authoring component** - a three-panel toggle (source, CLI command, map) for self-documenting examples.
+- **Zoomable SVG lightbox** - click any map to pan and zoom.
+- **Versioned docs with in-page version switcher** - each release deploys its own snapshot.
+- **Full-text search** via Pagefind.
+- **Color-chip swatches** in code blocks, Expressive Code formatting, link validation in CI, sitemap, and `lastUpdated` timestamps.
 
-## All four flow directions now supported
+## Interactive browser playground
+
+A browser-based `.mmd` editor powered by [Pyodide](https://pyodide.org/) runs the full Python nf-metro engine client-side:
+
+- Load any bundled example from a dropdown, or import a Nextflow `-with-dag` Mermaid file directly.
+- Graphical topology editing writes back to the `.mmd` source.
+- Zoom controls, debug overlay, brand/mode toggles, and a prefilled bug-report link.
+- Share any diagram via a URL (gzip-compressed so larger diagrams fit).
+- The Pyodide runtime and nf-metro wheel cache on first load via a service worker; subsequent opens are instant.
+
+## Live workflow visualisation (`nf-metro serve`)
+
+`nf-metro serve` connects to a running Nextflow workflow and renders it as a live metro map in the browser, updating as processes start and finish.
+
+Two new options since the initial implementation:
+
+- **SVG input** - pass a previously rendered SVG (with embedded manifest) instead of a `.mmd` source file.
+- **`auto_process` mapping** - `%%metro auto_process: true` and `process_scope:` collapse a Nextflow DAG into a lean process-level map automatically.
+
+## All four flow directions
 
 nf-metro now supports all four Mermaid flow directions: `LR`, `RL`, `TB`, and `BT`.
 
-`graph BT` (bottom-to-top) is the mirror of `TB`: folded sections stack upward, exit ports emerge from the top, and inter-section seams are horizontal. `graph RL` is the mirror of `LR` with the same routing vocabulary.
-
-```metro
-graph BT
-    subgraph preprocess [Pre-processing]
-        %%metro entry: bottom | main
-        %%metro exit: top | main
-        ...
-    end
-```
+`graph BT` (bottom-to-top) mirrors `TB`: folded sections stack upward, exit ports emerge from the top, and inter-section seams are horizontal. `graph RL` mirrors `LR` with the full routing vocabulary.
 
 ## Light and dark as independent axes
 
-Brand (`nfcore`, `seqera`) and display mode (`light`, `dark`) are now independent axes. A single rendered SVG carries both palettes via CSS `light-dark()` and adapts to the viewer's `color-scheme` automatically. The `%%metro mode:` directive (or `--mode` CLI flag) only needs setting when baking a concrete PNG.
+Brand (`nfcore`, `seqera`) and display mode (`light`, `dark`) are now independent. A single rendered SVG carries both palettes via CSS `light-dark()` and adapts to the viewer's `color-scheme` automatically. Logo assets also adapt: the correct light or dark variant is picked without extra directives.
 
-The logo asset also adapts: `%%metro style: nfcore` now picks the correct light or dark logo variant depending on the viewer's color scheme, with no extra directives needed.
+## CSS offset-path animations
 
-## Playground improvements
-
-The [interactive playground](https://seqeralabs.github.io/nf-metro/playground/) is now a full Astro page embedded in the docs site:
-
-- **Service worker caching** - the Pyodide runtime and the nf-metro wheel cache on first load; subsequent opens are instant.
-- **Compressed share links** - shared URLs are gzip-compressed, fitting larger diagrams in a URL.
-- **Copy source button** - one click copies the current `.mmd` source to the clipboard.
-
-## Live serve improvements
-
-`nf-metro serve` gains two new modes:
-
-- **SVG input** - pass a previously rendered SVG (with embedded manifest) instead of a `.mmd` file. Useful for sharing interactive maps without exposing source.
-- **`auto_process` mapping** - `%%metro auto_process: true` and `process_scope:` directives create a lean process-level map from a Nextflow DAG, collapsing subgraph scaffolding automatically.
+Ball animations switch from SMIL `<animateMotion>` to CSS `offset-path`, fixing animation in browsers with SMIL disabled and removing a class of SVG-in-HTML embedding issues.
 
 ## Render API
 
-A stable Python API is now public:
+A stable Python API is available:
 
 ```python
 from nf_metro import render_graph, RenderConfig
@@ -67,27 +61,22 @@ from nf_metro import render_graph, RenderConfig
 svg = render_graph(graph_text, RenderConfig(theme="nfcore", mode="dark"))
 ```
 
-`RenderConfig` is a typed dataclass covering all CLI flags. The function warns on unknown kwargs rather than silently ignoring them.
-
-## CSS offset-path animations
-
-Ball animations switch from SMIL `<animateMotion>` to CSS `offset-path`. This makes animations work in more host environments (including browsers with SMIL disabled) and removes a class of SVG-in-HTML embedding issues.
+`RenderConfig` is a typed dataclass covering all CLI flags. The `render-many` CLI command enables batch rendering with the full option set (used internally for the docs build).
 
 ## CI and test improvements
 
-- **3-way parallel test split** with `pytest-split` - the suite runs in three parallel jobs, cutting wall-clock time roughly in half.
+- **3-way parallel test split** with `pytest-split`, roughly halving wall-clock test time.
 - **Python 3.10 dropped** - minimum is now Python 3.11.
 - **pip caching** on lint and test jobs.
 - **All GitHub Actions refs pinned to full commit SHAs** (seqeralabs org policy).
-- **Incremental render-diff** - PR render previews only re-render changed fixtures, not the full gallery.
+- **Incremental render-diff** - PR previews only re-render changed fixtures.
 
 ## Layout and routing fixes
 
-Dozens of routing correctness fixes across fold, bypass, convergence, and perpendicular-entry patterns. Key areas:
+Key areas fixed since 0.7.2:
 
-- **Fold routing** - fold-induced perp-entry fan crossing (#1144), folded LEFT-exit staircase ordering (#1143/#1161), folded bbox bottom alignment (#1162), tight 1-row fold bypass run-out (#1177), same-side cul-de-sac re-anchor (#1182), fold-induced opposing-line fold-backs gated as authoring errors (#1187).
-- **Convergence and bypass** - corridor-fed single-line re-centering (#1173), same-column RIGHT-entry corridor descent (#1178), fold-relocated convergence-sink port facing (#1167), disconnected component grid-row renormalisation (#1164).
-- **Symmetric diamonds** - half-pitch compact diamonds (#1076).
+- **Fold routing** - perp-entry fan line-crossing (#1144), folded LEFT-exit staircase ordering (#1143/#1161), folded bbox bottom alignment (#1162), tight 1-row fold bypass run-out (#1177), same-side cul-de-sac re-anchor (#1182), fold-induced opposing-line fold-backs gated as authoring errors (#1187).
+- **Convergence and bypass** - corridor-fed single-line re-centering (#1173), same-column RIGHT-entry corridor descent (#1178), fold-relocated convergence-sink port facing (#1167), disconnected-component grid-row renormalisation (#1164).
+- **Symmetric diamonds** - half-pitch compact layout (#1076).
 - **Upright label/icon spacing** via AxisFrame (#1043).
-- **Light theme** line width corrected to match `OFFSET_STEP` (#1073).
-- **Debug overlay** colors visible on light backgrounds.
+- **Light theme line width** corrected to match `OFFSET_STEP` (#1073).

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -1,0 +1,93 @@
+---
+title: "v1.0.0"
+slug: releases/1.0.0
+---
+
+_2026-06-30_ · [GitHub release](https://github.com/seqeralabs/nf-metro/releases/tag/1.0.0) · [Diff](https://github.com/seqeralabs/nf-metro/compare/0.7.2...1.0.0)
+
+Major milestone release. 300+ commits since 0.7.2, marking the project's move to the [seqeralabs](https://github.com/seqeralabs/nf-metro) GitHub organisation and a stable public API. Existing `.mmd` files render identically - all changes are additive or internal.
+
+## New documentation site
+
+The docs are rebuilt from scratch in [Astro](https://astro.build/) with the [Starlight](https://starlight.astro.build/) framework and a Seqera-branded theme. Highlights:
+
+- **Live metro maps embedded in docs** - every `.mmd` snippet in the guides renders live at build time via a Vite plugin; no pre-baked PNGs needed.
+- **`<Metro>` authoring component** - a three-panel toggle (source, CLI command, map) makes `.mmd` examples self-documenting.
+- **Zoomable SVG lightbox** - click any map in the docs to open a pan-and-zoom lightbox.
+- **Versioned docs with in-page version switcher** - each GitHub Release deploys its own snapshot; the switcher lets readers jump between versions.
+- **Full-text search** - Pagefind index, tuned for gallery pages.
+- **Color-chip swatches** - `%%metro` color hex codes render as inline swatches in code blocks.
+- **Expressive Code** - terminal frames, diff markers, and line highlights throughout.
+- **Link validation** in CI - broken internal links fail the build.
+- **Sitemap** and `lastUpdated` timestamps on every page.
+
+## All four flow directions now supported
+
+nf-metro now supports all four Mermaid flow directions: `LR`, `RL`, `TB`, and `BT`.
+
+`graph BT` (bottom-to-top) is the mirror of `TB`: folded sections stack upward, exit ports emerge from the top, and inter-section seams are horizontal. `graph RL` is the mirror of `LR` with the same routing vocabulary.
+
+```metro
+graph BT
+    subgraph preprocess [Pre-processing]
+        %%metro entry: bottom | main
+        %%metro exit: top | main
+        ...
+    end
+```
+
+## Light and dark as independent axes
+
+Brand (`nfcore`, `seqera`) and display mode (`light`, `dark`) are now independent axes. A single rendered SVG carries both palettes via CSS `light-dark()` and adapts to the viewer's `color-scheme` automatically. The `%%metro mode:` directive (or `--mode` CLI flag) only needs setting when baking a concrete PNG.
+
+The logo asset also adapts: `%%metro style: nfcore` now picks the correct light or dark logo variant depending on the viewer's color scheme, with no extra directives needed.
+
+## Playground improvements
+
+The [interactive playground](https://seqeralabs.github.io/nf-metro/playground/) is now a full Astro page embedded in the docs site:
+
+- **Service worker caching** - the Pyodide runtime and the nf-metro wheel cache on first load; subsequent opens are instant.
+- **Compressed share links** - shared URLs are gzip-compressed, fitting larger diagrams in a URL.
+- **Copy source button** - one click copies the current `.mmd` source to the clipboard.
+
+## Live serve improvements
+
+`nf-metro serve` gains two new modes:
+
+- **SVG input** - pass a previously rendered SVG (with embedded manifest) instead of a `.mmd` file. Useful for sharing interactive maps without exposing source.
+- **`auto_process` mapping** - `%%metro auto_process: true` and `process_scope:` directives create a lean process-level map from a Nextflow DAG, collapsing subgraph scaffolding automatically.
+
+## Render API
+
+A stable Python API is now public:
+
+```python
+from nf_metro import render_graph, RenderConfig
+
+svg = render_graph(graph_text, RenderConfig(theme="nfcore", mode="dark"))
+```
+
+`RenderConfig` is a typed dataclass covering all CLI flags. The function warns on unknown kwargs rather than silently ignoring them.
+
+## CSS offset-path animations
+
+Ball animations switch from SMIL `<animateMotion>` to CSS `offset-path`. This makes animations work in more host environments (including browsers with SMIL disabled) and removes a class of SVG-in-HTML embedding issues.
+
+## CI and test improvements
+
+- **3-way parallel test split** with `pytest-split` - the suite runs in three parallel jobs, cutting wall-clock time roughly in half.
+- **Python 3.10 dropped** - minimum is now Python 3.11.
+- **pip caching** on lint and test jobs.
+- **All GitHub Actions refs pinned to full commit SHAs** (seqeralabs org policy).
+- **Incremental render-diff** - PR render previews only re-render changed fixtures, not the full gallery.
+
+## Layout and routing fixes
+
+Dozens of routing correctness fixes across fold, bypass, convergence, and perpendicular-entry patterns. Key areas:
+
+- **Fold routing** - fold-induced perp-entry fan crossing (#1144), folded LEFT-exit staircase ordering (#1143/#1161), folded bbox bottom alignment (#1162), tight 1-row fold bypass run-out (#1177), same-side cul-de-sac re-anchor (#1182), fold-induced opposing-line fold-backs gated as authoring errors (#1187).
+- **Convergence and bypass** - corridor-fed single-line re-centering (#1173), same-column RIGHT-entry corridor descent (#1178), fold-relocated convergence-sink port facing (#1167), disconnected component grid-row renormalisation (#1164).
+- **Symmetric diamonds** - half-pitch compact diamonds (#1076).
+- **Upright label/icon spacing** via AxisFrame (#1043).
+- **Light theme** line width corrected to match `OFFSET_STEP` (#1073).
+- **Debug overlay** colors visible on light backgrounds.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -4,9 +4,10 @@ title: "Releases"
 
 Release notes for nf-metro, newest first.
 
-| Version                             | Date       | Highlights                                                                                      |
-| ----------------------------------- | ---------- | ----------------------------------------------------------------------------------------------- |
-| [v0.7.2](/nf-metro/releases/0.7.2/) | 2026-05-18 | Rowspan bbox shrink fix                                                                         |
+| Version                             | Date       | Highlights                                                                                                                   |
+| ----------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [v1.0.0](/nf-metro/releases/1.0.0/) | 2026-06-30 | Astro/Starlight docs site, all four flow directions, light/dark axis, playground overhaul, stable render API, CSS animations |
+| [v0.7.2](/nf-metro/releases/0.7.2/) | 2026-05-18 | Rowspan bbox shrink fix                                                                                                      |
 | [v0.7.1](/nf-metro/releases/0.7.1/) | 2026-05-17 | Bypass row-gap fix                                                                              |
 | [v0.7.0](/nf-metro/releases/0.7.0/) | 2026-05-17 | HTML export, new directives, dashed/dotted lines, richer file icons, layout invariant framework |
 | [v0.6.1](/nf-metro/releases/0.6.1/) | 2026-03-06 | Docs build fix                                                                                  |

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -4,33 +4,33 @@ title: "Releases"
 
 Release notes for nf-metro, newest first.
 
-| Version                             | Date       | Highlights                                                                                                                   |
-| ----------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| [v1.0.0](/nf-metro/releases/1.0.0/) | 2026-06-30 | Astro/Starlight docs site, all four flow directions, light/dark axis, playground overhaul, stable render API, CSS animations |
-| [v0.7.2](/nf-metro/releases/0.7.2/) | 2026-05-18 | Rowspan bbox shrink fix                                                                                                      |
-| [v0.7.1](/nf-metro/releases/0.7.1/) | 2026-05-17 | Bypass row-gap fix                                                                              |
-| [v0.7.0](/nf-metro/releases/0.7.0/) | 2026-05-17 | HTML export, new directives, dashed/dotted lines, richer file icons, layout invariant framework |
-| [v0.6.1](/nf-metro/releases/0.6.1/) | 2026-03-06 | Docs build fix                                                                                  |
-| [v0.6.0](/nf-metro/releases/0.6.0/) | 2026-03-06 | variantbenchmarking pipeline, routing improvements                                              |
-| [v0.5.4](/nf-metro/releases/0.5.4/) | 2026-02-27 | Animation timing fix, diamond path fix                                                          |
-| [v0.5.3](/nf-metro/releases/0.5.3/) | 2026-02-27 | Section header prominence                                                                       |
-| [v0.5.2](/nf-metro/releases/0.5.2/) | 2026-02-25 | Label spacing and file icon sizing                                                              |
-| [v0.5.1](/nf-metro/releases/0.5.1/) | 2026-02-25 | variantbenchmarking example and layout fixes                                                    |
-| [v0.5.0](/nf-metro/releases/0.5.0/) | 2026-02-24 | Diamond fork-joins, multi-line labels, multiple file icons, configurable spacing                |
-| [v0.4.7](/nf-metro/releases/0.4.7/) | 2026-02-20 | Animation and section box fixes                                                                 |
-| [v0.4.6](/nf-metro/releases/0.4.6/) | 2026-02-20 | SVG newline, TB spacing, bbox for file icons                                                    |
-| [v0.4.5](/nf-metro/releases/0.4.5/) | 2026-02-20 | Bold labels, animation stroke, symmetric diagonals                                              |
-| [v0.4.4](/nf-metro/releases/0.4.4/) | 2026-02-19 | Light theme visibility                                                                          |
-| [v0.4.3](/nf-metro/releases/0.4.3/) | 2026-02-19 | Font sizes, entry divergence padding, fork/join gap                                             |
-| [v0.4.2](/nf-metro/releases/0.4.2/) | 2026-02-19 | rnaseq label fixes                                                                              |
-| [v0.4.1](/nf-metro/releases/0.4.1/) | 2026-02-19 | Column gap, label bbox, canvas sizing                                                           |
-| [v0.4.0](/nf-metro/releases/0.4.0/) | 2026-02-19 | Nextflow DAG import, bypass routing below sections, span ordering                               |
-| [v0.3.0](/nf-metro/releases/0.3.0/) | 2026-02-18 | Guide examples, layout fixes                                                                    |
-| [v0.2.2](/nf-metro/releases/0.2.2/) | 2026-02-17 | Pages:write permission fix                                                                      |
-| [v0.2.1](/nf-metro/releases/0.2.1/) | 2026-02-17 | GitHub Pages build trigger fix                                                                  |
-| [v0.2.0](/nf-metro/releases/0.2.0/) | 2026-02-17 | Section overlap fixes, docs site, topology stress tests                                         |
-| [v0.1.1](/nf-metro/releases/0.1.1/) | 2026-02-16 | PyPI README image fix                                                                           |
-| [v0.1](/nf-metro/releases/0.1/)     | 2026-02-16 | Initial release                                                                                 |
+| Version                             | Date       | Highlights                                                                                                                                                                                  |
+| ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [v1.0.0](/nf-metro/releases/1.0.0/) | 2026-06-30 | Routing engine rebuilt onto a single centreline builder, all four flow directions (BT/RL added), light/dark as an orthogonal axis, stable render API, embedded data manifest, new docs site |
+| [v0.7.2](/nf-metro/releases/0.7.2/) | 2026-05-18 | Rowspan bbox shrink fix                                                                                                                                                                     |
+| [v0.7.1](/nf-metro/releases/0.7.1/) | 2026-05-17 | Bypass row-gap fix                                                                                                                                                                          |
+| [v0.7.0](/nf-metro/releases/0.7.0/) | 2026-05-17 | HTML export, new directives, dashed/dotted lines, richer file icons, layout invariant framework                                                                                             |
+| [v0.6.1](/nf-metro/releases/0.6.1/) | 2026-03-06 | Docs build fix                                                                                                                                                                              |
+| [v0.6.0](/nf-metro/releases/0.6.0/) | 2026-03-06 | variantbenchmarking pipeline, routing improvements                                                                                                                                          |
+| [v0.5.4](/nf-metro/releases/0.5.4/) | 2026-02-27 | Animation timing fix, diamond path fix                                                                                                                                                      |
+| [v0.5.3](/nf-metro/releases/0.5.3/) | 2026-02-27 | Section header prominence                                                                                                                                                                   |
+| [v0.5.2](/nf-metro/releases/0.5.2/) | 2026-02-25 | Label spacing and file icon sizing                                                                                                                                                          |
+| [v0.5.1](/nf-metro/releases/0.5.1/) | 2026-02-25 | variantbenchmarking example and layout fixes                                                                                                                                                |
+| [v0.5.0](/nf-metro/releases/0.5.0/) | 2026-02-24 | Diamond fork-joins, multi-line labels, multiple file icons, configurable spacing                                                                                                            |
+| [v0.4.7](/nf-metro/releases/0.4.7/) | 2026-02-20 | Animation and section box fixes                                                                                                                                                             |
+| [v0.4.6](/nf-metro/releases/0.4.6/) | 2026-02-20 | SVG newline, TB spacing, bbox for file icons                                                                                                                                                |
+| [v0.4.5](/nf-metro/releases/0.4.5/) | 2026-02-20 | Bold labels, animation stroke, symmetric diagonals                                                                                                                                          |
+| [v0.4.4](/nf-metro/releases/0.4.4/) | 2026-02-19 | Light theme visibility                                                                                                                                                                      |
+| [v0.4.3](/nf-metro/releases/0.4.3/) | 2026-02-19 | Font sizes, entry divergence padding, fork/join gap                                                                                                                                         |
+| [v0.4.2](/nf-metro/releases/0.4.2/) | 2026-02-19 | rnaseq label fixes                                                                                                                                                                          |
+| [v0.4.1](/nf-metro/releases/0.4.1/) | 2026-02-19 | Column gap, label bbox, canvas sizing                                                                                                                                                       |
+| [v0.4.0](/nf-metro/releases/0.4.0/) | 2026-02-19 | Nextflow DAG import, bypass routing below sections, span ordering                                                                                                                           |
+| [v0.3.0](/nf-metro/releases/0.3.0/) | 2026-02-18 | Guide examples, layout fixes                                                                                                                                                                |
+| [v0.2.2](/nf-metro/releases/0.2.2/) | 2026-02-17 | Pages:write permission fix                                                                                                                                                                  |
+| [v0.2.1](/nf-metro/releases/0.2.1/) | 2026-02-17 | GitHub Pages build trigger fix                                                                                                                                                              |
+| [v0.2.0](/nf-metro/releases/0.2.0/) | 2026-02-17 | Section overlap fixes, docs site, topology stress tests                                                                                                                                     |
+| [v0.1.1](/nf-metro/releases/0.1.1/) | 2026-02-16 | PyPI README image fix                                                                                                                                                                       |
+| [v0.1](/nf-metro/releases/0.1/)     | 2026-02-16 | Initial release                                                                                                                                                                             |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.0.0"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [{ name = "Jonathan Manning", email = "jonathan.manning@seqera.io" }]
 maintainers = [{ name = "Jonathan Manning", email = "jonathan.manning@seqera.io" }]
 keywords = [
@@ -28,7 +28,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -83,7 +82,7 @@ xfail_strict = true
 addopts = "-rxX -n auto"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "ANN", "C901"]
@@ -107,7 +106,7 @@ max-complexity = 30
 files = ["src"]
 mypy_path = "src"
 explicit_package_bases = true
-python_version = "3.10"
+python_version = "3.11"
 ignore_missing_imports = false
 strict_optional = true
 disallow_any_generics = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "0.7.2"
+version = "1.0.0"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "0.7.2"
+__version__ = "1.0.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- Bumps version to `1.0.0` in `pyproject.toml` and `__init__.py`
- Adds `docs/releases/1.0.0.md` and wires it into the releases index

**Highlights since 0.7.2 (300+ commits):**

- **Routing engine rebuilt, not just patched** - edge routing consolidated onto a single centreline builder with a declarative inter-section dispatch table (#791-#814, #845); layout heuristics migrated to a direction-agnostic `AxisFrame` + `Direction` enum (#918-#922, #1029-#1049); gate-arm triage + guard registry + explicit inter-phase state protocol for robustness (#687, #673, #921). This structural work is the bulk of the diff.
- **All four flow directions** - `RL` and `BT` join `LR` and `TB`, derived by mirroring at the seam classifier so handlers stay single-orientation
- **Fold-threshold routing** - `FoldThresholdError` gate plus a sprint of fold/bypass/convergence/corridor fixes (#1088, #1143-#1187)
- **Light/dark as orthogonal axes** - brand and mode independent; SVGs carry both palettes via `light-dark()` and adapt automatically
- **Embedded data manifest** - machine-readable JSON in every render, underpinning serve-from-SVG and host integrations (#623)
- **Font portability** - embed Inter or convert text to paths so maps render identically off-host (#839)
- **Public render API** - `render_string(text, theme=..., mode=..., config=RenderConfig(...))` stable typed interface, plus batch `render-many`
- **Astro/Starlight docs site** - rebuilt from scratch with Seqera theme, live embedded metro maps, versioned docs with in-page switcher, ZoomableSVG lightbox, full-text search, link validation in CI
- **Playground overhaul** - full Astro page, service-worker caching, gzip-compressed share links, copy source button
- **Live serve** - SVG input mode, `auto_process` mapping for lean process-level maps
- **CSS offset-path animations** - replace SMIL `<animateMotion>` for broader host compatibility
- **CI** - 3-way parallel pytest split, SHA-pinned actions, Python 3.10 dropped, pip caching
- **Repo transfer** to seqeralabs org with owner reference updates

## After merge

Create the GitHub Release at https://github.com/seqeralabs/nf-metro/releases/new

- **Tag:** `1.0.0`
- **Title:** `1.0.0 - Routing engine rebuild, all flow directions, stable API`
- **Body:** paste the content of `docs/releases/1.0.0.md` (drop the frontmatter block and the heading)

Publishing triggers:
- `publish.yml` -> builds and uploads to PyPI
- `docs.yml` -> deploys versioned docs and updates the `latest` alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)
