### PR TITLE
fix(render): emit generic fallback after Inter in --embed-font output

### DIFF
--- a/src/nf_metro/render/font_embed.py
+++ b/src/nf_metro/render/font_embed.py
@@ -24,11 +24,26 @@ import re
 from collections import namedtuple
 from pathlib import Path
 
-__all__ = ["embed_font", "text_to_paths", "EMBEDDED_FONT_FAMILY"]
+__all__ = [
+    "embed_font",
+    "text_to_paths",
+    "EMBEDDED_FONT_FAMILY",
+    "EMBEDDED_FONT_STACK",
+]
 
 _FONTS_DIR = Path(__file__).parent.parent / "fonts"
 
+# Face name declared by the injected @font-face rule.
 EMBEDDED_FONT_FAMILY = "Inter"
+
+# font-family value written onto text elements: the embedded face first, a
+# generic sans-serif fallback last.  Where the @font-face is honoured Inter
+# wins; where the <style> is stripped (e.g. GitHub's SVG sanitiser) the value
+# degrades to sans-serif instead of the browser's serif default for an
+# unknown family.
+EMBEDDED_FONT_STACK = (
+    f"{EMBEDDED_FONT_FAMILY}, 'Helvetica Neue', Helvetica, Arial, sans-serif"
+)
 
 # Attributes to drop from text elements when converting to paths
 # (they become meaningless once text is gone).
@@ -111,7 +126,7 @@ def _parse_dy(dy_str: str, font_size: float) -> float:
 
 
 def embed_font(svg: str) -> str:
-    """Inject an Inter @font-face block and update font-family to 'Inter'.
+    """Inject an Inter @font-face block and update font-family to the embedded stack.
 
     The bundled WOFF2 files cover Latin Basic and Latin-1 Supplement
     (U+0020-U+00FF), which is sufficient for typical nf-metro pipeline names.
@@ -144,10 +159,11 @@ def embed_font(svg: str) -> str:
             # Fallback: insert right after the opening <svg …> tag.
             svg = re.sub(r"(<svg\b[^>]*>)", r"\1" + style_block, svg, count=1)
 
-    # Replace all font-family attributes on text elements with Inter.
+    # Replace all font-family attributes on text elements with the embedded
+    # stack (Inter first, generic sans-serif fallback last).
     svg = re.sub(
         r'(font-family=")[^"]*(")',
-        rf"\g<1>{EMBEDDED_FONT_FAMILY}\g<2>",
+        rf"\g<1>{EMBEDDED_FONT_STACK}\g<2>",
         svg,
     )
     return svg

--- a/tests/test_font_portability.py
+++ b/tests/test_font_portability.py
@@ -7,6 +7,7 @@ Invariants:
   and leaves no <text> elements in the output.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -47,11 +48,18 @@ def test_embed_font_contains_base64_data_uri() -> None:
 
 
 @pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")
-def test_embed_font_replaces_font_family_with_inter() -> None:
-    """All font-family attributes must be updated to 'Inter' when embedding."""
-    svg = _render(FIXTURE_FILE, "embed")
-    assert "Helvetica" not in svg, "Helvetica family should be replaced by Inter"
-    assert 'font-family="Inter"' in svg or "font-family: Inter" in svg
+@pytest.mark.parametrize("fixture", EXAMPLES, ids=lambda p: p.name)
+def test_embed_font_family_has_generic_fallback(fixture: Path) -> None:
+    """Every embedded font-family must end in a generic family so a stripped
+    @font-face degrades to sans-serif (not the browser serif default)."""
+    svg = _render(fixture, "embed")
+    families = re.findall(r'font-family="([^"]*)"', svg)
+    assert families, "expected font-family attributes in embedded SVG"
+    for family in set(families):
+        assert family.startswith("Inter"), f"Inter must lead the stack: {family!r}"
+        assert family.rstrip().endswith("sans-serif"), (
+            f"embedded font-family lacks a generic fallback: {family!r}"
+        )
 
 
 @pytest.mark.skipif(FIXTURE_FILE is None, reason="no example fixtures found")


### PR DESCRIPTION
## Summary

With `--embed-font`, every text element was emitted as `font-family="Inter"` - a bare family name with no generic fallback, supplied only by an `@font-face` rule inside a `<style>` block. Where that `<style>` is stripped or the `@font-face` is not honoured (e.g. GitHub's README SVG sanitiser, some `<img>` SVG sandboxes, email clients), `Inter` matches nothing installed and browsers fall back to **serif**.

This changes the embed path to emit `font-family="Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif"`: the embedded Inter still wins wherever `@font-face` applies, and a stripped/unsupported face now degrades to sans-serif, matching the non-embed font stack.

The fallback chain is centralised in a new `EMBEDDED_FONT_STACK` constant in `render/font_embed.py`.

Fixes #1200

## Test plan
- [x] New parametrised test in `tests/test_font_portability.py` asserts every embedded `font-family` leads with `Inter` and ends in `sans-serif`, across all `examples/*.mmd`; verified failing before the fix, passing after.
- [x] Full `pytest` suite green (25289 passed).
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Visual review of render preview (no visual delta expected - same glyphs where Inter is honoured).

Generated with Claude Code