### PR TITLE
fix(layout): keep symfan source hub on its local lane in grid snap (#1206)

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -251,6 +251,10 @@ pass:
   snap, which must skip these half-pitch stations. Stage 6.17 runs after the
   last snap, so its writes mark branches for the invariant tests / straddle
   guard rather than feeding a later snap.
+- `graph.symfan_trunk_station_ids` - written by Stage 6.3 (`center_ports` only);
+  read by the Stage 6.4 grid snap, which must skip these source/trunk stations
+  so they stay on the symfan's local frame instead of snapping to a rowspan
+  neighbour's fractional row-grid origin.
 - `graph._consumers_grid_snapped` - set right after the Stage 6.4 snap; the
   Stage 6.6 off-track reanchor carries its own always-on guard on it.
 
@@ -733,12 +737,16 @@ in pipeline order.
   offsets so the section is 1 grid-unit tall instead of 2. Records
   the placed stations on the public `MetroGraph.half_grid_station_ids`
   field so Stage 6.4 leaves them alone -- this is the only cross-
-  phase channel for half-grid placement. Gated on `center_ports`.
+  phase channel for half-grid placement. The fan's remaining on-track
+  stations (its source/trunk) are recorded on
+  `MetroGraph.symfan_trunk_station_ids` so Stage 6.4 keeps them on the
+  same local frame. Gated on `center_ports`.
 - **Helper**: `_apply_half_grid_2branch_symfan`.
 - **Precondition**: Stages 6.1 / 6.2 done; symfan classification stable
   (`_section_symfan_uses_half_grid`).
 - **Postcondition**: Eligible symfan pairs share half-pitch offsets
-  from the trunk Y. `graph.half_grid_station_ids` contains their IDs.
+  from the trunk Y. `graph.half_grid_station_ids` contains their IDs;
+  `graph.symfan_trunk_station_ids` contains the fan's source/trunk IDs.
 - **Invariants preserved**: Trunk station Y. Other sections.
 - **Related tests**: `test_symfan_pairs_share_y`.
 - **Lifecycle:** invariant - 2-branch symfan pairs keep their half-pitch

--- a/src/nf_metro/layout/phase_state.py
+++ b/src/nf_metro/layout/phase_state.py
@@ -110,6 +110,18 @@ PHASE_FIELD_REGISTRY: dict[str, PhaseFieldSpec] = {
         ),
         run_condition_attr="center_ports",
     ),
+    "symfan_trunk_station_ids": PhaseFieldSpec(
+        name="symfan_trunk_station_ids",
+        writer_stage="6.3",
+        reader_stages=("6.4",),
+        enforcement=FieldEnforcement.REQUIRE_WRITER,
+        why=(
+            "source/trunk stations of a 2-branch symfan Stage 6.3 leaves on the "
+            "section's local frame; Stage 6.4's grid snap must skip them or it "
+            "drags them onto a rowspan neighbour's fractional row-grid origin"
+        ),
+        run_condition_attr="center_ports",
+    ),
     "_consumers_grid_snapped": PhaseFieldSpec(
         name="_consumers_grid_snapped",
         writer_stage="6.4",

--- a/src/nf_metro/layout/phases/fan_bundles.py
+++ b/src/nf_metro/layout/phases/fan_bundles.py
@@ -121,6 +121,26 @@ def _divergence_target_ys(graph: MetroGraph) -> set[str]:
     return anchors
 
 
+def _real_predecessors(graph: MetroGraph, target_ids: set[str]) -> set[str]:
+    """Real-station predecessors of ``target_ids``, seen through junctions.
+
+    A junction between a producer and the target is transparent: the producer
+    one step further back is returned in its place, so a fan fed through a single
+    bundle junction resolves to its source station.
+    """
+    junction_ids = graph.junction_ids
+    preds: set[str] = set()
+    for tid in target_ids:
+        for edge in graph.edges_to(tid):
+            src_id = edge.source
+            if src_id in junction_ids:
+                for e2 in graph.edges_to(src_id):
+                    preds.add(e2.source)
+            else:
+                preds.add(src_id)
+    return preds
+
+
 def _redistribute_fanout_siblings(graph: MetroGraph, y_spacing: float) -> None:
     """Symmetrically distribute fan-out siblings around a trunk junction.
 
@@ -308,6 +328,25 @@ def _apply_half_grid_2branch_symfan(
         branches[0].y = trunk_y - 0.5 * y_spacing
         branches[1].y = trunk_y + 0.5 * y_spacing
         graph.half_grid_station_ids.update(b.id for b in branches)
+
+        # The fan's source hub (the station feeding both branches) sits on this
+        # same local frame, so the row-grid snap must leave it there too rather
+        # than dragging it onto a foreign row origin.  Restrict to in-section
+        # branch predecessors: downstream terminus icons (file outputs) are off
+        # the frame and snap normally.
+        branch_ids = {b.id for b in branches}
+        for src_id in _real_predecessors(graph, branch_ids):
+            src = graph.stations.get(src_id)
+            if (
+                src is None
+                or src.is_port
+                or src.is_hidden
+                or src.off_track
+                or src.section_id != section.id
+                or src_id in branch_ids
+            ):
+                continue
+            graph.symfan_trunk_station_ids.add(src_id)
 
         # Half-grid branches consume half a y_spacing above and below
         # the trunk instead of a full slot.  Shrink the bbox top to match

--- a/src/nf_metro/layout/phases/grid_snap.py
+++ b/src/nf_metro/layout/phases/grid_snap.py
@@ -103,6 +103,8 @@ def _group_grid_origin(
     per_section_ports: dict[str, set[str]] = {}
     require_phase_field(graph, "half_grid_station_ids")
     half_grid_ids = graph.half_grid_station_ids
+    require_phase_field(graph, "symfan_trunk_station_ids")
+    symfan_trunk_ids = graph.symfan_trunk_station_ids
     for sec_id in sec_ids:
         section = graph.sections.get(sec_id)
         if section is None or section.bbox_h <= 0:
@@ -112,9 +114,9 @@ def _group_grid_origin(
         for sid in section.station_ids:
             if sid in port_ids:
                 continue
-            # Half-grid stations sit at origin + 0.5 * pitch by design; don't
-            # let them shift the row's grid origin.
-            if sid in half_grid_ids:
+            # Half-grid branches and the symfan source/trunk stations they share
+            # a frame with carry the section's own local Y, not the row origin.
+            if sid in half_grid_ids or sid in symfan_trunk_ids:
                 continue
             st = graph.stations.get(sid)
             if st is None or st.off_track:
@@ -142,6 +144,8 @@ def _snap_group_to_grid(
     origin_r, per_section_ports = origin_info
     require_phase_field(graph, "half_grid_station_ids")
     half_grid_ids = graph.half_grid_station_ids
+    require_phase_field(graph, "symfan_trunk_station_ids")
+    symfan_trunk_ids = graph.symfan_trunk_station_ids
 
     # Independent snapping can round two same-column stations onto one slot;
     # the later one keeps its pre-snap Y rather than collapsing.
@@ -153,7 +157,7 @@ def _snap_group_to_grid(
             continue
         vertical_flow = not lanes_run_along_y(section.direction)
         for sid in section.station_ids:
-            if sid in port_ids or sid in half_grid_ids:
+            if sid in port_ids or sid in half_grid_ids or sid in symfan_trunk_ids:
                 continue
             st = graph.stations.get(sid)
             if st is None or sid in convergence_sources:

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -502,6 +502,13 @@ class MetroGraph:
     # Stage 6.4 (``_snap_all_y_to_grid``) reads this set and skips those
     # stations so they keep their intentional half-grid Y.
     half_grid_station_ids: set[str] = field(default_factory=set, repr=False)
+    # Cross-phase channel: on-track non-branch station IDs (the source/trunk
+    # stations) of a 2-branch symfan section, recorded by Stage 6.3
+    # (``_apply_half_grid_2branch_symfan``).  They sit on the section's local
+    # symfan frame (the branch midpoint / inter-section port lane), so Stage 6.4
+    # (``_snap_all_y_to_grid``) skips them rather than dragging them onto the row
+    # group's grid origin, which a rowspan neighbour can leave fractional.
+    symfan_trunk_station_ids: set[str] = field(default_factory=set, repr=False)
     # Precondition flag for the off-track reanchor: set True right after the
     # Stage 6.4 grid snap so on-track consumer Ys are final.  The reanchor
     # (``_reanchor_off_track_to_consumer``) refuses to run while False,

--- a/tests/test_rowspan_band_distribution_invariant.py
+++ b/tests/test_rowspan_band_distribution_invariant.py
@@ -57,6 +57,31 @@ def test_stacked_rows_fill_rowspan_band(stem: str) -> None:
         )
 
 
+def test_symfan_source_hub_collinear_with_trunk_continuation() -> None:
+    """A fan-out source hub sits on the same lane as its trunk continuation (#1206).
+
+    In ``single_row_rowspan_neighbor`` the run_folder line's source icon
+    ``rundir_in`` fans to ``checkqc`` (upward branch) and ``rundirparser`` (the
+    straight trunk continuation).  ``rundir_in`` and ``rundirparser`` therefore
+    share one horizontal lane, while ``checkqc`` branches off it.  The fan
+    branches are protected half-grid symfan stations; the source hub must share
+    that local frame rather than snapping to the row group's fractional grid
+    origin (which the rowspan FASTQ neighbour's 13-way fan contaminates).
+    """
+    graph = parse_metro_mermaid(
+        (SHOWCASE_DIR / "single_row_rowspan_neighbor.mmd").read_text()
+    )
+    compute_layout(graph, validate=True)
+
+    hub = graph.stations["rundir_in"]
+    trunk = graph.stations["rundirparser"]
+    assert abs(hub.y - trunk.y) <= SAME_COORD_TOLERANCE, (
+        f"source hub 'rundir_in' (y={hub.y:.3f}) is not collinear with its trunk "
+        f"continuation 'rundirparser' (y={trunk.y:.3f}); off by "
+        f"{abs(hub.y - trunk.y):.3f}px"
+    )
+
+
 @pytest.mark.parametrize("stem", FIXTURES)
 def test_showcase_fixture_has_no_layout_errors(stem: str) -> None:
     """The relocated fixture skips the auto-globbed topology corpus, so run the


### PR DESCRIPTION
## Summary

A 2-branch symfan section's **source hub** sits at the fan's trunk Y, but it was not protected from the Stage 6.4 per-row grid snap the way its two half-grid branches are. When the section shares a row group with a rowspan neighbour whose own fan leaves the group's grid origin fractional, the snap drags the hub onto that fractional origin, leaving the source icon ~2.6px off its trunk-continuation lane.

In `single_row_rowspan_neighbor` (the nf-core/seqinspector map), the run_folder line's `RUNDIR` source icon ended up 2.619px above its straight-trunk continuation `Rundirparser`, inheriting the fractional Y of the rowspan FASTQ neighbour's 13-way fan centre.

- Record the fan's in-section source hub (the branches' shared predecessor, seen through bundle junctions) on `graph.symfan_trunk_station_ids` in Stage 6.3, mirroring the existing `half_grid_station_ids` channel.
- Stage 6.4's grid snap skips those ids (and excludes them from the row-grid origin), so the hub stays collinear with its trunk continuation.
- Downstream terminus icons (file outputs) are deliberately excluded, so they keep snapping to the grid.

Fixes #1206

## Test plan
- [x] New invariant test `test_symfan_source_hub_collinear_with_trunk_continuation` (fails on main with the 2.619px gap, passes with the fix)
- [x] Full suite green (25613 passed; only pre-existing xfails)
- [x] `genomic_pipeline` `test_all_stations_snap_to_grid` / `test_symfan_pairs_share_y` confirmed not regressed (fix narrowed from "all non-branch stations" to "branch predecessors" to avoid catching output icons)
- [x] ruff check + ruff format clean; mypy clean
- [ ] Visual review of render preview
- [ ] Render-preview verdict captured

Generated with Claude Code