### PR TITLE
feat(playground): line-gap as a main option; right-align build-SHA with report button

### DIFF
--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -97,6 +97,17 @@ import { base } from "../site";
           <label class="check"
             ><input type="checkbox" id="opt-center-ports" /> Centre ports</label
           >
+          <label
+            >Line gap
+            <input
+              type="number"
+              id="opt-track-gap"
+              min="0"
+              max="3"
+              step="0.5"
+              placeholder="1.0"
+            />
+          </label>
         </div>
 
         <div class="pane-toolbar">
@@ -105,15 +116,17 @@ import { base } from "../site";
           <button id="btn-png">PNG</button>
           <button id="btn-share">Share link</button>
           <button id="btn-copy-source">Copy source</button>
-          <a id="build-hint" class="muted small build-hint hidden"
-            target="_blank" rel="noopener"></a>
-          <button
-            id="btn-report"
-            class="report-btn"
-            title="Report a bug with this map"
-          >
-            Report a bug
-          </button>
+          <div class="toolbar-right">
+            <a id="build-hint" class="muted small build-hint hidden"
+              target="_blank" rel="noopener"></a>
+            <button
+              id="btn-report"
+              class="report-btn"
+              title="Report a bug with this map"
+            >
+              Report a bug
+            </button>
+          </div>
         </div>
 
         <details id="advanced" class="advanced">
@@ -148,17 +161,6 @@ import { base } from "../site";
             <label class="check"
               ><input type="checkbox" id="opt-compact-offsets" /> Compact offsets</label
             >
-            <label
-              >Line gap
-              <input
-                type="number"
-                id="opt-track-gap"
-                min="0"
-                max="3"
-                step="0.5"
-                placeholder="1.0"
-              />
-            </label>
             <label
               >Font scale
               <input
@@ -879,8 +881,13 @@ import { base } from "../site";
     z-index: 20;
   }
 
-  .report-btn {
+  .toolbar-right {
     margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px 12px;
+  }
+  .report-btn {
     color: var(--muted) !important;
   }
   .report-btn:hover {


### PR DESCRIPTION
## Summary

Two playground toolbar tweaks on top of #1220:

- **Line gap** moves out of *Advanced options* into the main preview toolbar, directly after **Centre ports** (it's a common layout control, not an advanced one). Same `#opt-track-gap` id, so behaviour is unchanged.
- The **build-SHA hint** is grouped with the **Report a bug** button in a right-aligned `.toolbar-right` cluster, so the SHA sits beside the button on the right instead of trailing *Copy source* on the left. `margin-left:auto` moves from `.report-btn` to the wrapper, so the button stays right-anchored even when the hint is hidden.

## Test plan
- [x] Single `#opt-track-gap`; HTML structure balanced
- [ ] `playground-e2e` (Playwright) + site build green on this PR
- [ ] Visual check of toolbar placement

Generated with Claude Code