### PR TITLE
fix(routing): run same-row exit-row bypass straight when the row is clear

### DIFF
--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -1623,6 +1623,29 @@ def _route_bypass(
         # double up here.
         base_y = sy + src_off
         nest_offset = 0.0
+    elif (
+        src_row is not None
+        and tgt_row is not None
+        and src_row == tgt_row
+        and tgt_entry is not None
+        and tgt_entry.is_entry
+        and base_y < sy - COORD_TOLERANCE
+        and not _h_segment_crosses_other_section(
+            graph,
+            sx,
+            effective_tx,
+            sy,
+            {sid for sid in (src.section_id, tgt.section_id) if sid is not None},
+            margin=BYPASS_CLEARANCE,
+        )
+    ):
+        # Same-row bypass whose source sits below the intervening sections that
+        # forced the classification: the computed lane hugs their bottoms above
+        # the source, so diving up to it at the exit and stepping up again into
+        # the target is an avoidable kink.  The source row threads clear across
+        # the span, so run straight along it and turn up once at the target.
+        base_y = sy + src_off
+        nest_offset = 0.0
 
     # Determine actual vertical direction at each gap from the geometry.
     # Gap1 goes from source Y to trunk Y; gap2 from trunk Y to target Y.

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -32,6 +32,7 @@ from typing import Any, Protocol
 
 from nf_metro.layout.constants import (
     BUNDLE_TO_BUNDLE_CLEARANCE,
+    BYPASS_CLEARANCE,
     COORD_TOLERANCE,
     COORD_TOLERANCE_FINE,
     CURVE_RADIUS,
@@ -3458,6 +3459,102 @@ def check_bottom_row_climb_run_on_source_track(
 
 
 @dataclass
+class ExitRowEarlyUpStep:
+    """A same-row bypass steps up to a mid-lane above a clear exit row.
+
+    When the source row threads clear of every intervening section across the
+    span, the bypass should run straight along that row and turn up once into
+    the target (see
+    :func:`~nf_metro.layout.routing.inter_section_handlers._route_bypass`).  A
+    route that instead steps up to a lane above the source for the long
+    traverse, then up again into the target, took an avoidable kink at the exit.
+    """
+
+    source: str
+    target: str
+    run_y: float
+    src_y: float
+
+    def message(self) -> str:
+        """Human-readable summary suitable for the engine error message."""
+        return (
+            f"exit-row bypass {self.source!r}->{self.target!r} runs its traverse "
+            f"at y={self.run_y:.1f}, above the clear exit row y={self.src_y:.1f} "
+            f"-- an avoidable up-step kink before the end-of-traverse climb"
+        )
+
+
+def check_exit_row_bypass_no_early_upstep(
+    graph: MetroGraph, routes: list[RoutedPath]
+) -> list[ExitRowEarlyUpStep]:
+    """Return same-row bypasses that step up to a mid-lane over a clear corridor.
+
+    When source and target share a grid row, the target is a real entry port,
+    a same-row section between them sits entirely above the exit row (so the
+    bypass lane hugs its bottom above the source -- ``base_y < sy``), and the
+    source row threads clear of every section across the span, the bypass must
+    run its traverse at the source row and climb only at the end.  A horizontal
+    run sitting *above* the source row while it overlaps such a section's column
+    is the early up-step this polices.  An up-step that lands at the target
+    port's own Y (the final approach to a port on a higher row) is not policed.
+    """
+    from nf_metro.layout.routing.normalize import _h_segment_crosses_other_section
+
+    tol = COORD_TOLERANCE
+    violations: list[ExitRowEarlyUpStep] = []
+    for r in routes:
+        if not r.is_inter_section or len(r.points) < 2:
+            continue
+        tgt_port = graph.ports.get(r.edge.target)
+        if tgt_port is None or not tgt_port.is_entry:
+            continue
+        src_station = graph.stations.get(r.edge.source)
+        tgt_station = graph.stations.get(r.edge.target)
+        if src_station is None or tgt_station is None:
+            continue
+        src_sec = resolve_section(graph, src_station)
+        tgt_sec = resolve_section(graph, tgt_station)
+        if (
+            src_sec is None
+            or tgt_sec is None
+            or src_sec.grid_row is None
+            or tgt_sec.grid_row is None
+            or src_sec.grid_row != tgt_sec.grid_row
+        ):
+            continue
+        src_y = src_station.y
+        exclude = {sid for sid in (src_sec.id, tgt_sec.id) if sid is not None}
+        if _h_segment_crosses_other_section(
+            graph, src_station.x, tgt_station.x, src_y, exclude, margin=BYPASS_CLEARANCE
+        ):
+            continue
+        lo, hi = (
+            min(src_sec.grid_col, tgt_sec.grid_col),
+            max(src_sec.grid_col, tgt_sec.grid_col),
+        )
+        lane_sources = [
+            s
+            for s in graph.sections.values()
+            if s.bbox_w > 0
+            and lo < s.grid_col < hi
+            and s.grid_row == src_sec.grid_row
+            and s.bbox_y + s.bbox_h < src_y - tol
+        ]
+        for (x0, y0), (x1, y1) in zip(r.points, r.points[1:]):
+            if abs(y1 - y0) > tol or y0 >= src_y - tol:
+                continue
+            seg_lo, seg_hi = min(x0, x1), max(x0, x1)
+            if any(
+                seg_lo < s.bbox_x + s.bbox_w and seg_hi > s.bbox_x for s in lane_sources
+            ):
+                violations.append(
+                    ExitRowEarlyUpStep(r.edge.source, r.edge.target, y0, src_y)
+                )
+                break
+    return violations
+
+
+@dataclass
 class UndeclaredGapChannel:
     """A vertical inter-section leg sits in a gap with no :class:`GapSlot`.
 
@@ -3715,6 +3812,10 @@ def assert_render_curve_invariants(
             check_bottom_row_climb_run_on_source_track(graph, routes),
         ),
         (
+            "exit-row bypass steps up over clear corridor",
+            check_exit_row_bypass_no_early_upstep(graph, routes),
+        ),
+        (
             "undeclared gap channel",
             check_gap_channels_materialized(graph, routes),
         ),
@@ -3810,6 +3911,7 @@ CHECK_REGISTRY: tuple[GuardSpec, ...] = (
     _check_spec(check_deferred_offsets_apply_laterally, "A"),
     _check_spec(check_bottom_row_climb_stays_at_row_level, "A"),
     _check_spec(check_bottom_row_climb_run_on_source_track, "A"),
+    _check_spec(check_exit_row_bypass_no_early_upstep, "A"),
     _check_spec(check_gap_channels_materialized, "A"),
     _check_spec(check_trunks_declared, "A"),
     _check_spec(check_peeloff_concentric, "A"),
@@ -3851,6 +3953,7 @@ __all__ = [
     "GuardSpec",
     "BottomRowClimbDive",
     "BottomRowClimbOffTrack",
+    "ExitRowEarlyUpStep",
     "BundleOrderViolation",
     "CollinearOverlapViolation",
     "DiagonalOverlapViolation",
@@ -3874,6 +3977,7 @@ __all__ = [
     "UndeclaredTrunk",
     "check_bottom_row_climb_stays_at_row_level",
     "check_bottom_row_climb_run_on_source_track",
+    "check_exit_row_bypass_no_early_upstep",
     "check_bundle_order_preserved",
     "check_gap_channels_materialized",
     "check_trunks_declared",

--- a/tests/test_exit_row_bypass_invariant.py
+++ b/tests/test_exit_row_bypass_invariant.py
@@ -1,0 +1,148 @@
+"""Tests for the exit-row bypass early-up-step invariant (#1215).
+
+A same-row inter-section bypass whose source already sits below the
+intervening sections that classified it as a bypass must run straight along
+its exit row and turn up once at the target.  Stepping up to a mid-height lane
+at the exit, running the long traverse there, then up again into the target is
+an avoidable kink whenever the exit row threads clear across the span.
+
+Covers:
+
+* Happy-path: every gallery example, showcase fixture, and topology fixture
+  routes without an exit-row bypass stepping up over a clear corridor.
+* Regression: the reported ``single_row_rowspan_neighbor`` map routes the
+  FASTQ-Files line to MultiQC straight along its exit row.
+* Meaningfulness: the checker fires on the reported up-step geometry and stays
+  silent on the straight-run geometry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.layout.routing.invariants import (
+    check_exit_row_bypass_no_early_upstep,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import Edge
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES = REPO_ROOT / "examples"
+SHOWCASE = EXAMPLES / "showcase"
+EXAMPLE_TOPOLOGIES = EXAMPLES / "topologies"
+FIXTURE_TOPOLOGIES = REPO_ROOT / "tests" / "fixtures" / "topologies"
+
+REPORTED_FIXTURE = SHOWCASE / "single_row_rowspan_neighbor.mmd"
+
+
+def _gather_fixtures() -> list[Path]:
+    paths: list[Path] = []
+    paths.extend(sorted(EXAMPLES.glob("*.mmd")))
+    paths.extend(sorted(SHOWCASE.glob("*.mmd")))
+    paths.extend(sorted(EXAMPLE_TOPOLOGIES.glob("*.mmd")))
+    paths.extend(sorted(FIXTURE_TOPOLOGIES.glob("*.mmd")))
+    return paths
+
+
+def _route(path: Path):
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    return graph, routes
+
+
+@pytest.mark.parametrize(
+    "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
+)
+def test_no_exit_row_bypass_early_upstep_in_gallery(path: Path) -> None:
+    """Every shipped fixture routes same-row bypasses straight along a clear
+    exit row, never stepping up to a mid-lane over the corridor."""
+    graph, routes = _route(path)
+    violations = check_exit_row_bypass_no_early_upstep(graph, routes)
+    assert not violations, "\n".join(v.message() for v in violations)
+
+
+def test_reported_fastq_line_runs_along_its_exit_row() -> None:
+    """The FASTQ-Files line to MultiQC runs its long traverse on the exit row.
+
+    The exit/convergence sits at the FASTQ-Files trunk Y; the BAM-Files box
+    below drops clear of that row, so the traverse to MultiQC must stay on the
+    exit row and climb only at the end -- no mid-lane up-step at the exit.
+    """
+    graph, routes = _route(REPORTED_FIXTURE)
+    src = graph.stations["__junction_5"]
+    target = "multiqc__entry_left_4"
+    matches = [
+        r for r in routes if r.edge.source == "__junction_5" and r.edge.target == target
+    ]
+    assert matches, "expected a routed FASTQ-Files line into MultiQC"
+    route = matches[0]
+
+    longest_dx = 0.0
+    traverse_y = src.y
+    for (x0, y0), (x1, y1) in zip(route.points, route.points[1:]):
+        if abs(y1 - y0) <= 1.0 and abs(x1 - x0) > longest_dx:
+            longest_dx = abs(x1 - x0)
+            traverse_y = y0
+    assert traverse_y == pytest.approx(src.y, abs=1.0), (
+        f"traverse ran at y={traverse_y:.1f}, not the exit row y={src.y:.1f}"
+    )
+
+
+def _build_graph():
+    graph = parse_metro_mermaid(REPORTED_FIXTURE.read_text())
+    compute_layout(graph)
+    return graph
+
+
+_EDGE = Edge("__junction_5", "multiqc__entry_left_4", "fastq_files")
+
+# The reported up-step: leave the exit at y=320, climb to a mid-lane y=275
+# (just below the intervening Run-Folder box), run the long traverse there,
+# then climb again into MultiQC.
+_UP_STEP = [
+    (474.0, 320.0),
+    (492.0, 275.0),
+    (865.0, 275.0),
+    (879.0, 138.0),
+    (904.0, 124.0),
+]
+# The straight run: stay on the exit row y=320 across the span, turn up once.
+_STRAIGHT = [
+    (474.0, 320.0),
+    (865.0, 320.0),
+    (879.0, 138.0),
+    (904.0, 124.0),
+]
+
+
+def _route_with(points: list[tuple[float, float]]) -> list[RoutedPath]:
+    return [
+        RoutedPath(
+            edge=_EDGE,
+            line_id="fastq_files",
+            points=points,
+            is_inter_section=True,
+        )
+    ]
+
+
+def test_checker_flags_exit_row_up_step() -> None:
+    """The checker fires when the same-row bypass steps up over a clear row."""
+    graph = _build_graph()
+    violations = check_exit_row_bypass_no_early_upstep(graph, _route_with(_UP_STEP))
+    assert violations, "expected an early-up-step violation over the clear corridor"
+    assert violations[0].source == "__junction_5"
+
+
+def test_checker_passes_straight_exit_row_run() -> None:
+    """The checker stays silent when the bypass runs straight along its row."""
+    graph = _build_graph()
+    violations = check_exit_row_bypass_no_early_upstep(graph, _route_with(_STRAIGHT))
+    assert not violations, "a straight exit-row run must not flag"


### PR DESCRIPTION
## Summary

A same-row inter-section bypass whose source sits **below** the intervening sections that classified it as a bypass stepped up to a lane hugging their bottoms right at the exit, ran the long traverse there, then stepped up again into the target. When the exit row is already clear all the way across, that early up-step is an avoidable kink: the line could run straight along its exit row and turn up only once, at the end.

This surfaced on the nf-core/seqinspector showcase map once #1207/#1209 landed (PR #1214): with `BAM Files` distributed down to fill the rowspan band, its box top drops below the `FASTQ Files` exit row, leaving that row clear, but the `FASTQ Files` line to MultiQC still kinked up early.

The fix gates tightly: a same-row bypass keeps its run on the source row only when the target is a real entry port, the bypass lane the engine computed sits above the source (`base_y < sy`), and the source row threads clear of every section across the span (reusing `_h_segment_crosses_other_section`). The early up-step is left intact when the exit row is *not* clear.

An always-on render-curve check (`check_exit_row_bypass_no_early_upstep`) flags a same-row bypass that steps up to a mid-lane over a clear corridor, scoped to the case where a same-row section between source and target sits entirely above the exit row (an up-step that lands at the target port's own Y, the final approach to a port on a higher row, is not policed).

Fixes #1215

## Test plan
- [x] `pytest` passes (full suite: 26062 passed, 7 pre-existing xfailed)
- [x] New parametrized invariant test over all gallery / showcase / topology fixtures, plus a regression lock on the seqinspector fixture and meaningfulness checks (flags the reported up-step geometry, silent on the straight run); verified the regression test fails on the unfixed tree
- [x] `ruff check` + `ruff format --check` + `mypy` clean on the whole repo
- [x] Runtime validator added (Tier A render chokepoint)
- [ ] Visual review of the render preview (only the seqinspector showcase fixture changes; no other fixture triggers the new branch)

Generated with Claude Code