### PR TITLE
fix(playground): support data-URI logos so a pasted map's logo isn't lost

### DIFF
--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Literal
 
 from nf_metro.layout import compute_layout
@@ -27,7 +26,7 @@ from nf_metro.parser.directives import apply_legend_directive
 from nf_metro.parser.model import LineSpread, MetroGraph
 from nf_metro.render import render_svg
 from nf_metro.render.html import render_html
-from nf_metro.render.legend import logo_is_resolvable
+from nf_metro.render.legend import logo_is_resolvable, resolve_logo_file
 from nf_metro.render.style import Theme
 from nf_metro.themes import DEFAULT_MODE, THEME_MODES, THEMES
 
@@ -175,10 +174,9 @@ def prepare_graph(
         graph.source_dir = source_dir
         for attr in ("logo_path", "logo_path_light", "logo_path_dark"):
             raw: str = getattr(graph, attr)
-            if raw and not logo_is_resolvable(raw):
-                candidate = Path(source_dir) / raw
-                if candidate.is_file():
-                    setattr(graph, attr, str(candidate))
+            resolved = resolve_logo_file(raw, source_dir) if raw else ""
+            if resolved:
+                setattr(graph, attr, resolved)
     if line_spread is not None:
         graph.line_spread = LineSpread(line_spread)
     if logo is not None:

--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -27,6 +27,7 @@ from nf_metro.parser.directives import apply_legend_directive
 from nf_metro.parser.model import LineSpread, MetroGraph
 from nf_metro.render import render_svg
 from nf_metro.render.html import render_html
+from nf_metro.render.legend import logo_is_resolvable
 from nf_metro.render.style import Theme
 from nf_metro.themes import DEFAULT_MODE, THEME_MODES, THEMES
 
@@ -174,7 +175,7 @@ def prepare_graph(
         graph.source_dir = source_dir
         for attr in ("logo_path", "logo_path_light", "logo_path_dark"):
             raw: str = getattr(graph, attr)
-            if raw and not Path(raw).is_file():
+            if raw and not logo_is_resolvable(raw):
                 candidate = Path(source_dir) / raw
                 if candidate.is_file():
                     setattr(graph, attr, str(candidate))
@@ -189,7 +190,7 @@ def prepare_graph(
 
     for _attr in ("logo_path", "logo_path_light", "logo_path_dark"):
         _raw: str = getattr(graph, _attr)
-        if _raw and not Path(_raw).is_file():
+        if _raw and not logo_is_resolvable(_raw):
             raise ValueError(f"%%metro logo: path {_raw!r} not found")
 
     compute_layout(graph)

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -4,15 +4,25 @@ from __future__ import annotations
 
 __all__ = [
     "compute_legend_dimensions",
+    "logo_image_kwargs",
+    "logo_is_resolvable",
     "marker_corner_radius",
     "marker_fill_color",
     "marker_stroke_color",
+    "open_logo_image",
     "render_legend",
 ]
 
+import base64
 from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import drawsvg as draw
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImageType
 
 from nf_metro.parser.model import (
     MARKER_FILL_OPEN,
@@ -41,6 +51,39 @@ from nf_metro.render.constants import (
 from nf_metro.render.ns import adaptive_logo_mask_ids as _adaptive_logo_mask_ids
 from nf_metro.render.ns import ns as _ns
 from nf_metro.render.style import Theme
+
+
+def logo_is_resolvable(path: str) -> bool:
+    """True when *path* can be opened as a logo image.
+
+    A logo is either a base64 data URI (self-contained, needs no filesystem -
+    this is what lets a logo travel into sandboxed contexts such as the
+    browser-based playground) or a path to an existing file.
+    """
+    return path.startswith("data:") or Path(path).is_file()
+
+
+def open_logo_image(path: str) -> "PILImageType":
+    """Open a logo image from a data URI or a file path."""
+    from PIL import Image as PILImage
+
+    if path.startswith("data:"):
+        header, _, payload = path.partition(",")
+        if ";base64" not in header:
+            raise ValueError("logo data URI must be base64-encoded")
+        return PILImage.open(BytesIO(base64.b64decode(payload)))
+    return PILImage.open(path)
+
+
+def logo_image_kwargs(path: str) -> dict[str, str | bool]:
+    """``drawsvg.Image`` kwargs that embed a logo from a data URI or file path.
+
+    A data URI is already a self-contained ``data:`` href, so it is passed
+    through unembedded; a file path is read and base64-embedded as usual.
+    """
+    if path.startswith("data:"):
+        return {"path": path, "embed": False}
+    return {"path": path, "embed": True}
 
 
 def marker_fill_color(fill: str, theme: Theme) -> str:
@@ -354,9 +397,8 @@ def render_legend(
                         logo_y,
                         scaled_w,
                         scaled_h,
-                        path=logo_path_dark,
-                        embed=True,
                         mask=f"url(#{dark_mask_id})",
+                        **logo_image_kwargs(logo_path_dark),
                     )
                 )
             if logo_path_light:
@@ -366,20 +408,19 @@ def render_legend(
                         logo_y,
                         scaled_w,
                         scaled_h,
-                        path=logo_path_light,
-                        embed=True,
                         mask=f"url(#{light_mask_id})",
+                        **logo_image_kwargs(logo_path_light),
                     )
                 )
         else:
+            assert logo_path  # has_adaptive is False, so active_logo == logo_path
             d.append(
                 draw.Image(
                     logo_x,
                     logo_y,
                     scaled_w,
                     scaled_h,
-                    path=logo_path,
-                    embed=True,
+                    **logo_image_kwargs(logo_path),
                 )
             )
         logo_offset = scaled_w + _logo_gap(graph)

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -11,6 +11,7 @@ __all__ = [
     "marker_stroke_color",
     "open_logo_image",
     "render_legend",
+    "resolve_logo_file",
 ]
 
 import base64
@@ -61,6 +62,22 @@ def logo_is_resolvable(path: str) -> bool:
     browser-based playground) or a path to an existing file.
     """
     return path.startswith("data:") or Path(path).is_file()
+
+
+def resolve_logo_file(raw: str, source_dir: str) -> str:
+    """Return a resolvable path/data-URI for *raw*, or empty string if not found.
+
+    Tries *raw* as-is first, then relative to *source_dir* (the directory the
+    map's ``.mmd`` came from), so a logo path can be written relative to the
+    source file rather than the caller's working directory.
+    """
+    if logo_is_resolvable(raw):
+        return raw
+    if source_dir:
+        candidate = Path(source_dir) / raw
+        if candidate.is_file():
+            return str(candidate)
+    return ""
 
 
 def open_logo_image(path: str) -> "PILImageType":
@@ -412,8 +429,7 @@ def render_legend(
                         **logo_image_kwargs(logo_path_light),
                     )
                 )
-        else:
-            assert logo_path  # has_adaptive is False, so active_logo == logo_path
+        elif logo_path:
             d.append(
                 draw.Image(
                     logo_x,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -129,9 +129,12 @@ from nf_metro.render.icons import (
 )
 from nf_metro.render.legend import (
     compute_legend_dimensions,
+    logo_image_kwargs,
+    logo_is_resolvable,
     marker_corner_radius,
     marker_fill_color,
     marker_stroke_color,
+    open_logo_image,
     render_legend,
 )
 from nf_metro.render.manifest import build_manifest, manifest_metadata_svg
@@ -634,6 +637,16 @@ def _render_svg_scaled(
     # Compute legend and logo dimensions
     adaptive_logo = chrome_css and _is_adaptive_mode(graph)
     show_logo, logo_w, logo_h, effective_logo = _resolve_logo(graph, adaptive_logo)
+    resolved_logo_light = (
+        _resolve_logo_file(graph.logo_path_light, graph.source_dir)
+        if graph.logo_path_light
+        else ""
+    )
+    resolved_logo_dark = (
+        _resolve_logo_file(graph.logo_path_dark, graph.source_dir)
+        if graph.logo_path_dark
+        else ""
+    )
 
     logo_in_legend = show_logo and effective_legend_position != "none"
     legend_logo_size = (logo_w, logo_h) if logo_in_legend else None
@@ -751,8 +764,8 @@ def _render_svg_scaled(
             if adaptive_logo:
                 _render_adaptive_logo(
                     d,
-                    graph.logo_path_light,
-                    graph.logo_path_dark,
+                    resolved_logo_light,
+                    resolved_logo_dark,
                     logo_x,
                     logo_y,
                     logo_w,
@@ -816,10 +829,10 @@ def _render_svg_scaled(
             legend_y,
             logo_path=effective_logo if (_in_legend and not adaptive_logo) else None,
             logo_path_light=(
-                graph.logo_path_light if (adaptive_logo and _in_legend) else None
+                resolved_logo_light if (adaptive_logo and _in_legend) else None
             ),
             logo_path_dark=(
-                graph.logo_path_dark if (adaptive_logo and _in_legend) else None
+                resolved_logo_dark if (adaptive_logo and _in_legend) else None
             ),
             logo_size=legend_logo_size,
         )
@@ -971,8 +984,8 @@ def _has_adaptive_logos(graph: MetroGraph) -> bool:
 
 
 def _resolve_logo_file(raw: str, source_dir: str) -> str:
-    """Return a resolvable path for *raw*, or empty string if not found."""
-    if Path(raw).is_file():
+    """Return a resolvable path/data-URI for *raw*, or empty string if not found."""
+    if logo_is_resolvable(raw):
         return raw
     if source_dir:
         candidate = Path(source_dir) / raw
@@ -1017,9 +1030,7 @@ def compute_logo_dimensions(
     logo_height: float = 80.0,
 ) -> tuple[float, float]:
     """Compute logo display dimensions preserving aspect ratio."""
-    from PIL import Image as PILImage
-
-    img = PILImage.open(logo_path)
+    img = open_logo_image(logo_path)
     aspect = img.width / img.height
     return logo_height * aspect, logo_height
 
@@ -1039,8 +1050,7 @@ def _render_logo(
             y,
             logo_w,
             logo_h,
-            path=logo_path,
-            embed=True,
+            **logo_image_kwargs(logo_path),
         )
     )
 
@@ -1056,23 +1066,21 @@ def _render_adaptive_logo(
 ) -> None:
     """Embed logo variant(s) using SVG masks driven by light-dark().
 
-    Either path may be absent; only variants whose files exist are rendered,
-    each masked to its respective mode. ``light-dark()`` inherits color-scheme
-    from the host document so logos follow a page's dark/light toggle, not
-    only the OS media preference.
+    *light_path*/*dark_path* must already be resolved (data URI or an
+    existing file path); either may be absent. ``light-dark()`` inherits
+    color-scheme from the host document so logos follow a page's dark/light
+    toggle, not only the OS media preference.
     """
     key_path = dark_path or light_path
     dark_mask_id, light_mask_id = _adaptive_logo_mask_ids(key_path)
-    has_dark = bool(dark_path) and Path(dark_path).is_file()
-    has_light = bool(light_path) and Path(light_path).is_file()
     defs_parts = []
-    if has_dark:
+    if dark_path:
         defs_parts.append(
             f'<mask id="{dark_mask_id}" maskContentUnits="objectBoundingBox">'
             f'<rect width="1" height="1" fill="light-dark(#000,#fff)"/>'
             f"</mask>"
         )
-    if has_light:
+    if light_path:
         defs_parts.append(
             f'<mask id="{light_mask_id}" maskContentUnits="objectBoundingBox">'
             f'<rect width="1" height="1" fill="light-dark(#fff,#000)"/>'
@@ -1081,28 +1089,26 @@ def _render_adaptive_logo(
     if not defs_parts:
         return
     d.append(draw.Raw(f"<defs>{''.join(defs_parts)}</defs>"))
-    if has_dark:
+    if dark_path:
         d.append(
             draw.Image(
                 x,
                 y,
                 logo_w,
                 logo_h,
-                path=dark_path,
-                embed=True,
                 mask=f"url(#{dark_mask_id})",
+                **logo_image_kwargs(dark_path),
             )
         )
-    if has_light:
+    if light_path:
         d.append(
             draw.Image(
                 x,
                 y,
                 logo_w,
                 logo_h,
-                path=light_path,
-                embed=True,
                 mask=f"url(#{light_mask_id})",
+                **logo_image_kwargs(light_path),
             )
         )
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -11,7 +11,6 @@ import textwrap
 import warnings
 from collections.abc import Iterable
 from dataclasses import replace
-from pathlib import Path
 from typing import Any, Literal, NamedTuple
 
 import drawsvg as draw
@@ -130,12 +129,12 @@ from nf_metro.render.icons import (
 from nf_metro.render.legend import (
     compute_legend_dimensions,
     logo_image_kwargs,
-    logo_is_resolvable,
     marker_corner_radius,
     marker_fill_color,
     marker_stroke_color,
     open_logo_image,
     render_legend,
+    resolve_logo_file,
 )
 from nf_metro.render.manifest import build_manifest, manifest_metadata_svg
 from nf_metro.render.ns import adaptive_logo_mask_ids as _adaptive_logo_mask_ids
@@ -638,12 +637,12 @@ def _render_svg_scaled(
     adaptive_logo = chrome_css and _is_adaptive_mode(graph)
     show_logo, logo_w, logo_h, effective_logo = _resolve_logo(graph, adaptive_logo)
     resolved_logo_light = (
-        _resolve_logo_file(graph.logo_path_light, graph.source_dir)
+        resolve_logo_file(graph.logo_path_light, graph.source_dir)
         if graph.logo_path_light
         else ""
     )
     resolved_logo_dark = (
-        _resolve_logo_file(graph.logo_path_dark, graph.source_dir)
+        resolve_logo_file(graph.logo_path_dark, graph.source_dir)
         if graph.logo_path_dark
         else ""
     )
@@ -978,20 +977,9 @@ def _is_adaptive_mode(graph: MetroGraph) -> bool:
 
 def _has_adaptive_logos(graph: MetroGraph) -> bool:
     """Return True when both logo variants are set and their files exist."""
-    return bool(_resolve_logo_file(graph.logo_path_light, graph.source_dir)) and bool(
-        _resolve_logo_file(graph.logo_path_dark, graph.source_dir)
+    return bool(resolve_logo_file(graph.logo_path_light, graph.source_dir)) and bool(
+        resolve_logo_file(graph.logo_path_dark, graph.source_dir)
     )
-
-
-def _resolve_logo_file(raw: str, source_dir: str) -> str:
-    """Return a resolvable path/data-URI for *raw*, or empty string if not found."""
-    if logo_is_resolvable(raw):
-        return raw
-    if source_dir:
-        candidate = Path(source_dir) / raw
-        if candidate.is_file():
-            return str(candidate)
-    return ""
 
 
 def _resolve_logo(graph: MetroGraph, adaptive: bool) -> tuple[bool, float, float, str]:
@@ -1004,7 +992,7 @@ def _resolve_logo(graph: MetroGraph, adaptive: bool) -> tuple[bool, float, float
     if adaptive:
         raw_candidates = (graph.logo_path_dark, graph.logo_path_light)
         dim_path = next(
-            (_resolve_logo_file(p, graph.source_dir) for p in raw_candidates if p),
+            (resolve_logo_file(p, graph.source_dir) for p in raw_candidates if p),
             "",
         )
         if dim_path:
@@ -1018,7 +1006,7 @@ def _resolve_logo(graph: MetroGraph, adaptive: bool) -> tuple[bool, float, float
     effective = _effective_logo_path(graph)
     if not effective:
         return False, 0.0, 0.0, ""
-    resolved = _resolve_logo_file(effective, graph.source_dir)
+    resolved = resolve_logo_file(effective, graph.source_dir)
     if resolved:
         w, h = compute_logo_dimensions(resolved)
         return True, w, h, resolved

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,6 +104,31 @@ def test_render_string_propagates_layout_error() -> None:
         render_string(cyclic)
 
 
+def _data_uri_logo_mmd(logo_directive: str) -> str:
+    return (
+        f"%%metro logo: {logo_directive}\n"
+        "%%metro line: a | A | #f00\n"
+        "graph LR\n  n1[N1] -->|a| n2[N2]\n"
+    )
+
+
+def test_render_string_embeds_data_uri_logo_with_no_source_dir() -> None:
+    """A data URI needs no filesystem access, so the browser playground (which
+    calls render_string with no source_dir) can embed a logo that was never on
+    disk in the first place."""
+    pixel = (
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4"
+        "nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
+    )
+    svg = render_string(_data_uri_logo_mmd(pixel))
+    assert pixel in svg
+
+
+def test_prepare_graph_rejects_unresolvable_logo_path() -> None:
+    with pytest.raises(ValueError, match="does/not/exist.png"):
+        prepare_graph(_data_uri_logo_mmd("does/not/exist.png"))
+
+
 def test_render_string_self_color_scheme_parity() -> None:
     src = (EXAMPLES / "rnaseq_auto.mmd").read_text()
     with_cs = render_string(src)

--- a/tests/test_mode_adaptive_logo.py
+++ b/tests/test_mode_adaptive_logo.py
@@ -1,5 +1,6 @@
 """Tests for mode-adaptive logo path selection."""
 
+import base64
 import io
 from pathlib import Path
 
@@ -7,6 +8,7 @@ import pytest
 from PIL import Image as PILImage
 
 from nf_metro.parser.model import MetroGraph
+from nf_metro.render.legend import logo_is_resolvable, open_logo_image
 from nf_metro.render.ns import adaptive_logo_mask_ids as _adaptive_logo_mask_ids
 from nf_metro.render.svg import (
     _effective_logo_path,
@@ -14,6 +16,13 @@ from nf_metro.render.svg import (
     _is_adaptive_mode,
     _resolve_logo,
 )
+
+
+def _png_data_uri(*, width: int = 100, height: int = 50) -> str:
+    img = PILImage.new("RGB", (width, height), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
 
 
 def _graph_with_logo(
@@ -206,6 +215,45 @@ def test_resolve_adaptive_logo_resolves_relative_to_source_dir(tmp_path):
     g.logo_path_light = "light.png"
     g.logo_path_dark = "dark.png"
     g.source_dir = str(tmp_path)
+
+    show, w, h, _ = _resolve_logo(g, adaptive=True)
+    assert show
+    assert w > 0
+
+
+def test_logo_is_resolvable_for_data_uri():
+    assert logo_is_resolvable(_png_data_uri())
+
+
+def test_logo_is_resolvable_false_for_missing_file():
+    assert not logo_is_resolvable("does/not/exist.png")
+
+
+def test_open_logo_image_decodes_data_uri():
+    img = open_logo_image(_png_data_uri(width=40, height=20))
+    assert (img.width, img.height) == (40, 20)
+
+
+def test_open_logo_image_rejects_non_base64_data_uri():
+    with pytest.raises(ValueError, match="base64"):
+        open_logo_image("data:image/png,not-base64")
+
+
+def test_resolve_logo_accepts_data_uri_single_path():
+    """A data URI needs no filesystem access, so it resolves with no source_dir."""
+    g = MetroGraph()
+    g.logo_path = _png_data_uri(width=40, height=20)
+
+    show, w, h, effective = _resolve_logo(g, adaptive=False)
+    assert show
+    assert effective == g.logo_path
+    assert w / h == 2.0
+
+
+def test_resolve_adaptive_logo_accepts_data_uris():
+    g = MetroGraph()
+    g.logo_path_light = _png_data_uri()
+    g.logo_path_dark = _png_data_uri()
 
     show, w, h, _ = _resolve_logo(g, adaptive=True)
     assert show

--- a/website/playground-tests/playground.spec.js
+++ b/website/playground-tests/playground.spec.js
@@ -282,6 +282,57 @@ test("syntax error surfaces inline and keeps the last good render", async () => 
   expect(await page.locator("#preview").innerHTML()).toBe(good);
 });
 
+// 1x1 red PNG, used as a stand-in logo upload.
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4" +
+  "nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+
+test("a logo path the playground cannot resolve gets a friendly hint", async () => {
+  await page.evaluate(() => {
+    window.__nfMetro.setValue(
+      "%%metro logo: does/not/exist.png\n%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n",
+    );
+  });
+  await expect(page.locator("#error")).toContainText("not found");
+  await expect(page.locator("#error")).toContainText("+ Logo");
+});
+
+test("attaching a logo embeds it as a data URI and renders it", async () => {
+  await page.evaluate(() => {
+    window.__nfMetro.setValue(
+      "%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n",
+    );
+  });
+
+  await page.locator("#btn-logo").click();
+  await expect(page.locator("#logo-modal")).toBeVisible();
+  await expect(page.locator("#logo-submit")).toBeDisabled();
+
+  await page.locator("#logo-file").setInputFiles({
+    name: "logo.png",
+    mimeType: "image/png",
+    buffer: Buffer.from(TINY_PNG_BASE64, "base64"),
+  });
+  await expect(page.locator("#logo-preview")).toBeVisible();
+  await expect(page.locator("#logo-submit")).toBeEnabled();
+
+  await page.locator("#logo-submit").click();
+  await expect(page.locator("#logo-modal")).toBeHidden();
+  await expect(page.locator("#error")).toBeHidden();
+
+  const value = await page.evaluate(() => window.__nfMetro.getValue());
+  expect(value).toContain("%%metro logo: data:image/png;base64,");
+  await expect(page.locator("#preview svg image")).toHaveCount(1);
+
+  // Removing it clears the directive and the embedded image.
+  await page.locator("#btn-logo").click();
+  await page.locator("#logo-remove").click();
+  await expect(page.locator("#preview svg image")).toHaveCount(0);
+  expect(await page.evaluate(() => window.__nfMetro.getValue())).not.toContain(
+    "%%metro logo:",
+  );
+});
+
 test("SVG and PNG export produce non-empty downloads", async () => {
   // Restore a valid map after the error test.
   await page.evaluate(() => {

--- a/website/playground-tests/playground.spec.js
+++ b/website/playground-tests/playground.spec.js
@@ -462,6 +462,36 @@ test("share link round-trips the editor content", async () => {
   expect(restored).toBe(source);
 });
 
+test("share link round-trips an attached logo", async () => {
+  await page.evaluate(() => {
+    window.__nfMetro.setValue(
+      "%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n",
+    );
+  });
+  await page.locator("#btn-logo").click();
+  await page.locator("#logo-file").setInputFiles({
+    name: "logo.png",
+    mimeType: "image/png",
+    buffer: Buffer.from(TINY_PNG_BASE64, "base64"),
+  });
+  await page.locator("#logo-submit").click();
+  await expect(page.locator("#preview svg image")).toHaveCount(1);
+  const source = await page.evaluate(() => window.__nfMetro.getValue());
+
+  await page.locator("#btn-share").click();
+  await page.waitForFunction(() => location.hash.includes("mmd-gz="));
+  const url = await page.evaluate(() => location.href);
+
+  // A full navigation to the shared URL starts from no prior editor state, so
+  // it stands in for the recipient opening the link cold: the logo must
+  // render with no network/disk access since the data URI travels entirely
+  // inside the link itself.
+  await page.goto(url);
+  await waitReady(page);
+  expect(await page.evaluate(() => window.__nfMetro.getValue())).toBe(source);
+  await expect(page.locator("#preview svg image")).toHaveCount(1);
+});
+
 // A two-section map used by the graphical-editing tests below.
 const EDIT_MAP =
   "%%metro line: a | A | #f00\n" +

--- a/website/public/playground/app.js
+++ b/website/public/playground/app.js
@@ -1737,6 +1737,9 @@ function submitConvert() {
 // nf-metro can decode and render them with no path lookup at all.
 const LOGO_DATA_URI_WARN_LENGTH = 70_000; // ~50KB of image data, base64-inflated
 
+// The data URI chosen in the logo modal, applied on "Use this logo".
+let pendingLogoUri = null;
+
 function readFileAsDataUri(file) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -1754,7 +1757,7 @@ function openLogo() {
   el("logo-warn").classList.add("hidden");
   el("logo-error").classList.add("hidden");
   el("logo-submit").disabled = true;
-  delete el("logo-modal").dataset.pendingUri;
+  pendingLogoUri = null;
   el("logo-modal").classList.remove("hidden");
 }
 
@@ -1779,14 +1782,13 @@ async function handleLogoFile(file) {
     "hidden",
     uri.length <= LOGO_DATA_URI_WARN_LENGTH,
   );
-  el("logo-modal").dataset.pendingUri = uri;
+  pendingLogoUri = uri;
   el("logo-submit").disabled = false;
 }
 
 function submitLogo() {
-  const uri = el("logo-modal").dataset.pendingUri;
-  if (!uri) return;
-  setDirective("logo", uri);
+  if (!pendingLogoUri) return;
+  setDirective("logo", pendingLogoUri);
   closeLogo();
   doRender();
 }

--- a/website/public/playground/app.js
+++ b/website/public/playground/app.js
@@ -277,7 +277,7 @@ function doRender() {
       applyZoom();
     } else {
       // Keep the last good render visible; just report the problem.
-      showError(res.error);
+      showError(friendlyRenderError(res.error));
     }
     refreshLineColors();
     syncDirectiveControls();
@@ -1727,6 +1727,90 @@ function submitConvert() {
   closeConvert();
 }
 
+/* ----------------------------- logo upload ------------------------------ */
+
+// The playground runs entirely in the browser (Pyodide has no access to the
+// user's disk), so a %%metro logo: directive can only resolve a path that
+// already exists inside that sandbox - which is never true for an uploaded
+// image. Embedding the image as a data: URI sidesteps the filesystem
+// entirely: the bytes travel as inline text in the map source itself, so
+// nf-metro can decode and render them with no path lookup at all.
+const LOGO_DATA_URI_WARN_LENGTH = 70_000; // ~50KB of image data, base64-inflated
+
+function readFileAsDataUri(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () =>
+      reject(reader.error || new Error("file read failed"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function openLogo() {
+  el("logo-file").value = "";
+  el("logo-preview").src = "";
+  el("logo-preview").classList.add("hidden");
+  el("logo-warn").classList.add("hidden");
+  el("logo-error").classList.add("hidden");
+  el("logo-submit").disabled = true;
+  delete el("logo-modal").dataset.pendingUri;
+  el("logo-modal").classList.remove("hidden");
+}
+
+function closeLogo() {
+  el("logo-modal").classList.add("hidden");
+}
+
+async function handleLogoFile(file) {
+  el("logo-error").classList.add("hidden");
+  if (!file) return;
+  let uri;
+  try {
+    uri = await readFileAsDataUri(file);
+  } catch (err) {
+    el("logo-error").textContent = "Could not read that file: " + err;
+    el("logo-error").classList.remove("hidden");
+    return;
+  }
+  el("logo-preview").src = uri;
+  el("logo-preview").classList.remove("hidden");
+  el("logo-warn").classList.toggle(
+    "hidden",
+    uri.length <= LOGO_DATA_URI_WARN_LENGTH,
+  );
+  el("logo-modal").dataset.pendingUri = uri;
+  el("logo-submit").disabled = false;
+}
+
+function submitLogo() {
+  const uri = el("logo-modal").dataset.pendingUri;
+  if (!uri) return;
+  setDirective("logo", uri);
+  closeLogo();
+  doRender();
+}
+
+function removeLogo() {
+  setDirective("logo", null);
+  closeLogo();
+  doRender();
+}
+
+// A %%metro logo: path the playground genuinely cannot resolve (it isn't a
+// data URI and there is no source repo on disk to resolve it against) is the
+// single most common reason a pasted map fails to render here; point at the
+// fix rather than leaving the raw parser error to puzzle out.
+function friendlyRenderError(msg) {
+  if (/%%metro logo:.*not found/.test(msg)) {
+    return (
+      msg +
+      '\n\nThe playground can\'t read logo files from disk - use the "+ Logo" button to attach the image instead.'
+    );
+  }
+  return msg;
+}
+
 /* -------------------------------- utils -------------------------------- */
 
 function debounce(fn, ms) {
@@ -1853,10 +1937,22 @@ function wireControls() {
     if (e.target === el("convert-modal")) closeConvert();
   });
 
+  el("btn-logo").addEventListener("click", openLogo);
+  el("logo-file").addEventListener("change", (e) =>
+    handleLogoFile(e.target.files[0]),
+  );
+  el("logo-cancel").addEventListener("click", closeLogo);
+  el("logo-remove").addEventListener("click", removeLogo);
+  el("logo-submit").addEventListener("click", submitLogo);
+  el("logo-modal").addEventListener("click", (e) => {
+    if (e.target === el("logo-modal")) closeLogo();
+  });
+
   document.addEventListener("keydown", (e) => {
     if (e.key !== "Escape") return;
     if (!el("report-modal").classList.contains("hidden")) closeReport();
     if (!el("convert-modal").classList.contains("hidden")) closeConvert();
+    if (!el("logo-modal").classList.contains("hidden")) closeLogo();
   });
 
   wireEditTools();

--- a/website/public/playground/harness.html
+++ b/website/public/playground/harness.html
@@ -58,6 +58,12 @@
               + Line
             </button>
             <button id="btn-edge" title="Insert an edge">+ Edge</button>
+            <button
+              id="btn-logo"
+              title="Attach a logo image (embedded inline, since the playground can't read files from disk)"
+            >
+              + Logo
+            </button>
             <span class="sep"></span>
             <span class="group-label">Lines</span>
             <div id="line-colors" class="swatches"></div>
@@ -344,6 +350,46 @@
           <div class="modal-actions">
             <button id="convert-cancel" class="ghost">Cancel</button>
             <button id="convert-submit">Convert</button>
+          </div>
+        </div>
+      </div>
+
+      <div
+        id="logo-modal"
+        class="modal-overlay hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="logo-title"
+      >
+        <div class="modal">
+          <h2 id="logo-title">Attach a logo</h2>
+          <p class="muted small">
+            Embeds the image directly into the
+            <code>%%metro logo:</code> directive as inline data, so it travels
+            with the map text. The playground runs entirely in your browser and
+            cannot read a logo file from your computer's disk by path.
+          </p>
+          <label for="logo-file">Image file</label>
+          <input
+            type="file"
+            id="logo-file"
+            accept="image/png,image/svg+xml,image/jpeg,image/gif,image/webp"
+          />
+          <img
+            id="logo-preview"
+            class="logo-preview hidden"
+            alt="Logo preview"
+          />
+          <div id="logo-warn" class="hidden modal-error">
+            This image is large; embedding it will make the map source (and any
+            share link) much bigger. A small logo (under ~50&nbsp;KB) works
+            best.
+          </div>
+          <div id="logo-error" class="hidden modal-error"></div>
+          <div class="modal-actions">
+            <button id="logo-remove" class="ghost">Remove logo</button>
+            <button id="logo-cancel" class="ghost">Cancel</button>
+            <button id="logo-submit" disabled>Use this logo</button>
           </div>
         </div>
       </div>

--- a/website/public/playground/style.css
+++ b/website/public/playground/style.css
@@ -539,6 +539,22 @@ button:disabled {
   white-space: pre-wrap;
 }
 
+.modal input[type="file"] {
+  width: 100%;
+  color: var(--text);
+  font-size: 12px;
+}
+.logo-preview {
+  display: block;
+  margin-top: 12px;
+  max-width: 100%;
+  max-height: 120px;
+  background: repeating-conic-gradient(#80808033 0% 25%, transparent 0% 50%)
+    50% / 16px 16px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
 .mode-btn[aria-pressed="true"] {
   background: var(--accent);
   border-color: var(--accent);

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -61,6 +61,12 @@ import { base } from "../site";
           </button>
           <button id="btn-line" title="Insert a line definition">+ Line</button>
           <button id="btn-edge" title="Insert an edge">+ Edge</button>
+          <button
+            id="btn-logo"
+            title="Attach a logo image (embedded inline, since the playground can't read files from disk)"
+          >
+            + Logo
+          </button>
           <span class="sep"></span>
           <span class="group-label">Lines</span>
           <div id="line-colors" class="swatches"></div>
@@ -342,6 +348,42 @@ import { base } from "../site";
         <div class="modal-actions">
           <button id="convert-cancel" class="ghost">Cancel</button>
           <button id="convert-submit">Convert</button>
+        </div>
+      </div>
+    </div>
+
+    <div
+      id="logo-modal"
+      class="modal-overlay hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="logo-title"
+    >
+      <div class="modal">
+        <h2 id="logo-title">Attach a logo</h2>
+        <p class="muted small">
+          Embeds the image directly into the
+          <code>%%metro logo:</code> directive as inline data, so it travels
+          with the map text. The playground runs entirely in your browser and
+          cannot read a logo file from your computer's disk by path.
+        </p>
+        <label for="logo-file">Image file</label>
+        <input
+          type="file"
+          id="logo-file"
+          accept="image/png,image/svg+xml,image/jpeg,image/gif,image/webp"
+        />
+        <img id="logo-preview" class="logo-preview hidden" alt="Logo preview" />
+        <div id="logo-warn" class="hidden modal-error">
+          This image is large; embedding it will make the map source (and any
+          share link) much bigger. A small logo (under ~50&nbsp;KB) works
+          best.
+        </div>
+        <div id="logo-error" class="hidden modal-error"></div>
+        <div class="modal-actions">
+          <button id="logo-remove" class="ghost">Remove logo</button>
+          <button id="logo-cancel" class="ghost">Cancel</button>
+          <button id="logo-submit" disabled>Use this logo</button>
         </div>
       </div>
     </div>
@@ -991,6 +1033,22 @@ import { base } from "../site";
     padding: 8px 10px;
     font-size: 12px;
     white-space: pre-wrap;
+  }
+
+  .nfm-playground .modal input[type="file"] {
+    width: 100%;
+    color: var(--text);
+    font-size: 12px;
+  }
+  .logo-preview {
+    display: block;
+    margin-top: 12px;
+    max-width: 100%;
+    max-height: 120px;
+    background: repeating-conic-gradient(#80808033 0% 25%, transparent 0% 50%) 50%
+      / 16px 16px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
   }
 
   .mode-btn[aria-pressed="true"] {


### PR DESCRIPTION
## Summary

The playground runs entirely in the browser via Pyodide, which has no access to the user's disk or a source repo. A `%%metro logo:` directive pointing at a file path could never resolve there, so pasting an existing pipeline's map into the playground either silently dropped the logo or (since the recent stricter `%%metro logo:` validation) hard-failed the whole render with `path '...' not found`.

- `%%metro logo:` now accepts a base64 `data:` URI in addition to a file path. A data URI is self-contained, so it resolves identically everywhere (CLI, embedding, and the sandboxed playground) with no filesystem lookup at all. A genuinely missing file path still raises the same clear error as before.
- Also fixed a latent bug where adaptive (`light | dark`) logo paths were resolved against `source_dir` for sizing but not for the actual render, so a relative adaptive logo could size correctly but fail to embed when rendered from a different cwd.
- The playground gets a new **"+ Logo"** button: pick an image, it's converted to a data URI client-side and written into `%%metro logo:`. Pasting a map with an unresolvable file-path logo now surfaces a hint pointing at that button instead of a bare parser error.
- The data URI lives inline in the map text, so it travels through the existing "Share link" feature automatically — verified with an e2e test that does a full fresh page load from a shared URL and confirms the logo renders with no prior state.

## Test plan

- [x] `pytest` (367 tests) — new coverage in `tests/test_mode_adaptive_logo.py` and `tests/test_api.py` for data-URI resolution, decoding, and the `prepare_graph` validation gate
- [x] `ruff check` / `ruff format --check` / `mypy src/` all clean
- [x] Playwright e2e (`website/playground-tests/`, 39 tests) — new coverage for attaching/removing a logo, the friendly-error hint, and the share-link + logo round trip
- [x] Manual CLI render with a data-URI logo (single and adaptive light/dark)