### PR TITLE
feat(ci): reusable workflow to keep metro-map SVG in sync

### DIFF
--- a/.github/workflows/render-metro-map.yml
+++ b/.github/workflows/render-metro-map.yml
@@ -1,0 +1,118 @@
+name: Render metro map
+
+# Reusable workflow for consumer pipeline repos. Renders a metro-map SVG from
+# its .mmd source and keeps the committed SVG in sync:
+#   - on push:         commit the re-rendered SVG (with [skip ci])
+#   - on pull_request:  post a warning comment; never commit
+#
+# Caller example (in the consumer repo):
+#
+#   on:
+#     push:         { paths: ['assets/metro_map.mmd'] }
+#     pull_request: { paths: ['assets/metro_map.mmd'] }
+#   jobs:
+#     metro:
+#       uses: seqeralabs/nf-metro/.github/workflows/render-metro-map.yml@1.1.0
+
+on:
+  workflow_call:
+    inputs:
+      input:
+        description: Path to the Mermaid .mmd source to render.
+        type: string
+        required: false
+        default: assets/metro_map.mmd
+      output:
+        description: Path for the rendered SVG (empty = sibling .svg of the input).
+        type: string
+        required: false
+        default: ""
+      theme:
+        description: "Visual theme (nfcore, seqera, ...)."
+        type: string
+        required: false
+        default: nfcore
+      mode:
+        description: Display mode to bake (light or dark; empty = adaptive).
+        type: string
+        required: false
+        default: ""
+      embed-font:
+        description: Inline the label font into the SVG.
+        type: string
+        required: false
+        default: "true"
+      version:
+        description: nf-metro version to install (empty = latest release).
+        type: string
+        required: false
+        default: ""
+      nf-metro-ref:
+        description: Git ref of seqeralabs/nf-metro whose action.yml runs.
+        type: string
+        required: false
+        default: "1.1.0"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Render metro map
+        id: render
+        uses: seqeralabs/nf-metro@${{ inputs.nf-metro-ref }}
+        with:
+          input: ${{ inputs.input }}
+          output: ${{ inputs.output }}
+          theme: ${{ inputs.theme }}
+          mode: ${{ inputs.mode }}
+          embed-font: ${{ inputs.embed-font }}
+          version: ${{ inputs.version }}
+
+      - name: Commit re-rendered SVG
+        if: >-
+          github.event_name == 'push' && steps.render.outputs.changed == 'true'
+        env:
+          OUTPUT_PATH: ${{ steps.render.outputs.output-path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$OUTPUT_PATH"
+          git commit -m "chore: re-render metro map [skip ci]"
+          git push
+
+      - name: Warn on stale SVG
+        if: >-
+          github.event_name == 'pull_request' && steps.render.outputs.changed == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          INPUT_PATH: ${{ inputs.input }}
+          OUTPUT_PATH: ${{ steps.render.outputs.output-path }}
+        with:
+          script: |
+            const marker = '<!-- nf-metro -->';
+            const { INPUT_PATH, OUTPUT_PATH } = process.env;
+            const body = `${marker}\n:warning: **\`${OUTPUT_PATH}\` is out of date with \`${INPUT_PATH}\`.**\n\n`
+              + 'It will be re-rendered automatically when this PR is merged, '
+              + 'or you can regenerate it locally with `nf-metro render`.';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/docs/automation.mdx
+++ b/docs/automation.mdx
@@ -32,3 +32,32 @@ Inputs (all optional): `input` (default `assets/metro_map.mmd`), `output`
 `embed-font` (default `true`), `version` (nf-metro version to install), and
 `extra-args` for any other `nf-metro render` flag (e.g.
 `extra-args: "--fold-threshold 20"`).
+
+## Reusable workflow
+
+The turn-key option. It wraps the action and keeps the committed SVG in sync:
+commit the re-render on pushes, warn on pull requests — no shell glue in your
+repo.
+
+```yaml
+# .github/workflows/metro-map.yml
+name: Metro map
+on:
+  push:
+    paths: ["assets/metro_map.mmd"]
+  pull_request:
+    paths: ["assets/metro_map.mmd"]
+
+jobs:
+  metro:
+    uses: seqeralabs/nf-metro/.github/workflows/render-metro-map.yml@1.1.0
+```
+
+Behaviour:
+
+- **push** — if the SVG changed, it is committed with `chore: re-render metro map [skip ci]` and pushed.
+- **pull_request** — if the SVG is out of date, a single warning comment is posted (and refreshed on re-runs); nothing is committed.
+
+Inputs mirror the action (`input`, `output`, `theme`, `mode`, `embed-font`,
+`version`), plus `nf-metro-ref` — the ref of `seqeralabs/nf-metro` whose action
+runs (default `1.1.0`).

--- a/docs/automation.mdx
+++ b/docs/automation.mdx
@@ -35,9 +35,7 @@ Inputs (all optional): `input` (default `assets/metro_map.mmd`), `output`
 
 ## Reusable workflow
 
-The turn-key option. It wraps the action and keeps the committed SVG in sync:
-commit the re-render on pushes, warn on pull requests — no shell glue in your
-repo.
+nf-metro provides a reusable action which will update an SVG based on your mermaid diagram. If the metro map has been updated it will commit the updated image.
 
 ```yaml
 # .github/workflows/metro-map.yml


### PR DESCRIPTION
## What

Adds `.github/workflows/render-metro-map.yml` — a `workflow_call` reusable workflow wrapping the [composite action](https://github.com/seqeralabs/nf-metro/pull/1242) with sync behavior (mirrors nf-core/rnadnavar):

- **push** (changed): commit the re-rendered SVG with `chore: re-render metro map [skip ci]`.
- **pull_request** (changed): post/refresh one marked warning comment; **no commit**.

## Usage (consumer repo)

```yaml
on:
  push:         { paths: ['assets/metro_map.mmd'] }
  pull_request: { paths: ['assets/metro_map.mmd'] }
jobs:
  metro:
    uses: seqeralabs/nf-metro/.github/workflows/render-metro-map.yml@1.1.0
```

## Details

- Uses `steps.render.outputs.changed` / `output-path` from the composite action.
- PR comment find-or-updated via a hidden `<!-- nf-metro -->` marker (github-script) — re-runs update, don't spam.
- `nf-metro-ref` default `1.1.0` (the action ref it runs); bumped each release by the release skill.
- `permissions: { contents: write, pull-requests: write }`.
- Docs: appends the **Reusable workflow** section to the CI & automation page.

## Stack

Second of three — **based on #1242**. References the action by tag; a release tag carrying `action.yml` (#1242) must exist before the default `nf-metro-ref` resolves.

## Verification

Parses as valid YAML. Full run needs the action tag + a consumer repo (post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)