### PR TITLE
chore: release 1.1.0

### DIFF
--- a/docs/releases/1.1.0.md
+++ b/docs/releases/1.1.0.md
@@ -1,0 +1,48 @@
+---
+title: "v1.1.0"
+slug: releases/1.1.0
+---
+
+_2026-07-01_ · [GitHub release](https://github.com/seqeralabs/nf-metro/releases/tag/1.1.0) · [Diff](https://github.com/seqeralabs/nf-metro/compare/1.0.0...1.1.0)
+
+A routing-focused follow-up to 1.0.0's rebuild, plus a new spacing control and several playground quality-of-life fixes. Existing `.mmd` files render with no changes.
+
+## `track_gap` directive and `--track-gap` flag
+
+`%%metro track_gap: <pixels>` sets the visual gap between adjacent line strokes in a bundle - the empty space between their edges, not their centres. The default is 1 px; set it to `0` to bring strokes flush against each other, or raise it (up to 3 px) for more breathing room between co-running lines:
+
+<Metro src="examples/guide/07_track_gap.mmd" />
+
+## Packing sections into a shared grid cell
+
+Hand-placed sections (`%%metro grid: <section> | <col>,<row>`) can now share a cell instead of getting one section per cell:
+
+```
+%%metro grid: gatk, variant_calling | 1,0
+%%metro grid: realign, reporting     | 1,1
+```
+
+The named sections pack side-by-side along the flow axis, and the cell sizes to fit its members - so a short+long pair in one row lines up top-to-bottom with a long+short pair packed into the same column below it. This keeps folded pipelines compact and frees the cleared corner for the legend. Each member keeps its own direction, ports, and internal layout; only their placement is shared. Stacked single-row sections sharing a rowspan band now distribute across the full band instead of leaving the bottom rows empty.
+
+## Playground improvements
+
+- **Logo upload.** The playground runs entirely in-browser via Pyodide, which has no access to the local filesystem, so a `%%metro logo:` file path pasted in from an existing map could never resolve there. A new "+ Logo" button reads a chosen image client-side and writes it into the directive as a `data:` URI.
+- **Line gap** is now a main toolbar control (next to Centre ports) instead of buried in Advanced options, wired to the new `track_gap` directive.
+- The build's commit SHA is shown next to **Report a bug** and pre-filled into the bug report, so reports carry the exact build they came from.
+- Fixed a service-worker caching bug where returning visitors kept running a stale build after every deploy, because the dev wheel's filename never changed between builds.
+
+## Gallery
+
+The nf-core pipelines page now lists an nf-core/seqinspector render, showcasing a `%%metro grid:` stack of two single-row sections beside a rowspan-2 section.
+
+## Notable fixes
+
+A long tail of routing and rendering fixes, mostly in fold, bypass, and convergence handling:
+
+- Fold-back routing: serpentine multi-line folds under `direction: RL` render correctly, fold reversal propagates through peel-off junctions, and the TB-exit-to-return-row connector no longer kinks.
+- Bypass routing: same-row bypasses route around (rather than through) a packed cell-mate or an intervening section, and clear exit rows run straight instead of kinking.
+- Convergence sinks: entry lanes order by feeder approach direction, and interchange labels clear their connector bridge and the enlarged end-knob.
+- Sectionless graphs: skip-lines with no subgraph now detour around non-consumer markers instead of breezing through them.
+- 2-way fans with an internal source now centre on their equal siblings.
+- `--mode` baked output now selects the correct logo variant and pins `color-scheme` so raster exports aren't theme-dependent.
+- `--embed-font` output falls back to a generic font family after `Inter`.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -6,6 +6,7 @@ Release notes for nf-metro, newest first.
 
 | Version                             | Date       | Highlights                                                                                                                                                                                  |
 | ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [v1.1.0](/nf-metro/releases/1.1.0/) | 2026-07-01 | `track_gap` option, packing sections into a shared grid cell, playground logo upload, long tail of fold/bypass/convergence routing fixes                                                    |
 | [v1.0.0](/nf-metro/releases/1.0.0/) | 2026-06-30 | Routing engine rebuilt onto a single centreline builder, all four flow directions (BT/RL added), light/dark as an orthogonal axis, stable render API, embedded data manifest, new docs site |
 | [v0.7.2](/nf-metro/releases/0.7.2/) | 2026-05-18 | Rowspan bbox shrink fix                                                                                                                                                                     |
 | [v0.7.1](/nf-metro/releases/0.7.1/) | 2026-05-17 | Bypass row-gap fix                                                                                                                                                                          |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nf-metro"
-version = "1.0.0"
+version = "1.1.0"
 description = "Generate metro-map-style SVG diagrams from Mermaid graph definitions"
 readme = "README.md"
 license = "MIT"

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,5 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- Bumps version to 1.1.0 in `pyproject.toml` and `__init__.py`
- Adds `docs/releases/1.1.0.md` and wires it into the releases index

New `track_gap` directive/CLI flag for controlling line-bundle spacing, support for packing multiple sections into a shared grid cell, several playground UX improvements (logo upload, promoted line-gap control, build-SHA hint, stale-cache fix), the nf-core/seqinspector gallery render, and a long tail of fold/bypass/convergence routing fixes.

## After merge

Create the GitHub Release at https://github.com/seqeralabs/nf-metro/releases/new
with tag `1.1.0` to trigger the PyPI publish and versioned docs deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)