### PR TITLE
chore(docs): point root redirect at latest/ instead of dev/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,21 +119,19 @@ jobs:
               --manifest gh-pages/versions.json --version dev
           fi
 
-          # Root redirects to dev/ while the Astro site lives only there. Revert
-          # the three dev/ references below to latest/ once the first Astro
-          # release is cut, so the root tracks the latest stable docs again.
+          # Root redirects to the latest stable release, not the in-progress dev build.
           cat > gh-pages/index.html <<'HTML'
           <!doctype html>
           <html>
             <head>
               <meta charset="utf-8" />
               <title>Redirecting</title>
-              <noscript><meta http-equiv="refresh" content="1; url=dev/" /></noscript>
+              <noscript><meta http-equiv="refresh" content="1; url=latest/" /></noscript>
               <script>
-                window.location.replace("dev/" + location.search + location.hash);
+                window.location.replace("latest/" + location.search + location.hash);
               </script>
             </head>
-            <body>Redirecting to <a href="dev/">dev/</a>...</body>
+            <body>Redirecting to <a href="latest/">latest/</a>...</body>
           </html>
           HTML
 


### PR DESCRIPTION
## Summary

- The docs deploy root (`https://seqeralabs.github.io/nf-metro/`) currently redirects to `dev/`, a stopgap from when the Astro site had no stable release yet.
- We've since cut two stable releases (1.0.0, 1.1.0), so the root now redirects to `latest/` instead.

## Test plan

- [x] Merging to `main` re-triggers `docs.yml` on the `push` event, which regenerates `gh-pages/index.html` unconditionally (not just on release), so the fix takes effect immediately without a new release.
- [ ] After merge, confirm `https://seqeralabs.github.io/nf-metro/` redirects to `latest/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)