### PR TITLE
fix(layout): only reserve the title band when render will draw it

### DIFF
--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -26,7 +26,11 @@ from nf_metro.parser.directives import apply_legend_directive
 from nf_metro.parser.model import LineSpread, MetroGraph
 from nf_metro.render import render_svg
 from nf_metro.render.html import render_html
-from nf_metro.render.legend import logo_is_resolvable, resolve_logo_file
+from nf_metro.render.legend import (
+    logo_certainly_shows,
+    logo_is_resolvable,
+    resolve_logo_file,
+)
 from nf_metro.render.style import Theme
 from nf_metro.themes import DEFAULT_MODE, THEME_MODES, THEMES
 
@@ -141,8 +145,18 @@ def prepare_graph(
     legend: str | None = None,
     layout_options: Mapping[str, object] | None = None,
     source_dir: str = "",
+    bare: bool = False,
+    output_format: Literal["svg", "html"] = "svg",
 ) -> MetroGraph:
     """Parse *text*, apply option overrides, and compute the layout in place.
+
+    ``bare`` and ``output_format`` mirror the eventual render call (the CLI's
+    ``--bare``/``--format`` flags): used here only to resolve
+    ``graph.reserve_title_band`` before layout runs, so the title-band
+    clearance in ``layout/phases/canvas.py`` doesn't reserve space for a
+    header the render won't actually draw. HTML output always draws its own
+    title/logo band regardless of ``bare``/``%%metro legend:`` (its embedded
+    SVG forces the legend off and ignores ``bare``), so it always reserves.
 
     Returns the settled graph. Propagates the pipeline's typed errors:
     :class:`ValueError` (parse), and the layout errors
@@ -190,6 +204,11 @@ def prepare_graph(
         _raw: str = getattr(graph, _attr)
         if _raw and not logo_is_resolvable(_raw):
             raise ValueError(f"%%metro logo: path {_raw!r} not found")
+
+    logo_in_legend = logo_certainly_shows(graph) and graph.legend_position != "none"
+    graph.reserve_title_band = output_format == "html" or (
+        not bare and not logo_in_legend
+    )
 
     compute_layout(graph)
     return graph
@@ -248,6 +267,8 @@ def render_string(
         logo=logo,
         legend=legend,
         layout_options=layout_options,
+        bare=bare if config is None else config.bare,
+        output_format=output_format if config is None else config.output_format,
     )
     theme_obj = resolve_theme(theme, graph, mode=mode)
     flat = RenderConfig(

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -391,6 +391,8 @@ def _render_one(
             legend=legend,
             layout_options=layout_opts,
             source_dir=str(input_file.resolve().parent),
+            bare=bare,
+            output_format=format_,
         )
     except (
         ValueError,

--- a/src/nf_metro/layout/phases/canvas.py
+++ b/src/nf_metro/layout/phases/canvas.py
@@ -122,14 +122,17 @@ def _canvas_top_shortfall(graph: MetroGraph, section_y_padding: float) -> float:
     """Downward shift needed so the graph clears both top floors (0 if none).
 
     Containment: every section must sit ``section_y_padding`` below the canvas
-    top.  Title: when the map is titled, a *drawn* section whose header badge
-    overlaps the title band (box top above ``TITLE_BAND_OVERLAP_FLOOR``) is
-    lifted clear to ``TITLE_BAND_CLEARANCE`` -- a map already clearing the
-    title, and implicit holders (which draw no badge), are left untouched.
+    top.  Title: when the map is titled *and* ``graph.reserve_title_band`` (set
+    by :func:`~nf_metro.api.prepare_graph` -- false for ``--bare`` or a logo
+    folded into the legend, cases where render draws nothing up there), a
+    *drawn* section whose header badge overlaps the title band (box top above
+    ``TITLE_BAND_OVERLAP_FLOOR``) is lifted clear to ``TITLE_BAND_CLEARANCE``
+    -- a map already clearing the title, and implicit holders (which draw no
+    badge), are left untouched.
     """
     min_all = _min_section_bbox_top(graph, section_y_padding)
     shortfall = max(0.0, section_y_padding - min_all)
-    if graph.title:
+    if graph.title and graph.reserve_title_band:
         min_drawn = _min_drawn_section_bbox_top(graph)
         if min_drawn is not None and min_drawn < TITLE_BAND_OVERLAP_FLOOR:
             shortfall = max(shortfall, TITLE_BAND_CLEARANCE - min_drawn)
@@ -143,13 +146,14 @@ def _canvas_top_preserved(
 
     The containment floor (``section_y_padding``) bounds all sections; the
     no-overlap floor (``TITLE_BAND_OVERLAP_FLOOR``) bounds drawn sections on a
-    titled map.  Lets the grid snap reject a candidate that would lift the top
-    above a floor.
+    titled map whose title band will actually be drawn (see
+    ``graph.reserve_title_band``).  Lets the grid snap reject a candidate that
+    would lift the top above a floor.
     """
     min_all = _min_section_bbox_top(graph, section_y_padding)
     if min_all + shift < section_y_padding - 1e-6:
         return False
-    if graph.title:
+    if graph.title and graph.reserve_title_band:
         min_drawn = _min_drawn_section_bbox_top(graph)
         if (
             min_drawn is not None

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -388,6 +388,14 @@ class MetroGraph:
     directional: bool = False
     strict: bool = False
     embed_manifest: bool = True
+    # Whether a render will actually draw a title/logo band at the canvas
+    # top for a titled map. Set by prepare_graph (from --bare, %%metro
+    # legend:, and whether a logo is configured) before compute_layout runs,
+    # mirroring render.svg's own drawing decision so the title-band
+    # clearance in layout/phases/canvas.py doesn't reserve space for a
+    # header nothing will occupy. Defaults to True (always reserve) for
+    # callers that build a graph directly and skip prepare_graph.
+    reserve_title_band: bool = True
     # When set, every real station with no explicit %%metro process: directive
     # gets its own id as a default process pattern, so a map whose station ids
     # already name their processes lights up live with no per-station mapping.

--- a/src/nf_metro/render/legend.py
+++ b/src/nf_metro/render/legend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 __all__ = [
     "compute_legend_dimensions",
+    "logo_certainly_shows",
     "logo_image_kwargs",
     "logo_is_resolvable",
     "marker_corner_radius",
@@ -62,6 +63,20 @@ def logo_is_resolvable(path: str) -> bool:
     browser-based playground) or a path to an existing file.
     """
     return path.startswith("data:") or Path(path).is_file()
+
+
+def logo_certainly_shows(graph: MetroGraph) -> bool:
+    """True when a logo will render for sure, independent of display mode.
+
+    A single ``logo_path`` renders regardless of mode; a light+dark pair
+    covers whichever mode is resolved. A lone light-only or dark-only
+    variant's fate depends on the resolved display mode and whether adaptive
+    mode is active (``_is_adaptive_mode`` in ``render.svg``, disabled by
+    ``--no-chrome-css``) -- neither of which a caller resolving this before
+    theming (e.g. :func:`~nf_metro.api.prepare_graph`) can know -- so that
+    case is treated as unconfigured rather than risking a false positive.
+    """
+    return bool(graph.logo_path) or bool(graph.logo_path_light and graph.logo_path_dark)
 
 
 def resolve_logo_file(raw: str, source_dir: str) -> str:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -23,6 +23,7 @@ import pytest
 from conftest import CONTENT_PLACEMENT_PHASES
 from layout_validator import check_route_segment_crossings, check_station_as_elbow
 
+from nf_metro.api import prepare_graph
 from nf_metro.layout.constants import (
     CURVE_RADIUS,
     DIAGONAL_SLOPE_RATIO,
@@ -1456,6 +1457,14 @@ _TITLE_TOGGLE_FIXTURES = [
 ]
 
 
+def _untitled_bbox_top(text: str) -> float | None:
+    """Lay out *text* with its title stripped and return the drawn top."""
+    untitled = parse_metro_mermaid(text)
+    untitled.title = ""
+    compute_layout(untitled)
+    return _min_drawn_section_bbox_top(untitled)
+
+
 @pytest.mark.parametrize("fixture", _TITLE_TOGGLE_FIXTURES)
 def test_title_only_moves_a_map_whose_header_would_overlap(fixture):
     """A title moves the top only when the header would otherwise overlap it.
@@ -1473,10 +1482,7 @@ def test_title_only_moves_a_map_whose_header_would_overlap(fixture):
     compute_layout(titled)
     titled_top = _min_drawn_section_bbox_top(titled)
 
-    untitled = parse_metro_mermaid(text)
-    untitled.title = ""
-    compute_layout(untitled)
-    untitled_top = _min_drawn_section_bbox_top(untitled)
+    untitled_top = _untitled_bbox_top(text)
 
     assert titled_top is not None and untitled_top is not None
     assert titled_top >= untitled_top - GUARD_TOLERANCE
@@ -1485,6 +1491,54 @@ def test_title_only_moves_a_map_whose_header_would_overlap(fixture):
         assert titled_top == pytest.approx(untitled_top, abs=GUARD_TOLERANCE)
     else:
         assert titled_top > untitled_top + GUARD_TOLERANCE
+
+
+# Fixtures whose header would overlap the title band (untitled top below
+# TITLE_BAND_OVERLAP_FLOOR), so the lift this test targets actually fires.
+_TITLE_BAND_OVERLAP_FIXTURES = [
+    "topologies/rowmate_tb_side_entry_top_align.mmd",
+    "sarek_metro.mmd",
+    "variantbenchmarking.mmd",
+    "topologies/off_track_input_above_consumer.mmd",
+]
+_PLACEHOLDER_LOGO = str(EXAMPLES / "placeholder_logo.png")
+
+
+@pytest.mark.parametrize("fixture", _TITLE_BAND_OVERLAP_FIXTURES)
+def test_title_band_not_reserved_when_nothing_drawn_there(fixture):
+    """A titled map reserves no title-band lift when render draws nothing there.
+
+    ``--bare`` omits the title outright, and a configured logo folded into
+    the legend (``%%metro legend:`` with a logo set) means neither the logo
+    nor the title text renders standalone at the canvas top (render.svg's
+    ``logo_in_legend`` branch beats both). Both cases must land exactly
+    where an untitled map would, even when the header would otherwise
+    overlap the title band.
+    """
+    text = _fixture_text(fixture)
+
+    untitled_top = _untitled_bbox_top(text)
+    assert untitled_top is not None
+    if untitled_top >= TITLE_BAND_OVERLAP_FLOOR - GUARD_TOLERANCE:
+        pytest.skip("fixture's header does not overlap the title band")
+
+    bare_graph = prepare_graph(text, bare=True)
+    bare_top = _min_drawn_section_bbox_top(bare_graph)
+    assert bare_top == pytest.approx(untitled_top, abs=GUARD_TOLERANCE), (
+        f"{fixture}: --bare top y={bare_top:.1f} reserves title-band space "
+        f"above the untitled baseline {untitled_top:.1f} despite drawing no "
+        f"title"
+    )
+
+    logo_in_legend_graph = prepare_graph(
+        text, logo=_PLACEHOLDER_LOGO, legend="bl", source_dir=str(EXAMPLES)
+    )
+    logo_in_legend_top = _min_drawn_section_bbox_top(logo_in_legend_graph)
+    assert logo_in_legend_top == pytest.approx(untitled_top, abs=GUARD_TOLERANCE), (
+        f"{fixture}: logo-in-legend top y={logo_in_legend_top:.1f} reserves "
+        f"title-band space above the untitled baseline {untitled_top:.1f} "
+        f"despite drawing neither a title nor a standalone logo"
+    )
 
 
 @pytest.mark.parametrize("fixture", ALL_FIXTURES)


### PR DESCRIPTION
## Summary
- `%%metro title:` reserved a top "title band" clearance in layout whenever a titled map's section header would otherwise overlap it, regardless of whether render actually draws a title or logo there.
- `render.svg` only draws a standalone title/logo when the map isn't `--bare` and a configured logo doesn't fold into the legend (`%%metro legend:` with a non-`none` position) — in both cases nothing is drawn at the canvas top, so the reserved clearance was wasted.
- `prepare_graph` now resolves a new `graph.reserve_title_band` field from `--bare`, `%%metro legend:`, and whether a logo is configured (via the new `render.legend.logo_certainly_shows` helper, which is conservative about light/dark-only logo variants whose resolution depends on display mode) before layout runs. `layout/phases/canvas.py`'s `_canvas_top_shortfall`/`_canvas_top_preserved` gate the title-band lift on it.
- HTML output always reserves the band regardless of `--bare`/`%%metro legend:`, since its embedded SVG unconditionally forces the legend off and never receives `--bare`, so it always draws a title/logo standalone.

## Note on the issue's minimized repro
The trimmed single-section repro pasted into #1278 doesn't actually reproduce the quoted `y=70` vs `y=50` numbers: a lone section's header badge already needs ~70px of top clearance on its own, so removing the title doesn't move it either way. The real numbers came from diffing nf-core/rnaseq's `assets/metro_map.mmd` (a 5-section grid) across the two nf-metro states, not from a title-toggle on the pasted snippet. The code-level defect the issue describes is real regardless (`_canvas_top_shortfall` gated purely on `graph.title`, with no `logo_in_legend`/`bare` awareness), and this fix is verified against real multi-section fixtures where the precondition holds (`sarek_metro.mmd`, `variantbenchmarking.mmd`, `topologies/rowmate_tb_side_entry_top_align.mmd`, `topologies/off_track_input_above_consumer.mmd`).

## Test plan
- [x] `pytest` passes (28139 passed, 105 skipped, 10 xfailed — all pre-existing/unrelated), including the new parametrized invariant test `test_title_band_not_reserved_when_nothing_drawn_there` across 4 fixtures whose header overlaps the title band
- [x] `ruff check` + `ruff format` clean on the whole repo
- [x] Runtime behavior: no separate `_guard_*` added, matching the sibling #1273 fix (title-band logic in `canvas.py` has no runtime guards; covered by parametrized unit tests only)
- [x] Visual review of render preview: [no visual changes detected](https://seqeralabs.github.io/nf-metro/_pr/1280/) — all gallery renders match `main` (expected: no gallery fixture combines a titled map, an overlapping header, and `--bare`/logo-in-legend)

Fixes #1278

Generated with Claude Code
