### PR TITLE
fix(render): give the label halo a dark fallback on transparent themes

### DIFF
--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -201,7 +201,7 @@ WATERMARK_FONT_SIZE: int = 8
 WATERMARK_PADDING_RATIO: float = 0.5
 """Fraction of canvas padding used for watermark X inset from right edge."""
 
-WATERMARK_Y_INSET: float = 10.0
+WATERMARK_Y_INSET: float = 12.0
 """Y distance from bottom edge for watermark text."""
 
 WATERMARK_BARE_X_INSET: float = 8.0

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -201,7 +201,7 @@ WATERMARK_FONT_SIZE: int = 8
 WATERMARK_PADDING_RATIO: float = 0.5
 """Fraction of canvas padding used for watermark X inset from right edge."""
 
-WATERMARK_Y_INSET: float = 12.0
+WATERMARK_Y_INSET: float = 8.0
 """Y distance from bottom edge for watermark text."""
 
 WATERMARK_BARE_X_INSET: float = 8.0

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -201,7 +201,7 @@ WATERMARK_FONT_SIZE: int = 8
 WATERMARK_PADDING_RATIO: float = 0.5
 """Fraction of canvas padding used for watermark X inset from right edge."""
 
-WATERMARK_Y_INSET: float = 8.0
+WATERMARK_Y_INSET: float = 10.0
 """Y distance from bottom edge for watermark text."""
 
 WATERMARK_BARE_X_INSET: float = 8.0

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -744,7 +744,7 @@ def _render_svg_scaled(
     if inject_dark_mode_css and (
         not theme.background_color or theme.background_color == "none"
     ):
-        _inject_dark_mode_style(d)
+        _inject_dark_mode_style(d, theme)
 
     # Background (skip for transparent themes)
     if theme.background_color and theme.background_color != "none":
@@ -1197,7 +1197,7 @@ def _inject_chrome_css(d: draw.Drawing, theme: Theme) -> None:
     d.append(draw.Raw(f"<style>{chr(10).join(lines)}</style>"))
 
 
-def _inject_dark_mode_style(d: draw.Drawing) -> None:
+def _inject_dark_mode_style(d: draw.Drawing, theme: Theme) -> None:
     """Inject CSS for dark-mode browsers viewing a transparent-background SVG.
 
     When the SVG has no opaque background, elements rendered directly on the
@@ -1205,15 +1205,23 @@ def _inject_dark_mode_style(d: draw.Drawing) -> None:
     browser supplies a dark page background.  A ``prefers-color-scheme: dark``
     media query adjusts those elements so they remain readable.  CSS rules
     override SVG presentation attributes, so we only need class selectors.
+
+    The label halo is a knockout of the (absent) background, so its light-mode
+    fallback of white would otherwise sit as a bright box on a dark host page;
+    give it a dark fallback here too, unless haloing is disabled.
     """
     sl = _ns("nf-metro-section-label")
     sc = _ns("nf-metro-section-num-circle")
     ti = _ns("nf-metro-title")
+    halo_rule = ""
+    if _label_halo_color(theme) is not None:
+        lh = _ns("nf-metro-label-halo")
+        halo_rule = f"\n            .{lh} {{ fill: #2b2b2b; stroke: #2b2b2b; }}"
     css = textwrap.dedent(f"""\
         @media (prefers-color-scheme: dark) {{
             .{sl} {{ fill: #d0d0d0; }}
             .{sc} {{ fill: #777777; }}
-            .{ti} {{ fill: #ffffff; }}
+            .{ti} {{ fill: #ffffff; }}{halo_rule}
         }}
     """)
     d.append(draw.Raw(f"<style>{css}</style>"))

--- a/tests/test_svg_namespace.py
+++ b/tests/test_svg_namespace.py
@@ -1,6 +1,7 @@
 """Tests for SVG class namespacing and dark-mode CSS opt-out."""
 
 import re
+from dataclasses import replace
 
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -55,6 +56,40 @@ def test_inject_dark_mode_css_true_matches_default():
     svg_default = render_svg(_make_graph(), LIGHT_THEME)
     svg_explicit = render_svg(_make_graph(), LIGHT_THEME, inject_dark_mode_css=True)
     assert svg_default == svg_explicit
+
+
+def _media_query_block(svg: str) -> str:
+    pattern = r"@media \(prefers-color-scheme: dark\) \{(.*?)\}\s*\}"
+    match = re.search(pattern, svg, re.DOTALL)
+    assert match is not None, "expected a prefers-color-scheme media query block"
+    return match.group(1)
+
+
+def test_dark_mode_css_gives_the_label_halo_a_dark_fallback():
+    """The knockout halo would otherwise stay hardcoded white on a dark host page."""
+    svg = render_svg(_make_graph(), LIGHT_THEME)
+    media = _media_query_block(svg)
+    halo_rule = r"\.nf-metro-label-halo\s*\{\s*fill:\s*#2b2b2b;\s*stroke:\s*#2b2b2b;"
+    assert re.search(halo_rule, media)
+
+
+def test_dark_mode_css_omits_label_halo_rule_when_halo_disabled():
+    """No halo class is drawn when haloing is disabled, so the override is skipped."""
+    theme = replace(LIGHT_THEME, label_halo_width=0.0)
+    svg = render_svg(_make_graph(), theme)
+    media = _media_query_block(svg)
+    assert "nf-metro-label-halo" not in media
+    # The rest of the dark-mode block is unaffected.
+    assert "nf-metro-title" in media
+
+
+def test_svg_class_prefix_applied_to_dark_mode_halo_selector():
+    """The halo override in the media query is namespaced like every other selector."""
+    prefix = "ns2"
+    svg = render_svg(_make_graph(), LIGHT_THEME, svg_class_prefix=prefix)
+    media = _media_query_block(svg)
+    assert f".{prefix}-nf-metro-label-halo" in media
+    assert ".nf-metro-label-halo" not in media
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Station-label halos on the transparent `light` embed theme fall back to a hardcoded white, since that theme has no background color to knock out against.
- That fallback never adapted to `prefers-color-scheme: dark`, so on a dark host page (grey/dark chrome) every label sat in a glaring white box.
- Extends the existing transparent-theme dark-mode media query (which already recolors the title, section labels, and section-number circles) to also darken the halo to `#2b2b2b`, unless haloing is disabled for the theme (`label_halo_width: 0` or `label_halo_color: none`).

Themes with a concrete background (nfcore, seqera) are unaffected — their halos already track the theme's own light/dark background via `--nfm-map-bg`.

## Test plan
- [x] Added tests in `tests/test_svg_namespace.py` covering: the dark-mode halo override is emitted, it's omitted when haloing is disabled, and it's correctly namespaced under `--svg-class-prefix`.
- [x] Full test suite passes (`pytest`, 28142 passed).
- [x] `ruff check` / `ruff format --check` clean.
- [x] Visually verified with a headless-Chromium render on a dark grey (`#2b2b2b`) host background with `prefers-color-scheme: dark` emulated: labels now blend into the background instead of showing white knockout boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)