### PR TITLE
ci: add a Pages artifact packaging dry run

### DIFF
--- a/.github/workflows/pages-artifact-dry-run.yml
+++ b/.github/workflows/pages-artifact-dry-run.yml
@@ -1,0 +1,30 @@
+name: Pages artifact dry run
+
+# Validates that the committed gh-pages branch packages cleanly through
+# actions/upload-pages-artifact - the same step an Actions-based Pages
+# deployment would use - without calling actions/deploy-pages. It never
+# touches the live Pages site or its Settings > Pages > Source, so it is
+# safe to run against the real gh-pages branch as a pre-migration check.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: gh-pages
+
+      - name: Report branch stats
+        run: |
+          echo "Files: $(find . -type f | wc -l)"
+          echo "Size: $(du -sh . | cut -f1)"
+          test -f .nojekyll && echo ".nojekyll present" || echo "WARNING: .nojekyll missing"
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: .


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch`-only workflow that checks out the `gh-pages` branch and packages it through `actions/upload-pages-artifact` (the same step an Actions-based Pages deployment would use), then stops.
- Does **not** call `actions/deploy-pages` and does not change Settings → Pages → Source, so it cannot affect the live site.
- Purpose: validate that the accumulated `gh-pages` branch (docs + versioned releases + PR render previews) packages cleanly before considering a migration off the legacy Pages builder, which has errored repeatedly today (see the stalled/errored builds behind PR #1281's preview, https://seqeralabs.github.io/nf-metro/_pr/1281/).
- `workflow_dispatch` requires the workflow file to exist on the default branch before it can be manually triggered, hence this PR rather than testing from a feature branch directly.

## Test plan
- [ ] After merge, dispatch via `gh workflow run pages-artifact-dry-run.yml --ref main` and confirm the job succeeds (branch stats printed, artifact uploaded without size/symlink errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)