### PR TITLE
ci: pin upload-pages-artifact to v5 (v3's internal action is unpinned)

### DIFF
--- a/.github/workflows/pages-artifact-dry-run.yml
+++ b/.github/workflows/pages-artifact-dry-run.yml
@@ -25,6 +25,6 @@ jobs:
           echo "Size: $(du -sh . | cut -f1)"
           test -f .nojekyll && echo ".nojekyll present" || echo "WARNING: .nojekyll missing"
 
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: .


### PR DESCRIPTION
## Summary
- The Pages artifact dry run (#1282) failed: `actions/upload-pages-artifact@v3` calls `actions/upload-artifact@v4` internally without a SHA, which this repo's pinned-actions policy rejects — even though the unpinned reference lives inside a third-party composite action, not our own workflow file.
- `actions/upload-pages-artifact@v5.0.0` already pins that internal call to a commit SHA upstream, so bumping the pin resolves it with no other changes needed.

## Test plan
- [ ] After merge, dispatch `pages-artifact-dry-run.yml` again and confirm it succeeds this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)