### PR TITLE
ci: fire Pages deploy via workflow_run, not gh-pages push

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,11 +1,15 @@
 name: Deploy Pages (Actions)
 
 # Publishes the gh-pages branch via GitHub's Actions-based Pages deployment.
-# docs.yml / pr-renders.yml / pr-cleanup.yml own writing content into the
-# gh-pages branch; this workflow only publishes whatever's currently there.
+# The listed workflows own writing content into the gh-pages branch; this
+# workflow only publishes whatever's currently there once one of them finishes.
 on:
-  push:
-    branches: [gh-pages]
+  workflow_run:
+    workflows:
+      - Deploy docs
+      - Publish render preview
+      - Clean up PR render preview
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -19,6 +23,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Problem

The Actions-based Pages deploy (`pages-deploy.yml`) never auto-publishes. Its `on: push: branches: [gh-pages]` trigger cannot fire: `gh-pages` is a content-only orphan branch with no `.github/workflows/` directory, and GitHub evaluates a `push` trigger against the workflow file **on the pushed ref**. With no workflow definition on that branch, the trigger has nothing to match. Since the switch to `build_type: workflow`, this means content pushed to `gh-pages` sits unpublished until someone manually dispatches the workflow.

## Fix

Trigger `pages-deploy.yml` on `workflow_run` completion of the three workflows that write into `gh-pages`:

- **Deploy docs** (`docs.yml`)
- **Publish render preview** (`pr-render-publish.yml`)
- **Clean up PR render preview** (`pr-cleanup.yml`)

`workflow_run` triggers are read from the default branch, so this fires regardless of which branch each publisher runs on. A job-level guard (`conclusion == 'success'`, or a manual `workflow_dispatch`) skips deploys for failed or no-op upstream runs. `workflow_dispatch` is retained for manual publishes.

No action SHAs change; the checkout still targets `ref: gh-pages`.