### PR TITLE
ci: gate render-preview comment on the URL being live

### DIFF
--- a/.github/workflows/pr-render-publish.yml
+++ b/.github/workflows/pr-render-publish.yml
@@ -70,14 +70,44 @@ jobs:
           destination_dir: _pr/${{ steps.meta.outputs.pr }}
           keep_files: true
 
-      - name: Comment on PR (changes found)
+      # A push to gh-pages only updates the branch; GitHub Pages then builds and
+      # publishes it asynchronously. Wait for the URL to actually serve before
+      # announcing it, so the link in the comment is never a 404.
+      - name: Wait for preview to be published
+        id: wait
         if: steps.meta.outputs.has_changes == 'true'
+        env:
+          URL: https://${{ github.repository_owner }}.github.io/nf-metro/_pr/${{ steps.meta.outputs.pr }}/index.html
+        run: |
+          live=false
+          for i in $(seq 1 20); do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" "${URL}?cb=${{ github.run_id }}-${i}" || echo 000)
+            echo "attempt ${i}: HTTP ${code}"
+            if [ "${code}" = "200" ]; then live=true; break; fi
+            sleep 15
+          done
+          echo "live=${live}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR (preview live)
+        if: steps.meta.outputs.has_changes == 'true' && steps.wait.outputs.live == 'true'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: render-preview
           number: ${{ steps.meta.outputs.pr }}
           message: |
             **Render preview** is ready for review:
+            :framed_picture: https://${{ github.repository_owner }}.github.io/nf-metro/_pr/${{ steps.meta.outputs.pr }}/
+
+            This preview shows only the renders that changed compared to `main`.
+
+      - name: Comment on PR (preview still publishing)
+        if: steps.meta.outputs.has_changes == 'true' && steps.wait.outputs.live != 'true'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        with:
+          header: render-preview
+          number: ${{ steps.meta.outputs.pr }}
+          message: |
+            **Render preview**: :hourglass_flowing_sand: rendered and pushed; GitHub Pages is still publishing it. The link will work shortly:
             :framed_picture: https://${{ github.repository_owner }}.github.io/nf-metro/_pr/${{ steps.meta.outputs.pr }}/
 
             This preview shows only the renders that changed compared to `main`.


### PR DESCRIPTION
The render-preview publish job pushes `_pr/<N>/` to the `gh-pages` branch, but GitHub Pages (branch builder) builds and serves it **asynchronously** afterwards. The "ready for review" sticky comment fired immediately after the push, so it advertised a link that 404s until the build finishes — worse when the builder is slow or stalls.

This polls the preview URL after pushing (up to ~5 min) and:
- posts the **ready** comment only once the URL serves 200;
- otherwise posts a **still-publishing** notice with the link, so the comment is never a false "ready".

The rendering-in-progress placeholder from the `pending` job is unchanged.

Scoped, targeted alternative to a build-watchdog: it makes the comment honest without adding tokens, secrets, or a re-trigger loop.