### PR TITLE
ci: gate render-preview comment on a per-run content marker

### DIFF
--- a/.github/workflows/pr-render-publish.yml
+++ b/.github/workflows/pr-render-publish.yml
@@ -71,19 +71,23 @@ jobs:
           keep_files: true
 
       # A push to gh-pages only updates the branch; GitHub Pages then builds and
-      # publishes it asynchronously. Wait for the URL to actually serve before
-      # announcing it, so the link in the comment is never a 404.
+      # publishes it asynchronously. Poll until the URL serves the page carrying
+      # THIS render run's marker, so an existing preview's stale content can't be
+      # mistaken for the new one and the announced link is never stale or a 404.
       - name: Wait for preview to be published
         id: wait
         if: steps.meta.outputs.has_changes == 'true'
         env:
           URL: https://${{ github.repository_owner }}.github.io/nf-metro/_pr/${{ steps.meta.outputs.pr }}/index.html
+          MARKER: ${{ github.event.workflow_run.id }}
         run: |
           live=false
           for i in $(seq 1 20); do
-            code=$(curl -sS -o /dev/null -w "%{http_code}" "${URL}?cb=${{ github.run_id }}-${i}" || echo 000)
-            echo "attempt ${i}: HTTP ${code}"
-            if [ "${code}" = "200" ]; then live=true; break; fi
+            body=$(curl -sS "${URL}?cb=${{ github.run_id }}-${i}" 2>/dev/null || true)
+            if printf '%s' "$body" | grep -qF "nf-metro-render-run\" content=\"${MARKER}\""; then
+              live=true; break
+            fi
+            echo "attempt ${i}: marker ${MARKER} not live yet"
             sleep 15
           done
           echo "live=${live}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-renders.yml
+++ b/.github/workflows/pr-renders.yml
@@ -86,7 +86,8 @@ jobs:
           set +e
           python scripts/build_render_diff.py \
             /tmp/base_renders /tmp/pr_renders /tmp/diff_site \
-            --pr ${{ github.event.number }}
+            --pr ${{ github.event.number }} \
+            --marker ${{ github.run_id }}
           EXIT_CODE=$?
           set -e
           if [ $EXIT_CODE -eq 0 ]; then

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -39,6 +39,7 @@ HTML_TEMPLATE = """\
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="nf-metro-render-run" content="{marker}">
 <title>Render diff{title_suffix}</title>
 <style>
   :root {{
@@ -473,7 +474,11 @@ def _build_metrics_html(
 
 
 def build_diff(
-    base_dir: Path, pr_dir: Path, output_dir: Path, pr_number: str | None = None
+    base_dir: Path,
+    pr_dir: Path,
+    output_dir: Path,
+    pr_number: str | None = None,
+    marker: str = "",
 ) -> bool:
     """Compare renders and generate diff page. Returns True if changes found."""
     base_svgs = {p.name for p in base_dir.glob("*.svg")} if base_dir.exists() else set()
@@ -614,6 +619,7 @@ def build_diff(
         metrics=metrics_html,
         toc=toc,
         entries="\n\n".join(entries_html),
+        marker=marker,
     )
     (output_dir / "index.html").write_text(html)
     return True
@@ -625,9 +631,17 @@ def main() -> None:
     parser.add_argument("pr_dir", type=Path, help="PR branch render directory")
     parser.add_argument("output_dir", type=Path, help="Output directory for diff site")
     parser.add_argument("--pr", default=None, help="PR number for title")
+    parser.add_argument(
+        "--marker",
+        default="",
+        help="Opaque build id embedded in the page so a publisher can confirm "
+        "this exact render is the one being served.",
+    )
     args = parser.parse_args()
 
-    has_changes = build_diff(args.base_dir, args.pr_dir, args.output_dir, args.pr)
+    has_changes = build_diff(
+        args.base_dir, args.pr_dir, args.output_dir, args.pr, args.marker
+    )
     if has_changes:
         print(f"Diff page written to {args.output_dir}/index.html")
         sys.exit(0)


### PR DESCRIPTION
Follow-up to #1288. That change made the publish job wait for the preview URL to return 200 before announcing it — which correctly gates a **brand-new** preview (404 to 200), but not an **update**: for an existing preview the URL already returns 200 from the previous render, so the comment could announce "ready" while the new render was still building (or stuck behind a slow Pages build).

This embeds a per-run marker in the diff page and gates on it:
- `build_render_diff.py` gains `--marker`, rendered into the page `<head>` as `<meta name="nf-metro-render-run" content="...">`.
- `pr-renders.yml` passes `--marker ${{ github.run_id }}`.
- `pr-render-publish.yml` polls until the served page carries **that** run's marker (which it already knows as `workflow_run.id`) before posting the ready comment; otherwise it posts a still-publishing notice.

Net effect: the announced link always points at the current render, whether the preview is new or updated. The old preview keeps serving until the new one is genuinely live (no 404 window).