### PR TITLE
fix(routing): nest convergent distinct-line descents by descent length (#1326)

### DIFF
--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -626,10 +626,14 @@ def _stack_distinct_port_descents(
 ) -> None:
     """Re-seat one coincident cluster of distinct-line port descents.
 
-    Lines are ordered by their per-line entry offset at the port and placed one
-    ``OFFSET_STEP`` apart from the cluster's outer edge inward, so the descent-X
-    order matches the entry-Y order (concentric into the port).  A cluster of a
-    single line, or already-separate descents, is left alone.
+    Lines are placed one ``OFFSET_STEP`` apart from the cluster's outer edge
+    inward, ordered longest-descent-first so the feeder that turns down furthest
+    from the port nests outermost.  Each feeder reaches its channel by a
+    horizontal traverse at its turn-down Y before dropping in; seating the
+    longest descent (whose turn spans the widest Y range) on the outer lane
+    keeps every traverse clear of the other feeders' descents, so the
+    convergent lanes stay parallel rather than crossing (#1326).  A cluster of
+    a single line, or already-separate descents, is left alone.
     """
     by_line: dict[str, list[_VChannel]] = defaultdict(list)
     for rp, ch in cluster:
@@ -637,7 +641,10 @@ def _stack_distinct_port_descents(
     if len(by_line) < 2:
         return
     offs = ctx.station_offsets or {}
-    ordered = sorted(by_line, key=lambda lid: offs.get((port.id, lid), 0.0))
+    span = {lid: max(ch.y_hi - ch.y_lo for ch in chs) for lid, chs in by_line.items()}
+    ordered = sorted(
+        by_line, key=lambda lid: (-span[lid], offs.get((port.id, lid), 0.0))
+    )
     xs = [ch.x for _rp, ch in cluster]
     step = ctx.offset_step
     left = port.side is PortSide.LEFT

--- a/tests/test_render_layout_invariants.py
+++ b/tests/test_render_layout_invariants.py
@@ -28,7 +28,11 @@ from nf_metro.layout.phases.guards import (
     assert_render_layout_invariants,
     render_layout_invariant_specs,
 )
-from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing import (
+    compute_station_offsets,
+    route_edges,
+    route_edges_centred,
+)
 from nf_metro.layout.routing.common import RoutedPath
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph
@@ -459,3 +463,76 @@ def test_tb_exit_terminal_on_carrier_validates_strict() -> None:
         (TOP_FIXTURES / "tb_exit_terminal_on_carrier.mmd").read_text()
     )
     compute_layout(graph, validate=True)
+
+
+def _axis_segment_crossing(
+    a: RoutedPath, b: RoutedPath
+) -> tuple[tuple[float, float], ...] | None:
+    """Return the interior crossing point of an H segment of *a* and a V segment
+    of *b* (or vice versa), or ``None`` when no pair of segments cross.
+
+    All routed legs are axis-aligned, so a proper crossing is a horizontal leg
+    at ``y=h`` spanning ``(x1, x2)`` meeting a vertical leg at ``x=v`` spanning
+    ``(y1, y2)`` with ``v`` strictly inside the horizontal span and ``h``
+    strictly inside the vertical span.  Shared endpoints (the common port) do
+    not count.
+    """
+
+    def legs(rp: RoutedPath) -> list[tuple[float, float, float, float]]:
+        return [
+            (rp.points[i][0], rp.points[i][1], rp.points[i + 1][0], rp.points[i + 1][1])
+            for i in range(len(rp.points) - 1)
+        ]
+
+    tol = 1.0
+    for ha in legs(a):
+        if abs(ha[1] - ha[3]) > tol:  # not horizontal
+            continue
+        hy = ha[1]
+        hx_lo, hx_hi = sorted((ha[0], ha[2]))
+        for vb in legs(b):
+            if abs(vb[0] - vb[2]) > tol:  # not vertical
+                continue
+            vx = vb[0]
+            vy_lo, vy_hi = sorted((vb[1], vb[3]))
+            if hx_lo + tol < vx < hx_hi - tol and vy_lo + tol < hy < vy_hi - tol:
+                return ((vx, hy),)
+    return None
+
+
+CONVERGENT_ENTRY_FIXTURES = [
+    "tb_exit_terminal_on_carrier.mmd",
+]
+
+
+@pytest.mark.parametrize("name", CONVERGENT_ENTRY_FIXTURES)
+def test_convergent_entry_feeders_do_not_cross(name: str) -> None:
+    """Distinct-line feeders converging on one entry port nest without crossing.
+
+    Feeders forced down the single gap left of a wide row-span target are
+    staggered into parallel channels; if the channel order does not account for
+    each feeder's turn-down height, the feeder that turns down higher is placed
+    to the port side and its long descent is raked by the other's horizontal
+    traverse (#1326).  No two feeders sharing a target port may cross before it.
+    """
+    graph = parse_metro_mermaid((TOP_FIXTURES / name).read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges_centred(graph, station_offsets=offsets)
+    by_target: dict[str, list[RoutedPath]] = {}
+    for rp in routes:
+        if rp.is_inter_section:
+            by_target.setdefault(rp.edge.target, []).append(rp)
+    crossings: list[str] = []
+    for target, feeders in by_target.items():
+        for i in range(len(feeders)):
+            for j in range(i + 1, len(feeders)):
+                pt = _axis_segment_crossing(feeders[i], feeders[j])
+                if pt is None:
+                    pt = _axis_segment_crossing(feeders[j], feeders[i])
+                if pt is not None:
+                    crossings.append(
+                        f"{feeders[i].line_id} x {feeders[j].line_id} "
+                        f"into {target} at {pt[0]}"
+                    )
+    assert not crossings, f"{name}: converging feeders cross: {crossings}"

--- a/tests/test_render_layout_invariants.py
+++ b/tests/test_render_layout_invariants.py
@@ -34,6 +34,10 @@ from nf_metro.layout.routing import (
     route_edges_centred,
 )
 from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.layout.routing.invariants import (
+    _first_axis_crossing,
+    _route_axis_segments,
+)
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph
 from nf_metro.render import render_svg
@@ -465,41 +469,6 @@ def test_tb_exit_terminal_on_carrier_validates_strict() -> None:
     compute_layout(graph, validate=True)
 
 
-def _axis_segment_crossing(
-    a: RoutedPath, b: RoutedPath
-) -> tuple[tuple[float, float], ...] | None:
-    """Return the interior crossing point of an H segment of *a* and a V segment
-    of *b* (or vice versa), or ``None`` when no pair of segments cross.
-
-    All routed legs are axis-aligned, so a proper crossing is a horizontal leg
-    at ``y=h`` spanning ``(x1, x2)`` meeting a vertical leg at ``x=v`` spanning
-    ``(y1, y2)`` with ``v`` strictly inside the horizontal span and ``h``
-    strictly inside the vertical span.  Shared endpoints (the common port) do
-    not count.
-    """
-
-    def legs(rp: RoutedPath) -> list[tuple[float, float, float, float]]:
-        return [
-            (rp.points[i][0], rp.points[i][1], rp.points[i + 1][0], rp.points[i + 1][1])
-            for i in range(len(rp.points) - 1)
-        ]
-
-    tol = 1.0
-    for ha in legs(a):
-        if abs(ha[1] - ha[3]) > tol:  # not horizontal
-            continue
-        hy = ha[1]
-        hx_lo, hx_hi = sorted((ha[0], ha[2]))
-        for vb in legs(b):
-            if abs(vb[0] - vb[2]) > tol:  # not vertical
-                continue
-            vx = vb[0]
-            vy_lo, vy_hi = sorted((vb[1], vb[3]))
-            if hx_lo + tol < vx < hx_hi - tol and vy_lo + tol < hy < vy_hi - tol:
-                return ((vx, hy),)
-    return None
-
-
 CONVERGENT_ENTRY_FIXTURES = [
     "tb_exit_terminal_on_carrier.mmd",
 ]
@@ -527,12 +496,12 @@ def test_convergent_entry_feeders_do_not_cross(name: str) -> None:
     for target, feeders in by_target.items():
         for i in range(len(feeders)):
             for j in range(i + 1, len(feeders)):
-                pt = _axis_segment_crossing(feeders[i], feeders[j])
-                if pt is None:
-                    pt = _axis_segment_crossing(feeders[j], feeders[i])
-                if pt is not None:
+                va, ha = _route_axis_segments(feeders[i])
+                vb, hb = _route_axis_segments(feeders[j])
+                hit = _first_axis_crossing(va, hb) or _first_axis_crossing(vb, ha)
+                if hit is not None:
                     crossings.append(
                         f"{feeders[i].line_id} x {feeders[j].line_id} "
-                        f"into {target} at {pt[0]}"
+                        f"into {target} at {hit}"
                     )
     assert not crossings, f"{name}: converging feeders cross: {crossings}"


### PR DESCRIPTION
## Summary

Fixes the converging-descent crossing left of the `te` (Translational efficiency) section in `tb_exit_terminal_on_carrier.mmd`, the last render glitch flagged on PR #1306's preview.

Two distinct-line feeders converge on `te`'s LEFT entry down the single gap left of the wide row-span target:
- riboseq (`psite_id` bottom exit) traverses left at y=546, then descends
- rnaseq (`quantification` right exit) turns down higher (y=463) and descends

`_stack_distinct_port_descents` staggered these lanes by per-line port entry-Y offset, which seated the feeder that turns down higher (rnaseq) on the port side; its long descent was then raked by the other feeder's horizontal traverse (crossing at ~(252, 546)).

- **`layout/routing/normalize.py`**: order the staggered lanes longest-descent-first, so the widest-spanning descent nests outermost and every horizontal traverse clears the other feeders' descents. rnaseq now descends at x=248 (outer/left), riboseq at x=252 (inner) — parallel, no crossing.
- **`tests/test_render_layout_invariants.py`**: `test_convergent_entry_feeders_do_not_cross` asserts no two feeders sharing a target port cross before it, reusing `_route_axis_segments` / `_first_axis_crossing`.

Based on `fix/1293-rnaseq-crosses-psite` (PR #1306), not `main` — the graduated fixture only exists on that branch.

Fixes #1326

## Test plan
- [x] pytest passes (30441 passed) including the new invariant test (fails pre-fix, passes post-fix)
- [x] ruff check + ruff format clean; mypy clean
- [x] Gate-coverage ratchet unaffected (sort-key change adds no gate arm)
- [ ] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1328/)
- No runtime validator: a corpus scan found 52 legitimate convergent-feeder crossings (multi-line fan-ins with bridges), so a broad guard would false-positive; the pass now orders correctly by construction and the unit test locks it.

Generated with Claude Code
