### PR TITLE
fix: route validate guards with the render's station_offsets (#1319)

### DIFF
--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -2832,12 +2832,19 @@ def _guard_title_band_clearance(
 def _ensure_routes(
     graph: MetroGraph, routes: list[RoutedPath] | None
 ) -> list[RoutedPath]:
-    """Return *routes*, routing all edges first if the caller didn't supply them."""
+    """Return *routes*, routing all edges first if the caller didn't supply them.
+
+    Routes with the same ``station_offsets`` the render uses so the guards
+    inspect the route the render actually draws: several dispatch predicates
+    gate on ``bool(ctx.station_offsets)`` (e.g. ``_InterFacts.is_tb_bottom_exit``),
+    so routing bare would fire a different handler than the render and make a
+    ``validate=True`` verdict disagree with the drawn picture (#1319).
+    """
     if routes is not None:
         return routes
-    from nf_metro.layout.routing import route_edges
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
 
-    return route_edges(graph)
+    return route_edges(graph, station_offsets=compute_station_offsets(graph))
 
 
 def _route_exit_side(graph: MetroGraph, rp: RoutedPath) -> PortSide | None:

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -2834,11 +2834,13 @@ def _ensure_routes(
 ) -> list[RoutedPath]:
     """Return *routes*, routing all edges first if the caller didn't supply them.
 
-    Routes with the same ``station_offsets`` the render uses so the guards
-    inspect the route the render actually draws: several dispatch predicates
-    gate on ``bool(ctx.station_offsets)`` (e.g. ``_InterFacts.is_tb_bottom_exit``),
-    so routing bare would fire a different handler than the render and make a
-    ``validate=True`` verdict disagree with the drawn picture (#1319).
+    Routes *with* ``station_offsets`` so the guards dispatch the same handler
+    the render does: several dispatch predicates gate on
+    ``bool(ctx.station_offsets)`` (e.g. ``_InterFacts.is_tb_bottom_exit``), so
+    routing bare would fire a different handler than the render and make a
+    ``validate=True`` verdict disagree with the drawn picture (#1319).  The
+    offset *magnitude* need not match the render's themed ``offset_step``; only
+    its presence gates dispatch.
     """
     if routes is not None:
         return routes

--- a/tests/test_guard_render_dispatch_parity_invariant.py
+++ b/tests/test_guard_render_dispatch_parity_invariant.py
@@ -12,10 +12,10 @@ sees, or pass a route the render draws badly.
 
 The invariant here is offset-magnitude-independent: it compares the *topology*
 (the H/V/D segment-direction sequence, which is exactly what dispatch selects)
-of every edge's guard-path route against its render-path route.  On the
-un-fixed tree the TB-bottom-exit class diverges (guard draws an ``H,V,H``
-dog-leg where the render drops straight ``V``); the fix aligns the guard's
-``station_offsets`` with the render's so the two paths dispatch identically.
+of every edge's guard-path route against its render-path route.  The
+TB-bottom-exit class is the sharp case: without offsets present the guard would
+draw an ``H,V,H`` dog-leg while the render drops straight ``V``, so the two
+paths must route with matching offset presence to dispatch identically.
 """
 
 from __future__ import annotations
@@ -23,14 +23,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from conftest import parse_and_layout
 
-from nf_metro.layout.constants import resolve_offset_step
-from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.constants import SAME_COORD_TOLERANCE, resolve_offset_step
 from nf_metro.layout.phases.guards import _ensure_routes
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.layout.routing.common import RoutedPath
-from nf_metro.parser.mermaid import parse_metro_mermaid
-from nf_metro.parser.model import MetroGraph
 from nf_metro.themes import THEMES
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
@@ -58,11 +56,11 @@ def _segment_dirs(points: list[tuple[float, float]]) -> tuple[str, ...]:
     dirs: list[str] = []
     for (x1, y1), (x2, y2) in zip(points, points[1:]):
         dx, dy = x2 - x1, y2 - y1
-        if abs(dx) < 0.5 and abs(dy) < 0.5:
+        if abs(dx) < SAME_COORD_TOLERANCE and abs(dy) < SAME_COORD_TOLERANCE:
             continue
-        if abs(dy) < 0.5:
+        if abs(dy) < SAME_COORD_TOLERANCE:
             dirs.append("H")
-        elif abs(dx) < 0.5:
+        elif abs(dx) < SAME_COORD_TOLERANCE:
             dirs.append("V")
         else:
             dirs.append("D")
@@ -73,15 +71,9 @@ def _by_edge(routes: list[RoutedPath]) -> dict[tuple[str, str, str], RoutedPath]
     return {(r.edge.source, r.edge.target, r.line_id): r for r in routes}
 
 
-def _laid_out(fixture: str) -> MetroGraph:
-    graph = parse_metro_mermaid((EXAMPLES / fixture).read_text())
-    compute_layout(graph, validate=False)
-    return graph
-
-
 @pytest.mark.parametrize("fixture", _FIXTURES)
 def test_guard_and_render_routes_dispatch_identically(fixture: str) -> None:
-    graph = _laid_out(fixture)
+    graph = parse_and_layout((EXAMPLES / fixture).read_text(), validate=False)
 
     guard_routes = _by_edge(_ensure_routes(graph, None))
 

--- a/tests/test_guard_render_dispatch_parity_invariant.py
+++ b/tests/test_guard_render_dispatch_parity_invariant.py
@@ -1,0 +1,107 @@
+"""Guard-path routing must dispatch identically to the render (#1319).
+
+The validate-strict layout guards inspect routes produced by
+:func:`nf_metro.layout.phases.guards._ensure_routes`.  The SVG render draws
+routes produced by ``route_edges_centred(graph, station_offsets=...)``.  If the
+guard path routes with a *different* ``station_offsets`` argument than the
+render, offset-gated dispatch predicates (e.g. ``_InterFacts.is_tb_bottom_exit``
+requires ``bool(ctx.station_offsets)``) fire differently, so a *different*
+handler routes the same edge in each path.  Then "passes ``validate=True``"
+stops meaning "renders clean": the guard can flag a crossing the user never
+sees, or pass a route the render draws badly.
+
+The invariant here is offset-magnitude-independent: it compares the *topology*
+(the H/V/D segment-direction sequence, which is exactly what dispatch selects)
+of every edge's guard-path route against its render-path route.  On the
+un-fixed tree the TB-bottom-exit class diverges (guard draws an ``H,V,H``
+dog-leg where the render drops straight ``V``); the fix aligns the guard's
+``station_offsets`` with the render's so the two paths dispatch identically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.layout.constants import resolve_offset_step
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.phases.guards import _ensure_routes
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.common import RoutedPath
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
+from nf_metro.themes import THEMES
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+# Fixtures spanning the offset-gated dispatch classes: TB bottom-exit straight
+# drops, LR->TB top entries, TB side-exits, plus general multi-section gallery
+# graphs as a control that the parity holds broadly, not only in the TB classes.
+_FIXTURES = [
+    "topologies/tb_bottom_exit_bundle_jog.mmd",
+    "topologies/tb_bottom_exit_fork_diamond.mmd",
+    "topologies/tb_column_continuation_two_lines.mmd",
+    "topologies/tb_right_entry_stack.mmd",
+    "topologies/tb_lr_exit_left.mmd",
+    "topologies/tb_lr_exit_right.mmd",
+    "topologies/fold_fan_across.mmd",
+    "topologies/fold_split_targets.mmd",
+    "topologies/lr_top_entry_cross_column.mmd",
+    "rnaseq_sections.mmd",
+    "rnaseq_auto.mmd",
+]
+
+
+def _segment_dirs(points: list[tuple[float, float]]) -> tuple[str, ...]:
+    """The H/V/D direction sequence of a polyline (its dispatch fingerprint)."""
+    dirs: list[str] = []
+    for (x1, y1), (x2, y2) in zip(points, points[1:]):
+        dx, dy = x2 - x1, y2 - y1
+        if abs(dx) < 0.5 and abs(dy) < 0.5:
+            continue
+        if abs(dy) < 0.5:
+            dirs.append("H")
+        elif abs(dx) < 0.5:
+            dirs.append("V")
+        else:
+            dirs.append("D")
+    return tuple(dirs)
+
+
+def _by_edge(routes: list[RoutedPath]) -> dict[tuple[str, str, str], RoutedPath]:
+    return {(r.edge.source, r.edge.target, r.line_id): r for r in routes}
+
+
+def _laid_out(fixture: str) -> MetroGraph:
+    graph = parse_metro_mermaid((EXAMPLES / fixture).read_text())
+    compute_layout(graph, validate=False)
+    return graph
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES)
+def test_guard_and_render_routes_dispatch_identically(fixture: str) -> None:
+    graph = _laid_out(fixture)
+
+    guard_routes = _by_edge(_ensure_routes(graph, None))
+
+    theme = THEMES["nfcore"]
+    render_offsets = compute_station_offsets(
+        graph, offset_step=resolve_offset_step(graph.track_gap, theme.line_width)
+    )
+    render_routes = _by_edge(route_edges(graph, station_offsets=render_offsets))
+
+    mismatches: list[str] = []
+    for key, guard_rp in guard_routes.items():
+        render_rp = render_routes.get(key)
+        if render_rp is None:
+            mismatches.append(f"{key[2]}: {key[0]}->{key[1]} missing from render path")
+            continue
+        gd, rd = _segment_dirs(guard_rp.points), _segment_dirs(render_rp.points)
+        if gd != rd:
+            mismatches.append(f"{key[2]}: {key[0]}->{key[1]} guard {gd} != render {rd}")
+
+    assert not mismatches, (
+        f"{fixture}: guard-path routing diverges from render-path dispatch "
+        f"(#1319):\n  " + "\n  ".join(mismatches)
+    )


### PR DESCRIPTION
## Summary

The validate-strict layout guards inspected a different route than the render draws, so "passes `validate=True`" did not mean "renders clean" - the second systemic fragility behind the recurring fold/wrap deferral chains (umbrella #323).

- The guards route through `_ensure_routes`, which called `route_edges(graph)` **bare** - no `station_offsets`. The render routes with `station_offsets=compute_station_offsets(...)`.
- Several dispatch predicates gate on `bool(ctx.station_offsets)` (e.g. `_InterFacts.is_tb_bottom_exit`), so a **different handler routed the same edge in each path**. A TB bottom-exit drew as an `H,V,H` dog-leg for the guards but a straight `V` drop in the render.
- A corpus sweep found this divergence on **53 edges** (dominated by the TB-bottom-exit / LR->TB-top-entry classes).

`_ensure_routes` now computes and passes the render's offsets, unifying the 12 guards that funnel through it onto one routing reality (Option 1 from the issue, "one routing reality"). This matches what the other offset-aware guards and `render/validate.py` already do; `_ensure_routes` was the odd one out.

The offset *magnitude* need not match the render's themed `offset_step` - only its presence gates dispatch - so this is purely a correctness fix on the validate path. **Rendered output is unchanged** (the render computes its own offsets and routes; nothing in this diff touches what it draws).

Fixes #1319

## Test plan
- [x] New parametrized invariant `test_guard_render_dispatch_parity_invariant.py` asserts guard-path and render-path routes share H/V/D topology per edge across the offset-gated TB classes plus general gallery graphs; fails on `main`, passes here.
- [x] Full suite: 30452 passed, 110 skipped, 11 xfailed (all pre-existing, unrelated).
- [x] ruff check + ruff format --check clean on `src/` + `tests/`; mypy clean.
- [x] Change is in `layout/phases/`, not `layout/routing/`, so the gate-coverage ratchet does not apply.
- [ ] Render-preview verdict (expected: **No visual changes detected**, since render output is untouched).

Generated with Claude Code
