### PR TITLE
fix(auto-layout): drop-in TOP entry for geometry-blind fold corners (#1347)

### DIFF
--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -12,10 +12,17 @@ from __future__ import annotations
 __all__ = ["infer_section_layout", "infer_interchanges", "detect_serpentine_runs"]
 
 from collections import defaultdict, deque
+from collections.abc import Callable
 from collections.abc import Set as AbstractSet
 
 from nf_metro.layout.layers import assign_layers
-from nf_metro.parser.model import Interchange, MetroGraph, PortSide, SectionDAG
+from nf_metro.parser.model import (
+    Interchange,
+    MetroGraph,
+    PortSide,
+    Section,
+    SectionDAG,
+)
 
 
 def infer_interchanges(graph: MetroGraph) -> None:
@@ -1300,6 +1307,30 @@ def _flow_aligned_sides(direction: str) -> tuple[PortSide, PortSide]:
     return PortSide.LEFT, PortSide.RIGHT
 
 
+def _has_predecessor_above(
+    graph: MetroGraph,
+    sec_id: str,
+    my_row: int,
+    predecessors: dict[str, set[str]],
+    predicate: Callable[[str, Section], bool] | None = None,
+) -> bool:
+    """True when a predecessor's bottom row sits above ``my_row``.
+
+    ``predicate`` optionally restricts the test to predecessors it accepts,
+    receiving each ``(src_id, src_section)`` pair.
+    """
+    for src in predecessors.get(sec_id, set()):
+        src_sec = graph.sections.get(src)
+        if not src_sec:
+            continue
+        _src_col, src_row, src_row_span, _src_col_span = _effective_grid_pos(graph, src)
+        if (src_row + src_row_span - 1) < my_row and (
+            predicate is None or predicate(src, src_sec)
+        ):
+            return True
+    return False
+
+
 def _feeds_from_vertical_drop_above(
     graph: MetroGraph,
     sec_id: str,
@@ -1315,15 +1346,38 @@ def _feeds_from_vertical_drop_above(
     predecessors instead exit sideways and wrap to a flow-aligned entry
     (a carriage-return chain or an around-section wrap), so they don't block it.
     """
-    for src in predecessors.get(sec_id, set()):
-        src_sec = graph.sections.get(src)
-        if not src_sec:
-            continue
-        _src_col, src_row, src_row_span, _src_col_span = _effective_grid_pos(graph, src)
-        is_vertical = src_sec.direction == "TB" or src in fold_sections
-        if is_vertical and (src_row + src_row_span - 1) < my_row:
-            return True
-    return False
+    return _has_predecessor_above(
+        graph,
+        sec_id,
+        my_row,
+        predecessors,
+        lambda src, src_sec: src_sec.direction == "TB" or src in fold_sections,
+    )
+
+
+def _is_foldback_drop_corner(
+    graph: MetroGraph,
+    sec_id: str,
+    my_row: int,
+    predecessors: dict[str, set[str]],
+) -> bool:
+    """True for a horizontal fold corner whose flow-aligned entry hits its exit.
+
+    On an explicit-grid fold the return-row section keeps its flow-aligned
+    orientation, so its leading-edge entry lands on the same side as its
+    backward exit: the feed jogs into that port and immediately folds back out
+    to reach the station.  When the section is fed from the row above, a
+    straight vertical drop onto its TOP edge reads cleaner than the jog.  A
+    genuine carriage-return wrap continues the flow (its exit is on the trailing
+    edge), so its flow-aligned entry never collides and it is left untouched.
+
+    The caller gates this on the section being horizontal (LR/RL, non-fold).
+    """
+    section = graph.sections[sec_id]
+    entry_aligned, _exit_aligned = _flow_aligned_sides(section.direction)
+    if not any(side == entry_aligned for side, _lines in section.exit_hints):
+        return False
+    return _has_predecessor_above(graph, sec_id, my_row, predecessors)
 
 
 def _infer_port_sides(
@@ -1390,7 +1444,13 @@ def _infer_port_sides(
             for src in predecessors[sec_id]:
                 all_entry_lines.update(edge_lines.get((src, sec_id), set()))
 
-            if flow_aligned_entry:
+            foldback_corner = horizontal and _is_foldback_drop_corner(
+                graph, sec_id, my_row, predecessors
+            )
+            if foldback_corner:
+                if all_entry_lines:
+                    section.entry_hints.append((PortSide.TOP, sorted(all_entry_lines)))
+            elif flow_aligned_entry:
                 if all_entry_lines:
                     section.entry_hints.append((entry_aligned, sorted(all_entry_lines)))
             else:

--- a/tests/data/guard_golden_baseline.json
+++ b/tests/data/guard_golden_baseline.json
@@ -36805,7 +36805,7 @@
   "examples/topologies/riboseq_fold_two_dir_entry.mmd": {
     "raised": [
       "PhaseInvariantError",
-      "after final: exit port 'orf_calling__exit_left_3' at y=338.0 is off its carrier row y=298.0 (carriers ['o0']); the boundary run will render as a diagonal instead of a riser"
+      "after final: route 'o0'->'orf_calling__exit_left_3' line 'ribo' crosses section 'psite_id' boundary at (640.0, 298.0) away from any declared port"
     ],
     "trace": [
       "_guard_no_same_row_backward_feed|None",
@@ -36951,7 +36951,45 @@
       "_guard_fanout_junction_shares_exit_port_y|after final",
       "_guard_fanout_junction_resolves_upstream|after final",
       "_guard_entry_port_fed_only_by_ports|after final",
-      "_guard_flow_exit_anchored_to_carrier|after final"
+      "_guard_flow_exit_anchored_to_carrier|after final",
+      "_guard_wrap_exit_anchored_to_carrier|after final",
+      "_guard_fold_lr_exit_follows_target|after final",
+      "_guard_fold_lr_exit_sections_share_bbox_bottom|after final",
+      "_guard_stacked_rows_fill_rowspan_band|after final",
+      "_guard_perp_fed_entry_anchored_to_consumer|after final",
+      "_guard_corridor_fed_solo_rides_trunk|after final",
+      "_guard_perp_entry_clears_vertical_trunk_head|after final",
+      "_guard_post_convergence_trunk_continues|after final",
+      "_guard_perp_entry_feed_not_collinear|after final",
+      "_guard_merge_port_approach_side|after final",
+      "_guard_convergence_shallow_feeder_concentric|after final",
+      "_guard_merge_port_outgoing_side_preserved|after final",
+      "_guard_exit_inherits_entry_bundle_order|after final",
+      "_guard_bypass_port_no_slot_gaps|after final",
+      "_guard_partial_branch_offset_gaps|after final",
+      "_guard_row_gaps|after final",
+      "_guard_section_top_padding|after final",
+      "_guard_section_bottom_padding|after final",
+      "_guard_terminus_icons_within_bbox|after final",
+      "_guard_inter_section_routes_in_row_band|after final",
+      "_guard_topmost_row_top_entry_hugs_section|after final",
+      "_guard_title_band_clearance|after final",
+      "_guard_off_track_output_clears_non_producer|after final",
+      "_guard_tb_exit_corner_column_order|after final",
+      "_guard_no_split_same_line_fanout_descents|after final",
+      "_guard_no_distinct_line_fanout_crossing|after final",
+      "_guard_fan_merge_no_partition_crossing|after final",
+      "_guard_trunk_continuation_drops_straight|after final",
+      "_guard_no_dogleg_crosses_exempt_trunk|after final",
+      "_guard_no_stacked_elbow_graze|after final",
+      "_guard_fanout_tail_join|after final",
+      "_guard_perp_entry_boundary_consistent|after final",
+      "_guard_perp_exit_over_leadin_no_overdip|after final",
+      "_guard_right_entry_drop_in_when_clear|after final",
+      "_guard_right_entry_corridor_descent_no_jog|after final",
+      "_guard_inter_section_route_no_backtrack|after final",
+      "_guard_inter_section_route_no_full_width_backtrack|after final",
+      "_guard_routes_enter_sections_at_ports|after final"
     ]
   },
   "examples/topologies/riboseq_fold_two_dir_entry_hintless.mmd": {

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -9198,3 +9198,28 @@ def test_interior_branch_stays_centred_on_loop(style):
             f"{fixture} [{style}]: branch {branch!r} off-centre -- "
             f"divergence run {div:.1f} != reconvergence run {recon:.1f}"
         )
+
+
+def test_explicit_fold_corner_drops_in_from_above():
+    """A return-row fold corner fed from the row above enters via a TOP drop.
+
+    ``orf_calling`` in ``riboseq_fold_two_dir_entry.mmd`` sits on an
+    explicit-grid return row (col3,row1), fed by ``quantification`` a row
+    above (col2,row0), and exits LEFT toward ``psite_id``.  A flow-aligned
+    LEFT entry would collide with that LEFT exit, forcing the feed to jog
+    down-and-left into a leading-edge port and then reverse rightward to the
+    station.  The inferred entry must instead be TOP so the drop lands
+    straight in, and must not share the exit's side (#1347).
+    """
+    graph = _layout("topologies/riboseq_fold_two_dir_entry.mmd")
+    section = graph.sections["orf_calling"]
+    entry_sides = {graph.ports[p].side for p in section.entry_ports}
+    exit_sides = {graph.ports[p].side for p in section.exit_ports}
+    assert entry_sides == {PortSide.TOP}, (
+        f"orf_calling entry should be TOP (vertical drop from the row above), "
+        f"got {[s.name for s in entry_sides]}"
+    )
+    assert not (entry_sides & exit_sides), (
+        f"orf_calling entry {[s.name for s in entry_sides]} collides with "
+        f"exit {[s.name for s in exit_sides]} -- leading-edge cul-de-sac"
+    )


### PR DESCRIPTION
## Summary

On an explicit-grid fold, a horizontal return-row section keeps its flow-aligned orientation. When it is fed by a predecessor a row above **and** its flow-aligned entry side coincides with its backward exit side, the feed jogs into a leading-edge port and immediately folds back out to reach the station (a leading-edge cul-de-sac). This infers a **TOP** entry for that case so the feed drops straight in.

- New `_is_foldback_drop_corner` in `layout/auto_layout.py` detects the entry/exit collision plus a row-above predecessor.
- The "predecessor bottom row is above me" test is factored into a shared `_has_predecessor_above` helper, reused by `_feeds_from_vertical_drop_above`.
- The predicate **uniquely selects `orf_calling`** across the whole corpus (examples + tests/fixtures): proven **0 entry/exit-port diffs** on every other section, so the 17 carriage-return-wrap sections that rely on flow-aligned entry are untouched.

For `riboseq_fold_two_dir_entry.mmd`, giving `orf_calling` a TOP entry also re-anchors its LEFT exit back onto its carrier row, so the exit-off-carrier `PhaseInvariantError` the tasking flagged is cleared by this change (no separate exit-anchor fix needed).

New regression test `test_explicit_fold_corner_drops_in_from_above`; guard-golden baseline regenerated (the orf trace now runs past the old early abort).

Fixes #1347. Stacked on #1346 (base `fix/1342-entry-side-geometry`); retarget to `main` once the parent chain lands.

## Fixture still partially red (by design)

`riboseq_fold_two_dir_entry.mmd` remains red on two **distinct roots**, both out of scope here:

- **Section overlap `orf_calling`/`psite_id`** (`#1344`): drives `test_no_section_overlap`, the `_guard_routes_enter_sections_at_ports` validate raise, and the aggregate validate=True tests.
- **Fan-out same-line parallel descent** (`#1349`, newly filed): `quantification` fans to two same-line TOP drops (`psite_id` straight below, `orf_calling` below-right); the router descends them in adjacent 10px lanes → `CurveInvariantError`. This is orientation-independent (fires identically if `orf_calling` reorients to RL) and lives in the perp-entry routing, not auto-layout, so it is a separate routing fix. It drives the render-time reds (`test_svg_paths::*`, `test_render_validate::*`, `test_no_merged_same_line_descents`).

The 5 entry/exit-anchor tests the tasking targeted now pass: `test_entry_approach_arrives_from_port_side`, `test_flow_exit_port_anchors_to_carrying_station`, `test_wrap_exit_port_stays_on_carrier_row`, `test_inter_section_route_no_x_backtrack`, `test_no_route_passes_through_unrelated_section`.

## Test plan
- [x] `ruff check` + `ruff format --check` clean on `src/` and `tests/`
- [x] Full suite: no failures outside the `riboseq_fold_two_dir_entry` fixture
- [x] Corpus port-side dump: only `orf_calling` changes (LEFT->TOP), exit unchanged
- [x] New invariant test fails before / passes after
- [x] guard-golden + routing-gate-coverage baselines in sync (3.11)
- [ ] Visual review of render preview

Generated with Claude Code
