### PR TITLE
refactor: consolidate column-gap loop + neighbour side-vote tally (#1357)

### DIFF
--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -1485,6 +1485,46 @@ def _infer_port_sides(
                         section.entry_hints.append((side, sorted(lines)))
 
 
+def _neighbour_side_votes(
+    graph: MetroGraph,
+    sec_id: str,
+    neighbours: AbstractSet[str],
+    edge_lines: dict[tuple[str, str], set[str]],
+    *,
+    edge_key: Callable[[str], tuple[str, str]],
+    skip_unplaced: bool = False,
+) -> dict[PortSide, int]:
+    """Tally which side of ``sec_id`` each neighbour faces, weighted by lines.
+
+    Each neighbour votes for the :func:`_relative_side` its grid cell falls on
+    relative to ``sec_id``, weighted by the number of lines on the connecting
+    edge (``edge_lines[edge_key(neighbour)]``).  ``edge_key`` orients the lookup
+    for either feed direction: ``(neighbour, sec_id)`` for predecessors,
+    ``(sec_id, neighbour)`` for successors.
+
+    Neighbours absent from ``graph.sections`` are skipped.  ``skip_unplaced``
+    additionally drops neighbours whose effective grid column is ``-1`` (an
+    unassigned position during the parser phase), leaving the post-tally
+    selection policy to each caller.
+    """
+    my_col, my_row, _my_row_span, my_col_span = _effective_grid_pos(graph, sec_id)
+
+    votes: dict[PortSide, int] = defaultdict(int)
+    for other in neighbours:
+        if other not in graph.sections:
+            continue
+        other_col, other_row, _other_row_span, other_col_span = _effective_grid_pos(
+            graph, other
+        )
+        if skip_unplaced and other_col < 0:
+            continue
+        side = _relative_side(
+            my_col, my_row, other_col, other_row, my_col_span, other_col_span
+        )
+        votes[side] += len(edge_lines.get(edge_key(other), set()))
+    return votes
+
+
 def _compute_fold_exit_side(
     graph: MetroGraph,
     sec_id: str,
@@ -1497,24 +1537,15 @@ def _compute_fold_exit_side(
     exit is LEFT. For multi-row spans where all successors are below,
     uses BOTTOM so lines continue their vertical flow.
     """
-    my_col, my_row, my_row_span, my_col_span = _effective_grid_pos(graph, sec_id)
+    _my_col, my_row, my_row_span, _my_col_span = _effective_grid_pos(graph, sec_id)
 
-    side_votes: dict[PortSide, int] = defaultdict(int)
-    for tgt in successors.get(sec_id, set()):
-        tgt_sec = graph.sections.get(tgt)
-        if not tgt_sec:
-            continue
-        tgt_col, tgt_row, _tgt_row_span, tgt_col_span = _effective_grid_pos(graph, tgt)
-        lines = edge_lines.get((sec_id, tgt), set())
-        side = _relative_side(
-            my_col,
-            my_row,
-            tgt_col,
-            tgt_row,
-            my_col_span,
-            tgt_col_span,
-        )
-        side_votes[side] += len(lines)
+    side_votes = _neighbour_side_votes(
+        graph,
+        sec_id,
+        successors.get(sec_id, set()),
+        edge_lines,
+        edge_key=lambda tgt: (sec_id, tgt),
+    )
 
     if not side_votes:
         return PortSide.BOTTOM

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -12,6 +12,7 @@ __all__ = ["place_sections", "position_ports"]
 
 import warnings
 from collections import defaultdict, deque
+from collections.abc import Callable
 from typing import TypeGuard
 
 from nf_metro.layout.constants import (
@@ -997,6 +998,72 @@ def _column_pair_min_gap(
     return effective_min, bundles
 
 
+def _apply_column_gap_deficits(
+    graph: MetroGraph,
+    col_assign: dict[str, int],
+    min_col: int,
+    max_col: int,
+    *,
+    min_gap: float,
+    right_extent: Callable[[Section], float],
+    left_extent: Callable[[Section], float],
+    shift: Callable[[Section, float], None],
+    requested_gap: float | None = None,
+) -> None:
+    """Widen each adjacent column pair to its minimum inter-section gap.
+
+    For every column ``col`` in ``[min_col, max_col)``, take the tightest gap
+    among row-overlapping section pairs (measured from ``right_extent`` of a
+    left-column section to ``left_extent`` of a right-column section) and, if
+    it falls short of the pair's :func:`_column_pair_min_gap`, ``shift`` all
+    sections in columns ``> col`` rightward by the deficit.
+
+    The extent readers and ``shift`` abstract over the coordinate space:
+    ``offset_x``-relative before Stage 2.1, absolute global coordinates after.
+    ``requested_gap`` (offset-space callers only) triggers a ``UserWarning``
+    whenever a bundle forces the gap wider than the user asked for.
+    """
+    col_sections: dict[int, list[Section]] = defaultdict(list)
+    for sid, section in graph.sections.items():
+        col_sections[col_assign.get(sid, 0)].append(section)
+
+    for col in range(min_col, max_col):
+        left_secs = col_sections.get(col, [])
+        right_secs = col_sections.get(col + 1, [])
+        if not left_secs or not right_secs:
+            continue
+
+        effective_min, bundles = _column_pair_min_gap(graph, col_assign, col, min_gap)
+
+        worst_gap: float | None = None
+        for ls in left_secs:
+            for rs in right_secs:
+                if not _rows_overlap(ls, rs):
+                    continue
+                gap = left_extent(rs) - right_extent(ls)
+                if worst_gap is None or gap < worst_gap:
+                    worst_gap = gap
+
+        if worst_gap is None or worst_gap >= effective_min:
+            continue
+
+        if requested_gap is not None and effective_min > requested_gap:
+            n_bundles = len(bundles)
+            total_lines = sum(bundles)
+            warnings.warn(
+                f"Section gap between columns {col} and {col + 1} "
+                f"widened from {requested_gap:.0f}px to {effective_min:.0f}px "
+                f"to accommodate {n_bundles} bundle(s) / "
+                f"{total_lines} routing line(s)",
+                stacklevel=3,
+            )
+
+        deficit = effective_min - worst_gap
+        for shift_col in range(col + 1, max_col + 1):
+            for s in col_sections.get(shift_col, []):
+                shift(s, deficit)
+
+
 def _enforce_min_column_gaps(
     graph: MetroGraph,
     col_assign: dict[str, int],
@@ -1012,56 +1079,27 @@ def _enforce_min_column_gaps(
     floor (MIN_INTER_SECTION_GAP).  If the physical gap is too narrow,
     columns are shifted rightward.  Warns when the gap had to be widened
     beyond the user's requested value.
+
+    Operates in ``offset_x`` space (Stage 1.3, before global coordinates
+    settle), so extents include ``offset_x`` and the shift adds to it.
     """
     if max_col <= min_col:
         return
 
-    # Group sections by their assigned column
-    col_sections: dict[int, list[Section]] = defaultdict(list)
-    for sid, section in graph.sections.items():
-        col = col_assign.get(sid, 0)
-        col_sections[col].append(section)
+    def _shift(s: Section, dx: float) -> None:
+        s.offset_x += dx
 
-    for col in range(min_col, max_col):
-        left_secs = col_sections.get(col, [])
-        right_secs = col_sections.get(col + 1, [])
-        if not left_secs or not right_secs:
-            continue
-
-        effective_min, bundles = _column_pair_min_gap(graph, col_assign, col, min_gap)
-
-        # Find the tightest gap among row-overlapping section pairs
-        worst_gap: float | None = None
-        for ls in left_secs:
-            for rs in right_secs:
-                if not _rows_overlap(ls, rs):
-                    continue
-                left_edge = ls.offset_x + ls.bbox_x + ls.bbox_w
-                right_edge = rs.offset_x + rs.bbox_x
-                gap = right_edge - left_edge
-                if worst_gap is None or gap < worst_gap:
-                    worst_gap = gap
-
-        if worst_gap is None or worst_gap >= effective_min:
-            continue
-
-        # Warn if we're overriding the user's requested gap
-        if requested_gap is not None and effective_min > requested_gap:
-            n_bundles = len(bundles)
-            total_lines = sum(bundles)
-            warnings.warn(
-                f"Section gap between columns {col} and {col + 1} "
-                f"widened from {requested_gap:.0f}px to {effective_min:.0f}px "
-                f"to accommodate {n_bundles} bundle(s) / "
-                f"{total_lines} routing line(s)",
-                stacklevel=2,
-            )
-
-        deficit = effective_min - worst_gap
-        # Shift all sections in columns > col rightward
-        for shift_col in range(col + 1, max_col + 1):
-            for s in col_sections.get(shift_col, []):
-                s.offset_x += deficit
+    _apply_column_gap_deficits(
+        graph,
+        col_assign,
+        min_col,
+        max_col,
+        min_gap=min_gap,
+        right_extent=lambda s: s.offset_x + s.bbox_x + s.bbox_w,
+        left_extent=lambda s: s.offset_x + s.bbox_x,
+        shift=_shift,
+        requested_gap=requested_gap,
+    )
 
 
 def reenforce_column_gaps(graph: MetroGraph) -> None:
@@ -1083,39 +1121,21 @@ def reenforce_column_gaps(graph: MetroGraph) -> None:
         return
 
     col_assign = {sid: s.grid_col for sid, s in graph.sections.items()}
-    col_sections: dict[int, list[Section]] = defaultdict(list)
-    for sid, section in graph.sections.items():
-        col_sections[col_assign[sid]].append(section)
-
     min_col = min(col_assign.values())
     max_col = max(
         col + graph.sections[sid].grid_col_span - 1 for sid, col in col_assign.items()
     )
 
-    for col in range(min_col, max_col):
-        left_secs = col_sections.get(col, [])
-        right_secs = col_sections.get(col + 1, [])
-        if not left_secs or not right_secs:
-            continue
-
-        effective_min, _ = _column_pair_min_gap(graph, col_assign, col)
-
-        worst_gap: float | None = None
-        for ls in left_secs:
-            for rs in right_secs:
-                if not _rows_overlap(ls, rs):
-                    continue
-                gap = rs.bbox_x - (ls.bbox_x + ls.bbox_w)
-                if worst_gap is None or gap < worst_gap:
-                    worst_gap = gap
-
-        if worst_gap is None or worst_gap >= effective_min:
-            continue
-
-        deficit = effective_min - worst_gap
-        for shift_col in range(col + 1, max_col + 1):
-            for s in col_sections.get(shift_col, []):
-                shift_section(graph, s, dx=deficit)
+    _apply_column_gap_deficits(
+        graph,
+        col_assign,
+        min_col,
+        max_col,
+        min_gap=MIN_INTER_SECTION_GAP,
+        right_extent=lambda s: s.bbox_x + s.bbox_w,
+        left_extent=lambda s: s.bbox_x,
+        shift=lambda s, dx: shift_section(graph, s, dx=dx),
+    )
 
 
 def _cols_overlap(a: Section, b: Section) -> bool:

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -823,23 +823,22 @@ def _dominant_entry_side(graph: MetroGraph, sec_id: str) -> PortSide | None:
     by ``_priority_side``.  Returns ``None`` when no predecessor with known grid
     geometry feeds the section, leaving the caller to fall back.
     """
-    from nf_metro.layout.auto_layout import _effective_grid_pos, _relative_side
+    from nf_metro.layout.auto_layout import _effective_grid_pos, _neighbour_side_votes
 
     dag = graph.section_dag
     if dag is None:
         return None
-    my_col, my_row, _row_span, my_col_span = _effective_grid_pos(graph, sec_id)
+    my_col, _my_row, _row_span, _my_col_span = _effective_grid_pos(graph, sec_id)
     if my_col < 0:
         return None
-    votes: dict[PortSide, int] = {}
-    for src in dag.predecessors.get(sec_id, set()):
-        src_col, src_row, _src_row_span, src_col_span = _effective_grid_pos(graph, src)
-        if src_col < 0:
-            continue
-        side = _relative_side(
-            my_col, my_row, src_col, src_row, my_col_span, src_col_span
-        )
-        votes[side] = votes.get(side, 0) + len(dag.edge_lines.get((src, sec_id), set()))
+    votes = _neighbour_side_votes(
+        graph,
+        sec_id,
+        dag.predecessors.get(sec_id, set()),
+        dag.edge_lines,
+        edge_key=lambda src: (src, sec_id),
+        skip_unplaced=True,
+    )
     if not votes:
         return None
     natural = _natural_entry_side(graph.sections[sec_id].direction)


### PR DESCRIPTION
## Summary

Two behaviour-preserving consolidations deferred from the #1342 entry-ports `/simplify` pass, each landed as its own `refactor:` commit.

**1. Unify the column-gap enforcement loop** (`section_placement.py`)
`_enforce_min_column_gaps` and `reenforce_column_gaps` duplicated the same worst-gap-then-shift loop over row-overlapping column pairs, differing only in coordinate space. Extract it into `_apply_column_gap_deficits`, parameterised over the extent readers and a shift function so one loop serves both the `offset_x`-relative regime (Stage 1.3, before global coordinates settle) and the absolute-global regime (post Stage 2.1). The requested-gap `UserWarning` stays with the offset-space caller (`stacklevel` bumped to point at the same user frame).

**2. Extract the neighbour side-vote tally** (`auto_layout.py` + `resolve.py`)
`_compute_fold_exit_side` and `_dominant_entry_side` shared the same tally (per-neighbour `_relative_side` weighted by edge line count). Extract it into `_neighbour_side_votes` in `auto_layout.py`, parameterised by neighbour direction (`edge_key` orients the edge lookup for predecessors vs successors) and `skip_unplaced` (the parser-phase `col < 0` skip). Each caller keeps its own post-tally selection policy. The looser third instance (`_compute_exit_hints_by_side`, which accumulates line-sets rather than counts) is left out, as the issue specifies.

Fixes #1357

## Test plan
- [x] pytest passes (full suite, no new failures; only pre-existing xfails)
- [x] ruff check + ruff format clean on changed files
- [x] Zero behaviour change verified: all 209 example + topology renders byte-for-byte identical to `origin/main`
- [ ] Visual review of render preview
- [ ] Render-preview verdict: expected "No visual changes detected"

Generated with Claude Code
