### PR TITLE
test: lock distinct-line lane separation in folded corridors (#1345)

### DIFF
--- a/examples/topologies/README.md
+++ b/examples/topologies/README.md
@@ -215,6 +215,12 @@ Three stacked analysis sections (RNA, ATAC, Protein) feed into a fold section (I
 
 Long linear pipeline whose main line wraps via a fold into a return row, with a secondary line joining mid-trunk and exiting before the end. Tests fold rowspan transitions while a partial-coverage line shares the trunk only across a sub-range of sections.
 
+### Folded Corridor Distinct Lanes
+
+Two lines (DNA, RNA) co-travel a trunk and its RL fold drop as adjacent lanes, diverge where RNA bypasses the Consensus section that DNA routes through, and reconverge at Realignment. Tests that distinct lines crowded into one folded return corridor stay an `OFFSET_STEP` apart on every shared channel rather than collapsing into a single stroke (issue #1345).
+
+![Folded Corridor Distinct Lanes](folded_corridor_distinct_lanes.png)
+
 ---
 
 ## Structural Stress Tests

--- a/examples/topologies/folded_corridor_distinct_lanes.mmd
+++ b/examples/topologies/folded_corridor_distinct_lanes.mmd
@@ -1,0 +1,61 @@
+%%metro title: Folded Corridor Distinct Lanes
+%%metro style: dark
+%%metro line: dna | DNA | #4a90d9
+%%metro line: rna | RNA | #e63946
+%%metro grid: preprocessing | 0,0
+%%metro grid: gatk | 1,0
+%%metro grid: variant_calling | 2,0
+%%metro grid: normalization | 2,1
+%%metro grid: consensus | 1,1
+%%metro grid: realignment | 0,1
+
+graph LR
+    subgraph preprocessing [Pre-processing]
+        %%metro exit: right | dna, rna
+        pp1[Trim]
+        pp2[Align]
+        pp1 -->|dna,rna| pp2
+    end
+    subgraph gatk [GATK]
+        %%metro entry: left | dna, rna
+        %%metro exit: right | dna, rna
+        gk1[BQSR]
+        gk2[Apply]
+        gk1 -->|dna,rna| gk2
+    end
+    subgraph variant_calling [Variant Calling]
+        %%metro entry: left | dna, rna
+        %%metro exit: bottom | dna, rna
+        vc1[Call]
+        vc2[Filter]
+        vc1 -->|dna,rna| vc2
+    end
+    subgraph normalization [Normalization]
+        %%metro direction: RL
+        %%metro entry: top | dna, rna
+        %%metro exit: left | dna, rna
+        nz1[Decompose]
+        nz2[Norm]
+        nz1 -->|dna,rna| nz2
+    end
+    subgraph consensus [Consensus]
+        %%metro direction: RL
+        %%metro entry: right | dna
+        %%metro exit: left | dna
+        cs1[Merge]
+        cs2[Vote]
+        cs1 -->|dna| cs2
+    end
+    subgraph realignment [Realignment]
+        %%metro direction: RL
+        %%metro entry: right | dna, rna
+        rl1[Realign]
+        rl2[Recall]
+        rl1 -->|dna,rna| rl2
+    end
+    pp2 -->|dna,rna| gk1
+    gk2 -->|dna,rna| vc1
+    vc2 -->|dna,rna| nz1
+    nz2 -->|dna| cs1
+    nz2 -->|rna| rl1
+    cs2 -->|dna| rl1

--- a/scripts/gallery.yaml
+++ b/scripts/gallery.yaml
@@ -130,6 +130,15 @@ gallery:
       same junction. The branch bundle keeps its concentric fan order, each
       spur's descent fuses onto the bundle rather than crossing it, and the
       single-line spur sections ride their own trunks."
+  - id: folded_corridor_distinct_lanes
+    source_dir: examples/topologies
+    category: Feature Showcase
+    description:
+      "Two distinct lines share a folded RL return corridor: they co-travel the
+      trunk and fold drop as adjacent lanes, diverge where one line bypasses a
+      section while the other routes through it, and reconverge at the final
+      section. Every shared channel keeps the two lines an OFFSET_STEP apart
+      rather than collapsing one stroke onto the other."
 
   # ── Realistic Pipelines ────────────────────────────────────────────────────
   - id: genomic_pipeline

--- a/tests/test_collinear_folded_corridor_1345.py
+++ b/tests/test_collinear_folded_corridor_1345.py
@@ -1,0 +1,95 @@
+"""Distinct lines stay in adjacent lanes through a folded return corridor.
+
+Regression coverage for issue #1345 (collinear overlays of distinct lines in
+dense folded maps). ``folded_corridor_distinct_lanes`` co-travels two lines
+through a trunk and its RL fold drop, diverges them where one line bypasses a
+section the other routes through, and reconverges them at the final section --
+the shape that surfaced the reported overlays. The engine must keep every
+shared channel an ``OFFSET_STEP`` apart rather than collapsing one line's
+stroke onto the other's:
+
+* the three collinear-overlay guards report no violation, and
+* any two distinct-line vertical legs that share a corridor (come within a
+  couple of ``OFFSET_STEP`` of each other while overlapping in Y) sit at least
+  one full ``OFFSET_STEP`` apart -- adjacent lanes, never fused.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nf_metro.layout.constants import OFFSET_STEP
+from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets, route_edges
+from nf_metro.layout.routing.invariants import (
+    _axis_aligned,
+    apply_route_offsets,
+    check_intra_section_collinear_distinct_lines,
+    check_no_collinear_distinct_diagonals,
+    check_no_collinear_distinct_lines,
+)
+from nf_metro.parser.mermaid import parse_metro_mermaid
+
+FIXTURE = "folded_corridor_distinct_lanes"
+TOPOLOGIES = Path(__file__).parent.parent / "examples" / "topologies"
+
+# Two vertical legs "share a corridor" when their xs sit within this band and
+# their Y extents overlap; distinct lines that do so must not fuse.
+_CORRIDOR_BAND = 2 * OFFSET_STEP
+_MIN_Y_OVERLAP = 8.0
+
+
+def _laid_out():
+    graph = parse_metro_mermaid((TOPOLOGIES / f"{FIXTURE}.mmd").read_text())
+    compute_layout(graph)
+    offsets = compute_station_offsets(graph)
+    routes = route_edges(graph, station_offsets=offsets)
+    return graph, offsets, routes
+
+
+def test_no_collinear_overlay():
+    """No two distinct lines coincide on a shared channel anywhere."""
+    graph, offsets, routes = _laid_out()
+    assert not check_no_collinear_distinct_lines(graph, routes, offsets)
+    assert not check_intra_section_collinear_distinct_lines(graph, routes, offsets)
+    assert not check_no_collinear_distinct_diagonals(graph, routes, offsets)
+
+
+def _distinct_line_vertical_legs(routes, offsets):
+    """(line_id, x, y_lo, y_hi) for every inter-section vertical leg."""
+    legs = []
+    for rp in routes:
+        if not rp.is_inter_section:
+            continue
+        pts = apply_route_offsets(rp, offsets)
+        for p1, p2 in zip(pts, pts[1:]):
+            axis, coord = _axis_aligned(p1, p2)
+            if axis == "V":
+                legs.append((rp.line_id, coord, min(p1[1], p2[1]), max(p1[1], p2[1])))
+    return legs
+
+
+def test_shared_corridor_legs_are_one_offset_step_apart():
+    """Distinct lines sharing a vertical corridor sit on adjacent lanes.
+
+    The overlay guard only forbids exact coincidence (within ~1px); this
+    asserts the stronger property #1345 is about -- two lines crowded into one
+    corridor render as two lanes an ``OFFSET_STEP`` apart, not one fat stroke.
+    """
+    _graph, offsets, routes = _laid_out()
+    legs = _distinct_line_vertical_legs(routes, offsets)
+    shared = 0
+    for i, (la, xa, lo_a, hi_a) in enumerate(legs):
+        for lb, xb, lo_b, hi_b in legs[i + 1 :]:
+            if la == lb or abs(xa - xb) > _CORRIDOR_BAND:
+                continue
+            if min(hi_a, hi_b) - max(lo_a, lo_b) <= _MIN_Y_OVERLAP:
+                continue
+            shared += 1
+            assert abs(xa - xb) >= OFFSET_STEP - 0.5, (
+                f"distinct lines {la!r}/{lb!r} share a corridor only "
+                f"{abs(xa - xb):.1f}px apart (< OFFSET_STEP)"
+            )
+    # A shared distinct-line corridor is the precondition this test asserts on;
+    # its absence would make the pass vacuous.
+    assert shared, "fixture produces no shared distinct-line corridor to check"


### PR DESCRIPTION
## Summary

Adds a folded multi-line regression fixture and test that lock **distinct-line lane separation** in dense folded maps. No engine change.

`examples/topologies/folded_corridor_distinct_lanes.mmd` co-travels two lines through a trunk and its RL fold drop as adjacent lanes, diverges them where one line bypasses a section the other routes through, and reconverges them at the final section - the shape #1345 reported overlays in. `tests/test_collinear_folded_corridor_1345.py` asserts the three collinear-overlay guards report clean **and** that any two distinct-line legs sharing a corridor sit at least one `OFFSET_STEP` apart (the stronger "adjacent lanes, not one fat stroke" property).

### Why no engine fix

Investigation found the collinear-overlay-of-distinct-lines family is **already covered** on the current tree (after the #1341/#1342 stack landed):

- Three Tier-A guards (`check_no_collinear_distinct_lines`, `check_intra_section_collinear_distinct_lines`, `check_no_collinear_distinct_diagonals`) reject any real overlay, backed by the offset machinery, `_coincide_same_line_tracks`, and `_stagger_convergent_distinct_lines`.
- A corpus scan (all `examples/` + `examples/topologies/`) with the port-convergence exclusion **disabled** found **zero** excused overlays.
- The original trigger (the dense manually-folded riboseq map) was never committed; the surviving WIP copies, laid out on the current tree, produce **zero** collinear-overlay violations from all three checks (their remaining distinct-line issues are `route_segment_crossing`, a separate family).
- In a real folded corridor the two lines sit exactly one `OFFSET_STEP` (4px) apart; every attempt to force an overlay instead trips an adjacent-family guard (perp-entry-boundary, corridor-fed-solo #1173, stacked-elbow-graze #663, backward-feed) before an overlay can form.

Closes #1345.

## Test plan
- [x] pytest passes (new fixture green across full invariant + topology suites; new #1345 test green)
- [x] ruff check + ruff format clean
- [x] Runtime validator: not needed (three collinear guards already wired into the validate block)
- [ ] Visual review of render preview
- [ ] Render-preview verdict

Generated with Claude Code
