### PR TITLE
fix: exclude rail above-label reach from content-bottom prediction (#1361)

### DIFF
--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -390,6 +390,29 @@ def _bundle_edge_padding(
     )
 
 
+def _rail_above_label_ids(graph: MetroGraph, section: Section) -> set[str]:
+    """Rail stations whose label hangs above the top rail rather than below.
+
+    Empty for non-rail sections and for rail sections whose per-line rail map is
+    not yet populated.  Mirrors the classification
+    :func:`_guard_rail_above_label_band` uses so the content-bottom prediction
+    and the guard agree on which stations reach up.
+    """
+    if not graph.is_rail_section(section.id):
+        return set()
+    per_line = graph._rail_y.get(section.id) or {}
+    if not per_line:
+        return set()
+    from nf_metro.layout.rail_mode import _rail_above_label_stations
+
+    real_ids = [
+        sid
+        for sid in section.station_ids
+        if (st := graph.stations.get(sid)) is not None and not st.is_port
+    ]
+    return _rail_above_label_stations(graph, real_ids, per_line)
+
+
 def _predict_section_content_bottom(
     graph: MetroGraph,
     section: Section,
@@ -424,6 +447,12 @@ def _predict_section_content_bottom(
     label_angle = graph.label_angle or 0.0 if section_dir in ("LR", "RL") else 0.0
     is_horizontal = section_dir in ("LR", "RL")
     fan_ids = _trunk_symmetric_fan_ids(graph, section) if is_horizontal else ()
+    # In a rail panel a single-rail station on the top rail labels *above* the
+    # bundle (:func:`labels._rail_label_side`), so its angled label hangs up
+    # rather than down and adds no downward reach; only the below-hanging labels
+    # anchor the bottom.  :func:`_guard_rail_above_label_band` covers the upward
+    # footprint of these stations.
+    rail_above_ids = _rail_above_label_ids(graph, section) if label_angle else set()
     if is_horizontal and offsets is None:
         from nf_metro.layout.routing import compute_station_offsets
 
@@ -445,7 +474,10 @@ def _predict_section_content_bottom(
                     sid in fan_ids,
                 ),
                 _terminus_y_overhang(graph.stations[sid], section_dir, graph)[1],
-                angled_label_reach(graph.stations[sid], label_angle),
+                angled_label_reach(
+                    graph.stations[sid],
+                    0.0 if sid in rail_above_ids else label_angle,
+                ),
             )
             for sid in _content_station_ids(graph, section)
         ]

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -390,29 +390,6 @@ def _bundle_edge_padding(
     )
 
 
-def _rail_above_label_ids(graph: MetroGraph, section: Section) -> set[str]:
-    """Rail stations whose label hangs above the top rail rather than below.
-
-    Empty for non-rail sections and for rail sections whose per-line rail map is
-    not yet populated.  Mirrors the classification
-    :func:`_guard_rail_above_label_band` uses so the content-bottom prediction
-    and the guard agree on which stations reach up.
-    """
-    if not graph.is_rail_section(section.id):
-        return set()
-    per_line = graph._rail_y.get(section.id) or {}
-    if not per_line:
-        return set()
-    from nf_metro.layout.rail_mode import _rail_above_label_stations
-
-    real_ids = [
-        sid
-        for sid in section.station_ids
-        if (st := graph.stations.get(sid)) is not None and not st.is_port
-    ]
-    return _rail_above_label_stations(graph, real_ids, per_line)
-
-
 def _predict_section_content_bottom(
     graph: MetroGraph,
     section: Section,
@@ -452,7 +429,12 @@ def _predict_section_content_bottom(
     # rather than down and adds no downward reach; only the below-hanging labels
     # anchor the bottom.  :func:`_guard_rail_above_label_band` covers the upward
     # footprint of these stations.
-    rail_above_ids = _rail_above_label_ids(graph, section) if label_angle else set()
+    rail_above_ids: set[str] = set()
+    if label_angle:
+        # Function-local: a module-level import would close a layout import cycle.
+        from nf_metro.layout.rail_mode import rail_above_label_ids
+
+        rail_above_ids = rail_above_label_ids(graph, section)
     if is_horizontal and offsets is None:
         from nf_metro.layout.routing import compute_station_offsets
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -1564,26 +1564,16 @@ def _guard_rail_above_label_band(graph: MetroGraph, phase: str) -> None:
     if not graph.has_rail_sections:
         return
     # Function-local: a module-level import would close a layout import cycle.
-    from nf_metro.layout.rail_mode import (
-        _rail_above_label_stations,
-        _rail_label_band,
-    )
+    from nf_metro.layout.rail_mode import _rail_label_band, rail_above_label_ids
 
     tol = 1.0
     for section in graph.sections.values():
         if section.bbox_h <= 0 or not graph.is_rail_section(section.id):
             continue
-        per_line = graph._rail_y.get(section.id) or {}
-        if not per_line:
-            continue
-        real_ids = [
-            sid
-            for sid in section.station_ids
-            if (st := graph.stations.get(sid)) is not None and not st.is_port
-        ]
-        above_ids = _rail_above_label_stations(graph, real_ids, per_line)
+        above_ids = rail_above_label_ids(graph, section)
         if not above_ids:
             continue
+        per_line = graph._rail_y.get(section.id) or {}
         needed = _rail_label_band(graph, above_ids)
         reserved = min(per_line.values()) - section.bbox_y
         if reserved + tol < needed:

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -582,6 +582,27 @@ def _rail_above_label_stations(
     return above
 
 
+def rail_above_label_ids(graph: MetroGraph, section: Section) -> set[str]:
+    """Section-level :func:`_rail_above_label_stations`: above-label station ids.
+
+    Resolves the section's real (non-port) stations and per-line rail map before
+    classifying, so callers that only have a ``Section`` need not repeat the
+    prep.  Empty for non-rail sections and for rail sections whose rail map is
+    not yet populated.
+    """
+    if not graph.is_rail_section(section.id):
+        return set()
+    per_line_y = graph._rail_y.get(section.id) or {}
+    if not per_line_y:
+        return set()
+    real_ids = [
+        sid
+        for sid in section.station_ids
+        if (st := graph.stations.get(sid)) is not None and not st.is_port
+    ]
+    return _rail_above_label_stations(graph, real_ids, per_line_y)
+
+
 def _label_aware_x_spacing(
     graph: MetroGraph,
     real_ids: list[str],

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1361,6 +1361,45 @@ def test_diagonal_rail_above_labels_share_a_common_baseline():
     assert below_seen, "fixture must also have a label below the bundle"
 
 
+def test_rail_above_label_reach_excluded_from_content_bottom():
+    """A rail section's content-bottom prediction must exclude the *downward*
+    angled-label reach of top-rail stations whose labels hang *above* the
+    bundle.  A wide above-label name would otherwise inflate the target far
+    below the settled bbox, so ``compute_layout(validate=True)`` (which runs
+    ``_guard_section_bottom_padding`` on the drawn geometry) rejects a render
+    the engine draws with a correctly padded bottom (issue #1361)."""
+    from nf_metro.layout.phases.bbox import _predict_section_content_bottom
+    from nf_metro.layout.rail_mode import _rail_above_label_stations
+    from nf_metro.layout.routing import compute_station_offsets
+
+    graph = parse_metro_mermaid(_STACKED_RAIL_MMD)
+    # Must not raise: the settled bbox bottom clears the below-hanging labels.
+    compute_layout(graph, validate=True)
+
+    section = graph.sections["calling"]
+    per_line = graph._rail_y.get("calling") or {}
+    real_ids = [
+        sid
+        for sid in section.station_ids
+        if (st := graph.stations.get(sid)) is not None and not st.is_port
+    ]
+    above_ids = _rail_above_label_stations(graph, real_ids, per_line)
+    assert above_ids, "fixture must have >=1 above-label (top-rail) station"
+
+    target = _predict_section_content_bottom(
+        graph, section, 20.0, compute_station_offsets(graph)
+    )
+    bbox_bottom = section.bbox_y + section.bbox_h
+    assert target is not None
+    assert target <= bbox_bottom + 1.0, (
+        f"content-bottom target {target:.1f} exceeds the drawn bbox bottom "
+        f"{bbox_bottom:.1f}; an above-label station's downward reach leaked in"
+    )
+    # The target sits below the top rail because the below-hanging labels
+    # (e.g. 'Tumor Tool') genuinely anchor it, so it is not merely zeroed out.
+    assert target > min(per_line.values())
+
+
 def test_above_rail_label_bottom_right_corner_seats_at_station():
     """An above-bundle diagonal rail label anchors its bottom-right corner at
     its station marker, so the name rises up-and-to-the-left out of the stop."""

--- a/tests/test_rail_mode.py
+++ b/tests/test_rail_mode.py
@@ -1369,7 +1369,7 @@ def test_rail_above_label_reach_excluded_from_content_bottom():
     ``_guard_section_bottom_padding`` on the drawn geometry) rejects a render
     the engine draws with a correctly padded bottom (issue #1361)."""
     from nf_metro.layout.phases.bbox import _predict_section_content_bottom
-    from nf_metro.layout.rail_mode import _rail_above_label_stations
+    from nf_metro.layout.rail_mode import rail_above_label_ids
     from nf_metro.layout.routing import compute_station_offsets
 
     graph = parse_metro_mermaid(_STACKED_RAIL_MMD)
@@ -1378,12 +1378,7 @@ def test_rail_above_label_reach_excluded_from_content_bottom():
 
     section = graph.sections["calling"]
     per_line = graph._rail_y.get("calling") or {}
-    real_ids = [
-        sid
-        for sid in section.station_ids
-        if (st := graph.stations.get(sid)) is not None and not st.is_port
-    ]
-    above_ids = _rail_above_label_stations(graph, real_ids, per_line)
+    above_ids = rail_above_label_ids(graph, section)
     assert above_ids, "fixture must have >=1 above-label (top-rail) station"
 
     target = _predict_section_content_bottom(


### PR DESCRIPTION
## Summary

A rail panel's top-rail stations label *above* the bundle (`labels._rail_label_side`), so with an angled label their names hang up-and-left, not down. `_predict_section_content_bottom` counted their *downward* angled reach anyway, inflating a section's content-bottom target far below the settled bbox. With the checkpoint now deferred onto the settled geometry (#1339 / PR #1362), `_guard_section_bottom_padding` then rejected a render whose bottom padding is actually correct - for the stacked-rail fixture, `calling` bbox bottom `590.9` vs an inflated target `690.0` driven by the wide "A Very Long Germline Caller Name" above-label.

- `_predict_section_content_bottom` excludes the downward angled-label reach of rail above-label stations, so the padding guard's target matches the geometry the renderer draws. The below-hanging labels (e.g. `Tumor Tool`) still anchor the bottom.
- The above-labels' upward footprint remains covered by `_guard_rail_above_label_band`.
- New `rail_mode.rail_above_label_ids(graph, section)` shares the "resolve real stations + per-line rail map, then classify" prep so `_predict_section_content_bottom` and `_guard_rail_above_label_band` call one definition.
- New regression test asserts the content-bottom target no longer exceeds the drawn bbox for the stacked-rail fixture (and stays anchored by the below-labels).

The rendered SVG is byte-identical before/after: the change is observational (it only corrects the predicted target the deferred guard checks).

Fixes #1361

Based on `fix/1339-defer-final-guards` (PR #1362), which defers the `"after final"` checkpoint onto the settled geometry and left `test_diagonal_rail_above_labels_share_a_common_baseline` failing as this bug's anchor. That test now passes.

## Test plan

- [x] pytest: `test_rail_above_label_reach_excluded_from_content_bottom` (new) and `test_diagonal_rail_above_labels_share_a_common_baseline` (anchor) pass; full suite has only the pre-existing `test_seam_orientation::test_residual_set_matches_documented_divergences` failure inherited from the base branch
- [x] ruff check + ruff format clean on the whole repo
- [x] mypy clean
- [ ] Visual review of the render preview (no pixel change expected - the guard is observational)

Generated with Claude Code
