### PR TITLE
Embedding and CLI quick wins: py.typed, API re-exports, api-routed scripts, CLI catch-all

### DIFF
--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -29,11 +29,12 @@ sys.path.insert(0, str(project_root / "tests"))
 
 from layout_metrics import compute_metrics  # noqa: E402
 
-from nf_metro.convert import convert_nextflow_dag  # noqa: E402
-from nf_metro.layout.engine import compute_layout  # noqa: E402
-from nf_metro.parser.mermaid import parse_metro_mermaid  # noqa: E402
-from nf_metro.render.svg import render_svg  # noqa: E402
-from nf_metro.themes import THEMES  # noqa: E402
+from nf_metro.api import (  # noqa: E402
+    RenderConfig,
+    prepare_graph,
+    render_graph,
+    resolve_theme,
+)
 
 DEBUG_RENDERS = "--debug" in sys.argv
 
@@ -125,17 +126,6 @@ def _seed_from_base() -> None:
             target.update(json.loads(path.read_text()))
 
 
-def render_drawn_svg(graph, theme, **kwargs) -> str:
-    """Render the drawn map only, with the embedded data manifest disabled.
-
-    The gallery is the visual-regression surface: the render diff compares
-    these SVGs byte-for-byte, and the data manifest carries no visual content.
-    Disabling it keeps the diff a true picture of what changed on screen.
-    """
-    graph.embed_manifest = False
-    return render_svg(graph, theme, **kwargs)
-
-
 def _record_metrics(graph, svg_name: str, svg_str: str) -> None:
     """Compute the layout-quality scorecard for a freshly rendered graph.
 
@@ -156,20 +146,26 @@ def render_mmd(
     *,
     debug: bool = DEBUG_RENDERS,
     self_color_scheme: bool = True,
+    from_nextflow: bool = False,
 ) -> str:
     """Parse, layout, and render a .mmd file to SVG; write it and return it.
 
+    Goes through :func:`nf_metro.api.prepare_graph`/:func:`~nf_metro.api.render_graph`
+    so this script resolves the option cascade the same way the CLI does.
+
     ``self_color_scheme`` is forwarded to the renderer: pages that inline the SVG
     (gallery, pipelines) pass False so the map inherits the page's color-scheme
-    and follows the light/dark toggle.
+    and follows the light/dark toggle. The embedded data manifest carries no
+    visual content, so it is disabled for every render here: the gallery is the
+    visual-regression surface and the render diff compares these SVGs
+    byte-for-byte.
     """
     text = mmd_path.read_text()
-    graph = parse_metro_mermaid(text)
-    compute_layout(graph)
-    theme_name = graph.style if graph.style in THEMES else "nfcore"
-    theme = THEMES[theme_name]
-    svg_str = render_drawn_svg(
-        graph, theme, debug=debug, self_color_scheme=self_color_scheme
+    graph = prepare_graph(text, from_nextflow=from_nextflow)
+    graph.embed_manifest = False
+    theme = resolve_theme(None, graph)
+    svg_str = render_graph(
+        graph, theme, RenderConfig(debug=debug, self_color_scheme=self_color_scheme)
     )
     svg_path.write_text(svg_str)
     _record_metrics(graph, svg_path.name, svg_str)
@@ -286,14 +282,7 @@ def render_guide_examples() -> None:
         _manifest[debug_svg.name] = section
     elif debug_src.exists():
         try:
-            text = debug_src.read_text()
-            graph = parse_metro_mermaid(text)
-            compute_layout(graph)
-            theme_name = graph.style if graph.style in THEMES else "nfcore"
-            theme = THEMES[theme_name]
-            svg_str = render_drawn_svg(graph, theme, debug=True)
-            debug_svg.write_text(svg_str)
-            _record_metrics(graph, debug_svg.name, svg_str)
+            render_mmd(debug_src, debug_svg, debug=True)
             _manifest[debug_svg.name] = section
             print("  rnaseq_auto_debug: OK")
         except Exception as e:
@@ -342,14 +331,7 @@ def render_nextflow_examples() -> None:
             _manifest[svg_path.name] = section
             continue
         try:
-            text = mmd_path.read_text()
-            converted = convert_nextflow_dag(text)
-            graph = parse_metro_mermaid(converted)
-            compute_layout(graph)
-            theme = THEMES[graph.style if graph.style in THEMES else "nfcore"]
-            svg_str = render_drawn_svg(graph, theme, debug=DEBUG_RENDERS)
-            svg_path.write_text(svg_str)
-            _record_metrics(graph, svg_path.name, svg_str)
+            render_mmd(mmd_path, svg_path, from_nextflow=True)
             _manifest[svg_path.name] = section
             print(f"  nf_{mmd_path.stem}: OK")
         except Exception as e:

--- a/scripts/render_topologies.py
+++ b/scripts/render_topologies.py
@@ -18,13 +18,31 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root / "src"))
 
-from nf_metro.convert import convert_nextflow_dag  # noqa: E402
-from nf_metro.layout.engine import compute_layout  # noqa: E402
-from nf_metro.parser.mermaid import parse_metro_mermaid  # noqa: E402
-from nf_metro.render.svg import render_svg  # noqa: E402
-from nf_metro.themes import THEMES  # noqa: E402
+from nf_metro.api import (  # noqa: E402
+    RenderConfig,
+    prepare_graph,
+    render_graph,
+    resolve_theme,
+)
+from nf_metro.layout import (  # noqa: E402
+    BackwardFlowError,
+    FoldThresholdError,
+    MixedEntryDirectionError,
+    PhaseInvariantError,
+)
+from nf_metro.parser import CyclicGraphError  # noqa: E402
 
 NEXTFLOW_DIR = project_root / "tests" / "fixtures" / "nextflow"
+
+# Errors from the layout stage of prepare_graph, distinguished from parse
+# errors so the batch summary keeps reporting which stage failed.
+_LAYOUT_ERRORS = (
+    BackwardFlowError,
+    CyclicGraphError,
+    FoldThresholdError,
+    MixedEntryDirectionError,
+    PhaseInvariantError,
+)
 
 
 def _collect_mmd_files() -> list[Path]:
@@ -64,29 +82,25 @@ def render_file(
     is_nextflow = NEXTFLOW_DIR in mmd_path.parents or mmd_path.parent == NEXTFLOW_DIR
     issues: list[str] = []
 
+    layout_options = {"diamond_style": "straight"} if straight_diamonds else None
     try:
         text = mmd_path.read_text()
-        if is_nextflow:
-            text = convert_nextflow_dag(text)
-        graph = parse_metro_mermaid(text)
+        graph = prepare_graph(
+            text, from_nextflow=is_nextflow, layout_options=layout_options
+        )
+    except _LAYOUT_ERRORS as e:
+        return name, [f"LAYOUT ERROR: {e}"]
     except Exception as e:
         return name, [f"PARSE ERROR: {e}"]
 
-    if straight_diamonds:
-        graph.diamond_style = "straight"
-
-    try:
-        compute_layout(graph)
-    except Exception as e:
-        return name, [f"LAYOUT ERROR: {e}"]
-
-    theme_name = graph.style if graph.style in THEMES else "nfcore"
-    theme = THEMES[theme_name]
+    theme = resolve_theme(None, graph)
 
     try:
         # chrome_css=False bakes concrete colors so the cairosvg PNG step below
         # works (cairosvg cannot parse the var() chrome custom properties).
-        svg_str = render_svg(graph, theme, debug=debug, chrome_css=False)
+        svg_str = render_graph(
+            graph, theme, RenderConfig(debug=debug, chrome_css=False)
+        )
     except Exception as e:
         return name, [f"RENDER ERROR: {e}"]
 

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,5 +1,13 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
+from nf_metro.api import RenderConfig, prepare_graph, render_graph, render_string
+
 __version__ = "1.1.0"
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "RenderConfig",
+    "prepare_graph",
+    "render_graph",
+    "render_string",
+]

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import warnings
 from collections.abc import Callable, Iterable
 from pathlib import Path
@@ -314,6 +315,10 @@ def render(
     to their own sibling <input>.<format>; every file is attempted even if an
     earlier one fails, successful outputs are kept, and a non-zero exit is
     returned if any failed.
+
+    Any exception not already recognised as a pipeline error surfaces as a
+    plain error message rather than a traceback; set NF_METRO_DEBUG=1 to
+    re-raise it instead.
     """
     if len(input_files) > 1 and output is not None:
         raise click.UsageError("-o/--output can only be used with a single INPUT_FILE.")
@@ -355,6 +360,64 @@ def render(
 
 
 def _render_one(
+    input_file: Path,
+    output: Path,
+    *,
+    format_: Literal["svg", "html"],
+    theme: str | None,
+    mode: str | None,
+    debug: bool,
+    logo: Path | None,
+    line_spread: str | None,
+    legend: str | None,
+    from_nextflow: bool,
+    title: str | None,
+    responsive: bool,
+    embed_font: bool,
+    text_to_paths: bool,
+    svg_class_prefix: str,
+    no_self_color_scheme: bool,
+    no_dark_mode_css: bool,
+    no_chrome_css: bool,
+    bare: bool,
+    validate_geometry: bool,
+    layout_opts: dict[str, object],
+    quiet: bool,
+) -> None:
+    try:
+        _render_one_unsafe(
+            input_file,
+            output,
+            format_=format_,
+            theme=theme,
+            mode=mode,
+            debug=debug,
+            logo=logo,
+            line_spread=line_spread,
+            legend=legend,
+            from_nextflow=from_nextflow,
+            title=title,
+            responsive=responsive,
+            embed_font=embed_font,
+            text_to_paths=text_to_paths,
+            svg_class_prefix=svg_class_prefix,
+            no_self_color_scheme=no_self_color_scheme,
+            no_dark_mode_css=no_dark_mode_css,
+            no_chrome_css=no_chrome_css,
+            bare=bare,
+            validate_geometry=validate_geometry,
+            layout_opts=layout_opts,
+            quiet=quiet,
+        )
+    except click.ClickException:
+        raise
+    except Exception as e:
+        if os.environ.get("NF_METRO_DEBUG") == "1":
+            raise
+        raise click.ClickException(f"{input_file}: unexpected error: {e}")
+
+
+def _render_one_unsafe(
     input_file: Path,
     output: Path,
     *,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,6 +242,38 @@ def test_render_nonexistent_file():
     assert result.exit_code != 0
 
 
+def test_render_unexpected_exception_becomes_click_exception(tmp_path, monkeypatch):
+    """An exception type outside the pipeline's known errors becomes a clean error."""
+
+    def _boom(*args, **kwargs):
+        raise KeyError("boom")
+
+    monkeypatch.delenv("NF_METRO_DEBUG", raising=False)
+    monkeypatch.setattr("nf_metro.cli.render_graph", _boom)
+    src = tmp_path / "a.mmd"
+    src.write_text(RNASEQ_MMD.read_text())
+    runner = CliRunner()
+    result = runner.invoke(cli, ["render", str(src), "-o", str(tmp_path / "out.svg")])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, SystemExit)
+    assert "unexpected error" in result.output
+
+
+def test_render_unexpected_exception_reraises_under_debug_env(tmp_path, monkeypatch):
+    """NF_METRO_DEBUG=1 re-raises the original exception instead of wrapping it."""
+
+    def _boom(*args, **kwargs):
+        raise KeyError("boom")
+
+    monkeypatch.setenv("NF_METRO_DEBUG", "1")
+    monkeypatch.setattr("nf_metro.cli.render_graph", _boom)
+    src = tmp_path / "a.mmd"
+    src.write_text(RNASEQ_MMD.read_text())
+    runner = CliRunner()
+    result = runner.invoke(cli, ["render", str(src), "-o", str(tmp_path / "out.svg")])
+    assert isinstance(result.exception, KeyError)
+
+
 def test_render_multiple_files(tmp_path):
     """render accepts more than one INPUT_FILE, each to its own sibling output."""
     a = tmp_path / "a.mmd"


### PR DESCRIPTION
## Summary

Four small, related fixes to the embedding/CLI surface (closes #1371):

- Ship a `src/nf_metro/py.typed` marker (PEP 561) so downstream importers get type information from the strictly-typed core. Confirmed it lands in the built wheel.
- Re-export the embedding surface from the package root: `import nf_metro; nf_metro.render_string(...)` now works, alongside `prepare_graph`, `render_graph`, and `RenderConfig`.
- Point `scripts/build_gallery.py` and `scripts/render_topologies.py` at `nf_metro.api`'s `prepare_graph`/`render_graph`/`resolve_theme` instead of hand-wiring `parse_metro_mermaid` + `compute_layout` + `render_svg` + a manual theme lookup. `build_gallery.py`'s three duplicated inline render blocks collapse onto its single `render_mmd` helper. This closes a real drift: two gallery fixtures (`differentialabundance`, `sarek_metro`) that combine a title and a logo were rendering with an unnecessary reserved title band the CLI doesn't reserve; verified the new script output is now geometry-identical to `nf-metro render` for these fixtures (module the deliberately-disabled embedded data manifest). `scripts/build_render_diff.py` needed no change — it only diffs SVGs already produced by `build_gallery.py` and doesn't render anything itself.
- Add a catch-all to the single-file `render` CLI path: any exception outside the pipeline's known error types now surfaces as a clean `ClickException` instead of a raw traceback, with `NF_METRO_DEBUG=1` as an escape hatch to re-raise for development.

## Test plan

- [x] `pytest` (full suite, 32064 passed)
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] `python -m build --wheel` and confirmed `py.typed` is packaged
- [x] `import nf_metro; nf_metro.render_string(...)` works
- [x] `python scripts/build_gallery.py` and `python scripts/render_topologies.py` run clean against the full corpus; diffed output against both the pre-change scripts and the CLI directly to confirm only the expected drift-fix changed
- [x] New CLI tests for the unexpected-exception catch-all and the `NF_METRO_DEBUG` escape hatch