### PR TITLE
fix: prevent duplicate SVG ids from breaking adaptive logo masks on the render-diff page

### DIFF
--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -378,9 +378,39 @@ _SVG_ROOT_RE = re.compile(r"(<svg)(\s[^>]*)(>)", re.DOTALL)
 _SELF_SCHEME_RE = re.compile(r'\s+style="color-scheme:\s*light\s+dark"')
 _WIDTH_RE = re.compile(r'\bwidth="(\d+)"')
 _HEIGHT_RE = re.compile(r'\bheight="(\d+)"')
+_ID_ATTR_RE = re.compile(r'\bid="([^"]+)"')
+_URL_REF_RE = re.compile(r"url\(#([^)]+)\)")
 
 
-def _inline_svg(path: Path) -> str:
+def _namespace_referenced_ids(content: str, namespace: str) -> str:
+    """Suffix ids that are the target of a url(#...) reference, plus the references.
+
+    Multiple copies of the same source SVG end up inlined together on one page
+    (e.g. a base and a PR render of the same pipeline). Their element ids are
+    then identical. A toggle that sets one copy's wrapper to display:none
+    leaves that copy's ids as the first same-id match in document order, so a
+    visible copy's url(#id) reference (e.g. a <mask>) resolves into the hidden
+    subtree and stops applying - the referencing element renders unmasked.
+    Suffixing every url(#...)-referenced id per inlined copy keeps each copy's
+    references pointing at its own, always-rendered elements.
+    """
+    referenced_ids = set(_URL_REF_RE.findall(content))
+    if not referenced_ids:
+        return content
+
+    def repl_id(m: re.Match[str]) -> str:
+        old = m.group(1)
+        return f'id="{old}--{namespace}"' if old in referenced_ids else m.group(0)
+
+    def repl_ref(m: re.Match[str]) -> str:
+        old = m.group(1)
+        return f"url(#{old}--{namespace})" if old in referenced_ids else m.group(0)
+
+    content = _ID_ATTR_RE.sub(repl_id, content)
+    return _URL_REF_RE.sub(repl_ref, content)
+
+
+def _inline_svg(path: Path, namespace: str) -> str:
     """Read SVG; strip self-declared color-scheme and add viewBox for CSS scaling.
 
     SVGs rendered with self_color_scheme=True carry style="color-scheme: light dark"
@@ -390,8 +420,12 @@ def _inline_svg(path: Path) -> str:
     toggle controls the renders.
 
     Adding viewBox (when absent) enables proportional CSS scaling via max-width/height.
+
+    *namespace* must be unique per inlined copy on the page (e.g. combining the
+    render's stem with "base"/"pr") - see :func:`_namespace_referenced_ids`.
     """
     content = path.read_text()
+    content = _namespace_referenced_ids(content, namespace)
     m = _SVG_ROOT_RE.search(content)
     if not m:
         return content
@@ -571,8 +605,8 @@ def build_diff(
             div_open = f'<div class="diff-entry" id="{stem}">'
 
             if kind == "changed":
-                base_svg = _inline_svg(base_dir / name)
-                pr_svg = _inline_svg(pr_dir / name)
+                base_svg = _inline_svg(base_dir / name, f"{stem}-base")
+                pr_svg = _inline_svg(pr_dir / name, f"{stem}-pr")
                 toggle = (
                     '<div class="toggle-bar">'
                     '<button class="active" data-mode="side-by-side">'
@@ -591,7 +625,7 @@ def build_diff(
                     f"</div>\n</div>"
                 )
             elif kind == "added":
-                pr_svg = _inline_svg(pr_dir / name)
+                pr_svg = _inline_svg(pr_dir / name, f"{stem}-pr")
                 entry = (
                     f"{div_open}\n{h3}\n"
                     f'<div class="side-only"><h4>New in PR</h4>'
@@ -599,7 +633,7 @@ def build_diff(
                     f"</div>"
                 )
             else:  # removed
-                base_svg = _inline_svg(base_dir / name)
+                base_svg = _inline_svg(base_dir / name, f"{stem}-base")
                 entry = (
                     f"{div_open}\n{h3}\n"
                     f'<div class="side-only"><h4>Removed (was in base)</h4>'

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -410,6 +410,14 @@ def _namespace_referenced_ids(content: str, namespace: str) -> str:
     return _URL_REF_RE.sub(repl_ref, content)
 
 
+def _panel_namespace(stem: str, side: str) -> str:
+    """Build the per-panel namespace passed to :func:`_inline_svg`.
+
+    *side* must be "base" or "pr" - the two panels a diff entry ever inlines.
+    """
+    return f"{stem}-{side}"
+
+
 def _inline_svg(path: Path, namespace: str) -> str:
     """Read SVG; strip self-declared color-scheme and add viewBox for CSS scaling.
 
@@ -605,8 +613,8 @@ def build_diff(
             div_open = f'<div class="diff-entry" id="{stem}">'
 
             if kind == "changed":
-                base_svg = _inline_svg(base_dir / name, f"{stem}-base")
-                pr_svg = _inline_svg(pr_dir / name, f"{stem}-pr")
+                base_svg = _inline_svg(base_dir / name, _panel_namespace(stem, "base"))
+                pr_svg = _inline_svg(pr_dir / name, _panel_namespace(stem, "pr"))
                 toggle = (
                     '<div class="toggle-bar">'
                     '<button class="active" data-mode="side-by-side">'
@@ -625,7 +633,7 @@ def build_diff(
                     f"</div>\n</div>"
                 )
             elif kind == "added":
-                pr_svg = _inline_svg(pr_dir / name, f"{stem}-pr")
+                pr_svg = _inline_svg(pr_dir / name, _panel_namespace(stem, "pr"))
                 entry = (
                     f"{div_open}\n{h3}\n"
                     f'<div class="side-only"><h4>New in PR</h4>'
@@ -633,7 +641,7 @@ def build_diff(
                     f"</div>"
                 )
             else:  # removed
-                base_svg = _inline_svg(base_dir / name, f"{stem}-base")
+                base_svg = _inline_svg(base_dir / name, _panel_namespace(stem, "base"))
                 entry = (
                     f"{div_open}\n{h3}\n"
                     f'<div class="side-only"><h4>Removed (was in base)</h4>'

--- a/tests/test_render_diff_inline_svg_ids.py
+++ b/tests/test_render_diff_inline_svg_ids.py
@@ -12,19 +12,16 @@ and dark logo variants render unmasked on top of each other.
 
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 
 from nf_metro.api import render_string
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-from build_render_diff import _inline_svg  # noqa: E402
+from build_render_diff import _ID_ATTR_RE as _ID_RE  # noqa: E402
+from build_render_diff import _URL_REF_RE, _inline_svg, build_diff  # noqa: E402
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
-
-_ID_RE = re.compile(r'\bid="([^"]+)"')
-_URL_REF_RE = re.compile(r"url\(#([^)]+)\)")
 
 
 def _render_adaptive_logo_svg() -> str:
@@ -72,4 +69,29 @@ def test_each_panel_still_resolves_its_own_references(tmp_path):
     for ref in _URL_REF_RE.findall(inlined):
         assert ref in defined_ids, (
             f"url(#{ref}) no longer resolves within its own panel"
+        )
+
+
+def test_build_diff_output_has_no_id_collisions(tmp_path):
+    """End-to-end: the generated diff page itself must not collide any panel's ids."""
+    svg_text = _render_adaptive_logo_svg()
+    base_dir = tmp_path / "base"
+    pr_dir = tmp_path / "pr"
+    base_dir.mkdir()
+    pr_dir.mkdir()
+    (base_dir / "sarek_metro.svg").write_text(svg_text)
+    # A trivial byte difference is enough to classify this as a "changed" render,
+    # matching the case that renders both panels onto the page together.
+    (pr_dir / "sarek_metro.svg").write_text(svg_text + "<!-- pr -->")
+
+    output_dir = tmp_path / "out"
+    assert build_diff(base_dir, pr_dir, output_dir)
+
+    page = (output_dir / "index.html").read_text()
+    referenced_ids = _URL_REF_RE.findall(page)
+    assert referenced_ids
+    defined_ids = _ID_RE.findall(page)
+    for ref in referenced_ids:
+        assert defined_ids.count(ref) == 1, (
+            f"id {ref!r} referenced by url(#{ref}) collides in the generated page"
         )

--- a/tests/test_render_diff_inline_svg_ids.py
+++ b/tests/test_render_diff_inline_svg_ids.py
@@ -1,0 +1,75 @@
+"""Regression test: duplicate SVG ids across inlined render-diff panels.
+
+The render-diff page (``scripts/build_render_diff.py``) inlines two copies of
+the same pipeline's SVG side by side (base + PR). When both copies share the
+same source (e.g. the mask markup is byte-identical), their ``id``s collide.
+The base/PR/side-by-side toggle buttons switch panels via ``display:none``,
+and a browser resolving ``url(#id)`` picks the first same-id element in
+document order - if that first element sits inside a now-hidden subtree, the
+reference stops working and the mask is dropped entirely, so both the light
+and dark logo variants render unmasked on top of each other.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from nf_metro.api import render_string
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from build_render_diff import _inline_svg  # noqa: E402
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+_ID_RE = re.compile(r'\bid="([^"]+)"')
+_URL_REF_RE = re.compile(r"url\(#([^)]+)\)")
+
+
+def _render_adaptive_logo_svg() -> str:
+    text = (EXAMPLES / "sarek_metro.mmd").read_text()
+    return render_string(text, self_color_scheme=False)
+
+
+def test_url_referenced_ids_are_unique_across_inlined_panels(tmp_path):
+    """No two url(#...)-referenced ids may collide once base+PR are inlined together."""
+    svg_text = _render_adaptive_logo_svg()
+    assert _URL_REF_RE.search(svg_text), (
+        "fixture must contain a url(#...) reference (e.g. an adaptive logo mask) "
+        "for this test to be meaningful"
+    )
+
+    base_path = tmp_path / "sarek_metro.svg"
+    pr_path = tmp_path / "sarek_metro_pr.svg"
+    base_path.write_text(svg_text)
+    pr_path.write_text(svg_text)
+
+    base_inlined = _inline_svg(base_path, "sarek_metro-base")
+    pr_inlined = _inline_svg(pr_path, "sarek_metro-pr")
+    combined = base_inlined + pr_inlined
+
+    referenced_ids = _URL_REF_RE.findall(combined)
+    assert referenced_ids, "expected url(#...) references to survive inlining"
+
+    defined_ids = _ID_RE.findall(combined)
+    for ref in referenced_ids:
+        assert defined_ids.count(ref) == 1, (
+            f"id {ref!r} referenced by url(#{ref}) must be unique across "
+            "inlined panels, or a display:none toggle on one panel breaks "
+            "mask resolution for the other"
+        )
+
+
+def test_each_panel_still_resolves_its_own_references(tmp_path):
+    """Renaming ids must not break a panel's own url(#...) -> id(...) resolution."""
+    svg_text = _render_adaptive_logo_svg()
+    path = tmp_path / "sarek_metro.svg"
+    path.write_text(svg_text)
+
+    inlined = _inline_svg(path, "sarek_metro-pr")
+    defined_ids = set(_ID_RE.findall(inlined))
+    for ref in _URL_REF_RE.findall(inlined):
+        assert ref in defined_ids, (
+            f"url(#{ref}) no longer resolves within its own panel"
+        )


### PR DESCRIPTION
## Summary

The render-diff page (`scripts/build_render_diff.py`) inlines two copies of the same pipeline's SVG on one page (base + PR). When a pipeline has an adaptive light/dark logo, both copies emit identically-`id`'d `<mask>` elements. The page's "Base only"/"PR only" toggle switches panels via `display:none`; a browser resolving `url(#id)` picks the first same-id element in document order, so once that first element sits inside a hidden panel, the reference stops applying and the still-visible panel's logo renders both light and dark variants unmasked on top of each other.

This is specific to the render-diff page's side-by-side comparison, not the core render engine or any single-instance embed (verified against the live production gallery pages, which only inline one copy per page).

- Adds `_namespace_referenced_ids()`: suffixes any `id` that's the target of a `url(#...)` reference (plus the reference itself) with a per-panel namespace, so two inlined copies of the same source SVG never collide.
- Threads a `namespace` parameter through `_inline_svg()` and its call sites, via a small `_panel_namespace(stem, side)` helper so the "base"/"pr" suffix convention lives in one place.
- Adds regression tests: unit-level id-uniqueness/self-resolution checks on `_inline_svg`, plus an end-to-end test that runs `build_diff()` and checks the generated page for collisions.

## Test plan
- [x] `pytest` passes (32065 passed, 110 skipped, 11 xfailed - no new skips/xfails)
- [x] `ruff check` + `ruff format --check` clean
- [x] Verified the fix visually with Playwright (Chromium) against a locally-generated render-diff page: "Base only"/"PR only"/"Side by side" all render a single, correctly-masked logo in both light and dark color schemes
- [ ] Render-preview verdict (this PR only touches `scripts/build_render_diff.py` and tests, so the gallery corpus itself is unchanged; no visual diff expected)

Fixes #1376