### PR TITLE
docs(fix-issue): triage engine-vs-authoring, cite fix evidence, reuse env, cost discipline

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-issue
-description: End-to-end workflow for fixing GitHub issues on the nf-metro repo with diagnostic rigor. Use when the user references a GitHub issue (by number, URL, or description) and wants it fixed. Handles worktree setup, a reused persistent env (no per-issue env creation), diagnostic-first investigation, authoring-mistake-vs-engine-bug triage (never dodge an engine bug by doctoring the reproducer), invariant-test-first implementation, runtime validators, evidence-cited fix verification, /simplify pass, full-repo lint, visual review via render preview, narrow-the-fix iteration on regressions, cost discipline (targeted tests, CI render-diff over local gallery rebuilds, skip-ci on WIP), additive-only PR hygiene (no force-push, no narrative comments), origin verification after every push, and PR creation. Trigger on phrases like "fix issue #N", "address #N", "work on issue N", or any request to fix a bug or implement a feature that references an issue. For shepherding a chain of already-existing PRs back to main, see `pr-chain-vet` instead.
+description: End-to-end workflow for fixing GitHub issues on the nf-metro repo with diagnostic rigor. Use when the user references a GitHub issue (by number, URL, or description) and wants it fixed. Handles worktree setup, a reused persistent env (no per-issue env creation), diagnostic-first investigation, authoring-mistake-vs-engine-bug triage (never dodge an engine bug by doctoring the reproducer), invariant-test-first implementation, runtime validators, evidence-cited fix verification, /simplify pass, full-repo lint, visual review via render preview, narrow-the-fix iteration on regressions, cost discipline (targeted tests, CI render-diff over local gallery rebuilds, skip-ci on WIP), standalone issue-body hygiene, additive-only PR hygiene (no force-push, no narrative comments), clean execution of an authorised admin-merge (preserve history, no CI re-run), origin verification after every push, and PR creation. Trigger on phrases like "fix issue #N", "address #N", "work on issue N", or any request to fix a bug or implement a feature that references an issue. For shepherding a chain of already-existing PRs back to main, see `pr-chain-vet` instead.
 ---
 
 # Fix Issue
@@ -8,6 +8,11 @@ description: End-to-end workflow for fixing GitHub issues on the nf-metro repo w
 Structured workflow for fixing nf-metro GitHub issues in an isolated worktree.
 Emphasises diagnostic-first investigation, invariant tests before code, and
 additive-only PR hygiene so a fix never silently regresses the gallery.
+
+**Communication:** keep status updates terse and lead any explanation of a
+mechanism or a render with one plain-English sentence before the code or
+coordinates. Prefer a narrow table to a wide one. When asked to "explain
+simply" or for "less words", cut - don't re-expand.
 
 **Conventions** (substitute if your setup differs):
 - Local nf-metro checkout: `~/projects/nf-metro`
@@ -24,6 +29,17 @@ gh issue view <N> --repo seqeralabs/nf-metro
 ```
 
 Summarize the problem and proposed approach. Wait for user confirmation before proceeding.
+
+### Issue hygiene
+
+Every issue is run through *this skill* fresh in a later session, so the
+**issue body must be standalone and self-contained**. When you learn
+something during the fix that a future session would need (the real cause, a
+repro, a constraint), fold it into the **issue body** - do not scatter it
+across comments, and do not leave superseded-approach detail that would
+mislead a fresh reader. Keep the body concise. If the fix uncovers a
+genuinely separable defect, file it as a **child issue** rather than
+expanding this one's scope or quietly hiding it.
 
 ## Step 2: Worktree + Environment Setup
 
@@ -93,6 +109,16 @@ before writing any code:
 
 Only after the symptom is pinned down to specific numbers should you reason
 about which layout pass / function produced them.
+
+### Check your premise against current `origin/main` first
+
+Diagnose against latest remote, not a stale tree. `git fetch origin main` and
+confirm the bug **still reproduces on latest** before reasoning about a cause -
+a sibling PR may already have fixed it or changed the very code you're reading.
+If the user says something is already addressed, re-fetch and look again before
+disagreeing; "I'm looking at outdated code" is a recurring wrong turn. If a
+related PR merges mid-session, `git merge origin/main` into the worktree and
+re-diagnose before continuing.
 
 ### Classify: authoring mistake or engine bug?
 
@@ -218,6 +244,12 @@ refactor: tighten <area> after fix for #<N>
 Keeping `fix:` and `refactor:` commits separate makes the fix itself easy
 to review and easy to revert in isolation if regressions surface.
 
+**Re-running it later:** `/simplify` is expensive, so don't re-run it after
+every follow-up commit. Only re-run it on the final aggregate diff if later
+steps (narrowing a regression, lint/mypy fixes) added a **substantial** chunk
+of new production code the first pass never saw. A couple of small,
+already-clean follow-up edits don't warrant a second pass.
+
 ## Step 7: Lint and Tests
 
 The repo's `prek` hooks (config `prek.toml`) run on every `git commit`: ruff
@@ -333,6 +365,35 @@ In **all** cases, merging is the user's call, made per-PR:
   cite "prior PRs were admin-merged" as authorisation; past instances
   are history, not standing consent.
 
+### When the user *does* authorise a merge
+
+Once the user says "merge" / "admin merge" for this PR, that word **is** the
+authorisation - execute it, don't re-litigate. The recurring mistakes (this
+is the single most-corrected behaviour across sessions) are all forms of
+doing *too much*:
+
+- **Merge with a merge commit, never squash:** `gh pr merge <N> --admin
+  --merge --delete-branch`. Preserve the branch's commit history;
+  `--squash` collapses it and is the wrong default here. (`--admin` bypasses
+  only the review gate, not CI - it's fine once CI is green or the unverified
+  delta is CI-irrelevant.) Omit `--delete-branch` if a child PR is based on
+  this branch - deleting it auto-closes the child; retarget children first
+  per Step 12.
+- **Do NOT update the branch first.** If GitHub says "head branch is not up
+  to date", do not `git merge origin/main` into it, do not push a commit, do
+  not "refresh" it - all of these fire a full CI re-run the user is
+  explicitly trying to avoid. The diff was already CI-validated; a trivial
+  base-behind is CI-irrelevant, which is exactly what `--admin` is for.
+- **Do NOT re-run or wait on fresh CI**, and cancel in-flight runs first if
+  any (`gh run cancel`). "Merge" means merge now, then clean up (Step 12) -
+  not "start another test cycle".
+
+This is the `pinin4fjords:eco-merge` philosophy; that skill encapsulates the
+"bypass the up-to-date requirement when the unverified delta is
+CI-irrelevant" check if you want it. The self-initiation guardrail above
+still holds: you never reach for admin-merge on your own; you execute it
+cleanly *when told*.
+
 ### State the evidence for every "it's fixed" claim
 
 Never assert a fix works without naming what proved it. Every "resolved" /
@@ -391,6 +452,11 @@ classify the visual delta as one of:
 - **N** (neutral) - keep
 - **D** (detrimental) - must be narrowed
 
+The bar is "no **meaningful** visual regression", not pixel-identity. A
+subtle spacing or coordinate shift that comes with a cleaner, more elegant
+implementation is fine (classify it N or I); do not contort the code to
+preserve a byte-identical render. Only a genuine degradation is a D.
+
 For each detrimental delta, find the **precondition** that distinguishes
 the target case (where the fix helps) from the regressing case (where it
 hurts). Gate the fix on that precondition (e.g. a topology predicate, a
@@ -441,6 +507,10 @@ Never rewrite shared history (no `--force`, no `--force-with-lease`, no
 interactive rebase on a pushed branch). This applies even when "it would
 be cleaner" - cleanliness is not worth the risk of an agent silently
 dropping work.
+
+An ordinary additive (fast-forward) push is **not** blocked by that hook -
+only rewrites are. Don't mistake an unrelated push failure for a force-push
+block, and don't ask the user to run a plain push you can run yourself.
 
 ### Narrative belongs in the PR description, not in comments
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -395,12 +395,12 @@ doing *too much*:
   delta is CI-irrelevant.) Omit `--delete-branch` if a child PR is based on
   this branch - deleting it auto-closes the child; retarget children first
   per Step 12.
-- **Do NOT update the branch first.** If GitHub says "head branch is not up
+- **Don't update the branch first.** If GitHub says "head branch is not up
   to date", do not `git merge origin/main` into it, do not push a commit, do
   not "refresh" it - all of these fire a full CI re-run the user is
   explicitly trying to avoid. The diff was already CI-validated; a trivial
   base-behind is CI-irrelevant, which is exactly what `--admin` is for.
-- **Do NOT re-run or wait on fresh CI**, and cancel in-flight runs first if
+- **Don't re-run or wait on fresh CI**, and cancel in-flight runs first if
   any (`gh run cancel`). "Merge" means merge now, then clean up (Step 12) -
   not "start another test cycle".
 
@@ -423,7 +423,7 @@ Two traps this closes:
 
 - **"Didn't abort" / "the one invariant passes" is not "renders
   correctly".** Removing an abort can merely expose a poor layout the abort
-  was masking. After any layout/routing fix, LOOK at the full render (crop
+  was masking. After any layout/routing fix, look at the full render (crop
   the region and read it) and run `probe_layout` + `inspect_layout` for the
   whole-layout picture (crossings, port alignment, column gaps), not only the
   invariant you targeted.
@@ -575,7 +575,9 @@ GitHub auto-closing dependent PRs:
    (or via the GitHub UI's auto-delete on merge).
 3. Remove the local worktree: `git worktree remove /tmp/nf-metro-fix-<N>`.
 4. Delete the local branch: `git branch -D fix/<N>-<slug>`.
-5. Remove the conda env: `/opt/homebrew/bin/micromamba env remove -n nf-metro-fix-<N> -y`.
+
+Leave the shared `nf-metro-dev` env in place - it is reused across issues
+(Step 2), so there is nothing per-issue to remove.
 
 Offer this cleanup to the user; only run it after they agree.
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -276,9 +276,25 @@ Layout iteration is where sessions burn tokens and compute. Keep it tight:
 
 - **Reuse the persistent env** (Step 2). Do not `micromamba create` per
   issue - it re-solves the whole dependency set every session for nothing.
-- **Iterate with targeted tests.** During the fix loop use
-  `python -m pytest -k <selector>` (or `path::test`), not the whole suite.
-  Run the **full** suite once before pushing, not on every edit.
+- **Full suite vs targeted.** `addopts` bakes in `-n auto`, so the whole
+  suite parallelises to ~half a minute - the cost of a full run is not
+  wall-time, it's *repetition* and each run's summary re-entering context.
+  So: inside the edit loop run the narrowest selection
+  (`python -m pytest tests/test_layout_invariants.py -k "<fixture-or-invariant>"`,
+  then `--lf` to re-run only what just failed), with `-q --no-header -x` to
+  keep the output tiny. Run the **full** suite once per stable state before a
+  push - and do **not** re-run it while it's still green; only after you've
+  changed code again. The routing/TB ratchets are 3.11-only, so keep the env
+  on 3.11 or they skip locally and red only in CI.
+- **Read coordinates, don't rasterize, for non-visual questions.**
+  `inspect_layout.py` / `probe_layout.py` print the geometry as cheap text;
+  a render -> cairosvg PNG -> open -> image-into-context cycle is far heavier
+  and only earns its cost for a genuine *visual* check. "Is station X on the
+  trunk?" is a coordinate read, not a screenshot.
+- **Poll CI once, in the background.** A single background watch
+  (`until gh pr checks <N> ...; done`) pulls you back when checks resolve;
+  re-running `gh pr checks` by hand each turn just dumps status into context
+  repeatedly.
 - **Lean on the CI render-diff for regression review; don't rebuild the
   gallery locally in a loop.** The CI preview (Step 8) is the authoritative
   whole-corpus diff. A local `build_gallery` / render-diff sweep repeated

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-issue
-description: End-to-end workflow for fixing GitHub issues on the nf-metro repo with diagnostic rigor. Use when the user references a GitHub issue (by number, URL, or description) and wants it fixed. Handles worktree setup, environment creation, diagnostic-first investigation, invariant-test-first implementation, runtime validators, /simplify pass, full-repo lint, visual review via render preview, narrow-the-fix iteration on regressions, additive-only PR hygiene (no force-push, no narrative comments), origin verification after every push, and PR creation. Trigger on phrases like "fix issue #N", "address #N", "work on issue N", or any request to fix a bug or implement a feature that references an issue. For shepherding a chain of already-existing PRs back to main, see `pr-chain-vet` instead.
+description: End-to-end workflow for fixing GitHub issues on the nf-metro repo with diagnostic rigor. Use when the user references a GitHub issue (by number, URL, or description) and wants it fixed. Handles worktree setup, a reused persistent env (no per-issue env creation), diagnostic-first investigation, authoring-mistake-vs-engine-bug triage (never dodge an engine bug by doctoring the reproducer), invariant-test-first implementation, runtime validators, evidence-cited fix verification, /simplify pass, full-repo lint, visual review via render preview, narrow-the-fix iteration on regressions, cost discipline (targeted tests, CI render-diff over local gallery rebuilds, skip-ci on WIP), additive-only PR hygiene (no force-push, no narrative comments), origin verification after every push, and PR creation. Trigger on phrases like "fix issue #N", "address #N", "work on issue N", or any request to fix a bug or implement a feature that references an issue. For shepherding a chain of already-existing PRs back to main, see `pr-chain-vet` instead.
 ---
 
 # Fix Issue
@@ -28,21 +28,56 @@ Summarize the problem and proposed approach. Wait for user confirmation before p
 ## Step 2: Worktree + Environment Setup
 
 ```bash
-# Worktree
+# Worktree (always off latest origin/main, never stale local main)
 cd ~/projects/nf-metro
 git fetch origin main
 git worktree add /tmp/nf-metro-fix-<N> -b fix/<N>-<slug> origin/main
-
-# Fix environment
-ulimit -n 1000000 && export CONDA_OVERRIDE_OSX=15.0 && /opt/homebrew/bin/micromamba create -n nf-metro-fix-<N> python=3.11 cairo -y
-source ~/.local/bin/mm-activate nf-metro-fix-<N>
-pip install -e "/tmp/nf-metro-fix-<N>[dev,docs,font]"
-
-# Install pre-commit hooks so lint runs automatically on every commit
-cd /tmp/nf-metro-fix-<N> && pre-commit install
 ```
 
 All subsequent work happens inside `/tmp/nf-metro-fix-<N>`.
+
+### Environment: reuse one persistent env, don't create one per issue
+
+nf-metro is pure Python; the deps (`cairo`, drawsvg, networkx, pillow,
+cairosvg, pytest, ruff, mypy, `types-networkx`) change rarely. Creating a
+fresh `micromamba` env per issue re-solves and re-downloads all of that
+every session for no benefit. Keep **one** long-lived deps env and point it
+at the worktree's code per-command:
+
+```bash
+# One-time, reused across all issues (skip if it already exists):
+ulimit -n 1000000 && export CONDA_OVERRIDE_OSX=15.0 && /opt/homebrew/bin/micromamba create -n nf-metro-dev python=3.11 cairo -y
+source ~/.local/bin/mm-activate nf-metro-dev
+pip install "drawsvg" "networkx" "pillow" "cairosvg" "pytest" "pytest-xdist" "ruff" "mypy" "types-networkx" "click"
+# Refresh this env only when pyproject deps actually change.
+```
+
+Then run the worktree's code by prepending its `src/` to `PYTHONPATH` on
+each command - **do not** `pip install -e` the worktree into this env:
+
+```bash
+source ~/.local/bin/mm-activate nf-metro-dev
+cd /tmp/nf-metro-fix-<N>
+export PYTHONPATH=/tmp/nf-metro-fix-<N>/src
+python -m nf_metro render <file.mmd> -o /tmp/out.svg    # runs THIS worktree
+python -m pytest -k <selector>
+```
+
+**Why per-command `PYTHONPATH`, not editable install:** an editable install
+binds one env's `site-packages` to exactly one worktree path, so it collides
+the moment you run two worktrees in parallel. `PYTHONPATH` is set per command
+and shadows whatever is installed, so any number of parallel worktree
+sessions share the single `nf-metro-dev` env with zero cross-talk. (If you
+genuinely want an isolated editable install for one worktree, dedicate a
+*separate* env to it - never editable-install a shared env against a
+worktree.)
+
+**Commit hooks** need the tools on `PATH` in the same Bash call: the repo
+uses `prek` (config `prek.toml`, not `pre-commit`), whose `mypy` hook is
+`language: system` and so needs `mypy` on `PATH`. Shell state does not
+persist between Bash calls, so run the commit as one call with the env
+activated: `source ~/.local/bin/mm-activate nf-metro-dev && cd <worktree> &&
+PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit ...`.
 
 ## Step 3: Diagnostic Before Fix
 
@@ -58,6 +93,42 @@ before writing any code:
 
 Only after the symptom is pinned down to specific numbers should you reason
 about which layout pass / function produced them.
+
+### Classify: authoring mistake or engine bug?
+
+Before touching anything, decide which of two things you're looking at:
+
+- **(a) An mmd authoring mistake** - the `.mmd` misdescribes the pipeline
+  (wrong line on a station, a missing edge, a bad directive). The fix *is* to
+  edit the input. `probe_layout.py` labels many of these ("authoring
+  mistakes vs engine bugs"); `nf-metro explain` shows the rule each inferred
+  decision followed.
+- **(b) An engine bug on correct mmd** - the input faithfully describes the
+  pipeline and the *engine* lays it out badly. The fix goes in `src/`
+  (layout / routing / parser). The reproducing `.mmd` stays untouched.
+
+State which one it is, in numbers, before writing code.
+
+### Once it's an engine bug, the reproducer is frozen evidence
+
+**Never "fix" an engine bug by editing the input to dodge the bad layout.**
+Do not simplify the reproducing `.mmd`'s labels, drop stations, reorder
+lines, or add directives to make the ugly render go away. That changes the
+question instead of answering it, and ships a false fix. The map is correct;
+the engine must handle it.
+
+This applies to fixtures you *author*, too: when building a new regression
+fixture, don't file it down to sidestep a second bad render you notice while
+constructing it (e.g. shortening a multi-line label so a label-interaction
+bug won't show). A second bad render is a **second finding** - note it, file
+it if warranted - not a licence to sculpt the fixture. A fixture that has
+been quietly simplified to look clean no longer locks the bug it was meant to
+lock. (Real example: a `"ORF quant"` -> `"ORFquant"` relabel that hid a
+multi-line-label interaction rather than reporting it.)
+
+The only legitimate input edits during an engine fix are: authoring a
+faithful *new* reproducer, or correcting a genuine (a)-class authoring
+mistake you've identified as the actual cause.
 
 ### Diagnostic tooling
 
@@ -149,22 +220,46 @@ to review and easy to revert in isolation if regressions surface.
 
 ## Step 7: Lint and Tests
 
-Pre-commit hooks were installed in Step 2 and run automatically on every
-`git commit` (ruff check/format on `src/` and `tests/`, mypy, trailing
-whitespace, yaml). If a commit fails due to hook errors, fix the issues
-and re-commit. Never skip hooks with `--no-verify`.
+The repo's `prek` hooks (config `prek.toml`) run on every `git commit`: ruff
+check/format on `src/` and `tests/`, mypy, trailing whitespace, yaml. If a
+commit fails on a hook, fix the issue and re-commit. Never skip hooks with
+`--no-verify`.
 
-To run the checks without committing:
+To run the checks without committing (needs `prek`, which lives on the
+`nf-core` env, plus a stub-complete `mypy`):
 
 ```bash
-cd /tmp/nf-metro-fix-<N> && pre-commit run --all-files
+micromamba run -n nf-core prek run --all-files
 ```
 
 Then run the test suite:
 
 ```bash
-pytest
+cd /tmp/nf-metro-fix-<N> && PYTHONPATH=src python -m pytest
 ```
+
+### Cost discipline (applies throughout)
+
+Layout iteration is where sessions burn tokens and compute. Keep it tight:
+
+- **Reuse the persistent env** (Step 2). Do not `micromamba create` per
+  issue - it re-solves the whole dependency set every session for nothing.
+- **Iterate with targeted tests.** During the fix loop use
+  `python -m pytest -k <selector>` (or `path::test`), not the whole suite.
+  Run the **full** suite once before pushing, not on every edit.
+- **Lean on the CI render-diff for regression review; don't rebuild the
+  gallery locally in a loop.** The CI preview (Step 8) is the authoritative
+  whole-corpus diff. A local `build_gallery` / render-diff sweep repeated
+  many times just duplicates it. Local rendering is for a *single* file's
+  quick sanity check.
+- **Read the big layout files in wide slices and stay oriented.**
+  Re-fetching `engine.py` / `fan_bundles.py` / `ordering.py` /
+  `routing/*` twenty times over a session is the single largest cache-read
+  cost. Read the region once, generously, and keep it in working context.
+- **Default `[skip ci]` on work-in-progress pushes** (WIP snapshots, refactor
+  passes). Let CI run on the final pre-review push - which this repo needs
+  anyway, because the render-diff *is* the visual review. (A commit that
+  fixes a known CI failure must re-run CI: no `[skip ci]` on those.)
 
 ### If your change touched `layout/routing/`: the gate-coverage ratchet
 
@@ -238,12 +333,41 @@ In **all** cases, merging is the user's call, made per-PR:
   cite "prior PRs were admin-merged" as authorisation; past instances
   are history, not standing consent.
 
+### State the evidence for every "it's fixed" claim
+
+Never assert a fix works without naming what proved it. Every "resolved" /
+"this is fixed" / "renders correctly" claim must cite the **specific render
+and the concrete numbers** it was checked against - the file, and the
+coordinate or element that moved from the observed value to the target value
+you wrote down in Step 3. "I believe it's resolved" with no named render is
+not a verdict; it invites the reply "which render did you re-assess on?".
+
+Two traps this closes:
+
+- **"Didn't abort" / "the one invariant passes" is not "renders
+  correctly".** Removing an abort can merely expose a poor layout the abort
+  was masking. After any layout/routing fix, LOOK at the full render (crop
+  the region and read it) and run `probe_layout` + `inspect_layout` for the
+  whole-layout picture (crossings, port alignment, column gaps), not only the
+  invariant you targeted.
+- **A clean render-diff verdict only covers the gallery corpus.** It says
+  nothing about a NEW fixture that isn't in the gallery yet. Put new
+  regression fixtures in `scripts/build_gallery.py` (`GALLERY_ENTRIES`), not
+  only `examples/topologies/`, so CI's render-diff makes them visible to a
+  human. A topologies-only or tests-only fixture is invisible in the PR
+  preview.
+
+Do not present a prototype as an improvement before the user has agreed it
+is one. If you rendered it and it still has problems, say so and keep
+working; don't defend a weak fix.
+
 ### Optional: quick local render of a single file
 
 For a fast sanity check of one specific `.mmd` file before pushing:
 
 ```bash
-source ~/.local/bin/mm-activate nf-metro-fix-<N>
+source ~/.local/bin/mm-activate nf-metro-dev
+export PYTHONPATH=/tmp/nf-metro-fix-<N>/src
 cd /tmp/nf-metro-fix-<N> && python -m nf_metro render <file.mmd> -o /tmp/<name>.svg
 python -c "import cairosvg; cairosvg.svg2png(url='/tmp/<name>.svg', write_to='/tmp/<name>.png', scale=2)"
 open /tmp/<name>.png
@@ -339,11 +463,13 @@ sticky render-preview comment.
 A fix-issue session is not done when `/simplify` returns control to the
 parent, or when the local tests pass. It is done when:
 
-1. Commits are pushed.
-2. Origin HEAD verified against local.
-3. CI is green on the final commit.
-4. Render-preview verdict is captured and gated on per Step 8.
-5. PR description is standalone (per Step 10).
+1. The fix lands in `src/`, not in a doctored reproducer (Step 3), and the
+   "it's fixed" claim cites the render + numbers that prove it (Step 8).
+2. Commits are pushed.
+3. Origin HEAD verified against local.
+4. CI is green on the final commit.
+5. Render-preview verdict is captured and gated on per Step 8.
+6. PR description is standalone (per Step 10).
 
 Do not hand back to the user partway through this list saying "the
 simplify pass is done" or "tests pass locally". Carry the work all the


### PR DESCRIPTION
## Summary

Folds recurring failure and waste patterns - mined from ~382 `fix-issue` sessions over the last month plus the crystallised feedback memory - into the `fix-issue` skill so they stop recurring.

**Correctness / rigour**
- **Engine-vs-authoring triage (Step 3).** Classify the symptom as an mmd *authoring mistake* (fix the input) or an *engine bug on correct mmd* (fix `src/`). Once it's an engine bug, the reproducer is frozen evidence - no simplifying labels, dropping stations, or adding dodge directives, for existing *or* newly-authored fixtures.
- **Premise freshness (Step 3).** Diagnose against current `origin/main`; re-fetch before disagreeing when the user says something is already fixed; reconcile when a sibling PR merges mid-session.
- **Cite the evidence for a fix (Step 8).** Every "it's fixed" claim names the render + before/after numbers that prove it. "Didn't abort" / one-invariant-passes / gallery-clean are each weaker than "renders correctly".

**Workflow / process**
- **Merge execution (Step 8).** The single most-corrected behaviour across sessions. Once the user authorises a merge: admin-merge with a merge commit (never `--squash`); do not update the branch, merge `main` in, or re-run CI; cancel in-flight runs, then clean up. Keeps the existing "never self-initiate an admin-merge" guardrail.
- **Issue hygiene (Step 1).** Issue bodies must be standalone and concise (each is re-run through this skill later): fold findings into the body, not comments; file separable defects as child issues.
- **Conditional /simplify re-run (Step 6).** Re-run on the final aggregate diff only when later steps added substantial new code - it is expensive.
- **Cost discipline (new subsection).** Targeted `pytest -k` while iterating; lean on the CI render-diff instead of rebuilding the gallery locally in a loop; wide-slice reads of the big layout files; default `[skip ci]` on WIP pushes.

**Environment**
- **Reuse one env (Step 2).** One long-lived deps env run against each worktree via per-command `PYTHONPATH=<worktree>/src`, replacing the per-issue `micromamba create` + editable install. Parallel-safe (verified: concurrent commands under one env each import their own worktree's source); an editable install is not.

**Style**
- Terse-communication note in the intro; "no *meaningful* visual regression, not pixel-identity" tolerance in Step 9; and a note that an ordinary additive push is not force-push-hook-blocked (Step 10).

Also refreshes stale references (`prek`, not `pre-commit`).

Docs-only change under a `.prettierignore`d path (`.claude/`); it cannot affect any test or render, so the commits carry a skip-CI marker.

## Test plan
- [x] `prek` commit hooks pass (trailing-whitespace, eof, prettier)
- [x] Env change parallel-safety verified empirically (two worktrees, one env, concurrent, each imports its own source)
- [ ] Human review of the guidance wording
