### PR TITLE
refactor(routing): unify fan opening-descent reconciliation into one pass (part of #1418)

### DIFF
--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -73,6 +73,7 @@ from nf_metro.layout.routing.normalize import (  # noqa: F401
     _bundle_divergent_distinct_traverses,
     _clamp_inter_row_band_top,
     _clear_channel_x_in_band,
+    _coincide_fanout_opening_descents,
     _coincide_merge_fanout_pivots,
     _coincide_same_line_tracks,
     _coincident_trunk_slots,
@@ -219,10 +220,12 @@ def _route_edges(
     # port-side track, the source-side track, the merge trunk's descent, and
     # the fan-out junction handoff tail), so a single line reads as one stroke.
     _coincide_same_line_tracks(routes, ctx)
-    # Distinct lines fanning out from one source leave the section as one bundle;
-    # keep their opening descents one step apart until each turns off, rather
-    # than on independent channels that read as separate strokes from the start.
-    _bundle_divergent_distinct_descents(routes, ctx)
+    # Settle every fan-out's opening-descent column in one pass: fuse each line's
+    # same-source descents onto the source-nearest track and nest the distinct
+    # lines one step apart until each turns off.  Runs after the coincidence pass
+    # so a perpendicular drop already resolved onto the junction column stays
+    # clear of an L-shaped sibling diverging to another column.
+    _coincide_fanout_opening_descents(routes, ctx)
     # Distinct lines fanning out share the corridor they turn onto; nest their
     # traverses one step apart so the bundle holds a constant width until each
     # line peels off, rather than running on independently-sized bands.

--- a/src/nf_metro/layout/routing/normalize.py
+++ b/src/nf_metro/layout/routing/normalize.py
@@ -569,6 +569,33 @@ def _coincide_merge_fanout_pivots(routes: list[RoutedPath], ctx: _RoutingCtx) ->
             _snap_group(_Coincidence(chans, ref))
 
 
+def _coincide_fanout_opening_descents(
+    routes: list[RoutedPath], ctx: _RoutingCtx
+) -> None:
+    """Own the opening-descent column of every fan-out, one owner for both intents.
+
+    A junction that fans branches out through different handlers leaves each
+    branch to open its own vertical descent, which :func:`_materialize_gap_slots`
+    then re-stacks per gap -- so branches of one fan open a few pixels apart and
+    read as separate strokes off the source.  This is the single pass that settles
+    a fan's opening-descent column: it fuses each line's same-source descents onto
+    the track nearest the source (:func:`_divergent_source_groups`), then nests the
+    distinct lines one ``OFFSET_STEP`` apart until each turns off
+    (:func:`_bundle_divergent_distinct_descents`).
+
+    It runs *after* :func:`_coincide_same_line_tracks` so convergence has already
+    settled the perpendicular drops: a branch that peels straight down the
+    junction's own column into a TOP/BOTTOM port (rounded later by
+    :func:`_round_junction_perp_peeloff`) lands on the junction column during
+    convergence, presenting here as a bare vertical drop rather than a
+    horizontal-then-vertical opening, so it stays clear of an L-shaped sibling
+    that genuinely diverges to another column.
+    """
+    for group in _divergent_source_groups(routes):
+        _snap_group(group)
+    _bundle_divergent_distinct_descents(routes, ctx)
+
+
 def _coincide_same_line_tracks(routes: list[RoutedPath], ctx: _RoutingCtx) -> None:
     """Fuse same-line vertical legs that should read as a single stroke.
 
@@ -599,8 +626,6 @@ def _coincide_same_line_tracks(routes: list[RoutedPath], ctx: _RoutingCtx) -> No
     the handler could have anticipated.
     """
     for group in _convergent_port_groups(routes, ctx):
-        _snap_group(group)
-    for group in _divergent_source_groups(routes):
         _snap_group(group)
     for group in _merge_feeder_groups(routes, ctx):
         _snap_group(group)

--- a/tests/test_same_line_parallel_run_invariant.py
+++ b/tests/test_same_line_parallel_run_invariant.py
@@ -84,6 +84,9 @@ def test_checker_fires_without_coincidence_pass(
     monkeypatch.setattr(
         routing_core, "_coincide_same_line_tracks", lambda routes, ctx: None
     )
+    monkeypatch.setattr(
+        routing_core, "_coincide_fanout_opening_descents", lambda routes, ctx: None
+    )
     graph, routes, offsets = _route(EXAMPLES / fixture)
     violations = check_no_same_line_parallel_descents(graph, routes, offsets)
     assert violations, "expected doubled same-line descents with merge passes off"

--- a/tests/test_split_fanout_descent_invariant.py
+++ b/tests/test_split_fanout_descent_invariant.py
@@ -68,7 +68,7 @@ def test_checker_fires_without_fuse_pass(monkeypatch: pytest.MonkeyPatch) -> Non
     """Disabling the fan-out fuse pass reproduces the split descents the
     invariant is meant to catch, proving the check is not vacuous."""
     monkeypatch.setattr(
-        routing_core, "_coincide_same_line_tracks", lambda routes, ctx: None
+        routing_core, "_coincide_fanout_opening_descents", lambda routes, ctx: None
     )
     graph, routes, offsets = _route(EXAMPLE_TOPOLOGIES / "divergent_fanout_split.mmd")
     violations = check_no_split_same_line_fanout_descents(graph, routes, offsets)


### PR DESCRIPTION
## Summary

Fold the **divergent-source half of `_coincide_same_line_tracks`** and the standalone **`_bundle_divergent_distinct_descents`** pipeline step into a single `_coincide_fanout_opening_descents` pass that owns a fan-out's opening-descent column:

- each line's same-source opening descents fuse onto the track nearest the source;
- distinct lines nest one `OFFSET_STEP` apart until each turns off.

It runs **after** `_coincide_same_line_tracks` so a perpendicular junction drop already resolved onto the junction column by convergence stays clear of an L-shaped sibling that genuinely diverges to another column (the ordering dependency proven below).

This gives the two scattered fan-descent passes one named owner — the `_coincide_merge_fanout_pivots` pattern from #1433 (merge fan-outs), generalised to every fan-out.

## What this does and does not do (re #1418)

This is a **byte-identical structural unification**, not the full by-construction retirement. It advances #1418's "retire the two descent passes" as a pass-level consolidation, but:

- The reconciliation logic still runs (relocated + unified), so it is not yet a deletable no-op.
- The 3 Tier-B fan guards are **not** demoted — they still verify the property and are not redundant-with-construction until the reconciliation is a no-op.

**Full by-construction retirement is blocked by `_materialize_gap_slots`** (proven this session): it spreads fan descents into per-gap bundles and performs essential *cross-junction* separation. A blunt per-route `normalize_exempt` to bypass it aborts the `differentialabundance` pipeline and merges distinct-junction same-line descents. And the divergent fusion is order-dependent — it must run after convergence degenerates perpendicular drops, or it wrongly fuses a perp-drop branch with its L-shaped sibling (`riboseq_fold_two_dir_entry`). Making the reconciliation a no-op therefore needs a corridor-aware rework of `_materialize_gap_slots`, a larger effort tracked in #1418.

## Test plan
- [x] pytest passes: 34960 passed, 0 failed (full suite, 3.11)
- [x] ruff check + ruff format clean; mypy clean
- [x] Render byte-identical across all 287 corpus fixtures (examples + topologies + tests/fixtures)
- [x] Non-vacuous-checker tests re-pointed at the new owning pass
- [ ] Render-preview verdict: expected **No visual changes** (byte-identical)

Part of #1418.

Generated with Claude Code
