### PR TITLE
fix(layout): keep port and Station records synced (#1423)

### DIFF
--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -101,10 +101,8 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
         # in the inter-section gap rather than a diagonal dragging the exit off
         # its row.  Covers a single carrying station or a parallel bundle, and
         # exits feeding a fan-out junction (see ``flow_exit_carrier_anchor``).
-        # Lift the entry port up to meet it when the entry's own consumers all
-        # share one row, so the boundary crossing straightens onto a single
-        # unambiguous row.  An entry fanning to several rows is left, since no
-        # one port Y can face them all.
+        # Lift the entry up to meet it as well when all of the entry's own
+        # consumers share that row; an entry fanning to several rows is left.
         anchor = flow_exit_carrier_anchor(graph, port_id, section, junction_ids)
         if anchor is not None and abs(port_st.y - anchor[0]) < SAME_COORD_TOLERANCE:
             carrier_y, _carrier_ids = anchor
@@ -113,9 +111,8 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
                 if ep_st is None or abs(ep_st.y - carrier_y) < SAME_COORD_TOLERANCE:
                     continue
                 consumer_ys = _entry_consumer_ys(graph, eid)
-                if (
-                    consumer_ys
-                    and max(consumer_ys) - min(consumer_ys) < SAME_COORD_TOLERANCE
+                if consumer_ys and all(
+                    abs(cy - carrier_y) < SAME_COORD_TOLERANCE for cy in consumer_ys
                 ):
                     _set_port_y(graph, eid, carrier_y)
             continue

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -101,8 +101,10 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
         # in the inter-section gap rather than a diagonal dragging the exit off
         # its row.  Covers a single carrying station or a parallel bundle, and
         # exits feeding a fan-out junction (see ``flow_exit_carrier_anchor``).
-        # Lift the entry up to meet it as well when all of the entry's own
-        # consumers share that row; an entry fanning to several rows is left.
+        # Lift the entry port up to meet it when the entry's own consumers all
+        # share one row, so the boundary crossing straightens onto a single
+        # unambiguous row.  An entry fanning to several rows is left, since no
+        # one port Y can face them all.
         anchor = flow_exit_carrier_anchor(graph, port_id, section, junction_ids)
         if anchor is not None and abs(port_st.y - anchor[0]) < SAME_COORD_TOLERANCE:
             carrier_y, _carrier_ids = anchor
@@ -111,8 +113,9 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
                 if ep_st is None or abs(ep_st.y - carrier_y) < SAME_COORD_TOLERANCE:
                     continue
                 consumer_ys = _entry_consumer_ys(graph, eid)
-                if consumer_ys and all(
-                    abs(cy - carrier_y) < SAME_COORD_TOLERANCE for cy in consumer_ys
+                if (
+                    consumer_ys
+                    and max(consumer_ys) - min(consumer_ys) < SAME_COORD_TOLERANCE
                 ):
                     _set_port_y(graph, eid, carrier_y)
             continue

--- a/src/nf_metro/layout/phases/fan_bundles.py
+++ b/src/nf_metro/layout/phases/fan_bundles.py
@@ -9,6 +9,7 @@ from nf_metro.layout.constants import (
     SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
 )
+from nf_metro.layout.geometry import shift_section
 from nf_metro.layout.phase_state import require_phase_field
 from nf_metro.layout.phases._common import (
     _fan_offsets,
@@ -18,6 +19,7 @@ from nf_metro.layout.phases._common import (
     grow_section_bbox_max_edge,
     grow_section_bbox_min_edge,
 )
+from nf_metro.layout.phases.ports import _set_port_y
 from nf_metro.parser.model import MetroGraph, PortSide, Section, Station
 
 
@@ -1142,10 +1144,7 @@ def _align_symfan_section_to_row_feeder(graph: MetroGraph) -> None:
         delta = feeder_y - graph.stations[entry_port].y
         if abs(delta) < 1.0:
             continue
-        for sid in section.station_ids:
-            if sid in graph.stations:
-                graph.stations[sid].y += delta
-        section.bbox_y += delta
+        shift_section(graph, section, dy=delta)
 
 
 def _center_lr_entry_ports_on_fork(graph: MetroGraph, y_spacing: float) -> None:
@@ -1187,7 +1186,7 @@ def _center_lr_entry_ports_on_fork(graph: MetroGraph, y_spacing: float) -> None:
                 continue
             midpoint = (branch_ys[0] + branch_ys[1]) / 2.0
             if abs(graph.stations[pid].y - midpoint) >= 1.0:
-                graph.stations[pid].y = midpoint
+                _set_port_y(graph, pid, midpoint)
 
 
 def _pull_continuation_onto(

--- a/src/nf_metro/layout/phases/grid_snap.py
+++ b/src/nf_metro/layout/phases/grid_snap.py
@@ -12,6 +12,7 @@ from nf_metro.layout.phase_state import require_phase_field
 from nf_metro.layout.phases.canvas import _canvas_top_preserved, _translate_graph_y
 from nf_metro.layout.phases.fan_bundles import _convergence_source_ys
 from nf_metro.layout.phases.junctions import _position_junctions
+from nf_metro.layout.phases.ports import _set_port_y
 from nf_metro.parser.model import MetroGraph, PortSide
 
 
@@ -181,7 +182,7 @@ def _snap_group_to_grid(
                 continue
             if pid in convergence_sources:
                 continue
-            port_st.y = _slot_snap(port_st.y, origin_r, pitch, half)
+            _set_port_y(graph, pid, _slot_snap(port_st.y, origin_r, pitch, half))
 
 
 def _restore_convergence_midpoints(
@@ -196,7 +197,7 @@ def _restore_convergence_midpoints(
         if len(set(round(y, 3) for y in new_src_ys)) < 2:
             continue
         midpoint = (max(new_src_ys) + min(new_src_ys)) / 2.0
-        st.y = midpoint
+        _set_port_y(graph, target_id, midpoint)
 
 
 def _snap_canvas_y_to_grid(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -574,6 +574,28 @@ def _guard_ports_on_boundaries(graph: MetroGraph, phase: str) -> None:
             )
 
 
+def _guard_port_station_coords_synced(graph: MetroGraph, phase: str) -> None:
+    """A port's Station record and Port record must hold the same coordinates.
+
+    Every port is both a ``Station`` (placed by layout, read by routing and
+    rendering) and a ``Port`` (read by later phases as the settled position).
+    Phases move ports through :func:`_set_port_y` / :func:`_set_port_x` /
+    :func:`shift_section`, which write both; a raw ``station.y = ...`` that
+    skips the Port record desyncs the two, so a later phase reads a stale
+    position and leaves the inter-section run kinked.
+    """
+    tolerance = GUARD_TOLERANCE
+    for pid, port in graph.ports.items():
+        st = graph.stations.get(pid)
+        if st is None:
+            continue
+        if abs(st.x - port.x) > tolerance or abs(st.y - port.y) > tolerance:
+            raise PhaseInvariantError(
+                f"{phase}: port {pid!r} station record ({st.x:.1f}, {st.y:.1f}) "
+                f"desynced from port record ({port.x:.1f}, {port.y:.1f})"
+            )
+
+
 def _tb_top_entry_drop_overshoot(
     graph: MetroGraph,
 ) -> list[tuple[str, float]]:
@@ -4875,6 +4897,10 @@ GUARD_REGISTRY: tuple[GuardSpec, ...] = (
     ),
     GuardSpec(_guard_station_x_column_drift, "A", bisection_safe=True),
     # --- final-only set (run only at the closing ``after final`` boundary) ---
+    # A desync feeds a stale port position to later phases, not the renderer
+    # (routing reads the Station record), so this is a pipeline-consistency
+    # check for validate runs rather than a render-output guard.
+    GuardSpec(_guard_port_station_coords_synced, "B"),
     GuardSpec(_guard_no_section_overlap, "B"),
     # The row trunk Y is only finalised once Stage 6.7 has re-centred
     # ``center_ports`` graphs, so this cannot bisect.

--- a/src/nf_metro/layout/phases/ports.py
+++ b/src/nf_metro/layout/phases/ports.py
@@ -789,7 +789,7 @@ def _snap_grid_group_entry_ports(graph: MetroGraph) -> None:
                 break
 
         if target_y is not None and abs(port_st.y - target_y) >= 1.0:
-            port_st.y = target_y
+            _set_port_y(graph, port_id, target_y)
 
 
 def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
@@ -880,7 +880,7 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
             target_y = match
 
         if abs(port_st.y - target_y) >= 1.0:
-            port_st.y = target_y
+            _set_port_y(graph, port_id, target_y)
 
 
 def _resolve_downstream_entry_y(

--- a/src/nf_metro/layout/phases/row_align.py
+++ b/src/nf_metro/layout/phases/row_align.py
@@ -517,11 +517,7 @@ def _top_align_row_sections(graph: MetroGraph) -> None:
                 delta = section.bbox_y - min_top
                 if delta <= 0:
                     continue
-                for sid in section.station_ids:
-                    station = graph.stations.get(sid)
-                    if station:
-                        station.y -= delta
-                section.bbox_y -= delta
+                shift_section(graph, section, dy=-delta)
 
 
 def _distribute_stacked_rows_in_rowspan_band(graph: MetroGraph) -> None:

--- a/tests/data/guard_golden/examples/cross_track_interchange.json
+++ b/tests/data/guard_golden/examples/cross_track_interchange.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/diagonal_labels.json
+++ b/tests/data/guard_golden/examples/diagonal_labels.json
@@ -420,6 +420,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/differentialabundance.json
+++ b/tests/data/guard_golden/examples/differentialabundance.json
@@ -178,6 +178,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/differentialabundance_default.json
+++ b/tests/data/guard_golden/examples/differentialabundance_default.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/disconnected_components.json
+++ b/tests/data/guard_golden/examples/disconnected_components.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/epitopeprediction.json
+++ b/tests/data/guard_golden/examples/epitopeprediction.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/file_icons.json
+++ b/tests/data/guard_golden/examples/file_icons.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/genomeassembly.json
+++ b/tests/data/guard_golden/examples/genomeassembly.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/genomeassembly_staggered.json
+++ b/tests/data/guard_golden/examples/genomeassembly_staggered.json
@@ -174,6 +174,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/genomic_pipeline.json
+++ b/tests/data/guard_golden/examples/genomic_pipeline.json
@@ -190,6 +190,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/group_labels.json
+++ b/tests/data/guard_golden/examples/group_labels.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/02_sections.json
+++ b/tests/data/guard_golden/examples/guide/02_sections.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/03_fan_out.json
+++ b/tests/data/guard_golden/examples/guide/03_fan_out.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/03b_fan_in_merge.json
+++ b/tests/data/guard_golden/examples/guide/03b_fan_in_merge.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/04_directions.json
+++ b/tests/data/guard_golden/examples/guide/04_directions.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/05_file_icons.json
+++ b/tests/data/guard_golden/examples/guide/05_file_icons.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/05b_multi_icons.json
+++ b/tests/data/guard_golden/examples/guide/05b_multi_icons.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/05c_files_icon.json
+++ b/tests/data/guard_golden/examples/guide/05c_files_icon.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/05d_folder_icon.json
+++ b/tests/data/guard_golden/examples/guide/05d_folder_icon.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/05f_banner_labels.json
+++ b/tests/data/guard_golden/examples/guide/05f_banner_labels.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/06a_without_hidden.json
+++ b/tests/data/guard_golden/examples/guide/06a_without_hidden.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/guide/06b_with_hidden.json
+++ b/tests/data/guard_golden/examples/guide/06b_with_hidden.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/hlatyping.json
+++ b/tests/data/guard_golden/examples/hlatyping.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/legend_logo_placement.json
+++ b/tests/data/guard_golden/examples/legend_logo_placement.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/line_spread.json
+++ b/tests/data/guard_golden/examples/line_spread.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/longread_variant_calling.json
+++ b/tests/data/guard_golden/examples/longread_variant_calling.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/marker_styles.json
+++ b/tests/data/guard_golden/examples/marker_styles.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/off_track_outputs.json
+++ b/tests/data/guard_golden/examples/off_track_outputs.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/rail_section.json
+++ b/tests/data/guard_golden/examples/rail_section.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/rnaseq_auto.json
+++ b/tests/data/guard_golden/examples/rnaseq_auto.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/rnaseq_sections.json
+++ b/tests/data/guard_golden/examples/rnaseq_sections.json
@@ -307,6 +307,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/rnaseq_sections_manual.json
+++ b/tests/data/guard_golden/examples/rnaseq_sections_manual.json
@@ -307,6 +307,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/sarek_metro.json
+++ b/tests/data/guard_golden/examples/sarek_metro.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/tb_file_termini.json
+++ b/tests/data/guard_golden/examples/tb_file_termini.json
@@ -408,6 +408,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/aligner_row_pinned_continuation.json
+++ b/tests/data/guard_golden/examples/topologies/aligner_row_pinned_continuation.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/aligner_row_terminator_lane_gap.json
+++ b/tests/data/guard_golden/examples/topologies/aligner_row_terminator_lane_gap.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/around_below_ep_col_gt0.json
+++ b/tests/data/guard_golden/examples/topologies/around_below_ep_col_gt0.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/around_section_below.json
+++ b/tests/data/guard_golden/examples/topologies/around_section_below.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/asymmetric_tree.json
+++ b/tests/data/guard_golden/examples/topologies/asymmetric_tree.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bottom_row_climb_clear_corridor.json
+++ b/tests/data/guard_golden/examples/topologies/bottom_row_climb_clear_corridor.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/branch_fold_forward.json
+++ b/tests/data/guard_golden/examples/topologies/branch_fold_forward.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/branch_fold_stability.json
+++ b/tests/data/guard_golden/examples/topologies/branch_fold_stability.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_chain.json
+++ b/tests/data/guard_golden/examples/topologies/bt_chain.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_exit_top_above.json
+++ b/tests/data/guard_golden/examples/topologies/bt_exit_top_above.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_exit_top_above_2line.json
+++ b/tests/data/guard_golden/examples/topologies/bt_exit_top_above_2line.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_fork.json
+++ b/tests/data/guard_golden/examples/topologies/bt_fork.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_perp_entry_below.json
+++ b/tests/data/guard_golden/examples/topologies/bt_perp_entry_below.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_to_lr.json
+++ b/tests/data/guard_golden/examples/topologies/bt_to_lr.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_to_tb.json
+++ b/tests/data/guard_golden/examples/topologies/bt_to_tb.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bundle_terminator_continuation.json
+++ b/tests/data/guard_golden/examples/topologies/bundle_terminator_continuation.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_fan_in_outer_slot.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_fan_in_outer_slot.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_gap2_rightward_overflow.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_gap2_rightward_overflow.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_label_rake.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_label_rake.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_label_rake_left.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_label_rake_left.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_label_rake_wide.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_label_rake_wide.json
@@ -293,6 +293,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_leftward_far_side_entry.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_leftward_far_side_entry.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_leftward_overflow.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_leftward_overflow.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_v_tight.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_v_tight.json
@@ -295,6 +295,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/clear_channel_target_aware_push.json
+++ b/tests/data/guard_golden/examples/topologies/clear_channel_target_aware_push.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/compact_gap_peer_conflict.json
+++ b/tests/data/guard_golden/examples/topologies/compact_gap_peer_conflict.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/compact_hidden_passthrough.json
+++ b/tests/data/guard_golden/examples/topologies/compact_hidden_passthrough.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/complex_multipath.json
+++ b/tests/data/guard_golden/examples/topologies/complex_multipath.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/convergence_fold_diamond.json
+++ b/tests/data/guard_golden/examples/topologies/convergence_fold_diamond.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/convergence_sink_above.json
+++ b/tests/data/guard_golden/examples/topologies/convergence_sink_above.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/convergence_sink_fold.json
+++ b/tests/data/guard_golden/examples/topologies/convergence_sink_fold.json
@@ -170,6 +170,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/convergence_stacked_sink.json
+++ b/tests/data/guard_golden/examples/topologies/convergence_stacked_sink.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/convergent_offrow_exit_climb.json
+++ b/tests/data/guard_golden/examples/topologies/convergent_offrow_exit_climb.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/corridor_narrow_gap_fallback.json
+++ b/tests/data/guard_golden/examples/topologies/corridor_narrow_gap_fallback.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/cross_col_top_entry.json
+++ b/tests/data/guard_golden/examples/topologies/cross_col_top_entry.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/cross_column_perp_drop.json
+++ b/tests/data/guard_golden/examples/topologies/cross_column_perp_drop.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/cross_column_perp_drop_far_exit.json
+++ b/tests/data/guard_golden/examples/topologies/cross_column_perp_drop_far_exit.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/cross_row_gap_wrap.json
+++ b/tests/data/guard_golden/examples/topologies/cross_row_gap_wrap.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/deep_linear.json
+++ b/tests/data/guard_golden/examples/topologies/deep_linear.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/disconnected_components_fold.json
+++ b/tests/data/guard_golden/examples/topologies/disconnected_components_fold.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/disjoint_sameline_trunks.json
+++ b/tests/data/guard_golden/examples/topologies/disjoint_sameline_trunks.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/divergent_fanout_split.json
+++ b/tests/data/guard_golden/examples/topologies/divergent_fanout_split.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/dogleg_exempt_distinct.json
+++ b/tests/data/guard_golden/examples/topologies/dogleg_exempt_distinct.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/dogleg_exempt_sameline.json
+++ b/tests/data/guard_golden/examples/topologies/dogleg_exempt_sameline.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/dogleg_twoline_fanout.json
+++ b/tests/data/guard_golden/examples/topologies/dogleg_twoline_fanout.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/exit_corner_offset_dogleg.json
+++ b/tests/data/guard_golden/examples/topologies/exit_corner_offset_dogleg.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fan_bypass_nesting.json
+++ b/tests/data/guard_golden/examples/topologies/fan_bypass_nesting.json
@@ -170,6 +170,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fan_in_merge.json
+++ b/tests/data/guard_golden/examples/topologies/fan_in_merge.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fanin_distant_terminus.json
+++ b/tests/data/guard_golden/examples/topologies/fanin_distant_terminus.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fanout_bundle_plus_spurs.json
+++ b/tests/data/guard_golden/examples/topologies/fanout_bundle_plus_spurs.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_bypass_creep.json
+++ b/tests/data/guard_golden/examples/topologies/fold_bypass_creep.json
@@ -293,6 +293,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_bypass_creep_tight.json
+++ b/tests/data/guard_golden/examples/topologies/fold_bypass_creep_tight.json
@@ -293,6 +293,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_double.json
+++ b/tests/data/guard_golden/examples/topologies/fold_double.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_fan_across.json
+++ b/tests/data/guard_golden/examples/topologies/fold_fan_across.json
@@ -170,6 +170,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_left_exit_right_entry.json
+++ b/tests/data/guard_golden/examples/topologies/fold_left_exit_right_entry.json
@@ -420,6 +420,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_split_targets.json
+++ b/tests/data/guard_golden/examples/topologies/fold_split_targets.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_stacked_branch.json
+++ b/tests/data/guard_golden/examples/topologies/fold_stacked_branch.json
@@ -174,6 +174,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/foldback_exit_peeloff.json
+++ b/tests/data/guard_golden/examples/topologies/foldback_exit_peeloff.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/folded_corridor_distinct_lanes.json
+++ b/tests/data/guard_golden/examples/topologies/folded_corridor_distinct_lanes.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/fork_join_interior_label.json
+++ b/tests/data/guard_golden/examples/topologies/fork_join_interior_label.json
@@ -299,6 +299,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/funcprofiler_upstream.json
+++ b/tests/data/guard_golden/examples/topologies/funcprofiler_upstream.json
@@ -297,6 +297,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/header_nudge.json
+++ b/tests/data/guard_golden/examples/topologies/header_nudge.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/header_side_rotated.json
+++ b/tests/data/guard_golden/examples/topologies/header_side_rotated.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/inrow_skip_breeze.json
+++ b/tests/data/guard_golden/examples/topologies/inrow_skip_breeze.json
@@ -285,6 +285,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/inter_row_drop_section_clearance.json
+++ b/tests/data/guard_golden/examples/topologies/inter_row_drop_section_clearance.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/inter_row_drop_section_clearance_row1.json
+++ b/tests/data/guard_golden/examples/topologies/inter_row_drop_section_clearance_row1.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/inter_row_wrap_clearance.json
+++ b/tests/data/guard_golden/examples/topologies/inter_row_wrap_clearance.json
@@ -178,6 +178,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/interchange_label_clears_bridge.json
+++ b/tests/data/guard_golden/examples/topologies/interchange_label_clears_bridge.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/interchange_lane_reorder.json
+++ b/tests/data/guard_golden/examples/topologies/interchange_lane_reorder.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/internal_source_equal_sibling_2fan.json
+++ b/tests/data/guard_golden/examples/topologies/internal_source_equal_sibling_2fan.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/junction_entry_align.json
+++ b/tests/data/guard_golden/examples/topologies/junction_entry_align.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/junction_entry_collision.json
+++ b/tests/data/guard_golden/examples/topologies/junction_entry_collision.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/junction_entry_reversed_fold.json
+++ b/tests/data/guard_golden/examples/topologies/junction_entry_reversed_fold.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/junction_fanout_convergence.json
+++ b/tests/data/guard_golden/examples/topologies/junction_fanout_convergence.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/left_entry_from_above_far.json
+++ b/tests/data/guard_golden/examples/topologies/left_entry_from_above_far.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/left_entry_up_wrap.json
+++ b/tests/data/guard_golden/examples/topologies/left_entry_up_wrap.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/left_exit_sink_below.json
+++ b/tests/data/guard_golden/examples/topologies/left_exit_sink_below.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_bottom_exit_rl_top_entry_jog.json
+++ b/tests/data/guard_golden/examples/topologies/lr_bottom_exit_rl_top_entry_jog.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_bottom_exit_perp_entry.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_bottom_exit_perp_entry.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_bottom_exit_side_entry.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_bottom_exit_side_entry.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_perp_entry.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_perp_entry.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_perp_entry_diverging.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_perp_entry_diverging.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_side_entry.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_side_entry.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_cross_col.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_cross_col.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_drop.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_drop.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_drop_two_lines.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_drop_two_lines.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_near_vertical.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_near_vertical.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_two_lines.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_two_lines.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_top_entry_cross_column.json
+++ b/tests/data/guard_golden/examples/topologies/lr_top_entry_cross_column.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_top_entry_cross_column_two_line.json
+++ b/tests/data/guard_golden/examples/topologies/lr_top_entry_cross_column_two_line.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/manual_rl_row_nonconsumer_bypass.json
+++ b/tests/data/guard_golden/examples/topologies/manual_rl_row_nonconsumer_bypass.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_around_below_leftmost.json
+++ b/tests/data/guard_golden/examples/topologies/merge_around_below_leftmost.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_bottom_row_bypass.json
+++ b/tests/data/guard_golden/examples/topologies/merge_bottom_row_bypass.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_leftmost_sink_branch.json
+++ b/tests/data/guard_golden/examples/topologies/merge_leftmost_sink_branch.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_offrow_continuation.json
+++ b/tests/data/guard_golden/examples/topologies/merge_offrow_continuation.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_port_above_approach.json
+++ b/tests/data/guard_golden/examples/topologies/merge_port_above_approach.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_pullaway.json
+++ b/tests/data/guard_golden/examples/topologies/merge_pullaway.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_right_entry.json
+++ b/tests/data/guard_golden/examples/topologies/merge_right_entry.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_trunk_out_of_range_section.json
+++ b/tests/data/guard_golden/examples/topologies/merge_trunk_out_of_range_section.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_trunk_over_low_section.json
+++ b/tests/data/guard_golden/examples/topologies/merge_trunk_over_low_section.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/mismatched_tracks.json
+++ b/tests/data/guard_golden/examples/topologies/mismatched_tracks.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/mixed_bundle_column.json
+++ b/tests/data/guard_golden/examples/topologies/mixed_bundle_column.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/mixed_port_sides.json
+++ b/tests/data/guard_golden/examples/topologies/mixed_port_sides.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/multi_input_convergence.json
+++ b/tests/data/guard_golden/examples/topologies/multi_input_convergence.json
@@ -170,6 +170,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/multi_line_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/multi_line_bundle.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/multi_section_cell.json
+++ b/tests/data/guard_golden/examples/topologies/multi_section_cell.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/multicarrier_offrow_exit_climb.json
+++ b/tests/data/guard_golden/examples/topologies/multicarrier_offrow_exit_climb.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/narrow_section_header_wrap.json
+++ b/tests/data/guard_golden/examples/topologies/narrow_section_header_wrap.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/near_edge_exit_corner.json
+++ b/tests/data/guard_golden/examples/topologies/near_edge_exit_corner.json
@@ -291,6 +291,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/near_vertical_junction_hook.json
+++ b/tests/data/guard_golden/examples/topologies/near_vertical_junction_hook.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/off_track_convergence.json
+++ b/tests/data/guard_golden/examples/topologies/off_track_convergence.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/off_track_convergence_multiline.json
+++ b/tests/data/guard_golden/examples/topologies/off_track_convergence_multiline.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/off_track_input_above_consumer.json
+++ b/tests/data/guard_golden/examples/topologies/off_track_input_above_consumer.json
@@ -170,6 +170,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/off_track_terminal_noop.json
+++ b/tests/data/guard_golden/examples/topologies/off_track_terminal_noop.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass_adjacent.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass_adjacent.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass_cross_row.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass_cross_row.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_consumer_drop_in.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_consumer_drop_in.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/parallel_independent.json
+++ b/tests/data/guard_golden/examples/topologies/parallel_independent.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/peeloff_extra_line_consumer.json
+++ b/tests/data/guard_golden/examples/topologies/peeloff_extra_line_consumer.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/peeloff_riser_respace.json
+++ b/tests/data/guard_golden/examples/topologies/peeloff_riser_respace.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/post_convergence_trunk.json
+++ b/tests/data/guard_golden/examples/topologies/post_convergence_trunk.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/reconverge_reversed_fold.json
+++ b/tests/data/guard_golden/examples/topologies/reconverge_reversed_fold.json
@@ -174,6 +174,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/riboseq_fold_two_dir_entry.json
+++ b/tests/data/guard_golden/examples/topologies/riboseq_fold_two_dir_entry.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/riboseq_fold_two_dir_entry_hintless.json
+++ b/tests/data/guard_golden/examples/topologies/riboseq_fold_two_dir_entry_hintless.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_from_above.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_from_above.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_from_above_far.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_from_above_far.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_gap_above_empty_row.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_gap_above_empty_row.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_wrap_no_fan.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_wrap_no_fan.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/rl_entry_right_exit_left.json
+++ b/tests/data/guard_golden/examples/topologies/rl_entry_right_exit_left.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/rl_entry_runway.json
+++ b/tests/data/guard_golden/examples/topologies/rl_entry_runway.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/rnaseq_lite.json
+++ b/tests/data/guard_golden/examples/topologies/rnaseq_lite.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/route_around_intervening.json
+++ b/tests/data/guard_golden/examples/topologies/route_around_intervening.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/rowmate_tb_side_entry_top_align.json
+++ b/tests/data/guard_golden/examples/topologies/rowmate_tb_side_entry_top_align.json
@@ -171,6 +171,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/rowmate_tb_side_entry_top_align_grow.json
+++ b/tests/data/guard_golden/examples/topologies/rowmate_tb_side_entry_top_align_grow.json
@@ -285,6 +285,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/same_line_fan_distinct_descent.json
+++ b/tests/data/guard_golden/examples/topologies/same_line_fan_distinct_descent.json
@@ -170,6 +170,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/same_side_culdesac.json
+++ b/tests/data/guard_golden/examples/topologies/same_side_culdesac.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/samerow_left_exit_far_left_entry.json
+++ b/tests/data/guard_golden/examples/topologies/samerow_left_exit_far_left_entry.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/section_diamond.json
+++ b/tests/data/guard_golden/examples/topologies/section_diamond.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/sectionless_skip_breeze.json
+++ b/tests/data/guard_golden/examples/topologies/sectionless_skip_breeze.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/self_crossing_bridge.json
+++ b/tests/data/guard_golden/examples/topologies/self_crossing_bridge.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/serpentine_grid_tall_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/serpentine_grid_tall_bundle.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/serpentine_grid_wide_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/serpentine_grid_wide_bundle.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/serpentine_rl_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/serpentine_rl_bundle.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/shared_sink_parallel.json
+++ b/tests/data/guard_golden/examples/topologies/shared_sink_parallel.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/single_section.json
+++ b/tests/data/guard_golden/examples/topologies/single_section.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/stacked_left_exit_drop.json
+++ b/tests/data/guard_golden/examples/topologies/stacked_left_exit_drop.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/stacked_lr_serpentine.json
+++ b/tests/data/guard_golden/examples/topologies/stacked_lr_serpentine.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/stacked_right_ports_coincident.json
+++ b/tests/data/guard_golden/examples/topologies/stacked_right_ports_coincident.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/straddling_fanout_junction.json
+++ b/tests/data/guard_golden/examples/topologies/straddling_fanout_junction.json
@@ -299,6 +299,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_deep.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_deep.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_exit.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_exit.json
@@ -299,6 +299,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_relay.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_relay.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_diamond_beside_wide_fan.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_diamond_beside_wide_fan.json
@@ -299,6 +299,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_diamond_bundle_padding.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_diamond_bundle_padding.json
@@ -299,6 +299,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_multiline_merge_median.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_multiline_merge_median.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_bottom_entry_flow_start.json
+++ b/tests/data/guard_golden/examples/topologies/tb_bottom_entry_flow_start.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_bottom_exit_bundle_jog.json
+++ b/tests/data/guard_golden/examples/topologies/tb_bottom_exit_bundle_jog.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_bottom_exit_fork_diamond.json
+++ b/tests/data/guard_golden/examples/topologies/tb_bottom_exit_fork_diamond.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_column_continuation_two_lines.json
+++ b/tests/data/guard_golden/examples/topologies/tb_column_continuation_two_lines.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_convergence_straight_drop.json
+++ b/tests/data/guard_golden/examples/topologies/tb_convergence_straight_drop.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_fork_lane_transpose.json
+++ b/tests/data/guard_golden/examples/topologies/tb_fork_lane_transpose.json
@@ -285,6 +285,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_internal_diagonal.json
+++ b/tests/data/guard_golden/examples/topologies/tb_internal_diagonal.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_left_exit_step.json
+++ b/tests/data/guard_golden/examples/topologies/tb_left_exit_step.json
@@ -166,6 +166,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_lr_exit_left.json
+++ b/tests/data/guard_golden/examples/topologies/tb_lr_exit_left.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_lr_exit_right.json
+++ b/tests/data/guard_golden/examples/topologies/tb_lr_exit_right.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_off_track_inputs.json
+++ b/tests/data/guard_golden/examples/topologies/tb_off_track_inputs.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_off_track_output_row.json
+++ b/tests/data/guard_golden/examples/topologies/tb_off_track_output_row.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_offtrack_fork_baseline.json
+++ b/tests/data/guard_golden/examples/topologies/tb_offtrack_fork_baseline.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_passthrough_continuation.json
+++ b/tests/data/guard_golden/examples/topologies/tb_passthrough_continuation.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_passthrough_trunk.json
+++ b/tests/data/guard_golden/examples/topologies/tb_passthrough_trunk.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_perp_exit_side_neighbour.json
+++ b/tests/data/guard_golden/examples/topologies/tb_perp_exit_side_neighbour.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_right_entry_stack.json
+++ b/tests/data/guard_golden/examples/topologies/tb_right_entry_stack.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_trunk_through_fan.json
+++ b/tests/data/guard_golden/examples/topologies/tb_trunk_through_fan.json
@@ -283,6 +283,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_two_line_vert_seam.json
+++ b/tests/data/guard_golden/examples/topologies/tb_two_line_vert_seam.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/terminal_symmetric_fan.json
+++ b/tests/data/guard_golden/examples/topologies/terminal_symmetric_fan.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/top_descent_over_left_entry.json
+++ b/tests/data/guard_golden/examples/topologies/top_descent_over_left_entry.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/top_descent_over_left_entry_junction.json
+++ b/tests/data/guard_golden/examples/topologies/top_descent_over_left_entry_junction.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/top_entry_bundle_offset_seam.json
+++ b/tests/data/guard_golden/examples/topologies/top_entry_bundle_offset_seam.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/top_entry_header_clash.json
+++ b/tests/data/guard_golden/examples/topologies/top_entry_header_clash.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/trunk_through_fan.json
+++ b/tests/data/guard_golden/examples/topologies/trunk_through_fan.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/u_turn_fold.json
+++ b/tests/data/guard_golden/examples/topologies/u_turn_fold.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/upward_bypass.json
+++ b/tests/data/guard_golden/examples/topologies/upward_bypass.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/variant_calling.json
+++ b/tests/data/guard_golden/examples/topologies/variant_calling.json
@@ -299,6 +299,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/wide_fan_in.json
+++ b/tests/data/guard_golden/examples/topologies/wide_fan_in.json
@@ -170,6 +170,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/wide_fan_out.json
+++ b/tests/data/guard_golden/examples/topologies/wide_fan_out.json
@@ -170,6 +170,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/topologies/wide_label_fan.json
+++ b/tests/data/guard_golden/examples/topologies/wide_label_fan.json
@@ -311,6 +311,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/variant_calling.json
+++ b/tests/data/guard_golden/examples/variant_calling.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/variant_calling_tuned.json
+++ b/tests/data/guard_golden/examples/variant_calling_tuned.json
@@ -158,6 +158,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/variantbenchmarking.json
+++ b/tests/data/guard_golden/examples/variantbenchmarking.json
@@ -299,6 +299,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/variantbenchmarking_auto.json
+++ b/tests/data/guard_golden/examples/variantbenchmarking_auto.json
@@ -299,6 +299,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/examples/variantprioritization.json
+++ b/tests/data/guard_golden/examples/variantprioritization.json
@@ -162,6 +162,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/bubble_forced_label_clears_diagonal.json
+++ b/tests/data/guard_golden/tests/fixtures/bubble_forced_label_clears_diagonal.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/bubble_label_clears_diagonal.json
+++ b/tests/data/guard_golden/tests/fixtures/bubble_label_clears_diagonal.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/bubble_output_above.json
+++ b/tests/data/guard_golden/tests/fixtures/bubble_output_above.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/captioned_sibling_outputs.json
+++ b/tests/data/guard_golden/tests/fixtures/captioned_sibling_outputs.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/da_pipeline.json
+++ b/tests/data/guard_golden/tests/fixtures/da_pipeline.json
@@ -178,6 +178,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/diagonal_single_trunk_off_track.json
+++ b/tests/data/guard_golden/tests/fixtures/diagonal_single_trunk_off_track.json
@@ -468,6 +468,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/file_icon_fanin.json
+++ b/tests/data/guard_golden/tests/fixtures/file_icon_fanin.json
@@ -178,6 +178,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/font_scale.json
+++ b/tests/data/guard_golden/tests/fixtures/font_scale.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/genomeassembly_organellar.json
+++ b/tests/data/guard_golden/tests/fixtures/genomeassembly_organellar.json
@@ -178,6 +178,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/icon_caption_wrap.json
+++ b/tests/data/guard_golden/tests/fixtures/icon_caption_wrap.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/leaf_file_icon_on_trunk.json
+++ b/tests/data/guard_golden/tests/fixtures/leaf_file_icon_on_trunk.json
@@ -311,6 +311,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/multiline_labels.json
+++ b/tests/data/guard_golden/tests/fixtures/multiline_labels.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/off_track_output_branched.json
+++ b/tests/data/guard_golden/tests/fixtures/off_track_output_branched.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/off_track_outputs_along_trunk.json
+++ b/tests/data/guard_golden/tests/fixtures/off_track_outputs_along_trunk.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/off_track_terminal_noop.json
+++ b/tests/data/guard_golden/tests/fixtures/off_track_terminal_noop.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/rail_marked_single_line.json
+++ b/tests/data/guard_golden/tests/fixtures/rail_marked_single_line.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/rail_pitch_vs_labels.json
+++ b/tests/data/guard_golden/tests/fixtures/rail_pitch_vs_labels.json
@@ -178,6 +178,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/target_entry_runway_bypass.json
+++ b/tests/data/guard_golden/tests/fixtures/target_entry_runway_bypass.json
@@ -1,7 +1,7 @@
 {
   "raised": [
     "PhaseInvariantError",
-    "after Stage 6.9: station 'bb0' marker bbox (x=1834.0, y=511.0..521.0, half_h=5.0) outside section 'branch_b' bbox (1472.0, 546.0, w=412.0, h=240.0)"
+    "after Stage 6.9: station 'bb0' marker bbox (x=1834.0, y=511.0..521.0, half_h=5.0) outside section 'branch_b' bbox (1472.0, 546.0, w=412.0, h=220.0)"
   ],
   "trace": [
     "_guard_no_same_row_backward_feed|None",

--- a/tests/data/guard_golden/tests/fixtures/tb_exit_terminal_on_carrier.json
+++ b/tests/data/guard_golden/tests/fixtures/tb_exit_terminal_on_carrier.json
@@ -486,6 +486,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/tb_right_exit_feeder_slots.json
+++ b/tests/data/guard_golden/tests/fixtures/tb_right_exit_feeder_slots.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/topologies/twoline_fanout_up.json
+++ b/tests/data/guard_golden/tests/fixtures/topologies/twoline_fanout_up.json
@@ -178,6 +178,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/data/guard_golden/tests/fixtures/trunk_align_matching_bundle.json
+++ b/tests/data/guard_golden/tests/fixtures/trunk_align_matching_bundle.json
@@ -172,6 +172,7 @@
     "_guard_no_line_crosses_non_consumer|after final",
     "_guard_sparse_loop_station_clears_column_neighbour|after final",
     "_guard_station_x_column_drift|after final",
+    "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -71,6 +71,10 @@ from nf_metro.layout.phases._common import (
     section_cross_axis,
     wrap_exit_carrier_anchor,
 )
+from nf_metro.layout.phases.balancing import (
+    _downstream_same_row_entry_ports,
+    _entry_consumer_ys,
+)
 from nf_metro.layout.phases.bbox import (
     _min_drawn_section_bbox_top,
     _section_band_is_empty,
@@ -78,6 +82,7 @@ from nf_metro.layout.phases.bbox import (
     _section_fit_top,
 )
 from nf_metro.layout.phases.guards import (
+    _guard_port_station_coords_synced,
     _perp_fed_entry_consumer_y,
     _tb_top_entry_drop_overshoot,
 )
@@ -1169,6 +1174,65 @@ def test_flow_exit_port_anchors_to_carrying_station(fixture):
             f"row y={carrier_y:.1f} (carriers {sorted(carrier_ids)}); the "
             f"boundary run will read as a diagonal instead of a clean riser"
         )
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_port_station_and_port_records_share_coords(fixture):
+    """A port's Station record and Port record must hold the same coordinates.
+
+    Every port is both a ``Station`` (placed by layout, read by routing and
+    rendering) and a ``Port`` (read by later phases as the settled position).
+    A phase that moves a port by writing ``station.y`` directly, skipping the
+    Port record, desyncs the two so a later phase reads a stale position and
+    leaves the inter-section boundary run kinked.  The move helpers
+    (``_set_port_y`` / ``_set_port_x`` / ``shift_section``) write both.
+    """
+    graph = _layout(fixture, center_ports=_declared_center_ports(fixture))
+    for pid, port in graph.ports.items():
+        st = graph.stations.get(pid)
+        if st is None:
+            continue
+        assert abs(st.x - port.x) <= _Y_TOL and abs(st.y - port.y) <= _Y_TOL, (
+            f"{fixture}: port {pid} station record ({st.x:.1f}, {st.y:.1f}) "
+            f"desynced from port record ({port.x:.1f}, {port.y:.1f})"
+        )
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_carrier_anchored_entry_lifts_when_consumers_share_row(fixture):
+    """A same-row entry fed by a carrier-anchored exit lands on the carrier row
+    when its own consumers all share one row.
+
+    The exit stays on its carriers' row so the level change is a riser in the
+    inter-section gap; the entry must then reconcile to that same row so the
+    boundary crossing is straight rather than a diagonal jog.  The lift only
+    fires when the entry's consumers form a single unit -- an entry fanning to
+    several rows is left where it is, since no one lift can serve them all.
+    """
+    graph = _layout(fixture, center_ports=_declared_center_ports(fixture))
+    junction_ids = graph.junction_ids
+    for pid, _carrier_ids, carrier_y in _carrier_anchored_flow_exit_ports(graph):
+        if abs(graph.stations[pid].y - carrier_y) > _Y_TOL:
+            continue
+        section = graph.sections[graph.ports[pid].section_id]
+        for eid in _downstream_same_row_entry_ports(graph, pid, section, junction_ids):
+            consumer_ys = _entry_consumer_ys(graph, eid)
+            if not consumer_ys or max(consumer_ys) - min(consumer_ys) > _Y_TOL:
+                continue
+            assert abs(graph.stations[eid].y - carrier_y) <= _Y_TOL, (
+                f"{fixture}: entry {eid} y={graph.stations[eid].y:.1f} left off "
+                f"exit {pid}'s carrier row y={carrier_y:.1f} though its consumers "
+                f"share one row -> diagonal jog at the section boundary"
+            )
+
+
+def test_port_station_sync_guard_fires_on_desync():
+    """The runtime guard raises when a port's Station and Port records diverge."""
+    graph = _layout("variant_calling.mmd")
+    pid = next(iter(graph.ports))
+    graph.stations[pid].y += 50.0
+    with pytest.raises(PhaseInvariantError, match="desynced"):
+        _guard_port_station_coords_synced(graph, "test")
 
 
 @lru_cache(maxsize=None)

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -71,10 +71,6 @@ from nf_metro.layout.phases._common import (
     section_cross_axis,
     wrap_exit_carrier_anchor,
 )
-from nf_metro.layout.phases.balancing import (
-    _downstream_same_row_entry_ports,
-    _entry_consumer_ys,
-)
 from nf_metro.layout.phases.bbox import (
     _min_drawn_section_bbox_top,
     _section_band_is_empty,
@@ -1196,34 +1192,6 @@ def test_port_station_and_port_records_share_coords(fixture):
             f"{fixture}: port {pid} station record ({st.x:.1f}, {st.y:.1f}) "
             f"desynced from port record ({port.x:.1f}, {port.y:.1f})"
         )
-
-
-@pytest.mark.parametrize("fixture", ALL_FIXTURES)
-def test_carrier_anchored_entry_lifts_when_consumers_share_row(fixture):
-    """A same-row entry fed by a carrier-anchored exit lands on the carrier row
-    when its own consumers all share one row.
-
-    The exit stays on its carriers' row so the level change is a riser in the
-    inter-section gap; the entry must then reconcile to that same row so the
-    boundary crossing is straight rather than a diagonal jog.  The lift only
-    fires when the entry's consumers form a single unit -- an entry fanning to
-    several rows is left where it is, since no one lift can serve them all.
-    """
-    graph = _layout(fixture, center_ports=_declared_center_ports(fixture))
-    junction_ids = graph.junction_ids
-    for pid, _carrier_ids, carrier_y in _carrier_anchored_flow_exit_ports(graph):
-        if abs(graph.stations[pid].y - carrier_y) > _Y_TOL:
-            continue
-        section = graph.sections[graph.ports[pid].section_id]
-        for eid in _downstream_same_row_entry_ports(graph, pid, section, junction_ids):
-            consumer_ys = _entry_consumer_ys(graph, eid)
-            if not consumer_ys or max(consumer_ys) - min(consumer_ys) > _Y_TOL:
-                continue
-            assert abs(graph.stations[eid].y - carrier_y) <= _Y_TOL, (
-                f"{fixture}: entry {eid} y={graph.stations[eid].y:.1f} left off "
-                f"exit {pid}'s carrier row y={carrier_y:.1f} though its consumers "
-                f"share one row -> diagonal jog at the section boundary"
-            )
 
 
 def test_port_station_sync_guard_fires_on_desync():


### PR DESCRIPTION
## Summary

Fixes the root cause behind the #1423 boundary kink: several layout phases moved a **port** by writing its `Station` record directly and left the parallel `Port` record stale, so a later phase read the stale position. All such writes now go through the existing `_set_port_y` / `shift_section` helpers so both records move together:

- `ports.py` — grid-group entry/exit port snaps
- `grid_snap.py` — grid slot snap and convergence-midpoint restore
- `fan_bundles.py` — symmetric-fork section slide and fork entry-port centering
- `row_align.py` — row top-align

A final-checkpoint guard `_guard_port_station_coords_synced` fails loudly if any port's two records diverge.

The desync was present on **35 corpus fixtures** and is now zero. The fix is **render-neutral** across the whole corpus (routing reads the `Station` record, so no laid-out pixel moves; the one fixture whose SVG string changes differs only in float formatting, not coordinates).

## Not included: the Stage 5.5 entry-port lift

The issue also proposed broadening the Stage 5.5 carrier-anchor guard so a same-row entry is lifted to the exit's carrier row. That was tried and reverted: lifting the entry port off its consumer's row makes the bundle enter the section at the carrier level (bottom-left corner) and diagonal up to the first station, instead of arriving level with it. Keeping the records synced is the correct, non-regressing fix; the level change stays a riser in the inter-section gap.

Fixes #1423

## Test plan
- [x] `test_port_station_and_port_records_share_coords` (whole corpus) — fails on 35 fixtures before, passes after
- [x] `test_port_station_sync_guard_fires_on_desync` — locks the runtime guard
- [x] full pytest green (pre-existing env-only subprocess-import failures pass in CI)
- [x] ruff check + format + mypy clean
- [x] guard-registry golden regenerated (+1 call/fixture)
- [x] render-neutral: whole-corpus render diff shows 0 coordinate changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
