### PR TITLE
fix(layout): don't stack a straight-diamond join on a contested base track (#1456)

### DIFF
--- a/examples/topologies/fanin_join_diff_length_branches.mmd
+++ b/examples/topologies/fanin_join_diff_length_branches.mmd
@@ -1,0 +1,34 @@
+%%metro title: RNA-seq fan-in example
+%%metro line: align | Alignment | #2db572
+%%metro line: qc | QC | #e6550d
+%%metro line: quant | Quantification | #0570b0
+%%metro line: fusion | Fusion detection | #756bb1
+
+graph LR
+    reads_in[Reads]
+    bbduk[BBDuk trim]
+    star[STAR 2-pass]
+    cram[samtools CRAM]
+    flagstat[flagstat + mosdepth]
+    markdup[sambamba markdup]
+    rnaseqc[RNA-SeQC]
+    rsem[RSEM]
+    geneann[Gene annotation]
+    arriba[Arriba]
+    starfusion[STAR-Fusion]
+    merge[Merge fusions]
+    draw[Draw fusions]
+
+    reads_in -->|align,qc,quant,fusion| bbduk
+    bbduk -->|align,qc,quant,fusion| star
+    star -->|align| cram
+    star -->|qc| flagstat
+    star -->|qc| markdup
+    markdup -->|qc| rnaseqc
+    star -->|quant| rsem
+    rsem -->|quant| geneann
+    star -->|fusion| arriba
+    star -->|fusion| starfusion
+    arriba -->|fusion| merge
+    starfusion -->|fusion| merge
+    merge -->|fusion| draw

--- a/scripts/gallery.yaml
+++ b/scripts/gallery.yaml
@@ -364,6 +364,14 @@ gallery:
       "A profiling section whose stacked tools share a fan-in/fan-out: a line the
       'FMH FunProfiler' station does not carry would rake its wide below-station label, so
       the label flips to its clear side and the diagonal no longer strikes the glyphs."
+  - id: fanin_join_diff_length_branches
+    source_dir: examples/topologies
+    category: Fan-out and Fan-in
+    description:
+      "One station fans out to four lines of differing branch lengths, one of which is a
+      two-way fork-join. Regression fixture for #1456: under the default `straight` diamond
+      the join snapped onto its line's declaration-order base track, which a wide fan-out had
+      already given to another line's station, stacking two stations in one cell."
 
   # ── Branching and Multipath ────────────────────────────────────────────────
   - id: asymmetric_tree

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -306,6 +306,17 @@ def _predecessor_avg(
     return sum(tracks[p] for p in preds) / len(preds)
 
 
+def _median_pred_track(preds: list[str], tracks: dict[str, float]) -> float | None:
+    """Median track of a node's already-placed predecessors, or None.
+
+    ``median_low`` returns an actual feeder track, so a merge anchored here
+    stays on-grid even for an even feeder count (a mean would land on a
+    half-track).
+    """
+    pred_tracks = [tracks[p] for p in preds if p in tracks]
+    return median_low(pred_tracks) if pred_tracks else None
+
+
 def _place_single_node(
     node: str,
     base: float,
@@ -337,6 +348,7 @@ def _place_single_node(
     # Detect divergence: predecessor has more lines than this node
     if graph is not None:
         preds = list(G.predecessors(node))
+        node_layer = layers.get(node, 0) if layers else 0
         node_lines = set(graph.station_lines(node))
         pred_lines: set[str] = set()
         for p in preds:
@@ -356,7 +368,6 @@ def _place_single_node(
                 if G.in_degree(preds[0]) > 1 or node in continuation_nodes:
                     return pred_avg
             # Check if this is a diamond (temporary fork-join)
-            node_layer = layers.get(node, 0) if layers else 0
             if diamond_members is not None and node in diamond_members:
                 # Diamond: compress toward trunk for compact visual
                 return pred_avg + (base - pred_avg) * DIAMOND_COMPRESSION
@@ -412,13 +423,11 @@ def _place_single_node(
                 # declared line's, often an extreme of the feeder spread, so
                 # snapping there forces every other feeder into a longer
                 # detour.  In symmetric mode anchor on the median feeder track,
-                # minimising total feeder bend; median_low returns an actual
-                # feeder track so the merge stays on-grid even for an even
-                # feeder count (a mean would land on a half-track).
+                # minimising total feeder bend.
                 if graph.diamond_style == "symmetric":
-                    pred_tracks = [tracks[p] for p in preds if p in tracks]
-                    if pred_tracks:
-                        return median_low(pred_tracks)
+                    median = _median_pred_track(preds, tracks)
+                    if median is not None:
+                        return median
                 return base
 
             # Trunk junction: at least one predecessor already carries the
@@ -444,16 +453,15 @@ def _place_single_node(
             and len(preds) > 1
             and any(p in diamond_members for p in preds)
         ):
-            node_layer = layers.get(node, 0) if layers else 0
             base_contested = (
                 layer_occupancy is not None
                 and _is_track_occupied_at_layer(base, node_layer, layer_occupancy, node)
             )
             if not base_contested:
                 return base
-            pred_tracks = [tracks[p] for p in preds if p in tracks]
-            if pred_tracks:
-                return median_low(pred_tracks)
+            median = _median_pred_track(preds, tracks)
+            if median is not None:
+                return median
 
     # Direct single-predecessor alignment: when a node has exactly one
     # predecessor on the same line(s), snap to the predecessor's track

--- a/src/nf_metro/layout/ordering.py
+++ b/src/nf_metro/layout/ordering.py
@@ -433,14 +433,27 @@ def _place_single_node(
 
         # Diamond merge: when straight diamonds are active, snap the
         # join node back to the base track so lines return to the trunk
-        # after an asymmetric fork-join.
+        # after an asymmetric fork-join.  The line's nominal base is its
+        # trunk only when it is free here; a wide fan-out can push another
+        # line's station onto that base track, so snapping would stack the
+        # join on top of it.  When contested, keep the join with its fork
+        # branches (their median track) instead of returning across the row.
         if (
             graph.diamond_style == "straight"
             and diamond_members is not None
             and len(preds) > 1
             and any(p in diamond_members for p in preds)
         ):
-            return base
+            node_layer = layers.get(node, 0) if layers else 0
+            base_contested = (
+                layer_occupancy is not None
+                and _is_track_occupied_at_layer(base, node_layer, layer_occupancy, node)
+            )
+            if not base_contested:
+                return base
+            pred_tracks = [tracks[p] for p in preds if p in tracks]
+            if pred_tracks:
+                return median_low(pred_tracks)
 
     # Direct single-predecessor alignment: when a node has exactly one
     # predecessor on the same line(s), snap to the predecessor's track

--- a/tests/data/guard_golden/examples/topologies/fanin_join_diff_length_branches.json
+++ b/tests/data/guard_golden/examples/topologies/fanin_join_diff_length_branches.json
@@ -1,0 +1,28 @@
+{
+  "raised": null,
+  "trace": [
+    "_guard_no_label_overlap|final",
+    "_guard_no_diagonal_strikes_horizontal_label|final",
+    "_guard_no_line_strikes_label|final",
+    "_guard_bypass_v_flat_visible|final",
+    "_guard_no_wrapped_label_trunk_strike|final",
+    "_guard_file_icon_no_name_label|final",
+    "_guard_no_line_crosses_file_icon|final",
+    "_guard_centered_line_spread_balanced|final",
+    "_guard_rail_above_label_band|final",
+    "_guard_rail_stations_seat_on_rails|final",
+    "_guard_rail_one_station_per_column|final",
+    "_guard_single_trunk_off_track_step|final",
+    "_guard_off_track_consumer_on_trunk|final",
+    "_guard_symfan_entry_port_on_feeder_trunk|final",
+    "_guard_off_track_input_column_stack|final",
+    "_guard_off_track_not_hub|final",
+    "_guard_interchange_bar_clears_non_members|final",
+    "_guard_interchange_label_clears_connector|final",
+    "_guard_tb_top_entry_drop_hugs_top|final",
+    "_guard_side_entered_vertical_top_not_below_feeder|final",
+    "_guard_symmetric_diamond_branches_straddle_trunk|final",
+    "_guard_symmetric_diamond_branches_half_pitch|final",
+    "_guard_converge_siblings_merge_locally|final"
+  ]
+}


### PR DESCRIPTION
## Summary

A valid fan-out graph — one station branching to several metro lines of **differing branch lengths**, one branch being a two-way fork-join — settled with two stations stacked in a single grid cell under the default `--diamond-style straight`, tripping the Tier-A layout guards (the render proceeds but is visibly broken; `--strict` turns it into a hard error). `--diamond-style symmetric` laid the same graph out cleanly.

**Cause.** In `_place_single_node` (track assignment), a straight-diamond fork-join snapped its join station back to the line's *declaration-order base track* to return to the trunk. That base is the line's trunk only when it is free; a wide fan-out at the join's layer can have already parked another line's station on that track, so the snap stacked the two stations in one cell and routed the line back across the occupied row.

**Fix.** Guard the snap on the base track being free at the join's layer. When it is contested, anchor the join on its fork branches' median track instead (`median_low` of the predecessors) — the same clean placement `diamond_style=symmetric` already produces for this graph.

Also factors the shared "anchor a merge on its predecessors' median track" logic (symmetric-convergence branch + this new contested-diamond branch) into `_median_pred_track` (separate refactor commit).

### Regression infra
- Frozen reproducer `examples/topologies/fanin_join_diff_length_branches.mmd` (also a gallery entry, so CI's render-diff surfaces it).
- Covered by the existing parametrised `test_no_coincident_stations` — fails on `main`, passes here.
- Guard-golden baseline added for the new fixture.

Fixes #1456

## Test plan
- [x] Full pytest suite passes (35498 passed, 11 xfailed) — new `test_no_coincident_stations[fanin_join_diff_length_branches]` passes; failed on `main`
- [x] ruff check + ruff format clean; mypy clean (prek hooks pass)
- [x] Existing Tier-A guards (`_guard_no_station_overlap`, `_guard_no_coincident_station_coords`) already provide the runtime check; the fix removes the violation at its source
- [ ] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1463/)
- [ ] Render-preview verdict

Generated with Claude Code
