### PR TITLE
fix: orient stacked-files icon back page away from station marker

### DIFF
--- a/src/nf_metro/render/icons.py
+++ b/src/nf_metro/render/icons.py
@@ -293,22 +293,26 @@ def render_files_icon(
     font_color: str,
     font_family: str,
     banner: bool = False,
+    back_dx_sign: float = 1.0,
+    back_dy_sign: float = -1.0,
 ) -> None:
     """Render a stacked-files icon (two overlapping documents).
 
     The front page (identical to the single file icon, and the one carrying the
     label) is centered on (cx, cy) so a files icon's left edge lines up with
-    single file icons sharing a row; the back page peeks up and to the right,
-    into the open space ahead of the icon, so it never crowds the icon to its
-    left.
+    single file icons sharing a row; the back page peeks out diagonally behind
+    it. ``back_dx_sign``/``back_dy_sign`` (each +1.0 or -1.0) pick which
+    diagonal the back page peeks into -- the caller must choose the signs that
+    point away from the station marker along the flow axis, or the back page
+    encroaches on the reserved marker clearance instead of extending past it.
     """
     off = width * FILES_ICON_OFFSET_RATIO
 
-    # Back page (peeks up-right behind the centered front page)
+    # Back page (peeks diagonally behind the centered front page)
     render_file_icon(
         d,
-        cx=cx + off,
-        cy=cy - off,
+        cx=cx + off * back_dx_sign,
+        cy=cy + off * back_dy_sign,
         width=width,
         height=height,
         fold_size=fold_size,

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -2367,6 +2367,17 @@ def _terminus_icon_centers_for(
     )
 
 
+def _terminus_icon_flow_sign(section_dir: str, is_source: bool) -> float:
+    """+1 if a terminus icon extends in the forward flow direction, else -1.
+
+    Sinks sit at the end of the flow and extend forwards; sources sit at
+    the start and extend backwards.  RL/BT reverse the forward direction so
+    icons always point to the outside of the diagram.
+    """
+    extends_forward = is_source if section_dir in ("RL", "BT") else not is_source
+    return 1.0 if extends_forward else -1.0
+
+
 def _terminus_icon_centers(
     station: Station,
     section_dir: str,
@@ -2393,10 +2404,7 @@ def _terminus_icon_centers(
     # the standard router handles) are untouched.
     if station.off_track and is_rail:
         return [(station.x, station.y - (first_offset + i * step)) for i in range(n)]
-    # Sinks sit at the end of the flow and extend forwards; sources sit at
-    # the start and extend backwards.  RL/BT reverse the forward direction.
-    extends_forward = is_source if section_dir in ("RL", "BT") else not is_source
-    sign = 1.0 if extends_forward else -1.0
+    sign = _terminus_icon_flow_sign(section_dir, is_source)
     centers: list[tuple[float, float]] = []
     for i in range(n):
         flow = sign * (first_offset + i * step)
@@ -2427,6 +2435,8 @@ def _render_terminus_icons(
     )
     section_dir = section.direction if section else "LR"
     is_vertical_flow = lanes_run_along_x(section_dir)
+    is_source = not graph.edges_to(station.id)
+    flow_sign = _terminus_icon_flow_sign(section_dir, is_source)
     icon_half_w = theme.terminus_width / 2
     icon_half_h = theme.terminus_height / 2
 
@@ -2493,8 +2503,16 @@ def _render_terminus_icons(
         if icon_type == ICON_TYPE_DIR:
             render_folder_icon(d, **common)
         elif icon_type == ICON_TYPE_FILES:
+            back_dx_sign, back_dy_sign = (
+                (1.0, flow_sign) if is_vertical_flow else (flow_sign, -1.0)
+            )
             render_files_icon(
-                d, **common, fold_size=theme.terminus_fold_size, banner=banner
+                d,
+                **common,
+                fold_size=theme.terminus_fold_size,
+                banner=banner,
+                back_dx_sign=back_dx_sign,
+                back_dy_sign=back_dy_sign,
             )
         else:
             render_file_icon(

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -8,11 +8,15 @@ from dataclasses import replace
 import pytest
 
 from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.geometry import lanes_run_along_x
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import Station
+from nf_metro.render.constants import FILES_ICON_OFFSET_RATIO
 from nf_metro.render.svg import (
     _label_halo_color,
     _terminus_icon_centers,
+    _terminus_icon_centers_for,
+    _terminus_icon_flow_sign,
     render_svg,
 )
 from nf_metro.themes import (
@@ -820,6 +824,57 @@ def test_terminus_icons_bt_mirror_tb():
         st, "BT", is_source=False, n=1, first_offset=10.0, step=4.0, bundle_center=0.0
     )
     assert sink == [(100.0, 40.0)]
+
+
+def _files_terminus_mmd(direction: str, role: str) -> str:
+    """A minimal graph with one `files:` terminus, station `t`, as source or sink."""
+    other_edge = "t -->|main| other" if role == "source" else "other -->|main| t"
+    return (
+        "%%metro line: main | Main | #ff0000\n"
+        "%%metro files: t | FASTQ | Reads\n"
+        "graph LR\n"
+        "    subgraph sec [Section]\n"
+        f"        %%metro direction: {direction}\n"
+        "        t[ ]\n"
+        "        other[Other]\n"
+        f"        {other_edge}\n"
+        "    end\n"
+    )
+
+
+@pytest.mark.parametrize("direction", ["LR", "RL", "TB", "BT"])
+@pytest.mark.parametrize("role", ["source", "sink"])
+def test_stacked_files_icon_back_page_does_not_crowd_marker(direction, role):
+    """A `files:` terminus's back page must sit at least as far from the
+    station marker as the front page, on every flow direction and role (#1460).
+    """
+    graph = parse_metro_mermaid(_files_terminus_mmd(direction, role))
+    compute_layout(graph)
+    station = graph.stations["t"]
+    section = graph.sections["sec"]
+    assert section.direction == direction
+    is_source = role == "source"
+
+    front_cx, front_cy = _terminus_icon_centers_for(
+        station, graph, NFCORE_THEME, 0.0, 0.0
+    )[0]
+    off = NFCORE_THEME.terminus_width * FILES_ICON_OFFSET_RATIO
+    flow_sign = _terminus_icon_flow_sign(direction, is_source)
+    is_vertical_flow = lanes_run_along_x(direction)
+
+    if is_vertical_flow:
+        marker_flow, front_flow = station.y, front_cy
+        back_flow = front_cy + off * flow_sign
+    else:
+        marker_flow, front_flow = station.x, front_cx
+        back_flow = front_cx + off * flow_sign
+
+    front_gap = abs(marker_flow - front_flow)
+    back_gap = abs(marker_flow - back_flow)
+    assert back_gap >= front_gap, (
+        f"{direction}/{role}: back page gap {back_gap:.1f} < front page gap "
+        f"{front_gap:.1f} -- back page crowds the marker"
+    )
 
 
 def test_render_tb_section_file_icon_below_station():


### PR DESCRIPTION
## Summary
- `render_files_icon`'s back page previously shifted by a fixed `(+x, -y)` offset regardless of the terminus's flow direction or source/sink role, which only pointed away from the station marker for a sink in LR (and RL/BT's mirrored case).
- For the opposite role/direction combination, the same offset shifted the back page toward the marker instead, eating into the reserved clearance (e.g. a source-side `files:` terminus in an LR section had its back page crowd to within ~1.8px of the marker instead of the intended ~6px).
- `render_files_icon` now takes `back_dx_sign`/`back_dy_sign` parameters, and the caller (`_render_terminus_icons`) derives them from the same flow-direction sign (`_terminus_icon_flow_sign`, extracted from `_terminus_icon_centers`) already used to place the icon, so the back page always extends away from the marker.

Fixes #1460

## Test plan
- [x] `pytest -k stacked_files_icon_back_page` passes: new test parametrized over all 4 section directions (LR/RL/TB/BT) x source/sink role (8 cases, the complete state space this fix depends on)
- [x] Confirmed the test fails pre-fix on the 4 buggy combinations (LR/source, RL/sink, TB/sink, BT/source) and passes post-fix on all 8
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean on changed files
- [ ] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1464/) once CI posts it

Generated with Claude Code