### PR TITLE
fix(layout): centre a flat-in fan-diamond sibling on its diagonal siblings' X (#1458)

### DIFF
--- a/src/nf_metro/layout/routing/postprocess.py
+++ b/src/nf_metro/layout/routing/postprocess.py
@@ -538,6 +538,41 @@ def _clamp_centering_shift(
     return max(lo, min(hi, shift))
 
 
+def _symfan_sibling_diag_end_x(
+    graph: MetroGraph,
+    ctx: _BubbleCtx,
+    sid: str,
+    station: Station,
+    flat_in_rp: RoutedPath,
+) -> float | None:
+    """Near-station straighten X shared by a flat-in fan sibling's diagonals.
+
+    A bubble station whose incoming edge is flat sits on its fork's entry row,
+    so its flat run reaches all the way back to the fork.  Measuring that
+    incoming flat from its far (fork) end places the station's centring midpoint
+    far left of a diagonal-in sibling's, splitting two branches that share a
+    column and should land at one X.  When the flat edge's fork also feeds
+    diagonal-in siblings that sit in this station's column, borrow the X where
+    their diagonals straighten near the station, so the flat sibling centres to
+    the same target by construction.  Returns None when no such sibling exists,
+    leaving an isolated flat-in station on its far-end measurement.
+
+    A fork's outgoing diagonals are exactly the sibling stations' incoming
+    diagonals, so the sibling straighten Xs are read off ``ctx.outgoing`` keyed
+    by the shared fork.
+    """
+    own_x = ctx.original_x.get(sid, station.x)
+    ends = [
+        rp.points[2][0]
+        for rp in ctx.outgoing.get(flat_in_rp.edge.source, [])
+        if rp.edge.target != sid
+        and (other := graph.stations.get(rp.edge.target)) is not None
+        and other.section_id == station.section_id
+        and abs(ctx.original_x.get(rp.edge.target, other.x) - own_x) <= 1
+    ]
+    return max(ends) if ends else None
+
+
 def _centering_candidate(
     graph: MetroGraph, ctx: _BubbleCtx, sid: str, station: Station
 ) -> _StationMoveCandidate | None:
@@ -597,7 +632,8 @@ def _centering_candidate(
         in_diag_end_x = in_rp.points[2][0]
     else:
         assert flat_in_rp is not None
-        in_diag_end_x = flat_in_rp.points[0][0]
+        borrowed = _symfan_sibling_diag_end_x(graph, ctx, sid, station, flat_in_rp)
+        in_diag_end_x = borrowed if borrowed is not None else flat_in_rp.points[0][0]
 
     if not multi_diag:
         if out_rp:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -1488,6 +1488,58 @@ def test_symfan_pairs_share_y(fixture):
             )
 
 
+def _diamond_sibling_columns(graph: MetroGraph) -> list[list[str]]:
+    """Same-column station groups sharing a fork predecessor and join successor.
+
+    These are fan-diamond siblings: they diverge from a common upstream node,
+    sit in one placement column (same pre-centring X), and reconverge on a
+    common downstream node.  Mirror images around the trunk, they must render at
+    one X.
+    """
+    preds: dict[str, set[str]] = defaultdict(set)
+    succs: dict[str, set[str]] = defaultdict(set)
+    for e in graph.edges:
+        preds[e.target].add(e.source)
+        succs[e.source].add(e.target)
+    by_col: dict[tuple[str | None, float], list[str]] = defaultdict(list)
+    for sid, st in graph.stations.items():
+        if st.is_port or st.is_hidden or st.off_track:
+            continue
+        by_col[(st.section_id, round(st.x, 1))].append(sid)
+    groups = []
+    for sids in by_col.values():
+        if len(sids) < 2:
+            continue
+        common_pred = set.intersection(*(preds[s] for s in sids))
+        common_succ = set.intersection(*(succs[s] for s in sids))
+        if common_pred and common_succ:
+            groups.append(sids)
+    return groups
+
+
+@pytest.mark.parametrize("fixture", ALL_FIXTURES)
+def test_fan_diamond_siblings_share_rendered_x(fixture):
+    """Fan-diamond siblings in one column render at the same X.
+
+    Two branches that fork from a common node, share a placement column, and
+    reconverge on a common node are mirror images and must land at one X after
+    the bubble-centring pass.  When one branch's incoming edge is flat (it sits
+    on the fork's entry row) its centring midpoint was measured from the far end
+    of that flat run rather than a near-station point comparable to a diagonal
+    sibling's, pulling it off the shared column (issue #1458).
+    """
+    graph = _layout(fixture)
+    groups = _diamond_sibling_columns(graph)
+    if not groups:
+        return
+    route_edges_centred(graph)
+    for sids in groups:
+        xs = {sid: round(graph.stations[sid].x, 1) for sid in sids}
+        assert max(xs.values()) - min(xs.values()) <= 1.0, (
+            f"Fan-diamond siblings must share rendered X, got {xs}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Grid snap keeps same-column stations on distinct slots
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A fan-diamond bubble station whose incoming edge is flat (it sits on its fork's entry row) measured its bubble-centring midpoint from the far end of that flat run, back at the fork, rather than a near-station point comparable to a diagonal-in sibling's. That pulled the flat-in branch of a symmetric fan-diamond off the column its diagonal siblings share, so two branches that should render at one X split apart.

`_centering_candidate` now borrows the near-station straighten X that the fork's diagonal-in siblings in the same column share (read off the fork's outgoing diagonals), so a flat-in sibling centres to the same target **by construction** rather than relying on the downstream majority-vote realignment. An isolated flat-in station (no diagonal sibling in its column) keeps its far-end measurement.

The originally-reported two-branch single-fork repro no longer splits on `main` because #1466 (merged after this issue was filed) re-centres that section's entry port so both branches become diagonal-in - the incidental row-assignment change the issue author predicted, not a fix to the underlying measurement. The defect is still live where #1466 doesn't reach and the majority-vote salvage can't (a two-source fork, or a group of two): `examples/variant_calling.mmd` renders GATK (flat-in) 22.5px left of its DeepVariant sibling. This fix aligns them.

Renders are byte-identical across the gallery except `variant_calling` / `variant_calling_tuned`, where GATK now shares its column with DeepVariant.

Fixes #1458

## Test plan
- [x] New parametrized invariant `test_fan_diamond_siblings_share_rendered_x` (same-column fork+join siblings share rendered X); fails on base for `variant_calling(_tuned)`, passes with the fix; 0 corpus false positives
- [x] `pytest tests/test_layout_invariants.py tests/test_topology_validation.py` green (20026 passed)
- [x] Routing gate-coverage ratchet green (both arms of the new branch exercised)
- [x] ruff check + ruff format --check + mypy clean
- [ ] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1469/) - expect: only `variant_calling(_tuned)` changed (GATK/DeepVariant aligned)

Generated with Claude Code
