### PR TITLE
Add --permissive render mode to downgrade guard failures to warnings

### DIFF
--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -19,11 +19,11 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
-from nf_metro.layout import compute_layout
+from nf_metro.layout import PhaseInvariantError, compute_layout
 from nf_metro.options import LAYOUT_OPTIONS
 from nf_metro.parser import parse_metro_mermaid
 from nf_metro.parser.directives import apply_legend_directive
-from nf_metro.parser.model import LineSpread, MetroGraph
+from nf_metro.parser.model import LineSpread, MetroGraph, PermissiveGuardWarning
 from nf_metro.render import render_svg
 from nf_metro.render.html import render_html
 from nf_metro.render.legend import (
@@ -164,6 +164,14 @@ def prepare_graph(
     :class:`~nf_metro.layout.BackwardFlowError`,
     :class:`~nf_metro.layout.MixedEntryDirectionError`,
     :class:`~nf_metro.layout.PhaseInvariantError`.
+
+    When ``graph.permissive`` is set (``%%metro permissive: true`` or
+    ``--permissive``), a :class:`~nf_metro.layout.PhaseInvariantError` raised
+    mid-layout is downgraded to a :class:`UserWarning` instead; the graph is
+    returned carrying whatever coordinates the engine had computed before the
+    failing phase, for a caller-side best-effort render attempt. A real
+    cycle, backward flow, or mixed entry directions raise unconditionally:
+    those leave no geometry to fall back to.
     """
     opts = layout_options or {}
 
@@ -210,7 +218,18 @@ def prepare_graph(
         not bare and not logo_in_legend
     )
 
-    compute_layout(graph)
+    if graph.permissive:
+        try:
+            compute_layout(graph)
+        except PhaseInvariantError as e:
+            warnings.warn(
+                f"layout guard downgraded under permissive mode: "
+                f"{type(e).__name__}: {e}",
+                category=PermissiveGuardWarning,
+                stacklevel=2,
+            )
+    else:
+        compute_layout(graph)
     return graph
 
 

--- a/src/nf_metro/cli.py
+++ b/src/nf_metro/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import warnings
 from collections.abc import Callable, Iterable
@@ -31,7 +32,11 @@ from nf_metro.parser import (
     parse_metro_mermaid,
     validate_graph,
 )
-from nf_metro.parser.model import LineSpread
+from nf_metro.parser.model import (
+    LineSpread,
+    PermissiveGuardWarning,
+    split_guard_warnings,
+)
 from nf_metro.render import validate_render
 from nf_metro.themes import THEMES
 
@@ -443,97 +448,124 @@ def _render_one_unsafe(
     quiet: bool,
 ) -> None:
     text = input_file.read_text()
+    permissive = bool(layout_opts.get("permissive"))
 
-    try:
-        graph = prepare_graph(
-            text,
-            from_nextflow=from_nextflow,
-            title=title,
-            line_spread=line_spread,
-            logo=str(logo) if logo is not None else None,
-            legend=legend,
-            layout_options=layout_opts,
-            source_dir=str(input_file.resolve().parent),
-            bare=bare,
-            output_format=format_,
-        )
-    except (
-        ValueError,
-        CyclicGraphError,
-        BackwardFlowError,
-        MixedEntryDirectionError,
-        PhaseInvariantError,
-    ) as e:
-        raise click.ClickException(str(e))
+    # Under --permissive, every warning raised during the render is captured
+    # here rather than printed live. Only PermissiveGuardWarning's filter is
+    # forced to "always" (so a guard downgrade is never lost to the default
+    # once-per-location dedup); any other captured warning is replayed
+    # through the normal printer afterwards, deduped exactly as it would be
+    # without --permissive.
+    warn_ctx = (
+        warnings.catch_warnings(record=True) if permissive else contextlib.nullcontext()
+    )
+    with warn_ctx as caught:
+        if permissive:
+            warnings.filterwarnings("always", category=PermissiveGuardWarning)
 
-    theme_obj = resolve_theme(theme, graph, mode=mode)
-
-    if format_ == "html":
-        # The interactive page supplies its own responsive frame, chrome, and
-        # per-map class scoping, so the SVG-only sizing/namespacing flags have
-        # nothing to act on. Font portability and the dark-mode block do reach
-        # the inlined SVG, so they are threaded through.
-        ignored = [
-            name
-            for name, enabled in (
-                ("--responsive", responsive),
-                ("--bare", bare),
-                ("--svg-class-prefix", bool(svg_class_prefix)),
+        try:
+            graph = prepare_graph(
+                text,
+                from_nextflow=from_nextflow,
+                title=title,
+                line_spread=line_spread,
+                logo=str(logo) if logo is not None else None,
+                legend=legend,
+                layout_options=layout_opts,
+                source_dir=str(input_file.resolve().parent),
+                bare=bare,
+                output_format=format_,
             )
-            if enabled
-        ]
-        if ignored:
+        except (
+            ValueError,
+            CyclicGraphError,
+            BackwardFlowError,
+            MixedEntryDirectionError,
+            PhaseInvariantError,
+        ) as e:
+            raise click.ClickException(str(e))
+
+        theme_obj = resolve_theme(theme, graph, mode=mode)
+
+        if format_ == "html":
+            # The interactive page supplies its own responsive frame, chrome, and
+            # per-map class scoping, so the SVG-only sizing/namespacing flags have
+            # nothing to act on. Font portability and the dark-mode block do reach
+            # the inlined SVG, so they are threaded through.
+            ignored = [
+                name
+                for name, enabled in (
+                    ("--responsive", responsive),
+                    ("--bare", bare),
+                    ("--svg-class-prefix", bool(svg_class_prefix)),
+                )
+                if enabled
+            ]
+            if ignored:
+                click.echo(
+                    f"Note: {', '.join(ignored)} only affect --format svg and are "
+                    "ignored for --format html (the interactive page is already "
+                    "responsive and scopes each map independently).",
+                    err=True,
+                )
+
+        # Tier-A layout-invariant violations on the settled geometry surface here
+        # under --strict (LayoutInvariantError is a PhaseInvariantError); without
+        # --strict they are warnings the default handler prints to stderr.
+        try:
+            content = render_graph(
+                graph,
+                theme_obj,
+                RenderConfig(
+                    output_format=format_,
+                    debug=debug,
+                    responsive=responsive,
+                    embed_font=embed_font,
+                    text_to_paths=text_to_paths,
+                    svg_class_prefix=svg_class_prefix,
+                    inject_dark_mode_css=not no_dark_mode_css,
+                    chrome_css=not no_chrome_css,
+                    self_color_scheme=not no_self_color_scheme,
+                    baked_mode=(mode or graph.mode).strip() or None,
+                    bare=bare,
+                    embed_basename=output.name,
+                ),
+            )
+        except (ValueError, FoldThresholdError, PhaseInvariantError) as e:
+            raise click.ClickException(str(e))
+
+        if validate_geometry:
+            if format_ == "html":
+                raise click.ClickException("--validate applies to --format svg only.")
+            findings = validate_render(content, graph=graph)
+            if findings:
+                detail = "\n".join(f"  - {f.message}" for f in findings)
+                raise click.ClickException(
+                    f"render-geometry validation found {len(findings)} "
+                    f"defect(s) in the drawn SVG:\n{detail}"
+                )
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(content if content.endswith("\n") else content + "\n")
+        if not quiet:
             click.echo(
-                f"Note: {', '.join(ignored)} only affect --format svg and are "
-                "ignored for --format html (the interactive page is already "
-                "responsive and scopes each map independently).",
+                f"Rendered {len(graph.stations)} stations, "
+                f"{len(graph.edges)} edges, "
+                f"{len(graph.lines)} lines -> {output}"
+            )
+
+    if permissive and caught:
+        guard_warnings, other_warnings = split_guard_warnings(caught)
+        for w in other_warnings:
+            warnings.showwarning(w.message, w.category, w.filename, w.lineno)
+        if guard_warnings:
+            click.echo(
+                f"--permissive: {len(guard_warnings)} guard(s) downgraded to "
+                "warnings; the rendered geometry may be defective at these points:",
                 err=True,
             )
-
-    # Tier-A layout-invariant violations on the settled geometry surface here
-    # under --strict (LayoutInvariantError is a PhaseInvariantError); without
-    # --strict they are warnings the default handler prints to stderr.
-    try:
-        content = render_graph(
-            graph,
-            theme_obj,
-            RenderConfig(
-                output_format=format_,
-                debug=debug,
-                responsive=responsive,
-                embed_font=embed_font,
-                text_to_paths=text_to_paths,
-                svg_class_prefix=svg_class_prefix,
-                inject_dark_mode_css=not no_dark_mode_css,
-                chrome_css=not no_chrome_css,
-                self_color_scheme=not no_self_color_scheme,
-                baked_mode=(mode or graph.mode).strip() or None,
-                bare=bare,
-                embed_basename=output.name,
-            ),
-        )
-    except (ValueError, FoldThresholdError, PhaseInvariantError) as e:
-        raise click.ClickException(str(e))
-
-    if validate_geometry:
-        if format_ == "html":
-            raise click.ClickException("--validate applies to --format svg only.")
-        findings = validate_render(content, graph=graph)
-        if findings:
-            detail = "\n".join(f"  - {f.message}" for f in findings)
-            raise click.ClickException(
-                f"render-geometry validation found {len(findings)} "
-                f"defect(s) in the drawn SVG:\n{detail}"
-            )
-
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(content if content.endswith("\n") else content + "\n")
-    if not quiet:
-        click.echo(
-            f"Rendered {len(graph.stations)} stations, "
-            f"{len(graph.edges)} edges, "
-            f"{len(graph.lines)} lines -> {output}"
-        )
+            for w in guard_warnings:
+                click.echo(f"  - {w.message}", err=True)
 
 
 @cli.command(name="render-many")

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -83,6 +83,7 @@ from nf_metro.layout.phases.spacing import (
 from nf_metro.parser.model import (
     LineSpread,
     MetroGraph,
+    PermissiveGuardWarning,
     Port,
     PortSide,
     Section,
@@ -5497,7 +5498,7 @@ def assert_render_layout_invariants(
     )
     if strict:
         raise LayoutInvariantError(msg)
-    warnings.warn(msg, stacklevel=2)
+    warnings.warn(msg, category=PermissiveGuardWarning, stacklevel=2)
 
 
 def render_header_collision(graph: MetroGraph) -> bool:
@@ -5537,4 +5538,4 @@ def assert_render_header_clearance(graph: MetroGraph, *, strict: bool = False) -
     )
     if strict:
         raise LayoutInvariantError(msg)
-    warnings.warn(msg, stacklevel=2)
+    warnings.warn(msg, category=PermissiveGuardWarning, stacklevel=2)

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -69,7 +69,14 @@ from nf_metro.layout.routing.common import (
     vertical_direction,
     vertical_flow_sections,
 )
-from nf_metro.parser.model import Edge, MetroGraph, PortSide, Section, Station
+from nf_metro.parser.model import (
+    Edge,
+    MetroGraph,
+    PermissiveGuardWarning,
+    PortSide,
+    Section,
+    Station,
+)
 
 # Segments shorter than this are sub-pixel artefacts of per-line
 # offsets and carry no meaningful direction of travel.
@@ -4395,7 +4402,9 @@ def assert_render_curve_invariants(
     through the builder too -- not to relax the check.
 
     Set ``NF_METRO_ALLOW_BAD_CURVES=1`` to downgrade to a warning (debugging a
-    work-in-progress handler only; not a supported render mode).
+    work-in-progress handler only; not a supported render mode). ``graph.permissive``
+    (``--permissive`` / ``%%metro permissive:``) downgrades the same way, as a
+    supported best-effort render mode.
 
     A layout that bridges a perpendicular connection across grid columns (a
     ``direction:`` override -- explicit or inferred -- that feeds a section's
@@ -4501,8 +4510,8 @@ def assert_render_curve_invariants(
         "concentric_corner_radius_at and fan every leg consistently.\n  "
         f"{detail}"
     )
-    if os.environ.get("NF_METRO_ALLOW_BAD_CURVES"):
-        warnings.warn(msg, stacklevel=2)
+    if graph.permissive or os.environ.get("NF_METRO_ALLOW_BAD_CURVES"):
+        warnings.warn(msg, category=PermissiveGuardWarning, stacklevel=2)
         return
     bridged = sorted(graph._cross_column_perp_bridges)
     if bridged:

--- a/src/nf_metro/options.py
+++ b/src/nf_metro/options.py
@@ -228,6 +228,13 @@ LAYOUT_OPTIONS: tuple[LayoutOption, ...] = (
         "geometry as an error (non-zero exit) instead of a warning.",
     ),
     LayoutOption(
+        name="permissive",
+        kind="bool",
+        help="Downgrade layout/render guard failures to warnings and render "
+        "best-effort on whatever geometry was computed, instead of aborting "
+        "with no output. Overrides --strict.",
+    ),
+    LayoutOption(
         name="auto_process",
         kind="bool",
         parse_time=True,

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Literal, TypedDict
@@ -14,6 +15,31 @@ class RowGridInfo(TypedDict):
     slot_count: int
     slot_spacing: float
     max_y_pad: float
+
+
+class PermissiveGuardWarning(UserWarning):
+    """A layout/render guard failure downgraded to a warning under ``graph.permissive``.
+
+    Distinct from an ordinary :class:`UserWarning` so a caller collecting
+    warnings (the CLI's ``--permissive`` report, the playground) can tell a
+    guard downgrade apart from an unrelated warning raised during the same
+    render.
+    """
+
+
+def split_guard_warnings(
+    caught: list[warnings.WarningMessage],
+) -> tuple[list[warnings.WarningMessage], list[warnings.WarningMessage]]:
+    """Split a ``warnings.catch_warnings(record=True)`` capture by category.
+
+    Returns ``(guard_warnings, other_warnings)``: entries categorised
+    :class:`PermissiveGuardWarning` (a guard downgrade), and everything else,
+    so a caller can report the former distinctly and replay the latter
+    through the normal warning printer (``warnings.showwarning``).
+    """
+    guard = [w for w in caught if issubclass(w.category, PermissiveGuardWarning)]
+    other = [w for w in caught if not issubclass(w.category, PermissiveGuardWarning)]
+    return guard, other
 
 
 @dataclass
@@ -433,6 +459,10 @@ class MetroGraph:
     animate: bool = False
     directional: bool = False
     strict: bool = False
+    # When True, a layout/render guard failure is downgraded to a UserWarning
+    # and the render proceeds best-effort on whatever geometry exists, instead
+    # of aborting with no output. Takes precedence over strict.
+    permissive: bool = False
     embed_manifest: bool = True
     # Whether a render will actually draw a title/logo band at the canvas
     # top for a titled map. Set by prepare_graph (from --bare, %%metro

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -618,8 +618,11 @@ def _settle_render_geometry(
 
     station_offsets = compute_station_offsets(graph, offset_step=offset_step)
     routes = route_edges_centred(graph, station_offsets=station_offsets)
+    effective_strict = graph.strict and not graph.permissive
     assert_render_curve_invariants(graph, routes, station_offsets)
-    assert_render_layout_invariants(graph, routes, station_offsets, strict=graph.strict)
+    assert_render_layout_invariants(
+        graph, routes, station_offsets, strict=effective_strict
+    )
 
     labels = _place(station_offsets, routes)
     if render_header_collision(graph) and not graph.has_rail_sections:
@@ -632,7 +635,7 @@ def _settle_render_geometry(
         routes = route_edges_centred(graph, station_offsets=station_offsets)
         labels = _place(station_offsets, routes)
         assert_render_curve_invariants(graph, routes, station_offsets)
-    assert_render_header_clearance(graph, strict=graph.strict)
+    assert_render_header_clearance(graph, strict=effective_strict)
     return station_offsets, routes, labels
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,9 +13,12 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+import nf_metro.api as api_module
 from nf_metro.api import RenderConfig, prepare_graph, render_string
 from nf_metro.cli import cli
+from nf_metro.layout import PhaseInvariantError
 from nf_metro.parser import CyclicGraphError
+from nf_metro.parser.model import PermissiveGuardWarning
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES = REPO_ROOT / "examples"
@@ -102,6 +105,26 @@ def test_render_string_propagates_layout_error() -> None:
     )
     with pytest.raises(CyclicGraphError):
         render_string(cyclic)
+
+
+def test_prepare_graph_permissive_downgrades_phase_invariant_error(monkeypatch) -> None:
+    """A layout guard failure aborts ``prepare_graph`` by default; under
+    ``permissive`` it is downgraded to a warning and the partially-laid-out
+    graph is returned instead, for a caller-side best-effort render."""
+    mmd = "%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n"
+
+    def _boom(graph, *args, **kwargs) -> None:
+        graph.stations["n1"].x = 42.0
+        raise PhaseInvariantError("synthetic guard trip")
+
+    monkeypatch.setattr(api_module, "compute_layout", _boom)
+
+    with pytest.raises(PhaseInvariantError, match="synthetic guard trip"):
+        prepare_graph(mmd)
+
+    with pytest.warns(PermissiveGuardWarning, match="synthetic guard trip"):
+        graph = prepare_graph(mmd, layout_options={"permissive": True})
+    assert graph.stations["n1"].x == 42.0
 
 
 def _data_uri_logo_mmd(logo_directive: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,6 +274,35 @@ def test_render_unexpected_exception_reraises_under_debug_env(tmp_path, monkeypa
     assert isinstance(result.exception, KeyError)
 
 
+def test_render_permissive_flag_reports_downgraded_guards(tmp_path, monkeypatch):
+    """``--permissive`` renders through a guard warning instead of aborting,
+    and reports what was downgraded on stderr."""
+    import warnings
+
+    from nf_metro.api import render_graph as real_render_graph
+    from nf_metro.parser.model import PermissiveGuardWarning
+
+    def _render_graph_with_warning(*args, **kwargs):
+        warnings.warn(
+            "synthetic guard trip for CLI test",
+            category=PermissiveGuardWarning,
+            stacklevel=2,
+        )
+        return real_render_graph(*args, **kwargs)
+
+    monkeypatch.setattr("nf_metro.cli.render_graph", _render_graph_with_warning)
+    src = tmp_path / "a.mmd"
+    src.write_text(RNASEQ_MMD.read_text())
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["render", "--permissive", str(src), "-o", str(tmp_path / "out.svg")]
+    )
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "out.svg").exists()
+    assert "--permissive: 1 guard(s) downgraded" in result.output
+    assert "synthetic guard trip for CLI test" in result.output
+
+
 def test_render_multiple_files(tmp_path):
     """render accepts more than one INPUT_FILE, each to its own sibling output."""
     a = tmp_path / "a.mmd"

--- a/tests/test_offset_regime.py
+++ b/tests/test_offset_regime.py
@@ -40,7 +40,7 @@ from nf_metro.layout.routing.invariants import (
     check_deferred_offsets_apply_laterally,
 )
 from nf_metro.parser.mermaid import parse_metro_mermaid
-from nf_metro.parser.model import Edge
+from nf_metro.parser.model import Edge, PermissiveGuardWarning
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXAMPLES = REPO_ROOT / "examples"
@@ -162,4 +162,15 @@ def test_planted_vertical_deferred_offset_aborts_render_path() -> None:
 
     _plant_vertical_deferred_offset(routes, offsets)
     with pytest.raises(CurveInvariantError, match="deferred route offset"):
+        assert_render_curve_invariants(graph, routes, offsets)
+
+
+def test_planted_vertical_deferred_offset_permissive_downgrades_to_warning() -> None:
+    """``graph.permissive`` downgrades the same defect to a warning instead of
+    aborting, letting a caller render the defective geometry best-effort."""
+    graph, routes, offsets = _route(FIXTURES / "rnaseq_sections.mmd")
+    _plant_vertical_deferred_offset(routes, offsets)
+
+    graph.permissive = True
+    with pytest.warns(PermissiveGuardWarning, match="deferred route offset"):
         assert_render_curve_invariants(graph, routes, offsets)

--- a/tests/test_render_layout_invariants.py
+++ b/tests/test_render_layout_invariants.py
@@ -40,7 +40,7 @@ from nf_metro.layout.routing.invariants import (
     _route_axis_segments,
 )
 from nf_metro.parser.mermaid import parse_metro_mermaid
-from nf_metro.parser.model import MetroGraph
+from nf_metro.parser.model import MetroGraph, PermissiveGuardWarning
 from nf_metro.render import render_svg
 from nf_metro.themes import THEMES
 
@@ -94,6 +94,16 @@ def test_injected_violation_warns_by_default(name: str) -> None:
     graph = _laid_out(name)
     _inject_coincident_stations(graph)
     with pytest.warns(UserWarning, match="Tier-A invariants"):
+        render_svg(graph, THEMES["nfcore"])
+
+
+@pytest.mark.parametrize("name", CLEAN_FIXTURES)
+def test_injected_violation_warning_is_a_permissive_guard_warning(name: str) -> None:
+    """The default-path warning is categorised so a ``--permissive`` caller can
+    tell a guard downgrade apart from an unrelated warning raised mid-render."""
+    graph = _laid_out(name)
+    _inject_coincident_stations(graph)
+    with pytest.warns(PermissiveGuardWarning, match="Tier-A invariants"):
         render_svg(graph, THEMES["nfcore"])
 
 
@@ -198,7 +208,7 @@ def test_render_header_clearance_guard_fires_under_strict() -> None:
 
     with pytest.raises(LayoutInvariantError, match="section header over the box"):
         assert_render_header_clearance(graph, strict=True)
-    with pytest.warns(UserWarning, match="section header over the box"):
+    with pytest.warns(PermissiveGuardWarning, match="section header over the box"):
         assert_render_header_clearance(graph, strict=False)
 
 

--- a/website/public/playground/app.js
+++ b/website/public/playground/app.js
@@ -55,12 +55,20 @@ const SAMPLE_NEXTFLOW_DAG = `flowchart TB
 // coordinates, so changing them skips layout and only re-runs render_svg.
 // The style: and mode: directives are stripped before hashing so toggling brand
 // or render mode doesn't bust the geometry cache.
+//
+// permissive is always forced on (see currentOptions()): a guard failure
+// downgrades to a PermissiveGuardWarning and the render proceeds best-effort,
+// instead of the whole editor going blank on one bad topology. Warnings are
+// collected per-call (never accumulated onto the cached graph) and returned
+// alongside the svg so the UI can show both.
 const PY_GLUE = `
 import hashlib
 import json
 import re as _re
+import warnings
 from nf_metro.api import prepare_graph, resolve_theme
 from nf_metro.convert import convert_nextflow_dag
+from nf_metro.parser.model import PermissiveGuardWarning, split_guard_warnings
 from nf_metro.render import render_svg
 
 _cached_graph = None
@@ -79,29 +87,37 @@ def nfm_render(mmd, opts_json):
     mmd_norm = _STYLE_RE.sub("", mmd).strip()
     cache_key = hashlib.md5((mmd_norm + "\\x00" + json.dumps(layout_geom, sort_keys=True)).encode()).hexdigest()
 
-    try:
-        if cache_key != _cached_key:
-            graph = prepare_graph(mmd, layout_options=layout_geom)
-            _cached_graph = graph
-            _cached_key = cache_key
-        else:
-            graph = _cached_graph
+    svg = None
+    error = None
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.filterwarnings("always", category=PermissiveGuardWarning)
+        try:
+            if cache_key != _cached_key:
+                graph = prepare_graph(mmd, layout_options=layout_geom)
+                _cached_graph = graph
+                _cached_key = cache_key
+            else:
+                graph = _cached_graph
 
-        for k, v in render_only.items():
-            setattr(graph, k, bool(v))
+            for k, v in render_only.items():
+                setattr(graph, k, bool(v))
 
-        theme_obj = resolve_theme(opts.get("theme") or None, graph, mode=opts.get("mode") or None)
-        svg = render_svg(
-            graph,
-            theme_obj,
-            debug=bool(opts.get("debug")),
-            responsive=True,
-            font_portability="embed",
-            self_color_scheme=False,
-        )
-        return json.dumps({"ok": True, "svg": svg})
-    except Exception as e:
-        return json.dumps({"ok": False, "error": f"{type(e).__name__}: {e}"})
+            theme_obj = resolve_theme(opts.get("theme") or None, graph, mode=opts.get("mode") or None)
+            svg = render_svg(
+                graph,
+                theme_obj,
+                debug=bool(opts.get("debug")),
+                responsive=True,
+                font_portability="embed",
+                self_color_scheme=False,
+            )
+        except Exception as e:
+            error = f"{type(e).__name__}: {e}"
+
+    guard_warnings = [str(w.message) for w in split_guard_warnings(caught)[0]]
+    if svg is not None:
+        return json.dumps({"ok": True, "svg": svg, "warnings": guard_warnings})
+    return json.dumps({"ok": False, "error": error, "warnings": guard_warnings})
 
 def nfm_convert(nextflow_dag):
     try:
@@ -236,6 +252,10 @@ function currentOptions() {
     layout_options: {
       animate: el("opt-animate").checked,
       directional: el("opt-directional").checked,
+      // Always on: a guard failure on a novel/edge-case topology should
+      // still produce a render (with a visible warning) instead of leaving
+      // the preview blank.
+      permissive: true,
     },
   };
 }
@@ -270,14 +290,25 @@ function doRender() {
       return;
     }
     el("preview").classList.remove("rendering");
-    if (res.ok) {
-      showError(null);
+    // permissive mode means a guard failure can still hand back an svg (of the
+    // defective geometry) alongside the warning(s) it downgraded, so the two
+    // are reported independently rather than one replacing the other.
+    if (res.svg) {
       lastSvg = res.svg;
       el("preview").innerHTML = res.svg;
       applyZoom();
+    }
+    const warnings =
+      res.warnings && res.warnings.length ? res.warnings.join("\n\n") : "";
+    if (!res.ok) {
+      // No svg at all (or a fatal error on top of any downgraded guards):
+      // keep the last good render visible and report everything we know.
+      const parts = warnings ? [warnings, res.error] : [res.error];
+      showError(friendlyRenderError(parts.join("\n\n")));
+    } else if (warnings) {
+      showError(friendlyRenderError(warnings));
     } else {
-      // Keep the last good render visible; just report the problem.
-      showError(friendlyRenderError(res.error));
+      showError(null);
     }
     refreshLineColors();
     syncDirectiveControls();


### PR DESCRIPTION
## Summary
- Adds a `permissive` field on `MetroGraph`, exposed as `--permissive` on `nf-metro render` and `%%metro permissive:` in source, mirroring the existing `strict` option.
- Under `permissive`, a layout-phase guard failure (`PhaseInvariantError`) is caught in `prepare_graph` and downgraded to a `PermissiveGuardWarning` instead of aborting, so the caller gets back whatever geometry the engine computed before the failing phase for a best-effort render attempt.
- The render-path guard chokepoints (curve invariants, Tier-A layout invariants, section-header clearance) downgrade to the same warning category under `permissive` (curve invariants previously needed the `NF_METRO_ALLOW_BAD_CURVES` env var; the two Tier-A checks already warned by default under `strict=False`, now correctly tagged so they're reported instead of silently blending into unrelated warnings).
- `nf-metro render --permissive` reports every downgraded guard in a labelled block on stderr, and replays any other warning through the normal printer unaffected.
- The browser playground always renders permissively now: a guard failure on a novel or edge-case topology shows the best-effort SVG *and* an error banner together, instead of leaving the preview blank with just a popup.
- Adds a shared `split_guard_warnings()` helper (`nf_metro/parser/model.py`) used by both the CLI and the playground's embedded Pyodide glue.

## Test plan
- [x] `pytest` (full suite): 35795 passed, 121 skipped, 11 xfailed — no regressions
- [x] New unit tests: `prepare_graph` permissive downgrade (`test_api.py`), curve-invariant downgrade (`test_offset_regime.py`), Tier-A/header-clearance category tagging (`test_render_layout_invariants.py`), CLI `--permissive` reporting (`test_cli.py`)
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean
- [x] Manual smoke test of the extracted playground Pyodide glue confirming: a clean render, a simulated guard downgrade (svg + warning both returned), a true failure (no svg, clean error, no crash), and no warning accumulation across cached-graph re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)