### PR TITLE
docs(fix-issue skill): require explicit model param, no silent opus inherit

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -41,14 +41,23 @@ loaded.
   needing its own worktree, or requiring you to load unfamiliar code is
   **not, by itself**, a reason to defer.
 - Use the `Agent` tool to protect your own context budget while doing this,
-  not as a reason to skip it. Hand each piece of fallout to a `sonnet`
-  subagent by default, or `opus` when the triage or fix genuinely needs
-  harder judgment; run agents in the background (or a separate worktree, per
-  the global worktree rule, if the fallout touches files you're not actively
-  editing) and fold results back in before the session ends. Independent
-  pieces of fallout can run as concurrent subagents instead of serially
-  eating your own context - that's what makes taking on a different
-  subsystem's fix tractable in the same session.
+  not as a reason to skip it. **Always pass an explicit `model` param on the
+  `Agent` call - never omit it and let the child silently inherit the
+  session's model.** Omitting `model` is not "no decision was made", it's
+  "opus got picked by default without anyone deciding that." Default to
+  `model: "sonnet"`; set `model: "opus"` only when you decide *before
+  spawning* that the triage or fix genuinely needs harder judgment, and say
+  so in one line when you do. If you notice after the fact that a child ran
+  on opus with no `model` param set, that's a mistake to correct (restart it
+  on sonnet), not a choice to defend - don't rationalize keeping it because
+  the task turned out to suit opus in hindsight; that judgment call has to
+  happen at spawn time, explicitly, or not at all. Run agents in the
+  background (or a separate worktree, per the global worktree rule, if the
+  fallout touches files you're not actively editing) and fold results back
+  in before the session ends. Independent pieces of fallout can run as
+  concurrent subagents instead of serially eating your own context - that's
+  what makes taking on a different subsystem's fix tractable in the same
+  session.
 - "Resolved in this session" does not mean "crammed into one PR." If folding
   the fallout into the primary PR would make it harder to review, ship it as
   its own sibling PR instead. The bar is that the fallout's PR gets built,


### PR DESCRIPTION
## Summary
- The fix-issue skill told agents to hand fallout to sonnet "by default", but the actual `Agent` tool call omitted `model`, so the child silently inherited the session's model (opus) instead
- When asked about it, the agent then rationalized keeping opus post-hoc rather than treating the missing decision as a mistake
- Updated the scope-discipline delegation guidance to require an explicit `model` param on every `Agent` call, and to make clear that a model choice has to happen at spawn time, not be justified in hindsight

## Test plan
- [x] Docs-only change, no code/tests affected