### PR TITLE
fix(routing): anchor the leftward bypass-fan channel on the source's own cell-mate

### DIFF
--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -2096,7 +2096,15 @@ def _route_bypass(
             ui, un = fan
             fan_delta = l_shape_stagger(ui, un, gap1_vertical, ctx.offset_step)
             near = sx - ctx.curve_radius - (un - 1) * ctx.offset_step / 2
-            slot = _gap_channel_base(graph, src_col - 1, src_row, un, ctx.offset_step)
+            slot = _gap_channel_base(
+                graph,
+                src_col - 1,
+                src_row,
+                un,
+                ctx.offset_step,
+                anchor_section_id=src_sec_id,
+                anchor_side=PortSide.LEFT,
+            )
             fan_mid_x = min(near, slot)
             off1 = fan_delta
             gap1_x = fan_mid_x + fan_delta

--- a/tests/data/routing_gate_coverage_baseline.json
+++ b/tests/data/routing_gate_coverage_baseline.json
@@ -208,6 +208,7 @@
   "normalize.py::if abs(dx) > COORD_TOLERANCE:::#1",
   "normalize.py::if abs(ly - pts[1][1]) < COORD_TOLERANCE:::#1",
   "normalize.py::if abs(x3 - x2) > COORD_TOLERANCE or abs(y3 - y2) <= COORD_TOLERANCE:::#1",
+  "normalize.py::if anchor_section_id is not None and anchor_side is not None:::#1",
   "normalize.py::if any(::#3",
   "normalize.py::if any(::#4",
   "normalize.py::if band is not None:::#1",

--- a/tests/data/routing_gate_triage.json
+++ b/tests/data/routing_gate_triage.json
@@ -527,6 +527,10 @@
     "note": "Every non-exempt inter-section route ends with a vertical descent into the target Y then a short horizontal port lead (V->H tail); routes with non-V tails are normalize_exempt. The second-to-last-not-vertical reject in _final_port_approach is unreachable. Reclassified candidate-dead -> defensive (#762): corpus instrumentation across 128 fixtures confirms the un-exercised arm is never taken.",
     "status": "defensive"
   },
+  "normalize.py::if anchor_section_id is not None and anchor_side is not None:::#1": {
+    "note": "_gap_channel_base falls back to the column gap when passed a null anchor. All six call sites (in _route_bypass) pass the bypass source/target section id, which is None only when that endpoint has no resolvable section (src_sec_id/tgt_sec_id in _route_bypass); the corpus has no bypass with a sectionless endpoint, so the null-anchor arm is never taken. Defensive guard for a sectionless bypass endpoint.",
+    "status": "defensive"
+  },
   "normalize.py::if any(::#4": {
     "note": "In _bundle_divergent_distinct_traverses: the section-cross veto. No corpus fan would re-band a traverse across a foreign section, so the veto arm is never taken. Defensive.",
     "status": "defensive"


### PR DESCRIPTION
## What

In `_route_bypass`, the going-**left** branch of the bypass-fan gap channel computed its descent X from the raw column gap, while the going-**right** fan branch and **both** non-fan branches anchor the channel on the source section's packed cell-mate (`_gap_channel_base(..., anchor_section_id=src_sec_id, anchor_side=...)`).

This mirrors the leftward fan branch to the same behaviour, anchoring on the source section with a `LEFT` facing side.

## Why

When the bypass source sits in a packed cell (`%%metro grid: a, b | col,row`) with a cell-mate on its **left**, the column-level gap reaches *past* that cell-mate. The unanchored channel could then land beyond the cell-mate instead of hugging the source's own cell, dropping the descent into the wrong gap. Anchoring on the cell-mate keeps the descent against the source section, the same correction the going-right branch already makes.

## Gate-coverage baseline

With this branch anchored, all six `_gap_channel_base` call sites now pass a section id, so the null-anchor arm of the function's `if anchor_section_id is not None and anchor_side is not None:` guard is no longer reached by the corpus. That arm stays a live guard for a bypass whose source/target has no resolvable section, so it is recorded as a **defensive** gap in the routing gate-coverage baseline and triage sidecar (rather than weakening the ratchet).

## Safety

- The anchor is a **no-op unless a left cell-mate exists**, so output is **byte-identical across the entire `examples/` + `examples/topologies/` corpus** (confirmed locally and by the CI render-diff, zero differences).
- Full CI suite green across Python 3.11 / 3.12 / 3.13, including the routing gate-coverage ratchet.

## Testing

- No dedicated regression fixture: every minimal topology that exercises this branch with a triggering left cell-mate also trips a **separate, pre-existing** merge-feeder routing abort, filed as #1495. Once that is fixed a clean fixture can be added to lock this in.
