### PR TITLE
Add JSON Schema and normative doc for the live state snapshot

### DIFF
--- a/docs/live.mdx
+++ b/docs/live.mdx
@@ -148,8 +148,20 @@ the same standard any non-metro tool can emit. Set `%%metro manifest: false`
 (or `--no-manifest`) to emit the drawn map only, with no manifest, no
 `data-node-*` attributes, and no station-group wrapper.
 
-`serve` is one ready-made consumer of that manifest. To drive the overlay from
-your **own** application instead, see the [Embedding guide](/nf-metro/embedding/).
+The manifest is only the static half of the contract. The **runtime state**
+this section drives an overlay from - the `pending`/`queued`/`running`/`done`/
+`failed` enum, the `done`/`total` counts, and the snapshot JSON shape `GET
+/state` and `/stream` below serve - is specified normatively, with its own
+JSON Schema, in [Data manifest → Drive a live
+overlay](/nf-metro/manifest/#drive-a-live-overlay-the-state-snapshot).
+Everything in this page below that point (the weblog receiver, `serve`, the
+Nextflow plugin) is **one binding** of that vocabulary to Nextflow; a host
+that already has its own authoritative task state needs only the manifest and
+the state schema, not this server.
+
+`serve` is one ready-made consumer of the manifest and one reference
+producer of the state snapshot. To drive the overlay from your **own**
+application instead, see the [Embedding guide](/nf-metro/embedding/).
 
 ## 2. Serve the map
 
@@ -247,12 +259,16 @@ switching style never re-renders the map. Animations respect
 
 ### Endpoints
 
-| Path           | Purpose                                                |
-| -------------- | ------------------------------------------------------ |
-| `GET /`        | The live page (static SVG + status overlay).           |
-| `GET /stream`  | Server-sent events; the page subscribes to this.       |
-| `GET /state`   | Current state as JSON (handy for scripting/debugging). |
-| `POST /events` | Nextflow weblog receiver.                              |
+| Path           | Purpose                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| `GET /`        | The live page (static SVG + status overlay).                                               |
+| `GET /stream`  | Server-sent events; the page subscribes to this. Each event's `data:` is a state snapshot. |
+| `GET /state`   | Current state snapshot as JSON (handy for scripting/debugging).                            |
+| `POST /events` | Nextflow weblog receiver.                                                                  |
+
+`/state` and each `/stream` message share one JSON shape - the [state
+snapshot](/nf-metro/manifest/#drive-a-live-overlay-the-state-snapshot), validatable
+via `nf_metro.live.state_schema()`.
 
 ## 2b. Persistent server (many runs)
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -329,10 +329,12 @@ each regex case-insensitively against the target, collecting the `id`s that hit.
 `matching_node_ids` is the same matcher over a plain `id -> [pattern]` mapping,
 for a producer whose data isn't manifest-shaped.
 
-## Drive a live overlay
+## Drive a live overlay: the state snapshot
 
-Everything above defines the compatibility contract; the state model below is
-optional convention. A consumer that only needs static addressing can stop here.
+Everything above defines the static compatibility contract (geometry and
+addressing); this section defines the second, optional half - **the runtime
+state vocabulary** a progress overlay is driven from. A consumer that only
+needs static addressing can stop at the manifest and skip this section.
 
 :::tip[Worked example]
 The [tutorial](#tutorial-light-up-a-diagram-as-a-job-runs) at the end of this
@@ -342,28 +344,138 @@ end to end, in ~40 lines.
 
 The manifest gives an overlay everything it needs without a re-render: the
 `viewBox` to share, and each node's `id`, centre, and radius. **The standard
-fixes the geometry and the addressing, not the visual style** - how you draw
-"running" vs "done" is yours.
+fixes the geometry, the addressing, and the state vocabulary below - not the
+visual style.** How you draw "running" vs "done" (a halo, a badge, a colour
+change on the node itself) is yours.
 
-A common shape for progress is a small per-node state model:
+### How the pieces fit together
 
-| Field            | Meaning                                                                                                                                      |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `state`          | One of `pending`, `queued`, `running`, `done`, `failed`.                                                                                     |
-| `done` / `total` | Tasks finished vs seen so far for that node. Nextflow's task count is dynamic, so this is "done / submitted so far", not a fixed percentage. |
+Three layers, each narrower than the last:
 
-plus a run-level `{ name, state }` where `state` is `idle` / `running` /
-`complete` / `error`.
+1. **The standard** - this manifest schema plus the state snapshot schema
+   below. Tool-neutral; any producer can emit it.
+2. **A binding** - turns one runtime's native events into the state snapshot.
+   nf-metro ships one binding for Nextflow: the `-with-weblog` HTTP receiver
+   (`nf-metro serve`) and, optionally, the
+   [nf-metro Nextflow plugin](https://github.com/seqeralabs/nf-metro-plugin)
+   that wires it up from pipeline config. A binding for another workflow
+   engine or CI system would translate that system's own events into the same
+   snapshot shape instead.
+3. **nf-metro itself** - one _producer_ of conforming SVGs, and the author of
+   the one binding above. A consumer that already owns authoritative task
+   state (for example, a platform that tracks a run's tasks directly) needs
+   only layer 1 - the manifest and this state vocabulary - not the weblog
+   server or the plugin.
 
-nf-metro's `serve` is **one reference implementation** of this: it draws a glowing
-LED halo per node and recolours it by state (see [Live progress](/nf-metro/live/)). A
-host application is free to map the same state vocabulary onto its own visual
-language - filled badges, a progress bar, a colour change on the node itself.
-Take the geometry and the state model from the standard; bring your own paint.
+### The snapshot shape
 
-To turn a specific runtime's events into that state model, write a binding.
-nf-metro ships one for Nextflow's `-with-weblog` stream; that path, the server,
-and the Nextflow plugin are documented under [Live progress](/nf-metro/live/).
+A **snapshot** is the full progress picture at one instant: every node's
+display state plus the run's own lifecycle state. nf-metro's live server
+serves one as `GET /state`, and pushes a fresh one as the `data:` payload of
+every Server-Sent Event on `GET /stream`:
+
+```json
+{
+  "run": { "name": "grave_babbage", "state": "running" },
+  "stations": {
+    "trim": { "state": "done", "done": 2, "total": 2 },
+    "qc": { "state": "running", "done": 0, "total": 1 }
+  }
+}
+```
+
+- **`stations`** is keyed by node id - the same `id` as a manifest node /
+  `data-node-id`, so a consumer joins the two without any translation. A node
+  the runtime hasn't reported on yet is simply absent from a hand-built
+  snapshot, or present with `{state: "pending", done: 0, total: 0}` in
+  nf-metro's own server (it pre-populates every mapped node so a fresh
+  subscriber never sees a missing key).
+- **`run`** is one lifecycle value for the whole snapshot, not per-node.
+
+A machine-readable **JSON Schema** (draft 2020-12) ships with the package
+(`nf_metro/live/state_schema.json`); `state_schema()` returns it as a dict,
+mirroring `manifest_schema()`:
+
+```python
+import jsonschema
+from nf_metro.live import state_schema
+
+jsonschema.validate(snapshot, state_schema())   # raises ValidationError if it doesn't conform
+```
+
+Unlike the manifest, **no `version` field travels inside the snapshot
+itself** - it's a live response, not a durable artifact committed to a repo.
+The schema file is versioned on disk (`STATE_SCHEMA_VERSION`, currently
+`"1.0"`) and evolves under the identical forward-compatibility rule as the
+manifest (below).
+
+### The state enum and its transitions
+
+Each station's `state` is one of:
+
+| State     | Meaning                                                                                                                                                                              |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pending` | No task has been submitted for this node yet. The initial value.                                                                                                                     |
+| `queued`  | At least one task has been submitted; none of them is running yet. `done` may already be greater than 0 if an earlier task for the same node finished before this one was submitted. |
+| `running` | At least one task for this node is currently running.                                                                                                                                |
+| `done`    | Every task submitted for this node reached a terminal status, and none of them failed.                                                                                               |
+| `failed`  | **Sticky** - once any task for this node has failed, it reports `failed` for the rest of the run, even if other tasks for the same node are later running or complete.               |
+
+The precedence a producer must apply when several conditions hold at once is
+`failed` > `running` > `queued` > `done` > `pending` (checked in that order):
+a node with one failed task and another still running still reads `failed`,
+never `running`.
+
+### `done` / `total` semantics
+
+- **`total`** is the count of tasks submitted so far for this node in the
+  current run - not a fixed denominator. A workflow engine's task count for a
+  node is dynamic (a scatter over samples, say), so `total` only ever
+  reflects what has been _seen_ so far, and can still grow after the node
+  starts reporting `running`.
+- **`done`** is the count of tasks that reached a _successful_ terminal
+  status for this node so far. A failed task is not counted in `done`.
+- Both are cumulative across the run and only ever reset by a fresh `started`
+  event (below) - they never decrease mid-run.
+
+### Run lifecycle
+
+The `run` object's `state` is one lifecycle shared by the whole snapshot:
+
+| State      | Meaning                                                                     |
+| ---------- | --------------------------------------------------------------------------- |
+| `idle`     | No run has reported in yet. The initial value; `name` is `null`.            |
+| `running`  | A run announced itself has started, and no terminal event has followed yet. |
+| `complete` | The run finished successfully.                                              |
+| `error`    | The run (or the binding reporting it) signalled a failure.                  |
+
+**Only a fresh `started`-equivalent event moves a run off `complete` or
+`error`**, and doing so resets every station back to `pending`/`0`/`0` - so
+re-running the same pipeline re-animates a clean map rather than layering a
+new run's progress on top of the last one's leftovers.
+
+### Forward compatibility
+
+Identical rule to the manifest: **consumers MUST ignore unknown fields**, so
+a producer can add fields to `run`, to a station entry, or a wholly new
+top-level key without breaking an existing reader. A change that is not
+purely additive (removing a field, changing an enum's existing members,
+changing `done`/`total` semantics) is a breaking change and bumps the schema
+file's own version and nf-metro's major version together, exactly as for the
+manifest.
+
+### Bring your own binding
+
+nf-metro's `serve` is **one reference implementation**: it turns Nextflow's
+`-with-weblog` task events into the snapshot above (`process_submitted` →
+`queued`, `process_started` → `running`, `process_completed` → `done` or
+`failed` depending on status), then draws a glowing halo per node and
+recolours it by state (see [Live progress](/nf-metro/live/)). A host
+application is free to write its **own** binding from its own runtime's
+events to this same snapshot shape, and to map the state vocabulary onto its
+own visual language - filled badges, a progress bar, a colour change on the
+node itself. Take the geometry (manifest) and the state vocabulary (this
+section) from the standard; bring your own events and your own paint.
 
 ## Tutorial: light up a diagram as a job runs
 

--- a/src/nf_metro/live/__init__.py
+++ b/src/nf_metro/live/__init__.py
@@ -7,8 +7,9 @@ may change without notice.
 The :mod:`~nf_metro.live.mapping` module holds the pure station<->process
 matching and the check-mapping linter; :mod:`~nf_metro.live.server` holds the
 HTTP/SSE server that drives a status overlay from Nextflow ``-with-weblog``
-events. Both are wired to the ``nf-metro serve`` and ``nf-metro check-mapping``
-CLI commands.
+events, aggregating task events into the state snapshot described by
+:mod:`~nf_metro.live.schema`. Both are wired to the ``nf-metro serve`` and
+``nf-metro check-mapping`` CLI commands.
 """
 
 from nf_metro.live.mapping import (
@@ -17,10 +18,13 @@ from nf_metro.live.mapping import (
     process_names_from_dag,
     stations_for_process,
 )
+from nf_metro.live.schema import STATE_SCHEMA_VERSION, state_schema
 
 __all__ = [
     "MappingReport",
+    "STATE_SCHEMA_VERSION",
     "check_mapping",
     "process_names_from_dag",
+    "state_schema",
     "stations_for_process",
 ]

--- a/src/nf_metro/live/schema.py
+++ b/src/nf_metro/live/schema.py
@@ -1,0 +1,27 @@
+"""Access to the JSON Schema describing a live state snapshot."""
+
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+from typing import Any
+
+# This file's own version, tracked alongside nf_metro.manifest.MANIFEST_SCHEMA_VERSION.
+# No version field is embedded in the snapshot itself (see state_schema.json); a
+# breaking change to this schema bumps this constant and nf-metro's major version
+# together.
+STATE_SCHEMA_VERSION = "1.0"
+
+
+def state_schema() -> dict[str, Any]:
+    """Return the JSON Schema (draft 2020-12) for a live state snapshot.
+
+    The machine-readable form of the vocabulary served by ``GET /state`` and
+    each Server-Sent Event on ``/stream``: validate any producer's snapshot
+    against it (in Python via ``jsonschema``, or in any language with a
+    standard validator). Shipped as ``state_schema.json`` beside this module
+    so it travels with the package.
+    """
+    text = files(__package__).joinpath("state_schema.json").read_text(encoding="utf-8")
+    schema: dict[str, Any] = json.loads(text)
+    return schema

--- a/src/nf_metro/live/state_schema.json
+++ b/src/nf_metro/live/state_schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pinin4fjords.github.io/nf-metro/state.schema.json",
+  "title": "Live state snapshot",
+  "description": "The runtime progress snapshot served by nf-metro's live server (GET /state, and each Server-Sent Event on /stream) - the state half of the live-diagram contract, paired with the diagram manifest (nf_metro/manifest/schema.json). A node's key here is the manifest's node.id / data-node-id join key. Tool-neutral and experimental (pre-1.0): unlike the manifest, no version field travels inside the snapshot itself, since it is a live response rather than a durable artifact; this schema file is versioned 1.0 and evolves under the same rule as the manifest - consumers MUST ignore unknown fields, and additive fields keep the same major version.",
+  "type": "object",
+  "required": ["run", "stations"],
+  "properties": {
+    "run": {
+      "type": "object",
+      "description": "Run-level lifecycle, reported once per snapshot regardless of station count.",
+      "required": ["name", "state"],
+      "properties": {
+        "name": {
+          "type": ["string", "null"],
+          "description": "The run name from the workflow engine's 'started' event, or null before any run has reported in."
+        },
+        "state": {
+          "enum": ["idle", "running", "complete", "error"],
+          "description": "idle: no run has reported in yet (the initial value). running: a 'started' event was received and no terminal event has followed. complete: a 'completed' event was received. error: an 'error' event was received. Only a fresh 'started' event moves off complete/error, resetting every station to pending."
+        }
+      }
+    },
+    "stations": {
+      "type": "object",
+      "description": "Per-node display state, keyed by node id. A node with no matching task events stays {state: pending, done: 0, total: 0}.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["state", "done", "total"],
+        "properties": {
+          "state": {
+            "enum": ["pending", "queued", "running", "done", "failed"],
+            "description": "pending: no task has been submitted for this node yet. queued: at least one task submitted, none yet running (done may already be > 0 if an earlier task for this node finished before a new one was submitted). running: at least one task currently running. done: every submitted task reached a terminal status and none failed. failed: sticky - once any task for this node fails, the node reports failed for the rest of the run even if other tasks for it are later running or complete."
+          },
+          "done": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of tasks that reached a successful terminal status for this node so far in the current run."
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of tasks submitted so far for this node in the current run. Not a fixed denominator: a workflow engine's task count for a node is dynamic, so this is 'done out of submitted so far', not a percentage of a known total."
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_live_state_schema.py
+++ b/tests/test_live_state_schema.py
@@ -1,0 +1,151 @@
+"""Schema conformance for the live progress snapshot.
+
+Mirrors ``tests/test_manifest.py``: the server's actually-emitted
+``ProgressState.snapshot()`` output is validated against the shipped JSON
+Schema (``nf_metro/live/state_schema.json``) at every stage of a run, so the
+schema cannot silently drift from what the server really produces.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import jsonschema
+import pytest
+from test_live_server import _ev, _model
+
+from nf_metro.live import STATE_SCHEMA_VERSION, state_schema
+from nf_metro.live.server import ProgressState
+
+
+def _assert_valid(snapshot: dict[str, Any]) -> None:
+    jsonschema.validate(snapshot, state_schema())
+
+
+def test_state_schema_has_expected_version() -> None:
+    schema = state_schema()
+    assert schema["required"] == ["run", "stations"]
+    assert STATE_SCHEMA_VERSION == "1.0"
+
+
+def test_initial_snapshot_validates() -> None:
+    state = ProgressState(_model())
+    snap = state.snapshot()
+    _assert_valid(snap)
+    assert snap["run"] == {"name": None, "state": "idle"}
+    assert snap["stations"]["trim"] == {"state": "pending", "done": 0, "total": 0}
+
+
+def test_run_lifecycle_snapshots_validate() -> None:
+    state = ProgressState(_model())
+    state.ingest({"event": "started", "runName": "r1"})
+    snap = state.snapshot()
+    _assert_valid(snap)
+    assert snap["run"] == {"name": "r1", "state": "running"}
+
+    state.ingest({"event": "completed"})
+    snap = state.snapshot()
+    _assert_valid(snap)
+    assert snap["run"]["state"] == "complete"
+
+    state.ingest({"event": "started", "runName": "r2"})
+    state.ingest({"event": "error"})
+    snap = state.snapshot()
+    _assert_valid(snap)
+    assert snap["run"] == {"name": "r2", "state": "error"}
+
+
+@pytest.mark.parametrize(
+    "events,expected",
+    [
+        pytest.param([], {"state": "pending", "done": 0, "total": 0}, id="pending"),
+        pytest.param(
+            [("process_submitted", 1, "TRIMGALORE", "SUBMITTED")],
+            {"state": "queued", "done": 0, "total": 1},
+            id="queued",
+        ),
+        pytest.param(
+            [
+                ("process_submitted", 1, "TRIMGALORE", "SUBMITTED"),
+                ("process_started", 1, "TRIMGALORE", "RUNNING"),
+            ],
+            {"state": "running", "done": 0, "total": 1},
+            id="running",
+        ),
+        pytest.param(
+            [
+                ("process_submitted", 1, "TRIMGALORE", "SUBMITTED"),
+                ("process_started", 1, "TRIMGALORE", "RUNNING"),
+                ("process_completed", 1, "TRIMGALORE", "COMPLETED"),
+            ],
+            {"state": "done", "done": 1, "total": 1},
+            id="done",
+        ),
+        pytest.param(
+            [
+                ("process_submitted", 1, "TRIMGALORE", "SUBMITTED"),
+                ("process_started", 1, "TRIMGALORE", "RUNNING"),
+                ("process_completed", 1, "TRIMGALORE", "FAILED"),
+            ],
+            {"state": "failed", "done": 0, "total": 1},
+            id="failed",
+        ),
+    ],
+)
+def test_every_display_state_validates(
+    events: list[tuple[str, int, str, str]], expected: dict[str, Any]
+) -> None:
+    state = ProgressState(_model())
+    for event, task_id, process, status in events:
+        state.ingest(_ev(event, task_id, process, status))
+    snap = state.snapshot()
+    _assert_valid(snap)
+    assert snap["stations"]["trim"] == expected
+
+
+def test_failed_state_is_sticky_and_keeps_validating() -> None:
+    """A station that ever fails stays failed even once a later task for it
+    runs and completes successfully - the sticky-failure rule the schema
+    documents must hold for the snapshot to keep validating too."""
+    state = ProgressState(_model())
+    state.ingest(_ev("process_started", 1, "TRIMGALORE", "RUNNING"))
+    state.ingest(_ev("process_completed", 1, "TRIMGALORE", "FAILED"))
+    state.ingest(_ev("process_submitted", 2, "TRIMGALORE", "SUBMITTED"))
+    state.ingest(_ev("process_started", 2, "TRIMGALORE", "RUNNING"))
+    state.ingest(_ev("process_completed", 2, "TRIMGALORE", "COMPLETED"))
+    snap = state.snapshot()
+    _assert_valid(snap)
+    assert snap["stations"]["trim"]["state"] == "failed"
+
+
+def test_multi_station_snapshot_validates() -> None:
+    state = ProgressState(_model())
+    state.ingest({"event": "started", "runName": "r"})
+    state.ingest(_ev("process_submitted", 1, "TRIMGALORE", "SUBMITTED"))
+    state.ingest(_ev("process_started", 1, "TRIMGALORE", "RUNNING"))
+    state.ingest(_ev("process_completed", 2, "FASTQC", "COMPLETED"))
+    snap = state.snapshot()
+    _assert_valid(snap)
+    assert snap["stations"]["trim"]["state"] == "running"
+    assert snap["stations"]["qc"]["state"] == "done"
+
+
+def test_new_run_reset_snapshot_validates() -> None:
+    state = ProgressState(_model())
+    state.ingest(_ev("process_completed", 1, "TRIMGALORE", "COMPLETED"))
+    _assert_valid(state.snapshot())
+    state.ingest({"event": "started", "runName": "r2"})
+    snap = state.snapshot()
+    _assert_valid(snap)
+    assert snap["stations"]["trim"] == {"state": "pending", "done": 0, "total": 0}
+
+
+def test_subscribe_snapshot_validates() -> None:
+    """The snapshot pushed immediately to a new SSE subscriber also conforms."""
+    state = ProgressState(_model())
+    state.ingest(_ev("process_started", 1, "TRIMGALORE", "RUNNING"))
+    q = state.subscribe()
+    pushed = json.loads(q.get_nowait())
+    _assert_valid(pushed)
+    assert pushed["stations"]["trim"]["state"] == "running"


### PR DESCRIPTION
## Summary

The manifest half of the live-diagram contract (`nf_metro/manifest/schema.json`, #626) already ships a versioned JSON Schema and a validating test. The runtime state vocabulary the live server emits - the per-node display state, `done`/`total` counts, and the run lifecycle - lived only as folklore in `live/server.py` (`ProgressState.snapshot`/`_station_state`).

- Adds `src/nf_metro/live/state_schema.json` (draft 2020-12) plus a `state_schema()` accessor in `src/nf_metro/live/schema.py`, mirroring `manifest_schema()`'s packaging convention; re-exported from `nf_metro.live` along with `STATE_SCHEMA_VERSION`.
- Adds `tests/test_live_state_schema.py`, which drives a real `ProgressState` through every state transition (pending/queued/running/done/failed, and the idle/running/complete/error run lifecycle) and validates each emitted snapshot against the schema, so the schema cannot drift from what the server actually produces.
- Expands the "Drive a live overlay" section of `docs/manifest.md` into a normative spec: the state enum and its precedence (`failed` > `running` > `queued` > `done` > `pending`), `done`/`total` semantics, run lifecycle, and the forward-compat rule (ignore unknown fields; additive change keeps the same major version).
- Frames the pieces explicitly: the manifest + this state vocabulary are the standard; nf-metro's weblog server and the Nextflow plugin are one binding of it to Nextflow; nf-metro is one producer. `docs/live.mdx` is updated to point at the normative section and note that a consumer with its own authoritative task state needs only the manifest + state schema, not the weblog server.

Out of scope (per the issue): a TS reader/matcher/overlay consumer package.

Fixes #1374

## Test plan
- [x] `pytest tests/test_manifest.py tests/test_live_state_schema.py tests/test_live_server.py tests/test_live_mapping.py` - 339 passed
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` - clean
- [x] `mypy` on the new/changed modules - clean
- [x] `/simplify` pass run (three parallel reviews: reuse, quality, efficiency); findings applied - reused `test_live_server`'s `MMD`/`_model`/`_ev` fixtures instead of duplicating them, tightened the `queued` state description (done can already be > 0), removed a comment referencing an external "Step 3"
- [ ] Visual review: this PR has no rendering/layout changes, so no gallery render-diff is expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)