### PR TITLE
feat(api): document render_string's exception contract for embedders

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -281,6 +281,62 @@ page).
 For a ready-made server that does exactly this for a live Nextflow run - no code
 to write - see [Live progress](/nf-metro/live/).
 
+## Calling the Python API directly
+
+The CLI wraps parse/layout errors into a clean `click.ClickException` message.
+An embedder calling `nf_metro.render_string()` (or `prepare_graph()` plus
+`render_graph()`) directly from Python gets the pipeline's typed errors raw,
+so it can decide for itself how to present a rejected input to its own users.
+
+Every one of the specific parse/layout-authoring error types below
+subclasses `nf_metro.NfMetroError`, so one `except` clause covers all of
+them without enumerating each type by name:
+
+```python
+from nf_metro import render_string, NfMetroError
+
+try:
+    svg = render_string(mmd_text)
+except NfMetroError as e:
+    # e.g. show the author their `.mmd` was rejected, with str(e) as the reason
+    ...
+except ValueError as e:
+    # a grammar/directive syntax error - not an NfMetroError, still worth
+    # catching separately if you want the same "bad input" handling for it
+    ...
+```
+
+| Raised when...                                                                   | Type                                                                     | When                 | Also a...    |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------------- | ------------ |
+| The `.mmd` grammar or a directive is malformed                                   | plain `ValueError` (**not** an `NfMetroError`, see below)                | parsing              | -            |
+| An edge or port survives parsing with a dangling reference                       | `nf_metro.parser.UnresolvedEndpointError` / `UnresolvedPortSectionError` | parsing/layout       | `ValueError` |
+| The station graph has a cycle                                                    | `nf_metro.parser.CyclicGraphError`                                       | layout               | `ValueError` |
+| An inter-section edge would have to flow backward                                | `nf_metro.layout.BackwardFlowError`                                      | layout               | `ValueError` |
+| One section is entered from more than one direction                              | `nf_metro.layout.MixedEntryDirectionError`                               | layout               | `ValueError` |
+| A layout-engine self-check fails mid-layout                                      | `nf_metro.layout.PhaseInvariantError`                                    | layout               | -            |
+| A user-set `fold_threshold` compresses the grid past what the router can resolve | `nf_metro.layout.FoldThresholdError`                                     | **render step only** | `ValueError` |
+
+The first row is deliberately outside the hierarchy: the parser raises a
+plain `ValueError` ad hoc for most grammar/directive problems rather than
+through a dedicated type, so `except ValueError` is the right catch-all for
+"the `.mmd` text itself doesn't parse." `except NfMetroError` covers every
+problem detected _after_ parsing succeeds - a graph that parsed fine but
+can't be laid out (or, for `FoldThresholdError`, drawn) honestly.
+
+Catch a specific row instead of the base class when the distinction matters -
+for example, offering "fix your fold threshold" only for
+`FoldThresholdError`, or falling back to `%%metro permissive: true`
+semantics only for `PhaseInvariantError`.
+
+**Not** part of this hierarchy: `render_string()`'s render step also runs a
+handful of self-checks (`CurveInvariantError`, `BridgeInvariantError`,
+`SectionHeaderClashError`, `SectionHeaderOverflowError`, `OffsetAnchorError`)
+that indicate a defect in nf-metro's own drawing rather than a problem with
+your input, so they are left out of `NfMetroError` on purpose - see the
+`render_string` docstring for the full list and rationale. Report one if you
+hit it; only catching `Exception` broadly shields a host page from them, and
+doing so also masks genuine nf-metro bugs.
+
 ## Versioning and stability
 
 The manifest schema and the driver contract are versioned independently, both

--- a/src/nf_metro/__init__.py
+++ b/src/nf_metro/__init__.py
@@ -1,11 +1,13 @@
 """nf-metro: Generate metro-map-style SVG diagrams from Mermaid graph definitions."""
 
 from nf_metro.api import RenderConfig, prepare_graph, render_graph, render_string
+from nf_metro.errors import NfMetroError
 
 __version__ = "1.1.0"
 
 __all__ = [
     "__version__",
+    "NfMetroError",
     "RenderConfig",
     "prepare_graph",
     "render_graph",

--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -158,12 +158,38 @@ def prepare_graph(
     title/logo band regardless of ``bare``/``%%metro legend:`` (its embedded
     SVG forces the legend off and ignores ``bare``), so it always reserves.
 
-    Returns the settled graph. Propagates the pipeline's typed errors:
-    :class:`ValueError` (parse), and the layout errors
-    :class:`~nf_metro.layout.CyclicGraphError`,
-    :class:`~nf_metro.layout.BackwardFlowError`,
-    :class:`~nf_metro.layout.MixedEntryDirectionError`,
-    :class:`~nf_metro.layout.PhaseInvariantError`.
+    Returns the settled graph.
+
+    **Exception contract.** Propagates the pipeline's typed errors. The
+    specific parse/layout-authoring types below all subclass
+    :class:`~nf_metro.NfMetroError`, so catching that one type handles "this
+    input was rejected" generically; catch a specific type instead to handle
+    that case distinctly. A grammar or directive error in the ``.mmd`` text
+    can also surface as a plain :class:`ValueError` that is *not* an
+    :class:`~nf_metro.NfMetroError` (the parser raises many of these ad hoc,
+    not through a dedicated type); catch ``ValueError`` separately to cover
+    that case too.
+
+    - A dangling edge or port reference that survived parsing:
+      :class:`~nf_metro.parser.UnresolvedEndpointError` /
+      :class:`~nf_metro.parser.UnresolvedPortSectionError` (both also
+      :class:`ValueError`).
+    - A cyclic station graph: :class:`~nf_metro.parser.CyclicGraphError`
+      (also a :class:`ValueError`).
+    - A section grid that cannot be rendered honestly:
+      :class:`~nf_metro.layout.BackwardFlowError` (an inter-section edge
+      would have to flow backward) or
+      :class:`~nf_metro.layout.MixedEntryDirectionError` (one section is
+      entered from more than one approach direction) - both also
+      :class:`ValueError`.
+    - An engine self-check failing mid-layout:
+      :class:`~nf_metro.layout.PhaseInvariantError` (not a ``ValueError``;
+      indicates a problem in the layout engine's own intermediate state
+      rather than the input).
+
+    This function only parses and lays out the graph; it never draws it, so
+    it cannot raise the render-time self-checks described in
+    :func:`render_string`'s docstring.
 
     When ``graph.permissive`` is set (``%%metro permissive: true`` or
     ``--permissive``), a :class:`~nf_metro.layout.PhaseInvariantError` raised
@@ -277,6 +303,29 @@ def render_string(
     resolve against the viewer's OS preference. Set ``False`` when inlining the
     SVG into a host page that owns the color-scheme (matches ``--no-self-color-scheme``
     on the CLI).
+
+    Raises everything :func:`prepare_graph` documents, plus two render-only
+    cases from the draw step (:func:`render_graph`):
+
+    - A ``fold_threshold`` set too small for the map can leave the router
+      unable to separate bundles at the compacted width; this is reframed
+      as :class:`~nf_metro.layout.FoldThresholdError` (also an
+      :class:`~nf_metro.NfMetroError` and a :class:`ValueError`) naming the
+      directive to relax, rather than the render-time engine self-check it
+      would otherwise raise.
+    - At the map's natural (un-folded) width, a raw render-time self-check
+      can fire directly:
+      :class:`~nf_metro.layout.routing.invariants.CurveInvariantError`,
+      :class:`~nf_metro.render.section_header.SectionHeaderClashError`,
+      :class:`~nf_metro.render.section_header.SectionHeaderOverflowError`,
+      :class:`~nf_metro.render.bridges.BridgeInvariantError`, or
+      :class:`~nf_metro.layout.routing.offsets.OffsetAnchorError`. These are
+      deliberately **not** part of the :class:`~nf_metro.NfMetroError`
+      hierarchy: they signal a defect in nf-metro's own drawing of an
+      otherwise-valid graph, not a problem with the caller's input, so they
+      are left uncaught here the same way the CLI leaves them as a raw
+      traceback rather than a clean error message - report them as nf-metro
+      bugs rather than handling them as expected input.
     """
     graph = prepare_graph(
         text,

--- a/src/nf_metro/errors.py
+++ b/src/nf_metro/errors.py
@@ -1,0 +1,24 @@
+"""Common base for the errors nf-metro's public API can raise.
+
+:func:`nf_metro.render_string` and :func:`nf_metro.prepare_graph` propagate the
+pipeline's typed parse- and layout-time errors rather than wrapping them (the
+CLI does that wrapping into ``click.ClickException`` for its own surface). An
+embedder that wants one ``except`` clause covering "nf-metro rejected this
+input or layout" - without enumerating every specific error type - can catch
+this base instead. Each specific error remains individually catchable and
+keeps its other base too (most are also :class:`ValueError`, since they
+describe an actionable problem with the input), so an ``except ValueError``
+or ``except SomeSpecificError`` call site catches exactly what it did before.
+"""
+
+from __future__ import annotations
+
+
+class NfMetroError(Exception):
+    """Base class for nf-metro's parse- and layout-time authoring/engine errors.
+
+    Every error :func:`~nf_metro.render_string` and
+    :func:`~nf_metro.prepare_graph` can raise for a parse failure or a layout
+    authoring/invariant problem subclasses this. See the ``prepare_graph``
+    docstring for the exhaustive list and when each is raised.
+    """

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from nf_metro.errors import NfMetroError
 from nf_metro.layout.constants import (
     COLLINEAR_AXIS_TOL,
     COMPONENT_BAND_OVERLAP_TOLERANCE,
@@ -104,7 +105,7 @@ if TYPE_CHECKING:
         def message(self) -> str: ...
 
 
-class PhaseInvariantError(Exception):
+class PhaseInvariantError(NfMetroError):
     """Raised when a layout phase produces invalid intermediate state."""
 
 
@@ -122,7 +123,7 @@ class LayoutInvariantError(PhaseInvariantError):
     """
 
 
-class BackwardFlowError(ValueError):
+class BackwardFlowError(NfMetroError, ValueError):
     """Raised when a layout places a section so an inter-section edge must
     flow backward against its own row's flow direction.
 
@@ -133,7 +134,7 @@ class BackwardFlowError(ValueError):
     """
 
 
-class MixedEntryDirectionError(ValueError):
+class MixedEntryDirectionError(NfMetroError, ValueError):
     """Raised when one section receives incoming lines from more than one
     approach direction (entry ports on more than one cardinal side).
 
@@ -146,7 +147,7 @@ class MixedEntryDirectionError(ValueError):
     """
 
 
-class FoldThresholdError(ValueError):
+class FoldThresholdError(NfMetroError, ValueError):
     """Raised when a ``fold_threshold`` the user set is too small for the map.
 
     A ``--fold-threshold`` / ``%%metro fold_threshold`` below a map's natural

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Literal, TypedDict
 
+from nf_metro.errors import NfMetroError
+
 
 class RowGridInfo(TypedDict):
     """Per-row grid metadata recorded by Stage 1.2 (``_align_row_y_grids``)."""
@@ -380,7 +382,7 @@ class RouteSegment:
     edge: Edge | None = None
 
 
-class UnresolvedEndpointError(ValueError):
+class UnresolvedEndpointError(NfMetroError, ValueError):
     """Raised when an edge references a station id that is not in the graph.
 
     The resolver inserts ports and junctions as real stations, so both
@@ -397,7 +399,7 @@ def format_unresolved_endpoint(edge: Edge, missing: list[str]) -> str:
     )
 
 
-class UnresolvedPortSectionError(ValueError):
+class UnresolvedPortSectionError(NfMetroError, ValueError):
     """Raised when a port's ``section_id`` is absent from the graph's sections.
 
     Every port carries a required ``section_id`` naming the section it bounds,

--- a/src/nf_metro/parser/validate.py
+++ b/src/nf_metro/parser/validate.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import networkx as nx
 
+from nf_metro.errors import NfMetroError
 from nf_metro.parser.model import (
     Edge,
     MetroGraph,
@@ -27,7 +28,7 @@ ERROR = "error"
 WARNING = "warning"
 
 
-class CyclicGraphError(ValueError):
+class CyclicGraphError(NfMetroError, ValueError):
     """Raised when a graph the layout engine requires to be a DAG has a cycle."""
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ import pytest
 from click.testing import CliRunner
 
 import nf_metro.api as api_module
+from nf_metro import NfMetroError
 from nf_metro.api import RenderConfig, prepare_graph, render_string
 from nf_metro.cli import cli
 from nf_metro.layout import PhaseInvariantError
@@ -100,11 +101,15 @@ def test_prepare_graph_returns_settled_graph() -> None:
 
 
 def test_render_string_propagates_layout_error() -> None:
+    """A cyclic graph raises CyclicGraphError, which is also an NfMetroError
+    (see tests/test_error_hierarchy.py for the rest of that contract:
+    backward-flow, mixed-entry, and the plain-ValueError parse-error case)."""
     cyclic = (
         "%%metro line: a | A | #f00\ngraph LR\n  n1[N1] -->|a| n2[N2]\n  n2 -->|a| n1\n"
     )
-    with pytest.raises(CyclicGraphError):
+    with pytest.raises(CyclicGraphError) as excinfo:
         render_string(cyclic)
+    assert isinstance(excinfo.value, NfMetroError)
 
 
 def test_prepare_graph_permissive_downgrades_phase_invariant_error(monkeypatch) -> None:

--- a/tests/test_error_hierarchy.py
+++ b/tests/test_error_hierarchy.py
@@ -1,0 +1,111 @@
+"""The parse/layout-authoring errors ``render_string`` can raise share one base.
+
+An embedder calling :func:`nf_metro.render_string` directly (rather than
+through the CLI, which converts these into a ``click.ClickException``) needs
+to know what it can catch. :class:`~nf_metro.NfMetroError` is the common base
+for the errors that mean "this input was rejected", documented precisely in
+:func:`nf_metro.api.prepare_graph`'s docstring and in the embedding guide.
+This module locks that contract: every specific error is-a
+:class:`NfMetroError`, and ``render_string`` raises the documented type for
+each representative class of bad input (a plain parse error, which is
+deliberately *not* an :class:`NfMetroError`, plus a same-row backward feed
+and a mixed-entry-direction section). The cyclic-graph case is covered
+alongside it in ``tests/test_api.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro import NfMetroError, render_string
+from nf_metro.layout import (
+    BackwardFlowError,
+    FoldThresholdError,
+    MixedEntryDirectionError,
+    PhaseInvariantError,
+)
+from nf_metro.layout.phases.guards import LayoutInvariantError
+from nf_metro.parser import (
+    CyclicGraphError,
+    UnresolvedEndpointError,
+    UnresolvedPortSectionError,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INVALID = REPO_ROOT / "tests" / "fixtures" / "invalid"
+NEXTFLOW_FLOWCHART = REPO_ROOT / "tests" / "fixtures" / "nextflow"
+
+# PhaseInvariantError/LayoutInvariantError report an engine self-check, not a
+# bad input, so they deliberately don't share ValueError's "invalid input"
+# base -- kept apart from the ValueError-based authoring errors below.
+NOT_VALUE_ERRORS = (PhaseInvariantError, LayoutInvariantError)
+AUTHORING_ERROR_TYPES = [
+    CyclicGraphError,
+    UnresolvedEndpointError,
+    UnresolvedPortSectionError,
+    BackwardFlowError,
+    MixedEntryDirectionError,
+    FoldThresholdError,
+    *NOT_VALUE_ERRORS,
+]
+
+
+@pytest.mark.parametrize("error_type", AUTHORING_ERROR_TYPES, ids=lambda t: t.__name__)
+def test_authoring_error_is_nf_metro_error(error_type: type[Exception]) -> None:
+    assert issubclass(error_type, NfMetroError)
+
+
+@pytest.mark.parametrize(
+    "error_type",
+    [t for t in AUTHORING_ERROR_TYPES if t not in NOT_VALUE_ERRORS],
+    ids=lambda t: t.__name__,
+)
+def test_authoring_error_keeps_its_value_error_base(
+    error_type: type[Exception],
+) -> None:
+    """Reparenting under NfMetroError must not drop the pre-existing base a
+    caller may already be catching (e.g. a bare ``except ValueError``)."""
+    assert issubclass(error_type, ValueError)
+
+
+def test_phase_invariant_error_is_not_a_value_error() -> None:
+    assert not issubclass(PhaseInvariantError, ValueError)
+
+
+def test_render_string_raises_plain_value_error_for_malformed_mmd() -> None:
+    """A genuine grammar/parse failure is a plain ValueError, not routed
+    through NfMetroError -- the parser raises many of these ad hoc, so this
+    stays outside the reparented hierarchy (see the ``prepare_graph``
+    docstring)."""
+    src = (NEXTFLOW_FLOWCHART / "flat_pipeline.mmd").read_text()
+    with pytest.raises(ValueError) as excinfo:
+        render_string(src)
+    assert not isinstance(excinfo.value, NfMetroError)
+
+
+@pytest.mark.parametrize(
+    "fixture,expected_type",
+    [
+        pytest.param(
+            INVALID / "merge_trunk_rightward_source.mmd",
+            BackwardFlowError,
+            id="backward-flow",
+        ),
+        pytest.param(
+            INVALID / "mixed_entry_opposing.mmd",
+            MixedEntryDirectionError,
+            id="mixed-entry",
+        ),
+    ],
+)
+def test_render_string_raises_documented_authoring_error(
+    fixture: Path, expected_type: type[Exception]
+) -> None:
+    """render_string raises the documented type for each class of rejected
+    input, and that type is always catchable as one NfMetroError -- the
+    entire point of the base class."""
+    with pytest.raises(expected_type) as excinfo:
+        render_string(fixture.read_text())
+    assert isinstance(excinfo.value, NfMetroError)


### PR DESCRIPTION
## Summary

- Introduce `NfMetroError` (`src/nf_metro/errors.py`) as a common base for the parse/layout-authoring errors `render_string`/`prepare_graph` can raise: `CyclicGraphError`, `UnresolvedEndpointError`, `UnresolvedPortSectionError`, `BackwardFlowError`, `MixedEntryDirectionError`, `FoldThresholdError`, `PhaseInvariantError` (and its subclass `LayoutInvariantError`). An embedder can now catch one type instead of enumerating each.
- Every reparented error keeps its original base too (most stay `ValueError` subclasses), so any existing `except ValueError` or `except SomeSpecificError` call site is unaffected.
- `NfMetroError` is exported from the top-level `nf_metro` package.
- Precisely enumerate the exception contract in the `prepare_graph`/`render_string` docstrings in `src/nf_metro/api.py`, including which render-time engine self-checks (`CurveInvariantError`, `BridgeInvariantError`, `SectionHeaderClashError`, `SectionHeaderOverflowError`, `OffsetAnchorError`) are deliberately **excluded** from the hierarchy (they signal a defect in nf-metro's own drawing, not a problem with the caller's input, so they stay raw the same way the CLI leaves them as a traceback rather than a clean message).
- Add a "Calling the Python API directly" section to `docs/embedding.md` with the same contract as a table, for embedders who don't read docstrings.
- Add `tests/test_error_hierarchy.py` locking the hierarchy (every named error is-a `NfMetroError` and keeps its prior base) and asserting `render_string` raises the documented type for representative bad input (a plain parse error, a cyclic graph, a backward feed, and a mixed-entry-direction section).

Fixes #983

## Test plan
- [x] `pytest tests/test_api.py tests/test_error_hierarchy.py tests/test_backward_feed.py tests/test_mixed_entry_directions.py tests/test_parser_grammar.py` - 402 passed
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` - clean
- [x] `mypy` on all changed files - clean
- [x] No layout/routing code touched (pure exception-hierarchy + docstring/docs change), so the gate-coverage ratchet and gallery render-diff are not expected to move
- [ ] Visual review of the [render preview](https://seqeralabs.github.io/nf-metro/_pr/) once CI posts it (expected: no visual changes, this PR touches no layout/render code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)