### PR TITLE
fix(layout): reject section-level cycles with a named diagnostic (#1445)

### DIFF
--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -24,6 +24,7 @@ from nf_metro.parser.model import (
     Section,
     SectionDAG,
 )
+from nf_metro.parser.validate import CyclicGraphError
 
 
 def infer_interchanges(graph: MetroGraph) -> None:
@@ -293,8 +294,14 @@ def _internal_station_depths(
 ) -> dict[str, int] | None:
     """Longest-path depth of each station through a section's internal edges.
 
-    Returns ``None`` when the section has no internal edges or contains a
-    cycle (no roots), so callers fall back to a station count.
+    Returns ``None`` when the section has no internal edges, so callers fall
+    back to a station count for the size estimate.
+
+    The graph is assumed acyclic: cyclic graphs are rejected by
+    ``compute_layout`` and reported by ``validate_graph`` before layout
+    inference reaches this estimator. A section whose internal edges form a
+    cycle would leave no root to rank from, so that case raises loudly rather
+    than falling back to a distorted station-count estimate.
     """
     section = graph.sections[section_id]
     station_ids = set(section.station_ids)
@@ -310,7 +317,10 @@ def _internal_station_depths(
         return None
     roots = station_ids - has_pred
     if not roots:
-        return None
+        raise CyclicGraphError(
+            f"Section '{section_id}' has cyclic internal edges: "
+            f"{', '.join(sorted(station_ids))}"
+        )
 
     depth: dict[str, int] = {sid: 0 for sid in station_ids}
     queue: deque[str] = deque(roots)

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -316,7 +316,9 @@ from nf_metro.parser.model import LineSpread, MetroGraph, Section, is_bypass_v
 from nf_metro.parser.validate import (
     CyclicGraphError,
     find_cycle,
+    find_section_cycle,
     format_cycle_error,
+    format_section_cycle_error,
     require_resolved_edge_endpoints,
     require_resolved_port_sections,
 )
@@ -472,6 +474,10 @@ def compute_layout(
     witness = find_cycle(graph)
     if witness is not None:
         raise CyclicGraphError(format_cycle_error(witness))
+
+    section_witness = find_section_cycle(graph)
+    if section_witness is not None:
+        raise CyclicGraphError(format_section_cycle_error(section_witness))
 
     require_resolved_edge_endpoints(graph)
     require_resolved_port_sections(graph)

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -43,6 +43,7 @@ from nf_metro.parser.resolve import (
     _remove_empty_sections,
     _resolve_sections,
 )
+from nf_metro.parser.validate import find_cycle, find_section_cycle
 
 # A row-wrap width no real map reaches, so section packing never folds: the
 # layout it yields is the unbounded baseline a user-set threshold is judged
@@ -241,8 +242,6 @@ def _finalize_graph(
     """Validate, run the post-parse resolution, and apply buffered metadata."""
     _validate_edge_annotations(graph)
 
-    # Remove empty sections, create implicit section for loose stations,
-    # auto-infer layout parameters, then resolve sections.
     if graph.sections:
         _remove_empty_sections(graph)
 
@@ -250,6 +249,30 @@ def _finalize_graph(
     if graph.sections:
         _create_implicit_section(graph)
 
+    # Layout inference (interchange expansion, section grids, port/junction
+    # resolution) assumes the graph is a DAG. A cyclic graph is rejected at the
+    # render boundary (compute_layout) and reported by validate_graph, so leave
+    # it un-inferred here rather than feed a distorted size estimate into
+    # strategy selection.
+    if find_cycle(graph) is None and find_section_cycle(graph) is None:
+        _infer_layout(graph, max_station_columns)
+
+    # A caller value (the --auto-process / --process-scope CLI flags) wins over
+    # the matching %%metro directive set during statement application.
+    if auto_process is not None:
+        graph.auto_process = auto_process
+    if process_scope is not None:
+        graph.process_scope = process_scope
+
+    _apply_pending_metadata(graph)
+
+
+def _infer_layout(graph: MetroGraph, max_station_columns: int | None) -> None:
+    """Run interchange expansion, section-grid inference, and section resolution.
+
+    The graph must be acyclic: the section-grid size estimator and the
+    topological passes this drives assume a DAG.
+    """
     from nf_metro.layout.auto_layout import (
         infer_interchanges,
         infer_section_layout,
@@ -298,15 +321,6 @@ def _finalize_graph(
         _insert_terminus_convergence_stations(graph)
         _resolve_sections(graph)
         _insert_bypass_stations(graph)
-
-    # A caller value (the --auto-process / --process-scope CLI flags) wins over
-    # the matching %%metro directive set during statement application.
-    if auto_process is not None:
-        graph.auto_process = auto_process
-    if process_scope is not None:
-        graph.process_scope = process_scope
-
-    _apply_pending_metadata(graph)
 
 
 def _apply_pending_metadata(graph: MetroGraph) -> None:

--- a/src/nf_metro/parser/validate.py
+++ b/src/nf_metro/parser/validate.py
@@ -80,16 +80,13 @@ def require_resolved_port_sections(graph: MetroGraph) -> None:
         )
 
 
-def find_cycle(graph: MetroGraph) -> list[str] | None:
-    """Return a node sequence witnessing a cycle, or ``None`` if acyclic.
+def _cycle_witness(g: nx.DiGraph[str]) -> list[str] | None:
+    """Return a node sequence witnessing a cycle in ``g``, or ``None`` if acyclic.
 
     The returned path closes back on its first node (``["a", "b", "a"]`` for a
     two-node cycle, ``["a", "a"]`` for a self-loop) so it reads directly as
     ``a -> b -> a`` when joined.
     """
-    g: nx.DiGraph[str] = nx.DiGraph()
-    for edge in graph.edges:
-        g.add_edge(edge.source, edge.target)
     if nx.is_directed_acyclic_graph(g):
         return None
     cycle_edges = nx.find_cycle(g)
@@ -98,9 +95,40 @@ def find_cycle(graph: MetroGraph) -> list[str] | None:
     return nodes
 
 
+def find_cycle(graph: MetroGraph) -> list[str] | None:
+    """Return a station-id sequence witnessing a cycle, or ``None`` if acyclic."""
+    g: nx.DiGraph[str] = nx.DiGraph()
+    for edge in graph.edges:
+        g.add_edge(edge.source, edge.target)
+    return _cycle_witness(g)
+
+
 def format_cycle_error(witness: list[str]) -> str:
     """Render a cycle witness path as a fatal error message."""
     return f"Graph contains a cycle: {' -> '.join(witness)}"
+
+
+def find_section_cycle(graph: MetroGraph) -> list[str] | None:
+    """Return a section-id sequence witnessing a section-DAG cycle, or ``None``.
+
+    Sections can close a loop (``sec_a`` feeds ``sec_b`` which feeds back into
+    ``sec_a``) while every underlying station edge still points forward, so the
+    station digraph in :func:`find_cycle` cannot see it. The returned path
+    closes back on its first section (``["sec_a", "sec_b", "sec_a"]``) so it
+    reads directly as ``sec_a -> sec_b -> sec_a`` when joined.
+    """
+    g: nx.DiGraph[str] = nx.DiGraph()
+    for edge in graph.edges:
+        src_sec = graph.section_for_station(edge.source)
+        tgt_sec = graph.section_for_station(edge.target)
+        if src_sec and tgt_sec and src_sec != tgt_sec:
+            g.add_edge(src_sec, tgt_sec)
+    return _cycle_witness(g)
+
+
+def format_section_cycle_error(witness: list[str]) -> str:
+    """Render a section-cycle witness path as a fatal error message."""
+    return f"Sections form a cycle: {' -> '.join(witness)}"
 
 
 @dataclass(frozen=True)
@@ -131,6 +159,12 @@ def validate_graph(graph: MetroGraph) -> list[ValidationIssue]:
     witness = find_cycle(graph)
     if witness is not None:
         issues.append(ValidationIssue(ERROR, format_cycle_error(witness)))
+
+    section_witness = find_section_cycle(graph)
+    if section_witness is not None:
+        issues.append(
+            ValidationIssue(ERROR, format_section_cycle_error(section_witness))
+        )
 
     for edge in graph.edges:
         if edge.line_id != "default" and edge.line_id not in graph.lines:

--- a/tests/test_cyclic_graph.py
+++ b/tests/test_cyclic_graph.py
@@ -5,8 +5,13 @@ A cycle or self-loop in the parsed graph must be rejected on both the
 ``validate`` plane (a structured :class:`ValidationIssue`) and the ``render``
 plane (a ``ValueError`` out of ``compute_layout``), naming at least one node
 so an author can locate the offending edge.
+
+The section meta-graph is checked as well as the station digraph: sections can
+form a cycle (``sec_a`` feeds ``sec_b`` which feeds ``sec_a``) while every
+station edge still points forward, so a station-only check would miss it.
 """
 
+import networkx as nx
 import pytest
 from click.testing import CliRunner
 
@@ -32,9 +37,41 @@ graph LR
     a[A] -->|l1| a
 """
 
+# A cycle at the section level whose station edges all point forward
+# (a1 -> b1, b2 -> a2): the station digraph is acyclic, only the section
+# meta-graph (seca -> secb -> seca) closes the loop.
+_SECTION_CYCLE = """\
+%%metro line: l1 | Line 1 | #ff0000 | solid
+graph LR
+    subgraph seca [Section A]
+        a1[A1]
+        a2[A2]
+    end
+    subgraph secb [Section B]
+        b1[B1]
+        b2[B2]
+    end
+    a1 -->|l1| b1
+    b2 -->|l1| a2
+"""
+
+# A station cycle contained inside a single section (a1 -> a2 -> a1). The
+# station digraph is cyclic, so the whole-graph check rejects it before any
+# section-internal layout estimate is attempted.
+_WITHIN_SECTION_CYCLE = """\
+%%metro line: l1 | Line 1 | #ff0000 | solid
+graph LR
+    subgraph seca [Section A]
+        a1[A1] -->|l1| a2[A2]
+        a2 -->|l1| a1
+    end
+    a2 -->|l1| b1[B1]
+"""
+
 _CYCLIC = [
     pytest.param(_TWO_NODE_CYCLE, id="two-node-cycle"),
     pytest.param(_SELF_LOOP, id="self-loop"),
+    pytest.param(_WITHIN_SECTION_CYCLE, id="within-section-cycle"),
 ]
 
 
@@ -76,3 +113,69 @@ def test_cli_rejects_cycle(mmd: str, command: str, tmp_path):
     assert result.exit_code != 0
     assert "cycle" in result.output.lower()
     assert "a" in result.output
+
+
+def test_validate_graph_flags_section_cycle():
+    graph = parse_metro_mermaid(_SECTION_CYCLE)
+
+    cycle_errors = [
+        issue
+        for issue in validate_graph(graph)
+        if issue.severity == ERROR and "cycle" in issue.message.lower()
+    ]
+
+    assert len(cycle_errors) == 1
+    message = cycle_errors[0].message
+    assert "seca" in message and "secb" in message
+
+
+def test_compute_layout_rejects_section_cycle():
+    graph = parse_metro_mermaid(_SECTION_CYCLE)
+
+    with pytest.raises(CyclicGraphError, match="cycle") as excinfo:
+        compute_layout(graph)
+
+    message = str(excinfo.value)
+    assert "seca" in message and "secb" in message
+
+
+def test_section_cycle_raises_cyclic_not_networkx():
+    """A section cycle surfaces as the authoring diagnostic, never a raw
+    ``networkx`` topological-sort failure leaking out of the engine."""
+    graph = parse_metro_mermaid(_SECTION_CYCLE)
+
+    with pytest.raises(CyclicGraphError) as excinfo:
+        compute_layout(graph)
+
+    assert not isinstance(excinfo.value, nx.NetworkXException)
+
+
+@pytest.mark.parametrize("command", ["render", "validate"])
+def test_cli_rejects_section_cycle(command: str, tmp_path):
+    src = tmp_path / "section_cyclic.mmd"
+    src.write_text(_SECTION_CYCLE)
+    args = [command, str(src)]
+    if command == "render":
+        args += ["-o", str(tmp_path / "out.svg")]
+
+    result = CliRunner().invoke(cli, args)
+
+    assert result.exit_code != 0
+    assert "cycle" in result.output.lower()
+    assert "seca" in result.output
+
+
+def test_internal_station_depths_raises_on_cyclic_section():
+    """The section size estimator rejects a section whose internal edges form a
+    cycle rather than returning a distorted depth map. The parser gate keeps
+    cyclic graphs away from this path, so it is exercised by calling the
+    estimator directly on a graph with a section-internal cycle."""
+    from nf_metro.layout.auto_layout import _internal_station_depths
+
+    graph = parse_metro_mermaid(_WITHIN_SECTION_CYCLE)
+    section_id = next(sid for sid, s in graph.sections.items() if "a1" in s.station_ids)
+
+    with pytest.raises(CyclicGraphError, match="cyclic internal edges") as excinfo:
+        _internal_station_depths(graph, section_id)
+
+    assert "a1" in str(excinfo.value) and "a2" in str(excinfo.value)


### PR DESCRIPTION
## Summary

Cyclic metro-map inputs previously surfaced as a raw `networkx` error on one path and a silent layout-size distortion on another. This rejects them as a first-class authoring diagnostic.

- Cycle detection now covers the **section meta-graph** as well as the station digraph (`find_section_cycle` in `parser/validate.py`). A loop between sections whose underlying station edges all point forward (`sec_a` feeds `sec_b` feeds `sec_a`) has an acyclic station digraph, so the station-only check missed it; it now raises `CyclicGraphError` naming the sections. Wired into both `validate_graph` (structured `ValidationIssue`) and `compute_layout` (raise), mirroring the existing station-cycle guard.
- Auto-layout inference is skipped for cyclic graphs at the resolve boundary (`_finalize_graph`), so the section-size estimator never runs on a cyclic graph. The estimator's no-root branch (`_internal_station_depths`) now raises loudly instead of silently falling back to a distorted station count that could steer strategy selection.
- The CLI reports both station and section cycles as a clean error (via the existing `CyclicGraphError` -> `ClickException` conversion), not a traceback.

Feedback-arc-set removal / rendering cycles remains out of scope (a follow-up per the issue).

Fixes #1445

## Test plan
- [x] `pytest tests/test_cyclic_graph.py` (new section-cycle, within-section-cycle, and direct-estimator tests) passes
- [x] Full suite green: 21046 passed, 64 skipped, 9 xfailed (pre-existing #348/#453); routing gate-coverage ratchet 19 passed
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` clean; mypy clean
- [x] Loud runtime guard added (`_internal_station_depths` raises on a cyclic section)
- [ ] Render-preview verdict (authoring-error fixtures do not render, so no gallery delta expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
