### PR TITLE
refactor(layout): register remaining graph._* side channels in PHASE_FIELD_REGISTRY

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -268,6 +268,25 @@ when `y_spacing` is auto-resolved), and `graph._resolved_x_spacing` (the
 resolved column pitch recorded before layout, read as the cross-axis off-track
 step for vertical-flow sections).
 
+A further group crosses a subsystem boundary rather than two numbered stages,
+so their `PhaseFieldSpec` names a lifecycle phase (`pre-layout`, `post-layout`,
+`rail-layout`) in place of a stage id. They carry no runtime check either:
+
+- `graph._cross_column_perp_bridges` - sections whose perpendicular drop was
+  bridged across grid columns, accumulated by the Stage 3.2 / 3.4 port
+  alignment; routing's render-curve invariant reads it to relax its abort to a
+  warning for those bundles.
+- `graph._fold_compressed_sections` / `graph._fold_reoriented_sections` -
+  recorded at parse/resolve time for sections a lowered fold threshold
+  relocated or whose flow direction was flipped; read by the fold-exit-side
+  guard, the render fold-abort chokepoint, and routing's exit-port offset.
+- `graph._rail_y` - the per-section `{line_id: rail_y}` map produced by the
+  opt-in rail-mode layout; read by the rail router, label placement, and rail
+  guards, empty when rail mode is off.
+- `graph._defer_final_guards` / `graph._after_final_deferred` - pass-control
+  flags `compute_layout` uses so the final-geometry guards defer while the
+  pre-bypass passes run, then validate the settled post-bypass geometry once.
+
 ## Stage overview
 
 The pipeline groups into six stages aligned with the coord-regime

--- a/src/nf_metro/layout/phase_state.py
+++ b/src/nf_metro/layout/phase_state.py
@@ -32,9 +32,25 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from nf_metro.parser.model import MetroGraph
 
-# Writer marker for a field populated before Stage 1.1 (i.e. during spacing
-# resolution in ``compute_layout``, before the stage pipeline begins).
+# Lifecycle-phase markers for fields whose writer or reader is not one of the
+# numbered section-layout stages.  They stand in for a stage id in a
+# ``PhaseFieldSpec`` so a channel that crosses a subsystem boundary (parse ->
+# routing, rail-mode layout, the bypass-pass control wrapper) is declarable as
+# data alongside the inter-stage channels.
+
+# Populated before Stage 1.1: parse/resolve rewrites or the spacing resolution
+# in ``compute_layout``, before the stage pipeline begins.
 PRE_LAYOUT = "pre-layout"
+# Written or read after the stage pipeline has positioned every station: by
+# routing, render, or the closing validate guards.
+POST_LAYOUT = "post-layout"
+# Owned by the opt-in rail-mode layout (``layout/rail_mode.py``), a
+# self-contained path that runs instead of the numbered section pipeline.
+RAIL_LAYOUT = "rail-layout"
+
+# Non-stage phases a writer_stage / reader_stage may name in place of a
+# CANONICAL_STAGE_ORDER id.
+NON_STAGE_PHASES: tuple[str, ...] = (PRE_LAYOUT, POST_LAYOUT, RAIL_LAYOUT)
 
 # Section-layout stage ids in execution order.  Mirrors the ``_snap(graph, ...)``
 # checkpoints in ``engine._compute_section_layout`` and its Pass C helpers;
@@ -186,6 +202,77 @@ PHASE_FIELD_REGISTRY: dict[str, PhaseFieldSpec] = {
             "resolved column pitch recorded before layout; a vertical-flow (TB/BT) "
             "section's off-track band is offset by this cross-axis pitch, read with "
             "a None/getattr fallback to X_SPACING when it is unset"
+        ),
+    ),
+    "_cross_column_perp_bridges": PhaseFieldSpec(
+        name="_cross_column_perp_bridges",
+        writer_stage="3.4",
+        reader_stages=(POST_LAYOUT,),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "section IDs whose perpendicular drop had to be bridged across grid "
+            "columns, accumulated by the Stage 3.2 entry-port and Stage 3.4 "
+            "exit-port alignment; routing's render-curve invariant reads the set "
+            "to relax its hard abort to a warning for those forced-perpendicular "
+            "bundles, tolerating the empty default"
+        ),
+    ),
+    "_fold_compressed_sections": PhaseFieldSpec(
+        name="_fold_compressed_sections",
+        writer_stage=PRE_LAYOUT,
+        reader_stages=("1.1", POST_LAYOUT),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "sections a lowered fold threshold relocated onto a return row, "
+            "recorded at parse time; the fold-exit-side guard at the Stage 1.1 "
+            "checkpoint and the render fold-abort chokepoint read the set and "
+            "tolerate its empty default when no fold compression occurred"
+        ),
+    ),
+    "_fold_reoriented_sections": PhaseFieldSpec(
+        name="_fold_reoriented_sections",
+        writer_stage=PRE_LAYOUT,
+        reader_stages=(POST_LAYOUT,),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "sections whose flow direction resolve.py flipped to keep a flow-axis "
+            "port on its consumer/producer end; routing's exit-port offset reads "
+            "the set to anchor on the feeder-bundle frame, tolerating the empty "
+            "default"
+        ),
+    ),
+    "_rail_y": PhaseFieldSpec(
+        name="_rail_y",
+        writer_stage=RAIL_LAYOUT,
+        reader_stages=(POST_LAYOUT,),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "per-section {line_id: rail_y} map produced by the opt-in rail-mode "
+            "layout; the rail router, label placement, and rail guards read it "
+            "and fall back to the empty default when rail mode is off"
+        ),
+    ),
+    "_defer_final_guards": PhaseFieldSpec(
+        name="_defer_final_guards",
+        writer_stage=PRE_LAYOUT,
+        reader_stages=(POST_LAYOUT,),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "pass-control flag compute_layout sets while the pre-bypass passes "
+            "run so the final-geometry guards defer on transient state; the "
+            "breeze-through and after-final guards read it, tolerating the False "
+            "default"
+        ),
+    ),
+    "_after_final_deferred": PhaseFieldSpec(
+        name="_after_final_deferred",
+        writer_stage=POST_LAYOUT,
+        reader_stages=(POST_LAYOUT,),
+        enforcement=FieldEnforcement.FALLBACK,
+        why=(
+            "flag the after-final checkpoint sets when it is reached but deferred, "
+            "so compute_layout runs the checkpoint once on the settled post-bypass "
+            "geometry; read by compute_layout, tolerating the False default"
         ),
     ),
 }

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -537,7 +537,7 @@ class MetroGraph:
     # flow-axis port on its consumer/producer's end (see resolve.py
     # _reanchor_flow_axis_ports).  Their exit-port offsets anchor on the
     # feeder bundle frame rather than re-centring on zero.
-    _fold_reoriented_sections: set[str] = field(default_factory=set)
+    _fold_reoriented_sections: set[str] = field(default_factory=set, repr=False)
     # Section IDs whose entry/exit port sides were author-specified via
     # %%metro entry:/exit: directives (tracked separately because auto_layout
     # fills entry_hints/exit_hints for sections that have none, so the hint
@@ -551,14 +551,14 @@ class MetroGraph:
     # through such a forced-perpendicular drop may not satisfy the strict
     # render-curve invariants, so their presence relaxes that check to a
     # warning instead of a hard render abort.
-    _cross_column_perp_bridges: set[str] = field(default_factory=set)
+    _cross_column_perp_bridges: set[str] = field(default_factory=set, repr=False)
     # Effective row-wrap width when the author set one (--fold-threshold or
     # %%metro fold_threshold), plus the auto-laid sections whose grid cell that
     # width shifted versus the unbounded layout.  A non-empty set means the
     # user-chosen threshold compressed the section grid; the render chokepoint
     # uses it to reframe a fold-induced routing abort as FoldThresholdError.
     _fold_threshold_effective: int | None = None
-    _fold_compressed_sections: set[str] = field(default_factory=set)
+    _fold_compressed_sections: set[str] = field(default_factory=set, repr=False)
     # Pending terminus designations: station_id ->
     # list of (label, icon_type, name, banner)
     _pending_terminus: dict[str, list[tuple[str, str, str, bool]]] = field(

--- a/tests/test_phase_state_registry.py
+++ b/tests/test_phase_state_registry.py
@@ -8,8 +8,8 @@ drift from:
 * the engine's ``_snap`` stage checkpoints (``CANONICAL_STAGE_ORDER``), and
 * ``CONTRACT.md``,
 
-and they fail when a new bare cross-phase ``graph._*`` poke is introduced
-without being declared, so the protocol can't grow an undocumented member.
+and they fail when any bare ``graph._*`` poke in the layout package is neither
+registered nor allowlisted, so the protocol can't grow an undocumented member.
 A behavioural test pins the write-before-read enforcement itself.
 """
 
@@ -23,6 +23,7 @@ import pytest
 
 from nf_metro.layout.phase_state import (
     CANONICAL_STAGE_ORDER,
+    NON_STAGE_PHASES,
     PHASE_FIELD_REGISTRY,
     PRE_LAYOUT,
     FieldEnforcement,
@@ -39,30 +40,26 @@ LAYOUT_DIR = REPO / "src" / "nf_metro" / "layout"
 ENGINE = LAYOUT_DIR / "engine.py"
 CONTRACT = LAYOUT_DIR / "CONTRACT.md"
 
-# Cross-phase ``graph._*`` channels that are deliberately NOT part of the
-# inter-phase positioning protocol, so they are not in PHASE_FIELD_REGISTRY:
-#   - _stages_completed / _validate_active: the enforcement mechanism itself.
-#   - _defer_final_guards: a pass-control flag toggled by compute_layout.
-#   - _explicit_directions: parse/auto-layout metadata, read by a guard.
-#   - _rail_y: rail-mode router metadata, not section positioning.
-#   - _cross_column_perp_bridges: a routing-invariant relaxation flag.
-_NON_PROTOCOL_CROSS_PHASE = {
+# ``graph._*`` names accessed in the layout package that are deliberately NOT
+# inter-phase positioning channels, so they are absent from PHASE_FIELD_REGISTRY:
+#   - _stages_completed / _validate_active: the write-before-read enforcement
+#     machinery itself.
+#   - _phase_snapshots_enabled: a per-run coordinate-snapshot flag stashed to
+#     avoid signature churn (#363), pure observation.
+#   - _explicit_grid / _explicit_directions: authoring provenance mutated by
+#     inference; owned by #681's provenance design rather than this protocol.
+_BOOKKEEPING_ALLOWLIST = {
     "_stages_completed",
     "_validate_active",
-    "_defer_final_guards",
+    "_phase_snapshots_enabled",
+    "_explicit_grid",
     "_explicit_directions",
-    "_rail_y",
-    "_cross_column_perp_bridges",
 }
 
 _COMMENT = re.compile(r"#.*$", re.MULTILINE)
 _SNAP_ID = re.compile(r'_snap\(graph,\s*"([^"]+)"\)')
 _STAGE_ID = re.compile(r"^\d+\.\d+[a-z]?$")
-_GRAPH_ATTR = re.compile(r"\bgraph\.([A-Za-z_][A-Za-z0-9_]*)")
-_GRAPH_WRITE = re.compile(
-    r"\bgraph\.([A-Za-z_][A-Za-z0-9_]*)\s*"
-    r"(?:=[^=]|\.(?:append|extend|update|add|clear|pop|setdefault|discard)\b|\[)"
-)
+_GRAPH_UNDERSCORE = re.compile(r"\bgraph\.(_[A-Za-z0-9_]*)")
 
 
 def _strip_comments(text: str) -> str:
@@ -93,12 +90,14 @@ def test_registered_field_is_a_repr_false_dataclass_field(name):
 @pytest.mark.parametrize("name", sorted(PHASE_FIELD_REGISTRY))
 def test_writer_and_reader_stages_are_known(name):
     spec = PHASE_FIELD_REGISTRY[name]
-    assert (
-        spec.writer_stage in CANONICAL_STAGE_ORDER or spec.writer_stage == PRE_LAYOUT
-    ), f"{name}: writer_stage {spec.writer_stage!r} is not a known stage"
+    known = set(CANONICAL_STAGE_ORDER) | set(NON_STAGE_PHASES)
+    assert spec.writer_stage in known, (
+        f"{name}: writer_stage {spec.writer_stage!r} is not a known stage or "
+        f"lifecycle phase"
+    )
     for r in spec.reader_stages:
-        assert r in CANONICAL_STAGE_ORDER, (
-            f"{name}: reader_stage {r!r} is not in CANONICAL_STAGE_ORDER"
+        assert r in known, (
+            f"{name}: reader_stage {r!r} is not a known stage or lifecycle phase"
         )
 
 
@@ -113,10 +112,12 @@ def test_require_writer_fields_have_writer_before_readers(name):
     spec = PHASE_FIELD_REGISTRY[name]
     if spec.enforcement is not FieldEnforcement.REQUIRE_WRITER:
         pytest.skip("FALLBACK field: write-before-read ordering not required")
-    if spec.writer_stage == PRE_LAYOUT:
+    if spec.writer_stage in NON_STAGE_PHASES:
         return
     w = CANONICAL_STAGE_ORDER.index(spec.writer_stage)
     for r in spec.reader_stages:
+        if r in NON_STAGE_PHASES:
+            continue
         assert w < CANONICAL_STAGE_ORDER.index(r), (
             f"{name}: writer Stage {spec.writer_stage} does not precede "
             f"reader Stage {r}"
@@ -160,40 +161,41 @@ def test_pass_c_bisection_order_is_a_subsequence():
         )
 
 
-# --- no unregistered cross-phase poke --------------------------------------
+# --- no unregistered graph channel -----------------------------------------
 
 
-def _cross_phase_underscore_attrs() -> set[str]:
-    """``graph._*`` attrs written in one layout module and read in another."""
-    writers: dict[str, set[str]] = {}
-    readers: dict[str, set[str]] = {}
+def _layout_graph_underscore_attrs() -> dict[str, set[str]]:
+    """Every ``graph._*`` attr accessed in the layout package -> modules using it."""
+    accessed: dict[str, set[str]] = {}
     for path in LAYOUT_DIR.rglob("*.py"):
         if path.name == "phase_state.py":
             continue  # the registry/helper module, not a phase
         text = _strip_comments(path.read_text())
         mod = str(path.relative_to(LAYOUT_DIR))
-        for m in _GRAPH_WRITE.finditer(text):
-            writers.setdefault(m.group(1), set()).add(mod)
-        for m in _GRAPH_ATTR.finditer(text):
-            readers.setdefault(m.group(1), set()).add(mod)
-    cross: set[str] = set()
-    for attr, ws in writers.items():
-        if not attr.startswith("_"):
-            continue
-        if readers.get(attr, set()) - ws:  # read somewhere it isn't written
-            cross.add(attr)
-    return cross
+        for m in _GRAPH_UNDERSCORE.finditer(text):
+            accessed.setdefault(m.group(1), set()).add(mod)
+    return accessed
 
 
-def test_no_unregistered_cross_phase_channel():
-    """A new cross-phase ``graph._*`` poke must be registered or allowlisted."""
-    cross = _cross_phase_underscore_attrs()
-    unaccounted = cross - set(PHASE_FIELD_REGISTRY) - _NON_PROTOCOL_CROSS_PHASE
+def test_no_unregistered_graph_channel():
+    """Every ``graph._*`` poke in layout must be registered or allowlisted.
+
+    Grepping the whole package (not only fields read across module boundaries)
+    means a new private channel between phases cannot enter without either a
+    ``PHASE_FIELD_REGISTRY`` entry declaring its dataflow or an explicit
+    ``_BOOKKEEPING_ALLOWLIST`` line marking it non-protocol.
+    """
+    accessed = _layout_graph_underscore_attrs()
+    unaccounted = set(accessed) - set(PHASE_FIELD_REGISTRY) - _BOOKKEEPING_ALLOWLIST
     assert not unaccounted, (
-        "These graph._* fields are written in one layout module and read in "
-        "another but are neither in PHASE_FIELD_REGISTRY nor allowlisted as "
-        f"non-protocol state: {sorted(unaccounted)}. Declare them in "
-        "phase_state.py (preferred) or add to _NON_PROTOCOL_CROSS_PHASE."
+        "These graph._* fields are accessed in the layout package but are "
+        "neither in PHASE_FIELD_REGISTRY nor on _BOOKKEEPING_ALLOWLIST: "
+        + ", ".join(
+            f"{name} (in {', '.join(sorted(accessed[name]))})"
+            for name in sorted(unaccounted)
+        )
+        + ". Declare them in phase_state.py (preferred) or add to "
+        "_BOOKKEEPING_ALLOWLIST with a rationale."
     )
 
 


### PR DESCRIPTION
## Summary

Completes the phase-state migration begun in `layout/phase_state.py`: every
`graph._*` side channel the layout package uses is now either declared in
`PHASE_FIELD_REGISTRY` or on an explicit bookkeeping allowlist, and a meta-test
grips the whole package so a new bare poke cannot appear silently.

- Register six previously-undeclared channels with their writer/reader phase
  and a `why`, all at `FALLBACK` enforcement (their reads tolerate the
  unwritten default and happen outside the numbered-stage `require_phase_field`
  path, so a write-before-read check would be dishonest):
  - `_cross_column_perp_bridges` (written Stage 3.2/3.4 port alignment, read by
    routing's render-curve invariant relaxation)
  - `_fold_compressed_sections`, `_fold_reoriented_sections` (written at
    parse/resolve, read by the fold guards and routing offsets)
  - `_rail_y` (rail-mode layout output, read by the rail router/labels/guards)
  - `_defer_final_guards`, `_after_final_deferred` (bypass-pass control flags
    read by the final-geometry guards and `compute_layout`)
- Add lifecycle-phase markers `POST_LAYOUT` and `RAIL_LAYOUT` alongside the
  existing `PRE_LAYOUT`, so a channel crossing a subsystem boundary
  (parse -> routing, rail-mode layout, the pass-control wrapper) is expressible
  as data. `NON_STAGE_PHASES` collects them; the stage-validity test accepts a
  writer/reader that names one.
- Mark the three set-valued channels (`_cross_column_perp_bridges`,
  `_fold_compressed_sections`, `_fold_reoriented_sections`) `repr=False`, in
  line with the inter-phase-channel convention the registry test enforces.
- Replace the narrow "cross-module poke" meta-test with
  `test_no_unregistered_graph_channel`, which greps every `graph._*` access in
  the layout package and asserts each is registered or on
  `_BOOKKEEPING_ALLOWLIST`. The allowlist holds only non-protocol state: the
  enforcement machinery (`_stages_completed`, `_validate_active`), the
  observation flag `_phase_snapshots_enabled` (#363), and the authoring
  provenance `_explicit_grid` / `_explicit_directions` (owned by #681).
- Document the new channels in `CONTRACT.md`.

Rendering is byte-identical: the change adds registry data, markers, comments,
and a `repr=False` flag only. No `require_phase_field` call sites are added and
no stage ordering changes.

Fixes #1440

## Test plan

- [x] `pytest tests/test_phase_state_registry.py` passes (73 passed, 11 skipped)
- [x] Full `pytest` suite green
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` clean
- [x] `mypy` clean on changed sources
- [x] Byte-identical render of `examples/rnaseq_sections.mmd` before/after
- [x] Meta-test verified meaningful (unregistering a field flags it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
