### PR TITLE
refactor(guards): single-source geometry checks shared by guards and validator oracle

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -124,7 +124,6 @@ from nf_metro.layout.phases.guards import (  # noqa: F401
     FoldThresholdError,
     MixedEntryDirectionError,
     PhaseInvariantError,
-    _bbox_guarded_stations,
     _bisection_should_run,
     _ensure_routes,
     _guard_anchors_frozen_during_placement,

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from nf_metro.parser.model import MetroGraph, Section
+    from nf_metro.layout.routing.common import RoutedPath
+    from nf_metro.parser.model import MetroGraph, Section, Station
 
 _Box = tuple[float, float, float, float]
 
@@ -62,6 +63,86 @@ def iter_section_overlaps(
             )
             if overlap_x and overlap_y:
                 yield sid_a, sid_b, box_a, box_b
+
+
+def iter_coincident_stations(
+    graph: MetroGraph, tolerance: float = 1.0
+) -> Iterator[tuple[str, str, float, float]]:
+    """Yield ``(sid_a, sid_b, x, y)`` for every pair of distinct visible
+    stations placed within *tolerance* of the same centre.
+
+    Two real (non-port, non-hidden) stations sharing an ``(x, y)`` render
+    their pill markers on top of each other.  Rail-mode stations are exempt:
+    their markers render as per-rail knobs distributed across the rail bundle,
+    so a shared centre is not a visual collision there.  Sorting by ``x`` lets
+    the inner scan stop once a candidate's ``x`` clears the tolerance window.
+    Shared by the runtime guard and the offline validator so the two cannot
+    drift.
+    """
+    exempt_rail = graph.has_rail_sections
+    placed: list[tuple[str, float, float]] = []
+    for sid, station in graph.stations.items():
+        if station.is_port or station.is_hidden:
+            continue
+        if exempt_rail and graph.station_is_rail(sid):
+            continue
+        placed.append((sid, station.x, station.y))
+    placed.sort(key=lambda p: p[1])
+    for i, (sid, x, y) in enumerate(placed):
+        for oid, ox, oy in placed[i + 1 :]:
+            if ox - x > tolerance:
+                break
+            if abs(y - oy) <= tolerance:
+                yield sid, oid, ox, oy
+
+
+def iter_bbox_checkable_stations(
+    graph: MetroGraph,
+) -> Iterator[tuple[str, Station, Section]]:
+    """Yield ``(sid, station, section)`` for each rendered station a
+    bbox-containment check should inspect: skips ports, junctions, and
+    stations whose section has no sized bbox.
+
+    Ports live on the boundary by construction and junctions are invisible
+    synthetic nodes, so neither is a visible-station containment concern.
+    Shared by the marker-edge guard, the centre-containment guard, and the
+    offline validator so they cannot drift on what they exempt.
+    """
+    junction_ids = graph.junction_ids
+    for sid, station in graph.stations.items():
+        section = graph.sections.get(station.section_id or "")
+        if (
+            section is None
+            or station.is_port
+            or sid in junction_ids
+            or section.bbox_w == 0
+        ):
+            continue
+        yield sid, station, section
+
+
+def iter_stations_outside_bbox(
+    graph: MetroGraph, margin: float
+) -> Iterator[tuple[str, Station, Section]]:
+    """Yield ``(sid, station, section)`` for each rendered station whose
+    centre lies outside its section's bbox by more than *margin*.
+
+    Shared by the always-on centre-containment guard and the offline
+    validator so the two report the same defect from one implementation.
+    """
+    for sid, station, section in iter_bbox_checkable_stations(graph):
+        inside_x = (
+            section.bbox_x - margin
+            <= station.x
+            <= section.bbox_x + section.bbox_w + margin
+        )
+        inside_y = (
+            section.bbox_y - margin
+            <= station.y
+            <= section.bbox_y + section.bbox_h + margin
+        )
+        if not (inside_x and inside_y):
+            yield sid, station, section
 
 
 class _HasXY(Protocol):
@@ -398,3 +479,80 @@ class BBoxXIndex:
             key, bbox = self._items[i]
             if bbox[2] >= qx_min:
                 yield key, bbox
+
+
+def _route_is_side_entry_turn_in(graph: MetroGraph, rp: RoutedPath) -> bool:
+    """Whether *rp* is the turn-in leg from an entry port perpendicular to flow.
+
+    An entry port on the axis perpendicular to its section's flow (LEFT/RIGHT
+    on a vertical-flow TB/BT section, TOP/BOTTOM on a horizontal-flow LR/RL
+    one) reaches the trunk via one traverse perpendicular to that flow.  That
+    leg is the entry, bounded by the section width, not a serpentine fold-back,
+    so backtrack accounting excludes it.
+    """
+    from nf_metro.parser.model import PortSide
+
+    port = graph.ports.get(rp.edge.source)
+    if not port or not port.is_entry:
+        return False
+    section = graph.sections.get(port.section_id)
+    if section is None:
+        return False
+    if lanes_run_along_y(section.direction):
+        return port.side in (PortSide.TOP, PortSide.BOTTOM)
+    return port.side in (PortSide.LEFT, PortSide.RIGHT)
+
+
+def iter_serpentine_backtracks(
+    graph: MetroGraph,
+    routes: list[RoutedPath],
+    offsets: dict[tuple[str, str], float],
+    *,
+    backtrack_frac: float = 0.5,
+    tolerance: float = 0.0,
+) -> Iterator[tuple[str, float, float, Section]]:
+    """Yield ``(sid, against, limit, section)`` for each stacked section that
+    backtracks against its flow beyond ``backtrack_frac`` of its width.
+
+    Same-direction sections stacked in one grid column and chained serpentine
+    their effective flow row by row so consecutive sections meet on a shared
+    side joined by a short vertical drop.  A section that fails to
+    alternate enters on the wrong side and folds its internal route back across
+    the section width.  For every section in a detected serpentine run this
+    sums the wrong-way horizontal travel of its internal segments, measured on
+    the rendered geometry (route offsets applied), and reports the section when
+    that travel exceeds ``backtrack_frac * width + tolerance``.  Shared by the
+    runtime guard and the offline validator so the two cannot drift.
+    """
+    from nf_metro.layout.auto_layout import detect_serpentine_runs
+    from nf_metro.layout.routing.common import apply_route_offsets
+
+    dag = graph.section_dag
+    if dag is None:
+        return
+    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
+    serpentine_sections = {sid for run in runs for sid in run}
+    if not serpentine_sections:
+        return
+
+    wrong_way: dict[str, float] = {sid: 0.0 for sid in serpentine_sections}
+    for rp in routes:
+        src_sec = graph.section_for_station(rp.edge.source)
+        if src_sec != graph.section_for_station(rp.edge.target):
+            continue
+        if src_sec not in serpentine_sections:
+            continue
+        if _route_is_side_entry_turn_in(graph, rp):
+            continue
+        forward = 1.0 if graph.sections[src_sec].direction != "RL" else -1.0
+        pts = apply_route_offsets(rp, offsets)
+        for k in range(len(pts) - 1):
+            dx = pts[k + 1][0] - pts[k][0]
+            if dx * forward < 0:
+                wrong_way[src_sec] += abs(dx)
+
+    for sid, against in wrong_way.items():
+        section = graph.sections[sid]
+        limit = backtrack_frac * max(section.bbox_w, 1.0)
+        if against > limit + tolerance:
+            yield sid, against, limit, section

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -34,7 +34,11 @@ from nf_metro.layout.constants import (
 from nf_metro.layout.geometry import (
     AxisFrame,
     BBoxXIndex,
+    iter_bbox_checkable_stations,
+    iter_coincident_stations,
     iter_section_overlaps,
+    iter_serpentine_backtracks,
+    iter_stations_outside_bbox,
     lanes_run_along_x,
     lanes_run_along_y,
     segment_intersects_bbox,
@@ -225,22 +229,6 @@ def _guard_coordinates_finite(graph: MetroGraph, phase: str) -> None:
                 )
 
 
-def _bbox_guarded_stations(
-    graph: MetroGraph,
-) -> Iterator[tuple[str, Station, Section]]:
-    """Yield ``(sid, station, section)`` for each rendered station that a
-    bbox-containment guard should check: skips ports, junctions, and
-    stations whose section has no sized bbox.  Shared by the marker-edge
-    and centre-containment guards so they can't drift on what they exempt.
-    """
-    junction_ids = graph.junction_ids
-    for sid, st in graph.stations.items():
-        sec = graph.sections.get(st.section_id or "")
-        if not sec or st.is_port or sid in junction_ids or sec.bbox_w == 0:
-            continue
-        yield sid, st, sec
-
-
 def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
     """After Stage 2.1+: rendered station markers (and terminus icons) must
     be fully within their section bbox.
@@ -254,7 +242,7 @@ def _guard_stations_in_sections(graph: MetroGraph, phase: str) -> None:
     section.
     """
     tol = GUARD_TOLERANCE
-    for sid, st, sec in _bbox_guarded_stations(graph):
+    for sid, st, sec in iter_bbox_checkable_stations(graph):
         # Off-track inputs and terminus icons render at icon scale; on-track
         # markers render at station-pill scale.  Use the wider reach so the
         # guard catches icon spill-over above the bbox top.
@@ -321,12 +309,7 @@ def _guard_stations_within_bbox(graph: MetroGraph, phase: str) -> None:
     the right of its own bbox, and the engine must reject that loudly
     rather than render it silently.
     """
-    tol = GUARD_TOLERANCE
-    for sid, st, sec in _bbox_guarded_stations(graph):
-        inside_x = sec.bbox_x - tol <= st.x <= sec.bbox_x + sec.bbox_w + tol
-        inside_y = sec.bbox_y - tol <= st.y <= sec.bbox_y + sec.bbox_h + tol
-        if inside_x and inside_y:
-            continue
+    for sid, st, sec in iter_stations_outside_bbox(graph, GUARD_TOLERANCE):
         detail = (
             f"{phase}: station {sid!r} centre ({st.x:.1f}, {st.y:.1f}) "
             f"outside section {st.section_id!r} bbox "
@@ -2179,21 +2162,10 @@ def _guard_no_coincident_station_coords(
     render as per-rail knobs across the rail bundle, so a shared centre is
     not a visual collision there.
     """
-    exempt_rail = graph.has_rail_sections
-    placed: list[tuple[str, float, float]] = []
-    for sid, st in graph.stations.items():
-        if st.is_port or st.is_hidden or (exempt_rail and graph.station_is_rail(sid)):
-            continue
-        placed.append((sid, st.x, st.y))
-    placed.sort(key=lambda p: p[1])
-    for i, (sid, x, y) in enumerate(placed):
-        for oid, ox, oy in placed[i + 1 :]:
-            if ox - x > tolerance:
-                break  # Sorted by x; no further coincidence possible.
-            if abs(y - oy) <= tolerance:
-                raise PhaseInvariantError(
-                    f"{phase}: {sid!r} and {oid!r} share coordinate ({x:.1f}, {y:.1f})"
-                )
+    for sid, oid, x, y in iter_coincident_stations(graph, tolerance):
+        raise PhaseInvariantError(
+            f"{phase}: {sid!r} and {oid!r} share coordinate ({x:.1f}, {y:.1f})"
+        )
 
 
 def _guard_no_line_crosses_non_consumer(
@@ -3777,31 +3749,12 @@ def _guard_no_artefactual_counter_flow(
             )
 
 
-def _is_side_entry_turn_in(graph: MetroGraph, rp: RoutedPath) -> bool:
-    """Whether *rp* is the turn-in leg from an entry port perpendicular to flow.
-
-    An entry port on the axis perpendicular to its section's flow (LEFT/RIGHT on
-    a vertical-flow TB/BT section, TOP/BOTTOM on a horizontal-flow LR/RL one)
-    reaches the trunk via one traverse perpendicular to that flow.  That leg is
-    the entry, bounded by the section width, not a serpentine fold-back, so
-    backtrack accounting excludes it.
-    """
-    port = graph.ports.get(rp.edge.source)
-    if not port or not port.is_entry:
-        return False
-    section = graph.sections.get(port.section_id)
-    if section is None:
-        return False
-    if lanes_run_along_y(section.direction):
-        return port.side in (PortSide.TOP, PortSide.BOTTOM)
-    return port.side in (PortSide.LEFT, PortSide.RIGHT)
-
-
 def _guard_serpentine_no_backtrack(
     graph: MetroGraph,
     phase: str,
     *,
     routes: list[RoutedPath] | None = None,
+    offsets: dict[tuple[str, str], float] | None = None,
 ) -> None:
     """After routing: stacked same-direction sections must not backtrack.
 
@@ -3813,46 +3766,20 @@ def _guard_serpentine_no_backtrack(
     run, the wrong-way horizontal travel of its internal segments must stay
     below half the section width.
     """
-    from nf_metro.layout.auto_layout import detect_serpentine_runs
-
     routes = _ensure_routes(graph, routes)
+    if offsets is None:
+        from nf_metro.layout.routing import compute_station_offsets
 
-    dag = graph.section_dag
-    if dag is None:
-        return
-    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
-    serpentine_sections = {sid for run in runs for sid in run}
-    if not serpentine_sections:
-        return
+        offsets = compute_station_offsets(graph)
 
-    wrong_way: dict[str, float] = {sid: 0.0 for sid in serpentine_sections}
-    for rp in routes:
-        src_sec = graph.section_for_station(rp.edge.source)
-        if src_sec != graph.section_for_station(rp.edge.target):
-            continue
-        if src_sec not in serpentine_sections:
-            continue
-        if _is_side_entry_turn_in(graph, rp):
-            # A LEFT/RIGHT entry port feeds the trunk via one turn-in leg
-            # perpendicular to the section's flow -- the entry itself, bounded
-            # by the section width, not a serpentine fold-back.
-            continue
-        forward = 1.0 if graph.sections[src_sec].direction != "RL" else -1.0
-        xs = [p[0] for p in rp.points]
-        for x1, x2 in zip(xs, xs[1:]):
-            dx = x2 - x1
-            if dx * forward < 0:
-                wrong_way[src_sec] += abs(dx)
-
-    for sid, against in wrong_way.items():
-        section = graph.sections[sid]
-        limit = 0.5 * max(section.bbox_w, 1.0)
-        if against > limit + GUARD_TOLERANCE:
-            raise PhaseInvariantError(
-                f"{phase}: stacked section {sid!r} (dir={section.direction}) "
-                f"backtracks {against:.1f}px against its flow (>{limit:.1f}px); "
-                f"the serpentine chain is kinking instead of dropping vertically"
-            )
+    for sid, against, limit, section in iter_serpentine_backtracks(
+        graph, routes, offsets, tolerance=GUARD_TOLERANCE
+    ):
+        raise PhaseInvariantError(
+            f"{phase}: stacked section {sid!r} (dir={section.direction}) "
+            f"backtracks {against:.1f}px against its flow (>{limit:.1f}px); "
+            f"the serpentine chain is kinking instead of dropping vertically"
+        )
 
 
 def _guard_inter_row_run_clearance(
@@ -5360,7 +5287,11 @@ GUARD_REGISTRY: tuple[GuardSpec, ...] = (
             "channel are not flagged."
         ),
     ),
-    GuardSpec(_guard_serpentine_no_backtrack, "A", needs=frozenset({"routes"})),
+    GuardSpec(
+        _guard_serpentine_no_backtrack,
+        "A",
+        needs=frozenset({"routes", "offsets"}),
+    ),
     GuardSpec(
         _guard_no_artefactual_counter_flow,
         "B",

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -11,9 +11,18 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from nf_metro.layout.constants import Y_SPACING
-from nf_metro.layout.geometry import iter_section_overlaps
-from nf_metro.layout.phases._common import section_axes
+from nf_metro.layout.geometry import (
+    iter_coincident_stations,
+    iter_section_overlaps,
+    iter_serpentine_backtracks,
+    iter_stations_outside_bbox,
+)
+from nf_metro.layout.phases._common import (
+    routes_through_unrelated_sections,
+    section_axes,
+)
 from nf_metro.layout.phases.off_track import _off_track_anchor_of
+from nf_metro.layout.phases.spacing import _residual_label_overlaps
 from nf_metro.layout.routing import compute_station_offsets, route_edges
 from nf_metro.layout.routing.common import RoutedPath, is_orthogonal_turn
 from nf_metro.parser.model import MetroGraph, PortSide
@@ -76,7 +85,7 @@ def validate_layout(graph: MetroGraph) -> list[Violation]:
     precomputed = _compute_routes(graph)
     violations.extend(check_edge_waypoints(graph, _precomputed=precomputed))
     if precomputed is not None:
-        violations.extend(check_label_overlap(graph, _precomputed=precomputed))
+        violations.extend(check_label_overlap(graph))
         violations.extend(check_edge_section_crossing(graph, _precomputed=precomputed))
         violations.extend(
             check_bypass_section_clearance(graph, _precomputed=precomputed)
@@ -137,37 +146,29 @@ def check_section_overlap(
 def check_station_containment(
     graph: MetroGraph, margin: float = 5.0
 ) -> list[Violation]:
-    """Check that non-port stations are within their section bbox (with margin)."""
+    """Check that non-port stations are within their section bbox (with margin).
+
+    Delegates the centre-in-bbox geometry to
+    :func:`iter_stations_outside_bbox`, the same predicate the always-on
+    runtime guard uses.
+    """
     violations: list[Violation] = []
 
-    for sid, station in graph.stations.items():
-        if station.is_port or station.section_id is None:
-            continue
-
-        section = graph.sections.get(station.section_id)
-        if not section or section.bbox_w == 0:
-            continue
-
-        sx1 = section.bbox_x - margin
-        sy1 = section.bbox_y - margin
-        sx2 = section.bbox_x + section.bbox_w + margin
-        sy2 = section.bbox_y + section.bbox_h + margin
-
-        if not (sx1 <= station.x <= sx2 and sy1 <= station.y <= sy2):
-            violations.append(
-                Violation(
-                    check="station_containment",
-                    severity=Severity.ERROR,
-                    message=(
-                        f"Station '{sid}' at ({station.x:.1f},{station.y:.1f}) "
-                        f"is outside section '{station.section_id}' "
-                        f"bbox ({section.bbox_x:.0f},{section.bbox_y:.0f},"
-                        f"{section.bbox_x + section.bbox_w:.0f},"
-                        f"{section.bbox_y + section.bbox_h:.0f})"
-                    ),
-                    context={"station": sid, "section": station.section_id},
-                )
+    for sid, station, section in iter_stations_outside_bbox(graph, margin):
+        violations.append(
+            Violation(
+                check="station_containment",
+                severity=Severity.ERROR,
+                message=(
+                    f"Station '{sid}' at ({station.x:.1f},{station.y:.1f}) "
+                    f"is outside section '{station.section_id}' "
+                    f"bbox ({section.bbox_x:.0f},{section.bbox_y:.0f},"
+                    f"{section.bbox_x + section.bbox_w:.0f},"
+                    f"{section.bbox_y + section.bbox_h:.0f})"
+                ),
+                context={"station": sid, "section": station.section_id},
             )
+        )
 
     return violations
 
@@ -273,27 +274,18 @@ def check_coincident_stations(
     """
     violations: list[Violation] = []
 
-    placed: list[tuple[str, float, float]] = []
-    for sid, station in graph.stations.items():
-        if station.is_port or station.is_hidden:
-            continue
-        if graph.station_is_rail(sid):
-            continue
-        for other, ox, oy in placed:
-            if abs(station.x - ox) <= tolerance and abs(station.y - oy) <= tolerance:
-                violations.append(
-                    Violation(
-                        check="coincident_stations",
-                        severity=Severity.ERROR,
-                        message=(
-                            f"Stations '{other}' and '{sid}' share coordinate "
-                            f"({station.x:.1f}, {station.y:.1f})"
-                        ),
-                        context={"stations": [other, sid]},
-                    )
-                )
-                break
-        placed.append((sid, station.x, station.y))
+    for sid_a, sid_b, x, y in iter_coincident_stations(graph, tolerance):
+        violations.append(
+            Violation(
+                check="coincident_stations",
+                severity=Severity.ERROR,
+                message=(
+                    f"Stations '{sid_a}' and '{sid_b}' share coordinate "
+                    f"({x:.1f}, {y:.1f})"
+                ),
+                context={"stations": [sid_a, sid_b]},
+            )
+        )
 
     return violations
 
@@ -348,45 +340,16 @@ def check_minimum_section_spacing(
     return violations
 
 
-def check_label_overlap(
-    graph: MetroGraph,
-    _precomputed: tuple[dict[tuple[str, str], float], list[RoutedPath]] | None = None,
-) -> list[Violation]:
+def check_label_overlap(graph: MetroGraph) -> list[Violation]:
     """Check that no station label overlaps another label or a marker.
 
-    Mirrors the runtime guard: label/label overlap is never allowed;
-    label/marker grazes within ``LABEL_OVERLAP_TOL`` are tolerated.  Uses the
-    same detector the engine and wrapping pass use, so this reports exactly
-    what the final render would draw.
+    Delegates to :func:`_residual_label_overlaps`, the same place-and-detect
+    pipeline the runtime guard validates, so this reports exactly the
+    fully-wrapped state the renderer will draw: label/label overlap is never
+    allowed; label/marker grazes within ``LABEL_OVERLAP_TOL`` are tolerated.
     """
-    from nf_metro.layout.labels import find_label_overlaps, place_labels
-
     violations: list[Violation] = []
-    if _precomputed is not None:
-        offsets, routes = _precomputed
-    else:
-        precomputed = _compute_routes(graph)
-        if precomputed is None:
-            return violations
-        offsets, routes = precomputed
-
-    try:
-        placements = place_labels(
-            graph,
-            station_offsets=offsets,
-            routes=routes,
-            label_angle=graph.label_angle or 0.0,
-        )
-    except Exception as e:
-        return [
-            Violation(
-                check="label_overlap",
-                severity=Severity.ERROR,
-                message=f"Label placement failed: {e}",
-            )
-        ]
-
-    for ov in find_label_overlaps(graph, placements, offsets):
+    for ov in _residual_label_overlaps(graph, allow_hyphenation=True):
         target = "label" if ov.kind == "label" else "marker"
         violations.append(
             Violation(
@@ -464,76 +427,6 @@ def check_edge_waypoints(
     return violations
 
 
-def _segment_crosses_bbox(
-    x1: float,
-    y1: float,
-    x2: float,
-    y2: float,
-    bx: float,
-    by: float,
-    bw: float,
-    bh: float,
-    margin: float = 2.0,
-) -> bool:
-    """Test if a line segment passes through (not just touches) an AABB.
-
-    Uses an inset margin so segments running along a bbox edge don't
-    trigger false positives.  Handles axis-aligned segments (common in
-    metro routing) as simple range overlaps.
-    """
-    # Inset the bbox by margin so edge-touching doesn't count
-    bx1 = bx + margin
-    by1 = by + margin
-    bx2 = bx + bw - margin
-    by2 = by + bh - margin
-
-    if bx1 >= bx2 or by1 >= by2:
-        return False  # Section too small after inset
-
-    # Normalise segment endpoints
-    seg_x_min, seg_x_max = min(x1, x2), max(x1, x2)
-    seg_y_min, seg_y_max = min(y1, y2), max(y1, y2)
-
-    # Quick reject: no overlap on either axis
-    if seg_x_max <= bx1 or seg_x_min >= bx2:
-        return False
-    if seg_y_max <= by1 or seg_y_min >= by2:
-        return False
-
-    # Horizontal segment
-    if abs(y1 - y2) < 0.5:
-        return by1 < y1 < by2
-
-    # Vertical segment
-    if abs(x1 - x2) < 0.5:
-        return bx1 < x1 < bx2
-
-    # Diagonal / general segment: use parametric clipping (Liang-Barsky)
-    dx = x2 - x1
-    dy = y2 - y1
-    t_min, t_max = 0.0, 1.0
-
-    for p, q in [
-        (-dx, x1 - bx1),
-        (dx, bx2 - x1),
-        (-dy, y1 - by1),
-        (dy, by2 - y1),
-    ]:
-        if abs(p) < 1e-9:
-            if q < 0:
-                return False
-        else:
-            t = q / p
-            if p < 0:
-                t_min = max(t_min, t)
-            else:
-                t_max = min(t_max, t)
-            if t_min > t_max:
-                return False
-
-    return t_min < t_max
-
-
 def _edge_home_sections(graph: MetroGraph, source_id: str, target_id: str) -> set[str]:
     """Return section IDs that own the source and target of an edge."""
     home: set[str] = set()
@@ -567,7 +460,14 @@ def check_edge_section_crossing(
     margin: float = 2.0,
     _precomputed: tuple[dict[tuple[str, str], float], list[RoutedPath]] | None = None,
 ) -> list[Violation]:
-    """Check no routed edge segment passes through a non-home section."""
+    """Check no routed segment passes through a section it does not connect to.
+
+    Delegates the crossing geometry to
+    :func:`routes_through_unrelated_sections`, the single-source helper the
+    always-on runtime guard uses (route offsets applied, every route including
+    fan bundles, section membership via ``section_for_station``, own-line trunk
+    overlays exempt).
+    """
     violations: list[Violation] = []
 
     if _precomputed is not None:
@@ -579,58 +479,29 @@ def check_edge_section_crossing(
         except Exception:
             return violations
 
-    # Pre-collect sections with valid bboxes
-    sections = [
-        (sid, s) for sid, s in graph.sections.items() if s.bbox_w > 0 and s.bbox_h > 0
-    ]
-
-    for route in routes:
-        if not route.is_inter_section:
-            continue
-
-        home = _edge_home_sections(graph, route.edge.source, route.edge.target)
-
-        for k in range(len(route.points) - 1):
-            x1, y1 = route.points[k]
-            x2, y2 = route.points[k + 1]
-
-            for sid, sec in sections:
-                if sid in home:
-                    continue
-
-                if _segment_crosses_bbox(
-                    x1,
-                    y1,
-                    x2,
-                    y2,
-                    sec.bbox_x,
-                    sec.bbox_y,
-                    sec.bbox_w,
-                    sec.bbox_h,
-                    margin=margin,
-                ):
-                    violations.append(
-                        Violation(
-                            check="edge_section_crossing",
-                            severity=Severity.ERROR,
-                            message=(
-                                f"Edge {route.edge.source}->{route.edge.target} "
-                                f"(line={route.line_id}) segment {k} "
-                                f"({x1:.0f},{y1:.0f})->({x2:.0f},{y2:.0f}) "
-                                f"crosses section '{sid}' "
-                                f"bbox ({sec.bbox_x:.0f},{sec.bbox_y:.0f},"
-                                f"{sec.bbox_x + sec.bbox_w:.0f},"
-                                f"{sec.bbox_y + sec.bbox_h:.0f})"
-                            ),
-                            context={
-                                "source": route.edge.source,
-                                "target": route.edge.target,
-                                "line": route.line_id,
-                                "segment": k,
-                                "crossed_section": sid,
-                            },
-                        )
-                    )
+    for route, sid in routes_through_unrelated_sections(
+        graph, inset=margin, routes=routes, offsets=offsets
+    ):
+        sec = graph.sections[sid]
+        violations.append(
+            Violation(
+                check="edge_section_crossing",
+                severity=Severity.ERROR,
+                message=(
+                    f"Edge {route.edge.source}->{route.edge.target} "
+                    f"(line={route.line_id}) crosses section '{sid}' "
+                    f"bbox ({sec.bbox_x:.0f},{sec.bbox_y:.0f},"
+                    f"{sec.bbox_x + sec.bbox_w:.0f},"
+                    f"{sec.bbox_y + sec.bbox_h:.0f})"
+                ),
+                context={
+                    "source": route.edge.source,
+                    "target": route.edge.target,
+                    "line": route.line_id,
+                    "crossed_section": sid,
+                },
+            )
+        )
 
     return violations
 
@@ -1657,18 +1528,6 @@ def check_exit_port_feeder_alignment(
     return violations
 
 
-def _entry_perpendicular_to_flow(port, section) -> bool:
-    """Whether an entry port sits on the axis perpendicular to its flow.
-
-    LEFT/RIGHT on a vertical-flow (TB/BT) section, TOP/BOTTOM on a
-    horizontal-flow (LR/RL) one.  Such a port's turn-in leg is the entry,
-    perpendicular to flow, not a serpentine fold-back.
-    """
-    if section.direction in ("LR", "RL"):
-        return port.side in (PortSide.TOP, PortSide.BOTTOM)
-    return port.side in (PortSide.LEFT, PortSide.RIGHT)
-
-
 def check_serpentine_no_backtrack(
     graph: MetroGraph,
     backtrack_frac: float = 0.5,
@@ -1676,19 +1535,15 @@ def check_serpentine_no_backtrack(
 ) -> list[Violation]:
     """Stacked same-direction sections must not backtrack horizontally.
 
-    When same-direction sections are stacked in one grid column and chained
-    (issue #421), the engine serpentines their effective flow so consecutive
-    sections meet on a shared side joined by a short vertical drop.  A section
-    that fails to serpentine instead enters on the wrong side and folds its
-    internal route back across (nearly) the full section width.
+    When same-direction sections are stacked in one grid column and chained,
+    the engine serpentines their effective flow so consecutive sections meet
+    on a shared side joined by a short vertical drop.  A section that fails to
+    serpentine instead enters on the wrong side and folds its internal route
+    back across (nearly) the full section width.
 
-    For every section in a detected serpentine run, this sums the horizontal
-    travel of its internal routed segments that runs *against* the section's
-    flow direction.  If that wrong-way travel exceeds ``backtrack_frac`` of the
-    section width, the section is kinking the chain.
+    Delegates the backtrack geometry to :func:`iter_serpentine_backtracks`,
+    the same predicate the runtime guard uses.
     """
-    from nf_metro.layout.auto_layout import detect_serpentine_runs
-
     violations: list[Violation] = []
 
     if _precomputed is not None:
@@ -1700,56 +1555,27 @@ def check_serpentine_no_backtrack(
         except Exception:
             return violations
 
-    dag = graph.section_dag
-    if dag is None:
-        return violations
-    runs = detect_serpentine_runs(graph, dag.successors, dag.predecessors)
-    serpentine_sections = {sid for run in runs for sid in run}
-    if not serpentine_sections:
-        return violations
-
-    # Internal route segments grouped by home section.
-    wrong_way: dict[str, float] = {sid: 0.0 for sid in serpentine_sections}
-    for route in routes:
-        src_sec = graph.section_for_station(route.edge.source)
-        tgt_sec = graph.section_for_station(route.edge.target)
-        if src_sec != tgt_sec or src_sec not in serpentine_sections:
-            continue
-        port = graph.ports.get(route.edge.source)
-        section = graph.sections[src_sec]
-        if port and port.is_entry and _entry_perpendicular_to_flow(port, section):
-            # An entry port's turn-in to the trunk is the entry, one leg
-            # perpendicular to flow, not a serpentine fold-back.
-            continue
-        forward = 1.0 if section.direction != "RL" else -1.0
-        pts = apply_route_offsets(route, offsets)
-        for k in range(len(pts) - 1):
-            dx = pts[k + 1][0] - pts[k][0]
-            if dx * forward < 0:
-                wrong_way[src_sec] += abs(dx)
-
-    for sid, against in wrong_way.items():
-        section = graph.sections[sid]
-        limit = backtrack_frac * max(section.bbox_w, 1.0)
-        if against > limit:
-            violations.append(
-                Violation(
-                    check="serpentine_no_backtrack",
-                    severity=Severity.ERROR,
-                    message=(
-                        f"Stacked section '{sid}' (dir={section.direction}) "
-                        f"backtracks {against:.0f}px against its flow "
-                        f"(>{limit:.0f}px = {backtrack_frac:.0%} of width "
-                        f"{section.bbox_w:.0f}); the serpentine chain is "
-                        f"kinking instead of dropping vertically"
-                    ),
-                    context={
-                        "section": sid,
-                        "direction": section.direction,
-                        "against": against,
-                        "limit": limit,
-                    },
-                )
+    for sid, against, limit, section in iter_serpentine_backtracks(
+        graph, routes, offsets, backtrack_frac=backtrack_frac
+    ):
+        violations.append(
+            Violation(
+                check="serpentine_no_backtrack",
+                severity=Severity.ERROR,
+                message=(
+                    f"Stacked section '{sid}' (dir={section.direction}) "
+                    f"backtracks {against:.0f}px against its flow "
+                    f"(>{limit:.0f}px = {backtrack_frac:.0%} of width "
+                    f"{section.bbox_w:.0f}); the serpentine chain is "
+                    f"kinking instead of dropping vertically"
+                ),
+                context={
+                    "section": sid,
+                    "direction": section.direction,
+                    "against": against,
+                    "limit": limit,
+                },
             )
+        )
 
     return violations

--- a/tests/test_guard_registry.py
+++ b/tests/test_guard_registry.py
@@ -143,6 +143,65 @@ def test_no_registry_guard_duplicates_an_always_on_check() -> None:
     )
 
 
+# Geometric properties checked by both a runtime guard and the offline
+# validator oracle, each single-sourced through one shared predicate: the
+# guard contributes tier/registry/raise semantics, the oracle contributes
+# ``Violation`` packaging, and neither re-implements the geometry.  The tuple
+# is ``(guard_name, oracle_name, shared_predicate_name)``.
+_SHARED_GEOMETRY_PREDICATES = (
+    ("_guard_no_section_overlap", "check_section_overlap", "iter_section_overlaps"),
+    (
+        "_guard_stations_within_bbox",
+        "check_station_containment",
+        "iter_stations_outside_bbox",
+    ),
+    (
+        "_guard_no_coincident_station_coords",
+        "check_coincident_stations",
+        "iter_coincident_stations",
+    ),
+    (
+        "_guard_no_route_through_section",
+        "check_edge_section_crossing",
+        "routes_through_unrelated_sections",
+    ),
+    ("_guard_no_label_overlap", "check_label_overlap", "_residual_label_overlaps"),
+    (
+        "_guard_serpentine_no_backtrack",
+        "check_serpentine_no_backtrack",
+        "iter_serpentine_backtracks",
+    ),
+)
+
+
+def test_guard_and_oracle_share_one_geometry_predicate() -> None:
+    """Each duplicated geometric property is single-sourced across the
+    guards/oracle file boundary: both the runtime guard and the offline
+    validator check must reference the same shared predicate, so a geometry
+    rule (tolerance, exemption scope) lives in exactly one place and the two
+    cannot silently drift."""
+    import layout_validator
+
+    missing: dict[str, list[str]] = {}
+    for guard_name, oracle_name, predicate in _SHARED_GEOMETRY_PREDICATES:
+        guard_src = inspect.getsource(getattr(guards, guard_name))
+        oracle_src = inspect.getsource(getattr(layout_validator, oracle_name))
+        absent = [
+            f"{side}:{name}"
+            for side, name, src in (
+                ("guard", guard_name, guard_src),
+                ("oracle", oracle_name, oracle_src),
+            )
+            if predicate not in src
+        ]
+        if absent:
+            missing[predicate] = absent
+    assert not missing, (
+        "guard/oracle pairs not routed through their shared predicate "
+        f"(each side must call it, not re-implement the geometry): {missing}"
+    )
+
+
 def test_every_guard_is_classified_in_exactly_one_registry() -> None:
     """Every defined ``_guard_*`` lives in exactly one of the two guard
     registries, so no guard escapes tier / issue-pin classification."""


### PR DESCRIPTION
## Summary

Five geometric properties were implemented twice - once in a runtime `_guard_*`
and once in the offline `tests/layout_validator.py` oracle - as independent
code that could drift silently. Each is now single-sourced through one shared
predicate that both call: the guard contributes tier/registry/raise semantics,
the oracle contributes `Violation` packaging, and neither re-implements the
geometry.

New shared predicates in `src/nf_metro/layout/geometry.py`:

- `iter_coincident_stations` - distinct visible stations sharing a centre.
- `iter_bbox_checkable_stations` / `iter_stations_outside_bbox` - station-centre
  containment within a section bbox (the guard's `_bbox_guarded_stations` is now
  a thin alias of the former).
- `iter_serpentine_backtracks` (+ `_route_is_side_entry_turn_in`) - wrong-way
  horizontal travel of stacked serpentine sections.

Reused existing shared helpers:

- `routes_through_unrelated_sections` (`phases/_common.py`) - the oracle's
  `check_edge_section_crossing` now delegates to the same #484 helper the guard
  uses, instead of its own `_segment_crosses_bbox` + `_edge_home_sections` scan.
- `_residual_label_overlaps` (`phases/spacing.py`) - the oracle's
  `check_label_overlap` now delegates to the same place-and-detect pipeline the
  guard validates.
- `iter_section_overlaps` - already shared (`_guard_no_section_overlap` /
  `check_section_overlap`); included in the meta-test for completeness.

The dedup meta-test is extended across the guards/oracle file boundary:
`test_guard_and_oracle_share_one_geometry_predicate` asserts each guard/oracle
pair references its shared predicate rather than re-implementing the geometry.

Dead code removed: `tests/layout_validator.py::_segment_crosses_bbox` and
`_entry_perpendicular_to_flow`; `guards.py::_is_side_entry_turn_in` (folded into
the shared predicate).

## Tolerance / exemption reconciliations (deliberate, not silent)

The two implementations of each pair were diffed before merging. Where they
differed, the shared predicate takes the stricter/more-correct behaviour:

- **Serpentine points source:** the guard previously summed wrong-way travel on
  raw `route.points`; the oracle used offset-applied (rendered) points. The
  shared predicate uses the rendered geometry (offset-applied) - what the viewer
  actually sees - so the guard now requests `offsets` too. The guard keeps its
  `GUARD_TOLERANCE` (5px) slack against float noise (passed as `tolerance`); the
  oracle keeps its zero-slack default. Verified no change on the corpus.
- **Route-through algorithm:** the oracle's crossing scan is replaced by the
  guard's `routes_through_unrelated_sections` (route offsets applied, every
  route incl. fan bundles, membership via `section_for_station`, own-line trunk
  overlays exempt). `check_bypass_section_clearance` is a distinct clearance
  property and is left unchanged.
- **Label overlap:** the oracle now validates the fully-wrapped/hyphenated
  renderer-faithful state via `_residual_label_overlaps` (the guard's pipeline)
  rather than a single `place_labels` pass. The overlap detector
  (`find_label_overlaps`) was already shared.
- **Station containment:** the oracle previously also inspected junction
  (synthetic, invisible) nodes; the shared selection matches the always-on
  guard's deliberate exemption of ports and junctions. Both use a 5px margin
  (the oracle default equals `GUARD_TOLERANCE`).

Empirical check: laying out all 257 example + topology fixtures, the guard-side
and oracle-side results agree exactly for the route-through and label pairs (0
discrepancies), so these reconciliations are behaviour-preserving on the corpus.
Rendering is unaffected - the guards only read geometry to decide whether to
raise; no coordinates change.

Fixes #1444

## Test plan
- [x] `pytest` full suite green (incl. new meta-test, guard-registry golden,
  topology validation, serpentine invariant)
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` clean
- [x] Gallery renders (rnaseq_sections, variantbenchmarking_auto,
  stacked_lr_serpentine, epitopeprediction) do not abort
- [ ] Render-preview verdict: expected "No visual changes" (refactor only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
