### PR TITLE
refactor(layout): named tolerances and retire Y-only bbox aliases (#1446)

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -391,6 +391,21 @@ into one coordinate."""
 SAME_Y_TOLERANCE: float = 0.1
 """Tolerance for treating two stations as sharing a base Y row."""
 
+COORD_GROUP_DIGITS_COARSE: int = 1
+"""Decimal places for the coarser of the two coordinate-grouping precisions.
+
+Several layout passes group stations into a column/row bucket by rounding a
+coordinate to a stable dict/set key (absorbing float drift from arithmetic
+like averaging).  This precision is used where the grouped axis only needs to
+resolve to sub-pixel-visible differences (e.g. off-track column stacking)."""
+
+COORD_GROUP_DIGITS_FINE: int = 3
+"""Decimal places for the finer of the two coordinate-grouping precisions.
+
+Used where a coordinate-grouping key must distinguish stations placed by
+finer arithmetic (e.g. sub-pixel column alignment during bundle balancing)
+than :data:`COORD_GROUP_DIGITS_COARSE` would resolve."""
+
 DIAGONAL_SLOPE_RATIO: float = 0.05
 """Slope above which a route segment counts as a diagonal (``|dy| >= |dx| *
 this``) rather than a flat trunk run.  A diagonal is what can rake a label."""
@@ -720,6 +735,10 @@ renderer lifts the icon by the same amount keeps the icon fixed and slides the
 nub clear below the caption.  Shared by ``rail_mode`` (the drop) and
 ``render.svg`` (the matching icon lift) so the two stay in lockstep."""
 
+OFF_TRACK_TRUNK_CLEARANCE_MARGIN: float = 2.0
+"""Small margin so an off-track icon's stroke doesn't touch a trunk line
+track it is being bumped clear of."""
+
 TERMINUS_ICON_GAP: float = 6.0
 """Gap between a terminus station pill and its first file icon.
 
@@ -789,6 +808,16 @@ COLLINEAR_AXIS_TOL: float = 0.5
 """Maximum constant-axis separation for two axis-aligned legs to count as
 sharing one track.  Tight (sub-pixel) so legs on a single track register as
 collinear while neighbouring legs one slot apart in a routing channel do not."""
+
+PORT_BOUNDARY_CROSSING_TOL: float = 24.0
+"""Distance from a declared port within which a routed segment crossing a
+section bbox edge is treated as that port's legitimate entry/exit, not a
+guard-forbidden cut through the box."""
+
+BOUNDARY_CROSSING_INSET: float = 4.0
+"""Inward slack on a section bbox edge when checking whether a crossing
+point falls within the edge's perpendicular extent, absorbing routed
+segments that land a few pixels past the box's own corner."""
 
 COMPONENT_BAND_OVERLAP_TOLERANCE: float = 0.5
 """Slack permitted when checking that independently-stacked disconnected

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -52,8 +52,6 @@ from nf_metro.layout.phases._common import (  # noqa: F401
     _fan_offsets,
     _grid_group_section_ids,
     _grid_rows_top_to_bottom,
-    _grow_section_bbox_downward,
-    _grow_section_bbox_upward,
     _max_stations_per_layer,
     _route_crosses_section_boundary,
     _row_contiguous_column_groups,

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -17,10 +17,9 @@ _Box = tuple[float, float, float, float]
 def quantize_coord(value: float, ndigits: int) -> float:
     """Round *value* to *ndigits* decimal places for use as a grouping key.
 
-    Single code path for the "snap a float coordinate to a stable dict/set
-    key" pattern used across layout passes to group stations sharing a
-    column, row, or trunk coordinate despite float drift from arithmetic
-    (averaging, offset accumulation).
+    Snaps a float coordinate to a stable dict/set key so layout passes can
+    group stations sharing a column, row, or trunk coordinate despite float
+    drift from arithmetic (averaging, offset accumulation).
     """
     return round(value, ndigits)
 

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -14,6 +14,17 @@ if TYPE_CHECKING:
 _Box = tuple[float, float, float, float]
 
 
+def quantize_coord(value: float, ndigits: int) -> float:
+    """Round *value* to *ndigits* decimal places for use as a grouping key.
+
+    Single code path for the "snap a float coordinate to a stable dict/set
+    key" pattern used across layout passes to group stations sharing a
+    column, row, or trunk coordinate despite float drift from arithmetic
+    (averaging, offset accumulation).
+    """
+    return round(value, ndigits)
+
+
 def shift_section(
     graph: MetroGraph, section: Section, *, dx: float = 0.0, dy: float = 0.0
 ) -> None:

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -1475,41 +1475,6 @@ def grow_section_bbox_max_edge(
     move_section_bbox_max_edge(graph, section, axis, new_max)
 
 
-def _set_section_bbox_top(
-    graph: MetroGraph, section: Section, new_bbox_top: float
-) -> None:
-    """Move a section's bbox top to *new_bbox_top* and pull TOP ports along.
-
-    Works in both directions: a smaller *new_bbox_top* grows the box
-    upward, a larger one shrinks it.  BOTTOM ports stay put because only
-    the top edge moves.  The Y-axis case of
-    :func:`move_section_bbox_min_edge`.
-    """
-    move_section_bbox_min_edge(graph, section, "y", new_bbox_top)
-
-
-def _grow_section_bbox_upward(
-    graph: MetroGraph, section: Section, new_bbox_top: float
-) -> None:
-    """Expand a section's bbox upward to *new_bbox_top* and pull TOP ports.
-
-    The Y-axis case of :func:`grow_section_bbox_min_edge`: grow-only, so a
-    *new_bbox_top* at or below the current top is a no-op.
-    """
-    grow_section_bbox_min_edge(graph, section, "y", new_bbox_top)
-
-
-def _grow_section_bbox_downward(
-    graph: MetroGraph, section: Section, new_bbox_bottom: float
-) -> None:
-    """Expand a section's bbox downward to *new_bbox_bottom* and pull BOTTOM
-    ports along.  Grow-only: a *new_bbox_bottom* at or above the current
-    bottom edge is a no-op, so the box is never raised.  The Y-axis case of
-    :func:`grow_section_bbox_max_edge`.
-    """
-    grow_section_bbox_max_edge(graph, section, "y", new_bbox_bottom)
-
-
 def exit_run_corridor_clear(
     graph: MetroGraph,
     exit_port_id: str,

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -8,7 +8,9 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
+    BOUNDARY_CROSSING_INSET,
     COORD_TOLERANCE,
+    PORT_BOUNDARY_CROSSING_TOL,
     SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
     STATION_RADIUS_APPROX,
@@ -629,9 +631,9 @@ def _route_crosses_section_boundary(
     graph: MetroGraph,
     routes: list[RoutedPath],
     *,
-    port_tol: float = 24.0,
-    inset: float = 4.0,
-    axis_tol: float = 1.0,
+    port_tol: float = PORT_BOUNDARY_CROSSING_TOL,
+    inset: float = BOUNDARY_CROSSING_INSET,
+    axis_tol: float = COORD_TOLERANCE,
 ) -> tuple[RoutedPath, str, float, float] | None:
     """Return the first ``(route, section_id, x, y)`` where an axis-aligned
     routed segment crosses a section bbox edge away from any declared port,

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -9,13 +9,20 @@ from typing import TYPE_CHECKING
 
 from nf_metro.layout.constants import (
     BOUNDARY_CROSSING_INSET,
+    COORD_GROUP_DIGITS_COARSE,
+    COORD_GROUP_DIGITS_FINE,
     COORD_TOLERANCE,
     PORT_BOUNDARY_CROSSING_TOL,
     SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
     STATION_RADIUS_APPROX,
 )
-from nf_metro.layout.geometry import AxisFrame, lanes_run_along_x, lanes_run_along_y
+from nf_metro.layout.geometry import (
+    AxisFrame,
+    lanes_run_along_x,
+    lanes_run_along_y,
+    quantize_coord,
+)
 from nf_metro.layout.phase_state import require_phase_field
 from nf_metro.parser.model import (
     Edge,
@@ -512,18 +519,22 @@ def _trunk_symmetric_fan_ids(graph: MetroGraph, section: Section) -> set[str]:
         return set()
     counts: dict[float, int] = defaultdict(int)
     for sid in content_ids:
-        counts[round(graph.stations[sid].y, 1)] += 1
+        counts[quantize_coord(graph.stations[sid].y, COORD_GROUP_DIGITS_COARSE)] += 1
     trunk_y = max(counts.items(), key=lambda kv: (kv[1], -kv[0]))[0]
     by_x: dict[float, list[str]] = defaultdict(list)
     for sid in content_ids:
-        by_x[round(graph.stations[sid].x, 1)].append(sid)
+        by_x[quantize_coord(graph.stations[sid].x, COORD_GROUP_DIGITS_COARSE)].append(
+            sid
+        )
     result: set[str] = set()
     for sids in by_x.values():
         if len(sids) < 2:
             continue
         seen_by_offset: dict[float, list[str]] = defaultdict(list)
         for sid in sids:
-            off = round(graph.stations[sid].y - trunk_y, 1)
+            off = quantize_coord(
+                graph.stations[sid].y - trunk_y, COORD_GROUP_DIGITS_COARSE
+            )
             if off == 0.0:
                 continue
             mirrors = seen_by_offset.get(-off)
@@ -1122,7 +1133,7 @@ def _section_trunk_y(graph: MetroGraph, section: Section) -> float | None:
                 and not is_bypass_v(other_id)
                 and set(graph.station_lines(other_id)) == bundle
             ):
-                trunk_ys.add(round(st.y, 3))
+                trunk_ys.add(quantize_coord(st.y, COORD_GROUP_DIGITS_FINE))
     return min(trunk_ys) if trunk_ys else None
 
 

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from collections import defaultdict
 
 from nf_metro.layout.constants import (
+    COORD_GROUP_DIGITS_COARSE,
+    COORD_GROUP_DIGITS_FINE,
     DIAGONAL_RUN,
     ICON_HALF_HEIGHT,
     SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
     STATION_RADIUS_APPROX,
 )
+from nf_metro.layout.geometry import quantize_coord
 from nf_metro.layout.phases._common import (
     _ref_bbox_top,
     _ref_y,
@@ -82,7 +85,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
         for edge in graph.edges_to(port_id):
             src = graph.station_for_edge_source(edge)
             if not src.is_port and edge.source not in port_set:
-                src_ys.add(round(src.y, 1))
+                src_ys.add(quantize_coord(src.y, COORD_GROUP_DIGITS_COARSE))
 
         # Fan-in exits (multiple distinct internal source Ys) want to
         # keep their centred-midpoint convergence Y, so don't move the
@@ -224,14 +227,19 @@ def _fan_free_content_upward(
 
         # Trunk candidates: stations in the entry column carrying the
         # full bundle; topmost stays pinned, others stack above it.
-        xs = sorted({round(graph.stations[sid].x, 3) for sid in internal_ids})
+        xs = sorted(
+            {
+                quantize_coord(graph.stations[sid].x, COORD_GROUP_DIGITS_FINE)
+                for sid in internal_ids
+            }
+        )
         if not xs:
             continue
         entry_x = xs[0] if section.direction == "LR" else xs[-1]
         trunk_candidates = [
             sid
             for sid in internal_ids
-            if round(graph.stations[sid].x, 3) == entry_x
+            if quantize_coord(graph.stations[sid].x, COORD_GROUP_DIGITS_FINE) == entry_x
             and set(graph.station_lines(sid)) == bundle
         ]
         if len(trunk_candidates) < 2:
@@ -241,7 +249,9 @@ def _fan_free_content_upward(
         # has already symmetrically fanned them around the section's
         # port Y and we must not collapse that into a one-sided stack.
         entry_col_all = [
-            sid for sid in internal_ids if round(graph.stations[sid].x, 3) == entry_x
+            sid
+            for sid in internal_ids
+            if quantize_coord(graph.stations[sid].x, COORD_GROUP_DIGITS_FINE) == entry_x
         ]
         if len(trunk_candidates) == len(entry_col_all) and graph.center_ports:
             continue
@@ -344,10 +354,17 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
         if not bundle:
             continue
 
-        xs = sorted({round(graph.stations[sid].x, 3) for sid in internal_ids})
+        xs = sorted(
+            {
+                quantize_coord(graph.stations[sid].x, COORD_GROUP_DIGITS_FINE)
+                for sid in internal_ids
+            }
+        )
         entry_x = xs[0] if section.direction == "LR" else xs[-1]
         entry_col = [
-            sid for sid in internal_ids if round(graph.stations[sid].x, 3) == entry_x
+            sid
+            for sid in internal_ids
+            if quantize_coord(graph.stations[sid].x, COORD_GROUP_DIGITS_FINE) == entry_x
         ]
         trunks = [s for s in entry_col if set(graph.station_lines(s)) == bundle]
         if len(trunks) != 1:
@@ -570,7 +587,7 @@ def _balance_one_section(graph: MetroGraph, section: Section, y_spacing: float) 
 
     cols: dict[float, list[str]] = defaultdict(list)
     for sid in internal_ids:
-        cols[round(graph.stations[sid].x, 3)].append(sid)
+        cols[quantize_coord(graph.stations[sid].x, COORD_GROUP_DIGITS_FINE)].append(sid)
 
     section_top_y = min(graph.stations[s].y for s in internal_ids)
     top_band = section_top_y - _ref_bbox_top(graph, section)
@@ -726,11 +743,13 @@ def _compact_below_trunk_band(
         st = graph.stations.get(sid)
         if st is None or st.is_hidden:
             continue
-        cols_nonmovable[round(st.x, 3)].add(round(st.y, 3))
+        cols_nonmovable[quantize_coord(st.x, COORD_GROUP_DIGITS_FINE)].add(
+            quantize_coord(st.y, COORD_GROUP_DIGITS_FINE)
+        )
     for sid in movables:
         st = graph.stations[sid]
         new_y = st.y - y_spacing
-        col_x = round(st.x, 3)
+        col_x = quantize_coord(st.x, COORD_GROUP_DIGITS_FINE)
         if any(
             abs(oy - new_y) < y_spacing / 2 - SAME_COORD_TOLERANCE
             for oy in cols_nonmovable.get(col_x, set())
@@ -893,7 +912,10 @@ def _loop_column_key(
             succ_x = t.x
     if pred_x is None or succ_x is None:
         return None
-    return (round(pred_x, 3), round(succ_x, 3))
+    return (
+        quantize_coord(pred_x, COORD_GROUP_DIGITS_FINE),
+        quantize_coord(succ_x, COORD_GROUP_DIGITS_FINE),
+    )
 
 
 def _build_loop_columns(

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -20,14 +20,14 @@ from nf_metro.layout.phases._common import (
     _bbox_cols_overlap,
     _content_station_ids,
     _content_station_ys,
-    _grow_section_bbox_upward,
     _is_side_entered_vertical_section,
     _pull_section_ports_to_edge,
     _ref_y,
-    _set_section_bbox_top,
     _side_entered_vertical_feeder_pairs,
     _station_bundle_offset_span,
     _trunk_symmetric_fan_ids,
+    grow_section_bbox_min_edge,
+    move_section_bbox_min_edge,
 )
 from nf_metro.layout.phases.single_section import (
     _terminus_y_overhang,
@@ -834,8 +834,8 @@ def _fit_bboxes_to_content_top(
 
     The grow branch keeps precedence, so a section whose top the row-above
     ceiling pushed down is grown rather than shrunk into the badge.  Both
-    moves go through the bidirectional :func:`_set_section_bbox_top` (TOP
-    ports follow the new edge).
+    moves go through the bidirectional :func:`move_section_bbox_min_edge`
+    (TOP ports follow the new edge).
     """
     from nf_metro.layout.routing import compute_station_offsets
 
@@ -847,7 +847,7 @@ def _fit_bboxes_to_content_top(
             graph, section, section_y_padding, section_y_gap, offsets
         )
         if target is not None and target < section.bbox_y - SAME_COORD_TOLERANCE:
-            _set_section_bbox_top(graph, section, target)
+            move_section_bbox_min_edge(graph, section, "y", target)
             continue
         hug = _section_content_hug_top(graph, section, section_y_padding, offsets)
         if (
@@ -855,7 +855,7 @@ def _fit_bboxes_to_content_top(
             and hug > section.bbox_y + SAME_COORD_TOLERANCE
             and _section_band_is_empty(graph, section)
         ):
-            _set_section_bbox_top(graph, section, hug)
+            move_section_bbox_min_edge(graph, section, "y", hug)
 
 
 def _top_align_side_entered_vertical_to_feeder(graph: MetroGraph) -> None:
@@ -874,7 +874,7 @@ def _top_align_side_entered_vertical_to_feeder(graph: MetroGraph) -> None:
     """
     for section, neighbour in _side_entered_vertical_feeder_pairs(graph):
         if section.bbox_y - neighbour.bbox_y > SAME_COORD_TOLERANCE:
-            _grow_section_bbox_upward(graph, section, neighbour.bbox_y)
+            grow_section_bbox_min_edge(graph, section, "y", neighbour.bbox_y)
 
 
 def _tighten_lower_rows_after_shrink(graph: MetroGraph, section_y_gap: float) -> None:

--- a/src/nf_metro/layout/phases/off_track.py
+++ b/src/nf_metro/layout/phases/off_track.py
@@ -7,6 +7,7 @@ from collections import Counter, defaultdict
 from collections.abc import Iterator
 
 from nf_metro.layout.constants import (
+    COORD_GROUP_DIGITS_COARSE,
     DIAGONAL_RUN,
     EXIT_GAP_MULTIPLIER,
     ICON_CAPTION_FONT_HEIGHT,
@@ -14,13 +15,14 @@ from nf_metro.layout.constants import (
     ICON_HALF_HEIGHT,
     LABEL_BBOX_MARGIN,
     MIN_STRAIGHT_EDGE,
+    OFF_TRACK_TRUNK_CLEARANCE_MARGIN,
     SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
     TERMINUS_WIDTH,
     X_SPACING,
     resolve_offset_step,
 )
-from nf_metro.layout.geometry import AxisFrame, lanes_run_along_x
+from nf_metro.layout.geometry import AxisFrame, lanes_run_along_x, quantize_coord
 from nf_metro.layout.labels import _label_text_height, label_text_width
 from nf_metro.layout.phases._common import (
     _content_station_ids,
@@ -1196,7 +1198,9 @@ def _off_track_output_below(graph: MetroGraph) -> set[str]:
                 continue
         signed = [fan_sign * getattr(st, cross) for st in trunk_sts]
         if signed:
-            baseline_signed = dominant_value(round(v, 1) for v in signed)
+            baseline_signed = dominant_value(
+                quantize_coord(v, COORD_GROUP_DIGITS_COARSE) for v in signed
+            )
             section_baseline[section.id] = (cross, fan_sign, baseline_signed)
 
     below: set[str] = set()
@@ -1278,7 +1282,7 @@ def _section_distinct_trunk_cross_coords(
     """
     axis = section_cross_axis(section)
     return {
-        round(getattr(st, axis), 1)
+        quantize_coord(getattr(st, axis), COORD_GROUP_DIGITS_COARSE)
         for st in _iter_trunk_stations(graph, section, junction_ids)
     }
 
@@ -1358,7 +1362,7 @@ def _per_column_stack_steps(
     steps: dict[str, int] = {}
     per_col: dict[float, int] = defaultdict(int)
     for st in innermost_first:
-        col = round(getattr(st, flow_axis), 1)
+        col = quantize_coord(getattr(st, flow_axis), COORD_GROUP_DIGITS_COARSE)
         per_col[col] += 1
         steps[st.id] = per_col[col]
     return steps
@@ -1434,11 +1438,15 @@ def _place_off_track_relative_to_anchors(
                 step,
                 section,
                 junction_ids,
-                sibling_cross=used_cross_per_col[round(getattr(st, flow_axis), 1)],
+                sibling_cross=used_cross_per_col[
+                    quantize_coord(getattr(st, flow_axis), COORD_GROUP_DIGITS_COARSE)
+                ],
                 direction=bump_dir,
             )
         setattr(st, cross_axis, candidate)
-        used_cross_per_col[round(getattr(st, flow_axis), 1)].append(candidate)
+        used_cross_per_col[
+            quantize_coord(getattr(st, flow_axis), COORD_GROUP_DIGITS_COARSE)
+        ].append(candidate)
         signed = lift_sign * candidate
         if bump_dir == lift_sign:
             if lift_extreme is None or signed > lift_sign * lift_extreme:
@@ -1506,8 +1514,6 @@ def _bump_off_track_clear_of_trunks(
     # half-width on X.
     icon_half = ICON_HALF_HEIGHT if cross_axis == "y" else TERMINUS_WIDTH / 2
 
-    # A small margin so the icon's stroke doesn't touch a track.
-    MARGIN = 2.0
     # Limit attempts so a pathological column doesn't pull the icon off-canvas.
     MAX_STEPS = 6
 
@@ -1553,11 +1559,11 @@ def _bump_off_track_clear_of_trunks(
         if cross_axis == "y" and off_st.terminus_names and any(off_st.terminus_names)
         else 0.0
     )
-    sibling_clearance = 2 * icon_half + caption_reach + MARGIN
+    sibling_clearance = 2 * icon_half + caption_reach + OFF_TRACK_TRUNK_CLEARANCE_MARGIN
 
     def _overlaps(c: float) -> bool:
-        lo = c - icon_half - MARGIN
-        hi = c + icon_half + MARGIN
+        lo = c - icon_half - OFF_TRACK_TRUNK_CLEARANCE_MARGIN
+        hi = c + icon_half + OFF_TRACK_TRUNK_CLEARANCE_MARGIN
         for band_lo, band_hi in zip(trunk_bands[::2], trunk_bands[1::2]):
             if not (hi < band_lo or band_hi < lo):
                 return True

--- a/src/nf_metro/layout/phases/ports.py
+++ b/src/nf_metro/layout/phases/ports.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 from nf_metro.layout.constants import (
+    COORD_TOLERANCE,
     CURVE_RADIUS,
     ENTRY_SHIFT_TB,
     EXIT_CORRIDOR_ICON_CLEARANCE,
@@ -696,7 +697,7 @@ def _align_ports_to_downstream(graph: MetroGraph) -> None:
                 center_y = shorter.bbox_y + shorter.bbox_h / 2
                 lo = min(upstream_y, target_y)
                 hi = max(upstream_y, target_y)
-                if lo <= center_y <= hi or abs(upstream_y - target_y) < 1.0:
+                if lo <= center_y <= hi or abs(upstream_y - target_y) < COORD_TOLERANCE:
                     target_y = center_y
 
         # Only move if target_y fits within both section bboxes
@@ -810,7 +811,7 @@ def _snap_sole_layer_stations_to_ports(graph: MetroGraph) -> None:
                 if len(siblings) > 1:
                     break
 
-                if abs(st.y - port_y) >= 1.0:
+                if abs(st.y - port_y) >= COORD_TOLERANCE:
                     st.y = port_y
 
                 # Only continue the chain when center_ports is on.
@@ -882,7 +883,7 @@ def _snap_grid_group_entry_ports(graph: MetroGraph) -> None:
                     target_y = tgt.y
                     break
 
-        if target_y is not None and abs(port_st.y - target_y) >= 1.0:
+        if target_y is not None and abs(port_st.y - target_y) >= COORD_TOLERANCE:
             _set_port_y(graph, port_id, target_y)
 
 
@@ -941,7 +942,7 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
         unique_source_ys = sorted(set(source_ys))
         spread = unique_source_ys[-1] - unique_source_ys[0]
         n_unique = len(unique_source_ys)
-        single_source = n_unique == 1 or spread <= 1.0
+        single_source = n_unique == 1 or spread <= COORD_TOLERANCE
 
         # A flow-aligned exit anchors on its carriers' shared row, so the level
         # change becomes a riser in the inter-section gap rather than a diagonal
@@ -951,7 +952,9 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
         # bundle, a fan-in, or a merge junction keep the downstream-aligned
         # placement so the inter-section run stays straight (see
         # ``flow_exit_carrier_anchor``).
-        keep_downstream_aligned = ds_y is not None and abs(port_st.y - ds_y) < 1.0
+        keep_downstream_aligned = (
+            ds_y is not None and abs(port_st.y - ds_y) < COORD_TOLERANCE
+        )
         anchors_to_carrier = (
             flow_exit_carrier_anchor(graph, port_id, section, junction_ids) is not None
         )
@@ -968,12 +971,14 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
             # redundant rather than a true fan-in).
             if ds_y is None or (n_unique >= 3 and len(exit_lines) < 2):
                 continue
-            match = next((y for y in unique_source_ys if abs(y - ds_y) < 1.0), None)
+            match = next(
+                (y for y in unique_source_ys if abs(y - ds_y) < COORD_TOLERANCE), None
+            )
             if match is None:
                 continue
             target_y = match
 
-        if abs(port_st.y - target_y) >= 1.0:
+        if abs(port_st.y - target_y) >= COORD_TOLERANCE:
             _set_port_y(graph, port_id, target_y)
 
 


### PR DESCRIPTION
## Summary

Lands 2 of the 3 independent hygiene items from #1446 (the third, section
topo-columns, is deferred — see below):

- **Named tolerances**: `ports.py`'s seven bare `1.0` "already aligned"
  epsilons now use `COORD_TOLERANCE`; `_route_crosses_section_boundary`'s
  `port_tol`/`inset`/`axis_tol` defaults are now
  `PORT_BOUNDARY_CROSSING_TOL`/`BOUNDARY_CROSSING_INSET`/`COORD_TOLERANCE`;
  `off_track.py`'s local `MARGIN = 2.0` is now
  `OFF_TRACK_TRUNK_CLEARANCE_MARGIN`. Every new constant has the same value
  as the literal it replaces, so behavior is unchanged.
- **One quantisation helper**: `balancing.py` and `off_track.py` grouped
  coordinates into dict/set keys via a mix of `round(x, 1)` and
  `round(x, 3)`. Both now call a single `quantize_coord()` helper
  (`geometry.py`), passing the named `COORD_GROUP_DIGITS_COARSE`/`_FINE`
  precision each site already used — one code path instead of nine ad hoc
  `round()` calls, with each site's original precision preserved.
- **Retired Y-only bbox aliases**: `_set_section_bbox_top`,
  `_grow_section_bbox_upward`, and `_grow_section_bbox_downward` were each a
  one-line Y-axis delegation to the axis-agnostic
  `move_section_bbox_min_edge`/`grow_section_bbox_min_edge`/
  `grow_section_bbox_max_edge`. Their three call sites (all in `bbox.py`)
  now call the axis-agnostic functions directly; the aliases and their
  now-unused re-export in `engine.py` are removed.

**Deferred: section topo-columns (item 3).** Unifying the two independent
BFS column-assignment implementations (`auto_layout.py`'s
`_bfs_section_columns` and `section_placement.py`'s `_assign_grid_layout`)
behind one `SectionDAG.topo_columns()` method was attempted but reverted:
it rendered byte-identical across all 242 gallery/topology fixtures, but
reproducibly failed `tests/test_topology_validation.py::TestUpwardBypass`
(and one `test_auto_layout.py` test) when compared against a clean
pre-change baseline run with the identical command — the two BFS
implementations do genuinely disagree on some case the CLI-rendered
corpus doesn't exercise. Left in #1446 with findings for a future attempt.

## Test plan

- [x] Full targeted pytest run: `tests/test_layout_invariants.py` +
      `tests/test_topology_validation.py` — 20871 passed, 0 failed, only
      pre-existing xfails/skips.
- [x] `ruff check src/ tests/` and `ruff format --check src/ tests/` clean
      on the whole repo.
- [x] `mypy src/` clean (89 source files).
- [x] Byte-identical rendering verified across all 242
      `examples/`+`examples/topologies/` fixtures (before/after diff empty).
- [ ] Visual review of the [render preview](https://seqeralabs.github.io/nf-metro/_pr/1506/) once CI posts it (expected: no visual changes, this is a pure refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
