### PR TITLE
test: prove compensation passes are end-of-layout no-ops

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,26 @@ CONTENT_PLACEMENT_PHASES = (
     "_recenter_loop_side_stations",  # Stage 6.12
 )
 
+# Six named compensation-pass call sites, keyed by (stage label,
+# engine-module attribute name(s) invoked at that stage).  Each corrects a
+# specific earlier stage's side effect rather than being derived from graph
+# structure directly, so idempotence at end-of-layout is not guaranteed by
+# construction and must be checked.  3.5/4.7 and 5.3/6.9 name the same
+# underlying helper under two labels because each label identifies the
+# distinct disturber its engine.py call site corrects; removing one call
+# site should retire only its own entry here, independent of the other
+# label's. 6.16 is a composite: ``_position_junctions`` reads the entry-port
+# Ys ``_align_entry_ports`` just settled, so the pair is applied together,
+# in order, as a single unit.
+COMPENSATION_PASSES = (
+    ("3.5", ("_top_align_row_sections",)),
+    ("4.7", ("_top_align_row_sections",)),
+    ("5.3", ("_top_align_row_bboxes_only",)),
+    ("6.8", ("_reanchor_off_track_to_consumer",)),
+    ("6.9", ("_top_align_row_bboxes_only",)),
+    ("6.16", ("_align_entry_ports", "_position_junctions")),
+)
+
 
 # --- Render corpus ---
 
@@ -128,16 +148,26 @@ def compute_corpus_layout(path: Path, is_nextflow: bool) -> MetroGraph:
 Coords = dict[str, tuple[float, float]]
 
 
-def snapshot_graph_state(graph: MetroGraph) -> tuple[Coords, Coords]:
-    """Capture every station ``(x, y)`` and section ``(bbox_y, bbox_h)``."""
+def snapshot_graph_state(graph: MetroGraph) -> tuple[Coords, Coords, Coords]:
+    """Capture every station ``(x, y)``, section ``(bbox_y, bbox_h)``, and
+    port ``(x, y)``.
+
+    Every port also exists as a station with the same id (``add_port``), so
+    the station dict alone already reflects a port's current position; the
+    separate ``Port`` object (``graph.ports``) is snapshotted too because a
+    probe that calls a real phase a second time and then restores only the
+    station side would leave ``graph.ports`` at the second call's position,
+    desyncing the two id-aliased objects for the rest of the pipeline.
+    """
     stations = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
     bboxes = {sec.id: (sec.bbox_y, sec.bbox_h) for sec in graph.sections.values()}
-    return stations, bboxes
+    ports = {pid: (p.x, p.y) for pid, p in graph.ports.items()}
+    return stations, bboxes, ports
 
 
-def restore_graph_state(graph: MetroGraph, snap: tuple[Coords, Coords]) -> None:
+def restore_graph_state(graph: MetroGraph, snap: tuple[Coords, Coords, Coords]) -> None:
     """Write a :func:`snapshot_graph_state` result back onto ``graph``."""
-    stations, bboxes = snap
+    stations, bboxes, ports = snap
     for sid, (x, y) in stations.items():
         st = graph.stations.get(sid)
         if st is not None:
@@ -146,6 +176,10 @@ def restore_graph_state(graph: MetroGraph, snap: tuple[Coords, Coords]) -> None:
         sec = graph.sections.get(sid)
         if sec is not None:
             sec.bbox_y, sec.bbox_h = y, h
+    for pid, (x, y) in ports.items():
+        port = graph.ports.get(pid)
+        if port is not None:
+            port.x, port.y = x, y
 
 
 # --- Parse/layout helpers ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,21 +71,27 @@ CONTENT_PLACEMENT_PHASES = (
     "_recenter_loop_side_stations",  # Stage 6.12
 )
 
-# Six named compensation-pass call sites, keyed by (stage label,
-# engine-module attribute name(s) invoked at that stage).  Each corrects a
-# specific earlier stage's side effect rather than being derived from graph
-# structure directly, so idempotence at end-of-layout is not guaranteed by
+# Compensation-pass call sites in engine.py, keyed by (stage label,
+# attribute name(s) invoked at that stage).  Each corrects a specific
+# earlier stage's side effect rather than being derived from graph structure
+# directly, so idempotence at end-of-layout is not guaranteed by
 # construction and must be checked.  3.5/4.7 and 5.3/6.9 name the same
 # underlying helper under two labels because each label identifies the
-# distinct disturber its engine.py call site corrects; removing one call
-# site should retire only its own entry here, independent of the other
-# label's. 6.16 is a composite: ``_position_junctions`` reads the entry-port
-# Ys ``_align_entry_ports`` just settled, so the pair is applied together,
-# in order, as a single unit.
+# distinct disturber its own engine.py call site corrects; removing one
+# call site should retire only its own entry here, independent of the other
+# label's.  6.6 and 6.8 also share a helper but are not equivalent: 6.6 runs
+# unconditionally while 6.8 (like 6.9) only runs when
+# ``graph.center_ports or graph.diamond_style == "symmetric"`` -- see the
+# test's ``_CONDITIONAL_STAGES`` gate, which keeps a fixture that never
+# reaches the 6.8/6.9 block from having a finding misattributed to it.
+# 6.16 is a composite: ``_position_junctions`` reads the entry-port Ys
+# ``_align_entry_ports`` just settled, so the pair is applied together, in
+# order, as a single unit.
 COMPENSATION_PASSES = (
     ("3.5", ("_top_align_row_sections",)),
     ("4.7", ("_top_align_row_sections",)),
     ("5.3", ("_top_align_row_bboxes_only",)),
+    ("6.6", ("_reanchor_off_track_to_consumer",)),
     ("6.8", ("_reanchor_off_track_to_consumer",)),
     ("6.9", ("_top_align_row_bboxes_only",)),
     ("6.16", ("_align_entry_ports", "_position_junctions")),
@@ -146,6 +152,16 @@ def compute_corpus_layout(path: Path, is_nextflow: bool) -> MetroGraph:
 # --- Mutable-geometry snapshot/restore ---
 
 Coords = dict[str, tuple[float, float]]
+Diff = tuple[str, tuple[float, float] | None, tuple[float, float] | None]
+
+
+def snapshot_stations(graph: MetroGraph) -> Coords:
+    """Capture every station ``(x, y)`` only.
+
+    Cheaper than :func:`snapshot_graph_state` for a read-only diff that
+    never needs to restore bboxes or ports afterwards.
+    """
+    return {sid: (s.x, s.y) for sid, s in graph.stations.items()}
 
 
 def snapshot_graph_state(graph: MetroGraph) -> tuple[Coords, Coords, Coords]:
@@ -159,27 +175,47 @@ def snapshot_graph_state(graph: MetroGraph) -> tuple[Coords, Coords, Coords]:
     station side would leave ``graph.ports`` at the second call's position,
     desyncing the two id-aliased objects for the rest of the pipeline.
     """
-    stations = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
     bboxes = {sec.id: (sec.bbox_y, sec.bbox_h) for sec in graph.sections.values()}
     ports = {pid: (p.x, p.y) for pid, p in graph.ports.items()}
-    return stations, bboxes, ports
+    return snapshot_stations(graph), bboxes, ports
+
+
+def _write_xy(objects: dict, coords: Coords) -> None:
+    """Write each ``coords`` entry's ``(x, y)`` onto the same-id object in
+    ``objects``, skipping any id absent from ``objects``."""
+    for oid, (x, y) in coords.items():
+        obj = objects.get(oid)
+        if obj is not None:
+            obj.x, obj.y = x, y
 
 
 def restore_graph_state(graph: MetroGraph, snap: tuple[Coords, Coords, Coords]) -> None:
     """Write a :func:`snapshot_graph_state` result back onto ``graph``."""
     stations, bboxes, ports = snap
-    for sid, (x, y) in stations.items():
-        st = graph.stations.get(sid)
-        if st is not None:
-            st.x, st.y = x, y
+    _write_xy(graph.stations, stations)
     for sid, (y, h) in bboxes.items():
         sec = graph.sections.get(sid)
         if sec is not None:
             sec.bbox_y, sec.bbox_h = y, h
-    for pid, (x, y) in ports.items():
-        port = graph.ports.get(pid)
-        if port is not None:
-            port.x, port.y = x, y
+    _write_xy(graph.ports, ports)
+
+
+def diff_station_coords(before: Coords, after: Coords, tol: float = 1e-6) -> list[Diff]:
+    """Return per-station ``(id, before, after)`` diffs beyond ``tol``.
+
+    Shared by the content-placement idempotence probe and the
+    compensation-pass end-of-layout replay so both compare snapshots the
+    same way.
+    """
+    diffs: list[Diff] = []
+    for sid, (x1, y1) in before.items():
+        if sid not in after:
+            diffs.append((sid, (x1, y1), None))
+        elif abs(after[sid][0] - x1) > tol or abs(after[sid][1] - y1) > tol:
+            diffs.append((sid, (x1, y1), after[sid]))
+    for sid in after.keys() - before.keys():
+        diffs.append((sid, None, after[sid]))
+    return diffs
 
 
 # --- Parse/layout helpers ---

--- a/tests/test_compensation_passes_idempotent.py
+++ b/tests/test_compensation_passes_idempotent.py
@@ -1,0 +1,170 @@
+"""Each compensation pass is a geometric no-op when replayed after full
+layout settling.
+
+Six ``engine.py`` call sites exist purely to correct a side effect an
+*earlier* stage introduced (a bbox push, a bbox grow, a consumer move) --
+see ``COMPENSATION_PASSES`` in ``conftest.py`` for the stage/disturber table.
+The property that matters for a compensation pass is not
+``test_content_placement_idempotent``'s back-to-back ``P(P(x)) == P(x))``:
+because a compensation pass exists to correct the disturber stage that ran
+before it, the meaningful question is whether it remains a no-op once every
+later stage has also run and the whole layout has settled. If invoking it
+again at that point moves something, a later stage violates the
+precondition the compensation pass assumed, and that later stage is where
+the real fix belongs.
+
+Mechanism: monkeypatch each of the five distinct helper functions backing
+the six stage labels with a probe that applies the real pass (so the
+pipeline computes its ordinary output) and records the ``(args, kwargs)``
+it was invoked with most recently. Once the full corpus fixture's layout has
+settled, replay each stage's helper(s) with those captured arguments
+directly on the settled graph, diff against a snapshot taken just before,
+then restore. Restoring covers ports as well as stations (see
+``snapshot_graph_state``) so the diagnostic replay leaves the graph's
+station/port pair in sync for anything running after this test.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import (
+    COMPENSATION_PASSES,
+    compute_corpus_layout,
+    content_corpus,
+    restore_graph_state,
+    snapshot_graph_state,
+)
+
+import nf_metro.layout.engine as engine
+from nf_metro.parser.model import MetroGraph
+
+CORPUS = content_corpus()
+
+TOL = 1e-6
+
+_Point = tuple[float, float]
+_Diff = tuple[str, _Point | None, _Point | None]
+
+_HELPER_NAMES = sorted({name for _, names in COMPENSATION_PASSES for name in names})
+
+_Call = tuple[tuple, dict]
+
+# Fixtures where a stage's compensation pass is not currently a no-op when
+# replayed after full layout settling, keyed to the stage label(s) that
+# reproduce it. In every ``{"3.5", "4.7"}`` case the mechanism is the same:
+# a section grid-row-mate's bbox top grows upward later in the layout (fan
+# content redistributed above the trunk, or an off-track lift) without a
+# corresponding shift for sibling sections in its row, breaking the row-top
+# flush alignment ``_top_align_row_sections`` established by the time the
+# whole layout has settled. ``topologies/tb_off_track_inputs``'s "6.8" entry is
+# a distinct mechanism: replaying ``_reanchor_off_track_to_consumer`` swaps
+# the X positions of two off-track sibling stations instead of reproducing
+# them, so the pass is order-sensitive rather than idempotent.
+#
+# Entries are removed only when the underlying stage genuinely becomes an
+# end-of-layout no-op; the assertions below fail loudly both on any new,
+# unregistered gap and on any registered gap that stops reproducing, so this
+# dict can't silently drift out of sync with engine behaviour.
+_KNOWN_END_OF_LAYOUT_GAPS: dict[str, frozenset[str]] = {
+    "examples/differentialabundance": frozenset({"3.5", "4.7"}),
+    "examples/differentialabundance_default": frozenset({"3.5", "4.7"}),
+    "tests/da_pipeline": frozenset({"3.5", "4.7"}),
+    "tests/trunk_align_matching_bundle": frozenset({"3.5", "4.7"}),
+    "topologies/exit_fan_label_strike": frozenset({"3.5", "4.7"}),
+    "topologies/fanout_hub_two_line_trunk": frozenset({"3.5", "4.7"}),
+    "topologies/internal_source_equal_sibling_2fan": frozenset({"3.5", "4.7"}),
+    "topologies/off_track_convergence": frozenset({"3.5", "4.7"}),
+    "topologies/off_track_convergence_multiline": frozenset({"3.5", "4.7"}),
+    "topologies/off_track_input_above_consumer": frozenset({"3.5", "4.7"}),
+    "topologies/packed_multiline_serpentine_grid": frozenset({"3.5", "4.7"}),
+    "topologies/rl_entry_right_exit_left": frozenset({"3.5", "4.7"}),
+    "topologies/rowmate_tb_side_entry_top_align_grow": frozenset({"3.5", "4.7"}),
+    "topologies/shared_cell_fork_trunk_align": frozenset({"3.5", "4.7"}),
+    "topologies/symmetric_deadend_fanout": frozenset({"3.5", "4.7"}),
+    "topologies/symmetric_deadend_fanout_deep": frozenset({"3.5", "4.7"}),
+    "topologies/symmetric_deadend_fanout_exit": frozenset({"3.5", "4.7"}),
+    "topologies/symmetric_deadend_fanout_relay": frozenset({"3.5", "4.7"}),
+    "topologies/tb_off_track_inputs": frozenset({"6.8"}),
+    "topologies/terminal_symmetric_fan": frozenset({"3.5", "4.7"}),
+    "topologies/trunk_through_fan": frozenset({"3.5", "4.7"}),
+}
+
+
+def _make_capture_probe(original, last_call: dict[str, _Call], name: str):
+    """Wrap ``original`` to apply it for real and record the most recent
+    ``(args, kwargs)`` it was invoked with under ``name``."""
+
+    def probe(graph: MetroGraph, *args, **kwargs):
+        original(graph, *args, **kwargs)
+        last_call[name] = (args, kwargs)
+
+    return probe
+
+
+def _diff_stations(before: dict[str, _Point], after: dict[str, _Point]) -> list[_Diff]:
+    diffs: list[_Diff] = []
+    for sid, (x1, y1) in before.items():
+        if sid not in after:
+            diffs.append((sid, (x1, y1), None))
+        elif abs(after[sid][0] - x1) > TOL or abs(after[sid][1] - y1) > TOL:
+            diffs.append((sid, (x1, y1), after[sid]))
+    for sid in after.keys() - before.keys():
+        diffs.append((sid, None, after[sid]))
+    return diffs
+
+
+@pytest.mark.parametrize(
+    "fid,path,is_nextflow", CORPUS, ids=[fid for fid, _, _ in CORPUS]
+)
+def test_compensation_pass_is_end_of_layout_noop(fid, path, is_nextflow, monkeypatch):
+    """Every compensation pass is a no-op when replayed after full settling
+    on ``fid``.
+
+    All six stage labels share one layout pass: their helpers are captured
+    (not disturbed) while the real pipeline runs, then replayed in stage
+    order on the settled graph, one at a time, each restored before the
+    next runs so a failure in an earlier stage can't mask a later one.
+    """
+    original_fns = {name: getattr(engine, name) for name in _HELPER_NAMES}
+    last_call: dict[str, _Call] = {}
+    for name in _HELPER_NAMES:
+        monkeypatch.setattr(
+            engine, name, _make_capture_probe(original_fns[name], last_call, name)
+        )
+
+    graph = compute_corpus_layout(path, is_nextflow)
+
+    diffs_by_stage: dict[str, list[_Diff]] = {}
+    for stage_label, helper_names in COMPENSATION_PASSES:
+        missing = [name for name in helper_names if name not in last_call]
+        if missing:
+            continue  # this stage's call site never fired for this fixture
+
+        snap = snapshot_graph_state(graph)
+        before = snap[0]
+        for name in helper_names:
+            args, kwargs = last_call[name]
+            original_fns[name](graph, *args, **kwargs)
+        after = snapshot_graph_state(graph)[0]
+        diffs_by_stage[stage_label] = _diff_stations(before, after)
+        restore_graph_state(graph, snap)
+
+    found_gaps = {label for label, diffs in diffs_by_stage.items() if diffs}
+    expected_gaps = _KNOWN_END_OF_LAYOUT_GAPS.get(fid, frozenset())
+
+    unexpected = found_gaps - expected_gaps
+    assert not unexpected, (
+        f"end-of-layout non-idempotence on {fid} not covered by "
+        f"_KNOWN_END_OF_LAYOUT_GAPS: {sorted(unexpected)}. Stations per stage "
+        f"(station: before -> after): "
+        + "; ".join(
+            f"{label}: {[(s, a, b) for s, a, b in diffs_by_stage[label][:8]]}"
+            for label in sorted(unexpected)
+        )
+    )
+
+    resolved = expected_gaps - found_gaps
+    assert not resolved, (
+        f"{fid} no longer reproduces the registered end-of-layout gap(s) "
+        f"{sorted(resolved)}; remove the entry from _KNOWN_END_OF_LAYOUT_GAPS"
+    )

--- a/tests/test_compensation_passes_idempotent.py
+++ b/tests/test_compensation_passes_idempotent.py
@@ -1,7 +1,7 @@
 """Each compensation pass is a geometric no-op when replayed after full
 layout settling.
 
-Six ``engine.py`` call sites exist purely to correct a side effect an
+Named ``engine.py`` call sites exist purely to correct a side effect an
 *earlier* stage introduced (a bbox push, a bbox grow, a consumer move) --
 see ``COMPENSATION_PASSES`` in ``conftest.py`` for the stage/disturber table.
 The property that matters for a compensation pass is not
@@ -13,26 +13,32 @@ again at that point moves something, a later stage violates the
 precondition the compensation pass assumed, and that later stage is where
 the real fix belongs.
 
-Mechanism: monkeypatch each of the five distinct helper functions backing
-the six stage labels with a probe that applies the real pass (so the
-pipeline computes its ordinary output) and records the ``(args, kwargs)``
-it was invoked with most recently. Once the full corpus fixture's layout has
-settled, replay each stage's helper(s) with those captured arguments
-directly on the settled graph, diff against a snapshot taken just before,
-then restore. Restoring covers ports as well as stations (see
-``snapshot_graph_state``) so the diagnostic replay leaves the graph's
-station/port pair in sync for anything running after this test.
+Mechanism: monkeypatch each distinct helper function backing the stage
+labels with a mock that wraps the real implementation (so the pipeline
+computes its ordinary output) and records the call it was invoked with most
+recently. Once the full corpus fixture's layout has settled, replay each
+stage's helper(s) with that captured call directly on the settled graph,
+diff against a snapshot taken just before, then restore. Restoring covers
+ports as well as stations (see ``snapshot_graph_state``) so the diagnostic
+replay leaves the graph's station/port pair in sync for anything running
+after this test.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
 import pytest
 from conftest import (
     COMPENSATION_PASSES,
+    Diff,
     compute_corpus_layout,
     content_corpus,
+    diff_station_coords,
     restore_graph_state,
     snapshot_graph_state,
+    snapshot_stations,
 )
 
 import nf_metro.layout.engine as engine
@@ -40,14 +46,18 @@ from nf_metro.parser.model import MetroGraph
 
 CORPUS = content_corpus()
 
-TOL = 1e-6
-
-_Point = tuple[float, float]
-_Diff = tuple[str, _Point | None, _Point | None]
-
 _HELPER_NAMES = sorted({name for _, names in COMPENSATION_PASSES for name in names})
 
-_Call = tuple[tuple, dict]
+# Stages 6.7 through 6.9 in engine.py execute only when
+# ``graph.center_ports or graph.diamond_style == "symmetric"``. A stage
+# gated here is skipped for a fixture where that block never runs, so a
+# helper's most-recently-recorded call -- from an earlier, unconditional
+# call site that happens to share the same function -- is never mistaken
+# for this stage's own execution.
+_CONDITIONAL_STAGES: dict[str, Callable[[MetroGraph], bool]] = {
+    "6.8": lambda graph: graph.center_ports or graph.diamond_style == "symmetric",
+    "6.9": lambda graph: graph.center_ports or graph.diamond_style == "symmetric",
+}
 
 # Fixtures where a stage's compensation pass is not currently a no-op when
 # replayed after full layout settling, keyed to the stage label(s) that
@@ -56,10 +66,10 @@ _Call = tuple[tuple, dict]
 # content redistributed above the trunk, or an off-track lift) without a
 # corresponding shift for sibling sections in its row, breaking the row-top
 # flush alignment ``_top_align_row_sections`` established by the time the
-# whole layout has settled. ``topologies/tb_off_track_inputs``'s "6.8" entry is
-# a distinct mechanism: replaying ``_reanchor_off_track_to_consumer`` swaps
-# the X positions of two off-track sibling stations instead of reproducing
-# them, so the pass is order-sensitive rather than idempotent.
+# whole layout has settled. ``topologies/tb_off_track_inputs``'s "6.6" entry
+# is a distinct mechanism: replaying ``_reanchor_off_track_to_consumer``
+# swaps the X positions of two off-track sibling stations instead of
+# reproducing them, so the pass is order-sensitive rather than idempotent.
 #
 # Entries are removed only when the underlying stage genuinely becomes an
 # end-of-layout no-op; the assertions below fail loudly both on any new,
@@ -84,33 +94,10 @@ _KNOWN_END_OF_LAYOUT_GAPS: dict[str, frozenset[str]] = {
     "topologies/symmetric_deadend_fanout_deep": frozenset({"3.5", "4.7"}),
     "topologies/symmetric_deadend_fanout_exit": frozenset({"3.5", "4.7"}),
     "topologies/symmetric_deadend_fanout_relay": frozenset({"3.5", "4.7"}),
-    "topologies/tb_off_track_inputs": frozenset({"6.8"}),
+    "topologies/tb_off_track_inputs": frozenset({"6.6"}),
     "topologies/terminal_symmetric_fan": frozenset({"3.5", "4.7"}),
     "topologies/trunk_through_fan": frozenset({"3.5", "4.7"}),
 }
-
-
-def _make_capture_probe(original, last_call: dict[str, _Call], name: str):
-    """Wrap ``original`` to apply it for real and record the most recent
-    ``(args, kwargs)`` it was invoked with under ``name``."""
-
-    def probe(graph: MetroGraph, *args, **kwargs):
-        original(graph, *args, **kwargs)
-        last_call[name] = (args, kwargs)
-
-    return probe
-
-
-def _diff_stations(before: dict[str, _Point], after: dict[str, _Point]) -> list[_Diff]:
-    diffs: list[_Diff] = []
-    for sid, (x1, y1) in before.items():
-        if sid not in after:
-            diffs.append((sid, (x1, y1), None))
-        elif abs(after[sid][0] - x1) > TOL or abs(after[sid][1] - y1) > TOL:
-            diffs.append((sid, (x1, y1), after[sid]))
-    for sid in after.keys() - before.keys():
-        diffs.append((sid, None, after[sid]))
-    return diffs
 
 
 @pytest.mark.parametrize(
@@ -120,34 +107,35 @@ def test_compensation_pass_is_end_of_layout_noop(fid, path, is_nextflow, monkeyp
     """Every compensation pass is a no-op when replayed after full settling
     on ``fid``.
 
-    All six stage labels share one layout pass: their helpers are captured
-    (not disturbed) while the real pipeline runs, then replayed in stage
-    order on the settled graph, one at a time, each restored before the
-    next runs so a failure in an earlier stage can't mask a later one.
+    All stage labels share one layout pass: their helpers are wrapped (not
+    disturbed) while the real pipeline runs, then replayed in stage order on
+    the settled graph, one at a time, each restored before the next runs so
+    a failure in an earlier stage can't mask a later one.
     """
     original_fns = {name: getattr(engine, name) for name in _HELPER_NAMES}
-    last_call: dict[str, _Call] = {}
-    for name in _HELPER_NAMES:
-        monkeypatch.setattr(
-            engine, name, _make_capture_probe(original_fns[name], last_call, name)
-        )
+    mocks = {name: MagicMock(wraps=original_fns[name]) for name in _HELPER_NAMES}
+    for name, mock in mocks.items():
+        monkeypatch.setattr(engine, name, mock)
 
     graph = compute_corpus_layout(path, is_nextflow)
 
-    diffs_by_stage: dict[str, list[_Diff]] = {}
+    full_snap = snapshot_graph_state(graph)
+    before = full_snap[0]
+
+    diffs_by_stage: dict[str, list[Diff]] = {}
     for stage_label, helper_names in COMPENSATION_PASSES:
-        missing = [name for name in helper_names if name not in last_call]
-        if missing:
+        gate = _CONDITIONAL_STAGES.get(stage_label)
+        if gate is not None and not gate(graph):
+            continue  # this stage's call site is never reached for this fixture
+        if any(mocks[name].call_args is None for name in helper_names):
             continue  # this stage's call site never fired for this fixture
 
-        snap = snapshot_graph_state(graph)
-        before = snap[0]
         for name in helper_names:
-            args, kwargs = last_call[name]
-            original_fns[name](graph, *args, **kwargs)
-        after = snapshot_graph_state(graph)[0]
-        diffs_by_stage[stage_label] = _diff_stations(before, after)
-        restore_graph_state(graph, snap)
+            call = mocks[name].call_args
+            original_fns[name](graph, *call.args[1:], **call.kwargs)
+        after = snapshot_stations(graph)
+        diffs_by_stage[stage_label] = diff_station_coords(before, after)
+        restore_graph_state(graph, full_snap)
 
     found_gaps = {label for label, diffs in diffs_by_stage.items() if diffs}
     expected_gaps = _KNOWN_END_OF_LAYOUT_GAPS.get(fid, frozenset())

--- a/tests/test_content_placement_idempotent.py
+++ b/tests/test_content_placement_idempotent.py
@@ -26,8 +26,10 @@ from __future__ import annotations
 import pytest
 from conftest import (
     CONTENT_PLACEMENT_PHASES,
+    Diff,
     compute_corpus_layout,
     content_corpus,
+    diff_station_coords,
     restore_graph_state,
     snapshot_graph_state,
 )
@@ -37,13 +39,8 @@ from nf_metro.parser.model import MetroGraph
 
 CORPUS = content_corpus()
 
-TOL = 1e-6
 
-_Point = tuple[float, float]
-_Diff = tuple[str, _Point | None, _Point | None]
-
-
-def _make_idempotence_probe(original, diffs: list[_Diff]):
+def _make_idempotence_probe(original, diffs: list[Diff]):
     """Wrap ``original`` to check ``P(P(x)) == P(x)`` locally, recording into
     ``diffs`` any station added, removed or moved by the second application."""
 
@@ -55,13 +52,7 @@ def _make_idempotence_probe(original, diffs: list[_Diff]):
         original(graph, *args, **kwargs)
         after2 = snapshot_graph_state(graph)[0]
 
-        for sid, (x1, y1) in after1.items():
-            if sid not in after2:
-                diffs.append((sid, (x1, y1), None))
-            elif abs(after2[sid][0] - x1) > TOL or abs(after2[sid][1] - y1) > TOL:
-                diffs.append((sid, (x1, y1), after2[sid]))
-        for sid in after2.keys() - after1.keys():
-            diffs.append((sid, None, after2[sid]))
+        diffs.extend(diff_station_coords(after1, after2))
 
         restore_graph_state(graph, snap1)
 
@@ -81,7 +72,7 @@ def test_placement_phase_is_idempotent(fid, path, is_nextflow, monkeypatch):
     cascaded final layout, and covers the same (fixture, phase) pairs at
     one-eighth the layout cost.
     """
-    diffs_by_phase: dict[str, list[_Diff]] = {}
+    diffs_by_phase: dict[str, list[Diff]] = {}
     for phase_name in CONTENT_PLACEMENT_PHASES:
         diffs_by_phase[phase_name] = []
         original = getattr(engine, phase_name)


### PR DESCRIPTION
## Summary

Part 1/6 of the compensation-passes program (#674): adds the diagnostic test that scopes the rest of it.

- Extends `snapshot_graph_state`/`restore_graph_state` in `tests/conftest.py` to also capture/restore port `(x, y)`. A port is aliased to a same-id station and the two are kept in sync throughout the layout code, but only the station side was previously snapshotted — a probe that replays a phase and restores just that side would leave the port object at the replay's position, desyncing the pair for anything running after the probe. Backward compatible: existing callers only ever indexed `[0]` (the stations dict) or passed the tuple straight to `restore_graph_state`.
- Adds `COMPENSATION_PASSES` to `conftest.py`: the named `engine.py` call sites that exist purely to correct an earlier stage's side effect (a bbox push, a bbox grow, a consumer move), each tagged with the helper(s) it re-invokes. Stages 6.8/6.9 are gated on the same `graph.center_ports or graph.diamond_style == "symmetric"` condition their engine.py call sites use, so a fixture that never reaches that block can't have a finding misattributed to it (this surfaced during review: `_reanchor_off_track_to_consumer` has an unconditional call site at Stage 6.6 as well as the gated one at 6.8, and the two are otherwise indistinguishable from a captured call alone).
- Adds `tests/test_compensation_passes_idempotent.py`: wraps each helper with `MagicMock(wraps=...)` while the real pipeline runs (so the pipeline itself is undisturbed) to capture its most recent call, then once the corpus fixture's layout has fully settled, replays each stage's helper(s) directly on the settled graph and asserts nothing moves.
- Shares a `diff_station_coords`/`snapshot_stations` helper between this test and the existing `test_content_placement_idempotent.py`, which previously carried its own copy of the same before/after diff loop.

The replay is not a no-op everywhere: 21 of 278 corpus fixtures currently show a later stage (fan-content redistribution above the trunk, or an off-track lift) growing one row-mate section's bbox top without a corresponding shift for its siblings, breaking the row-top-flush alignment stage 3.5/4.7 established. A separate case (`topologies/tb_off_track_inputs`) shows the Stage-6.6 off-track reanchor swapping two stations' X positions on replay instead of reproducing them. These are registered by fixture and stage label in `_KNOWN_END_OF_LAYOUT_GAPS`; the test fails loudly both on any new/unregistered gap and on any registered gap that stops reproducing, so the registry can't silently drift out of sync with engine behaviour as the later children in this program (each retiring one stage) land.

No `src/` changes — the render corpus is byte-identical by construction.

## Test plan
- [x] `pytest tests/test_compensation_passes_idempotent.py` passes (278 fixtures)
- [x] `pytest tests/test_content_placement_idempotent.py tests/test_content_placement_pure.py` passes (conftest signature change and shared-helper reuse didn't break the existing callers)
- [x] Full suite passes (38428 passed, 9 pre-existing xfails, no `src/` diff so gate-coverage/guard-golden are unaffected)
- [x] `ruff check`/`ruff format --check` clean on the whole repo
- [x] `mypy` clean (scoped to `src/` per project config; unaffected)
- [x] No visual/render changes possible (test-only diff)

Fixes #1020
