### PR TITLE
fix(layout): keep a perpendicular port clear of the box edges it crosses (#1540)

### DIFF
--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -597,6 +597,19 @@ fixtures (n=1, 2) while still ensuring clearance for wide fans (n>=3).
 MIN_PORT_STATION_GAP: float = 16.0
 """Minimum gap between entry port and internal stations (TB perpendicular)."""
 
+PERP_PORT_EDGE_INSET: float = SECTION_Y_PADDING - MIN_PORT_STATION_GAP
+"""Room a perpendicular port keeps from the flow-axis bbox edge it faces.
+
+A port seated the minimum station gap beyond the outermost station already earns
+this much, because the edge itself trails that station by ``SECTION_Y_PADDING``.
+A port seated further out -- a perpendicular entry sits a whole entry shift clear
+of the row -- would otherwise be left with only the remainder and read as pinched
+against the border, so the box extends to give it the same room instead.
+
+Distinct from ``PERP_PORT_EDGE_CLEARANCE``: that is the hard floor a runtime
+guard enforces, this is the wider spacing placement aims for.
+"""
+
 STATION_ELBOW_TOLERANCE: float = 12.0
 """Tolerance for station-as-elbow detection."""
 

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -12,6 +12,7 @@ from nf_metro.layout.constants import (
     COORD_GROUP_DIGITS_COARSE,
     COORD_GROUP_DIGITS_FINE,
     COORD_TOLERANCE,
+    PERP_PORT_EDGE_INSET,
     PORT_BOUNDARY_CROSSING_TOL,
     SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
@@ -21,6 +22,7 @@ from nf_metro.layout.geometry import (
     AxisFrame,
     lanes_run_along_x,
     lanes_run_along_y,
+    perpendicular_port_sides,
     quantize_coord,
 )
 from nf_metro.layout.phase_state import require_phase_field
@@ -1374,6 +1376,28 @@ def _fan_offsets(n: int) -> list[int]:
     if n % 2 == 0:
         return list(range(-(n // 2), 0)) + list(range(1, n // 2 + 1))
     return list(range(-(n // 2), n // 2 + 1))
+
+
+def port_edge_inset(port: Port | None, section_direction: str, axis: str) -> float:
+    """Room *port* owes a bbox edge normal to *axis* (``"x"`` or ``"y"``).
+
+    A station flagged as a port but carrying no ``Port`` record has no side to
+    judge by, so it owes nothing and stays hard-contained.
+
+    A port pinned to that edge belongs on it and owes nothing: an LR section's
+    TOP port *is* its top edge.  A port merely crossing the axis reads as
+    running along the border unless the box keeps ``PERP_PORT_EDGE_INSET``
+    beyond it -- and a port crosses the axis exactly when it is free along it,
+    which is when it is perpendicular to its section's flow and that flow runs
+    down *axis*.
+    """
+    if port is None:
+        return 0.0
+    if AxisFrame.axes_for_direction(section_direction)[0] != axis:
+        return 0.0
+    if port.side in perpendicular_port_sides(section_direction):
+        return PERP_PORT_EDGE_INSET
+    return 0.0
 
 
 def _expand_bbox_for_y(section: Section, y: float) -> None:

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -28,6 +28,7 @@ from nf_metro.layout.phases._common import (
     _trunk_symmetric_fan_ids,
     grow_section_bbox_min_edge,
     move_section_bbox_min_edge,
+    port_edge_inset,
 )
 from nf_metro.layout.phases.single_section import (
     _terminus_y_overhang,
@@ -484,7 +485,7 @@ def _predict_section_content_bottom(
         if sid in graph.stations and is_bypass_v(sid)
     ]
     port_max_ys = [
-        graph.stations[sid].y
+        graph.stations[sid].y + port_edge_inset(graph.ports.get(sid), section_dir, "y")
         for sid in section.station_ids
         if sid in graph.stations and graph.stations[sid].is_port
     ]
@@ -709,7 +710,7 @@ def _section_content_hug_top(
         if sid in graph.stations and is_bypass_v(sid)
     ]
     port_min_ys = [
-        graph.stations[sid].y
+        graph.stations[sid].y - port_edge_inset(graph.ports.get(sid), section_dir, "y")
         for sid in section.station_ids
         if sid in graph.stations and graph.stations[sid].is_port
     ]

--- a/src/nf_metro/layout/phases/row_align.py
+++ b/src/nf_metro/layout/phases/row_align.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from nf_metro.layout.constants import (
     FONT_HEIGHT,
     LABEL_OFFSET,
-    PERP_PORT_EDGE_CLEARANCE,
+    PERP_PORT_EDGE_INSET,
     SAME_COORD_TOLERANCE,
     STATION_RADIUS_APPROX,
     resolve_offset_step,
@@ -753,7 +753,7 @@ def _perp_port_lead_edge_reserve(
     no special case either.
 
     A section with fewer than two perpendicular ports has no pair to balance and
-    keeps the bare ``PERP_PORT_EDGE_CLEARANCE`` floor, so it does not pay padding
+    keeps the bare ``PERP_PORT_EDGE_INSET`` floor, so it does not pay padding
     for a symmetry it cannot show; the floor also wins outright where a port sits
     closer to its own edge than the floor allows.
     """
@@ -769,7 +769,7 @@ def _perp_port_lead_edge_reserve(
         if (st := graph.stations.get(sid)) is not None and not st.is_port
     ]
     if not content_high:
-        return PERP_PORT_EDGE_CLEARANCE
+        return PERP_PORT_EDGE_INSET
 
     perp_sides = perpendicular_port_sides(sec_dir)
     perp_coords = []
@@ -783,12 +783,12 @@ def _perp_port_lead_edge_reserve(
         if port.side in perp_sides:
             perp_coords.append(coord(station))
     if len(perp_coords) < 2:
-        return PERP_PORT_EDGE_CLEARANCE
+        return PERP_PORT_EDGE_INSET
 
     desired_high = max(content_high) + section_padding
     if port_coords:
         desired_high = max(desired_high, max(port_coords))
-    return max(PERP_PORT_EDGE_CLEARANCE, desired_high - max(perp_coords))
+    return max(PERP_PORT_EDGE_INSET, desired_high - max(perp_coords))
 
 
 def _compact_row_content_to_bbox_top(

--- a/tests/test_compensation_passes_idempotent.py
+++ b/tests/test_compensation_passes_idempotent.py
@@ -78,6 +78,12 @@ _CONDITIONAL_STAGES: dict[str, Callable[[MetroGraph], bool]] = {
 # after Stage 6.15a: it immediately reds ``test_section_bbox_top_hugs_content``
 # on these exact fixtures).
 #
+# The vertical-flow entries added for the perpendicular-port inset
+# (``bt_perp_left_entry_right_exit``, ``bt_to_tb``, ``longread_variant_calling``)
+# are the same intentional class: the box now extends past its content to keep
+# ``PERP_PORT_EDGE_INSET`` beyond a perpendicular port, so replaying the row
+# realign finds the same movement the content-hug pass is entitled to undo.
+#
 # ``topologies/tb_off_track_inputs``'s "6.6" entry is unrelated and NOT
 # confirmed intentional: replaying ``_reanchor_off_track_to_consumer`` swaps
 # the X positions of two off-track sibling stations instead of reproducing
@@ -89,9 +95,12 @@ _CONDITIONAL_STAGES: dict[str, Callable[[MetroGraph], bool]] = {
 # dict can't silently drift out of sync with engine behaviour.
 _KNOWN_END_OF_LAYOUT_GAPS: dict[str, frozenset[str]] = {
     "examples/differentialabundance": frozenset({"4.7"}),
+    "examples/longread_variant_calling": frozenset({"4.7"}),
     "examples/differentialabundance_default": frozenset({"4.7"}),
     "tests/da_pipeline": frozenset({"4.7"}),
     "tests/trunk_align_matching_bundle": frozenset({"4.7"}),
+    "topologies/bt_perp_left_entry_right_exit": frozenset({"4.7"}),
+    "topologies/bt_to_tb": frozenset({"4.7"}),
     "topologies/fanout_hub_two_line_trunk": frozenset({"4.7"}),
     "topologies/internal_source_equal_sibling_2fan": frozenset({"4.7"}),
     "topologies/off_track_convergence": frozenset({"4.7"}),

--- a/tests/test_perp_port_edge_clearance_1494.py
+++ b/tests/test_perp_port_edge_clearance_1494.py
@@ -29,6 +29,7 @@ import pytest
 
 from nf_metro.layout.constants import (
     PERP_PORT_EDGE_CLEARANCE,
+    PERP_PORT_EDGE_INSET,
     SAME_COORD_TOLERANCE,
     SECTION_Y_PADDING,
 )
@@ -185,7 +186,7 @@ def test_carrier_row_ports_sit_symmetrically_in_their_box() -> None:
     "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
 )
 def test_lone_perpendicular_port_reserves_only_the_floor(path: Path) -> None:
-    """A section with no perpendicular pair pays no padding for symmetry."""
+    """A section with no perpendicular pair falls back to the designed inset."""
     graph = parse_metro_mermaid(path.read_text())
     compute_layout(graph)
     for section in graph.sections.values():
@@ -201,7 +202,7 @@ def test_lone_perpendicular_port_reserves_only_the_floor(path: Path) -> None:
             continue
         assert _perp_port_lead_edge_reserve(
             graph, section, SECTION_Y_PADDING
-        ) == pytest.approx(PERP_PORT_EDGE_CLEARANCE, abs=EPSILON)
+        ) == pytest.approx(PERP_PORT_EDGE_INSET, abs=EPSILON)
 
 
 def _lr_section_with_perp_pair(entry_x: float, exit_x: float) -> MetroGraph:
@@ -250,22 +251,22 @@ def test_lead_edge_reserve_measures_on_x_for_a_horizontal_flow() -> None:
     # so the floor governs.
     assert _perp_port_lead_edge_reserve(
         graph, section, SECTION_Y_PADDING
-    ) == pytest.approx(PERP_PORT_EDGE_CLEARANCE, abs=EPSILON)
+    ) == pytest.approx(PERP_PORT_EDGE_INSET, abs=EPSILON)
 
     # Pull the rightmost port inside the padded right edge and the reserve becomes
     # that port's own right-edge clearance: 200 - 170 = 30.
-    graph.stations["pout"].x = 170.0
-    graph.ports["pout"].x = 170.0
+    graph.stations["pout"].x = 150.0
+    graph.ports["pout"].x = 150.0
     assert _perp_port_lead_edge_reserve(
         graph, section, SECTION_Y_PADDING
-    ) == pytest.approx(30.0, abs=EPSILON)
+    ) == pytest.approx(50.0, abs=EPSILON)
 
     # Moving a port along Y cannot change an X-axis reserve.
     graph.stations["pout"].y = 100.0
     graph.ports["pout"].y = 100.0
     assert _perp_port_lead_edge_reserve(
         graph, section, SECTION_Y_PADDING
-    ) == pytest.approx(30.0, abs=EPSILON)
+    ) == pytest.approx(50.0, abs=EPSILON)
 
 
 def _row_group_slacks(graph, section) -> list[float]:


### PR DESCRIPTION
Stacked on #1538 (`fix/1494-carrier-row-entry-headroom-label`) — review that first.

## Summary

A section's flow-axis bbox edges were sized from **content** alone, folding ports in at zero inset. Zero is correct for a flow-aligned port (an LR section's TOP port *is* its top edge) but wrong for a perpendicular port, which only crosses that axis. So clearance depended on how far out the port happened to be seated:

| seat | clearance | why |
| --- | --- | --- |
| `content ± MIN_PORT_STATION_GAP` (16) | 34px | edge trails content by `SECTION_Y_PADDING` (50) |
| `content ± entry shift` (40) | **10px** | only the remainder is left |

At 10px the inbound bundle reads as running along the border. On `examples/topologies/bt_perp_left_entry_right_exit.mmd`, `align` had both its ports at 10px and `calling`'s bundle traced its bottom edge.

Both edges now reserve `PERP_PORT_EDGE_INSET` (34 = `SECTION_Y_PADDING - MIN_PORT_STATION_GAP`) beyond a perpendicular port, via the axis-aware `port_edge_inset(port, direction, axis)` helper — so the box extends past its content where a port needs the room. Every perpendicular port on a vertical-flow section now sits at 34px; `align` is symmetric 34/34.

A port station carrying no `Port` record has no side to judge by, so it owes nothing and stays hard-contained — preserving `test_section_fit_top_clamps_to_port_above_content`.

Fixes #1540

## Growing the box past content is deliberate

`test_section_bbox_top_hugs_content` wants boxes to hug their content, which is in direct tension with reserving room for a port outside that content. Resolved in favour of the port: a port pinned against a perpendicular edge is the worse artefact. The three added `_KNOWN_END_OF_LAYOUT_GAPS` entries are the same intentional class the 18 existing `4.7` entries already document — a box extending past its content gives the row realign movement to find on replay, which the content-hug pass is entitled to undo.

Staggered row tops are the normal end state here, not a regression: 25 corpus fixtures already show it (`off_track_convergence` 233.6px, `da_pipeline` 116.8px, `sarek_metro` 80px), because content-hug wins over row-flush by design. `_fit_bboxes_to_content_top`'s docstring states this, and the registry comment records that forcing a row realign after Stage 6.15a immediately reds `test_section_bbox_top_hugs_content`.

## Test plan

- [x] Full suite: 42010 passed, 132 skipped, 9 xfailed.
- [x] `prek run --all-files` clean.
- [x] Corpus renders via `render_string()`: 12 changed, no new aborts (1 pre-existing `CurveInvariantError` on `twoline_fanout_up`, unchanged).
- [x] Guard-trace goldens unchanged (304 passed, no regeneration needed).
- [x] Every perpendicular port on a vertical-flow section measures exactly 34px from the edge it faces; the only remaining 10px cases are LEFT/RIGHT ports on **LR** sections, where they are flow-aligned and sit on the trunk.
- [ ] Visual review of the render preview
- [ ] Render-preview verdict

## Not in this PR

"An in-section route keeps a minimum distance from the edge it runs parallel to" is a separate, broader rule than port placement. Measured across 8112 in-section axis-aligned runs: the corpus floor is 10.0px and five runs sit under 20px (`genomeassembly_staggered` and `merge_trunk_over_low_section` at 10.0, `rail_offtrack_fan` at 12.5/16.5). Enforcing it needs a chosen minimum and its own guard, and would grow boxes for flow-aligned ports too — which this PR deliberately leaves alone.
