### PR TITLE
feat(layout): level a grid column's box edges on one axis-generic pass

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -142,9 +142,8 @@ perpendicular case), `_clamp_tb_entry_port`, `_resolve_tb_exit_y`,
 `_align_tb_section_bbox_bottoms`, and `_tb_trunk_x` (the secondary-axis trunk
 coordinate is a *median* for a vertical section but the bundle-connected topmost
 for a horizontal one - `_section_trunk_y` - so the two are not the same code and
-should not be forced behind one name). The `section_placement.py` RL-or-TB
-column right-alignment and `_apply_tb_fold_spans` selection are domain
-groupings, not axis swaps, and likewise stay.
+should not be forced behind one name). The `_apply_tb_fold_spans` selection is a
+domain grouping, not an axis swap, and likewise stays.
 
 ## Validate-mode guards
 
@@ -345,6 +344,13 @@ in pipeline order.
   positions from `auto_layout`. Still all local-coord.
 - **Postcondition**: Every section has `offset_x`, `offset_y` set such
   that `(local + offset)` lands sections on a non-overlapping grid.
+- **Column seating**: A column is seated on the edge its members' box
+  extents grow away from (`box_growth_sign`, `layout/geometry.py`): the left
+  one by default, the right one when a member's extent grows leftward (its
+  flow runs that way, or its lanes fan that way). A right-seated member's
+  slack is its column's width minus its own `_effective_section_width`, the
+  same measure the column width was reserved from, so the column's boxes
+  land on one X.
 - **Disconnected graphs**: When the section meta-graph has 2+
   weakly-connected components and the author pinned no explicit
   `%%metro grid:` positions, each component is placed in its own local
@@ -521,40 +527,52 @@ in pipeline order.
   `test_perp_port_edge_clearance_1494.py::test_horizontal_perp_ports_keep_the_designed_inset`.
 - **Lifecycle:** invariant - the inset holds at the final boundary.
 
-### Stage 3.6: level a grid column's shared-runway left edges
+### Stage 3.6: level a grid column's shared-runway X edges
 - **Purpose**: Give column mates that start their content at one X a
-  common bbox left edge, so the runway in front of that shared content
-  column is the same width in each. The X mirror of the row top-align
-  (Stages 5.3 / 6.9), narrowed: a grid row's sections share a trunk Y, so
-  their tops are always comparable, whereas a grid column's sections share
-  no trunk X, and levelling boxes whose content starts at different X
-  moves an edge without moving anything a viewer reads.
-- **Helper**: `_left_align_column_bboxes_only` (`phases/bbox.py`), grouping
+  common bbox edge on that side, so the runway between that edge and the
+  shared content column is the same width in each. The X half of the same
+  levelling primitive the row top-align uses (Stages 5.3 / 6.9), narrowed:
+  a grid row's sections share a trunk Y, so their tops are always
+  comparable, whereas a grid column's sections share no trunk X, and
+  levelling boxes whose content starts at different X moves an edge
+  without moving anything a viewer reads. Both X edges are levelled,
+  because unlike the box top - which carries the header badge, and so is
+  privileged by text a rotation does not carry with it - neither X edge is
+  the one a column must agree on.
+- **Helper**: `_level_column_anchor_edges` (`phases/bbox.py`), grouping
   via `_column_contiguous_row_groups` (`phases/_common.py`) then
-  `_shared_left_runway_runs` (`phases/bbox.py`).
+  `_shared_anchor_runway_runs` (`phases/bbox.py`), levelling each run
+  through `level_group_anchor_edges` (`phases/bbox.py`, shared with the
+  row top-align).
 - **Precondition**: Every X-axis box mover has run - Stage 1.1 sizing,
-  the Stage 3.3 perp-entry runway grow, the Stage 3.5 perp inset - so the
-  levelled edge is not re-broken by a later widen.
-- **Postcondition**: Within each maximal run of adjacent grid rows in one
-  column whose sections' leftmost content stations share an X, every
-  section shares the run's leftmost `bbox_x`, except one held short by a
-  left neighbour overlapping its own row band (which keeps
-  `MIN_INTER_SECTION_GAP` of inter-column corridor). Members of a packed
-  cell are out of scope: they sit side-by-side along X inside one cell, so
-  no common vertical edge exists. A rail-flagged section breaks the run:
-  `_retrofit_section_rails_phase` re-derives its interior from its bbox, so
-  growing its left edge would slide its stations rather than widen a
-  runway in front of them.
+  the Stage 1.3 column seating, the Stage 3.3 perp-entry runway grow, the
+  Stage 3.5 perp inset - so the levelled edge is not re-broken by a later
+  widen.
+- **Postcondition**: For each X side, within each maximal run of adjacent
+  grid rows in one column whose sections' content stations nearest that
+  side share an X, every section shares the run's outermost edge on that
+  side, except one held short by a neighbour overlapping its own row band
+  (which keeps `MIN_INTER_SECTION_GAP` of inter-column corridor). Members
+  of a packed cell are out of scope: they sit side-by-side along X inside
+  one cell, so no common vertical edge exists. Two kinds of section break a
+  run: a rail-flagged one, because `_retrofit_section_rails_phase`
+  re-derives its interior from its bbox, so growing its edge would slide
+  its stations rather than widen a runway in front of them; and one whose
+  exit port rides the edge under test, because that port's coordinate is
+  where the inter-section route leaves and the clearances downstream of it
+  are measured from there.
 - **Invariants preserved**: Station coords (only `bbox_x` / `bbox_w`
-  move); the cross-max (right) edge; every port's own edge anchoring
-  (LEFT ports move with the edge they are pinned to). Because a run's
-  members share a content X, growing each to the run's leftmost edge can
-  only raise a narrower runway to the widest already present in the run,
-  so the spread of runway widths within a grid column never grows.
+  move); the opposite edge of the pair being levelled; every port's own
+  edge anchoring (LEFT/RIGHT ports move with the edge they are pinned
+  to). Because a run's members share a content X on the side being
+  levelled, growing each to the run's outermost edge on that side can only
+  raise a narrower runway to the widest already present in the run, so the
+  spread of runway widths within a grid column never grows.
 - **Validate guard after**: `_guard_ports_on_boundaries`.
-- **Related tests**: `test_column_left_edge_alignment.py`.
+- **Related tests**: `test_grid_column_anchor_edge.py`.
 - **Lifecycle:** invariant - the levelled edge holds at the final
-  boundary for the sections the stage moved.
+  boundary for the sections the stage moved
+  (`_guard_column_run_shares_its_anchored_edge`).
 
 ### Stage 4.1: align ports to downstream
 - **Purpose**: For non-fold LR/RL sections, pull exit-entry port

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -81,7 +81,7 @@ from nf_metro.layout.phases.balancing import (  # noqa: F401
 from nf_metro.layout.phases.bbox import (  # noqa: F401
     _aggregate_bypass_spans,
     _fit_bboxes_to_content_top,
-    _left_align_column_bboxes_only,
+    _level_column_anchor_edges,
     _lift_would_cause_uturn,
     _loop_corner_x,
     _min_section_bbox_top,
@@ -1483,12 +1483,12 @@ def _compute_section_layout(
         reenforce_column_gaps(graph)
     _snap(graph, "3.5")
 
-    # Stage 3.6: Level the left edges of the boxes in a grid column that start
-    # their content at one X, the X mirror of the row top-align at Stage 5.3.
-    # Runs once every X-axis box mover has settled (Stage 1.1 sizing, the Stage
-    # 3.3 runway grow, the Stage 3.5 perp inset), so the levelled edge is not
-    # re-broken by a later widen.
-    _left_align_column_bboxes_only(graph)
+    # Stage 3.6: Level the anchored edges of the boxes in a grid column that
+    # start their content at one X, the X mirror of the row top-align at Stage
+    # 5.3.  Runs once every X-axis box mover has settled (Stage 1.1 sizing, the
+    # Stage 3.3 runway grow, the Stage 3.5 perp inset), so the levelled edge is
+    # not re-broken by a later widen.
+    _level_column_anchor_edges(graph)
     _snap(graph, "3.6")
 
     if validate:

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -264,6 +264,28 @@ def lanes_run_along_x(direction: str) -> bool:
     return AxisFrame.axes_for_direction(direction)[1] == "x"
 
 
+def box_growth_sign(direction: str, axis: str) -> float:
+    """Which way a section's box extent grows along *axis* from its anchored edge.
+
+    ``+1`` when the extent grows toward larger coordinates, so the box is
+    anchored on the axis minimum (its left or top edge); ``-1`` when it grows the
+    other way, anchoring the box on the axis maximum.  A section's content
+    marches along its flow axis and fans across its lane axis, so the answer is
+    whichever of the two signs *axis* carries for *direction*:
+    :meth:`AxisFrame.flow_sign` along the flow axis,
+    :meth:`AxisFrame.secondary_sign_for` across it.
+
+    On X this distinguishes the four flows by the two independent reasons a box
+    can grow leftward: RL because its flow runs that way, TB because its lanes
+    fan that way.  BT shares neither, so it is anchored left by the same rule
+    rather than by falling through to a default.
+    """
+    primary, _secondary = AxisFrame.axes_for_direction(direction)
+    if axis == primary:
+        return AxisFrame.flow_sign(direction)
+    return AxisFrame.secondary_sign_for(direction)
+
+
 def perpendicular_port_sides(direction: str) -> tuple[PortSide, PortSide]:
     """The two port sides that run perpendicular to *direction*'s flow.
 

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -1683,6 +1683,35 @@ def grow_section_bbox_max_edge(
     move_section_bbox_max_edge(graph, section, axis, new_max)
 
 
+def section_anchor_edge(section: Section, axis: str, sign: float) -> float:
+    """The *axis* box edge a *sign*-anchored section's content starts at.
+
+    ``sign`` is a :func:`...geometry.box_growth_sign` value: ``+1`` reads the
+    axis-min edge (left / top), ``-1`` the axis-max one (right / bottom).  The
+    single accessor a group-levelling pass needs so the anchor side is a
+    parameter rather than a second code path.
+    """
+    origin_attr, size_attr = _CROSS_BBOX_FIELDS[axis]
+    origin = getattr(section, origin_attr)
+    return origin if sign > 0 else origin + getattr(section, size_attr)
+
+
+def grow_section_bbox_to_anchor(
+    graph: MetroGraph, section: Section, axis: str, sign: float, target: float
+) -> None:
+    """Extend a section's *sign*-anchored *axis* edge out to *target*.
+
+    The signed counterpart of :func:`grow_section_bbox_min_edge` /
+    :func:`grow_section_bbox_max_edge`, dispatched on the anchor side that
+    :func:`section_anchor_edge` reads.  Grow-only in both directions, and the
+    ports on the moved edge follow it.
+    """
+    if sign > 0:
+        grow_section_bbox_min_edge(graph, section, axis, target)
+    else:
+        grow_section_bbox_max_edge(graph, section, axis, target)
+
+
 def exit_run_corridor_clear(
     graph: MetroGraph,
     exit_port_id: str,

--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable
+from functools import partial
 
 from nf_metro.layout.constants import (
     BYPASS_CLEARANCE,
@@ -30,9 +32,11 @@ from nf_metro.layout.phases._common import (
     _trunk_symmetric_fan_ids,
     grow_section_bbox_max_edge,
     grow_section_bbox_min_edge,
+    grow_section_bbox_to_anchor,
     move_section_bbox_min_edge,
     port_bundle_edge_reach,
     port_edge_inset,
+    section_anchor_edge,
 )
 from nf_metro.layout.phases.single_section import (
     _terminus_y_overhang,
@@ -809,64 +813,77 @@ def _reserve_perp_port_edge_inset(graph: MetroGraph) -> bool:
     return grew
 
 
-def _column_left_neighbour_limit(graph: MetroGraph, section: Section) -> float:
-    """Leftmost X ``section``'s box may reach without crowding a left neighbour.
+def _column_neighbour_anchor_limit(
+    graph: MetroGraph, section: Section, sign: float
+) -> float:
+    """Furthest X ``section``'s *sign*-anchored edge may reach past a neighbour.
 
-    A section already clear to the left of ``section`` and sharing vertical
+    A section already clear on that side of ``section`` and sharing vertical
     extent with it (headers included, since a badge protrudes above its box top)
     keeps ``MIN_INTER_SECTION_GAP`` of routing corridor.  Inter-column gaps are
     enforced per overlapping row band rather than per column, so the column's
-    leftmost box being clear says nothing about a row-mate further down.
-    ``-inf`` when nothing sits to the left.
+    outermost box being clear says nothing about a row-mate further down.
+    Infinite in the growth direction when that side is empty.
     """
     top = section.bbox_y - SECTION_HEADER_PROTRUSION
     bottom = section.bbox_y + section.bbox_h
-    limit = float("-inf")
+    here = section_anchor_edge(section, "x", sign)
+    limit = float("-inf") * sign
     for other in graph.sections.values():
         if other is section or other.bbox_w <= 0:
             continue
-        right = other.bbox_x + other.bbox_w
-        if right > section.bbox_x + SAME_COORD_TOLERANCE:
+        facing = section_anchor_edge(other, "x", -sign)
+        if (facing - here) * sign > SAME_COORD_TOLERANCE:
             continue
         if (
             other.bbox_y - SECTION_HEADER_PROTRUSION >= bottom
             or top >= other.bbox_y + other.bbox_h
         ):
             continue
-        limit = max(limit, right + MIN_INTER_SECTION_GAP)
+        corridor = facing + MIN_INTER_SECTION_GAP * sign
+        limit = max(limit, corridor) if sign > 0 else min(limit, corridor)
     return limit
 
 
-def _shared_left_runway_runs(
-    graph: MetroGraph, group: list[Section]
+def _shared_anchor_runway_runs(
+    graph: MetroGraph, group: list[Section], sign: float
 ) -> list[list[Section]]:
     """Split ``group`` into runs whose boxes start their content at one X.
 
     A grid row's sections share a trunk Y, so a levelled box top always frames
     the same thing in each and lines up something a viewer reads.  A grid
-    column's sections share no trunk X: the space left of a box's first station
-    is that section's entry runway, and two column mates only mean the same
-    thing by it when their first stations stand at one X.  Level those and the
-    shared edge reads as one runway; level a mate whose content starts further
-    right and it gains an empty band the width of the difference instead.
+    column's sections share no trunk X: the space between a box's anchored edge
+    and the content nearest it is that section's runway, and two column mates
+    only mean the same thing by it when that content stands at one X.  Level
+    those and the shared edge reads as one runway; level a mate whose content
+    starts further in and it gains an empty band the width of the difference
+    instead.
 
-    A rail-flagged section is a break in the run either way: its internal
-    geometry is re-derived from its bbox downstream
-    (:func:`...engine._retrofit_section_rails_phase`), so growing its left edge
-    slides its stations along with it rather than widening a runway in front of
-    them.
+    Two kinds of section break the run either way.  A rail-flagged one, because
+    its internal geometry is re-derived from its bbox downstream
+    (:func:`...engine._retrofit_section_rails_phase`), so growing its anchored
+    edge slides its stations along with it rather than widening a runway in front
+    of them.  And one whose exit port rides the edge under test, because that
+    port's coordinate is where the inter-section route leaves and the clearances
+    downstream of it are measured from there -- a cosmetic levelling must not
+    move it.
     """
     runs: list[list[Section]] = []
     current: list[Section] = []
     anchor = 0.0
+    edge_side = PortSide.LEFT if sign > 0 else PortSide.RIGHT
     for section in group:
         xs = [graph.stations[sid].x for sid in _content_station_ids(graph, section)]
-        first = None if graph.is_rail_section(section.id) or not xs else min(xs)
-        if first is None:
+        exits_on_edge = any(
+            (port := graph.ports.get(pid)) is not None and port.side == edge_side
+            for pid in section.exit_ports
+        )
+        if graph.is_rail_section(section.id) or exits_on_edge or not xs:
             if len(current) >= 2:
                 runs.append(current)
             current = []
             continue
+        first = min(xs) if sign > 0 else max(xs)
         if current and abs(first - anchor) <= SAME_COORD_TOLERANCE:
             current.append(section)
             continue
@@ -878,28 +895,53 @@ def _shared_left_runway_runs(
     return runs
 
 
-def _left_align_column_bboxes_only(graph: MetroGraph) -> None:
-    """Align bbox left edges within each grid column by growing boxes leftward.
+def level_group_anchor_edges(
+    graph: MetroGraph,
+    run: list[Section],
+    axis: str,
+    sign: float,
+    limit: Callable[[Section], float] | None = None,
+) -> None:
+    """Grow every box in *run* out to the run's outermost *sign*-anchored edge.
 
-    The X mirror of :func:`...row_align._top_align_row_bboxes_only`, restricted
-    to column mates that share a left runway (:func:`_shared_left_runway_runs`).
-    Only ``bbox_x`` and ``bbox_w`` move, so the interior and the cross-max edge
-    are left as they were -- a column placement right-aligned keeps its shared
-    right edge and gains a shared left edge.  LEFT ports ride the left edge and
-    are carried out to it.
+    The one levelling primitive both grid axes use: a grid row levels its boxes'
+    tops (``axis="y"``, ``sign=+1``), a grid column each of its members' X edges
+    (:func:`_level_column_anchor_edges`).  Only the edge named by *sign* and the
+    box's size move, so interiors and the opposite edge stay as they were, and
+    the ports riding the moved edge are carried with it.
 
-    A run's leftmost box sets the target; a left neighbour whose own row band
-    the growth would eat into holds a box short of it
-    (:func:`_column_left_neighbour_limit`).
+    *limit* bounds each box's reach on the anchored side, for callers whose
+    growth can eat into a neighbour's corridor; ``None`` leaves it unbounded.
+    """
+    outermost = [section_anchor_edge(s, axis, sign) for s in run]
+    target = min(outermost) if sign > 0 else max(outermost)
+    for section in run:
+        reach = target
+        if limit is not None:
+            bound = limit(section)
+            reach = max(target, bound) if sign > 0 else min(target, bound)
+        grow_section_bbox_to_anchor(graph, section, axis, sign, reach)
+
+
+COLUMN_ANCHOR_SIGNS = (1.0, -1.0)
+
+
+def _level_column_anchor_edges(graph: MetroGraph) -> None:
+    """Level each X bbox edge across the column mates anchored to it.
+
+    The X half of :func:`level_group_anchor_edges`.  A grid row levels one edge,
+    its tops, because it is the header badge -- text, which a rotation does not
+    carry with it -- that rides the box top.  Neither X edge is privileged that
+    way, so both are levelled, each across the runs whose content nearest it
+    stands at one X (:func:`_shared_anchor_runway_runs`).  A neighbour whose own
+    row band the growth would eat into holds a box short of the shared edge
+    (:func:`_column_neighbour_anchor_limit`).
     """
     for group in _column_contiguous_row_groups(graph):
-        for run in _shared_left_runway_runs(graph, group):
-            target = min(s.bbox_x for s in run)
-            for section in run:
-                if section.bbox_x - target <= SAME_COORD_TOLERANCE:
-                    continue
-                limit = _column_left_neighbour_limit(graph, section)
-                grow_section_bbox_min_edge(graph, section, "x", max(target, limit))
+        for sign in COLUMN_ANCHOR_SIGNS:
+            limit = partial(_column_neighbour_anchor_limit, graph, sign=sign)
+            for run in _shared_anchor_runway_runs(graph, group, sign):
+                level_group_anchor_edges(graph, run, "x", sign, limit)
 
 
 def _section_band_is_empty(graph: MetroGraph, section: Section) -> bool:

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -733,15 +733,26 @@ def _guard_side_entered_vertical_top_not_below_feeder(
             )
 
 
-def _guard_column_run_shares_its_anchored_edge(graph: MetroGraph, phase: str) -> None:
-    """Final: column mates sharing a runway meet on the edge nearest that runway.
+class _ShortAnchorEdge(NamedTuple):
+    """A column-run member whose anchored edge falls short of the run's."""
+
+    section: Section
+    sign: float
+    here: float
+    target: float
+    shortfall: float
+    run: tuple[Section, ...]
+
+
+def _column_run_anchor_shortfalls(graph: MetroGraph) -> Iterator[_ShortAnchorEdge]:
+    """Yield column-run members short of the anchored edge their run shares.
 
     Within a contiguous run of rows in one grid column whose members' content
     nearest an X edge stands at one X (:func:`...bbox._shared_anchor_runway_runs`)
     that edge is common, so a box short of it is a member the seating or the
     Stage 3.6 levelling left behind.  A neighbour whose own row band the reach
     would eat into is the one legitimate shortfall
-    (:func:`...bbox._column_neighbour_anchor_limit`).
+    (:func:`...bbox._column_neighbour_anchor_limit`) and is not yielded.
     """
     tol = SAME_COORD_TOLERANCE
     for group in _column_contiguous_row_groups(graph):
@@ -757,14 +768,25 @@ def _guard_column_run_shares_its_anchored_edge(graph: MetroGraph, phase: str) ->
                     limit = _column_neighbour_anchor_limit(graph, section, sign)
                     if (here - limit) * sign <= tol:
                         continue
-                    side = "left" if sign > 0 else "right"
-                    raise PhaseInvariantError(
-                        f"{phase}: section {section.id!r} {side} edge x={here:.1f} "
-                        f"sits {shortfall:.1f}px short of the x={target:.1f} its "
-                        f"grid column {section.grid_col} shares with "
-                        f"{sorted(s.id for s in run if s is not section)}, with no "
-                        f"neighbour corridor to explain it"
+                    yield _ShortAnchorEdge(
+                        section, sign, here, target, shortfall, tuple(run)
                     )
+
+
+def _guard_column_run_shares_its_anchored_edge(graph: MetroGraph, phase: str) -> None:
+    """Final: column mates sharing a runway meet on the edge nearest that runway.
+
+    Raises on the first shortfall :func:`_column_run_anchor_shortfalls` reports.
+    """
+    for short in _column_run_anchor_shortfalls(graph):
+        side = "left" if short.sign > 0 else "right"
+        raise PhaseInvariantError(
+            f"{phase}: section {short.section.id!r} {side} edge x={short.here:.1f} "
+            f"sits {short.shortfall:.1f}px short of the x={short.target:.1f} its "
+            f"grid column {short.section.grid_col} shares with "
+            f"{sorted(s.id for s in short.run if s is not short.section)}, with no "
+            f"neighbour corridor to explain it"
+        )
 
 
 def _guard_symmetric_diamond_branches_straddle_trunk(

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -48,6 +48,7 @@ from nf_metro.layout.geometry import (
 from nf_metro.layout.phases._common import (
     _bbox_cols_overlap,
     _canvas_width,
+    _column_contiguous_row_groups,
     _restoring_layout_geometry,
     _route_crosses_section_boundary,
     _section_bundle_lines,
@@ -68,14 +69,18 @@ from nf_metro.layout.phases._common import (
     port_bundle_edge_reach,
     routes_through_own_section_interior,
     routes_through_unrelated_sections,
+    section_anchor_edge,
     section_axes,
     section_cross_axis,
     wrap_exit_carrier_anchor,
 )
 from nf_metro.layout.phases.bbox import (
+    COLUMN_ANCHOR_SIGNS,
+    _column_neighbour_anchor_limit,
     _min_drawn_section_bbox_top,
     _predict_section_content_bottom,
     _section_fit_top,
+    _shared_anchor_runway_runs,
 )
 from nf_metro.layout.phases.off_track import (
     _is_single_trunk_section,
@@ -726,6 +731,40 @@ def _guard_side_entered_vertical_top_not_below_feeder(
                 f"{section.bbox_y - neighbour.bbox_y:.1f}px below its feeder "
                 f"row-mate {neighbour.id!r} (top y={neighbour.bbox_y:.1f})"
             )
+
+
+def _guard_column_run_shares_its_anchored_edge(graph: MetroGraph, phase: str) -> None:
+    """Final: column mates sharing a runway meet on the edge nearest that runway.
+
+    Within a contiguous run of rows in one grid column whose members' content
+    nearest an X edge stands at one X (:func:`...bbox._shared_anchor_runway_runs`)
+    that edge is common, so a box short of it is a member the seating or the
+    Stage 3.6 levelling left behind.  A neighbour whose own row band the reach
+    would eat into is the one legitimate shortfall
+    (:func:`...bbox._column_neighbour_anchor_limit`).
+    """
+    tol = SAME_COORD_TOLERANCE
+    for group in _column_contiguous_row_groups(graph):
+        for sign in COLUMN_ANCHOR_SIGNS:
+            for run in _shared_anchor_runway_runs(graph, group, sign):
+                edges = [section_anchor_edge(s, "x", sign) for s in run]
+                target = min(edges) if sign > 0 else max(edges)
+                for section in run:
+                    here = section_anchor_edge(section, "x", sign)
+                    shortfall = (target - here) * -sign
+                    if shortfall <= tol:
+                        continue
+                    limit = _column_neighbour_anchor_limit(graph, section, sign)
+                    if (here - limit) * sign <= tol:
+                        continue
+                    side = "left" if sign > 0 else "right"
+                    raise PhaseInvariantError(
+                        f"{phase}: section {section.id!r} {side} edge x={here:.1f} "
+                        f"sits {shortfall:.1f}px short of the x={target:.1f} its "
+                        f"grid column {section.grid_col} shares with "
+                        f"{sorted(s.id for s in run if s is not section)}, with no "
+                        f"neighbour corridor to explain it"
+                    )
 
 
 def _guard_symmetric_diamond_branches_straddle_trunk(
@@ -5073,6 +5112,18 @@ GUARD_REGISTRY: tuple[GuardSpec, ...] = (
     # check for validate runs rather than a render-output guard.
     GuardSpec(_guard_port_station_coords_synced, "B"),
     GuardSpec(_guard_no_section_overlap, "B"),
+    GuardSpec(
+        _guard_column_run_shares_its_anchored_edge,
+        "B",
+        issue_pin=("#1545",),
+        narrow_reason=(
+            "Scoped to contiguous column runs whose content nearest the edge "
+            "under test stands at one X, because that is the only case where the "
+            "column's boxes have a common edge to reach: a mate whose content "
+            "starts further in would trade the shared edge for an empty band, so "
+            "its own edge is correct and levelling it would be the defect."
+        ),
+    ),
     # The row trunk Y is only finalised once Stage 6.7 has re-centred
     # ``center_ports`` graphs, so this cannot bisect.
     GuardSpec(_guard_row_trunk_cy_consistent, "B", needs=frozenset({"offsets"})),

--- a/src/nf_metro/layout/phases/row_align.py
+++ b/src/nf_metro/layout/phases/row_align.py
@@ -581,24 +581,19 @@ def _top_align_row_bboxes_only(graph: MetroGraph) -> None:
     off-track inputs to lift; TOP ports, which ride the top edge, are
     carried up to the new top so they stay on the boundary.
 
+    The Y half of :func:`...bbox.level_group_anchor_edges`.  A row's boxes are
+    levelled on their tops whichever way their flows run, because it is the
+    header badge -- text, which a rotation does not carry with it -- that rides
+    the box top.
+
     Used after ``_lift_off_track_stations`` so off-track expansion in
     one section doesn't leave other row-mates with misaligned bbox
     tops.
     """
+    from nf_metro.layout.phases.bbox import level_group_anchor_edges
+
     for group in _row_contiguous_column_groups(graph):
-        min_top = min(s.bbox_y for s in group)
-        for section in group:
-            delta = section.bbox_y - min_top
-            if delta <= 0:
-                continue
-            section.bbox_y = min_top
-            section.bbox_h += delta
-            # TOP ports ride the top edge; the upward growth must carry them to
-            # the new top so they don't strand inside the box.
-            for pid in (*section.entry_ports, *section.exit_ports):
-                port = graph.ports.get(pid)
-                if port is not None and port.side == PortSide.TOP:
-                    _set_port_y(graph, pid, min_top)
+        level_group_anchor_edges(graph, group, "y", 1.0)
 
 
 def _align_row_trunk_ys(graph: MetroGraph) -> None:

--- a/src/nf_metro/layout/phases/row_align.py
+++ b/src/nf_metro/layout/phases/row_align.py
@@ -31,6 +31,7 @@ from nf_metro.layout.phases._common import (
     _section_trunk_y,
     iter_stacked_rows_in_rowspan_band,
 )
+from nf_metro.layout.phases.bbox import level_group_anchor_edges
 from nf_metro.layout.phases.ports import _set_port_y
 from nf_metro.layout.phases.single_section import (
     _multiline_label_padding,
@@ -590,8 +591,6 @@ def _top_align_row_bboxes_only(graph: MetroGraph) -> None:
     one section doesn't leave other row-mates with misaligned bbox
     tops.
     """
-    from nf_metro.layout.phases.bbox import level_group_anchor_edges
-
     for group in _row_contiguous_column_groups(graph):
         level_group_anchor_edges(graph, group, "y", 1.0)
 

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -35,6 +35,7 @@ from nf_metro.layout.constants import (
 )
 from nf_metro.layout.geometry import (
     AxisFrame,
+    box_growth_sign,
     lanes_run_along_x,
     lanes_run_along_y,
     shift_section,
@@ -214,11 +215,13 @@ def _compute_section_offsets(
         scoped, row_assign, row_offsets, row_heights, max_row, section_y_gap
     )
 
-    # Right-align columns containing RL or TB sections
-    right_align_cols: set[int] = set()
-    for sid, section in scoped.items():
-        if section.direction in ("RL", "TB") and section.grid_col_span == 1:
-            right_align_cols.add(col_assign.get(sid, 0))
+    # A section whose box extent grows leftward starts its content at the
+    # column's right edge, so the whole column is anchored there.
+    right_align_cols: set[int] = {
+        col_assign.get(sid, 0)
+        for sid, section in scoped.items()
+        if section.grid_col_span == 1 and box_growth_sign(section.direction, "x") < 0
+    }
 
     # Set section offsets and adjust for spanning.  Packed members keep their
     # row offset here but defer their column offset to ``_pack_cells``, which
@@ -231,12 +234,16 @@ def _compute_section_offsets(
             continue
         section.offset_x = col_offsets.get(section.grid_col, 0)
 
-        if section.grid_col_span == 1 and (
-            section.direction in ("RL", "TB") or section.grid_col in right_align_cols
-        ):
-            col_w = col_widths.get(section.grid_col, 0)
-            if col_w > section.bbox_w:
-                section.offset_x += col_w - section.bbox_w
+        if section.grid_col_span == 1 and section.grid_col in right_align_cols:
+            # The slack must be measured in the frame the column width was
+            # reserved in - a right reach re-anchored to the standard left edge
+            # (:func:`_effective_section_width`) - or each box lands displaced
+            # by its own leftward overhang and the column's right edges scatter.
+            slack = col_widths.get(section.grid_col, 0) - _effective_section_width(
+                section
+            )
+            if slack > 0:
+                section.offset_x += slack
 
     _pack_cells(scoped, packs, col_offsets, col_widths, right_align_cols, section_x_gap)
 

--- a/tests/data/guard_golden/examples/cross_track_interchange.json
+++ b/tests/data/guard_golden/examples/cross_track_interchange.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/diagonal_labels.json
+++ b/tests/data/guard_golden/examples/diagonal_labels.json
@@ -422,6 +422,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/differentialabundance.json
+++ b/tests/data/guard_golden/examples/differentialabundance.json
@@ -180,6 +180,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/differentialabundance_default.json
+++ b/tests/data/guard_golden/examples/differentialabundance_default.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/disconnected_components.json
+++ b/tests/data/guard_golden/examples/disconnected_components.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/epitopeprediction.json
+++ b/tests/data/guard_golden/examples/epitopeprediction.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/file_icons.json
+++ b/tests/data/guard_golden/examples/file_icons.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/genomeassembly.json
+++ b/tests/data/guard_golden/examples/genomeassembly.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/genomeassembly_staggered.json
+++ b/tests/data/guard_golden/examples/genomeassembly_staggered.json
@@ -176,6 +176,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/genomic_pipeline.json
+++ b/tests/data/guard_golden/examples/genomic_pipeline.json
@@ -192,6 +192,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/group_labels.json
+++ b/tests/data/guard_golden/examples/group_labels.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/02_sections.json
+++ b/tests/data/guard_golden/examples/guide/02_sections.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/03_fan_out.json
+++ b/tests/data/guard_golden/examples/guide/03_fan_out.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/03b_fan_in_merge.json
+++ b/tests/data/guard_golden/examples/guide/03b_fan_in_merge.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/04_directions.json
+++ b/tests/data/guard_golden/examples/guide/04_directions.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/05_file_icons.json
+++ b/tests/data/guard_golden/examples/guide/05_file_icons.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/05b_multi_icons.json
+++ b/tests/data/guard_golden/examples/guide/05b_multi_icons.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/05c_files_icon.json
+++ b/tests/data/guard_golden/examples/guide/05c_files_icon.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/05d_folder_icon.json
+++ b/tests/data/guard_golden/examples/guide/05d_folder_icon.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/05f_banner_labels.json
+++ b/tests/data/guard_golden/examples/guide/05f_banner_labels.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/06a_without_hidden.json
+++ b/tests/data/guard_golden/examples/guide/06a_without_hidden.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/guide/06b_with_hidden.json
+++ b/tests/data/guard_golden/examples/guide/06b_with_hidden.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/hlatyping.json
+++ b/tests/data/guard_golden/examples/hlatyping.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/legend_logo_placement.json
+++ b/tests/data/guard_golden/examples/legend_logo_placement.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/line_spread.json
+++ b/tests/data/guard_golden/examples/line_spread.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/longread_variant_calling.json
+++ b/tests/data/guard_golden/examples/longread_variant_calling.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/marker_styles.json
+++ b/tests/data/guard_golden/examples/marker_styles.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/off_track_outputs.json
+++ b/tests/data/guard_golden/examples/off_track_outputs.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/rail_section.json
+++ b/tests/data/guard_golden/examples/rail_section.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/rnaseq_auto.json
+++ b/tests/data/guard_golden/examples/rnaseq_auto.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/rnaseq_sections.json
+++ b/tests/data/guard_golden/examples/rnaseq_sections.json
@@ -309,6 +309,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/rnaseq_sections_manual.json
+++ b/tests/data/guard_golden/examples/rnaseq_sections_manual.json
@@ -309,6 +309,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/sarek_metro.json
+++ b/tests/data/guard_golden/examples/sarek_metro.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/tb_file_termini.json
+++ b/tests/data/guard_golden/examples/tb_file_termini.json
@@ -410,6 +410,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/aligner_row_pinned_continuation.json
+++ b/tests/data/guard_golden/examples/topologies/aligner_row_pinned_continuation.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/aligner_row_terminator_lane_gap.json
+++ b/tests/data/guard_golden/examples/topologies/aligner_row_terminator_lane_gap.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/around_below_ep_col_gt0.json
+++ b/tests/data/guard_golden/examples/topologies/around_below_ep_col_gt0.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/around_section_below.json
+++ b/tests/data/guard_golden/examples/topologies/around_section_below.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/asymmetric_tree.json
+++ b/tests/data/guard_golden/examples/topologies/asymmetric_tree.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bottom_exit_junction_collinear_top_entry.json
+++ b/tests/data/guard_golden/examples/topologies/bottom_exit_junction_collinear_top_entry.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bottom_exit_junction_offset_target.json
+++ b/tests/data/guard_golden/examples/topologies/bottom_exit_junction_offset_target.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bottom_row_climb_clear_corridor.json
+++ b/tests/data/guard_golden/examples/topologies/bottom_row_climb_clear_corridor.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/branch_fold_forward.json
+++ b/tests/data/guard_golden/examples/topologies/branch_fold_forward.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/branch_fold_stability.json
+++ b/tests/data/guard_golden/examples/topologies/branch_fold_stability.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_chain.json
+++ b/tests/data/guard_golden/examples/topologies/bt_chain.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_exit_top_above.json
+++ b/tests/data/guard_golden/examples/topologies/bt_exit_top_above.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_exit_top_above_2line.json
+++ b/tests/data/guard_golden/examples/topologies/bt_exit_top_above_2line.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_fork.json
+++ b/tests/data/guard_golden/examples/topologies/bt_fork.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_infer_ports.json
+++ b/tests/data/guard_golden/examples/topologies/bt_infer_ports.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_perp_entry_below.json
+++ b/tests/data/guard_golden/examples/topologies/bt_perp_entry_below.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_perp_left_entry_right_exit.json
+++ b/tests/data/guard_golden/examples/topologies/bt_perp_left_entry_right_exit.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_to_lr.json
+++ b/tests/data/guard_golden/examples/topologies/bt_to_lr.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bt_to_tb.json
+++ b/tests/data/guard_golden/examples/topologies/bt_to_tb.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bundle_terminator_continuation.json
+++ b/tests/data/guard_golden/examples/topologies/bundle_terminator_continuation.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_fan_in_outer_slot.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_fan_in_outer_slot.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_gap2_rightward_overflow.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_gap2_rightward_overflow.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_label_rake.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_label_rake.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_label_rake_left.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_label_rake_left.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_label_rake_wide.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_label_rake_wide.json
@@ -295,6 +295,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_leftward_far_side_entry.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_leftward_far_side_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_leftward_overflow.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_leftward_overflow.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/bypass_v_tight.json
+++ b/tests/data/guard_golden/examples/topologies/bypass_v_tight.json
@@ -297,6 +297,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/clear_channel_target_aware_push.json
+++ b/tests/data/guard_golden/examples/topologies/clear_channel_target_aware_push.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/compact_gap_peer_conflict.json
+++ b/tests/data/guard_golden/examples/topologies/compact_gap_peer_conflict.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/compact_hidden_passthrough.json
+++ b/tests/data/guard_golden/examples/topologies/compact_hidden_passthrough.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/complex_multipath.json
+++ b/tests/data/guard_golden/examples/topologies/complex_multipath.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/convergence_fold_diamond.json
+++ b/tests/data/guard_golden/examples/topologies/convergence_fold_diamond.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/convergence_sink_above.json
+++ b/tests/data/guard_golden/examples/topologies/convergence_sink_above.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/convergence_sink_fold.json
+++ b/tests/data/guard_golden/examples/topologies/convergence_sink_fold.json
@@ -172,6 +172,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/convergence_stacked_sink.json
+++ b/tests/data/guard_golden/examples/topologies/convergence_stacked_sink.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/convergent_offrow_exit_climb.json
+++ b/tests/data/guard_golden/examples/topologies/convergent_offrow_exit_climb.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/corridor_fed_trunk_output_spur.json
+++ b/tests/data/guard_golden/examples/topologies/corridor_fed_trunk_output_spur.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/corridor_narrow_gap_fallback.json
+++ b/tests/data/guard_golden/examples/topologies/corridor_narrow_gap_fallback.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/cross_col_top_entry.json
+++ b/tests/data/guard_golden/examples/topologies/cross_col_top_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/cross_column_perp_drop.json
+++ b/tests/data/guard_golden/examples/topologies/cross_column_perp_drop.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/cross_column_perp_drop_far_exit.json
+++ b/tests/data/guard_golden/examples/topologies/cross_column_perp_drop_far_exit.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/cross_row_gap_wrap.json
+++ b/tests/data/guard_golden/examples/topologies/cross_row_gap_wrap.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/crowded_header_nudge_overtop.json
+++ b/tests/data/guard_golden/examples/topologies/crowded_header_nudge_overtop.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/deep_linear.json
+++ b/tests/data/guard_golden/examples/topologies/deep_linear.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/disconnected_components_fold.json
+++ b/tests/data/guard_golden/examples/topologies/disconnected_components_fold.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/disjoint_sameline_trunks.json
+++ b/tests/data/guard_golden/examples/topologies/disjoint_sameline_trunks.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/divergent_fanout_split.json
+++ b/tests/data/guard_golden/examples/topologies/divergent_fanout_split.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/dogleg_exempt_distinct.json
+++ b/tests/data/guard_golden/examples/topologies/dogleg_exempt_distinct.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/dogleg_exempt_sameline.json
+++ b/tests/data/guard_golden/examples/topologies/dogleg_exempt_sameline.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/dogleg_twoline_fanout.json
+++ b/tests/data/guard_golden/examples/topologies/dogleg_twoline_fanout.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/exit_corner_offset_dogleg.json
+++ b/tests/data/guard_golden/examples/topologies/exit_corner_offset_dogleg.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/exit_fan_label_strike.json
+++ b/tests/data/guard_golden/examples/topologies/exit_fan_label_strike.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fan_bypass_nesting.json
+++ b/tests/data/guard_golden/examples/topologies/fan_bypass_nesting.json
@@ -172,6 +172,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fan_in_merge.json
+++ b/tests/data/guard_golden/examples/topologies/fan_in_merge.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fan_top_entry_over_tall_section.json
+++ b/tests/data/guard_golden/examples/topologies/fan_top_entry_over_tall_section.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fanin_distant_terminus.json
+++ b/tests/data/guard_golden/examples/topologies/fanin_distant_terminus.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fanout_bundle_plus_spurs.json
+++ b/tests/data/guard_golden/examples/topologies/fanout_bundle_plus_spurs.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fanout_hub_two_line_trunk.json
+++ b/tests/data/guard_golden/examples/topologies/fanout_hub_two_line_trunk.json
@@ -311,6 +311,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fanout_intersection_shared_channel.json
+++ b/tests/data/guard_golden/examples/topologies/fanout_intersection_shared_channel.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fanout_line_reused_nonadjacent_leg.json
+++ b/tests/data/guard_golden/examples/topologies/fanout_line_reused_nonadjacent_leg.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_bypass_creep.json
+++ b/tests/data/guard_golden/examples/topologies/fold_bypass_creep.json
@@ -295,6 +295,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_bypass_creep_tight.json
+++ b/tests/data/guard_golden/examples/topologies/fold_bypass_creep_tight.json
@@ -295,6 +295,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_double.json
+++ b/tests/data/guard_golden/examples/topologies/fold_double.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_fan_across.json
+++ b/tests/data/guard_golden/examples/topologies/fold_fan_across.json
@@ -172,6 +172,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_left_exit_right_entry.json
+++ b/tests/data/guard_golden/examples/topologies/fold_left_exit_right_entry.json
@@ -422,6 +422,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_split_targets.json
+++ b/tests/data/guard_golden/examples/topologies/fold_split_targets.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fold_stacked_branch.json
+++ b/tests/data/guard_golden/examples/topologies/fold_stacked_branch.json
@@ -176,6 +176,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/foldback_exit_peeloff.json
+++ b/tests/data/guard_golden/examples/topologies/foldback_exit_peeloff.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/folded_corridor_distinct_lanes.json
+++ b/tests/data/guard_golden/examples/topologies/folded_corridor_distinct_lanes.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/fork_join_interior_label.json
+++ b/tests/data/guard_golden/examples/topologies/fork_join_interior_label.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/funcprofiler_upstream.json
+++ b/tests/data/guard_golden/examples/topologies/funcprofiler_upstream.json
@@ -299,6 +299,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/header_nudge.json
+++ b/tests/data/guard_golden/examples/topologies/header_nudge.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/header_side_rotated.json
+++ b/tests/data/guard_golden/examples/topologies/header_side_rotated.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/inrow_skip_breeze.json
+++ b/tests/data/guard_golden/examples/topologies/inrow_skip_breeze.json
@@ -287,6 +287,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/inter_row_drop_section_clearance.json
+++ b/tests/data/guard_golden/examples/topologies/inter_row_drop_section_clearance.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/inter_row_drop_section_clearance_row1.json
+++ b/tests/data/guard_golden/examples/topologies/inter_row_drop_section_clearance_row1.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/inter_row_wrap_clearance.json
+++ b/tests/data/guard_golden/examples/topologies/inter_row_wrap_clearance.json
@@ -180,6 +180,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/interchange_label_clears_bridge.json
+++ b/tests/data/guard_golden/examples/topologies/interchange_label_clears_bridge.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/interchange_lane_reorder.json
+++ b/tests/data/guard_golden/examples/topologies/interchange_lane_reorder.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/internal_source_equal_sibling_2fan.json
+++ b/tests/data/guard_golden/examples/topologies/internal_source_equal_sibling_2fan.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/junction_entry_align.json
+++ b/tests/data/guard_golden/examples/topologies/junction_entry_align.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/junction_entry_collision.json
+++ b/tests/data/guard_golden/examples/topologies/junction_entry_collision.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/junction_entry_reversed_fold.json
+++ b/tests/data/guard_golden/examples/topologies/junction_entry_reversed_fold.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/junction_fanout_convergence.json
+++ b/tests/data/guard_golden/examples/topologies/junction_fanout_convergence.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/left_entry_from_above_far.json
+++ b/tests/data/guard_golden/examples/topologies/left_entry_from_above_far.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/left_entry_up_wrap.json
+++ b/tests/data/guard_golden/examples/topologies/left_entry_up_wrap.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/left_exit_sink_below.json
+++ b/tests/data/guard_golden/examples/topologies/left_exit_sink_below.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_bottom_exit_rl_top_entry_jog.json
+++ b/tests/data/guard_golden/examples/topologies/lr_bottom_exit_rl_top_entry_jog.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_bottom_exit_perp_entry.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_bottom_exit_perp_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_bottom_exit_side_entry.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_bottom_exit_side_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_top_entry_bottom_exit.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_top_entry_bottom_exit.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_perp_entry.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_perp_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_perp_entry_diverging.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_perp_entry_diverging.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_side_entry.json
+++ b/tests/data/guard_golden/examples/topologies/lr_perp_top_exit_side_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_cross_col.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_cross_col.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_drop.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_drop.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_drop_two_lines.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_drop_two_lines.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_near_vertical.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_near_vertical.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_to_tb_top_two_lines.json
+++ b/tests/data/guard_golden/examples/topologies/lr_to_tb_top_two_lines.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_top_entry_bundle_east_turn.json
+++ b/tests/data/guard_golden/examples/topologies/lr_top_entry_bundle_east_turn.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_top_entry_cross_column.json
+++ b/tests/data/guard_golden/examples/topologies/lr_top_entry_cross_column.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/lr_top_entry_cross_column_two_line.json
+++ b/tests/data/guard_golden/examples/topologies/lr_top_entry_cross_column_two_line.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/manual_rl_row_nonconsumer_bypass.json
+++ b/tests/data/guard_golden/examples/topologies/manual_rl_row_nonconsumer_bypass.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_around_below_leftmost.json
+++ b/tests/data/guard_golden/examples/topologies/merge_around_below_leftmost.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_bottom_row_bypass.json
+++ b/tests/data/guard_golden/examples/topologies/merge_bottom_row_bypass.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_feeder_shared_channel_gap.json
+++ b/tests/data/guard_golden/examples/topologies/merge_feeder_shared_channel_gap.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_leftmost_sink_branch.json
+++ b/tests/data/guard_golden/examples/topologies/merge_leftmost_sink_branch.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_offrow_continuation.json
+++ b/tests/data/guard_golden/examples/topologies/merge_offrow_continuation.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_port_above_approach.json
+++ b/tests/data/guard_golden/examples/topologies/merge_port_above_approach.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_pullaway.json
+++ b/tests/data/guard_golden/examples/topologies/merge_pullaway.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_right_entry.json
+++ b/tests/data/guard_golden/examples/topologies/merge_right_entry.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_trunk_out_of_range_section.json
+++ b/tests/data/guard_golden/examples/topologies/merge_trunk_out_of_range_section.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/merge_trunk_over_low_section.json
+++ b/tests/data/guard_golden/examples/topologies/merge_trunk_over_low_section.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/mismatched_tracks.json
+++ b/tests/data/guard_golden/examples/topologies/mismatched_tracks.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/mixed_bundle_column.json
+++ b/tests/data/guard_golden/examples/topologies/mixed_bundle_column.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/mixed_port_sides.json
+++ b/tests/data/guard_golden/examples/topologies/mixed_port_sides.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/multi_input_convergence.json
+++ b/tests/data/guard_golden/examples/topologies/multi_input_convergence.json
@@ -172,6 +172,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/multi_line_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/multi_line_bundle.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/multi_section_cell.json
+++ b/tests/data/guard_golden/examples/topologies/multi_section_cell.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/multicarrier_offrow_exit_climb.json
+++ b/tests/data/guard_golden/examples/topologies/multicarrier_offrow_exit_climb.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/multirow_source_stacked_fan.json
+++ b/tests/data/guard_golden/examples/topologies/multirow_source_stacked_fan.json
@@ -311,6 +311,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/narrow_section_header_wrap.json
+++ b/tests/data/guard_golden/examples/topologies/narrow_section_header_wrap.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/near_edge_exit_corner.json
+++ b/tests/data/guard_golden/examples/topologies/near_edge_exit_corner.json
@@ -293,6 +293,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/near_vertical_junction_hook.json
+++ b/tests/data/guard_golden/examples/topologies/near_vertical_junction_hook.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/off_track_convergence.json
+++ b/tests/data/guard_golden/examples/topologies/off_track_convergence.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/off_track_convergence_multiline.json
+++ b/tests/data/guard_golden/examples/topologies/off_track_convergence_multiline.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/off_track_input_above_consumer.json
+++ b/tests/data/guard_golden/examples/topologies/off_track_input_above_consumer.json
@@ -172,6 +172,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/off_track_terminal_noop.json
+++ b/tests/data/guard_golden/examples/topologies/off_track_terminal_noop.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/offtrack_output_peel_before_successor.json
+++ b/tests/data/guard_golden/examples/topologies/offtrack_output_peel_before_successor.json
@@ -295,6 +295,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/opposing_bypass_corridor.json
+++ b/tests/data/guard_golden/examples/topologies/opposing_bypass_corridor.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/opposing_return_row_pair.json
+++ b/tests/data/guard_golden/examples/topologies/opposing_return_row_pair.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/orbit_perp_exit_back_row_entry.json
+++ b/tests/data/guard_golden/examples/topologies/orbit_perp_exit_back_row_entry.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/orbit_perp_exit_flow_entry.json
+++ b/tests/data/guard_golden/examples/topologies/orbit_perp_exit_flow_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/orbit_perp_exit_perp_entry.json
+++ b/tests/data/guard_golden/examples/topologies/orbit_perp_exit_perp_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/orbit_perp_exit_turning_entry.json
+++ b/tests/data/guard_golden/examples/topologies/orbit_perp_exit_turning_entry.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/out_of_section_retag_fan.json
+++ b/tests/data/guard_golden/examples/topologies/out_of_section_retag_fan.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass_adjacent.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass_adjacent.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass_cross_row.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_cellmate_bypass_cross_row.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_consumer_drop_in.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_consumer_drop_in.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_cell_left_entry_under_neighbour.json
+++ b/tests/data/guard_golden/examples/topologies/packed_cell_left_entry_under_neighbour.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/packed_multiline_serpentine_grid.json
+++ b/tests/data/guard_golden/examples/topologies/packed_multiline_serpentine_grid.json
@@ -293,6 +293,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/parallel_independent.json
+++ b/tests/data/guard_golden/examples/topologies/parallel_independent.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/peeloff_extra_line_consumer.json
+++ b/tests/data/guard_golden/examples/topologies/peeloff_extra_line_consumer.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/peeloff_riser_respace.json
+++ b/tests/data/guard_golden/examples/topologies/peeloff_riser_respace.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/peeloff_straight_drop_near_wall.json
+++ b/tests/data/guard_golden/examples/topologies/peeloff_straight_drop_near_wall.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/post_convergence_trunk.json
+++ b/tests/data/guard_golden/examples/topologies/post_convergence_trunk.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/reconverge_reversed_fold.json
+++ b/tests/data/guard_golden/examples/topologies/reconverge_reversed_fold.json
@@ -176,6 +176,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/render_labelwrap_row_gap.json
+++ b/tests/data/guard_golden/examples/topologies/render_labelwrap_row_gap.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/riboseq_fold_two_dir_entry.json
+++ b/tests/data/guard_golden/examples/topologies/riboseq_fold_two_dir_entry.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/riboseq_fold_two_dir_entry_hintless.json
+++ b/tests/data/guard_golden/examples/topologies/riboseq_fold_two_dir_entry_hintless.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_from_above.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_from_above.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_from_above_far.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_from_above_far.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_gap_above_empty_row.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_gap_above_empty_row.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_over_top_tall_upstream.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_over_top_tall_upstream.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/right_entry_wrap_no_fan.json
+++ b/tests/data/guard_golden/examples/topologies/right_entry_wrap_no_fan.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/rl_bottom_exit_lr_top_entry_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/rl_bottom_exit_lr_top_entry_bundle.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/rl_entry_right_exit_left.json
+++ b/tests/data/guard_golden/examples/topologies/rl_entry_right_exit_left.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/rl_entry_runway.json
+++ b/tests/data/guard_golden/examples/topologies/rl_entry_runway.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/rnaseq_lite.json
+++ b/tests/data/guard_golden/examples/topologies/rnaseq_lite.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/route_around_far_column_top_entry.json
+++ b/tests/data/guard_golden/examples/topologies/route_around_far_column_top_entry.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/route_around_intervening.json
+++ b/tests/data/guard_golden/examples/topologies/route_around_intervening.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/route_around_to_top_entry.json
+++ b/tests/data/guard_golden/examples/topologies/route_around_to_top_entry.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/rowmate_tb_side_entry_top_align.json
+++ b/tests/data/guard_golden/examples/topologies/rowmate_tb_side_entry_top_align.json
@@ -173,6 +173,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/rowmate_tb_side_entry_top_align_grow.json
+++ b/tests/data/guard_golden/examples/topologies/rowmate_tb_side_entry_top_align_grow.json
@@ -287,6 +287,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/same_line_fan_distinct_descent.json
+++ b/tests/data/guard_golden/examples/topologies/same_line_fan_distinct_descent.json
@@ -172,6 +172,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/same_side_culdesac.json
+++ b/tests/data/guard_golden/examples/topologies/same_side_culdesac.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/samerow_left_exit_far_left_entry.json
+++ b/tests/data/guard_golden/examples/topologies/samerow_left_exit_far_left_entry.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/section_diamond.json
+++ b/tests/data/guard_golden/examples/topologies/section_diamond.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/section_trunk_short_output_branch.json
+++ b/tests/data/guard_golden/examples/topologies/section_trunk_short_output_branch.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/sectionless_skip_breeze.json
+++ b/tests/data/guard_golden/examples/topologies/sectionless_skip_breeze.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/self_crossing_bridge.json
+++ b/tests/data/guard_golden/examples/topologies/self_crossing_bridge.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/serpentine_grid_tall_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/serpentine_grid_tall_bundle.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/serpentine_grid_wide_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/serpentine_grid_wide_bundle.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/serpentine_rl_bundle.json
+++ b/tests/data/guard_golden/examples/topologies/serpentine_rl_bundle.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/shared_cell_fork_trunk_align.json
+++ b/tests/data/guard_golden/examples/topologies/shared_cell_fork_trunk_align.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/shared_sink_parallel.json
+++ b/tests/data/guard_golden/examples/topologies/shared_sink_parallel.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/side_branch_ascent_label_strike.json
+++ b/tests/data/guard_golden/examples/topologies/side_branch_ascent_label_strike.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/single_line_dual_source_stacked_exit.json
+++ b/tests/data/guard_golden/examples/topologies/single_line_dual_source_stacked_exit.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/single_section.json
+++ b/tests/data/guard_golden/examples/topologies/single_section.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/stacked_left_exit_drop.json
+++ b/tests/data/guard_golden/examples/topologies/stacked_left_exit_drop.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/stacked_lr_serpentine.json
+++ b/tests/data/guard_golden/examples/topologies/stacked_lr_serpentine.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/stacked_right_ports_coincident.json
+++ b/tests/data/guard_golden/examples/topologies/stacked_right_ports_coincident.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/straddling_fanout_junction.json
+++ b/tests/data/guard_golden/examples/topologies/straddling_fanout_junction.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/straight_drop_below.json
+++ b/tests/data/guard_golden/examples/topologies/straight_drop_below.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_deep.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_deep.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_exit.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_exit.json
@@ -444,6 +444,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_relay.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_deadend_fanout_relay.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_diamond_beside_wide_fan.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_diamond_beside_wide_fan.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_diamond_bundle_padding.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_diamond_bundle_padding.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_diamond_odd_slot_entry.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_diamond_odd_slot_entry.json
@@ -173,6 +173,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/symmetric_multiline_merge_median.json
+++ b/tests/data/guard_golden/examples/topologies/symmetric_multiline_merge_median.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_bottom_entry_flow_start.json
+++ b/tests/data/guard_golden/examples/topologies/tb_bottom_entry_flow_start.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_bottom_exit_bundle_jog.json
+++ b/tests/data/guard_golden/examples/topologies/tb_bottom_exit_bundle_jog.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_bottom_exit_fork_diamond.json
+++ b/tests/data/guard_golden/examples/topologies/tb_bottom_exit_fork_diamond.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_column_continuation_two_lines.json
+++ b/tests/data/guard_golden/examples/topologies/tb_column_continuation_two_lines.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_convergence_straight_drop.json
+++ b/tests/data/guard_golden/examples/topologies/tb_convergence_straight_drop.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_fork_lane_transpose.json
+++ b/tests/data/guard_golden/examples/topologies/tb_fork_lane_transpose.json
@@ -287,6 +287,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_internal_diagonal.json
+++ b/tests/data/guard_golden/examples/topologies/tb_internal_diagonal.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_left_exit_step.json
+++ b/tests/data/guard_golden/examples/topologies/tb_left_exit_step.json
@@ -168,6 +168,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_lr_exit_left.json
+++ b/tests/data/guard_golden/examples/topologies/tb_lr_exit_left.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_lr_exit_right.json
+++ b/tests/data/guard_golden/examples/topologies/tb_lr_exit_right.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_off_track_inputs.json
+++ b/tests/data/guard_golden/examples/topologies/tb_off_track_inputs.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_off_track_output_row.json
+++ b/tests/data/guard_golden/examples/topologies/tb_off_track_output_row.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_offtrack_fork_baseline.json
+++ b/tests/data/guard_golden/examples/topologies/tb_offtrack_fork_baseline.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_passthrough_continuation.json
+++ b/tests/data/guard_golden/examples/topologies/tb_passthrough_continuation.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_passthrough_trunk.json
+++ b/tests/data/guard_golden/examples/topologies/tb_passthrough_trunk.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_perp_exit_side_neighbour.json
+++ b/tests/data/guard_golden/examples/topologies/tb_perp_exit_side_neighbour.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_right_entry_stack.json
+++ b/tests/data/guard_golden/examples/topologies/tb_right_entry_stack.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_trunk_through_fan.json
+++ b/tests/data/guard_golden/examples/topologies/tb_trunk_through_fan.json
@@ -285,6 +285,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tb_two_line_vert_seam.json
+++ b/tests/data/guard_golden/examples/topologies/tb_two_line_vert_seam.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/terminal_symmetric_fan.json
+++ b/tests/data/guard_golden/examples/topologies/terminal_symmetric_fan.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/tn_wes_input_fan_somatic_tree.json
+++ b/tests/data/guard_golden/examples/topologies/tn_wes_input_fan_somatic_tree.json
@@ -474,6 +474,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/top_descent_over_left_entry.json
+++ b/tests/data/guard_golden/examples/topologies/top_descent_over_left_entry.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/top_descent_over_left_entry_junction.json
+++ b/tests/data/guard_golden/examples/topologies/top_descent_over_left_entry_junction.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/top_entry_bundle_offset_seam.json
+++ b/tests/data/guard_golden/examples/topologies/top_entry_bundle_offset_seam.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/top_entry_header_clash.json
+++ b/tests/data/guard_golden/examples/topologies/top_entry_header_clash.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/top_entry_left_neighbour.json
+++ b/tests/data/guard_golden/examples/topologies/top_entry_left_neighbour.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/trunk_through_fan.json
+++ b/tests/data/guard_golden/examples/topologies/trunk_through_fan.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/u_turn_fold.json
+++ b/tests/data/guard_golden/examples/topologies/u_turn_fold.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/upward_bypass.json
+++ b/tests/data/guard_golden/examples/topologies/upward_bypass.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/variant_calling.json
+++ b/tests/data/guard_golden/examples/topologies/variant_calling.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/wide_fan_in.json
+++ b/tests/data/guard_golden/examples/topologies/wide_fan_in.json
@@ -172,6 +172,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/wide_fan_out.json
+++ b/tests/data/guard_golden/examples/topologies/wide_fan_out.json
@@ -172,6 +172,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/topologies/wide_label_fan.json
+++ b/tests/data/guard_golden/examples/topologies/wide_label_fan.json
@@ -313,6 +313,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/variant_calling.json
+++ b/tests/data/guard_golden/examples/variant_calling.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/variant_calling_tuned.json
+++ b/tests/data/guard_golden/examples/variant_calling_tuned.json
@@ -160,6 +160,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/variantbenchmarking.json
+++ b/tests/data/guard_golden/examples/variantbenchmarking.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/variantbenchmarking_auto.json
+++ b/tests/data/guard_golden/examples/variantbenchmarking_auto.json
@@ -301,6 +301,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/examples/variantprioritization.json
+++ b/tests/data/guard_golden/examples/variantprioritization.json
@@ -164,6 +164,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/bubble_forced_label_clears_diagonal.json
+++ b/tests/data/guard_golden/tests/fixtures/bubble_forced_label_clears_diagonal.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/bubble_label_clears_diagonal.json
+++ b/tests/data/guard_golden/tests/fixtures/bubble_label_clears_diagonal.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/bubble_output_above.json
+++ b/tests/data/guard_golden/tests/fixtures/bubble_output_above.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/captioned_sibling_outputs.json
+++ b/tests/data/guard_golden/tests/fixtures/captioned_sibling_outputs.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/da_pipeline.json
+++ b/tests/data/guard_golden/tests/fixtures/da_pipeline.json
@@ -180,6 +180,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/diagonal_single_trunk_off_track.json
+++ b/tests/data/guard_golden/tests/fixtures/diagonal_single_trunk_off_track.json
@@ -470,6 +470,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/file_icon_fanin.json
+++ b/tests/data/guard_golden/tests/fixtures/file_icon_fanin.json
@@ -180,6 +180,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/font_scale.json
+++ b/tests/data/guard_golden/tests/fixtures/font_scale.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/genomeassembly_organellar.json
+++ b/tests/data/guard_golden/tests/fixtures/genomeassembly_organellar.json
@@ -180,6 +180,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/icon_caption_wrap.json
+++ b/tests/data/guard_golden/tests/fixtures/icon_caption_wrap.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/leaf_file_icon_on_trunk.json
+++ b/tests/data/guard_golden/tests/fixtures/leaf_file_icon_on_trunk.json
@@ -313,6 +313,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/multiline_labels.json
+++ b/tests/data/guard_golden/tests/fixtures/multiline_labels.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/off_track_output_branched.json
+++ b/tests/data/guard_golden/tests/fixtures/off_track_output_branched.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/off_track_outputs_along_trunk.json
+++ b/tests/data/guard_golden/tests/fixtures/off_track_outputs_along_trunk.json
@@ -327,6 +327,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/off_track_terminal_noop.json
+++ b/tests/data/guard_golden/tests/fixtures/off_track_terminal_noop.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/rail_marked_single_line.json
+++ b/tests/data/guard_golden/tests/fixtures/rail_marked_single_line.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/rail_pitch_vs_labels.json
+++ b/tests/data/guard_golden/tests/fixtures/rail_pitch_vs_labels.json
@@ -180,6 +180,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/tb_exit_terminal_on_carrier.json
+++ b/tests/data/guard_golden/tests/fixtures/tb_exit_terminal_on_carrier.json
@@ -345,6 +345,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/tb_right_exit_feeder_slots.json
+++ b/tests/data/guard_golden/tests/fixtures/tb_right_exit_feeder_slots.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/topologies/twoline_fanout_up.json
+++ b/tests/data/guard_golden/tests/fixtures/topologies/twoline_fanout_up.json
@@ -180,6 +180,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/data/guard_golden/tests/fixtures/trunk_align_matching_bundle.json
+++ b/tests/data/guard_golden/tests/fixtures/trunk_align_matching_bundle.json
@@ -174,6 +174,7 @@
     "_guard_station_x_column_drift|after final",
     "_guard_port_station_coords_synced|after final",
     "_guard_no_section_overlap|after final",
+    "_guard_column_run_shares_its_anchored_edge|after final",
     "_guard_row_trunk_cy_consistent|after final",
     "_guard_off_track_clear_of_anchor|after final",
     "_guard_fanout_junction_shares_exit_port_y|after final",

--- a/tests/test_axis_frame.py
+++ b/tests/test_axis_frame.py
@@ -6,6 +6,7 @@ import pytest
 
 from nf_metro.layout.geometry import (
     AxisFrame,
+    box_growth_sign,
     lane_delta,
     lane_delta_to_normal_offset,
     lanes_run_along_y,
@@ -151,3 +152,27 @@ def test_accessors_read_and_write_named_coordinate(direction: str) -> None:
     assert {frame.primary.name, frame.secondary.name} == {"x", "y"}
     assert getattr(station, frame.primary.name) == 5.0
     assert getattr(station, frame.secondary.name) == 7.0
+
+
+@pytest.mark.parametrize(
+    ("direction", "axis", "expected"),
+    [
+        # Along the flow axis the box grows the way the flow runs.
+        ("LR", "x", 1.0),
+        ("RL", "x", -1.0),
+        ("TB", "y", 1.0),
+        ("BT", "y", -1.0),
+        # Across it, the box grows the way the lanes fan. On X that is the two
+        # independent reasons a box can grow leftward: RL because its flow does,
+        # TB because its lanes do. BT shares neither and grows right.
+        ("LR", "y", 1.0),
+        ("RL", "y", 1.0),
+        ("TB", "x", -1.0),
+        ("BT", "x", 1.0),
+    ],
+)
+def test_box_growth_sign_covers_every_direction_and_axis(
+    direction: str, axis: str, expected: float
+) -> None:
+    """The anchor side is settled for all four flows on both axes."""
+    assert box_growth_sign(direction, axis) == expected

--- a/tests/test_direction_predicate_ratchet.py
+++ b/tests/test_direction_predicate_ratchet.py
@@ -45,7 +45,7 @@ _SCANNED_PACKAGES = ("layout", "parser", "render")
 _EXEMPT = frozenset({"layout/geometry.py"})
 
 # Lower this (never raise it) when a call site migrates onto AxisFrame.
-_BASELINE = 66
+_BASELINE = 64
 
 _FLOWS = frozenset(FLOW_DIRECTIONS)
 

--- a/tests/test_grid_column_anchor_edge.py
+++ b/tests/test_grid_column_anchor_edge.py
@@ -1,29 +1,33 @@
-"""Column mates that share a left runway share a bbox left edge.
+"""A grid column's boxes meet on each X edge their content is anchored to.
 
 A grid row's sections share a trunk Y, so levelling their bbox tops always lines
-up something a viewer reads.  A grid column's sections share no trunk X: the
-space left of a box's first station is that section's entry runway, and two
-column mates only mean the same thing by it when their first stations stand at
-one X.  ``_left_align_column_bboxes_only`` (Stage 3.6) levels exactly those,
-growing the narrower boxes leftward so interior stations and the right edge stay
-put.  Column mates whose content starts at different X keep their own edges --
-levelling those would buy an aligned edge at the price of an empty band the width
-of the difference.
+up something a viewer reads, and it is the header badge -- text -- that rides the
+box top.  A grid column's sections share no trunk X and neither X edge carries
+anything comparable, so both are levelled: the space between a box edge and the
+content nearest it is that section's runway on that side, and two column mates
+only mean the same thing by it when that content stands at one X.
+``_level_column_anchor_edges`` (Stage 3.6) levels exactly those, growing the
+shorter boxes outward so interiors and the opposite edge stay put.  Column mates
+whose content starts at different X keep their own edges -- levelling those would
+buy an aligned edge at the price of an empty band the width of the difference.
 
 Covers:
 
 * Corpus: within every shared-runway run, each member either sits on the run's
-  left edge or a left neighbour in its own row band explains the shortfall.
+  edge for that side or a neighbour in its own row band explains the shortfall.
 * Corpus: the runway spread within a grid column never exceeds what the stage's
   own inputs already had, so levelling can only equalise interior space.
 * Meaningfulness: shipped fixtures hold runs the stage actually levelled, and
   column mates it declined because their content starts at different X, so
-  neither the property nor the restriction is vacuous.
+  neither the property nor the restriction is vacuous; and both X sides occur,
+  so the right-edge half is not vacuous either.
 * Regression: ``convergence_fold_diamond``'s two mirror branches end on one left
   edge with equal runways, while the ``finish`` box below them -- whose content
   starts 90px further left relative to its box -- keeps its own edge.
+* Regression: ``foldback_exit_peeloff`` and ``fold_bypass_creep``, columns whose
+  RL member has section placement seat them on the right, end on one right edge.
 * Regression: ``foldback_exit_peeloff``'s ``reporting`` box, whose content starts
-  197.5px right of its column mate's, is left alone.
+  197.5px right of its column mate's, keeps its own left edge.
 * The neighbour-corridor bound, on a hand-built grid: no shipped fixture stacks a
   wide left-column section beside a narrow column mate.
 """
@@ -40,11 +44,13 @@ from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.phases._common import (
     _column_contiguous_row_groups,
     _content_station_ids,
+    section_anchor_edge,
 )
 from nf_metro.layout.phases.bbox import (
-    _column_left_neighbour_limit,
-    _left_align_column_bboxes_only,
-    _shared_left_runway_runs,
+    COLUMN_ANCHOR_SIGNS,
+    _column_neighbour_anchor_limit,
+    _level_column_anchor_edges,
+    _shared_anchor_runway_runs,
 )
 from nf_metro.layout.routing.invariants import CurveInvariantError
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -65,55 +71,62 @@ def _gather_fixtures() -> list[Path]:
     return paths
 
 
-def _runway(graph: MetroGraph, section: Section) -> float | None:
+def _runway(graph: MetroGraph, section: Section, sign: float = 1.0) -> float | None:
+    """Distance from the *sign*-anchored box edge to the content nearest it."""
     xs = [graph.stations[sid].x for sid in _content_station_ids(graph, section)]
-    return min(xs) - section.bbox_x if xs else None
+    if not xs:
+        return None
+    nearest = min(xs) if sign > 0 else max(xs)
+    return (nearest - section_anchor_edge(section, "x", sign)) * sign
 
 
 def _unexplained_short_edges(graph: MetroGraph) -> list[tuple[str, float]]:
-    """``(section_id, shortfall)`` for every box right of its run's left edge
-    that the neighbour-corridor bound does not account for."""
+    """``(section_id, shortfall)`` for every box short of its run's anchored
+    edge that the neighbour-corridor bound does not account for."""
     out: list[tuple[str, float]] = []
     for group in _column_contiguous_row_groups(graph):
-        for run in _shared_left_runway_runs(graph, group):
-            target = min(s.bbox_x for s in run)
-            for section in run:
-                shortfall = section.bbox_x - target
-                if shortfall <= SAME_COORD_TOLERANCE:
-                    continue
-                if section.bbox_x <= _column_left_neighbour_limit(graph, section) + (
-                    SAME_COORD_TOLERANCE
-                ):
-                    continue
-                out.append((section.id, shortfall))
+        for sign in COLUMN_ANCHOR_SIGNS:
+            for run in _shared_anchor_runway_runs(graph, group, sign):
+                edges = [section_anchor_edge(s, "x", sign) for s in run]
+                target = min(edges) if sign > 0 else max(edges)
+                for section in run:
+                    here = section_anchor_edge(section, "x", sign)
+                    shortfall = (target - here) * -sign
+                    if shortfall <= SAME_COORD_TOLERANCE:
+                        continue
+                    limit = _column_neighbour_anchor_limit(graph, section, sign)
+                    if (here - limit) * sign <= SAME_COORD_TOLERANCE:
+                        continue
+                    out.append((section.id, shortfall))
     return out
 
 
 @pytest.mark.parametrize(
     "path", _gather_fixtures(), ids=lambda p: p.relative_to(REPO_ROOT).as_posix()
 )
-def test_shared_runway_runs_share_a_left_edge(path: Path) -> None:
+def test_shared_runway_runs_share_an_anchored_edge(path: Path) -> None:
     graph = parse_metro_mermaid(path.read_text())
     compute_layout(graph)
     unexplained = _unexplained_short_edges(graph)
     assert not unexplained, (
-        f"{path.name}: sections sit right of the left edge of the run they share a "
-        f"runway with, with no left neighbour to explain it: {unexplained}"
+        f"{path.name}: sections sit short of the anchored edge of the run they "
+        f"share a runway with, with no neighbour to explain it: {unexplained}"
     )
 
 
-def _column_runway_spreads(graph: MetroGraph) -> dict[int, float]:
-    """Widest minus narrowest content runway, per grid column."""
-    by_col: dict[int, list[float]] = defaultdict(list)
+def _column_runway_spreads(graph: MetroGraph) -> dict[tuple[int, float], float]:
+    """Widest minus narrowest content runway, per grid column and X side."""
+    by_col: dict[tuple[int, float], list[float]] = defaultdict(list)
     for section in graph.sections.values():
         if section.bbox_w <= 0 or section.grid_col < 0:
             continue
-        runway = _runway(graph, section)
-        if runway is not None:
-            by_col[section.grid_col].append(runway)
+        for sign in COLUMN_ANCHOR_SIGNS:
+            runway = _runway(graph, section, sign)
+            if runway is not None:
+                by_col[(section.grid_col, sign)].append(runway)
     return {
-        col: max(runways) - min(runways)
-        for col, runways in by_col.items()
+        key: max(runways) - min(runways)
+        for key, runways in by_col.items()
         if len(runways) >= 2
     }
 
@@ -129,13 +142,13 @@ def test_levelling_never_spreads_a_column_runway(
     at different X.  Compares every corpus fixture against the same layout with
     the stage stubbed out.
     """
-    worse: list[tuple[str, int, float, float]] = []
+    worse: list[tuple[str, tuple[int, float], float, float]] = []
     for path in _gather_fixtures():
         text = path.read_text()
         try:
             with monkeypatch.context() as patched:
                 patched.setattr(
-                    "nf_metro.layout.engine._left_align_column_bboxes_only",
+                    "nf_metro.layout.engine._level_column_anchor_edges",
                     lambda graph: None,
                 )
                 without = parse_metro_mermaid(text)
@@ -148,16 +161,17 @@ def test_levelling_never_spreads_a_column_runway(
             continue
         before = _column_runway_spreads(without)
         after = _column_runway_spreads(graph)
-        for col, spread in after.items():
-            if spread > before.get(col, spread) + SAME_COORD_TOLERANCE:
-                worse.append((path.name, col, before[col], spread))
+        for key, spread in after.items():
+            if spread > before.get(key, spread) + SAME_COORD_TOLERANCE:
+                worse.append((path.name, key, before[key], spread))
     assert not worse, f"columns left with wider-spread runways: {worse}"
 
 
 def test_corpus_levels_shared_runways_and_leaves_the_rest() -> None:
-    """The property and the shared-runway restriction are both exercised."""
+    """The property, the restriction and both anchor sides are all exercised."""
     levelled = 0
     declined = 0
+    signs: set[float] = set()
     for path in _gather_fixtures():
         graph = parse_metro_mermaid(path.read_text())
         try:
@@ -165,13 +179,22 @@ def test_corpus_levels_shared_runways_and_leaves_the_rest() -> None:
         except CurveInvariantError:
             continue
         for group in _column_contiguous_row_groups(graph):
-            runs = _shared_left_runway_runs(graph, group)
-            levelled += sum(
-                1 for run in runs if len({round(s.bbox_x, 1) for s in run}) == 1
-            )
-            declined += len(group) - sum(len(run) for run in runs)
+            for sign in COLUMN_ANCHOR_SIGNS:
+                runs = _shared_anchor_runway_runs(graph, group, sign)
+                if runs:
+                    signs.add(sign)
+                levelled += sum(
+                    1
+                    for run in runs
+                    if len({round(section_anchor_edge(s, "x", sign), 1) for s in run})
+                    == 1
+                )
+                declined += len(group) - sum(len(run) for run in runs)
     assert levelled > 0, "no shipped fixture has a levelled grid column"
     assert declined > 0, "no shipped column mate is held out of the levelling"
+    assert signs == {1.0, -1.0}, (
+        f"only anchor sides {sorted(signs)} are levelled; the property is half-vacuous"
+    )
 
 
 def _stacked_column_graph() -> MetroGraph:
@@ -213,10 +236,12 @@ def _seat_one_station(graph: MetroGraph, section_id: str, x: float) -> None:
 def test_neighbour_limit_keeps_the_inter_column_corridor() -> None:
     """A left neighbour sharing the row band reserves the routing corridor."""
     graph = _stacked_column_graph()
-    assert _column_left_neighbour_limit(graph, graph.sections["lower"]) == (
+    assert _column_neighbour_anchor_limit(graph, graph.sections["lower"], 1.0) == (
         330.0 + MIN_INTER_SECTION_GAP
     )
-    assert _column_left_neighbour_limit(graph, graph.sections["upper"]) == float("-inf")
+    assert _column_neighbour_anchor_limit(graph, graph.sections["upper"], 1.0) == float(
+        "-inf"
+    )
 
 
 def test_alignment_stops_at_the_neighbour_corridor() -> None:
@@ -224,7 +249,7 @@ def test_alignment_stops_at_the_neighbour_corridor() -> None:
     graph = _stacked_column_graph()
     for section_id in ("upper", "lower"):
         _seat_one_station(graph, section_id, 450.0)
-    _left_align_column_bboxes_only(graph)
+    _level_column_anchor_edges(graph)
     lower = graph.sections["lower"]
     assert lower.bbox_x == 330.0 + MIN_INTER_SECTION_GAP
     assert lower.bbox_x + lower.bbox_w == 500.0
@@ -236,8 +261,8 @@ def test_column_mates_with_different_content_columns_keep_their_edges() -> None:
     _seat_one_station(graph, "upper", 450.0)
     _seat_one_station(graph, "lower", 500.0)
     upper, lower = graph.sections["upper"], graph.sections["lower"]
-    assert _shared_left_runway_runs(graph, [upper, lower]) == []
-    _left_align_column_bboxes_only(graph)
+    assert _shared_anchor_runway_runs(graph, [upper, lower], 1.0) == []
+    _level_column_anchor_edges(graph)
     assert lower.bbox_x == 380.0
 
 
@@ -257,8 +282,29 @@ def test_mirror_branches_share_a_left_edge_and_runway() -> None:
     )
 
 
-def test_peeloff_reporting_box_keeps_its_own_edge() -> None:
-    """A column mate whose content starts far right is not grown out to the edge."""
+@pytest.mark.parametrize(
+    ("fixture", "section_ids"),
+    [
+        ("foldback_exit_peeloff", ("preprocessing", "reporting")),
+        ("fold_bypass_creep", ("prep", "report")),
+    ],
+)
+def test_right_anchored_column_shares_its_right_edge(
+    fixture: str, section_ids: tuple[str, ...]
+) -> None:
+    """A column an RL member anchors on the right ends on one right edge."""
+    path = REPO_ROOT / "examples" / "topologies" / f"{fixture}.mmd"
+    graph = parse_metro_mermaid(path.read_text())
+    compute_layout(graph)
+    rights = {
+        round(graph.sections[sid].bbox_x + graph.sections[sid].bbox_w, 1)
+        for sid in section_ids
+    }
+    assert len(rights) == 1, f"{fixture}: right edges {sorted(rights)} disagree"
+
+
+def test_peeloff_reporting_box_keeps_its_own_left_edge() -> None:
+    """A column mate whose content starts far right keeps its unanchored edge."""
     path = REPO_ROOT / "examples" / "topologies" / "foldback_exit_peeloff.mmd"
     graph = parse_metro_mermaid(path.read_text())
     compute_layout(graph)

--- a/tests/test_grid_column_anchor_edge.py
+++ b/tests/test_grid_column_anchor_edge.py
@@ -52,6 +52,7 @@ from nf_metro.layout.phases.bbox import (
     _level_column_anchor_edges,
     _shared_anchor_runway_runs,
 )
+from nf_metro.layout.phases.guards import _column_run_anchor_shortfalls
 from nf_metro.layout.routing.invariants import CurveInvariantError
 from nf_metro.parser.mermaid import parse_metro_mermaid
 from nf_metro.parser.model import MetroGraph, Section
@@ -82,23 +83,15 @@ def _runway(graph: MetroGraph, section: Section, sign: float = 1.0) -> float | N
 
 def _unexplained_short_edges(graph: MetroGraph) -> list[tuple[str, float]]:
     """``(section_id, shortfall)`` for every box short of its run's anchored
-    edge that the neighbour-corridor bound does not account for."""
-    out: list[tuple[str, float]] = []
-    for group in _column_contiguous_row_groups(graph):
-        for sign in COLUMN_ANCHOR_SIGNS:
-            for run in _shared_anchor_runway_runs(graph, group, sign):
-                edges = [section_anchor_edge(s, "x", sign) for s in run]
-                target = min(edges) if sign > 0 else max(edges)
-                for section in run:
-                    here = section_anchor_edge(section, "x", sign)
-                    shortfall = (target - here) * -sign
-                    if shortfall <= SAME_COORD_TOLERANCE:
-                        continue
-                    limit = _column_neighbour_anchor_limit(graph, section, sign)
-                    if (here - limit) * sign <= SAME_COORD_TOLERANCE:
-                        continue
-                    out.append((section.id, shortfall))
-    return out
+    edge that the neighbour-corridor bound does not account for.
+
+    Reads the scan the guard raises from, so the two cannot disagree about what
+    counts as a shortfall.
+    """
+    return [
+        (short.section.id, short.shortfall)
+        for short in _column_run_anchor_shortfalls(graph)
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_orientation_equivalence.py
+++ b/tests/test_orientation_equivalence.py
@@ -47,24 +47,62 @@ from nf_metro.parser.model import MetroGraph
 # A residual is excepted by the *kind* of defect behind it, so one entry covers
 # every orbit member the same defect breaks.
 KNOWN_DIVERGENCES: dict[tuple[str, str], str] = {
-    # Grid rows are aligned to a common bbox top (_top_align_row_bboxes_only,
-    # _align_row_trunk_ys, _fit_bboxes_to_content_top) with no counterpart for
-    # grid columns, so a quarter turn carries an aligned row onto an unaligned
-    # column.
+    # Whether a grid group shares a box edge is decided by a content-hug policy
+    # on both axes: a row's bbox top hugs its content (_fit_bboxes_to_content_top)
+    # and a column's box edges are levelled only across mates whose content
+    # nearest that edge stands at one X (Stage 3.6).  Hugged edges coincide only
+    # when the members' content extents happen to match, and a rotation does not
+    # carry text extents with it, so the boolean is not rotation-invariant where
+    # the hug wins over the flush.
     **{
-        (stem, "group_alignment"): "no column counterpart to row top-alignment (#1545)"
+        (stem, "group_alignment"): (
+            "hugged row tops coincide only when the row-mates' content-top "
+            "padding matches, which a quarter turn does not preserve (#1545)"
+        )
+        for stem in (
+            "bt_perp_left_entry_right_exit",
+            "lr_to_tb_top_drop_two_lines",
+            "tb_two_line_vert_seam",
+        )
+    },
+    # A column mate whose content starts at a different X is held out of the
+    # Stage 3.6 levelling, because levelling it would trade the shared edge for a
+    # widened runway spread.  The Stage 3.3 perpendicular-entry runway is what
+    # puts the content at a different X here: it re-wraps the box around the
+    # shifted run, moving the box's own edge with it.
+    **{
+        (stem, "group_alignment"): (
+            "column mate held out of the levelling because the perpendicular-entry "
+            "runway moved its content off the column's content X (#1545)"
+        )
         for stem in (
             "bt_exit_top_above",
             "bt_exit_top_above_2line",
-            "bt_perp_left_entry_right_exit",
             "bt_to_tb",
-            "lr_to_tb_top_cross_col",
-            "lr_to_tb_top_drop_two_lines",
             "lr_top_entry_cross_column",
             "lr_top_entry_cross_column_two_line",
-            "orbit_perp_exit_back_row_entry",
-            "tb_two_line_vert_seam",
         )
+    },
+    # Both levelling passes act on maximal runs of *adjacent* rows / columns, so
+    # a group with a hole in it is levelled as separate runs and any shared edge
+    # across the hole is incidental.
+    **{
+        (stem, "group_alignment"): (
+            "grid group's members sit in non-adjacent cells, so no single run "
+            "levels them (#1545)"
+        )
+        for stem in ("lr_to_tb_top_cross_col",)
+    },
+    # A column of same-flow sections lands on one edge only when their leftward
+    # box overhangs match: Stage 1.5 absorbs the largest overhang globally, so a
+    # member with a smaller one is seated further in, and its content moves with
+    # it out of the levelling's reach.
+    **{
+        (stem, "group_alignment"): (
+            "column mates seated apart by their differing box overhangs, which "
+            "the global Stage 1.5 absorption does not equalise (#1545)"
+        )
+        for stem in ("orbit_perp_exit_back_row_entry",)
     },
     # A folded flow-axis port is resolved either by reversing the section's flow
     # or by re-anchoring the port, but _FLIP_HORIZONTAL makes the reversal

--- a/tests/test_tb_branch_ratchet.py
+++ b/tests/test_tb_branch_ratchet.py
@@ -14,7 +14,7 @@ from pathlib import Path
 _LAYOUT_DIR = Path(__file__).resolve().parents[1] / "src/nf_metro/layout"
 
 # Lower this (never raise it) when a heuristic migrates onto AxisFrame.
-_BASELINE_TB_BRANCHES = 22
+_BASELINE_TB_BRANCHES = 20
 
 
 def _count_in_file(path: Path) -> int:


### PR DESCRIPTION
Grid rows are levelled to a common bbox top by dedicated machinery. The column
axis had only a left-edge half of it, and section placement's right-seating of a
column measured its slack in the wrong frame, so a right-seated column's boxes
never actually met at one X. This folds both halves onto one axis-parameterised
levelling primitive and corrects the seating.

## What changed

**One levelling primitive, two axes.** `level_group_anchor_edges`
(`phases/bbox.py`) grows every box in a run out to the run's outermost edge on a
given axis and edge side. `_top_align_row_bboxes_only` is its Y half;
`_level_column_anchor_edges` (Stage 3.6) is its X half. The signed edge accessor
and grower it needs, `section_anchor_edge` and `grow_section_bbox_to_anchor`, sit
in `phases/_common.py` beside the existing min/max edge primitives.

A row levels one edge, its tops, because it is the header badge - text, which a
rotation does not carry with it - that rides the box top. Neither X edge is
privileged that way, so Stage 3.6 levels both, each across the runs whose content
nearest that edge stands at one X. A run also breaks at a section whose exit port
rides the edge under test: that port's coordinate is where the inter-section
route leaves and the clearances downstream of it are measured from there.

**The anchor side is read from `AxisFrame`.** `box_growth_sign(direction, axis)`
(`layout/geometry.py`) answers which way a section's box extent grows along an
axis from `AxisFrame.flow_sign` along the flow axis and
`AxisFrame.secondary_sign_for` across it. It replaces the two
`section.direction in ("RL", "TB")` membership tests in `section_placement.py`,
which conflated two independent reasons a box grows leftward (RL because its flow
runs that way, TB because its lanes fan that way) and left BT anchored left by
falling through to a default rather than by rule.

**The seating slack is measured in the frame the column width was reserved in.**
A right-seated section's slack is now its column's width minus its own
`_effective_section_width`, the measure `_compute_col_widths` sums. Measured as
`bbox_w` it left each box's right edge displaced by that section's own leftward
overhang, so the column's right edges scattered.

**Runtime guard.** `_guard_column_run_shares_its_anchored_edge` holds the
property at the final boundary, registered in `GUARD_REGISTRY` as tier B with a
`narrow_reason`. Chosen as a live guard rather than a corpus ratchet on measured
evidence: over 600 randomly generated multi-section maps the layout-abort rate is
73/600 both with and without this change, and the guarded property holds on all
527 that laid out, as well as on all 297 corpus fixtures.

## Census

Measured over `examples/`, `examples/topologies/` and `tests/fixtures/`, grouping
sections by `grid_row` / `grid_col` and asking whether a group of 2+ shares one
of the two box edges perpendicular to the group's own axis (top or bottom for a
row, left or right for a column - a right-seated column shares its right edge, so
measuring left edges alone miscounts it). "Clean" excludes cell-packed and
`grid_row_span` / `grid_col_span` members, which are supposed to sit at different
offsets.

| axis | groups | shares neither edge (before) | clean (before) | shares neither edge (after) | clean (after) |
| --- | --- | --- | --- | --- | --- |
| row | 263 | 22 | 17 | 22 | 17 |
| col | 200 | 50 | **34** | 42 | **26** |

No grid group loses an edge it agreed on before: across the corpus the change
gains 10 shared column edges and loses 0.

## Residual classification

All 26 remaining cleanly-unaligned column groups are the stated Stage 3.6
exception: their members' content starts at a different X on both sides, so
levelling would buy the shared edge at the cost of a widened runway spread, which
`test_levelling_never_spreads_a_column_runway` forbids.

| cause | groups |
| --- | --- |
| content starts at different X, plus an exit port riding the edge | 17 |
| content starts at different X | 8 |
| content starts at different X, plus an exit port riding the edge, plus a rail section | 1 |

The row axis reaches the same trade-off by the opposite route: it levels tops
unconditionally and then reclaims a genuinely empty band
(`_fit_bboxes_to_content_top`), which is what leaves 17 row groups unaligned.

`tests/test_orientation_equivalence.py` keeps its ten `group_alignment`
exceptions, each re-worded from the placeholder to the real structural cause:

- Three (`bt_perp_left_entry_right_exit`, `lr_to_tb_top_drop_two_lines`,
  `tb_two_line_vert_seam`) are hugged row tops, which coincide only when the
  row-mates' content-top padding matches.
- Five (`bt_exit_top_above`, `bt_exit_top_above_2line`, `bt_to_tb`,
  `lr_top_entry_cross_column`, `lr_top_entry_cross_column_two_line`) are column
  mates the Stage 3.3 perpendicular-entry runway moved off the column's content
  X, which re-wraps the box around the shifted run and takes the box edge with
  it.
- One (`lr_to_tb_top_cross_col`) is a grid group whose members sit in
  non-adjacent cells, so no single contiguous run levels them.
- One (`orbit_perp_exit_back_row_entry`) is a column whose members' leftward box
  overhangs differ; Stage 1.5 absorbs the largest one globally, so the member
  with the smaller overhang is seated further in.

None is retired by this PR: each names a different mechanism from the one fixed
here, and the underlying question - whether a hug-based sizing policy can make
"this grid group shares an edge" rotation-invariant at all, given that a hugged
edge's position is a function of glyph extents - is worth settling before more of
them are chased.

## Test plan

- `tests/test_grid_column_anchor_edge.py` (renamed from
  `test_column_left_edge_alignment.py`, generalised to both X edges): the
  corpus-wide parametrised invariant, the runway-spread ratchet, vacuity checks
  covering both edge sides, the neighbour-corridor bound on a hand-built grid,
  and named regressions on `convergence_fold_diamond`, `foldback_exit_peeloff`
  and `fold_bypass_creep`. The right-edge regressions fail on
  `fix/1545-orientation-equivalence` (`foldback_exit_peeloff` right edges
  `[478.0, 486.0]`, `fold_bypass_creep` `[190.0, 220.0]`) and pass here (single
  values `486.0` and `190.0`).
- Full suite green.
- `tests/test_orientation_equivalence.py` green, including
  `test_known_divergences_all_still_bite`.
- Guard goldens regenerated: 287 files, one added trace line each
  (`_guard_column_run_shares_its_anchored_edge|after final`), with no other
  change, so the baseline is not architecture-divergent.
- `tests/test_tb_branch_ratchet.py` baseline lowered 22 -> 20 and
  `tests/test_direction_predicate_ratchet.py` baseline lowered 66 -> 64, matching
  the two membership tests the `AxisFrame` query replaced.
- Render review: 10 of 297 corpus fixtures change (md5 of `render_svg()`
  output). Every one is an improvement, none neutral or detrimental:
  `fold_bypass_creep` and `fold_bypass_creep_tight` gain a flush right edge on
  the fold column and a straight vertical descent instead of a jog;
  `crowded_header_nudge_overtop` levels both X edges of its column and narrows
  the canvas; `tb_left_exit_step` levels two columns' right edges and narrows the
  canvas 75px; `parallel_independent` and `foldback_exit_peeloff` gain a flush
  right edge; `longread_variant_calling` levels column 5's right edges and
  narrows the canvas 90px; `manual_rl_row_nonconsumer_bypass` levels its column-0
  right edges; `top_entry_bundle_offset_seam` and
  `riboseq_fold_two_dir_entry_hintless` tighten by 36px with no structural
  change.

Refs #1545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
