### PR TITLE
fix(render): measure and guard the geometry the renderer drew

### DIFF
--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -489,6 +489,10 @@ def compute_layout(
     require_resolved_edge_endpoints(graph)
     require_resolved_port_sections(graph)
 
+    # Laying out invalidates any geometry a previous render published: the
+    # coordinates it was routed against are about to be recomputed.
+    graph.rendered_geometry = None
+
     if x_spacing is None:
         x_spacing = graph.x_spacing
     if y_spacing is None:

--- a/src/nf_metro/layout/routing/__init__.py
+++ b/src/nf_metro/layout/routing/__init__.py
@@ -7,12 +7,14 @@ Public API:
 - OffsetRegime: Which line-separation regime a route is in
 - apply_route_offsets: A route's final render geometry, separation applied
 - GapSlot: Symbolic gap-relative slot for a vertical channel run
+- RenderedGeometry: The offsets + routes a render drew, for readers of the picture
 - compute_station_offsets: Per-station Y offset computation
 """
 
 from nf_metro.layout.routing.common import (
     GapSlot,
     OffsetRegime,
+    RenderedGeometry,
     RoutedPath,
     apply_route_offsets,
 )
@@ -22,6 +24,7 @@ from nf_metro.layout.routing.offsets import compute_station_offsets
 __all__ = [
     "GapSlot",
     "OffsetRegime",
+    "RenderedGeometry",
     "RoutedPath",
     "apply_route_offsets",
     "compute_station_offsets",

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -823,6 +823,31 @@ def apply_route_offsets(
     return pts
 
 
+@dataclass(frozen=True)
+class RenderedGeometry:
+    """The routed geometry a render drew, published for readers of the picture.
+
+    Routing consults section bounding boxes, and label placement grows those
+    boxes after the routes are settled, so re-routing a rendered graph routes
+    against different boxes and yields paths that were never drawn.  Readers of
+    what the viewer sees -- the render-diff quality scorecard, the
+    offset-collapse oracle -- therefore consume this instead of re-deriving.
+
+    Holds the routes by reference: they are the drawn objects, not copies, so a
+    reader sees exactly the geometry the renderer emitted.
+    """
+
+    station_offsets: dict[tuple[str, str], float]
+    routes: tuple[RoutedPath, ...]
+
+    def offset_polylines(self) -> list[tuple[str, list[tuple[float, float]]]]:
+        """Each drawn route as ``(line_id, points)`` with its separation applied."""
+        return [
+            (route.line_id, apply_route_offsets(route, self.station_offsets))
+            for route in self.routes
+        ]
+
+
 def initial_fanout_descent_span(
     rp: RoutedPath,
 ) -> tuple[float, float, float, bool] | None:

--- a/src/nf_metro/layout/routing/common.py
+++ b/src/nf_metro/layout/routing/common.py
@@ -833,8 +833,10 @@ class RenderedGeometry:
     what the viewer sees -- the render-diff quality scorecard, the
     offset-collapse oracle -- therefore consume this instead of re-deriving.
 
-    Holds the routes by reference: they are the drawn objects, not copies, so a
-    reader sees exactly the geometry the renderer emitted.
+    Holds the offsets and routes by reference rather than copying them: they are
+    the objects the renderer goes on to draw, so a reader sees exactly the
+    geometry that was emitted.  ``compute_layout`` clears the published record,
+    since a fresh layout moves the coordinates it was routed against.
     """
 
     station_offsets: dict[tuple[str, str], float]

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict
 
 from nf_metro.errors import NfMetroError
+
+if TYPE_CHECKING:
+    from nf_metro.layout.routing.common import RenderedGeometry
 
 
 class RowGridInfo(TypedDict):
@@ -530,6 +533,11 @@ class MetroGraph:
     bypass_label_obstacles: dict[str, tuple[float, float, float, float]] = field(
         default_factory=dict
     )
+    # The offsets and routes the renderer drew, published once the render
+    # settles. Routing consults section bboxes and label placement grows them
+    # afterwards, so a re-route cannot reproduce the drawn paths; readers of the
+    # picture consume this. None until this graph has been rendered.
+    rendered_geometry: "RenderedGeometry | None" = field(default=None, repr=False)
     # %%metro legend_combo entries: (line_ids, label) pairs.
     legend_combos: list[tuple[tuple[str, ...], str]] = field(default_factory=list)
     # Placement modifiers for the bundled legend+logo block. The corner/edge

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -39,6 +39,7 @@ from nf_metro.layout.phases.guards import (
 )
 from nf_metro.layout.phases.spacing import _bypass_label_obstacles
 from nf_metro.layout.routing import (
+    RenderedGeometry,
     RoutedPath,
     apply_route_offsets,
     compute_station_offsets,
@@ -589,9 +590,13 @@ def _settle_render_geometry(
     lower section's header badge up into the box above.  Only that genuine
     collision is reconciled -- push the lower rows down to restore
     ``section_y_gap``, then re-settle so routes and labels track the shifted
-    sections (routing is idempotent on the settled ``Station.x``, so the second
-    pass grows the same bboxes).  A smaller sub-``section_y_gap`` shortfall
-    draws no overlap and is left as laid out.
+    sections.  A smaller sub-``section_y_gap`` shortfall draws no overlap and is
+    left as laid out.
+
+    The settled geometry is published on ``graph.rendered_geometry``: label
+    placement grows section bboxes that routing consults, so a graph re-routed
+    after this returns yields paths that were never drawn.  Publishing is the
+    only way a later reader of the picture can see it.
 
     Rail-mode sections run a separate layout pipeline whose per-line centrelines
     are anchored during ``compute_layout`` and cannot be re-derived from a
@@ -636,6 +641,9 @@ def _settle_render_geometry(
         labels = _place(station_offsets, routes)
         assert_render_curve_invariants(graph, routes, station_offsets)
     assert_render_header_clearance(graph, strict=effective_strict)
+    graph.rendered_geometry = RenderedGeometry(
+        station_offsets=dict(station_offsets), routes=tuple(routes)
+    )
     return station_offsets, routes, labels
 
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -642,7 +642,7 @@ def _settle_render_geometry(
         assert_render_curve_invariants(graph, routes, station_offsets)
     assert_render_header_clearance(graph, strict=effective_strict)
     graph.rendered_geometry = RenderedGeometry(
-        station_offsets=dict(station_offsets), routes=tuple(routes)
+        station_offsets=station_offsets, routes=tuple(routes)
     )
     return station_offsets, routes, labels
 

--- a/src/nf_metro/render/validate.py
+++ b/src/nf_metro/render/validate.py
@@ -22,8 +22,9 @@ validate a produced file standalone without re-running layout.  The
 same-slot bundle (distinct lines the regime put on one offset, drawn flush by
 design) from a real collapse (lines the regime spread apart, drawn flush)
 needs the assigned offsets, which the bare artifact cannot supply.  It
-therefore runs only when the laid-out ``graph`` is passed alongside the SVG;
-the standalone path runs the two artifact-only checks.
+therefore runs only when the ``graph`` that produced the SVG is passed
+alongside it, carrying the geometry the render published; the standalone path
+runs the two artifact-only checks.
 
 All three see the render-only geometry (the offset regime, label Y-shifts, the
 wrapped-label lift) that the pre-render layout guards never observe.
@@ -374,9 +375,9 @@ def check_offset_collapse(
     distinguish that from a real collapse.  This compares the *drawn* gap on a
     shared run against the gap the offset regime *assigned* the pair there: a
     pair drawn flush whose assigned gap is at least one offset step has
-    collapsed into a single stroke.  The assigned geometry comes from the
-    engine, the drawn geometry from the artifact, so a finding is a real
-    render-time merge, not a re-derivation mismatch.
+    collapsed into a single stroke.  The assigned geometry is the geometry the
+    renderer published, the drawn geometry comes from the artifact, so a finding
+    is a real render-time merge, not a re-derivation mismatch.
     """
     expected = _expected_line_segments(graph)
     if not expected:
@@ -417,21 +418,21 @@ def check_offset_collapse(
 
 
 def _expected_line_segments(graph: MetroGraph) -> dict[str, list[_Segment]]:
-    """The post-offset routed segments the engine assigns, grouped by line."""
-    from nf_metro.layout.routing import compute_station_offsets, route_edges
-    from nf_metro.layout.routing.common import apply_route_offsets
+    """The post-offset routed segments the render drew, grouped by line.
 
-    offsets = compute_station_offsets(graph)
-    try:
-        routes = route_edges(graph, station_offsets=offsets)
-    except Exception:  # noqa: BLE001 - routing failure surfaces on the render path
+    Read from the geometry the renderer published rather than re-routed: label
+    placement grows the section bboxes routing consults, so a re-route of a
+    rendered graph produces paths that were never drawn, and comparing the drawn
+    ink against those would both invent collapses and clear real ones.  Empty for
+    a graph that was never rendered, which leaves the offset-collapse check to
+    skip rather than judge the ink against a geometry it cannot know.
+    """
+    drawn = graph.rendered_geometry
+    if drawn is None:
         return {}
     segments: dict[str, list[_Segment]] = {}
-    for routed in routes:
-        pts = apply_route_offsets(routed, offsets)
-        line = segments.setdefault(routed.line_id, [])
-        for i in range(len(pts) - 1):
-            line.append((pts[i], pts[i + 1]))
+    for line_id, pts in drawn.offset_polylines():
+        segments.setdefault(line_id, []).extend(zip(pts, pts[1:]))
     return segments
 
 
@@ -505,11 +506,12 @@ def validate_render(
     Reads the embedded manifest for node identities and parses the drawn route
     and label ink, then checks the geometry as drawn for label strikes and
     non-consumer marker crossings (both pure artifact oracles).  When the
-    laid-out *graph* is supplied it additionally checks for offset-pitch
-    collapse, which needs the engine's assigned offsets to tell an intended
-    same-slot bundle from a real merge.  Returns an empty list for a clean
-    render, or when the SVG carries no manifest (nothing addressable to
-    validate).
+    *graph* that produced this SVG is supplied it additionally checks for
+    offset-pitch collapse, which needs the assigned offsets to tell an intended
+    same-slot bundle from a real merge, and so reads the geometry that graph
+    published when it rendered.  Returns an empty list for a clean render, when
+    the SVG carries no manifest (nothing addressable to validate), or when the
+    supplied graph has not been rendered.
     """
     manifest = read_manifest(svg)
     if manifest is None:

--- a/tests/layout_metrics.py
+++ b/tests/layout_metrics.py
@@ -11,6 +11,10 @@ excessive column gaps) and the label-strike count reuses the engine's own
 strike definition (``iter_line_label_strikes``), so a score only moves when a
 real geometric property of the render moves.
 
+Scoring the render means scoring the geometry the renderer drew, which a
+rendered graph carries and which cannot be re-derived from it -- see
+``measured_geometry``.
+
 Module-level imports are kept stdlib-only so the spec and formatting helpers
 can be imported by ``build_render_diff.py`` without pulling in the layout
 engine; the heavy ``nf_metro`` imports live inside ``compute_metrics``.
@@ -50,6 +54,34 @@ METRICS: list[MetricSpec] = [
 METRIC_KEYS: list[str] = [m.key for m in METRICS]
 
 
+def measured_geometry(
+    graph: MetroGraph,
+) -> tuple[dict[tuple[str, str], float], list[RoutedPath]]:
+    """The ``(station_offsets, routes)`` the scorecard scores.
+
+    A rendered graph carries the geometry the renderer drew, which is the only
+    faithful answer: label placement grows the section bboxes routing consults,
+    so re-routing a rendered graph yields paths that were never drawn.  A graph
+    that was laid out but never rendered has no published geometry, so it is
+    routed here -- pre-label-growth, which is what such a graph would draw.
+    ``route_edges`` rather than ``route_edges_centred`` keeps the read free of
+    side effects: the centred variant settles markers onto ``graph.stations``.
+
+    The single seam between the scorecard and the geometry it reads, so a test
+    can assert that geometry is the ink the renderer drew.
+    """
+    from nf_metro.layout.routing import compute_station_offsets, route_edges
+
+    drawn = graph.rendered_geometry
+    if drawn is not None:
+        return drawn.station_offsets, list(drawn.routes)
+    try:
+        offsets = compute_station_offsets(graph)
+        return offsets, route_edges(graph, station_offsets=offsets)
+    except Exception:  # noqa: BLE001 - routing failure surfaces in the validator
+        return {}, []
+
+
 def compute_metrics(
     graph: MetroGraph, *, canvas: tuple[float, float] | None = None
 ) -> dict[str, float]:
@@ -64,15 +96,10 @@ def compute_metrics(
     from layout_validator import validate_layout
 
     from nf_metro.layout.phases.guards import iter_line_label_strikes
-    from nf_metro.layout.routing import compute_station_offsets, route_edges
 
     counts = Counter(v.check for v in validate_layout(graph))
 
-    try:
-        offsets = compute_station_offsets(graph)
-        routes = route_edges(graph, station_offsets=offsets)
-    except Exception:  # noqa: BLE001 - routing failure surfaces in the validator
-        offsets, routes = {}, []
+    offsets, routes = measured_geometry(graph)
 
     # Distinct (line, station) strikes: one visual mark per line crossing a
     # label, not one per route segment that happens to clip it.

--- a/tests/test_rendered_geometry.py
+++ b/tests/test_rendered_geometry.py
@@ -1,0 +1,165 @@
+"""The geometry instruments read is the geometry the renderer drew (#1590).
+
+Routing consults section bounding boxes, and label placement grows those boxes
+*after* the routes are settled.  Re-routing a rendered graph therefore routes
+against grown boxes and yields paths the viewer never saw -- on the corpus the
+divergence reaches 24px.  Anything that claims to measure or guard the render
+(the render-diff quality scorecard, the offset-collapse oracle) must read the
+geometry the renderer published rather than re-derive it.
+
+The oracle here is the drawn SVG ink: ``parse_route_polylines`` recovers each
+route's logical vertices exactly (smoothing ``Q`` control points collapse back
+to their pre-smoothing corner), so every vertex of the measured geometry must
+appear in the ink of its line.  Bridge hop gaps and corner smoothing only add
+vertices, never move them, which is why containment is the exact relation and
+not an approximation.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+from conftest import parse_and_layout
+from layout_metrics import measured_geometry
+
+from nf_metro.layout.routing.common import RoutedPath, apply_route_offsets
+from nf_metro.render import render_svg
+from nf_metro.render.validate import _expected_line_segments, parse_route_polylines
+from nf_metro.themes import THEMES
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+# Fixtures whose render mutates a section bbox enough to move a re-routed path
+# (sarek_metro by 24px, the widest on the corpus), alongside clean maps where the
+# two agreed all along.
+FIXTURES = [
+    EXAMPLES / "sarek_metro.mmd",
+    EXAMPLES / "diagonal_labels.mmd",
+    EXAMPLES / "longread_variant_calling.mmd",
+    EXAMPLES / "guide" / "04_directions.mmd",
+    EXAMPLES / "topologies" / "bypass_leftward_far_side_entry.mmd",
+    EXAMPLES / "simple_pipeline.mmd",
+    EXAMPLES / "rnaseq_auto.mmd",
+]
+
+_PRECISION = 3
+
+
+def _render(path: Path):
+    """Lay out and render *path*, returning ``(graph, svg)``."""
+    graph = parse_and_layout(path.read_text())
+    theme = graph.style if graph.style in THEMES else "nfcore"
+    return graph, render_svg(graph, THEMES[theme])
+
+
+def _ink_vertices(svg: str) -> dict[str, set[tuple[float, float]]]:
+    """Every drawn route vertex in the SVG, grouped by line id."""
+    ink: dict[str, set[tuple[float, float]]] = defaultdict(set)
+    for line_id, subpaths in parse_route_polylines(svg):
+        for subpath in subpaths:
+            ink[line_id].update(
+                (round(x, _PRECISION), round(y, _PRECISION)) for x, y in subpath
+            )
+    return ink
+
+
+def _route_vertices(
+    offsets: dict[tuple[str, str], float], routes: list[RoutedPath]
+) -> dict[str, set[tuple[float, float]]]:
+    """Every post-offset route vertex, grouped by line id."""
+    out: dict[str, set[tuple[float, float]]] = defaultdict(set)
+    for route in routes:
+        out[route.line_id].update(
+            (round(x, _PRECISION), round(y, _PRECISION))
+            for x, y in apply_route_offsets(route, offsets)
+        )
+    return out
+
+
+def _segment_vertices(
+    segments: dict[str, list[tuple[tuple[float, float], tuple[float, float]]]],
+) -> dict[str, set[tuple[float, float]]]:
+    """Every endpoint of the offset-collapse oracle's segments, by line id."""
+    out: dict[str, set[tuple[float, float]]] = defaultdict(set)
+    for line_id, segs in segments.items():
+        for a, b in segs:
+            out[line_id].update(
+                (round(p[0], _PRECISION), round(p[1], _PRECISION)) for p in (a, b)
+            )
+    return out
+
+
+def _assert_contained_in_ink(
+    measured: dict[str, set[tuple[float, float]]], svg: str, what: str
+) -> None:
+    ink = _ink_vertices(svg)
+    stray = {
+        line_id: sorted(verts - ink[line_id])
+        for line_id, verts in measured.items()
+        if verts - ink[line_id]
+    }
+    assert not stray, (
+        f"{what} reads {sum(len(v) for v in stray.values())} vertex/vertices the "
+        f"render never drew: "
+        + "; ".join(f"line {ln!r} at {pts[:3]}" for ln, pts in sorted(stray.items()))
+    )
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_scorecard_measures_the_drawn_geometry(path: Path) -> None:
+    """Every route vertex the quality scorecard scores was actually drawn."""
+    graph, svg = _render(path)
+    _assert_contained_in_ink(
+        _route_vertices(*measured_geometry(graph)), svg, "the quality scorecard"
+    )
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_offset_collapse_oracle_reads_the_drawn_geometry(path: Path) -> None:
+    """The offset-collapse oracle's reference segments were actually drawn.
+
+    It compares the drawn ink against the separation the offset regime assigned,
+    so a reference derived from paths the renderer never emitted would report
+    collapses (and clear real ones) against a picture that does not exist.
+    """
+    graph, svg = _render(path)
+    _assert_contained_in_ink(
+        _segment_vertices(_expected_line_segments(graph)),
+        svg,
+        "the offset-collapse oracle",
+    )
+
+
+def test_offset_collapse_needs_a_rendered_graph() -> None:
+    """The oracle abstains on a graph that was laid out but never rendered.
+
+    It has no drawn geometry to compare the ink against, and re-deriving one is
+    exactly the defect; abstaining is deliberate, not an accident of the lookup.
+    """
+    graph = parse_and_layout((EXAMPLES / "sarek_metro.mmd").read_text())
+    assert graph.rendered_geometry is None
+    assert _expected_line_segments(graph) == {}
+
+    render_svg(graph, THEMES["nfcore"])
+    assert graph.rendered_geometry is not None
+    assert _expected_line_segments(graph)
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_reading_the_geometry_does_not_perturb_the_render(path: Path) -> None:
+    """Measuring leaves station coordinates and offsets as the render left them.
+
+    An instrument that settled bubble-centred markers onto ``graph.stations``
+    would move the very geometry the next reader measures, so reads must stay
+    free of side effects.
+    """
+    graph, _ = _render(path)
+    before = {sid: (s.x, s.y) for sid, s in graph.stations.items()}
+
+    offsets, _ = measured_geometry(graph)
+    _expected_line_segments(graph)
+
+    assert {sid: (s.x, s.y) for sid, s in graph.stations.items()} == before
+    assert measured_geometry(graph)[0] == offsets

--- a/tests/test_rendered_geometry.py
+++ b/tests/test_rendered_geometry.py
@@ -18,12 +18,14 @@ not an approximation.
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
 from conftest import parse_and_layout
 from layout_metrics import measured_geometry
 
+from nf_metro.layout.engine import compute_layout
 from nf_metro.layout.routing.common import RoutedPath, apply_route_offsets
 from nf_metro.render import render_svg
 from nf_metro.render.validate import _expected_line_segments, parse_route_polylines
@@ -54,41 +56,43 @@ def _render(path: Path):
     return graph, render_svg(graph, THEMES[theme])
 
 
+def _vertices_by_line(
+    runs: Iterable[tuple[str, Iterable[tuple[float, float]]]],
+) -> dict[str, set[tuple[float, float]]]:
+    """Pool each ``(line_id, points)`` run into one rounded vertex set per line."""
+    out: dict[str, set[tuple[float, float]]] = defaultdict(set)
+    for line_id, points in runs:
+        out[line_id].update(
+            (round(x, _PRECISION), round(y, _PRECISION)) for x, y in points
+        )
+    return out
+
+
 def _ink_vertices(svg: str) -> dict[str, set[tuple[float, float]]]:
     """Every drawn route vertex in the SVG, grouped by line id."""
-    ink: dict[str, set[tuple[float, float]]] = defaultdict(set)
-    for line_id, subpaths in parse_route_polylines(svg):
-        for subpath in subpaths:
-            ink[line_id].update(
-                (round(x, _PRECISION), round(y, _PRECISION)) for x, y in subpath
-            )
-    return ink
+    return _vertices_by_line(
+        (line_id, subpath)
+        for line_id, subpaths in parse_route_polylines(svg)
+        for subpath in subpaths
+    )
 
 
 def _route_vertices(
     offsets: dict[tuple[str, str], float], routes: list[RoutedPath]
 ) -> dict[str, set[tuple[float, float]]]:
     """Every post-offset route vertex, grouped by line id."""
-    out: dict[str, set[tuple[float, float]]] = defaultdict(set)
-    for route in routes:
-        out[route.line_id].update(
-            (round(x, _PRECISION), round(y, _PRECISION))
-            for x, y in apply_route_offsets(route, offsets)
-        )
-    return out
+    return _vertices_by_line(
+        (route.line_id, apply_route_offsets(route, offsets)) for route in routes
+    )
 
 
 def _segment_vertices(
     segments: dict[str, list[tuple[tuple[float, float], tuple[float, float]]]],
 ) -> dict[str, set[tuple[float, float]]]:
     """Every endpoint of the offset-collapse oracle's segments, by line id."""
-    out: dict[str, set[tuple[float, float]]] = defaultdict(set)
-    for line_id, segs in segments.items():
-        for a, b in segs:
-            out[line_id].update(
-                (round(p[0], _PRECISION), round(p[1], _PRECISION)) for p in (a, b)
-            )
-    return out
+    return _vertices_by_line(
+        (line_id, segment) for line_id, segs in segments.items() for segment in segs
+    )
 
 
 def _assert_contained_in_ink(
@@ -145,6 +149,21 @@ def test_offset_collapse_needs_a_rendered_graph() -> None:
     render_svg(graph, THEMES["nfcore"])
     assert graph.rendered_geometry is not None
     assert _expected_line_segments(graph)
+
+
+def test_laying_out_again_discards_the_published_geometry() -> None:
+    """A fresh layout drops the record rather than leaving a stale one readable.
+
+    The published routes are only meaningful against the coordinates they were
+    routed from, which a re-layout is free to move.
+    """
+    text = (EXAMPLES / "sarek_metro.mmd").read_text()
+    graph = parse_and_layout(text)
+    render_svg(graph, THEMES["nfcore"])
+    assert graph.rendered_geometry is not None
+
+    compute_layout(graph)
+    assert graph.rendered_geometry is None
 
 
 @pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)


### PR DESCRIPTION
## Summary

The render-diff quality scorecard (`tests/layout_metrics.py`) and the offset-collapse render oracle (`src/nf_metro/render/validate.py`) both re-routed the graph to obtain "the" geometry. Routing consults section bounding boxes, and label placement grows those boxes *after* the routes settle, so re-routing a rendered graph yields paths that were never drawn. Across the 322 corpus fixtures that render, the re-derived geometry diverges from the drawn geometry on **24**, by up to **24.3px**: on `sarek_metro.mmd` the `core` line through `markduplicates -> mosdepth` turns at `x=623.4` as drawn and `x=647.7` as measured.

- `_settle_render_geometry` publishes the settled offsets and routes on `graph.rendered_geometry` (a frozen `RenderedGeometry` record alongside `RoutedPath`), and both readers consume that instead of re-deriving it.
- `compute_layout` clears the record, so it cannot outlive the coordinates it was routed against — matching how the sibling `bypass_label_obstacles` field self-heals.
- `tests/test_rendered_geometry.py` asserts every vertex either reader reads appears in the drawn SVG ink. The relation is exact rather than approximate: `parse_route_polylines` collapses each smoothing `Q` back to its pre-smoothing corner, and bridge hop gaps add vertices without moving them. The assertion fails on `main` for the 24 divergent fixtures.
- Three docstrings that documented these readers as measuring the render now describe what they read.

The issue suggested pointing both callers at `route_edges_centred` instead. That would not have worked: both entrypoints return identical route points on all 323 fixtures, so no route divergence closes, and the centred variant settles bubble-centred markers onto `graph.stations`, so an instrument calling it would perturb the geometry the next reader measures (it is non-idempotent on 4 fixtures, by up to 60px). A test pins that reads stay side-effect-free.

Renders are byte-identical: this changes what the instruments read, never what the renderer draws. Of the 24 fixtures whose measured geometry changes, only **2** move a scorecard value, both in `wasted_canvas` only (`longread_variant_calling` 0.261 -> 0.264, `bypass_leftward_far_side_entry` 0.523 -> 0.530) — the defect counts derive from `validate_layout`, which reads the graph rather than the routes. The metrics table is measurement-only and gates nothing.

Fixes #1590

## Test plan
- [x] `pytest` passes: 44693 passed, 135 skipped, 46 xfailed, no XPASS
- [x] New invariant test verified to fail on `main` (10 failures across the 5 named divergent fixtures) and pass with the fix
- [x] Corpus sweep: 0/322 fixtures where either reader reads an undrawn vertex, and 0/322 where measuring perturbs station coordinates
- [x] `ruff check` + `ruff format --check` + `mypy` clean; full `prek run --all-files` clean
- [x] CI green on all 13 checks (3 shards x 3.11/3.12/3.13, lint, format, e2e, render-diff)
- [x] Render-preview verdict: no visual changes detected, all renders match `main` ([preview](https://seqeralabs.github.io/nf-metro/_pr/1592/))

Generated with Claude Code
