### PR TITLE
fix(validator): read alignment axis from the port side, not the section flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,8 @@ Lines support an optional style (4th field): `solid` (default), `dashed`, or `do
 
 **NEVER position a perpendicular port at the same coordinate as an internal station.** This is validated by `check_station_as_elbow` in `tests/layout_validator.py` (10px tolerance).
 
-- TOP/BOTTOM ports on LR/RL sections must NOT share X with any internal station.
-- LEFT/RIGHT ports on TB sections must NOT share Y with any internal station.
+- TOP/BOTTOM ports on horizontal-flow (LR/RL) sections must NOT share X with any internal station.
+- LEFT/RIGHT ports on vertical-flow (TB/BT) sections must NOT share Y with any internal station.
 
 When fixing routing or alignment issues, do NOT "solve" a kink by moving a port to match a station's coordinate. That creates a station-as-elbow violation where the line visually passes through the station marker. Instead, accept small offsets between ports and stations and handle them via routing (near-vertical drops, gentle curves, etc.).
 

--- a/docs/dev/routing.mdx
+++ b/docs/dev/routing.mdx
@@ -124,8 +124,10 @@ terminates at a real anchor rather than hanging in open space:
 <Aside type="danger" title="Station-as-elbow constraint">
 Never position a port at the same coordinate as an internal station (within the 10 px tolerance checked by `check_station_as_elbow` in `tests/layout_validator.py`):
 
-- TOP/BOTTOM ports on LR/RL sections must not share X with any internal station.
-- LEFT/RIGHT ports on TB sections must not share Y with any internal station.
+- TOP/BOTTOM ports on horizontal-flow (LR/RL) sections must not share X with any internal station.
+- LEFT/RIGHT ports on vertical-flow (TB/BT) sections must not share Y with any internal station.
+
+In both cases the port is perpendicular to its section's flow, so the line has to turn 90 degrees to reach it and the offset is what gives that turn its runway. `check_exit_port_feeder_alignment` therefore exempts perpendicular ports rather than asking them to line up with their feeder: the two rules would demand opposite geometry.
 
 When fixing a routing kink, **do not** move a port onto a station's coordinate to make the line appear straight. That creates a station-as-elbow violation where the routed line visually passes through the station marker. Instead, accept a small offset between port and station and handle the geometry via routing (near-vertical drops, gentle curves, etc.).
 

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -315,6 +315,20 @@ def perpendicular_port_sides(direction: str) -> tuple[PortSide, PortSide]:
     return (PortSide.TOP, PortSide.BOTTOM)
 
 
+def port_free_axis(side: PortSide) -> str:
+    """The axis a port on *side* can slide along.
+
+    A port is pinned to the section edge it sits on, so a LEFT/RIGHT port has a
+    fixed x and moves only on y, and a TOP/BOTTOM port the reverse.  The answer
+    depends on the side alone: the section's flow direction decides which sides
+    are perpendicular (:func:`perpendicular_port_sides`), not which coordinate a
+    given side leaves free.
+    """
+    from nf_metro.parser.model import PortSide
+
+    return "y" if side in (PortSide.LEFT, PortSide.RIGHT) else "x"
+
+
 Point = tuple[float, float]
 
 

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -1354,8 +1354,8 @@ def check_intra_section_chain_alignment(
     Two non-port stations connected by an edge on the same metro line should
     share the line's track, so the intra-section edge runs along the flow
     rather than cutting across it. The track coordinate is the section's lane
-    axis, read from :func:`lanes_run_along_x` so all four flow directions are
-    covered: Y for a horizontal flow (LR/RL), X for a vertical one (TB/BT).
+    axis; :func:`lanes_run_along_x` says which screen axis that is for the
+    section's flow direction.
 
     Diagonal intra-section edges typically arise when one endpoint is a
     multi-line hub centred across many tracks while the other sits on a
@@ -1457,7 +1457,7 @@ def check_intra_section_chain_alignment(
                 continue
 
         axis = "x" if lanes_run_along_x(section.direction) else "y"
-        src_coord, tgt_coord = (src.x, tgt.x) if axis == "x" else (src.y, tgt.y)
+        src_coord, tgt_coord = getattr(src, axis), getattr(tgt, axis)
         delta = abs(src_coord - tgt_coord)
 
         if delta > tolerance:
@@ -1550,23 +1550,22 @@ def check_exit_port_feeder_alignment(
             continue
 
         axis = port_free_axis(port.side)
-        port_coord = port_station.y if axis == "y" else port_station.x
+        port_coord = getattr(port_station, axis)
 
         # Compute deltas; only emit if no feeder aligns within tolerance.
-        deltas: list[tuple[str, object, float]] = []
+        deltas: list[tuple[str, float, float]] = []
         any_aligned = False
         for st_id, st in feeder_list:
-            st_coord = st.y if axis == "y" else st.x
+            st_coord = getattr(st, axis)
             delta = abs(port_coord - st_coord)
-            deltas.append((st_id, st, delta))
+            deltas.append((st_id, st_coord, delta))
             if delta <= tolerance:
                 any_aligned = True
 
         if any_aligned:
             continue
 
-        for st_id, st, delta in deltas:
-            st_coord = st.y if axis == "y" else st.x
+        for st_id, st_coord, delta in deltas:
             violations.append(
                 Violation(
                     check="exit_port_feeder_alignment",

--- a/tests/layout_validator.py
+++ b/tests/layout_validator.py
@@ -20,6 +20,7 @@ from nf_metro.layout.geometry import (
     iter_stations_outside_bbox,
     lanes_run_along_x,
     perpendicular_port_sides,
+    port_free_axis,
 )
 from nf_metro.layout.phases._common import (
     routes_through_unrelated_sections,
@@ -1350,10 +1351,11 @@ def check_intra_section_chain_alignment(
 ) -> list[Violation]:
     """Check that consecutive same-line stations within a section share a track.
 
-    Within an LR section, two non-port stations connected by an edge on the
-    same metro line should sit at the same Y (the line's track), so the
-    intra-section edge runs horizontally. Within a TB section the same
-    invariant applies on the X axis.
+    Two non-port stations connected by an edge on the same metro line should
+    share the line's track, so the intra-section edge runs along the flow
+    rather than cutting across it. The track coordinate is the section's lane
+    axis, read from :func:`lanes_run_along_x` so all four flow directions are
+    covered: Y for a horizontal flow (LR/RL), X for a vertical one (TB/BT).
 
     Diagonal intra-section edges typically arise when one endpoint is a
     multi-line hub centred across many tracks while the other sits on a
@@ -1454,16 +1456,9 @@ def check_intra_section_chain_alignment(
             if next_st is not None and next_st.is_terminus:
                 continue
 
-        if section.direction in ("LR", "RL"):
-            delta = abs(src.y - tgt.y)
-            axis = "y"
-            src_coord, tgt_coord = src.y, tgt.y
-        elif section.direction == "TB":
-            delta = abs(src.x - tgt.x)
-            axis = "x"
-            src_coord, tgt_coord = src.x, tgt.x
-        else:
-            continue
+        axis = "x" if lanes_run_along_x(section.direction) else "y"
+        src_coord, tgt_coord = (src.x, tgt.x) if axis == "x" else (src.y, tgt.y)
+        delta = abs(src_coord - tgt_coord)
 
         if delta > tolerance:
             violations.append(
@@ -1499,11 +1494,21 @@ def check_exit_port_feeder_alignment(
 ) -> list[Violation]:
     """Check that section exit ports align with their internal feeder station.
 
-    For each exit port P, every internal (non-port, non-junction) station
-    inside the same section that has an edge directly into P should share
-    P's perpendicular coordinate (Y for LR/RL sections, X for TB). This
-    keeps the connecting segment axis-aligned and avoids kinks in the
-    horizontal exit run.
+    For each flow-aligned exit port P, every internal (non-port, non-junction)
+    station inside the same section that has an edge directly into P should
+    share the coordinate P is free to slide along, so the line leaves the
+    section straight instead of kinking into the port.
+
+    The comparison axis is read from :func:`port_free_axis` - i.e. from the
+    side P sits on, not from the section's flow direction. P is pinned to its
+    edge on the other axis, so comparing that one against an interior station
+    reports a misalignment no layout could resolve.
+
+    Perpendicular ports are exempt entirely rather than checked on their free
+    axis. Such a port sits on a lane-axis edge, so the line must turn 90 degrees
+    to reach it, and the station-as-elbow rule *requires* the port to be offset
+    from every internal station along that free axis - aligning it would put
+    the marker in the elbow. :func:`check_station_as_elbow` owns that geometry.
 
     Multi-feeder fan-ins inherently misalign all but one feeder, so this
     check fires only when the port matches *none* of its feeders - i.e.
@@ -1541,15 +1546,11 @@ def check_exit_port_feeder_alignment(
         section = graph.sections.get(port.section_id)
         if section is None:
             continue
-
-        if section.direction in ("LR", "RL"):
-            axis = "y"
-            port_coord = port_station.y
-        elif section.direction == "TB":
-            axis = "x"
-            port_coord = port_station.x
-        else:
+        if port.side in perpendicular_port_sides(section.direction):
             continue
+
+        axis = port_free_axis(port.side)
+        port_coord = port_station.y if axis == "y" else port_station.x
 
         # Compute deltas; only emit if no feeder aligns within tolerance.
         deltas: list[tuple[str, object, float]] = []

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -372,27 +372,28 @@ def test_no_intra_section_chain_misalignment_across_gallery(mmd_path):
 
 # A port is pinned to the section edge it sits on and can only slide along
 # that edge, so the alignable axis follows the side: a LEFT/RIGHT port has a
-# fixed x and a free y, a TOP/BOTTOM port the reverse. Comparing the pinned
-# coordinate against an interior station's yields a complaint no layout
-# change could satisfy.
+# fixed x and a free y, a TOP/BOTTOM port the reverse. Spelled out here rather
+# than imported from the validator's own helper so the two are independent.
 _FREE_AXIS_FOR_PORT_SIDE = {"left": "y", "right": "y", "top": "x", "bottom": "x"}
 
-_PORT_AXIS_FILES = [
-    VARIANT_CALLING_FILE,
-    RNASEQ_FILE,
-    EPITOPEPREDICTION_FILE,
-    HLATYPING_FILE,
-    TB_FILE_TERMINI_FILE,
-    *TOPOLOGY_FILES,
-]
+_PORT_AXIS_FILES = [*_CHAIN_ALIGNMENT_FILES, TB_FILE_TERMINI_FILE]
 
 
 @pytest.mark.parametrize("mmd_path", _PORT_AXIS_FILES, ids=lambda p: p.stem)
-def test_exit_port_feeder_alignment_compares_the_ports_free_axis(mmd_path):
-    """Every reported exit-port misalignment is on an axis the port can move."""
+def test_exit_port_feeder_alignment_reports_only_satisfiable_offsets(mmd_path):
+    """Every reported exit-port misalignment is one the layout could resolve.
+
+    Two ways a complaint can be unsatisfiable. It can name the axis the port is
+    pinned to, where no layout change moves the port at all. Or it can name a
+    perpendicular port, which must stay offset from every internal station on
+    its free axis or the line's 90-degree turn into it passes through a station
+    marker - demanding alignment there asks for exactly the geometry
+    ``check_station_as_elbow`` rejects, so the two checks would contradict.
+    """
     graph = _load_and_layout(mmd_path)
     for violation in check_exit_port_feeder_alignment(graph):
-        side = graph.ports[violation.context["port"]].side.value
+        port = graph.ports[violation.context["port"]]
+        side = port.side.value
         expected = _FREE_AXIS_FOR_PORT_SIDE[side]
         assert violation.context["axis"] == expected, (
             f"{violation.context['port']} sits on the {side} edge, so only "
@@ -400,23 +401,10 @@ def test_exit_port_feeder_alignment_compares_the_ports_free_axis(mmd_path):
             f"{violation.context['axis']}: {violation.message}"
         )
 
-
-@pytest.mark.parametrize("mmd_path", _PORT_AXIS_FILES, ids=lambda p: p.stem)
-def test_exit_port_feeder_alignment_exempts_perpendicular_ports(mmd_path):
-    """Feeder alignment is never demanded where station-as-elbow forbids it.
-
-    A perpendicular exit port must stay offset from every internal station on
-    its free axis, or the line's 90-degree turn into it passes through a
-    station marker. Demanding feeder alignment there asks for exactly the
-    geometry ``check_station_as_elbow`` rejects, so the two would contradict.
-    """
-    graph = _load_and_layout(mmd_path)
-    for violation in check_exit_port_feeder_alignment(graph):
-        port = graph.ports[violation.context["port"]]
         direction = graph.sections[violation.context["section"]].direction
         assert port.side not in perpendicular_port_sides(direction), (
-            f"{violation.context['port']} is a perpendicular ({port.side.value}) "
-            f"port on a {direction} section, where the "
+            f"{violation.context['port']} is a perpendicular ({side}) port on "
+            f"a {direction} section, where the "
             f"{violation.context['delta']:.1f}px offset is required clearance: "
             f"{violation.message}"
         )

--- a/tests/test_topology_validation.py
+++ b/tests/test_topology_validation.py
@@ -29,6 +29,7 @@ from layout_validator import (
 )
 
 from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.geometry import perpendicular_port_sides
 from nf_metro.layout.routing.common import row_bottom_edge
 from nf_metro.layout.routing.context import _resolve_section_row
 from nf_metro.parser.mermaid import parse_metro_mermaid
@@ -365,6 +366,105 @@ def test_no_intra_section_chain_misalignment_across_gallery(mmd_path):
     graph = _load_and_layout(mmd_path)
     violations = check_intra_section_chain_alignment(graph)
     assert not violations, "\n".join(v.message for v in violations)
+
+
+# --- #1599: alignment checks read the axis from the port side, not the flow ---
+
+# A port is pinned to the section edge it sits on and can only slide along
+# that edge, so the alignable axis follows the side: a LEFT/RIGHT port has a
+# fixed x and a free y, a TOP/BOTTOM port the reverse. Comparing the pinned
+# coordinate against an interior station's yields a complaint no layout
+# change could satisfy.
+_FREE_AXIS_FOR_PORT_SIDE = {"left": "y", "right": "y", "top": "x", "bottom": "x"}
+
+_PORT_AXIS_FILES = [
+    VARIANT_CALLING_FILE,
+    RNASEQ_FILE,
+    EPITOPEPREDICTION_FILE,
+    HLATYPING_FILE,
+    TB_FILE_TERMINI_FILE,
+    *TOPOLOGY_FILES,
+]
+
+
+@pytest.mark.parametrize("mmd_path", _PORT_AXIS_FILES, ids=lambda p: p.stem)
+def test_exit_port_feeder_alignment_compares_the_ports_free_axis(mmd_path):
+    """Every reported exit-port misalignment is on an axis the port can move."""
+    graph = _load_and_layout(mmd_path)
+    for violation in check_exit_port_feeder_alignment(graph):
+        side = graph.ports[violation.context["port"]].side.value
+        expected = _FREE_AXIS_FOR_PORT_SIDE[side]
+        assert violation.context["axis"] == expected, (
+            f"{violation.context['port']} sits on the {side} edge, so only "
+            f"{expected} is alignable, but the violation compares "
+            f"{violation.context['axis']}: {violation.message}"
+        )
+
+
+@pytest.mark.parametrize("mmd_path", _PORT_AXIS_FILES, ids=lambda p: p.stem)
+def test_exit_port_feeder_alignment_exempts_perpendicular_ports(mmd_path):
+    """Feeder alignment is never demanded where station-as-elbow forbids it.
+
+    A perpendicular exit port must stay offset from every internal station on
+    its free axis, or the line's 90-degree turn into it passes through a
+    station marker. Demanding feeder alignment there asks for exactly the
+    geometry ``check_station_as_elbow`` rejects, so the two would contradict.
+    """
+    graph = _load_and_layout(mmd_path)
+    for violation in check_exit_port_feeder_alignment(graph):
+        port = graph.ports[violation.context["port"]]
+        direction = graph.sections[violation.context["section"]].direction
+        assert port.side not in perpendicular_port_sides(direction), (
+            f"{violation.context['port']} is a perpendicular ({port.side.value}) "
+            f"port on a {direction} section, where the "
+            f"{violation.context['delta']:.1f}px offset is required clearance: "
+            f"{violation.message}"
+        )
+
+
+# Both alignment checks branch on the section's flow direction, so a missing
+# direction arm silences them entirely rather than degrading them. These tests
+# displace geometry the checks are meant to catch and assert the complaint
+# surfaces, which fails outright when BT falls through unhandled.
+
+_BT_CHAIN_FILE = TOPOLOGIES_DIR / "bt_chain.mmd"
+_BT_FLOW_EXIT_FILE = TOPOLOGIES_DIR / "bt_exit_top_above.mmd"
+
+
+def _displace_bt_stations(graph, attr: str, amount: float = 60.0) -> None:
+    """Push every interior station of a BT section off its section trunk."""
+    bt_sections = {
+        sid for sid, section in graph.sections.items() if section.direction == "BT"
+    }
+    moved = 0
+    for index, (station_id, station) in enumerate(sorted(graph.stations.items())):
+        if station.is_port or station_id in graph.junctions:
+            continue
+        if station.section_id not in bt_sections:
+            continue
+        offset = amount if index % 2 else -amount
+        setattr(station, attr, getattr(station, attr) + offset)
+        moved += 1
+    assert moved, "fixture has no interior BT stations to displace"
+
+
+def test_intra_section_chain_alignment_covers_bt_sections():
+    graph = _load_and_layout(_BT_CHAIN_FILE)
+    assert not check_intra_section_chain_alignment(graph)
+    _displace_bt_stations(graph, "x")
+    assert check_intra_section_chain_alignment(graph), (
+        "BT chains zig-zagging by 120px went unreported"
+    )
+
+
+def test_exit_port_feeder_alignment_covers_bt_sections():
+    """A BT section's flow-aligned (top) exit port is checked like any other."""
+    graph = _load_and_layout(_BT_FLOW_EXIT_FILE)
+    assert not check_exit_port_feeder_alignment(graph)
+    _displace_bt_stations(graph, "x")
+    assert check_exit_port_feeder_alignment(graph), (
+        "a BT feeder dragged 120px off its top exit port went unreported"
+    )
 
 
 # --- Regression guard: rnaseq example ---


### PR DESCRIPTION
## Summary

`check_exit_port_feeder_alignment` and `check_intra_section_chain_alignment` in `tests/layout_validator.py` picked their comparison axis from the section's **flow direction**. For an exit port that meant comparing the coordinate the port is **pinned** to by the section boundary against an interior station's, whenever the port sat on a side perpendicular to the flow. 89 of the check's 139 corpus violations were complaints no layout change could satisfy.

Swapping the axis to the port's free one is not the fix, and this is the part the issue got wrong. A perpendicular exit port must stay offset from every internal station on its free axis, or the 90-degree turn into the port passes through a station marker: exactly the geometry `check_station_as_elbow` rejects. All 52 perpendicular exit ports in the corpus sit 16-110px off their nearest feeder and **none** is within tolerance, so the check could never pass there in either axis. They are exempted, and `check_station_as_elbow` owns that geometry.

Deriving the surviving axis from the port side (new `port_free_axis` in `layout/geometry.py`, alongside the existing `perpendicular_port_sides`) removes the direction branch from both functions. That also closes a second defect: neither had a `"BT"` arm, so BT sections fell through to `continue` and were **never checked at all** by either function.

Corpus effect, all 332 fixtures:

| check | before | after |
| --- | --- | --- |
| `exit_port_feeder_alignment` | 139 violations / 62 fixtures | 50 violations / 17 fixtures |
| `intra_section_chain_alignment` | 0 (BT silently unchecked) | 0 (BT now checked) |

The 50 survivors are all flow-aligned ports (46 LR/right, 4 RL/left) - the check's legitimate output, unchanged.

## Not covered

A perpendicular exit port drifting arbitrarily far from its feeder is now invisible to this check, and no version of it could see that: the check is binary aligned/not-aligned, and alignment is forbidden there. The corpus tops out at 110px (three fixtures), which is one grid row of trunk continuing past the last station before the turn - verified correct by render, not drift. Bounding that offset would need a new threshold and its own fuzz measurement.

## Verification

- `check_exit_port_feeder_alignment` was and is test-only: `grep -rn "layout_validator" src/nf_metro/` finds nothing but a docstring mention. No render can change. `port_free_axis` is additive and uncalled from `src/`.
- Rendered `examples/topologies/tb_lr_exit_left.mmd` (the largest exempted case, `work__exit_left_1` at 110px): the line runs down the TB trunk past `Collect`, then turns once at the bottom-left into `Publish`. Aligning the port with `Collect` (y delta 110px) would put the corner on its marker.
- New tests fail against `origin/main`'s validator (36 failures) and pass with the fix.
- Full suite: 44937 passed, 135 skipped, 46 xfailed, 0 failed.

## Test plan

- [x] New invariant test fails on `main`, passes with the fix
- [x] `pytest` full suite passes (44937 passed, 0 failed)
- [x] `ruff check` + `ruff format --check` clean on `src/` and `tests/`; `mypy src/` clean
- [ ] No runtime validator added: the invariant is a property of the validator's own axis selection, not of layout geometry, so there is nothing for `compute_layout` to guard. The two new tests are the guard.
- [ ] Render-preview verdict: expected "no visual changes detected" (no code reachable from a render was changed)

Generated with Claude Code
