### PR TITLE
fix: weight the layout-quality objective by measured signal, and add the metrics that carry it

### DIFF
--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -112,7 +112,7 @@ _manifest: dict[str, str] = {}
 
 # Layout-quality scorecard per SVG filename, written to RENDERS_DIR/metrics.json
 # and reported as per-render deltas in the render-diff page. Advisory only.
-_metrics: dict[str, dict[str, float]] = {}
+_metrics: dict[str, dict[str, float | None]] = {}
 
 _SVG_DIMS_RE = re.compile(r'<svg[^>]*\bwidth="([\d.]+)"[^>]*\bheight="([\d.]+)"')
 

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -483,7 +483,7 @@ def _build_metrics_html(
         for spec in METRICS:
             bv = base.get(spec.key) if base else None
             pv = pr.get(spec.key) if pr else None
-            direction = delta_direction(bv, pv)
+            direction = delta_direction(spec, bv, pv)
             cls = {-1: "m-better", 1: "m-worse", 0: "m-flat"}[direction]
             both_present = bv is not None and pv is not None
             if both_present and direction != 0:
@@ -506,9 +506,9 @@ def _build_metrics_html(
     return (
         '<div class="metrics">\n<h2>Layout-quality metrics</h2>\n'
         '<p class="caption">Advisory only &mdash; nothing gates on these. '
-        "Lower is better; "
         '<span class="m-better">green</span> improved, '
-        '<span class="m-worse">red</span> regressed.</p>\n'
+        '<span class="m-worse">red</span> regressed. '
+        "Lower is better except in the &uarr; column.</p>\n"
         f"<table>\n<tr><th>Render</th>{header_cells}</tr>\n"
         + "\n".join(rows)
         + "\n</table>\n</div>"

--- a/scripts/build_render_diff.py
+++ b/scripts/build_render_diff.py
@@ -460,8 +460,8 @@ def _load_json(render_dir: Path, filename: str) -> dict:
 
 def _build_metrics_html(
     changed: list[tuple[str, str]],
-    base_metrics: dict[str, dict[str, float]],
-    pr_metrics: dict[str, dict[str, float]],
+    base_metrics: dict[str, dict[str, float | None]],
+    pr_metrics: dict[str, dict[str, float | None]],
 ) -> str:
     """Build the advisory layout-quality delta table for the changed renders.
 

--- a/scripts/optimize_layout.py
+++ b/scripts/optimize_layout.py
@@ -71,6 +71,14 @@ WEIGHTS = {
 # route count, so weighting both would re-count one signal in proportion to map
 # size, penalising big maps for being big.
 
+PERM_CAP = 24
+"""Row-order permutations kept per stacked grid column.
+
+Permuting several stacked columns together multiplies out, and every candidate
+costs a full parse plus layout, so the search is bounded per column and reports
+what it left unexplored.
+"""
+
 GRID_RE = re.compile(
     r"^\s*%%metro\s+(grid|direction|fold_threshold)\s*:", re.IGNORECASE
 )
@@ -175,14 +183,6 @@ def score(text: str, fold: int | None = None) -> dict[str, float | None] | None:
         return None
 
 
-def topo_columns(text: str) -> dict[int, list[str]]:
-    g = parse_metro_mermaid(strip_layout_directives(text))
-    cols: dict[int, list[str]] = {}
-    for sid, sec in g.sections.items():
-        cols.setdefault(sec.grid_col, []).append(sid)
-    return cols
-
-
 def _fmt(label: str, o: float, m: dict[str, float | None]) -> str:
     gap = m["marker_clearance"]
     return (
@@ -213,14 +213,21 @@ def optimize(
     head, blocks, loose = split_subgraphs(auto_text)
     block_by_id = {bid: blk for bid, blk in blocks}
     order = [bid for bid, _ in blocks]
-    sids = list(parse_metro_mermaid(auto_text).sections.keys())
 
-    cols = topo_columns(text)
+    # Auto-layout runs at parse time, so one parse yields both the section list
+    # and the grid columns it inferred.
+    auto_graph = parse_metro_mermaid(auto_text)
+    sids = list(auto_graph.sections.keys())
+    cols: dict[int, list[str]] = {}
+    for sid, sec in auto_graph.sections.items():
+        cols.setdefault(sec.grid_col, []).append(sid)
+
     stacked = {c: ids for c, ids in cols.items() if 2 <= len(ids) <= max_perm_col}
     stacked_ids = {x for ids in stacked.values() for x in ids}
 
     # Within-column row-order permutations (the crossing-relevant lever).
     candidate_orders = [order]
+    dropped = 0
     for ids in stacked.values():
         present = [s for s in order if s in ids]
         if len(present) < 2:
@@ -235,10 +242,12 @@ def optimize(
                 for slot, sid in zip(pos, perm):
                     no[slot] = sid
                 more.append(no)
-        candidate_orders.extend(more[:24])
+        candidate_orders.extend(more[:PERM_CAP])
+        dropped += max(0, len(more) - PERM_CAP)
 
     best = (base_obj, "baseline (pure auto-layout, default order)", base)
-    seen: set[tuple] = set()
+    # The baseline is the default order at the parser's own fold, already scored.
+    seen: set[tuple] = {("fold", None, tuple(order))}
 
     # Axis 1: fold x row-order.
     for fold in fold_values:
@@ -275,6 +284,10 @@ def optimize(
     tag = "  ** lower score found **" if improved else "  (default auto-layout is best)"
     print(f"\n=== {path.stem} ==={tag}")
     print(_fmt("baseline", base_obj, base))
+    if dropped:
+        print(
+            f"  searched {len(candidate_orders)} row orders, {dropped} left unexplored"
+        )
     if improved:
         print(_fmt("best", b_obj, b_m))
         print(f"  via: {b_desc}")

--- a/scripts/optimize_layout.py
+++ b/scripts/optimize_layout.py
@@ -1,0 +1,315 @@
+"""Auto-layout minimiser: search section arrangements that lower the quality metrics.
+
+Holds a pipeline's ``.mmd`` content fixed and explores the levers auto-layout
+exposes to an author who writes NO explicit ``%%metro grid:``:
+
+  * ``fold_threshold`` (row-wrap width / ``max_station_columns``)
+  * within-topo-column section row order (== subgraph declaration order)
+  * per-section ``direction`` (LR vs TB)
+  * ``center_ports``
+
+For each candidate it re-parses (auto-layout runs at parse time) and scores the
+laid-out graph with the same metrics the CI render-diff reports
+(``tests/layout_metrics.py``). It reports the best-scoring arrangement against
+the pure-auto-layout baseline and the directives that reproduce it.
+
+IMPORTANT: the metrics are a proxy, not ground truth, and the weights over them
+are binned measurements rather than a fitted model. A lower weighted score is
+evidence for an arrangement, not proof of one -- always eyeball a suggestion
+before adopting it. ``excessive_gaps`` in particular fires on the healthy
+vertical gap between two parallel processing tracks, which is why it carries
+almost no weight.
+
+Usage:
+    python scripts/optimize_layout.py examples/genomic_pipeline.mmd [more.mmd ...]
+    python scripts/optimize_layout.py --all
+    python scripts/optimize_layout.py            # the complex real pipelines
+"""
+
+from __future__ import annotations
+
+import itertools
+import re
+import sys
+import warnings
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "tests"))
+warnings.filterwarnings("ignore")
+
+from layout_metrics import compute_metrics  # noqa: E402
+
+from nf_metro.layout import compute_layout  # noqa: E402
+from nf_metro.layout.constants import Y_SPACING  # noqa: E402
+from nf_metro.parser import parse_metro_mermaid  # noqa: E402
+
+# Each weight is a coarse bin of how often that metric moves the same way as
+# human layout judgement, measured over the preference pairs in
+# `datasets/layout_preferences`. Plausibility is not evidence here: crossings
+# and wasted canvas both agree with the judgement about as often as a coin, so
+# however obviously they ought to matter they can only be weak hints, and a
+# heavy weight on either buys suggestions nobody would accept.
+WEIGHTS = {
+    # Agree with the judgement on ~90% of pairs.
+    "single_diagonals": 3.0,
+    "bends_per_route": 3.0,
+    "marker_crowding": 3.0,
+    # ~70%.
+    "turn_angle_per_route": 2.0,
+    # Unmeasured -- a strike needs render-time label boxes the pairs lack -- but
+    # a line through a label is a defect nobody argues about.
+    "label_strikes": 2.0,
+    # No resolvable signal: no better than a coin, or too rare to measure.
+    "crossings": 0.5,
+    "near_horizontal": 0.5,
+    "wasted_canvas": 0.5,
+    "excessive_gaps": 0.25,
+}
+# `corners_total` is deliberately absent: it is `bends_per_route` times the
+# route count, so weighting both would re-count one signal in proportion to map
+# size, penalising big maps for being big.
+
+GRID_RE = re.compile(
+    r"^\s*%%metro\s+(grid|direction|fold_threshold)\s*:", re.IGNORECASE
+)
+SUBGRAPH_RE = re.compile(r"^(\s*)subgraph\s+([A-Za-z0-9_]+)")
+GRAPH_RE = re.compile(r"^\s*graph\s+(LR|RL|TB|BT|TD)", re.IGNORECASE)
+END_RE = re.compile(r"^\s*end\s*$")
+
+
+def marker_crowding(clearance: float | None) -> float:
+    """How far the nearest line intrudes on a foreign marker, as a 0..1 fraction.
+
+    A penalty for tight clearance, never a reward for loose clearance: a term
+    that kept paying for more room would be minimised by spreading the map out.
+    One lane pitch is room enough, so clearance beyond it scores nothing.
+    """
+    if clearance is None:
+        return 0.0
+    return max(0.0, Y_SPACING - clearance) / Y_SPACING
+
+
+def objective(m: dict[str, float | None]) -> float:
+    """The weighted score to minimise. A metric this map cannot define is skipped."""
+    scores = dict(m)
+    scores["marker_crowding"] = marker_crowding(scores.get("marker_clearance"))
+    total = 0.0
+    for key, weight in WEIGHTS.items():
+        value = scores.get(key)
+        if value is not None:
+            total += weight * value
+    return total
+
+
+def strip_layout_directives(text: str) -> str:
+    return "\n".join(line for line in text.splitlines() if not GRID_RE.match(line))
+
+
+def inject_direction(text: str, sec_id: str, direction: str) -> str:
+    out: list[str] = []
+    for line in text.splitlines():
+        out.append(line)
+        m = SUBGRAPH_RE.match(line)
+        if m and m.group(2) == sec_id:
+            out.append(f"{m.group(1)}    %%metro direction: {direction}")
+    return "\n".join(out)
+
+
+def set_global(text: str, key: str, val: str) -> str:
+    lines = text.splitlines()
+    gi = next(i for i, line in enumerate(lines) if GRAPH_RE.match(line))
+    lines.insert(gi, f"%%metro {key}: {val}")
+    return "\n".join(lines)
+
+
+def split_subgraphs(
+    text: str,
+) -> tuple[list[str], list[tuple[str, list[str]]], list[str]]:
+    """Return (head_lines, [(section_id, block_lines)...], loose_lines)."""
+    lines = text.splitlines()
+    gi = next((i for i, line in enumerate(lines) if GRAPH_RE.match(line)), None)
+    if gi is None:
+        return lines, [], []
+    head = lines[: gi + 1]
+    blocks: list[tuple[str, list[str]]] = []
+    loose: list[str] = []
+    depth = 0
+    cur: list[str] | None = None
+    cur_id = ""
+    for line in lines[gi + 1 :]:
+        msg = SUBGRAPH_RE.match(line)
+        if msg and depth == 0:
+            depth = 1
+            cur = [line]
+            cur_id = msg.group(2)
+        elif cur is not None:
+            cur.append(line)
+            if SUBGRAPH_RE.match(line):
+                depth += 1
+            elif END_RE.match(line):
+                depth -= 1
+                if depth == 0:
+                    blocks.append((cur_id, cur))
+                    cur = None
+        else:
+            loose.append(line)
+    return head, blocks, loose
+
+
+def reassemble(head, blocks, loose) -> str:
+    out = list(head)
+    for _id, blk in blocks:
+        out.extend(blk)
+    out.extend(loose)
+    return "\n".join(out)
+
+
+def score(text: str, fold: int | None = None) -> dict[str, float | None] | None:
+    try:
+        g = parse_metro_mermaid(text, max_station_columns=fold)
+        compute_layout(g)
+        return compute_metrics(g)
+    except Exception:  # noqa: BLE001 - a crash is itself a result we report
+        return None
+
+
+def topo_columns(text: str) -> dict[int, list[str]]:
+    g = parse_metro_mermaid(strip_layout_directives(text))
+    cols: dict[int, list[str]] = {}
+    for sid, sec in g.sections.items():
+        cols.setdefault(sec.grid_col, []).append(sid)
+    return cols
+
+
+def _fmt(label: str, o: float, m: dict[str, float | None]) -> str:
+    gap = m["marker_clearance"]
+    return (
+        f"  {label:30} obj={o:6.1f}  bends={m['bends_per_route']:.2f} "
+        f"turn={m['turn_angle_per_route']:.2f} "
+        f"gap={'n/a' if gap is None else format(gap, '.0f')} "
+        f"diag={int(m['single_diagonals'])} strike={int(m['label_strikes'])} "
+        f"cross={int(m['crossings'])} near={int(m['near_horizontal'])} "
+        f"exc={int(m['excessive_gaps'])} waste={m['wasted_canvas']:.2f}"
+    )
+
+
+def optimize(
+    path: Path, fold_values=(8, 10, 12, 15, 20, 30, None), max_perm_col: int = 4
+) -> None:
+    text = path.read_text()
+    auto_text = strip_layout_directives(text)
+
+    base = score(auto_text)
+    if base is None:
+        print(f"\n=== {path.stem} ===  BASELINE CRASHES under pure auto-layout")
+        cur = score(text)
+        if cur is not None:
+            print(_fmt("curated (as authored)", objective(cur), cur))
+        return
+    base_obj = objective(base)
+
+    head, blocks, loose = split_subgraphs(auto_text)
+    block_by_id = {bid: blk for bid, blk in blocks}
+    order = [bid for bid, _ in blocks]
+    sids = list(parse_metro_mermaid(auto_text).sections.keys())
+
+    cols = topo_columns(text)
+    stacked = {c: ids for c, ids in cols.items() if 2 <= len(ids) <= max_perm_col}
+    stacked_ids = {x for ids in stacked.values() for x in ids}
+
+    # Within-column row-order permutations (the crossing-relevant lever).
+    candidate_orders = [order]
+    for ids in stacked.values():
+        present = [s for s in order if s in ids]
+        if len(present) < 2:
+            continue
+        more: list[list[str]] = []
+        for base_order in candidate_orders:
+            pos = [i for i, s in enumerate(base_order) if s in ids]
+            for perm in itertools.permutations(present):
+                if list(perm) == present:
+                    continue
+                no = list(base_order)
+                for slot, sid in zip(pos, perm):
+                    no[slot] = sid
+                more.append(no)
+        candidate_orders.extend(more[:24])
+
+    best = (base_obj, "baseline (pure auto-layout, default order)", base)
+    seen: set[tuple] = set()
+
+    # Axis 1: fold x row-order.
+    for fold in fold_values:
+        for co in candidate_orders:
+            key = ("fold", fold, tuple(co))
+            if key in seen:
+                continue
+            seen.add(key)
+            m = score(reassemble(head, [(b, block_by_id[b]) for b in co], loose), fold)
+            if m is None:
+                continue
+            o = objective(m)
+            if o < best[0] - 1e-6:
+                desc = f"fold={fold or 'none'}"
+                if co != order:
+                    desc += f", reorder {[s for s in co if s in stacked_ids]}"
+                best = (o, desc, m)
+
+    # Axis 2: per-section TB + center_ports (each against default order).
+    extra = [
+        (f"direction: TB | {s}", inject_direction(auto_text, s, "TB")) for s in sids
+    ]
+    extra.append(("center_ports: true", set_global(auto_text, "center_ports", "true")))
+    for desc, cand in extra:
+        m = score(cand)
+        if m is None:
+            continue
+        o = objective(m)
+        if o < best[0] - 1e-6:
+            best = (o, desc, m)
+
+    b_obj, b_desc, b_m = best
+    improved = b_obj < base_obj - 1e-6
+    tag = "  ** lower score found **" if improved else "  (default auto-layout is best)"
+    print(f"\n=== {path.stem} ==={tag}")
+    print(_fmt("baseline", base_obj, base))
+    if improved:
+        print(_fmt("best", b_obj, b_m))
+        print(f"  via: {b_desc}")
+        print("  NOTE: verify by eye before adopting -- the metric is a proxy.")
+    cur = score(text)
+    if cur is not None and path.read_text() != auto_text:
+        print(_fmt("curated (as authored)", objective(cur), cur))
+
+
+def main(argv: list[str]) -> None:
+    if argv and argv[0] == "--all":
+        paths = sorted((REPO / "examples").glob("*.mmd"))
+    elif argv:
+        paths = [Path(a) if Path(a).is_absolute() else REPO / a for a in argv]
+    else:
+        names = [
+            "genomic_pipeline",
+            "longread_variant_calling",
+            "differentialabundance",
+            "variantbenchmarking_auto",
+            "variantbenchmarking",
+            "genomeassembly",
+            "genomeassembly_staggered",
+            "rnaseq_auto",
+            "sarek_metro",
+            "hlatyping",
+            "epitopeprediction",
+        ]
+        paths = [REPO / "examples" / f"{n}.mmd" for n in names]
+    for p in paths:
+        if p.exists():
+            optimize(p)
+        else:
+            print(f"{p}: not found")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/nf_metro/layout/geometry.py
+++ b/src/nf_metro/layout/geometry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import bisect
 import math
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
@@ -484,6 +484,30 @@ def segment_intersects_quad(
         ) != _ccw(x1, y1, x2, y2, dx, dy):
             return True
     return False
+
+
+def point_to_polyline_distance(
+    p: tuple[float, float], pts: Sequence[tuple[float, float]]
+) -> float:
+    """Shortest distance from point *p* to a polyline through *pts*.
+
+    The projection onto each segment is clamped to that segment's span, so a
+    point beyond an end measures to the end rather than to the infinite line.
+    """
+    px, py = p
+    best = float("inf")
+    for k in range(len(pts) - 1):
+        ax, ay = pts[k]
+        bx, by = pts[k + 1]
+        dx, dy = bx - ax, by - ay
+        seg_sq = dx * dx + dy * dy
+        if seg_sq == 0.0:
+            t = 0.0
+        else:
+            t = max(0.0, min(1.0, ((px - ax) * dx + (py - ay) * dy) / seg_sq))
+        cx, cy = ax + t * dx, ay + t * dy
+        best = min(best, math.hypot(px - cx, py - cy))
+    return best
 
 
 def segment_intersects_bbox(

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -43,7 +43,12 @@ from nf_metro.layout.constants import (
     SAME_Y_TOLERANCE,
     resolve_offset_step,
 )
-from nf_metro.layout.geometry import AxisFrame, axis_split, lanes_run_along_y
+from nf_metro.layout.geometry import (
+    AxisFrame,
+    axis_split,
+    lanes_run_along_y,
+    point_to_polyline_distance,
+)
 from nf_metro.layout.phases.guards import GuardSpec
 from nf_metro.layout.routing.common import (
     Direction,
@@ -3548,26 +3553,6 @@ class MergeBranchHang:
         )
 
 
-def _point_to_polyline_distance(
-    p: tuple[float, float], pts: Sequence[tuple[float, float]]
-) -> float:
-    """Shortest distance from point *p* to a polyline through *pts*."""
-    px, py = p
-    best = float("inf")
-    for k in range(len(pts) - 1):
-        ax, ay = pts[k]
-        bx, by = pts[k + 1]
-        dx, dy = bx - ax, by - ay
-        seg_sq = dx * dx + dy * dy
-        if seg_sq == 0.0:
-            t = 0.0
-        else:
-            t = max(0.0, min(1.0, ((px - ax) * dx + (py - ay) * dy) / seg_sq))
-        cx, cy = ax + t * dx, ay + t * dy
-        best = min(best, ((px - cx) ** 2 + (py - cy) ** 2) ** 0.5)
-    return best
-
-
 def _merge_entry_port(graph: MetroGraph, merge_id: str) -> Station | None:
     """The entry-port successor of a merge junction, if any."""
     for e in graph.edges_from(merge_id):
@@ -3617,7 +3602,7 @@ def check_merge_branches_meet_trunk(
             ) ** 0.5
             d_sibling = min(
                 (
-                    _point_to_polyline_distance(end, other)
+                    point_to_polyline_distance(end, other)
                     for other_edge, other in polylines
                     if other_edge is not edge
                 ),
@@ -3719,7 +3704,7 @@ def check_no_hanging_routes(
                 continue
             d_join = min(
                 (
-                    _point_to_polyline_distance(end, other_pts)
+                    point_to_polyline_distance(end, other_pts)
                     for other, other_pts in polylines
                     if other is not r
                 ),

--- a/tests/layout_metrics.py
+++ b/tests/layout_metrics.py
@@ -11,6 +11,12 @@ excessive column gaps) and the label-strike count reuses the engine's own
 strike definition (``iter_line_label_strikes``), so a score only moves when a
 real geometric property of the render moves.
 
+The bend, corner, turn-angle and marker-clearance scores have no engine-side
+detector to borrow -- the engine's non-consumer guard answers a boolean, not a
+distance -- so they are read straight off the drawn polylines.  Their
+definitions are those measured against human layout judgement in
+``datasets/layout_preferences/scripts/extract_features.py``.
+
 Scoring the render means scoring the geometry the renderer drew, which a
 rendered graph carries and which cannot be re-derived from it -- see
 ``measured_geometry``.
@@ -22,6 +28,7 @@ engine; the heavy ``nf_metro`` imports live inside ``compute_metrics``.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -36,20 +43,32 @@ class MetricSpec:
 
     key: str
     label: str
-    kind: str  # "count" or "ratio"
+    kind: str  # "count", "decimal", or "ratio"
+    higher_is_better: bool = False
 
 
-# Every metric is oriented so LOWER IS BETTER: a negative delta is an
-# improvement.  This list is the canonical schema for ``metrics.json`` and the
-# column order of the render-diff metrics table.
+# Most metrics count a defect, so lower is better; ``higher_is_better`` marks
+# the ones measuring room rather than damage.  This list is the canonical schema
+# for ``metrics.json`` and the column order of the render-diff metrics table.
 METRICS: list[MetricSpec] = [
     MetricSpec("crossings", "Crossings", "count"),
     MetricSpec("near_horizontal", "Near-horiz.", "count"),
     MetricSpec("single_diagonals", "Lone diag.", "count"),
+    MetricSpec("bends_per_route", "Bends/route", "decimal"),
+    MetricSpec("corners_total", "Corners", "count"),
+    MetricSpec("turn_angle_per_route", "Turn/route (rad)", "decimal"),
     MetricSpec("label_strikes", "Label strikes", "count"),
+    MetricSpec("marker_clearance", "Marker gap ↑", "decimal", higher_is_better=True),
     MetricSpec("excessive_gaps", "Excess gaps", "count"),
     MetricSpec("wasted_canvas", "Wasted canvas", "ratio"),
 ]
+
+TURN_FLOOR = math.radians(5.0)
+"""Smallest direction change counted as a bend.
+
+Applying a bundle's line separation can leave two collinear segments meeting at
+a fraction of a degree; below this floor there is no corner a reader sees.
+"""
 
 METRIC_KEYS: list[str] = [m.key for m in METRICS]
 
@@ -82,9 +101,117 @@ def measured_geometry(
         return {}, []
 
 
+def drawn_polylines(
+    routes: list[RoutedPath], offsets: dict[tuple[str, str], float]
+) -> list[tuple[RoutedPath, list[tuple[float, float]]]]:
+    """Each route paired with the polyline the renderer draws for it.
+
+    ``apply_route_offsets`` is the one place a route's stored points become
+    drawable coordinates, so a deferred-offset route only reveals its drawn
+    shape here.  Repeated waypoints are dropped: a zero-length step has no
+    direction, so it would otherwise register as a turn against due east.
+    """
+    from nf_metro.layout.routing.common import apply_route_offsets
+
+    out: list[tuple[RoutedPath, list[tuple[float, float]]]] = []
+    for route in routes:
+        pts: list[tuple[float, float]] = []
+        for point in apply_route_offsets(route, offsets):
+            if not pts or point != pts[-1]:
+                pts.append(point)
+        if len(pts) > 1:
+            out.append((route, pts))
+    return out
+
+
+def _turn_angle(
+    before: tuple[float, float],
+    at: tuple[float, float],
+    after: tuple[float, float],
+) -> float:
+    """Absolute direction change at ``at``, in radians (0 = straight on)."""
+    incoming = math.atan2(at[1] - before[1], at[0] - before[0])
+    outgoing = math.atan2(after[1] - at[1], after[0] - at[0])
+    delta = abs(outgoing - incoming) % (2 * math.pi)
+    return min(delta, 2 * math.pi - delta)
+
+
+def _bend_scores(
+    polylines: list[tuple[RoutedPath, list[tuple[float, float]]]],
+) -> tuple[float, float, float]:
+    """``(corners, corners per route, radians turned per route)``.
+
+    The per-route forms are the scale-free ones: a bigger map draws more
+    corners without each of its routes being any more tortuous.
+    """
+    corners = 0
+    turned = 0.0
+    for _route, pts in polylines:
+        for i in range(1, len(pts) - 1):
+            angle = _turn_angle(pts[i - 1], pts[i], pts[i + 1])
+            if angle > TURN_FLOOR:
+                corners += 1
+                turned += angle
+    routed = max(len(polylines), 1)
+    return float(corners), corners / routed, turned / routed
+
+
+def _point_segment_distance(
+    point: tuple[float, float],
+    start: tuple[float, float],
+    end: tuple[float, float],
+) -> float:
+    dx, dy = end[0] - start[0], end[1] - start[1]
+    span = dx * dx + dy * dy
+    if span <= 0.0:
+        return math.dist(point, start)
+    t = ((point[0] - start[0]) * dx + (point[1] - start[1]) * dy) / span
+    t = max(0.0, min(1.0, t))
+    return math.dist(point, (start[0] + t * dx, start[1] + t * dy))
+
+
+def _min_non_consumer_clearance(
+    graph: MetroGraph,
+    polylines: list[tuple[RoutedPath, list[tuple[float, float]]]],
+) -> float | None:
+    """How close the nearest line gets to a station marker it does not serve.
+
+    A line running just past a marker reads as stopping there, so the room it
+    leaves is a quality score in its own right -- the engine's non-consumer
+    guard only catches the endpoint of the same spectrum, where the line
+    reaches the marker's box.  Ports and hidden stations draw no marker, so
+    nothing can crowd them, and the guard's own exemption is honoured so the
+    score does not report the deliberate rail idiom as crowding.
+
+    ``None`` when every line serves every station it passes, which leaves the
+    clearance undefined rather than arbitrarily large.
+    """
+    from nf_metro.layout.phases._common import marker_cross_exempt
+
+    markers = [
+        ((float(s.x), float(s.y)), set(graph.station_lines(sid)))
+        for sid, s in graph.stations.items()
+        if not (s.is_port or s.is_hidden)
+        and s.x is not None
+        and s.y is not None
+        and not marker_cross_exempt(graph, sid)
+    ]
+
+    closest: float | None = None
+    for route, pts in polylines:
+        for centre, own_lines in markers:
+            if route.line_id in own_lines:
+                continue
+            for start, end in zip(pts, pts[1:]):
+                gap = _point_segment_distance(centre, start, end)
+                if closest is None or gap < closest:
+                    closest = gap
+    return closest
+
+
 def compute_metrics(
     graph: MetroGraph, *, canvas: tuple[float, float] | None = None
-) -> dict[str, float]:
+) -> dict[str, float | None]:
     """Compute the layout-quality scorecard for one laid-out graph.
 
     ``canvas`` is the rendered SVG ``(width, height)`` in user units; when
@@ -100,6 +227,8 @@ def compute_metrics(
     counts = Counter(v.check for v in validate_layout(graph))
 
     offsets, routes = measured_geometry(graph)
+    polylines = drawn_polylines(routes, offsets)
+    corners, bends_per_route, turn_per_route = _bend_scores(polylines)
 
     # Distinct (line, station) strikes: one visual mark per line crossing a
     # label, not one per route segment that happens to clip it.
@@ -114,7 +243,11 @@ def compute_metrics(
         ),
         "near_horizontal": float(counts["almost_horizontal_edge"]),
         "single_diagonals": float(counts["single_segment_diagonal"]),
+        "bends_per_route": bends_per_route,
+        "corners_total": corners,
+        "turn_angle_per_route": turn_per_route,
         "label_strikes": float(len(strikes)),
+        "marker_clearance": _min_non_consumer_clearance(graph, polylines),
         "excessive_gaps": float(counts["excessive_column_gap"]),
         "wasted_canvas": _wasted_canvas_ratio(graph, routes, canvas),
     }
@@ -167,9 +300,11 @@ def _wasted_canvas_ratio(
 
 
 def _format_magnitude(kind: str, value: float) -> str:
-    """Format a non-negative magnitude as a percentage (ratio) or integer (count)."""
+    """Format a non-negative magnitude for display, by value kind."""
     if kind == "ratio":
         return f"{value:.0%}"
+    if kind == "decimal":
+        return f"{value:.1f}"
     return f"{value:.0f}"
 
 
@@ -191,14 +326,12 @@ def format_delta(spec: MetricSpec, base: float | None, pr: float | None) -> str:
     return f"{sign}{_format_magnitude(spec.kind, abs(delta))}"
 
 
-def delta_direction(base: float | None, pr: float | None) -> int:
-    """Sign of a base->PR change: ``-1`` better, ``+1`` worse, ``0`` flat/undefined.
-
-    Every metric is lower-is-better, so a drop is an improvement.
-    """
+def delta_direction(spec: MetricSpec, base: float | None, pr: float | None) -> int:
+    """Sign of a base->PR change: ``-1`` better, ``+1`` worse, ``0`` flat/undefined."""
     if base is None or pr is None:
         return 0
     delta = pr - base
     if abs(delta) < 1e-9:
         return 0
-    return 1 if delta > 0 else -1
+    grew = delta > 0
+    return -1 if grew == spec.higher_is_better else 1

--- a/tests/layout_metrics.py
+++ b/tests/layout_metrics.py
@@ -30,11 +30,13 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from nf_metro.layout.routing.common import RoutedPath
     from nf_metro.parser.model import MetroGraph
+
+MetricKind = Literal["count", "decimal", "ratio"]
 
 
 @dataclass(frozen=True)
@@ -43,7 +45,7 @@ class MetricSpec:
 
     key: str
     label: str
-    kind: str  # "count", "decimal", or "ratio"
+    kind: MetricKind
     higher_is_better: bool = False
 
 
@@ -156,20 +158,6 @@ def _bend_scores(
     return float(corners), corners / routed, turned / routed
 
 
-def _point_segment_distance(
-    point: tuple[float, float],
-    start: tuple[float, float],
-    end: tuple[float, float],
-) -> float:
-    dx, dy = end[0] - start[0], end[1] - start[1]
-    span = dx * dx + dy * dy
-    if span <= 0.0:
-        return math.dist(point, start)
-    t = ((point[0] - start[0]) * dx + (point[1] - start[1]) * dy) / span
-    t = max(0.0, min(1.0, t))
-    return math.dist(point, (start[0] + t * dx, start[1] + t * dy))
-
-
 def _min_non_consumer_clearance(
     graph: MetroGraph,
     polylines: list[tuple[RoutedPath, list[tuple[float, float]]]],
@@ -185,7 +173,12 @@ def _min_non_consumer_clearance(
 
     ``None`` when every line serves every station it passes, which leaves the
     clearance undefined rather than arbitrarily large.
+
+    Measured to the marker centre, so a station carrying a wide bundle -- whose
+    drawn pill extends well past its centre -- reports more room than the
+    picture shows.
     """
+    from nf_metro.layout.geometry import point_to_polyline_distance
     from nf_metro.layout.phases._common import marker_cross_exempt
 
     markers = [
@@ -202,10 +195,9 @@ def _min_non_consumer_clearance(
         for centre, own_lines in markers:
             if route.line_id in own_lines:
                 continue
-            for start, end in zip(pts, pts[1:]):
-                gap = _point_segment_distance(centre, start, end)
-                if closest is None or gap < closest:
-                    closest = gap
+            gap = point_to_polyline_distance(centre, pts)
+            if closest is None or gap < closest:
+                closest = gap
     return closest
 
 
@@ -299,7 +291,7 @@ def _wasted_canvas_ratio(
     return round(max(0.0, min(1.0, 1.0 - used)), 3)
 
 
-def _format_magnitude(kind: str, value: float) -> str:
+def _format_magnitude(kind: MetricKind, value: float) -> str:
     """Format a non-negative magnitude for display, by value kind."""
     if kind == "ratio":
         return f"{value:.0%}"

--- a/tests/test_layout_metrics.py
+++ b/tests/test_layout_metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import sys
 from pathlib import Path
 
@@ -11,18 +12,27 @@ from layout_metrics import (
     METRIC_KEYS,
     METRICS,
     MetricSpec,
+    _bend_scores,
+    _turn_angle,
     compute_metrics,
     delta_direction,
+    drawn_polylines,
     format_delta,
     format_value,
+    measured_geometry,
 )
 
+from nf_metro.layout.constants import STATION_RADIUS_APPROX
 from nf_metro.layout.phases import guards
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from build_render_diff import _build_metrics_html  # noqa: E402
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+# Scores a map need not define: a map on which no line passes a station it does
+# not serve has no clearance to report.
+OPTIONAL_KEYS = {"marker_clearance"}
 
 # A spread of real fixtures: a minimal map, dense pipelines, and a wide fan.
 FIXTURES = [
@@ -45,11 +55,14 @@ def test_compute_metrics_returns_full_schema(path: Path) -> None:
     assert set(metrics) == set(METRIC_KEYS)
     for spec in METRICS:
         value = metrics[spec.key]
+        if value is None:
+            assert spec.key in OPTIONAL_KEYS, f"{spec.key} may not be undefined"
+            continue
         assert isinstance(value, float)
         assert value >= 0.0
         if spec.kind == "count":
             assert value == float(int(value)), f"{spec.key} count must be integral"
-        else:
+        elif spec.kind == "ratio":
             assert 0.0 <= value <= 1.0
 
 
@@ -111,16 +124,79 @@ def test_guard_and_enumerator_share_strike_definition(monkeypatch) -> None:
         guards._guard_no_line_strikes_label(graph, "test")
 
 
+# --- Route-shape scores ---
+
+
+def test_turn_angle_measures_the_direction_change() -> None:
+    right_angle = _turn_angle((0.0, 0.0), (10.0, 0.0), (10.0, 10.0))
+    assert right_angle == pytest.approx(math.pi / 2)
+    assert _turn_angle((0.0, 0.0), (10.0, 0.0), (20.0, 0.0)) == pytest.approx(0.0)
+    assert _turn_angle((0.0, 0.0), (10.0, 0.0), (20.0, 10.0)) == pytest.approx(
+        math.pi / 4
+    )
+
+
+def test_bend_scores_count_corners_above_the_floor_only() -> None:
+    """Two right angles on one route and a sub-floor wobble on another: three
+    waypoints turn, two of them enough to draw a corner."""
+    staircase = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (20.0, 10.0)]
+    wobble = [(0.0, 50.0), (100.0, 50.0), (200.0, 51.0)]
+    corners, per_route, turned = _bend_scores([(None, staircase), (None, wobble)])
+    assert corners == 2.0
+    assert per_route == pytest.approx(1.0)
+    assert turned == pytest.approx(math.pi / 2)
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_corner_total_and_per_route_agree(path: Path) -> None:
+    """The two bend scores are one measurement at two scales, so the total is
+    the per-route mean times the routes it was drawn from."""
+    graph = _layout(path)
+    metrics = compute_metrics(graph)
+    offsets, routes = measured_geometry(graph)
+    routed = len(drawn_polylines(routes, offsets))
+    expected = metrics["bends_per_route"] * routed
+    assert metrics["corners_total"] == pytest.approx(expected)
+
+
+def test_single_line_map_has_no_clearance_to_report() -> None:
+    """Every station serves the only line, so no line passes a marker it does
+    not serve and the clearance is undefined rather than zero or huge."""
+    graph = parse_and_layout(
+        """%%metro line: only | Only | #ff0000
+graph LR
+    subgraph s [S]
+        a[A] -->|only| b[B]
+        b -->|only| c[C]
+    end
+"""
+    )
+    assert compute_metrics(graph)["marker_clearance"] is None
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.stem)
+def test_clearance_exceeds_the_marker_it_measures(path: Path) -> None:
+    """A line closer to a foreign marker than the marker's own radius would be
+    drawn inside it, which the engine's non-consumer guard forbids -- so a
+    measured clearance below that means the score has mis-attributed a line."""
+    clearance = compute_metrics(_layout(path))["marker_clearance"]
+    if clearance is not None:
+        assert clearance > STATION_RADIUS_APPROX
+
+
 # --- Formatting + delta helpers ---
 
 COUNT = MetricSpec("c", "C", "count")
 RATIO = MetricSpec("r", "R", "ratio")
+DECIMAL = MetricSpec("d", "D", "decimal")
+ROOMIER = MetricSpec("g", "G", "decimal", higher_is_better=True)
 
 
 def test_format_value() -> None:
     assert format_value(COUNT, None) == "n/a"
     assert format_value(COUNT, 3.0) == "3"
     assert format_value(RATIO, 0.125) == "12%"
+    assert format_value(DECIMAL, 1.25) == "1.2"
 
 
 def test_format_delta_sign_and_zero() -> None:
@@ -132,10 +208,17 @@ def test_format_delta_sign_and_zero() -> None:
 
 
 def test_delta_direction() -> None:
-    assert delta_direction(5.0, 2.0) == -1  # lower is better
-    assert delta_direction(2.0, 5.0) == 1
-    assert delta_direction(3.0, 3.0) == 0
-    assert delta_direction(None, 3.0) == 0
+    assert delta_direction(COUNT, 5.0, 2.0) == -1  # lower is better
+    assert delta_direction(COUNT, 2.0, 5.0) == 1
+    assert delta_direction(COUNT, 3.0, 3.0) == 0
+    assert delta_direction(COUNT, None, 3.0) == 0
+
+
+def test_delta_direction_follows_the_metric_orientation() -> None:
+    """A metric measuring room, not damage, improves as it grows."""
+    assert delta_direction(ROOMIER, 12.0, 40.0) == -1
+    assert delta_direction(ROOMIER, 40.0, 12.0) == 1
+    assert delta_direction(ROOMIER, 12.0, 12.0) == 0
 
 
 # --- Render-diff table assembly ---

--- a/tests/test_optimize_layout.py
+++ b/tests/test_optimize_layout.py
@@ -1,0 +1,67 @@
+"""Tests for the advisory auto-layout minimiser (``scripts/optimize_layout``)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from conftest import parse_and_layout
+from layout_metrics import compute_metrics
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from optimize_layout import (  # noqa: E402
+    WEIGHTS,
+    inject_direction,
+    marker_crowding,
+    objective,
+    strip_layout_directives,
+)
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+
+def _score(text: str) -> float:
+    return objective(compute_metrics(parse_and_layout(text)))
+
+
+def test_objective_prefers_parallel_tracks_over_a_collapsed_column() -> None:
+    """The known false positive: on hlatyping, forcing the HLA Typing section to
+    TB collapses two parallel processing tracks into one column and loops both
+    lines back out of its foot, which reads far worse than the default LR
+    arrangement.  The objective has to rank the default the better of the two,
+    or every suggestion it makes is suspect.
+    """
+    auto = strip_layout_directives((EXAMPLES / "hlatyping.mmd").read_text())
+    parallel_tracks = _score(auto)
+    collapsed_column = _score(inject_direction(auto, "hla_typing", "TB"))
+    assert parallel_tracks < collapsed_column
+
+
+def test_metrics_that_predict_the_judgement_outweigh_the_ones_that_do_not() -> None:
+    """The measured ranking, pinned: route shape agrees with human judgement on
+    ~90% of the preference pairs while crossings and wasted canvas are near
+    chance, so no weighting may let the near-chance pair outvote route shape.
+    """
+    for measured in ("single_diagonals", "bends_per_route", "marker_crowding"):
+        for near_chance in ("crossings", "wasted_canvas", "excessive_gaps"):
+            assert WEIGHTS[measured] > WEIGHTS[near_chance]
+    assert WEIGHTS["bends_per_route"] > WEIGHTS["turn_angle_per_route"]
+    assert "corners_total" not in WEIGHTS
+
+
+def test_marker_crowding_penalises_tightness_without_rewarding_sprawl() -> None:
+    """Clearance beyond one lane pitch is free, so no arrangement can lower the
+    objective by pushing its content further apart."""
+    assert marker_crowding(None) == 0.0
+    assert marker_crowding(0.0) == 1.0
+    assert marker_crowding(20.0) == 0.5
+    assert marker_crowding(40.0) == 0.0
+    assert marker_crowding(400.0) == 0.0
+
+
+def test_objective_skips_a_metric_the_map_cannot_define() -> None:
+    """An undefined clearance contributes nothing rather than crashing the search."""
+    defined = {key: 0.0 for key in WEIGHTS}
+    del defined["marker_crowding"]
+    assert objective({**defined, "marker_clearance": None}) == 0.0
+    assert objective({**defined, "marker_clearance": 0.0}) == WEIGHTS["marker_crowding"]


### PR DESCRIPTION
## Summary

The advisory auto-layout objective put its two heaviest weights on the two metrics that agree with human layout judgement about as often as a coin, and its lightest on the strongest predictor available. The metrics that do discriminate were not computed anywhere.

**Scorecard (`tests/layout_metrics.py`)** gains four columns, definitions taken from the validated feature set in `datasets/layout_preferences/scripts/extract_features.py`:

| metric | what it reads | agreement with judgement |
| --- | --- | --- |
| `bends_per_route` | direction changes over 5° per drawn route | 89.5% |
| `corners_total` | the same count, unnormalised | 89.5% |
| `turn_angle_per_route` | radians turned per drawn route | 69% |
| `marker_clearance` | closest a line passes to a marker it does not serve | 85% |

`MetricSpec` gains a `higher_is_better` flag, since clearance is the first score measuring room rather than damage, and `delta_direction` now takes the spec so the render-diff colours it the right way. `marker_clearance` is `None` on a map where every line serves every station it passes; the table already renders a missing value as `n/a`.

**Objective (`scripts/optimize_layout.py`)**, previously uncommitted, is now in the repo, weighted by measured agreement rather than plausibility: `single_diagonals` / `bends_per_route` / marker crowding at 3.0, `turn_angle_per_route` / `label_strikes` at 2.0, `crossings` / `wasted_canvas` / `near_horizontal` at 0.5, `excessive_gaps` at 0.25. Clearance enters as a penalty that saturates at one lane pitch, not as a bonus — a term that kept paying for more room would be minimised by sprawl.

**`layout/geometry.py`** gains `point_to_polyline_distance`, moved out of `routing/invariants.py` where it was private, so the clearance score reuses it instead of taking a fourth copy of the formula.

## Does the section-3 result invert?

`AUTO_LAYOUT_FINDINGS`' "naive minimisation makes layouts worse" rested on two suggestions the metrics preferred and a human rejected:

| suggestion | old weights | new weights |
| --- | --- | --- |
| hlatyping `direction: TB \| hla_typing` | 4.86 → **1.38**, TB wins | 3.47 → 3.76, **default wins** |
| genomeassembly `direction: TB \| polishing` | 19.65 → **16.40**, TB wins | 8.05 → 8.00, TB wins by 0.05 |

The primary case inverts, and for the right reason: the collapsed column costs bends (0.50 → 0.67) and turning (28.4° → 45.5°), which nothing previously measured. The polishing suggestion's margin falls from 3.25 to 0.05 and is no longer driven by wasted canvas — what remains is a real crossing reduction (6 → 5) that the tool prints a verify-by-eye note against.

Re-weighting alone could not have done this: hlatyping's entire old score was `excessive_gaps` + `wasted_canvas`, and the TB variant scored zero on every other authored metric, so it won under any positive weighting of the original six. The new metrics are load-bearing for the result, not an extra.

## Scope

Measurement only. Nothing in the engine reads these scores, CI never fails on them, and no render changes. `marker_clearance` is measured to the marker centre, so a station carrying a wide bundle reports more room than its drawn pill leaves — noted in the docstring, and a candidate refinement once #1586 fits the objective.

Fixes #1602

## Test plan

- [x] `test_objective_prefers_parallel_tracks_over_a_collapsed_column` verified failing before the re-weight (4.856 < 1.38 asserted false), passing after
- [x] Full suite green locally: 44955 passed, 46 xfailed (all pre-existing)
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [x] Render-preview verdict: **no visual changes detected, all renders match `main`**

Generated with Claude Code
