### PR TITLE
fix: bin the layout objective's weights by what the corpus measured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ package-lock.json
 .coverage
 
 # Intermediate per-revision geometry vectors (regenerate with datasets/layout_preferences/scripts/replay.py)
-datasets/layout_preferences/geometry/
+datasets/layout_preferences/scripts/geometry/
 datasets/layout_preferences/geometry_vectors.tar.gz

--- a/datasets/layout_preferences/README.md
+++ b/datasets/layout_preferences/README.md
@@ -130,7 +130,13 @@ python scripts/assemble_labels.py      # GitHub history -> labels.json
 python scripts/relabel.py              # mergeCommit^1 pairing + attribution
 python scripts/replay.py --shard N --shards 6 --shas shas_needed.txt
 python scripts/build_dataset.py        # join geometry onto labels
+python scripts/build_dataset.py --from-pairs   # signal check alone, no geometry needed
 ```
+
+`--from-pairs` re-prints the directional signal check from the committed
+`dataset_pairs.jsonl`, which is what the bottom section of `dataset_report.txt`
+is. It exists so the report's percentages can be recomputed without the 30-minute
+replay, since the vectors they are derived from are committed inline.
 
 `replay.py` shards across throwaway worktrees; 971 revisions take roughly 30
 minutes on 6 shards. The per-revision geometry vectors it produces (~15MB
@@ -148,19 +154,26 @@ are unaffected.
 
 ## Headline finding
 
-`crossings` shows **no directional signal** (54.8% of directional pairs, n=42),
-yet it carries the second-heaviest weight in `scripts/optimize_layout.py`'s
-authored objective. `ink_density` (51.8%) and `detour_mean` (58.1%) are flat
-too. What does carry signal is bend and corner quality: `lone_diagonals` 90%,
-`bends_per_route` and `corners_total` 89.5%, `non_45_segments` 82%,
-`min_marker_gap` increasing in 85% of pairs.
+Every percentage here is fixture-grouped: each fixture gets one vote, so a map
+that appears in many pairs cannot state a corpus-wide trend on its own.
+
+`crossings` shows **no directional signal** (44.9% agreement over 42 pairs and 25
+fixtures, the largest sample in the corpus), which is why it sits in the lowest
+weight bin of `scripts/optimize_layout.py`'s objective rather than near the top.
+`detour_mean` (53.4%, n=148) and `detour_max` (54.1%) are flat too. What carries
+signal is bend and corner quality: `bends_per_route` and `corners_total` 94.8%,
+`lone_diagonals` 93.8%, `non_45_segments` 83.3%, `turn_angle_per_route` 75.4%.
 
 The authored weights load onto features that do not discriminate and omit those
 that do, which is a measured explanation for the "naive minimisation makes
 layouts worse" result in the auto-layout investigation.
 
-These are univariate counts over correlated pairs, not a fit. Fixture-grouped
-cross-validation in #1586 is what decides viability.
+Grouping is not a uniform haircut on the raw per-pair numbers, which
+`dataset_report.txt` prints alongside: it sharpens the bend family (89.5% ->
+94.8%), pushes `crossings` from just above chance to just below, and drops
+`bbox_w` out of discriminative range altogether. These are still univariate
+counts over correlated pairs, not a fit. Fixture-grouped cross-validation in
+#1586 is what decides viability.
 
 ## Fitted model and gate result
 
@@ -222,20 +235,24 @@ held out rather than statements about layout.
 
 ### Findings that outlast the gate
 
-- **`marker_crowding` is inert on this corpus.** It holds one of the three
-  heaviest authored weights (3.0) and has zero delta on 189 of 192 directional
-  pairs, because `min_marker_gap` is undefined on 164 of them and beyond one lane
-  pitch on most of the rest.
-- **The univariate percentages above are inflated by fixture repetition.**
-  `path_len_per_route` reads 67% directional univariately, but 55.3% under
-  fixture-grouped cross-validation, and the `only_path_len` control _loses_ to
-  the authored objective head-to-head (46.3%). Triage features fixture-grouped,
-  not univariately.
+- **`marker_crowding` is inert on this corpus.** It has zero delta on 189 of 192
+  directional pairs: `min_marker_gap` is undefined on 25 of them, and unchanged
+  or beyond one lane pitch on the rest. Three moved pairs cannot measure a term,
+  so it is weighted as unmeasured rather than as measured-and-agreeing, and
+  re-binning it moved the `authored` arm by 0.00 pp on every arm above, which is
+  what "inert" means quantitatively.
+- **Raw per-pair percentages are inflated by fixture repetition.**
+  `path_len_per_route` reads 67% directional per pair but 59% grouped by fixture,
+  and the `only_path_len` control _loses_ to the authored objective head-to-head
+  (46.3%) at 55.3% under cross-validation. Triage features fixture-grouped;
+  `dataset_report.txt` prints both.
 - **The bend family is precise but narrow.** `only_bend_family` is right on 82.8%
   of pairs, but only speaks to 15.1% of them. It corroborates the bend/corner
   headline while showing why those three terms cannot carry an objective alone.
 - **`crossings` earns a fitted weight of ~0** in every arm that includes it,
-  against the 0.5 it is authored with, matching its 54.8% univariate coin-flip.
+  matching its 44.9% grouped agreement, so it is authored at the floor. The
+  fitted sign is slightly negative and must not be read as a reward: minimising a
+  negative weight would instruct a search to _add_ crossings.
 - **The weak-label warning is confirmed empirically.** Adding `pr_signoff` rows
   to training at a tenth of a directional row's weight costs `iter2` 5.2 points.
   Set-level ratifications are not per-render positives.

--- a/datasets/layout_preferences/README.md
+++ b/datasets/layout_preferences/README.md
@@ -159,7 +159,7 @@ that appears in many pairs cannot state a corpus-wide trend on its own.
 
 `crossings` shows **no directional signal** (44.9% agreement over 42 pairs and 25
 fixtures, the largest sample in the corpus), which is why it sits in the lowest
-weight bin of `scripts/optimize_layout.py`'s objective rather than near the top.
+weight bin of `scripts/optimize_layout.py`'s objective.
 `detour_mean` (53.4%, n=148) and `detour_max` (54.1%) are flat too. What carries
 signal is bend and corner quality: `bends_per_route` and `corners_total` 94.8%,
 `lone_diagonals` 93.8%, `non_45_segments` 83.3%, `turn_angle_per_route` 75.4%.
@@ -238,9 +238,9 @@ held out rather than statements about layout.
 - **`marker_crowding` is inert on this corpus.** It has zero delta on 189 of 192
   directional pairs: `min_marker_gap` is undefined on 25 of them, and unchanged
   or beyond one lane pitch on the rest. Three moved pairs cannot measure a term,
-  so it is weighted as unmeasured rather than as measured-and-agreeing, and
-  re-binning it moved the `authored` arm by 0.00 pp on every arm above, which is
-  what "inert" means quantitatively.
+  so it is weighted as unmeasured rather than as measured-and-agreeing. Re-binning
+  it left every score in the table above unchanged to the decimal, which is what
+  "inert" means quantitatively.
 - **Raw per-pair percentages are inflated by fixture repetition.**
   `path_len_per_route` reads 67% directional per pair but 59% grouped by fixture,
   and the `only_path_len` control _loses_ to the authored objective head-to-head

--- a/datasets/layout_preferences/dataset_report.txt
+++ b/datasets/layout_preferences/dataset_report.txt
@@ -24,21 +24,24 @@ distinct fixtures in pairs: 186
 features per vector: 31
 
 === directional signal check (issue-fix pairs) ===
-fraction of pairs where the feature DECREASED after the fix:
-  aspect_log                    71.7%  (n= 92)  <-- discriminative
-  bbox_h                        23.8%  (n= 80)  <-- discriminative
-  bbox_w                        31.2%  (n= 16)  <-- discriminative
-  bends_per_route               89.5%  (n= 19)  <-- discriminative
-  corners_total                 89.5%  (n= 19)  <-- discriminative
-  crossings                     54.8%  (n= 42)
-  crossings_per_route           54.8%  (n= 42)
-  detour_max                    53.9%  (n= 76)
-  detour_mean                   58.1%  (n=148)
-  lone_diagonals                90.0%  (n= 10)  <-- discriminative
-  lone_diagonals_per_route      90.0%  (n= 10)  <-- discriminative
-  min_marker_gap                14.8%  (n= 27)  <-- discriminative
-  non_45_frac                   52.9%  (n= 17)
-  non_45_segments               81.8%  (n= 11)  <-- discriminative
-  path_len_per_route            32.6%  (n=141)
-  path_len_per_station          32.6%  (n=141)
-  turn_angle_per_route          69.0%  (n= 29)  <-- discriminative
+share of the moves that DECREASED the feature.
+`raw` counts every pair, so a fixture in many pairs speaks many times;
+`grouped` gives each fixture one vote. Triage on grouped.
+  feature                          raw  grouped  pairs  fixtures
+  aspect_log                     71.7%    69.1%     92        55  <-- discriminative
+  bbox_h                         23.8%    28.0%     80        50  <-- discriminative
+  bbox_w                         31.2%    37.5%     16        12
+  bends_per_route                89.5%    94.8%     19        16  <-- discriminative
+  corners_total                  89.5%    94.8%     19        16  <-- discriminative
+  crossings                      54.8%    44.9%     42        25
+  crossings_per_route            54.8%    44.9%     42        25
+  detour_max                     53.9%    54.1%     76        43
+  detour_mean                    58.1%    53.4%    148        69
+  lone_diagonals                 90.0%    93.8%     10         8  <-- discriminative
+  lone_diagonals_per_route       90.0%    93.8%     10         8  <-- discriminative
+  min_marker_gap                 14.8%    13.6%     27        22  <-- discriminative
+  non_45_frac                    52.9%    55.6%     17        12
+  non_45_segments                81.8%    83.3%     11         9  <-- discriminative
+  path_len_per_route             32.6%    40.6%    141        68
+  path_len_per_station           32.6%    40.6%    141        68
+  turn_angle_per_route           69.0%    75.4%     29        23  <-- discriminative

--- a/datasets/layout_preferences/fit_report.txt
+++ b/datasets/layout_preferences/fit_report.txt
@@ -62,10 +62,10 @@ positive = more of this is worse, matching the authored convention
 -- refit
    turn_angle_per_route        +5.73   (authored 2.00)
    bends_per_route             +3.00   (authored 3.00)
-   marker_crowding             +1.87   (authored 3.00)
+   marker_crowding             +1.87   (authored 2.00)
    lone_diagonals              +0.49   (authored 3.00)
    near_horizontal             +0.27   (authored 0.50) SIGN FLIPS ACROSS FOLDS
-   crossings                   -0.02   (authored 0.50)
+   crossings                   -0.02   (authored 0.25)
    lane_gap_excess             -0.02   (authored 0.25)
 -- iter1
    turn_angle_per_route        +5.40   (authored 2.00)
@@ -80,7 +80,7 @@ positive = more of this is worse, matching the authored convention
    turn_angle_per_route        +2.96   (authored 2.00)
    non_45_frac                 +2.16   (not authored) SIGN FLIPS ACROSS FOLDS
    path_len_per_route          -0.01   (not authored)
-   crossings                   -0.01   (authored 0.50)
+   crossings                   -0.01   (authored 0.25)
    min_marker_gap              -0.00   (not authored) SIGN FLIPS ACROSS FOLDS
    bbox_h                      -0.00   (not authored) SIGN FLIPS ACROSS FOLDS
 -- only_bend_family

--- a/datasets/layout_preferences/scripts/build_dataset.py
+++ b/datasets/layout_preferences/scripts/build_dataset.py
@@ -13,17 +13,36 @@ one revision and raises at the other is the cleanest label in the corpus: no
 human judgement is involved and the direction is unambiguous.
 
 Usage:
-    python build_dataset.py
+    python build_dataset.py                # join geometry onto labels
+    python build_dataset.py --from-pairs   # directional signal from the committed pairs
 """
 
 from __future__ import annotations
 
+import argparse
 import json
-from collections import Counter
+import statistics
+from collections import Counter, defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 
 S = Path(__file__).parent
-FEATURE_KEYS: list[str] = []
+PAIRS = S.parent / "dataset_pairs.jsonl"
+
+MIN_MOVED = 8
+"""Moved pairs a feature needs before the report will state a percentage for it."""
+
+FLAG_MARGIN = 0.18
+"""Distance from chance at which the grouped reading is called discriminative."""
+
+SENTINEL = frozenset({"min_marker_gap", "min_station_distance"})
+"""Features whose extractor emits ``-1.0`` for "no such measurement exists".
+
+A map with no foreign line near any marker has no minimum gap. Read as the
+number -1 the sentinel would be the tightest clearance in the corpus, inverting
+the feature, so a pair undefined at either revision contributes no movement.
+Mirrors ``fit_objective.SENTINEL``.
+"""
 
 
 def load_geometry() -> dict[str, dict]:
@@ -42,22 +61,112 @@ def vecs_differ(a: dict, b: dict) -> bool:
     return any(abs(a[k] - b[k]) > 1e-6 for k in a if k in b)
 
 
+@dataclass(frozen=True)
+class Signal:
+    """How often one feature moved down across the pairs that moved it at all."""
+
+    feature: str
+    raw: float
+    grouped: float
+    n_pairs: int
+    n_fixtures: int
+
+    @property
+    def discriminative(self) -> bool:
+        return abs(self.grouped - 0.5) > FLAG_MARGIN
+
+
+def feature_keys(pairs: list[dict]) -> list[str]:
+    for p in pairs:
+        if p.get("features_before"):
+            return sorted(p["features_before"])
+    return []
+
+
+def moves_by_fixture(pairs: list[dict], key: str) -> dict[str, list[float]]:
+    """Per-fixture deltas on ``key``, keeping only the pairs that moved it."""
+    out: dict[str, list[float]] = defaultdict(list)
+    for p in pairs:
+        before, after = p.get("features_before"), p.get("features_after")
+        if not before or not after or key not in before or key not in after:
+            continue
+        if key in SENTINEL and -1.0 in (before[key], after[key]):
+            continue
+        delta = after[key] - before[key]
+        if abs(delta) > 1e-6:
+            out[p["fixture"]].append(delta)
+    return out
+
+
+def directional_signal(pairs: list[dict]) -> list[Signal]:
+    """Share of moves that DECREASED each feature, counted two ways.
+
+    ``raw`` weights a fixture by how many pairs it contributes, so one map
+    appearing in fifty pairs states a corpus-wide trend by itself; that is how
+    `path_len_per_route` came to read as a quality signal. ``grouped`` gives
+    every fixture one vote, and is the figure to triage features on.
+    """
+    signals = []
+    for key in feature_keys(pairs):
+        by_fixture = moves_by_fixture(pairs, key)
+        deltas = [d for ds in by_fixture.values() for d in ds]
+        if len(deltas) < MIN_MOVED:
+            continue
+        down = [sum(1 for d in ds if d < 0) / len(ds) for ds in by_fixture.values()]
+        signals.append(
+            Signal(
+                feature=key,
+                raw=sum(1 for d in deltas if d < 0) / len(deltas),
+                grouped=statistics.fmean(down),
+                n_pairs=len(deltas),
+                n_fixtures=len(by_fixture),
+            )
+        )
+    return signals
+
+
+def print_directional_signal(pairs: list[dict]) -> None:
+    print("\n=== directional signal check (issue-fix pairs) ===")
+    print("share of the moves that DECREASED the feature.")
+    print("`raw` counts every pair, so a fixture in many pairs speaks many times;")
+    print("`grouped` gives each fixture one vote. Triage on grouped.")
+    print(f"  {'feature':28s} {'raw':>7} {'grouped':>8} {'pairs':>6} {'fixtures':>9}")
+    for s in directional_signal(pairs):
+        flag = "  <-- discriminative" if s.discriminative else ""
+        print(
+            f"  {s.feature:28s} {s.raw * 100:6.1f}% {s.grouped * 100:7.1f}%"
+            f" {s.n_pairs:6d} {s.n_fixtures:9d}{flag}"
+        )
+
+
+def load_pairs(path: Path) -> list[dict]:
+    return [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+
+
+def directional_pairs(pairs: list[dict]) -> list[dict]:
+    return [
+        p for p in pairs if p["label"] == "after_better" and p["kind"] == "preference"
+    ]
+
+
 def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--from-pairs",
+        action="store_true",
+        help="re-print the signal check from the committed pairs, skipping the "
+        "join (which needs the uncommitted per-revision geometry)",
+    )
+    if ap.parse_args().from_pairs:
+        print_directional_signal(directional_pairs(load_pairs(PAIRS)))
+        return
+
     labels = json.load(open(S / "labels.json"))
     xfail_path = S / "labels_xfail.json"
     if xfail_path.exists():
         labels += json.load(open(xfail_path))
     geo = load_geometry()
     print(f"geometry revisions available: {len(geo)}")
-
-    global FEATURE_KEYS
-    for d in geo.values():
-        for rec in d["fixtures"].values():
-            if rec.get("status") == "ok":
-                FEATURE_KEYS = sorted(rec["features"])
-                break
-        if FEATURE_KEYS:
-            break
 
     pairs: list[dict] = []
     anchors: list[dict] = []
@@ -192,32 +301,17 @@ def main() -> None:
     for k, v in sorted(drop.items(), key=lambda kv: -kv[1]):
         print(f"  {k:34s} {v}")
 
-    strong = [
-        p for p in pairs if p["label"] == "after_better" and p["kind"] == "preference"
-    ]
+    strong = directional_pairs(pairs)
     print(f"\ntotal pairs: {len(pairs)}   directional (after_better): {len(strong)}")
     print(
         f"abort transitions: {sum(1 for p in pairs if p['kind'] == 'abort_transition')}"
     )
     print(f"anchors: {len(anchors)}")
     print(f"distinct fixtures in pairs: {len({p['fixture'] for p in pairs})}")
-    print(f"features per vector: {len(FEATURE_KEYS)}")
+    print(f"features per vector: {len(feature_keys(pairs))}")
 
     if strong:
-        print("\n=== directional signal check (issue-fix pairs) ===")
-        print("fraction of pairs where the feature DECREASED after the fix:")
-        for k in FEATURE_KEYS:
-            d = [
-                p["features_after"][k] - p["features_before"][k]
-                for p in strong
-                if p["features_before"] and p["features_after"]
-            ]
-            moved = [x for x in d if abs(x) > 1e-6]
-            if len(moved) < 8:
-                continue
-            down = sum(1 for x in moved if x < 0) / len(moved)
-            flag = "  <-- discriminative" if abs(down - 0.5) > 0.18 else ""
-            print(f"  {k:28s} {down * 100:5.1f}%  (n={len(moved):3d}){flag}")
+        print_directional_signal(strong)
 
 
 if __name__ == "__main__":

--- a/datasets/layout_preferences/scripts/build_dataset.py
+++ b/datasets/layout_preferences/scripts/build_dataset.py
@@ -102,9 +102,9 @@ def directional_signal(pairs: list[dict]) -> list[Signal]:
     """Share of moves that DECREASED each feature, counted two ways.
 
     ``raw`` weights a fixture by how many pairs it contributes, so one map
-    appearing in fifty pairs states a corpus-wide trend by itself; that is how
-    `path_len_per_route` came to read as a quality signal. ``grouped`` gives
-    every fixture one vote, and is the figure to triage features on.
+    appearing in fifty pairs can state a corpus-wide trend by itself, and the
+    extent features are the ones most exposed to it. ``grouped`` gives every
+    fixture one vote, and is the figure to triage features on.
     """
     signals = []
     for key in feature_keys(pairs):

--- a/datasets/layout_preferences/scripts/fit_objective.py
+++ b/datasets/layout_preferences/scripts/fit_objective.py
@@ -77,9 +77,9 @@ undefined on either side means the feature says nothing about this preference.
 AUTHORED_WEIGHTS = {
     "lone_diagonals": 3.0,
     "bends_per_route": 3.0,
-    "marker_crowding": 3.0,
+    "marker_crowding": 2.0,
     "turn_angle_per_route": 2.0,
-    "crossings": 0.5,
+    "crossings": 0.25,
     "near_horizontal": 0.5,
     "lane_gap_excess": 0.25,
 }

--- a/scripts/optimize_layout.py
+++ b/scripts/optimize_layout.py
@@ -45,26 +45,42 @@ from nf_metro.layout import compute_layout  # noqa: E402
 from nf_metro.layout.constants import Y_SPACING  # noqa: E402
 from nf_metro.parser import parse_metro_mermaid  # noqa: E402
 
-# Each weight is a coarse bin of how often that metric moves the same way as
-# human layout judgement, measured over the preference pairs in
-# `datasets/layout_preferences`. Plausibility is not evidence here: crossings
-# and wasted canvas both agree with the judgement about as often as a coin, so
-# however obviously they ought to matter they can only be weak hints, and a
-# heavy weight on either buys suggestions nobody would accept.
+# The bins encode three distinct states of knowledge, and conflating them is
+# what made an earlier version of this objective wrong: measured-with-signal
+# outranks not-measured, which outranks measured-without-signal. Plausibility on
+# its own buys nothing. Agreement is the share of the fixtures a metric moves on
+# where it moves the same way as human layout judgement, over the preference
+# pairs in `datasets/layout_preferences` (fixture-grouped, since a raw count
+# lets one repetitive map speak for the corpus).
 WEIGHTS = {
-    # Agree with the judgement on ~90% of pairs.
+    # Measured, and agree with the judgement on ~95% of the fixtures they move.
     "single_diagonals": 3.0,
     "bends_per_route": 3.0,
-    "marker_crowding": 3.0,
-    # ~70%.
+    # Measured at ~75%.
     "turn_angle_per_route": 2.0,
-    # Unmeasured -- a strike needs render-time label boxes the pairs lack -- but
-    # a line through a label is a defect nobody argues about.
+    # Invisible to the instrument, not absent from renders: a strike needs
+    # render-time label boxes the replayed pairs never captured. Frequent and
+    # complained about, and a line through a label is a defect nobody argues
+    # about, so it is weighted on that rather than on a measurement.
     "label_strikes": 2.0,
-    # No resolvable signal: no better than a coin, or too rare to measure.
-    "crossings": 0.5,
+    # Visible to the instrument and almost never happens, because ERROR-level
+    # guards reject it upstream: it has a non-zero delta on 3 of 192 pairs, too
+    # few to measure. Weighted below the measured terms and kept non-zero as
+    # cover for a future change that starts producing it.
+    "marker_crowding": 2.0,
+    # Too rare in the corpus to measure at all (`near_horizontal` moves on two
+    # pairs; `wasted_canvas` needs a canvas size the pairs lack).
     "near_horizontal": 0.5,
     "wasted_canvas": 0.5,
+    # Measured, with the largest sample of any term here (`crossings` moves on
+    # 42 pairs across 25 fixtures) and no signal to show for it: 44.9%
+    # agreement. Read that as a coin flip with a wobble, NOT as evidence that
+    # crossings are desirable: a negative weight would instruct the search to
+    # add them, which is the failure mode that keeps this objective out of the
+    # optimiser.
+    "crossings": 0.25,
+    # Measured, and points the wrong way for a knowable reason: it fires on the
+    # healthy vertical gap between two parallel processing tracks.
     "excessive_gaps": 0.25,
 }
 # `corners_total` is deliberately absent: it is `bends_per_route` times the

--- a/scripts/optimize_layout.py
+++ b/scripts/optimize_layout.py
@@ -16,9 +16,7 @@ the pure-auto-layout baseline and the directives that reproduce it.
 IMPORTANT: the metrics are a proxy, not ground truth, and the weights over them
 are binned measurements rather than a fitted model. A lower weighted score is
 evidence for an arrangement, not proof of one -- always eyeball a suggestion
-before adopting it. ``excessive_gaps`` in particular fires on the healthy
-vertical gap between two parallel processing tracks, which is why it carries
-almost no weight.
+before adopting it.
 
 Usage:
     python scripts/optimize_layout.py examples/genomic_pipeline.mmd [more.mmd ...]
@@ -45,13 +43,15 @@ from nf_metro.layout import compute_layout  # noqa: E402
 from nf_metro.layout.constants import Y_SPACING  # noqa: E402
 from nf_metro.parser import parse_metro_mermaid  # noqa: E402
 
-# The bins encode three distinct states of knowledge, and conflating them is
-# what made an earlier version of this objective wrong: measured-with-signal
-# outranks not-measured, which outranks measured-without-signal. Plausibility on
-# its own buys nothing. Agreement is the share of the fixtures a metric moves on
-# where it moves the same way as human layout judgement, over the preference
-# pairs in `datasets/layout_preferences` (fixture-grouped, since a raw count
-# lets one repetitive map speak for the corpus).
+# The bins encode three distinct states of knowledge, and conflating any two of
+# them is how a metric ends up weighted on plausibility instead of evidence:
+# measured-with-signal outranks not-measured, which outranks
+# measured-without-signal, because a measured null is stronger grounds for
+# discounting a metric than never having measured it. Agreement below is the
+# share of the fixtures a metric moves on where it moves the same way as human
+# layout judgement, over the preference pairs in `datasets/layout_preferences`.
+# It is fixture-grouped, since a raw per-pair count lets one repetitive map
+# speak for the corpus.
 WEIGHTS = {
     # Measured, and agree with the judgement on ~95% of the fixtures they move.
     "single_diagonals": 3.0,

--- a/tests/test_layout_preference_fit.py
+++ b/tests/test_layout_preference_fit.py
@@ -2,9 +2,9 @@
 
 The verdict written up under "Fitted model and gate result" in
 `datasets/layout_preferences/README.md` rests on numbers, and the dataset it
-rests on is regenerable. These assertions fail if a
-regeneration moves any of the four claims the verdict is built from, so the
-write-up cannot quietly drift out of agreement with the data.
+rests on is regenerable. These assertions fail if a regeneration moves any of the
+claims the verdict is built from, so the write-up cannot quietly drift out of
+agreement with the data.
 
 The same dataset also decides which weight bin each term of the advisory
 objective belongs in, and how `dataset_report.txt` reports a feature's
@@ -19,8 +19,11 @@ from pathlib import Path
 
 import pytest
 
-DATASET_DIR = Path(__file__).resolve().parent.parent / "datasets" / "layout_preferences"
-SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+REPO = Path(__file__).resolve().parent.parent
+DATASET_DIR = REPO / "datasets" / "layout_preferences"
+
+sys.path.insert(0, str(REPO / "scripts"))
+from optimize_layout import WEIGHTS as ADVISORY_WEIGHTS  # noqa: E402
 
 # `optimize_layout` reads four terms off validator verdict counts that the
 # dataset measures geometrically instead, so a name-for-name comparison of the
@@ -54,27 +57,22 @@ def _load_fitter():
     return _load_dataset_script("fit_objective")
 
 
-def _load_advisory_weights() -> dict[str, float]:
-    sys.path.insert(0, str(SCRIPTS))
-    from optimize_layout import WEIGHTS
-
-    return WEIGHTS
-
-
 @pytest.fixture(scope="module")
-def directional():
-    fitter = _load_fitter()
-    pairs, _, _ = fitter.load(DATASET_DIR / "dataset_pairs.jsonl")
-    assert len(pairs) == 192, "dataset changed shape; re-read the verdict"
-    return pairs
-
-
-@pytest.fixture(scope="module")
-def arms():
+def dataset():
     fitter = _load_fitter()
     directional, weak, _ = fitter.load(DATASET_DIR / "dataset_pairs.jsonl")
     assert len(directional) == 192, "dataset changed shape; re-read the verdict"
-    return fitter.cross_validate(directional, weak, weak_weight=0.0)
+    return directional, weak
+
+
+@pytest.fixture(scope="module")
+def directional(dataset):
+    return dataset[0]
+
+
+@pytest.fixture(scope="module")
+def arms(dataset):
+    return _load_fitter().cross_validate(*dataset, weak_weight=0.0)
 
 
 def pooled(arms: dict, name: str) -> float:
@@ -123,12 +121,11 @@ def test_the_top_weight_bin_holds_only_terms_the_corpus_measured(directional):
     """The heaviest weight is reserved for terms the corpus can actually measure.
 
     A term that barely moves across the pairs has no measured agreement to
-    justify a weight with, however plausible it looks. `marker_crowding` is the
-    case in point: binned heaviest on a univariate reading of `min_marker_gap`,
-    then found to move on three pairs. The bar is the minimum sample the report
-    itself will print a percentage for.
+    justify a weight with, however plausible it looks, so promoting one into the
+    top bin has to fail here. The bar is the minimum sample the report itself
+    will print a percentage for.
     """
-    weights = _load_advisory_weights()
+    weights = ADVISORY_WEIGHTS
     floor = _load_dataset_script("build_dataset").MIN_MOVED
     heaviest = max(weights.values())
 
@@ -187,13 +184,19 @@ def test_an_undefined_measurement_is_not_read_as_the_tightest_one():
     assert signal.raw == 0.0
 
 
+def test_both_dataset_scripts_mask_the_same_sentinel_features():
+    """The two scripts are standalone by design, so the sentinel list is stated
+    twice. A feature masked in one and read as the number -1 in the other would
+    give the report and the fit opposite readings of the same pair."""
+    assert _load_dataset_script("build_dataset").SENTINEL == _load_fitter().SENTINEL
+
+
 def test_the_fit_scores_the_weights_the_advisory_objective_actually_uses():
     """`AUTHORED_WEIGHTS` is the advisory table restated over dataset feature
     names, so the arm the gate compares against has to be the live one. Left to
     drift, the fit would report a margin over weights nobody uses."""
-    advisory = _load_advisory_weights()
     assert _load_fitter().AUTHORED_WEIGHTS == {
         _dataset_key(term): weight
-        for term, weight in advisory.items()
+        for term, weight in ADVISORY_WEIGHTS.items()
         if term not in NOT_IN_DATASET
     }

--- a/tests/test_layout_preference_fit.py
+++ b/tests/test_layout_preference_fit.py
@@ -1,10 +1,14 @@
-"""Lock the layout-objective gate verdict against the committed preference dataset.
+"""Lock the claims that rest on the committed layout-preference dataset.
 
 The verdict written up under "Fitted model and gate result" in
 `datasets/layout_preferences/README.md` rests on numbers, and the dataset it
 rests on is regenerable. These assertions fail if a
 regeneration moves any of the four claims the verdict is built from, so the
 write-up cannot quietly drift out of agreement with the data.
+
+The same dataset also decides which weight bin each term of the advisory
+objective belongs in, and how `dataset_report.txt` reports a feature's
+directional signal, so those are pinned here too.
 """
 
 from __future__ import annotations
@@ -16,17 +20,53 @@ from pathlib import Path
 import pytest
 
 DATASET_DIR = Path(__file__).resolve().parent.parent / "datasets" / "layout_preferences"
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+# `optimize_layout` reads four terms off validator verdict counts that the
+# dataset measures geometrically instead, so a name-for-name comparison of the
+# two weight tables needs the translation. `fit_objective.AUTHORED_WEIGHTS`
+# documents the pairing.
+ADVISORY_TO_DATASET = {
+    "single_diagonals": "lone_diagonals",
+    "excessive_gaps": "lane_gap_excess",
+}
+# Neither the rendered canvas size nor render-time label boxes were captured by
+# the replay, so these two terms have no counterpart in the pair vectors.
+NOT_IN_DATASET = frozenset({"label_strikes", "wasted_canvas"})
 
 
-def _load_fitter():
-    """Import the fit script by path; `datasets/` is not an importable package."""
-    path = DATASET_DIR / "scripts" / "fit_objective.py"
-    spec = importlib.util.spec_from_file_location("fit_objective", path)
+def _dataset_key(advisory_term: str) -> str:
+    return ADVISORY_TO_DATASET.get(advisory_term, advisory_term)
+
+
+def _load_dataset_script(stem: str):
+    """Import a dataset script by path; `datasets/` is not an importable package."""
+    path = DATASET_DIR / "scripts" / f"{stem}.py"
+    spec = importlib.util.spec_from_file_location(stem, path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _load_fitter():
+    return _load_dataset_script("fit_objective")
+
+
+def _load_advisory_weights() -> dict[str, float]:
+    sys.path.insert(0, str(SCRIPTS))
+    from optimize_layout import WEIGHTS
+
+    return WEIGHTS
+
+
+@pytest.fixture(scope="module")
+def directional():
+    fitter = _load_fitter()
+    pairs, _, _ = fitter.load(DATASET_DIR / "dataset_pairs.jsonl")
+    assert len(pairs) == 192, "dataset changed shape; re-read the verdict"
+    return pairs
 
 
 @pytest.fixture(scope="module")
@@ -77,3 +117,83 @@ def test_degenerate_controls_do_not_explain_the_margin(arms, control):
     """
     margin = pooled(arms, control) - pooled(arms, "authored")
     assert margin < 0.02, f"control {control} now beats authored by {margin:+.3f}"
+
+
+def test_the_top_weight_bin_holds_only_terms_the_corpus_measured(directional):
+    """The heaviest weight is reserved for terms the corpus can actually measure.
+
+    A term that barely moves across the pairs has no measured agreement to
+    justify a weight with, however plausible it looks. `marker_crowding` is the
+    case in point: binned heaviest on a univariate reading of `min_marker_gap`,
+    then found to move on three pairs. The bar is the minimum sample the report
+    itself will print a percentage for.
+    """
+    weights = _load_advisory_weights()
+    floor = _load_dataset_script("build_dataset").MIN_MOVED
+    heaviest = max(weights.values())
+
+    for term, weight in weights.items():
+        if weight < heaviest or term in NOT_IN_DATASET:
+            continue
+        key = _dataset_key(term)
+        moved = sum(1 for p in directional if abs(p.delta.get(key, 0.0)) > 1e-6)
+        assert moved >= floor, (
+            f"{term} carries the heaviest weight ({weight}) but moves on only "
+            f"{moved} of {len(directional)} pairs, below the {floor} the report "
+            f"needs to state a percentage"
+        )
+
+
+def _synthetic_pair(fixture: str, before: float, after: float, key: str) -> dict:
+    return {
+        "fixture": fixture,
+        "features_before": {key: before},
+        "features_after": {key: after},
+    }
+
+
+def test_one_repetitive_fixture_cannot_carry_a_corpus_wide_percentage():
+    """Every fixture gets one vote in the grouped figure.
+
+    A raw percentage weights a fixture by how many pairs it contributes, so a
+    single map appearing in many pairs can state a trend on its own. Here ten
+    pairs of one map disagree with five other maps, and only the raw reading
+    calls that a majority.
+    """
+    report = _load_dataset_script("build_dataset")
+    pairs = [_synthetic_pair("loud", 2.0, 1.0, "f") for _ in range(10)]
+    pairs += [_synthetic_pair(f"quiet_{i}", 1.0, 2.0, "f") for i in range(5)]
+
+    (signal,) = report.directional_signal(pairs)
+
+    assert (signal.n_pairs, signal.n_fixtures) == (15, 6)
+    assert signal.raw == pytest.approx(10 / 15)
+    assert signal.grouped == pytest.approx(1 / 6)
+
+
+def test_an_undefined_measurement_is_not_read_as_the_tightest_one():
+    """A `-1.0` gap means no foreign line came near any marker, so a pair whose
+    gap is undefined at either revision says nothing about the preference. Read
+    as the number -1 it would be the tightest clearance in the corpus, so a map
+    that stopped crowding markers would count as having started."""
+    report = _load_dataset_script("build_dataset")
+    key = "min_marker_gap"
+    widened = [_synthetic_pair(f"real_{i}", 30.0, 40.0, key) for i in range(8)]
+    undefined = [_synthetic_pair(f"gone_{i}", 12.0, -1.0, key) for i in range(20)]
+
+    (signal,) = report.directional_signal(widened + undefined)
+
+    assert signal.n_pairs == 8
+    assert signal.raw == 0.0
+
+
+def test_the_fit_scores_the_weights_the_advisory_objective_actually_uses():
+    """`AUTHORED_WEIGHTS` is the advisory table restated over dataset feature
+    names, so the arm the gate compares against has to be the live one. Left to
+    drift, the fit would report a margin over weights nobody uses."""
+    advisory = _load_advisory_weights()
+    assert _load_fitter().AUTHORED_WEIGHTS == {
+        _dataset_key(term): weight
+        for term, weight in advisory.items()
+        if term not in NOT_IN_DATASET
+    }

--- a/tests/test_optimize_layout.py
+++ b/tests/test_optimize_layout.py
@@ -43,8 +43,8 @@ def test_the_weight_bins_keep_the_three_states_of_knowledge_apart() -> None:
     A metric measured to track human judgement outranks one the corpus could not
     measure, which in turn outranks one measured and found to carry no signal: a
     measured null is stronger grounds for ignoring a metric than never having
-    measured it. Collapsing the last two bins together is what let route shape
-    and marker crowding be weighted as if they had the same standing.
+    measured it. Every term must be classified into one of the three, so a new
+    one cannot be added without deciding which kind of evidence backs it.
     """
     tracks_judgement = ("single_diagonals", "bends_per_route", "turn_angle_per_route")
     unmeasurable = (

--- a/tests/test_optimize_layout.py
+++ b/tests/test_optimize_layout.py
@@ -37,14 +37,32 @@ def test_objective_prefers_parallel_tracks_over_a_collapsed_column() -> None:
     assert parallel_tracks < collapsed_column
 
 
-def test_metrics_that_predict_the_judgement_outweigh_the_ones_that_do_not() -> None:
-    """The measured ranking, pinned: route shape agrees with human judgement on
-    ~90% of the preference pairs while crossings and wasted canvas are near
-    chance, so no weighting may let the near-chance pair outvote route shape.
+def test_the_weight_bins_keep_the_three_states_of_knowledge_apart() -> None:
+    """The bins rank evidence, not plausibility.
+
+    A metric measured to track human judgement outranks one the corpus could not
+    measure, which in turn outranks one measured and found to carry no signal: a
+    measured null is stronger grounds for ignoring a metric than never having
+    measured it. Collapsing the last two bins together is what let route shape
+    and marker crowding be weighted as if they had the same standing.
     """
-    for measured in ("single_diagonals", "bends_per_route", "marker_crowding"):
-        for near_chance in ("crossings", "wasted_canvas", "excessive_gaps"):
-            assert WEIGHTS[measured] > WEIGHTS[near_chance]
+    tracks_judgement = ("single_diagonals", "bends_per_route", "turn_angle_per_route")
+    unmeasurable = (
+        "label_strikes",
+        "marker_crowding",
+        "near_horizontal",
+        "wasted_canvas",
+    )
+    measured_null = ("crossings", "excessive_gaps")
+    assert set(WEIGHTS) == {*tracks_judgement, *unmeasurable, *measured_null}
+
+    heaviest_null = max(WEIGHTS[m] for m in measured_null)
+    assert min(WEIGHTS[m] for m in tracks_judgement) > heaviest_null
+    assert min(WEIGHTS[m] for m in unmeasurable) > heaviest_null
+    assert max(WEIGHTS[m] for m in unmeasurable) < max(
+        WEIGHTS[m] for m in tracks_judgement
+    ), "an unmeasured metric may not be weighted level with the best-measured one"
+
     assert WEIGHTS["bends_per_route"] > WEIGHTS["turn_angle_per_route"]
     assert "corners_total" not in WEIGHTS
 


### PR DESCRIPTION
## Summary

Two corrections to the layout-objective measurement surface. Both are advisory
or measurement-only: `optimize_layout.py` gates nothing and the dataset scripts
touch no engine code, so there is no behaviour change to a render.

**The weight bins now say what is known rather than what is plausible.**
`marker_crowding` held one of the three heaviest weights in the advisory
objective on the strength of a univariate reading of `min_marker_gap`, but it has
a non-zero delta on 3 of 192 directional pairs, so there was never a measurement
behind it. It moves to 2.0, in a bin for terms the corpus cannot measure, and
`crossings` moves to 0.25, in a bin for terms it measured and found flat.

Three bins, ordered by strength of evidence: measured-with-signal (3.0) >
not-measured (2.0 / 0.5) > measured-without-signal (0.25). A measured null is
stronger grounds for discounting a metric than never having measured it, which is
why the middle bin outranks the last. The two not-measured cases are commented
separately because they are unmeasured for opposite reasons: a label strike is
invisible to the instrument (the replay never captured render-time label boxes)
but frequent, while marker crowding is perfectly visible and almost never happens
because ERROR-level guards reject it upstream.

**Re-binning moves the `authored` arm of the objective fit by 0.00 pp on every
arm.** The only lines that change in the whole of `fit_report.txt` are three
`(authored X.XX)` annotations; every score, margin, sign test and per-family
figure is byte-identical. That is the cleanest available statement of why the
original objective failed: its heaviest weights sat on quantities that never
moved, so no reweighting of them could change a single prediction.

**The report's univariate percentages are now fixture-grouped.** They weighted
each fixture by how many pairs it contributed, so one repetitive map could state
a corpus-wide trend by itself. `dataset_report.txt` prints raw and grouped side
by side, with the discriminative flag driven by grouped.

Grouping is not a uniform haircut, which is why the re-triage was worth doing
rather than assuming everything drifts toward chance:

| feature | raw | grouped | pairs / fixtures |
| --- | --- | --- | --- |
| `bends_per_route` | 89.5% | **94.8%** | 19 / 16 |
| `turn_angle_per_route` | 69.0% | **75.4%** | 29 / 23 |
| `crossings` | 54.8% | **44.9%** | 42 / 25 |
| `path_len_per_route` | 32.6% | **40.6%** | 141 / 68 |
| `bbox_w` | 31.2% | **37.5%** | 16 / 12 |

It sharpens the bend family, moves `crossings` from just above chance to just
below, and drops `bbox_w` out of discriminative range altogether. So the grouping
prunes artefacts and sharpens real signal rather than flattening everything.

## Also in the diff

- The `-1.0` "no such measurement exists" sentinel is masked in the report's
  statistic, matching what `fit_objective.py` already documents. Inert on this
  corpus (all 25 undefined pairs are undefined at both revisions) but it was a
  latent wrong figure: read as the number -1 it is the tightest clearance in the
  corpus, so a map that *stopped* crowding markers would count as having started.
- `build_dataset.py --from-pairs` re-prints the signal check from the committed
  `dataset_pairs.jsonl`, so the report's percentages can be recomputed without
  the 30-minute geometry replay.
- The `.gitignore` entry for the geometry cache pointed at
  `datasets/layout_preferences/geometry/`, but `replay.py` writes it to
  `datasets/layout_preferences/scripts/geometry/`. The ~104MB intermediate was
  not actually ignored.
- `README.md`'s headline finding is restated on the grouped figures. It also
  cited `ink_density` at 51.8%, which the extractor no longer emits.

## New pins

| test | what it locks |
| --- | --- |
| `test_the_weight_bins_keep_the_three_states_of_knowledge_apart` | the three bins stay ordered, and every term in `WEIGHTS` is classified into one |
| `test_the_top_weight_bin_holds_only_terms_the_corpus_measured` | a term moving on fewer pairs than the report needs to state a percentage cannot hold the heaviest weight |
| `test_the_fit_scores_the_weights_the_advisory_objective_actually_uses` | `AUTHORED_WEIGHTS` cannot drift from `optimize_layout.WEIGHTS` |
| `test_one_repetitive_fixture_cannot_carry_a_corpus_wide_percentage` | grouped gives each fixture one vote (10 pairs of one map vs 5 other maps) |
| `test_an_undefined_measurement_is_not_read_as_the_tightest_one` | the sentinel contributes no movement |

The first two fail on `main`.

Fixes #1605

## Test plan

- [x] `pytest tests/test_layout_preference_fit.py tests/test_optimize_layout.py tests/test_layout_metrics.py` passes
- [x] the two weight-bin pins verified to fail with the old bins restored
- [x] `prek run --all-files` clean (ruff, ruff format, prettier, mypy)
- [x] `fit_report.txt` and `dataset_report.txt` regenerated from committed data, diffs reviewed line by line
- [ ] Render-preview verdict: expected "No visual changes detected" (no engine code in the diff)

Generated with Claude Code
