### PR TITLE
Establish whether a safe layout objective exists

### DIFF
--- a/datasets/layout_preferences/README.md
+++ b/datasets/layout_preferences/README.md
@@ -20,8 +20,10 @@ to be recoverable from artifacts that were never written as a dataset.
 | `dataset_report.txt`        | -       | emitted/dropped counts and the per-feature directional check       |
 | `fit_report.txt`            | -       | the fitted model, its cross-validated gate result and its controls |
 | `iter2_weights.json`        | -       | the fitted weights the render-diff reads (see below)               |
+| `safe_weights.json`         | -       | the constrained fit, the only weights safe to minimise             |
+| `safety_report.txt`         | -       | the structural check and the growth probe behind that claim        |
 | `feature_parity_report.txt` | -       | render-diff vs `extract_features.py` feature-source parity check   |
-| `scripts/`                  | 14      | the generating pipeline, plus `fit_objective.py`                   |
+| `scripts/`                  | 16      | the generating pipeline, plus `fit_objective.py`                   |
 
 The tables above are the historical backfill, which is a one-off.
 [Forward capture](#forward-capture) is how the same signal keeps arriving, into
@@ -282,6 +284,13 @@ runs the #1586 gate. `fit_report.txt` is its committed output; regenerate with:
 python scripts/fit_objective.py --out fit_report.txt
 ```
 
+The constrained arms and the safety report regenerate with:
+
+```bash
+python scripts/fit_objective.py --dump-weights safe --weights-out ../safe_weights.json
+python scripts/check_objective_safety.py --out ../safety_report.txt
+```
+
 Agreement is measured over held-out pairs under 5-fold cross-validation grouped
 by whole fixture. An arm whose features all have zero delta across a pair has no
 opinion about it; those abstentions are counted as half a hit in `pooled` and
@@ -320,16 +329,162 @@ features, not the weights.
 - **Primary gate (promote to a measurement, #1587): pass.** The fitted objective
   beats the hand-binned weights by 13.8 points pooled, 7.4 on coverage-matched
   pairs, p=0.0001.
-- **Secondary gate (promote to an optimisation target, #1588 / #1589): fail.**
-  The absolute bar is 85% held-out agreement; `iter2` reaches 68.5% pooled and
-  69.6% decided.
+- **Secondary gate (promote to an optimisation target, #1588 / #1589): fail**, on
+  the grounds below rather than on the 85% bar. A safe objective does exist and
+  is committed; it adds nothing over what already ships.
 
-Two findings say the secondary bar should stay shut even if agreement later
-climbs. `iter2` carries **negative** fitted weights on `bbox_h` and
-`path_len_per_route`, so an optimiser minimising it would inflate the drawing
-without bound - the PR #353 failure mode exactly. And four of its eight weights
-flip sign between folds, so their magnitudes are artefacts of which fixtures were
-held out rather than statements about layout.
+## Is any of it safe to minimise?
+
+A score is safe to descend when no input can improve it without bound. `iter2`
+is not: minimising it inflates the drawing forever, which is the PR #353 failure
+mode. That is the one property a human reviewing every candidate cannot
+compensate for, because it degenerates _every_ candidate rather than
+occasionally offering a bad one, so it is the question #1588 exists to settle.
+
+### The safety property, and why it is structural
+
+If every feature is non-negative and every weight is non-negative, the score is
+a non-negative combination of non-negative terms: bounded below by zero, and
+monotone non-decreasing in every feature. No input can drive it arbitrarily low.
+That is a one-line proof, and it needs the _features_ to cooperate, which two of
+them do not:
+
+| feature          | verdict          | why no weight on it is safe                                                                       |
+| ---------------- | ---------------- | ------------------------------------------------------------------------------------------------- |
+| `min_marker_gap` | `terms.ANTITONE` | more clearance is better and clearance is always wideable, so its useful weight is negative       |
+| `aspect_log`     | `terms.SIGNED`   | `log10(w/h)`, so a negative weight buys an arbitrarily tall drawing and a positive one a wide one |
+
+`scripts/terms.py` holds `ADMISSIBILITY`, a verdict for every feature the
+extractor emits, so a feature added without being classified cannot slip into a
+minimisable objective unexamined. `min_marker_gap` has a repair -
+`marker_crowding`, a one-sided penalty saturating at one lane pitch - and
+`aspect_log` does not, so it stays out.
+
+Only features that are **unbounded above** actually need their weight pinned: a
+negative weight on a term confined to `[0, 1]` costs a finite amount. Both arms
+are fitted, so a collapse cannot be blamed on constraining more than safety
+requires:
+
+| arm        | pinned                        | pooled | decided | coverage |
+| ---------- | ----------------------------- | ------ | ------- | -------- |
+| `iter2`    | nothing                       | 68.5%  | 69.6%   | 94.3%    |
+| `safe`     | all 8 weights                 | 54.4%  | 79.3%   | 15.1%    |
+| `safe_min` | the 6 unbounded-above weights | 54.4%  | 79.3%   | 15.1%    |
+
+`safe` and `safe_min` are identical to the decimal, so the constraint is not the
+variable. Excluding the growth features outright, #1588's third option, is the
+same model again: the constraint lands on the boundary at **exactly zero** for
+`bbox_h`, `path_len_per_route` and `crossings`, and a weight pinned at zero
+predicts identically to an absent feature.
+
+### 1. Is it safe? Demonstrated, not asserted
+
+`x_spacing` and `y_spacing` are ordinary knobs - a CLI flag and a `%%metro`
+directive - so a uniformly inflated drawing is a _reachable_ input.
+`scripts/check_objective_safety.py` lays five fixtures out at 1x, 2x, 4x and 8x
+the default spacing through the real engine and rescores them:
+
+```bash
+python scripts/check_objective_safety.py --out ../safety_report.txt
+```
+
+| arm     | score fell under growth | `genomic_pipeline.mmd` 1x -> 8x |
+| ------- | ----------------------- | ------------------------------- |
+| `iter2` | 5 of 5 fixtures         | 8.53 -> **-13.90**              |
+| `safe`  | 0 of 5 fixtures         | 18.54 -> 19.43                  |
+
+The growth terms are linear in the multiple, so nothing about 8x ends `iter2`'s
+fall. `safety_report.txt` is the committed output and
+`tests/test_objective_safety.py` locks both directions - the unconstrained arm is
+kept as a live counter-example, so the probe is known to be capable of catching
+an unsafe objective rather than merely passing a safe one.
+
+The constraint fixed the fold instability too, as a side effect rather than by
+design: `safe` has an empty `sign_flips_across_folds`, against three for `iter2`.
+A weight that cannot cross zero cannot change sign between folds.
+
+### 2. What constraining cost: all of the reach
+
+`iter2` loses 14.1 points pooled and 79.2 points of coverage. The mechanism is
+that **reach and correct direction sit on disjoint sets of features**. Over the
+192 directional pairs, for every admissible feature:
+
+| feature                    | moves on | agrees ("more is worse") |
+| -------------------------- | -------- | ------------------------ |
+| `detour_mean`              | 77.6%    | 50.7%                    |
+| `path_len_per_route`       | 73.4%    | **33.8%**                |
+| `bbox_h`                   | 41.7%    | **26.0%**                |
+| `crossings`                | 21.9%    | 48.0%                    |
+| `turn_angle_per_route`     | 15.1%    | 69.6%                    |
+| `bends_per_route`          | 9.9%     | 93.8%                    |
+| `lone_diagonals_per_route` | 5.2%     | 87.5%                    |
+| `marker_crowding`          | 1.6%     | 100.0%                   |
+
+Every feature with reach above 20% either points the wrong way or is a coin
+flip; every feature that points the right way moves on under 16% of pairs.
+`iter2`'s 94.3% coverage was **entirely** the growth terms: the four bend-family
+terms it shares with `safe` move on 29 of 192 pairs between them, and 15.1% is
+exactly the reach of `only_bend_family`. Pinning the growth weights therefore
+does not degrade the model so much as delete most of it.
+
+**Why the reachy terms point the wrong way.** All 192 directional rows are defect
+repairs - 181 issue fixes and 11 xfail-registry clearings - so the `after` side
+is always a map whose defect the engine had just learned to avoid. Repairs cost
+space: a curve gets its full radius of runway, a port gets its own lane, two
+sections are pushed apart. So on this corpus the preferred layout is usually the
+longer and taller one. That is a true statement about repairs, not a statement
+that space is good, and a pairwise fit cannot tell the two apart. It is also why
+this is **not** a proof that no safe objective exists: it is a measurement that
+_this corpus, in this regime,_ cannot fit one.
+
+### 3. Does it beat the incumbent? No
+
+The incumbent is the hand-binned `optimize_layout.WEIGHTS`, since that is what
+ships. Simulating what a search driven by each arm would offer over the 192 pairs
+
+- `surfaced` = it ranks the human-preferred arrangement first, `wasted` = it
+  ranks the rejected one first and costs a review, `silent` = it abstains and the
+  engine's own output stands:
+
+| arm                 | surfaced | wasted | silent | useful:wasted |
+| ------------------- | -------- | ------ | ------ | ------------- |
+| greedy (status quo) | 0        | 0      | 192    | -             |
+| `authored`          | 43       | 25     | 124    | 1.72:1        |
+| `iter2`             | 126      | 55     | 11     | 2.29:1        |
+| `safe`              | 23       | 6      | 163    | 3.83:1        |
+| `only_bend_family`  | 24       | 5      | 163    | **4.80:1**    |
+
+`safe` is the most _precise_ candidate arm, and it is beaten on its own terms by
+a three-feature control with no fit at all - which is what `CONTROL_SETS` exists
+to detect. Its 54.4% pooled is also 0.3 points _below_ `authored` (22 wins, 22
+losses, sign test p=1.0), so on the gating comparison it is indistinguishable
+from the weights already in the tree while surfacing half as many improvements
+(23 against 43).
+
+`wasted` is the only column that costs anything, and the 960 ratified-neutral
+`pr_signoff` rows deliberately have no equivalent. Those rows mean "no changed
+render in this PR was blocking", so an arm preferring the `before` side there
+would have declined a change that turned out fine - a non-improvement, not a
+harm. `fit_report.txt` reports them separately for that reason: missing a real
+improvement and declining an acceptable one are not the same cost, and adding
+the second into a waste column would overstate the price of a cautious arm.
+
+So: **#1588's second stop condition.** A safe objective exists, is committed, and
+adds nothing over the top weight bin of the objective `optimize_layout.py`
+already has. Closed on those grounds rather than for missing a threshold - and
+#1589 stays shut, because there is nothing here for a search to descend that the
+authored weights do not already express.
+
+### What none of this measures
+
+The corpus has **no candidate sets**. Every row is two arrangements of one map
+produced by two engine revisions, and every number above is about ordering that
+pair the way a human did. A search would instead rank many arrangements
+generated at one revision, most of them unlike anything in this corpus, and
+would be free to seek out whichever region of the score it likes best. A good
+useful:wasted ratio is therefore evidence about ordering two known layouts and
+**not** evidence that ranking generated alternatives will work. Whatever a future
+phase concludes, it needs candidate-set data to conclude it from.
 
 ### Findings that outlast the gate
 
@@ -351,6 +506,13 @@ held out rather than statements about layout.
   matching its 44.9% grouped agreement, so it is authored at the floor. The
   fitted sign is slightly negative and must not be read as a reward: minimising a
   negative weight would instruct a search to _add_ crossings.
+- **An absent measurement is the cleanest state, not the worst.**
+  `min_marker_gap` emits `-1.0` for "no line comes near a marker it does not
+  serve", which 104 of the 278 fixtures carrying a vector are in. Fed to the
+  crowding formula as a gap it reads 1.025 - past the term's ceiling and above
+  every real value - so a non-negative weight would penalise precisely the
+  fixtures with the most room. `terms.marker_crowding` masks the sentinel to zero
+  and clamps to `[0, 1]`; every consumer reads that one definition.
 - **The weak-label warning is confirmed empirically.** Adding `pr_signoff` rows
   to training at a tenth of a directional row's weight costs `iter2` 5.2 points.
   Set-level ratifications are not per-render positives.

--- a/datasets/layout_preferences/fit_report.txt
+++ b/datasets/layout_preferences/fit_report.txt
@@ -17,6 +17,8 @@ authored_no_gap    55.5%    66.2%     33.9%   51.3%  55.1%  59.2%  52.6%  59.2%
 refit              54.7%    63.2%     35.4%   55.1%  48.7%  59.2%  55.3%  55.3%
 iter1              50.0%    50.0%     62.5%   64.1%  33.3%  57.9%  43.4%  51.3%
 iter2              68.5%    69.6%     94.3%   82.1%  67.9%  68.4%  56.6%  67.1%
+safe               54.4%    79.3%     15.1%   53.8%  51.3%  59.2%  52.6%  55.3%
+safe_min           54.4%    79.3%     15.1%   53.8%  51.3%  59.2%  52.6%  55.3%
 only_bend_family   54.9%    82.8%     15.1%   53.8%  51.3%  59.2%  55.3%  55.3%  [control]
 only_path_len      53.9%    55.3%     73.4%   71.8%  28.2%  57.9%  53.9%  57.9%  [control]
 only_bbox_h        53.1%    57.5%     41.7%   65.4%  30.8%  52.6%  61.8%  55.3%  [control]
@@ -25,6 +27,8 @@ only_bbox_h        53.1%    57.5%     41.7%   65.4%  30.8%  52.6%  61.8%  55.3% 
 refit              54.7%  vs  54.7%    +0.0 pp
 iter1              50.0%  vs  54.7%    -4.7 pp
 iter2              68.5%  vs  54.7%   +13.8 pp
+safe               54.4%  vs  54.7%    -0.3 pp
+safe_min           54.4%  vs  54.7%    -0.3 pp
 only_bend_family   54.9%  vs  54.7%    +0.3 pp  [control]
 only_path_len      53.9%  vs  54.7%    -0.8 pp  [control]
 only_bbox_h        53.1%  vs  54.7%    -1.6 pp  [control]
@@ -37,6 +41,8 @@ authored_no_gap    65.4%  (n=68)
 refit              63.2%  (n=68)
 iter1              54.4%  (n=68)
 iter2              70.6%  (n=68)
+safe               62.5%  (n=68)
+safe_min           62.5%  (n=68)
 only_bend_family   64.0%  (n=68)  [control]
 only_path_len      46.3%  (n=68)  [control]
 only_bbox_h        48.5%  (n=68)  [control]
@@ -47,15 +53,125 @@ abstentions and shared hits cannot manufacture a margin
 refit             wins  22  losses  22  n= 44  p=1.0000
 iter1             wins  56  losses  63  n=119  p=0.5825
 iter2             wins  98  losses  50  n=148  p=0.0001
+safe              wins  22  losses  22  n= 44  p=1.0000
+safe_min          wins  22  losses  22  n= 44  p=1.0000
 only_bend_family  wins  23  losses  22  n= 45  p=1.0000  [control]
 only_path_len     wins  74  losses  63  n=137  p=0.3930  [control]
 only_bbox_h       wins  62  losses  61  n=123  p=1.0000  [control]
+
+=== safety: where the box constraint lands ===
+a weight resting at exactly 0 means the constraint is ACTIVE: the
+unconstrained fit wanted the opposite sign, so pinning the term and
+dropping it from the feature set give identical predictions
+-- safe
+   pinned >= 0        8/8
+   left free          (none)
+   constraint ACTIVE  bbox_h, crossings, path_len_per_route
+   score bound        score >= 0.00
+-- safe_min
+   pinned >= 0        6/8
+   left free          non_45_frac, marker_crowding
+   constraint ACTIVE  bbox_h, crossings, path_len_per_route
+   score bound        score >= 0.00
+
+=== reach and direction, per admissible feature ===
+moves = directional pairs whose delta is non-zero; agrees = share of the
+fixtures it moves on where it DECREASED, i.e. where 'more is worse' is
+the right reading. Fixture-grouped, so one repetitive map cannot speak
+for the corpus. This is the whole mechanism behind the constrained
+arms: reach and correct direction sit on disjoint sets of features.
+feature                       moves   reach   agrees  verdict
+detour_mean                     149   77.6%    50.7%
+path_len_per_station            141   73.4%    33.8%  reach, wrong direction
+path_len_per_route              141   73.4%    33.8%  reach, wrong direction
+bbox_h                           80   41.7%    26.0%  reach, wrong direction
+detour_max                       76   39.6%    53.5%
+crossings_per_route              42   21.9%    48.0%  reach, wrong direction
+crossings                        42   21.9%    48.0%  reach, wrong direction
+turn_angle_per_route             29   15.1%    69.6%  direction, no reach
+corners_total                    19    9.9%    93.8%  direction, no reach
+bends_per_route                  19    9.9%    93.8%  direction, no reach
+non_45_frac                      17    8.9%    50.0%
+bbox_w                           16    8.3%    33.3%
+non_45_segments                  11    5.7%    77.8%  direction, no reach
+lone_diagonals_per_route         10    5.2%    87.5%  direction, no reach
+lone_diagonals                   10    5.2%    87.5%  direction, no reach
+max_bends_one_route               4    2.1%   100.0%  direction, no reach
+marker_crowding                   3    1.6%   100.0%  direction, no reach
+lane_gap_excess                   3    1.6%     0.0%
+exit_port_misalignment            3    1.6%   100.0%  direction, no reach
+near_horizontal_frac              2    1.0%    50.0%
+near_horizontal                   2    1.0%    50.0%
+
+=== why the reachy terms point the wrong way ===
+Every directional row is a DEFECT REPAIR -- an issue fix, or an xfail
+registry entry clearing -- so the `after` side is always a map whose
+defect the engine had just learned to avoid. Repairs cost space: a curve
+gets its full radius of runway, a port gets its own lane, two sections
+are pushed apart. So on this corpus the preferred layout is usually the
+LONGER and TALLER one. That is a true statement about repairs and not a
+statement that space is good, but a pairwise fit cannot tell the two
+apart, and it is the entire reason the extent and length weights come
+out negative.
+Label source of the directional rows:
+  issue_fix                 181
+  xfail_cleared              11
+
+=== decision simulation: what a search driven by each arm would offer ===
+over the 192 directional pairs, where a human preferred the `after`
+arrangement. `surfaced` is the arm ranking that arrangement first, so a
+search would offer it; `wasted` is it ranking the rejected arrangement
+first, costing one human review; `silent` is an abstention, where the
+search has nothing to say and the engine's own output stands.
+greedy is the status quo: no ranking at all, so it is silent throughout.
+arm                 surfaced  wasted  silent  useful:wasted
+greedy                     0       0     192            n/a
+authored                  43      25     124         1.72:1
+authored_no_gap           43      22     127         1.95:1
+refit                     43      25     124         1.72:1
+iter1                     60      60      72         1.00:1
+iter2                    126      55      11         2.29:1
+safe                      23       6     163         3.83:1
+safe_min                  23       6     163         3.83:1
+only_bend_family          24       5     163         4.80:1  [control]
+only_path_len             78      63      51         1.24:1  [control]
+only_bbox_h               46      34     112         1.35:1  [control]
+
+=== the same arms over the ratified-neutral rows ===
+`pr_signoff` rows mean 'no changed render in this PR was blocking', so
+neither ranking is harmful here and this is not a second waste column.
+An arm preferring `before` would have declined a change that turned out
+fine, which costs a candidate and nothing else; preferring `after`
+agrees with a change that was ratified. Scored with each arm's
+full-data weights, which never saw these rows in training.
+arm                   agreed  declined  silent
+authored                 184       172     604
+authored_no_gap          159       142     659
+refit                    205       151     604
+iter1                    372       412     176
+iter2                    514       417      29
+safe                     140       109     711
+safe_min                 140       109     711
+only_bend_family         130       107     723  [control]
+only_path_len            448       398     114  [control]
+only_bbox_h              201        87     672  [control]
+
+=== what none of the above measures ===
+The corpus has no candidate SETS. Every row is two arrangements of one
+map, produced by two engine revisions, and the measurement is whether
+an arm orders that pair the way a human did. A search (#1589) would
+instead rank many arrangements generated at one revision, most of them
+unlike anything in this corpus, and would be free to seek out whichever
+region of the score it likes best. A good useful:wasted number above is
+therefore evidence about ordering two known layouts, and NOT evidence
+that ranking generated alternatives will work.
 
 === how many features move within a single pair ===
 a sparse objective abstains; when it does speak, usually one term moves,
 so the weight on that term cannot change the predicted direction
   authored (7 features)   0:124  1:40  2:18  3:8  4:2
   iter2 (8 features)      0:11  1:72  2:67  3:22  4:10  5:8  6:1  7:1
+  safe (8 features)       0:15  1:79  2:62  3:19  4:7  5:8  6:1  7:1
 
 === fitted weights (rescaled so bends_per_route = 3.0) ===
 positive = more of this is worse, matching the authored convention
@@ -83,6 +199,24 @@ positive = more of this is worse, matching the authored convention
    crossings                   -0.01   (authored 0.25)
    min_marker_gap              -0.00   (not authored) SIGN FLIPS ACROSS FOLDS
    bbox_h                      -0.00   (not authored) SIGN FLIPS ACROSS FOLDS
+-- safe
+   lone_diagonals_per_route   +16.38   (not authored)
+   turn_angle_per_route        +3.63   (authored 2.00)
+   bends_per_route             +3.00   (authored 3.00)
+   non_45_frac                 +1.87   (not authored)
+   marker_crowding             +1.56   (authored 2.00)
+   bbox_h                      +0.00   (not authored)
+   path_len_per_route          +0.00   (not authored)
+   crossings                   +0.00   (authored 0.25)
+-- safe_min
+   lone_diagonals_per_route   +16.38   (not authored)
+   turn_angle_per_route        +3.63   (authored 2.00)
+   bends_per_route             +3.00   (authored 3.00)
+   non_45_frac                 +1.87   (not authored) SIGN FLIPS ACROSS FOLDS
+   marker_crowding             +1.56   (authored 2.00)
+   bbox_h                      +0.00   (not authored)
+   path_len_per_route          +0.00   (not authored)
+   crossings                   +0.00   (authored 0.25)
 -- only_bend_family
    turn_angle_per_route        +4.17   (authored 2.00)
    bends_per_route             +3.00   (authored 3.00)
@@ -98,6 +232,8 @@ authored              50.0% (n=16)    55.8% (n=26)    53.1% (n=16)    56.2% (n=4
 refit                 43.8% (n=16)    51.9% (n=26)    59.4% (n=16)    58.8% (n=40)    58.8% (n=40)    55.9% (n=93)
 iter1                 56.2% (n=16)    23.1% (n=26)    71.9% (n=16)    51.2% (n=40)    63.7% (n=40)    47.3% (n=93)
 iter2                 65.6% (n=16)    76.9% (n=26)    75.0% (n=16)    85.0% (n=40)    80.0% (n=40)    61.3% (n=93)
+safe                  46.9% (n=16)    53.8% (n=26)    56.2% (n=16)    58.8% (n=40)    57.5% (n=40)    54.3% (n=93)
+safe_min              46.9% (n=16)    53.8% (n=26)    56.2% (n=16)    58.8% (n=40)    57.5% (n=40)    54.3% (n=93)
 only_bend_family      53.1% (n=16)    53.8% (n=26)    56.2% (n=16)    58.8% (n=40)    57.5% (n=40)    54.3% (n=93)
 only_path_len         37.5% (n=16)    51.9% (n=26)    78.1% (n=16)    58.8% (n=40)    70.0% (n=40)    49.5% (n=93)
 only_bbox_h           53.1% (n=16)    55.8% (n=26)    59.4% (n=16)    63.7% (n=40)    60.0% (n=40)    47.3% (n=93)
@@ -108,6 +244,8 @@ authored               55.0% (n=129)      54.0% (n=63)
 refit                  54.3% (n=129)      55.6% (n=63)
 iter1                  52.7% (n=129)      44.4% (n=63)
 iter2                  71.7% (n=129)      61.9% (n=63)
+safe                   54.7% (n=129)      54.0% (n=63)
+safe_min               54.7% (n=129)      54.0% (n=63)
 only_bend_family       55.4% (n=129)      54.0% (n=63)
 only_path_len          57.8% (n=129)      46.0% (n=63)
 only_bbox_h            56.2% (n=129)      46.8% (n=63)
@@ -118,3 +256,5 @@ arm                  without      with    delta
 refit              54.7% 56.2%    +1.6 pp
 iter1              50.0% 48.4%    -1.6 pp
 iter2              68.5% 63.3%    -5.2 pp
+safe               54.4% 53.6%    -0.8 pp
+safe_min           54.4% 53.6%    -0.8 pp

--- a/datasets/layout_preferences/iter2_weights.json
+++ b/datasets/layout_preferences/iter2_weights.json
@@ -7,7 +7,9 @@
     "decided": 0.6961325966850829,
     "pooled": 0.6848958333333334
   },
-  "note": "Fitted to predict a pairwise preference direction, not to be minimised -- see #1587/#1588/#1589. Report the aggregate weighted delta only; per-feature contributions are not meaningful when sign_flips_across_folds is non-empty.",
+  "note": "Fitted to predict a pairwise preference direction -- see #1587/#1588/#1589. Report the aggregate weighted delta only; per-feature contributions are not meaningful when sign_flips_across_folds is non-empty. With safe_to_minimise false, a search descending this score can improve it without bound by inflating the drawing; check_objective_safety.py says through which term.",
+  "pinned_non_negative": [],
+  "safe_to_minimise": false,
   "sign_flips_across_folds": ["bbox_h", "min_marker_gap", "non_45_frac"],
   "weights": {
     "bbox_h": -0.0003657885907026656,

--- a/datasets/layout_preferences/safe_weights.json
+++ b/datasets/layout_preferences/safe_weights.json
@@ -1,0 +1,33 @@
+{
+  "anchor_feature": "bends_per_route",
+  "anchor_value": 3.0,
+  "arm": "safe",
+  "gate": {
+    "coverage": 0.15104166666666666,
+    "decided": 0.7931034482758621,
+    "pooled": 0.5442708333333334
+  },
+  "note": "Fitted to predict a pairwise preference direction -- see #1587/#1588/#1589. Report the aggregate weighted delta only; per-feature contributions are not meaningful when sign_flips_across_folds is non-empty. With safe_to_minimise false, a search descending this score can improve it without bound by inflating the drawing; check_objective_safety.py says through which term.",
+  "pinned_non_negative": [
+    "bbox_h",
+    "bends_per_route",
+    "crossings",
+    "lone_diagonals_per_route",
+    "marker_crowding",
+    "non_45_frac",
+    "path_len_per_route",
+    "turn_angle_per_route"
+  ],
+  "safe_to_minimise": true,
+  "sign_flips_across_folds": [],
+  "weights": {
+    "bbox_h": 0.0,
+    "bends_per_route": 3.0,
+    "crossings": 0.0,
+    "lone_diagonals_per_route": 16.384160278883886,
+    "marker_crowding": 1.5576456332981168,
+    "non_45_frac": 1.8747540359245198,
+    "path_len_per_route": 0.0,
+    "turn_angle_per_route": 3.626282034682665
+  }
+}

--- a/datasets/layout_preferences/safety_report.txt
+++ b/datasets/layout_preferences/safety_report.txt
@@ -1,0 +1,57 @@
+=== structural check ===
+a score whose features are all non-negative and whose weights are all
+non-negative is bounded below by zero, so no input improves it without
+bound. Anything listed under an arm is a way to break that.
+-- iter2: UNSAFE
+     bbox_h: weight -0.000366 rewards a feature that is unbounded above, so the score has no floor
+     crossings: weight -0.011830 rewards a feature that is unbounded above, so the score has no floor
+     min_marker_gap: larger is better and always reachable, so its useful weight is negative and the score has no floor
+     path_len_per_route: weight -0.011891 rewards a feature that is unbounded above, so the score has no floor
+-- safe: SAFE
+
+=== growth probe: the same map at rising spacing ===
+x_spacing and y_spacing are a CLI flag and a %%metro directive, so this
+is a reachable input. Every row below is the SAME map with the grid
+multiplied: bends per route hold while extent and path length rise in
+proportion. A score that falls down a column is one a search could
+minimise by inflating the drawing, and nothing about 8x ends the fall --
+the growth terms are linear in the multiple.
+-- examples/rnaseq_sections.mmd
+      x    bbox_h  path/route   bends  cross       score:iter2        score:safe
+     1x       502         103    0.59     30              5.44              8.90
+     2x       642         174    0.59     30              4.76              9.19
+     4x      1122         332    0.59     28              2.96              9.48
+     8x      2082         659    0.59     28             -1.16              9.63
+     1x -> 8x change: iter2 -6.61 safe +0.73
+-- examples/rnaseq_auto.mmd
+      x    bbox_h  path/route   bends  cross       score:iter2        score:safe
+     1x       399          89    0.35      0              2.73              4.93
+     2x       558         142    0.35      0              2.16              5.11
+     4x       958         255    0.35      0              0.80              5.28
+     8x      1758         507    0.35      0             -2.42              5.37
+     1x -> 8x change: iter2 -5.15 safe +0.44
+-- examples/genomic_pipeline.mmd
+      x    bbox_h  path/route   bends  cross       score:iter2        score:safe
+     1x      1120         319    1.27    212              8.53             18.54
+     2x      1954         532    1.27    200              6.02             19.01
+     4x      3714        1047    1.27    182             -0.44             19.28
+     8x      7234        2083    1.27    180            -13.90             19.43
+     1x -> 8x change: iter2 -22.43 safe +0.88
+-- examples/topologies/fan_in_merge.mmd
+      x    bbox_h  path/route   bends  cross       score:iter2        score:safe
+     1x        79         106    0.56      0              2.61              4.87
+     2x        79         132    0.56      0              2.30              4.87
+     4x        79         185    0.56      0              1.67              4.87
+     8x        79         291    0.56      0              0.41              4.87
+     1x -> 8x change: iter2 -2.20 safe +0.00
+-- examples/topologies/convergence_fold_diamond.mmd
+      x    bbox_h  path/route   bends  cross       score:iter2        score:safe
+     1x       506          99    0.48      1              1.94              4.14
+     2x       666         146    0.48      1              1.32              4.14
+     4x       986         239    0.48      1              0.10              4.14
+     8x      1626         426    0.48      1             -2.36              4.14
+     1x -> 8x change: iter2 -4.29 safe +0.00
+
+=== verdict ===
+iter2     UNSAFE  score fell under growth on 5/5 fixtures
+safe      SAFE    score fell under growth on 0/5 fixtures

--- a/datasets/layout_preferences/scripts/build_dataset.py
+++ b/datasets/layout_preferences/scripts/build_dataset.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pair_rules import emit_anchors, emit_pairs
+from terms import SENTINEL, UNDEFINED
 
 S = Path(__file__).parent
 PAIRS = S.parent / "dataset_pairs.jsonl"
@@ -28,15 +29,6 @@ MIN_MOVED = 8
 
 FLAG_MARGIN = 0.18
 """Distance from chance at which the grouped reading is called discriminative."""
-
-SENTINEL = frozenset({"min_marker_gap", "min_station_distance"})
-"""Features whose extractor emits ``-1.0`` for "no such measurement exists".
-
-A map with no foreign line near any marker has no minimum gap. Read as the
-number -1 the sentinel would be the tightest clearance in the corpus, inverting
-the feature, so a pair undefined at either revision contributes no movement.
-Mirrors ``fit_objective.SENTINEL``.
-"""
 
 
 def load_geometry() -> dict[str, dict]:
@@ -80,7 +72,7 @@ def moves_by_fixture(pairs: list[dict], key: str) -> dict[str, list[float]]:
         before, after = p.get("features_before"), p.get("features_after")
         if not before or not after or key not in before or key not in after:
             continue
-        if key in SENTINEL and -1.0 in (before[key], after[key]):
+        if key in SENTINEL and UNDEFINED in (before[key], after[key]):
             continue
         delta = after[key] - before[key]
         if abs(delta) > 1e-6:

--- a/datasets/layout_preferences/scripts/check_objective_safety.py
+++ b/datasets/layout_preferences/scripts/check_objective_safety.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Check a fitted objective cannot be improved without bound, and demonstrate it.
+
+Two halves, because either alone is weak evidence:
+
+**Structural.** Every feature the objective reads is looked up in
+``terms.ADMISSIBILITY``, and every weight that needs pinning for boundedness is
+checked against its sign. An objective whose features are all non-negative and
+whose weights are all non-negative is bounded below by zero, so no input can
+drive it arbitrarily low. This is a proof about the weights, and it is cheap.
+
+**Empirical.** The proof only binds if the classification is right, so the growth
+transform is also *run*, through the real engine. ``x_spacing`` and ``y_spacing``
+are ordinary knobs -- a CLI flag and a ``%%metro`` directive -- so uniformly
+inflating a drawing is a reachable input rather than a thought experiment. Each
+fixture is laid out at rising multiples of the default spacing and rescored. An
+unsafe objective's score falls as the multiple rises, without limit; a safe one's
+cannot fall.
+
+Usage:
+
+    python scripts/check_objective_safety.py --out ../safety_report.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+if str(REPO / "src") not in sys.path:
+    sys.path.insert(0, str(REPO / "src"))
+
+import extract_features  # noqa: E402
+import terms  # noqa: E402
+
+X_SPACING_DEFAULT = 60.0
+Y_SPACING_DEFAULT = 40.0
+"""The spacing a plain ``nf-metro render`` uses, and the base of the multiples."""
+
+MULTIPLES = (1, 2, 4, 8)
+"""Uniform growth factors applied to both spacings.
+
+Near-similar drawings: the same map with every lane pitch and column stride
+multiplied, so the extent and length features rise while the topology holds. It
+is not *exactly* a similarity transform, because label boxes and station markers
+keep their absolute size while the grid around them grows, so the angle terms
+drift by a little and a crossing or two can resolve. What isolates the growth
+terms is that the extent and length features are the only ones that rise in
+proportion.
+"""
+
+PROBE_FIXTURES = (
+    "examples/rnaseq_sections.mmd",
+    "examples/rnaseq_auto.mmd",
+    "examples/genomic_pipeline.mmd",
+    "examples/topologies/fan_in_merge.mmd",
+    "examples/topologies/convergence_fold_diamond.mmd",
+)
+"""Maps to inflate. A mix of hand-gridded, auto-laid-out and synthetic."""
+
+
+def load_artifact(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+# --------------------------------------------------------------------------- #
+# Structural
+# --------------------------------------------------------------------------- #
+
+
+def structural_findings(weights: dict[str, float]) -> list[str]:
+    """Every reason this weight vector is not bounded below, or an empty list."""
+    return [
+        f"{key}: {reason}"
+        for key, reason in sorted(terms.unbounded_below(weights).items())
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Empirical
+# --------------------------------------------------------------------------- #
+
+
+def vector_at(text: str, multiple: int) -> dict[str, float]:
+    """One fixture's feature vector, laid out at ``multiple`` times the spacing."""
+    from nf_metro.layout import compute_layout
+    from nf_metro.layout.routing import compute_station_offsets, route_edges_centred
+    from nf_metro.parser import parse_metro_mermaid
+
+    graph = parse_metro_mermaid(text)
+    compute_layout(
+        graph,
+        x_spacing=X_SPACING_DEFAULT * multiple,
+        y_spacing=Y_SPACING_DEFAULT * multiple,
+    )
+    offsets = compute_station_offsets(graph)
+    routes = route_edges_centred(graph, station_offsets=offsets)
+    return extract_features.features(graph, routes)
+
+
+def score(weights: dict[str, float], vector: dict[str, float]) -> float:
+    """Absolute score of one layout: what a minimising search would descend."""
+    readable = terms.readable(vector)
+    return sum(
+        weight * value
+        for key, weight in weights.items()
+        if (value := readable.get(key)) is not None
+    )
+
+
+def growth_probe(fixtures: tuple[str, ...], arms: dict[str, dict[str, float]]) -> dict:
+    """Score every fixture at every growth multiple, under every arm."""
+    out: dict[str, dict] = {}
+    for rel in fixtures:
+        path = REPO / rel
+        if not path.exists():
+            out[rel] = {"error": "missing"}
+            continue
+        text = path.read_text()
+        rows: dict[int, dict[str, float]] = {}
+        try:
+            for multiple in MULTIPLES:
+                vector = vector_at(text, multiple)
+                rows[multiple] = {
+                    "bbox_h": vector["bbox_h"],
+                    "path_len_per_route": vector["path_len_per_route"],
+                    "bends_per_route": vector["bends_per_route"],
+                    "crossings": vector["crossings"],
+                    **{f"score:{arm}": score(w, vector) for arm, w in arms.items()},
+                }
+        except Exception as exc:  # noqa: BLE001 - a fixture that will not lay out
+            out[rel] = {"error": f"{type(exc).__name__}: {exc}"[:160]}
+            continue
+        out[rel] = {"rows": rows}
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Report
+# --------------------------------------------------------------------------- #
+
+
+def report(arms: dict[str, dict[str, float]], probe: dict) -> str:
+    out: list[str] = []
+    add = out.append
+
+    add("=== structural check ===")
+    add("a score whose features are all non-negative and whose weights are all")
+    add("non-negative is bounded below by zero, so no input improves it without")
+    add("bound. Anything listed under an arm is a way to break that.")
+    for name, weights in arms.items():
+        findings = structural_findings(weights)
+        add(f"-- {name}: {'UNSAFE' if findings else 'SAFE'}")
+        for finding in findings:
+            add(f"     {finding}")
+
+    add("")
+    add("=== growth probe: the same map at rising spacing ===")
+    add("x_spacing and y_spacing are a CLI flag and a %%metro directive, so this")
+    add("is a reachable input. Every row below is the SAME map with the grid")
+    add("multiplied: bends per route hold while extent and path length rise in")
+    add("proportion. A score that falls down a column is one a search could")
+    add("minimise by inflating the drawing, and nothing about 8x ends the fall --")
+    add("the growth terms are linear in the multiple.")
+    arm_names = list(arms)
+    for rel, record in probe.items():
+        add(f"-- {rel}")
+        if "error" in record:
+            add(f"     skipped: {record['error']}")
+            continue
+        head = (
+            f"{'x':>4}{'bbox_h':>10}{'path/route':>12}{'bends':>8}{'cross':>7}"
+            + "".join(f"{'score:' + n:>18}" for n in arm_names)
+        )
+        add("   " + head)
+        first: dict[str, float] = {}
+        for multiple, row in record["rows"].items():
+            cells = (
+                f"{str(multiple) + 'x':>4}{row['bbox_h']:>10.0f}"
+                f"{row['path_len_per_route']:>12.0f}{row['bends_per_route']:>8.2f}"
+                f"{row['crossings']:>7.0f}"
+            )
+            for name in arm_names:
+                value = row[f"score:{name}"]
+                first.setdefault(name, value)
+                cells += f"{value:>18.2f}"
+            add("   " + cells)
+        last = record["rows"][MULTIPLES[-1]]
+        moved = " ".join(
+            f"{name} {last[f'score:{name}'] - first[name]:+.2f}" for name in arm_names
+        )
+        add(f"     {MULTIPLES[0]}x -> {MULTIPLES[-1]}x change: {moved}")
+
+    add("")
+    add("=== verdict ===")
+    for name, weights in arms.items():
+        findings = structural_findings(weights)
+        moved = [
+            rec["rows"][MULTIPLES[-1]][f"score:{name}"]
+            - rec["rows"][MULTIPLES[0]][f"score:{name}"]
+            for rec in probe.values()
+            if "rows" in rec
+        ]
+        fell = sum(1 for d in moved if d < -1e-9)
+        add(
+            f"{name:<10}{'UNSAFE' if findings else 'SAFE':<8}"
+            f"score fell under growth on {fell}/{len(moved)} fixtures"
+        )
+
+    return "\n".join(out) + "\n"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--weights",
+        action="append",
+        default=None,
+        metavar="NAME=PATH",
+        help="a weights artifact to check; repeatable. Defaults to the two "
+        "committed ones.",
+    )
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args()
+
+    specs = args.weights or [
+        f"iter2={HERE.parent / 'iter2_weights.json'}",
+        f"safe={HERE.parent / 'safe_weights.json'}",
+    ]
+    arms = {}
+    for spec in specs:
+        name, _, path = spec.partition("=")
+        arms[name] = load_artifact(Path(path))["weights"]
+
+    text = report(arms, growth_probe(PROBE_FIXTURES, arms))
+    print(text, end="")
+    if args.out:
+        args.out.write_text(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/datasets/layout_preferences/scripts/fit_objective.py
+++ b/datasets/layout_preferences/scripts/fit_objective.py
@@ -1,23 +1,32 @@
 #!/usr/bin/env python3
 """Fit a pairwise layout objective and gate it against the hand-binned weights.
 
-The question this answers is narrow: does *fitting* weights add anything beyond
-reading the univariate directional measurements and binning the weights by hand,
-as `scripts/optimize_layout.py` currently does?
+Two questions, both narrow, answered on identical fixture-grouped splits.
 
-Four candidate arms are compared on identical fixture-grouped splits:
+**Does fitting weights add anything** beyond reading the univariate directional
+measurements and binning the weights by hand, as `scripts/optimize_layout.py`
+does? (#1586)
 
-| arm        | features                 | weights     |
-| ---------- | ------------------------ | ----------- |
-| `authored` | the authored objective's | hand-binned |
-| `refit`    | the authored objective's | fitted      |
-| `iter1`    | discriminative subset    | fitted      |
-| `iter2`    | second subset            | fitted      |
+**Is any of it safe to minimise** -- can a search descending the score improve it
+without bound? (#1588)
 
-`refit` is the arm that isolates the question. It sees exactly the information
-the authored objective sees, so any gap between it and `authored` is
-attributable to the weights alone, and any gap between it and `iter1`/`iter2`
-is attributable to the feature choice.
+| arm        | features                 | weights                    |
+| ---------- | ------------------------ | -------------------------- |
+| `authored` | the authored objective's | hand-binned                |
+| `refit`    | the authored objective's | fitted                     |
+| `iter1`    | discriminative subset    | fitted                     |
+| `iter2`    | second subset            | fitted                     |
+| `safe`     | `iter2`, terms repaired  | fitted, every weight >= 0  |
+| `safe_min` | `iter2`, terms repaired  | fitted, unbounded terms >=0 |
+
+`refit` isolates the first question. It sees exactly the information the
+authored objective sees, so any gap between it and `authored` is attributable to
+the weights alone, and any gap between it and `iter1`/`iter2` is attributable to
+the feature choice.
+
+`safe` and `safe_min` isolate the second. Both read `SAFE_FEATURES`, so any gap
+between them and `iter2` is the cost of the constraint and nothing else; the pair
+differ only in how much of the box safety actually requires.
 
 `CONTROL_SETS` adds deliberately impoverished arms alongside these. They exist
 to be beaten: a candidate whose margin a one-feature control reproduces has not
@@ -26,6 +35,8 @@ measured layout quality.
 Usage:
 
     python scripts/fit_objective.py --out ../fit_report.txt
+    python scripts/fit_objective.py --dump-weights safe \
+        --weights-out ../safe_weights.json
 """
 
 from __future__ import annotations
@@ -33,20 +44,18 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import sys
 from collections import Counter
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+import terms  # noqa: E402
+
 DATASET = HERE.parent / "dataset_pairs.jsonl"
-
-Y_SPACING = 40.0
-"""One lane pitch, mirroring ``nf_metro.layout.constants.Y_SPACING``.
-
-Hardcoded so this script stays importable without the package, matching the
-rest of the generating pipeline.  ``marker_crowding`` is the only feature that
-needs it.
-"""
 
 INERT = frozenset(
     {
@@ -64,14 +73,8 @@ INERT = frozenset(
     }
 )
 
-SENTINEL = frozenset({"min_marker_gap", "min_station_distance"})
-"""Features whose extractor emits ``-1.0`` for "no such measurement exists".
-
-A map with no foreign line near any marker has no minimum gap.  Treating the
-sentinel as the number -1 would read as the tightest possible clearance, which
-inverts the feature, so a pair is given a zero delta on that feature instead:
-undefined on either side means the feature says nothing about this preference.
-"""
+SENTINEL = terms.SENTINEL
+"""Re-exported so a reader of this module sees which features carry one."""
 
 
 AUTHORED_WEIGHTS = {
@@ -131,6 +134,44 @@ FEATURE_SETS = {
     ],
 }
 
+SAFE_FEATURES = [
+    "lone_diagonals_per_route",
+    "bends_per_route",
+    "turn_angle_per_route",
+    "non_45_frac",
+    "marker_crowding",
+    "bbox_h",
+    "path_len_per_route",
+    "crossings",
+]
+"""`iter2`'s features, with the one inadmissible term replaced by its repair.
+
+`iter2` reads `min_marker_gap` raw, which is `terms.ANTITONE`: more clearance is
+better and clearance is always wideable, so the negative weight the fit gives it
+is a reward for spreading the drawing out. `terms.DERIVED` turns it into
+`marker_crowding`, which saturates at one lane pitch. Every other term is
+`terms.ADMISSIBLE`, so a non-negative weight on it can only penalise.
+"""
+
+SAFE_ARMS = {
+    # Every weight pinned. The score is then a non-negative combination of
+    # non-negative terms, so it is bounded below by zero.
+    "safe": frozenset(SAFE_FEATURES),
+    # The *weakest* constraint that still bounds the score below: only the terms
+    # that are unbounded above are pinned, leaving the two confined to [0, 1]
+    # free to take whatever sign the data wants. Included so a collapse in
+    # `safe` cannot be attributed to constraining more than safety requires --
+    # if `safe_min` collapses too, the constraint is not the thing to relax.
+    "safe_min": frozenset(terms.must_be_non_negative(SAFE_FEATURES)),
+}
+"""The constrained arms, keyed by name and valued by which weights are pinned.
+
+Excluding the growth features outright, the third option #1588 lists, is not a
+separate arm: a feature pinned at exactly zero and a feature absent from the set
+produce identical predictions, and the report states whether the constraint
+lands on the boundary.
+"""
+
 CONTROL_SETS = {
     # Controls, not candidates. Each is too impoverished to be a real objective,
     # so if one matches a candidate arm's agreement then that arm's margin is not
@@ -167,6 +208,14 @@ REAL_PIPELINES = (
 
 N_FOLDS = 5
 
+FITTED_ARMS = ("refit", *FEATURE_SETS, *SAFE_ARMS)
+CANDIDATE_ARMS = ("authored", "authored_no_gap", *FITTED_ARMS)
+
+ADMISSIBLE_COLUMNS = frozenset(
+    k for k, v in terms.ADMISSIBILITY.items() if v == terms.ADMISSIBLE
+)
+"""Columns a minimisable score may read; see ``terms.ADMISSIBILITY``."""
+
 
 # --------------------------------------------------------------------------- #
 # Data
@@ -175,17 +224,7 @@ N_FOLDS = 5
 
 def derive(vec: dict[str, float]) -> dict[str, float | None]:
     """Copy a feature vector, masking sentinels and adding derived columns."""
-    out: dict[str, float | None] = {
-        k: (None if k in SENTINEL and v == -1.0 else v) for k, v in vec.items()
-    }
-    gap = out.get("min_marker_gap")
-    # A penalty for tight clearance that never pays for loose clearance, so the
-    # term cannot be minimised by spreading the map out.  Mirrors
-    # `optimize_layout.marker_crowding`.
-    out["marker_crowding"] = (
-        None if gap is None else max(0.0, Y_SPACING - gap) / Y_SPACING
-    )
-    return out
+    return terms.readable(vec)
 
 
 class Pair:
@@ -330,6 +369,7 @@ def fit(
     l2: float = 1.0,
     iters: int = 50,
     tol: float = 1e-9,
+    nonneg: frozenset[str] = frozenset(),
 ) -> dict[str, float]:
     """Fit a Bradley-Terry / logistic model over feature deltas.
 
@@ -340,6 +380,18 @@ def fit(
 
     Ridge-penalised Newton steps, since a handful of features over a couple of
     hundred rows makes the exact Hessian cheaper than tuning a step size.
+
+    ``nonneg`` names the features whose weight is confined to ``>= 0``, by
+    projected Newton: the step is solved over the free coordinates only, then
+    the named coordinates are clamped, and one resting at zero is released again
+    only when the loss gradient there is negative (so moving it positive would
+    help).  The per-feature RMS rescaling below is by a positive constant, so a
+    weight non-negative in scaled space is non-negative in raw space too.
+
+    A box constraint is the point of this arm rather than a detail of it: the
+    unconstrained fit is free to put a *negative* weight on a term that grows
+    without bound, and that is what makes a score unsafe to minimise. See
+    :data:`SAFE_FEATURES`.
     """
     scales = []
     for key in keys:
@@ -353,6 +405,8 @@ def fit(
     ]
     total = sum(w for _, w in rows) or 1.0
     n = len(keys)
+
+    pinned = frozenset(i for i, k in enumerate(keys) if k in nonneg)
 
     w = [0.0] * n
     for _ in range(iters):
@@ -373,9 +427,24 @@ def fit(
         for i in range(n):
             for j in range(i):
                 hess[i][j] = hess[j][i]
-        step = _solve(hess, grad)
-        w = [wj - sj for wj, sj in zip(w, step)]
-        if max(abs(s) for s in step) < tol:
+
+        # A pinned coordinate resting on the boundary with a non-negative
+        # gradient is at its optimum and drops out of the step; every other
+        # coordinate is free.
+        free = [i for i in range(n) if i not in pinned or w[i] > 0.0 or grad[i] < 0.0]
+        if not free:
+            break
+        reduced = _solve(
+            [[hess[i][j] for j in free] for i in free], [grad[i] for i in free]
+        )
+        step = [0.0] * n
+        for i, s in zip(free, reduced):
+            step[i] = s
+        w = [
+            max(0.0, wj - sj) if i in pinned else wj - sj
+            for i, (wj, sj) in enumerate(zip(w, step))
+        ]
+        if max(abs(step[i]) for i in free) < tol:
             break
 
     return {k: wj / s for k, wj, s in zip(keys, w, scales)}
@@ -465,7 +534,11 @@ def cross_validate(
     authored_keys = list(AUTHORED_WEIGHTS)
     no_gap = {k: v for k, v in AUTHORED_WEIGHTS.items() if k != SCALE_MISMATCHED}
 
-    fitted_sets = {**FEATURE_SETS, **CONTROL_SETS}
+    fitted_sets = {
+        **FEATURE_SETS,
+        **{name: SAFE_FEATURES for name in SAFE_ARMS},
+        **CONTROL_SETS,
+    }
     arms = {
         name: Arm() for name in ("authored", "authored_no_gap", "refit", *fitted_sets)
     }
@@ -486,7 +559,8 @@ def cross_validate(
             ]
         arms["refit"].record(test, fit(train_rows, authored_keys))
         for name, keys in fitted_sets.items():
-            arms[name].record(test, fit(train_rows, keys))
+            pins = SAFE_ARMS.get(name, frozenset())
+            arms[name].record(test, fit(train_rows, keys, nonneg=pins))
 
     # Weights for inspection come from a fit on everything; the fold weights
     # kept on each arm are what the spread check reads.
@@ -497,7 +571,7 @@ def cross_validate(
     arms["authored_no_gap"].weights = dict(no_gap)
     arms["refit"].weights = fit(full, authored_keys)
     for name, keys in fitted_sets.items():
-        arms[name].weights = fit(full, keys)
+        arms[name].weights = fit(full, keys, nonneg=SAFE_ARMS.get(name, frozenset()))
     return arms
 
 
@@ -516,6 +590,16 @@ def binomial_two_sided(successes: int, trials: int) -> float:
         return float("nan")
     tail = sum(math.comb(trials, k) for k in range(successes + 1))
     return min(1.0, 2 * tail / 2**trials)
+
+
+def _score_bound(weights: dict[str, float]) -> str:
+    """``terms.lower_bound`` as a line of the report."""
+    bound = terms.lower_bound(weights)
+    if bound is None:
+        return "UNBOUNDED BELOW via " + ", ".join(
+            sorted(terms.unbounded_below(weights))
+        )
+    return f"score >= {bound:.2f}"
 
 
 def report(
@@ -543,14 +627,12 @@ def report(
     for key, count in sorted(zeroed.items()):
         add(f"    {key}: {count}/{len(directional)}")
 
-    candidates = ("authored", "authored_no_gap", "refit", *FEATURE_SETS)
-
     add("")
     add(f"=== fixture-grouped {N_FOLDS}-fold agreement ===")
     add("pooled counts an abstention as half a hit; decided excludes abstentions")
     add(f"{'arm':<18}{'pooled':>8}{'decided':>9}{'coverage':>10}  per fold (pooled)")
     baseline_pooled, _ = arms["authored"].pooled()
-    for name in (*candidates, *CONTROL_SETS):
+    for name in (*CANDIDATE_ARMS, *CONTROL_SETS):
         arm = arms[name]
         pooled, _ = arm.pooled()
         acc, coverage = arm.decided()
@@ -560,7 +642,7 @@ def report(
 
     add("")
     add("=== margin over the hand-binned authored objective ===")
-    for name in ("refit", *FEATURE_SETS, *CONTROL_SETS):
+    for name in (*FITTED_ARMS, *CONTROL_SETS):
         pooled, _ = arms[name].pooled()
         delta = (pooled - baseline_pooled) * 100
         marker = "  [control]" if name in CONTROL_SETS else ""
@@ -575,7 +657,7 @@ def report(
     add("flatter either side")
     ref = arms["authored"].by_pair()
     decided_ids = {i for i, d in ref.items() if abs(d) >= TIE}
-    for name in (*candidates, *CONTROL_SETS):
+    for name in (*CANDIDATE_ARMS, *CONTROL_SETS):
         arm = arms[name]
         rows = [d for i, d in arm.by_pair().items() if i in decided_ids]
         marker = "  [control]" if name in CONTROL_SETS else ""
@@ -585,7 +667,7 @@ def report(
     add("=== paired sign test against `authored`, over all held-out pairs ===")
     add("counts only the pairs the two arms disagree on, so the shared")
     add("abstentions and shared hits cannot manufacture a margin")
-    for name in ("refit", *FEATURE_SETS, *CONTROL_SETS):
+    for name in (*FITTED_ARMS, *CONTROL_SETS):
         wins = losses = 0
         for i, delta in arms[name].by_pair().items():
             mine, theirs = hit(delta), hit(ref[i])
@@ -601,12 +683,126 @@ def report(
         )
 
     add("")
+    add("=== safety: where the box constraint lands ===")
+    add("a weight resting at exactly 0 means the constraint is ACTIVE: the")
+    add("unconstrained fit wanted the opposite sign, so pinning the term and")
+    add("dropping it from the feature set give identical predictions")
+    for name, pins in SAFE_ARMS.items():
+        arm = arms[name]
+        free = [k for k in SAFE_FEATURES if k not in pins]
+        active = sorted(k for k in pins if abs(arm.weights.get(k, 0.0)) < TIE)
+        add(f"-- {name}")
+        add(f"   pinned >= 0        {len(pins)}/{len(SAFE_FEATURES)}")
+        add(f"   left free          {', '.join(free) or '(none)'}")
+        add(f"   constraint ACTIVE  {', '.join(active) or '(none)'}")
+        add(f"   score bound        {_score_bound(arm.weights)}")
+
+    add("")
+    add("=== reach and direction, per admissible feature ===")
+    add("moves = directional pairs whose delta is non-zero; agrees = share of the")
+    add("fixtures it moves on where it DECREASED, i.e. where 'more is worse' is")
+    add("the right reading. Fixture-grouped, so one repetitive map cannot speak")
+    add("for the corpus. This is the whole mechanism behind the constrained")
+    add("arms: reach and correct direction sit on disjoint sets of features.")
+    add(f"{'feature':<28}{'moves':>7}{'reach':>8}{'agrees':>9}  verdict")
+    rows_by_reach = []
+    for key in sorted(k for k in ADMISSIBLE_COLUMNS if k not in INERT):
+        moved = [p for p in directional if abs(p.delta.get(key, 0.0)) > TIE]
+        if not moved:
+            continue
+        by_fixture: dict[str, list[float]] = {}
+        for pair in moved:
+            by_fixture.setdefault(pair.fixture, []).append(pair.delta[key])
+        down = sum(
+            1
+            for deltas in by_fixture.values()
+            if sum(1 for d in deltas if d < 0) * 2 > len(deltas)
+        )
+        rows_by_reach.append(
+            (len(moved), key, len(moved) / len(directional), down / len(by_fixture))
+        )
+    for moves, key, reach, agrees in sorted(rows_by_reach, reverse=True):
+        verdict = (
+            "reach, wrong direction"
+            if reach >= 0.20 and agrees < 0.50
+            else "direction, no reach"
+            if reach < 0.20 and agrees >= 0.65
+            else ""
+        )
+        add(f"{key:<28}{moves:>7}{pct(reach):>8}{pct(agrees):>9}  {verdict}")
+
+    add("")
+    add("=== why the reachy terms point the wrong way ===")
+    add("Every directional row is a DEFECT REPAIR -- an issue fix, or an xfail")
+    add("registry entry clearing -- so the `after` side is always a map whose")
+    add("defect the engine had just learned to avoid. Repairs cost space: a curve")
+    add("gets its full radius of runway, a port gets its own lane, two sections")
+    add("are pushed apart. So on this corpus the preferred layout is usually the")
+    add("LONGER and TALLER one. That is a true statement about repairs and not a")
+    add("statement that space is good, but a pairwise fit cannot tell the two")
+    add("apart, and it is the entire reason the extent and length weights come")
+    add("out negative.")
+    add("Label source of the directional rows:")
+    for source, count in sorted(Counter(p.source for p in directional).items()):
+        add(f"  {source:<24}{count:>5}")
+
+    add("")
+    add("=== decision simulation: what a search driven by each arm would offer ===")
+    add("over the 192 directional pairs, where a human preferred the `after`")
+    add("arrangement. `surfaced` is the arm ranking that arrangement first, so a")
+    add("search would offer it; `wasted` is it ranking the rejected arrangement")
+    add("first, costing one human review; `silent` is an abstention, where the")
+    add("search has nothing to say and the engine's own output stands.")
+    add("greedy is the status quo: no ranking at all, so it is silent throughout.")
+    add(f"{'arm':<18}{'surfaced':>10}{'wasted':>8}{'silent':>8}{'useful:wasted':>15}")
+    add(f"{'greedy':<18}{0:>10}{0:>8}{len(directional):>8}{'n/a':>15}")
+    for name in (*CANDIDATE_ARMS, *CONTROL_SETS):
+        deltas = [d for _, d in arms[name].predictions]
+        surfaced = sum(1 for d in deltas if d < -TIE)
+        wasted = sum(1 for d in deltas if d > TIE)
+        silent = len(deltas) - surfaced - wasted
+        ratio = f"{surfaced / wasted:.2f}:1" if wasted else "inf"
+        marker = "  [control]" if name in CONTROL_SETS else ""
+        add(f"{name:<18}{surfaced:>10}{wasted:>8}{silent:>8}{ratio:>15}{marker}")
+
+    add("")
+    add("=== the same arms over the ratified-neutral rows ===")
+    add("`pr_signoff` rows mean 'no changed render in this PR was blocking', so")
+    add("neither ranking is harmful here and this is not a second waste column.")
+    add("An arm preferring `before` would have declined a change that turned out")
+    add("fine, which costs a candidate and nothing else; preferring `after`")
+    add("agrees with a change that was ratified. Scored with each arm's")
+    add("full-data weights, which never saw these rows in training.")
+    add(f"{'arm':<18}{'agreed':>10}{'declined':>10}{'silent':>8}")
+    for name in (*CANDIDATE_ARMS, *CONTROL_SETS):
+        deltas = [score_delta(arms[name].weights, p) for p in weak]
+        agreed = sum(1 for d in deltas if d < -TIE)
+        declined = sum(1 for d in deltas if d > TIE)
+        marker = "  [control]" if name in CONTROL_SETS else ""
+        add(
+            f"{name:<18}{agreed:>10}{declined:>10}"
+            f"{len(deltas) - agreed - declined:>8}{marker}"
+        )
+
+    add("")
+    add("=== what none of the above measures ===")
+    add("The corpus has no candidate SETS. Every row is two arrangements of one")
+    add("map, produced by two engine revisions, and the measurement is whether")
+    add("an arm orders that pair the way a human did. A search (#1589) would")
+    add("instead rank many arrangements generated at one revision, most of them")
+    add("unlike anything in this corpus, and would be free to seek out whichever")
+    add("region of the score it likes best. A good useful:wasted number above is")
+    add("therefore evidence about ordering two known layouts, and NOT evidence")
+    add("that ranking generated alternatives will work.")
+
+    add("")
     add("=== how many features move within a single pair ===")
     add("a sparse objective abstains; when it does speak, usually one term moves,")
     add("so the weight on that term cannot change the predicted direction")
     for label, keys in (
         ("authored (7 features)", list(AUTHORED_WEIGHTS)),
         ("iter2 (8 features)", FEATURE_SETS["iter2"]),
+        ("safe (8 features)", SAFE_FEATURES),
     ):
         hist = Counter(
             sum(1 for k in keys if abs(p.delta.get(k, 0.0)) > TIE) for p in directional
@@ -617,7 +813,7 @@ def report(
     add("")
     add("=== fitted weights (rescaled so bends_per_route = 3.0) ===")
     add("positive = more of this is worse, matching the authored convention")
-    for name in ("refit", *FEATURE_SETS, *CONTROL_SETS):
+    for name in (*FITTED_ARMS, *CONTROL_SETS):
         arm = arms[name]
         add(f"-- {name}")
         scaled = rescale_to(arm.weights, "bends_per_route")
@@ -634,7 +830,7 @@ def report(
     families = [fam for fam, _ in FAMILY_RULES] + ["unclassified"]
     header = f"{'arm':<18}" + "".join(f"{f:>16}" for f in families)
     add(header)
-    for name in ("authored", "refit", *FEATURE_SETS, *CONTROL_SETS):
+    for name in ("authored", *FITTED_ARMS, *CONTROL_SETS):
         arm = arms[name]
         cells = []
         for fam in families:
@@ -645,7 +841,7 @@ def report(
     add("")
     add("=== synthetic topology fixtures vs real pipeline maps ===")
     add(f"{'arm':<18}{'synthetic':>18}{'real':>18}")
-    for name in ("authored", "refit", *FEATURE_SETS, *CONTROL_SETS):
+    for name in ("authored", *FITTED_ARMS, *CONTROL_SETS):
         arm = arms[name]
         syn, n_syn = arm.subset(lambda p: not p.is_real_pipeline())
         real, n_real = arm.subset(lambda p: p.is_real_pipeline())
@@ -657,7 +853,7 @@ def report(
     add("=== ablation: weak pr_signoff rows added to training ===")
     add("set-level ratifications, weighted 0.1 against a directional row's 1.0")
     add(f"{'arm':<18}{'without':>10}{'with':>10}{'delta':>9}")
-    for name in ("refit", *FEATURE_SETS):
+    for name in FITTED_ARMS:
         base, _ = arms[name].pooled()
         aug, _ = weak_arms[name].pooled()
         add(f"{name:<18}{pct(base)}{pct(aug)}{(aug - base) * 100:+8.1f} pp")
@@ -678,15 +874,20 @@ def weights_artifact(arm: Arm, name: str) -> dict:
     prediction; it exists purely so a consumer reads the same numbers a human
     reviewing ``fit_report.txt`` does.
 
-    Carries the gate result and the sign-flip warning as data, not just prose,
-    so a consumer (the render-diff scorecard) cannot quote the weights without
-    also seeing why per-feature contributions are not meant to be surfaced.
+    Carries the gate result, the sign-flip warning and whether the weights are
+    safe to minimise as data, not just prose, so a consumer (the render-diff
+    scorecard) cannot quote the weights without also seeing what they may be
+    used for.
     """
     pooled, _ = arm.pooled()
     decided, coverage = arm.decided()
     scaled = rescale_to(arm.weights, ANCHOR_FEATURE)
     spread = arm.weight_spread()
     flips = sorted(k for k, (lo, hi) in spread.items() if lo * hi < 0)
+    pins = SAFE_ARMS.get(name, frozenset())
+    minimisable = not terms.inadmissible(scaled) and not terms.must_be_non_negative(
+        [k for k, v in scaled.items() if v < 0.0]
+    )
     return {
         "arm": name,
         "anchor_feature": ANCHOR_FEATURE,
@@ -694,11 +895,16 @@ def weights_artifact(arm: Arm, name: str) -> dict:
         "weights": scaled,
         "gate": {"pooled": pooled, "decided": decided, "coverage": coverage},
         "sign_flips_across_folds": flips,
+        "pinned_non_negative": sorted(pins),
+        "safe_to_minimise": minimisable,
         "note": (
-            "Fitted to predict a pairwise preference direction, not to be "
-            "minimised -- see #1587/#1588/#1589. Report the aggregate "
-            "weighted delta only; per-feature contributions are not "
-            "meaningful when sign_flips_across_folds is non-empty."
+            "Fitted to predict a pairwise preference direction -- see "
+            "#1587/#1588/#1589. Report the aggregate weighted delta only; "
+            "per-feature contributions are not meaningful when "
+            "sign_flips_across_folds is non-empty. With safe_to_minimise "
+            "false, a search descending this score can improve it without "
+            "bound by inflating the drawing; check_objective_safety.py says "
+            "through which term."
         ),
     }
 

--- a/datasets/layout_preferences/scripts/terms.py
+++ b/datasets/layout_preferences/scripts/terms.py
@@ -1,0 +1,275 @@
+"""How a feature vector may be read: sentinels, derived terms, admissibility.
+
+Every consumer of a vector produced by ``extract_features`` needs the same three
+rules, and each one has been got wrong somewhere at least once:
+
+1. **Two features carry a sentinel.** ``min_marker_gap`` and
+   ``min_station_distance`` emit ``-1.0`` for "no such measurement exists".
+   Read as the number -1 the sentinel is the tightest clearance in the corpus,
+   which inverts the feature.
+2. **A clearance cannot be read as a penalty directly.** More clearance is
+   better and unbounded, so a term that pays for it is minimised by spreading
+   the drawing out. It has to be turned into a saturating one-sided penalty
+   first, and the sentinel state -- no foreign segment anywhere near a marker --
+   is the *cleanest* state, so it scores zero penalty rather than the maximum.
+3. **Not every feature can appear in a score that will be minimised.** A
+   feature that is signed, or that improves as the drawing grows, makes the
+   score unbounded below however its weight is fitted. ``ADMISSIBILITY`` gives
+   every feature a verdict, so an objective assembled from it cannot silently
+   include one that has no bound.
+
+Held here rather than in ``extract_features`` because that module runs inside a
+worktree parked at a historical SHA and must stay standalone; this one is
+imported by today's consumers only.
+"""
+
+from __future__ import annotations
+
+UNDEFINED = -1.0
+"""``extract_features``'s "no such measurement exists" value."""
+
+SENTINEL = frozenset({"min_marker_gap", "min_station_distance"})
+"""Features that emit :data:`UNDEFINED`.
+
+A map with no foreign line near any marker has no minimum gap, and a map with
+fewer than two real stations has no minimum station distance.
+"""
+
+CROWDING_PITCH = 40.0
+"""One lane pitch, mirroring ``nf_metro.layout.constants.Y_SPACING``.
+
+Clearance beyond one pitch is room enough, so this is where
+:func:`marker_crowding` saturates. Hardcoded to match the literal in
+``extract_features``: a feature's meaning must not track a constant the engine
+may retune, or a vector measured today would not be comparable with one
+measured at an older revision.
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Sentinels
+# --------------------------------------------------------------------------- #
+
+
+def defined(key: str, value: float) -> float | None:
+    """``value``, or ``None`` when it is this feature's undefined sentinel."""
+    return None if key in SENTINEL and value == UNDEFINED else value
+
+
+# --------------------------------------------------------------------------- #
+# Derived terms
+# --------------------------------------------------------------------------- #
+
+
+def marker_crowding(gap: float | None) -> float:
+    """How far the nearest foreign line intrudes on a marker, as a 0..1 fraction.
+
+    One-sided and saturating, so the term penalises tight clearance without ever
+    paying for loose clearance: a term that kept paying would be minimised by
+    spreading the map out, which is the failure mode
+    :data:`ADMISSIBILITY` exists to exclude.
+
+    An absent measurement scores **zero** crowding. No foreign line coming near
+    any marker is the cleanest state a map can be in, not the worst: 104 of the
+    278 fixtures carrying a vector in the committed corpus are in it, and
+    reading their ``-1.0`` as a gap would score every one of them as maximally
+    crowded and drive a non-negative weight to penalise the fixtures with the
+    best clearance in the corpus.
+    """
+    if gap is None or gap == UNDEFINED:
+        return 0.0
+    return min(1.0, max(0.0, (CROWDING_PITCH - gap) / CROWDING_PITCH))
+
+
+DERIVED = {"marker_crowding": ("min_marker_gap", marker_crowding)}
+"""Admissible terms computed from an inadmissible feature.
+
+Keyed by the derived name, valued by the source feature and the transform. A
+consumer that wants the source's signal in a minimisable score reaches for the
+derived term instead of repairing the raw feature locally.
+"""
+
+
+def derived_values(vector: dict[str, float]) -> dict[str, float]:
+    """The :data:`DERIVED` terms this vector supports."""
+    return {
+        name: transform(defined(source, vector[source]))
+        for name, (source, transform) in DERIVED.items()
+        if source in vector
+    }
+
+
+def readable(vector: dict[str, float]) -> dict[str, float | None]:
+    """A vector with its sentinels masked and its derived terms added.
+
+    The one way to turn what the extractor emitted into what a score may read.
+    ``None`` marks a measurement that does not exist for this map, which a
+    consumer must skip rather than substitute a number for.
+    """
+    out: dict[str, float | None] = {k: defined(k, v) for k, v in vector.items()}
+    out.update(derived_values(vector))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Admissibility
+# --------------------------------------------------------------------------- #
+
+ADMISSIBLE = "admissible"
+"""Non-negative on every layout, and larger means worse.
+
+A non-negative weight on such a feature can only penalise, so a score built
+from these alone is bounded below by zero.
+"""
+
+ANTITONE = "antitone"
+"""Non-negative, but larger means *better*, so its useful weight is negative.
+
+Unbounded above -- a clearance can always be widened -- so a negative weight
+makes the score unbounded below. Only reachable through :data:`DERIVED`.
+"""
+
+SIGNED = "signed"
+"""Takes either sign, so either sign of weight is unbounded below.
+
+``aspect_log`` is ``log10(bbox_w / bbox_h)``: a negative weight buys an
+arbitrarily tall drawing and a positive one an arbitrarily wide drawing. A
+minimisable form would have to be one-sided, e.g. its magnitude.
+"""
+
+ADMISSIBILITY = {
+    # Angle and turn quality: counts and sums of positive quantities.
+    "bends_per_route": ADMISSIBLE,
+    "corners_total": ADMISSIBLE,
+    "max_bends_one_route": ADMISSIBLE,
+    "turn_angle_per_route": ADMISSIBLE,
+    "lone_diagonals": ADMISSIBLE,
+    "lone_diagonals_per_route": ADMISSIBLE,
+    "non_45_frac": ADMISSIBLE,
+    "non_45_segments": ADMISSIBLE,
+    "near_horizontal": ADMISSIBLE,
+    "near_horizontal_frac": ADMISSIBLE,
+    # Crossings and strikes: counts.
+    "crossings": ADMISSIBLE,
+    "crossings_per_route": ADMISSIBLE,
+    "marker_strikes": ADMISSIBLE,
+    "marker_strikes_per_station": ADMISSIBLE,
+    # Extent and length. Admissible but unbounded above, so these are exactly
+    # the terms whose weight sign decides whether a search can inflate the
+    # drawing for free.
+    "bbox_h": ADMISSIBLE,
+    "bbox_w": ADMISSIBLE,
+    "path_len_per_route": ADMISSIBLE,
+    "path_len_per_station": ADMISSIBLE,
+    "detour_max": ADMISSIBLE,
+    "detour_mean": ADMISSIBLE,
+    "lane_gap_excess": ADMISSIBLE,
+    "exit_port_misalignment": ADMISSIBLE,
+    # Size of the input, not of the drawing: identical on both sides of a pair
+    # by construction, and not something a layout search can move at all.
+    "n_stations": ADMISSIBLE,
+    "n_routes": ADMISSIBLE,
+    "n_sections": ADMISSIBLE,
+    "n_ports": ADMISSIBLE,
+    "stations_per_route": ADMISSIBLE,
+    "ports_per_section": ADMISSIBLE,
+    # Clearances: better when larger, and always wideable.
+    "min_marker_gap": ANTITONE,
+    "min_station_distance": ANTITONE,
+    # Shape.
+    "aspect_log": SIGNED,
+    # Derived.
+    "marker_crowding": ADMISSIBLE,
+}
+"""Verdict per feature name, covering everything a vector can contain.
+
+Assembling a minimisable objective from anything but :data:`ADMISSIBLE` terms
+leaves the score unbounded below, so this table is what
+``check_objective_safety`` checks a candidate feature set against.
+"""
+
+
+BOUNDED_ABOVE = frozenset(
+    {
+        # Fractions of a total, and a saturating penalty, so all three are
+        # confined to [0, 1] by construction.
+        "non_45_frac",
+        "near_horizontal_frac",
+        "marker_crowding",
+    }
+)
+"""Admissible features that are also bounded above.
+
+The distinction matters because it decides how *much* of a box constraint the
+safety property actually needs. A negative weight on a term confined to [0, 1]
+can improve the score by at most that weight's magnitude, so the score stays
+bounded below; a negative weight on a term that is unbounded above makes it
+unbounded below. Only the latter has to be pinned, which is what
+``fit_objective``'s ``safe_min`` arm tests: the weakest constraint that still
+buys boundedness, so a collapse cannot be blamed on over-constraining.
+"""
+
+
+def must_be_non_negative(keys: object) -> list[str]:
+    """The subset of ``keys`` whose weight has to be pinned for boundedness."""
+    return [
+        k for k in keys if ADMISSIBILITY.get(k) == ADMISSIBLE and k not in BOUNDED_ABOVE
+    ]
+
+
+def inadmissible(keys: object) -> dict[str, str]:
+    """The keys that cannot appear in a minimisable score, and why.
+
+    An unknown name is reported too: a feature with no verdict has not been
+    reasoned about, which is not the same as being safe.
+    """
+    out = {}
+    for key in keys:
+        verdict = ADMISSIBILITY.get(key)
+        if verdict is None:
+            out[key] = "unclassified"
+        elif verdict != ADMISSIBLE:
+            out[key] = verdict
+    return out
+
+
+VERDICT_REASON = {
+    ANTITONE: (
+        "larger is better and always reachable, so its useful weight is "
+        "negative and the score has no floor"
+    ),
+    SIGNED: "signed, so a weight of either sign can be driven without bound",
+    "unclassified": "carries no admissibility verdict, so it is unexamined, not safe",
+}
+"""Why a non-:data:`ADMISSIBLE` feature cannot appear in a minimisable score."""
+
+
+def unbounded_below(weights: dict[str, float]) -> dict[str, str]:
+    """Every reason a score with these weights has no lower bound, by feature.
+
+    Empty means the score is bounded below, which is the whole safety property:
+    an objective a search can improve without limit degenerates every candidate
+    it produces, rather than occasionally offering a poor one.
+    """
+    out = {
+        key: VERDICT_REASON[verdict] for key, verdict in inadmissible(weights).items()
+    }
+    for key in must_be_non_negative(weights):
+        if weights[key] < 0.0:
+            out[key] = (
+                f"weight {weights[key]:+.6f} rewards a feature that is unbounded "
+                "above, so the score has no floor"
+            )
+    return out
+
+
+def lower_bound(weights: dict[str, float]) -> float | None:
+    """The greatest lower bound on the score, or ``None`` when there is none.
+
+    Only a :data:`BOUNDED_ABOVE` term may carry a negative weight and still
+    leave the score bounded, and it can subtract at most its weight's magnitude,
+    since those terms are confined to ``[0, 1]``.
+    """
+    if unbounded_below(weights):
+        return None
+    return sum(w for w in weights.values() if w < 0.0)

--- a/scripts/optimize_layout.py
+++ b/scripts/optimize_layout.py
@@ -35,12 +35,13 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src"))
 sys.path.insert(0, str(REPO / "tests"))
+sys.path.insert(0, str(REPO / "datasets" / "layout_preferences" / "scripts"))
 warnings.filterwarnings("ignore")
 
 from layout_metrics import compute_metrics  # noqa: E402
+from terms import marker_crowding  # noqa: E402
 
 from nf_metro.layout import compute_layout  # noqa: E402
-from nf_metro.layout.constants import Y_SPACING  # noqa: E402
 from nf_metro.parser import parse_metro_mermaid  # noqa: E402
 
 # The bins encode three distinct states of knowledge, and conflating any two of
@@ -101,18 +102,6 @@ GRID_RE = re.compile(
 SUBGRAPH_RE = re.compile(r"^(\s*)subgraph\s+([A-Za-z0-9_]+)")
 GRAPH_RE = re.compile(r"^\s*graph\s+(LR|RL|TB|BT|TD)", re.IGNORECASE)
 END_RE = re.compile(r"^\s*end\s*$")
-
-
-def marker_crowding(clearance: float | None) -> float:
-    """How far the nearest line intrudes on a foreign marker, as a 0..1 fraction.
-
-    A penalty for tight clearance, never a reward for loose clearance: a term
-    that kept paying for more room would be minimised by spreading the map out.
-    One lane pitch is room enough, so clearance beyond it scores nothing.
-    """
-    if clearance is None:
-        return 0.0
-    return max(0.0, Y_SPACING - clearance) / Y_SPACING
 
 
 def objective(m: dict[str, float | None]) -> float:

--- a/tests/test_layout_preference_fit.py
+++ b/tests/test_layout_preference_fit.py
@@ -106,6 +106,57 @@ def test_fitted_objective_still_misses_the_optimisation_bar(arms):
     assert pooled(arms, "iter2") < 0.85, "iter2 now clears 85%; re-gate the target"
 
 
+def test_constraining_the_growth_weights_costs_the_fitted_arm_its_coverage(arms):
+    """The #1588 finding: `iter2`'s reach came from the terms that made it unsafe.
+
+    `safe` reads the same features, differing only in that no weight may reward a
+    feature the drawing can grow without bound. Its coverage has to collapse to
+    roughly the bend family's reach, because the extent and length terms are
+    where the corpus's movement lives and the constraint zeroes them.
+    """
+    _, safe_coverage = arms["safe"].decided()
+    _, iter2_coverage = arms["iter2"].decided()
+    _, bend_coverage = arms["only_bend_family"].decided()
+
+    assert iter2_coverage > 0.85
+    assert safe_coverage < 0.30
+    assert safe_coverage == pytest.approx(bend_coverage, abs=0.05)
+
+
+def test_the_weakest_safety_constraint_collapses_the_arm_too(arms):
+    """`safe_min` pins only the weights that are unbounded above, which is the
+    least a bounded-below score can be built from. A gap between it and `safe`
+    would mean the collapse is an artefact of over-constraining rather than of
+    where the corpus's signal lies.
+    """
+    assert pooled(arms, "safe_min") == pytest.approx(pooled(arms, "safe"), abs=0.01)
+
+
+def test_no_safe_arm_beats_the_hand_binned_weights(arms):
+    """The #1588 stop condition. The authored objective is the incumbent: it
+    ships in `optimize_layout.py`, so a constrained fit that does not beat it
+    adds nothing, whatever its safety property.
+
+    A failure here is a reason to revisit the verdict, not to relax the
+    assertion: it would mean a safe objective has become worth driving layout
+    with, and #1589 comes back into play.
+    """
+    for arm in ("safe", "safe_min"):
+        margin = pooled(arms, arm) - pooled(arms, "authored")
+        assert margin < 0.0, f"{arm} now beats authored by {margin:+.3f}; re-gate"
+
+
+def test_the_bend_control_reproduces_the_safe_arms_precision(arms):
+    """Three hand-picked bend terms, unfitted, are at least as precise as the
+    constrained fit over the pairs either will speak to. That is what makes the
+    #1588 verdict "adds nothing" rather than "missed a threshold".
+    """
+    safe_decided, _ = arms["safe"].decided()
+    control_decided, _ = arms["only_bend_family"].decided()
+
+    assert control_decided >= safe_decided
+
+
 @pytest.mark.parametrize("control", ["only_path_len", "only_bbox_h"])
 def test_degenerate_controls_do_not_explain_the_margin(arms, control):
     """A single extent-like feature must not reproduce the fitted arm's margin.
@@ -185,10 +236,12 @@ def test_an_undefined_measurement_is_not_read_as_the_tightest_one():
 
 
 def test_both_dataset_scripts_mask_the_same_sentinel_features():
-    """The two scripts are standalone by design, so the sentinel list is stated
-    twice. A feature masked in one and read as the number -1 in the other would
-    give the report and the fit opposite readings of the same pair."""
-    assert _load_dataset_script("build_dataset").SENTINEL == _load_fitter().SENTINEL
+    """A feature masked in one script and read as the number -1 in the other
+    would give the report and the fit opposite readings of the same pair, so both
+    read one definition."""
+    shared = _load_dataset_script("terms").SENTINEL
+    assert _load_dataset_script("build_dataset").SENTINEL is shared
+    assert _load_fitter().SENTINEL is shared
 
 
 def test_the_fit_scores_the_weights_the_advisory_objective_actually_uses():

--- a/tests/test_objective_safety.py
+++ b/tests/test_objective_safety.py
@@ -1,0 +1,217 @@
+"""Lock the property that makes a fitted layout objective safe to minimise.
+
+A score is safe to descend when it cannot be improved without bound. The
+committed `safe_weights.json` is built to have that property structurally --
+every feature it reads is non-negative on every layout, and every weight on it
+is non-negative, so the score is bounded below by zero. These tests check both
+halves against real geometry rather than against the arithmetic that produced
+them, and pin the failure mode they exist to prevent: `iter2_weights.json` is
+kept alongside as a live counter-example, so the growth probe is known to be
+capable of catching an unsafe objective.
+
+See `datasets/layout_preferences/README.md` for the measurement this rests on
+and for why nothing here gates CI on a score value.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+DATASET_DIR = REPO / "datasets" / "layout_preferences"
+SCRIPTS = DATASET_DIR / "scripts"
+
+GROWTH_MULTIPLE = 4
+"""Spacing multiple the monotonicity check inflates a map by.
+
+Enough that a linear growth term moves by far more than any incidental drift in
+the angle terms, and small enough to stay one extra layout pass per fixture.
+"""
+
+PROBE = (
+    "examples/rnaseq_sections.mmd",
+    "examples/genomic_pipeline.mmd",
+    "examples/topologies/convergence_fold_diamond.mmd",
+)
+
+
+def _load(stem: str):
+    """Import a dataset script by path; `datasets/` is not an importable package."""
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    path = SCRIPTS / f"{stem}.py"
+    spec = importlib.util.spec_from_file_location(stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def terms():
+    return _load("terms")
+
+
+@pytest.fixture(scope="module")
+def safety():
+    return _load("check_objective_safety")
+
+
+@pytest.fixture(scope="module")
+def safe_weights() -> dict[str, float]:
+    return json.loads((DATASET_DIR / "safe_weights.json").read_text())["weights"]
+
+
+@pytest.fixture(scope="module")
+def iter2_weights() -> dict[str, float]:
+    return json.loads((DATASET_DIR / "iter2_weights.json").read_text())["weights"]
+
+
+@pytest.fixture(scope="module")
+def corpus_vectors() -> list[dict[str, float]]:
+    """Every feature vector committed in the corpus, from both sides of a pair."""
+    vectors = []
+    for name in ("dataset_pairs.jsonl", "dataset_anchors.jsonl"):
+        for line in (DATASET_DIR / name).read_text().splitlines():
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            for key in ("features", "features_before", "features_after"):
+                if row.get(key):
+                    vectors.append(row[key])
+    assert vectors
+    return vectors
+
+
+# --- The sentinel, which inverts the term it appears in --------------------- #
+
+
+def test_an_absent_clearance_is_the_cleanest_state_not_the_worst(terms):
+    """`-1.0` means no line came near a marker it does not serve, which is the
+    best a map can do. Fed to the crowding formula as a gap it reads as 1.025 --
+    past the ceiling and above every real value -- so a non-negative weight on
+    the term would penalise exactly the fixtures with the most room."""
+    assert terms.marker_crowding(terms.UNDEFINED) == 0.0
+    assert terms.marker_crowding(None) == 0.0
+
+
+def test_crowding_is_confined_to_the_unit_interval(terms):
+    """The term stands for "how much of one lane pitch has been eaten", so a gap
+    of zero saturates it. Values outside [0, 1] would let one term dominate a
+    weighted sum by an unbounded margin."""
+    gaps = [terms.UNDEFINED, -5.0, 0.0, 1.0, 20.0, 39.9, 40.0, 400.0]
+    assert all(0.0 <= terms.marker_crowding(g) <= 1.0 for g in gaps)
+    assert terms.marker_crowding(0.0) == 1.0
+    assert terms.marker_crowding(terms.CROWDING_PITCH) == 0.0
+
+
+def test_a_map_with_no_foreign_segment_scores_no_crowding(terms):
+    """The end-to-end version of the two checks above, over a real layout: a
+    single-line map has no line passing a marker it does not serve, so the
+    engine reports no clearance and the term has to read zero."""
+    sys.path.insert(0, str(REPO / "tests"))
+    from layout_metrics import compute_metrics
+
+    from nf_metro.layout import compute_layout
+    from nf_metro.parser import parse_metro_mermaid
+
+    graph = parse_metro_mermaid(
+        """%%metro line: only | Only | #ff0000
+graph LR
+    subgraph s [S]
+        a[A] -->|only| b[B]
+        b -->|only| c[C]
+    end
+"""
+    )
+    compute_layout(graph)
+
+    assert compute_metrics(graph)["marker_clearance"] is None
+    assert terms.marker_crowding(compute_metrics(graph)["marker_clearance"]) == 0.0
+
+
+# --- The admissibility table, against the data ----------------------------- #
+
+
+def test_every_feature_in_the_corpus_has_an_admissibility_verdict(
+    terms, corpus_vectors
+):
+    """A feature with no verdict has not been reasoned about, which is not the
+    same as being safe. Adding a feature to the extractor without classifying it
+    would otherwise let it into a minimisable objective unexamined."""
+    seen = {key for vector in corpus_vectors for key in vector}
+    assert not (seen - set(terms.ADMISSIBILITY))
+
+
+def test_admissible_features_are_non_negative_across_the_corpus(terms, corpus_vectors):
+    """The bound `score >= 0` rests on the features themselves being
+    non-negative, so the classification is checked against every vector the
+    corpus holds rather than asserted from the extractor's source."""
+    offenders: dict[str, float] = {}
+    for vector in corpus_vectors:
+        for key, value in vector.items():
+            if terms.ADMISSIBILITY.get(key) == terms.ADMISSIBLE and value < 0.0:
+                offenders[key] = min(value, offenders.get(key, 0.0))
+    assert not offenders
+
+
+# --- The committed artifact ------------------------------------------------- #
+
+
+def test_the_safe_artifact_is_structurally_safe(safety, safe_weights):
+    assert safety.structural_findings(safe_weights) == []
+
+
+def test_the_safe_artifact_reads_only_admissible_features(terms, safe_weights):
+    assert terms.inadmissible(safe_weights) == {}
+
+
+def test_the_safe_artifact_has_no_negative_weight(safe_weights):
+    """The half of the bound that the fit itself has to deliver: a negative
+    weight on a feature that grows without bound is what makes a score
+    minimisable to minus infinity."""
+    assert {k: v for k, v in safe_weights.items() if v < 0.0} == {}
+
+
+def test_the_unconstrained_artifact_is_still_detected_as_unsafe(safety, iter2_weights):
+    """`iter2` is the live counter-example. If this ever passes as safe, the
+    detector has stopped working rather than the weights having become safe --
+    the arm is fitted with no constraint at all."""
+    findings = safety.structural_findings(iter2_weights)
+    assert findings
+    assert any("path_len_per_route" in f for f in findings)
+
+
+# --- Growth monotonicity, through the real engine --------------------------- #
+
+
+@pytest.mark.parametrize("rel", PROBE)
+def test_inflating_a_map_cannot_improve_the_safe_score(safety, safe_weights, rel):
+    """`x_spacing` and `y_spacing` are a CLI flag and a `%%metro` directive, so a
+    uniformly inflated drawing is a reachable input and not a hypothetical. The
+    same map on a larger grid must not score better, or a search could buy score
+    with nothing but space."""
+    text = (REPO / rel).read_text()
+    base = safety.score(safe_weights, safety.vector_at(text, 1))
+    grown = safety.score(safe_weights, safety.vector_at(text, GROWTH_MULTIPLE))
+
+    assert grown >= base - 1e-9
+
+
+@pytest.mark.parametrize("rel", PROBE)
+def test_inflating_a_map_does_improve_the_unconstrained_score(
+    safety, iter2_weights, rel
+):
+    """The counter-example that gives the check above its teeth: on the same
+    fixtures, the unconstrained weights reward the inflation outright."""
+    text = (REPO / rel).read_text()
+    base = safety.score(iter2_weights, safety.vector_at(text, 1))
+    grown = safety.score(iter2_weights, safety.vector_at(text, GROWTH_MULTIPLE))
+
+    assert grown < base


### PR DESCRIPTION
## Summary

Answers #1588's question: does a layout objective exist that a search cannot game? Yes, it is committed as `safe_weights.json`, and it adds nothing over the objective `optimize_layout.py` already ships.

**The safety property is structural.** `scripts/terms.py` gives every feature an admissibility verdict, so a score assembled from it cannot silently include one with no lower bound. `min_marker_gap` is antitone (more clearance is better, and clearance is always wideable) and reaches a minimisable score only through the derived `marker_crowding`; `aspect_log` is signed and has no repair, so it stays out. With every feature non-negative and every weight non-negative the score is bounded below by zero.

**Demonstrated, not asserted.** `x_spacing` and `y_spacing` are a CLI flag and a `%%metro` directive, so a uniformly inflated drawing is reachable input. `scripts/check_objective_safety.py` lays five fixtures out at 1x/2x/4x/8x through the real engine: the unconstrained score falls on 5 of 5 (`genomic_pipeline.mmd` 8.53 -> -13.90, still falling), the constrained one on none.

**Two arms, so a collapse cannot be blamed on over-constraining.** `safe` pins all 8 weights; `safe_min` pins only the 6 that are unbounded above, which is the least a bounded-below score can be built from. They are identical to the decimal.

| arm | pinned | pooled | decided | coverage |
| --- | --- | --- | --- | --- |
| `iter2` | nothing | 68.5% | 69.6% | 94.3% |
| `safe` | all 8 weights | 54.4% | 79.3% | 15.1% |
| `safe_min` | the 6 unbounded-above | 54.4% | 79.3% | 15.1% |

**What it cost, and why.** The constraint lands on the boundary at exactly zero for `bbox_h`, `path_len_per_route` and `crossings` (so pinning them and excluding them outright are the same model). Reach and correct direction sit on disjoint feature sets: every admissible feature moving on more than a fifth of pairs either points the wrong way (`path_len_per_route` 73.4% reach / 33.8% agreement, `bbox_h` 41.7% / 26.0%) or is a coin flip, while every feature that points the right way moves on under 16%. All 192 directional rows are defect repairs, and repairs cost space, so on this corpus the preferred layout is usually the longer and taller one.

**It does not beat the incumbent.** 54.4% pooled against the hand-binned 54.7%, 22 wins to 22 losses, sign test p=1.0. On a decision simulation `safe` is the most precise candidate arm at 3.83:1 useful:wasted, and a three-feature bend control with no fit at all reaches 4.80:1 - which is what `CONTROL_SETS` exists to detect. #1588's second stop condition: adds nothing, rather than missed a threshold.

**Scope stated in the write-up.** The corpus has no candidate sets, so nothing here tests ranking over generated alternatives, which is what #1589 would do. The README says so where a good ratio might otherwise be read as evidence the search will work.

## Also fixed

`marker_crowding` fed the undefined sentinel through its formula as a gap, giving 1.025 - past the term's [0, 1] ceiling and above every real value. 104 of the 278 fixtures carrying a vector in the corpus are at the sentinel, so a non-negative weight would have penalised the fixtures with the best clearance in the corpus. Now masked to zero and clamped, from one shared definition that `build_dataset.py`, `fit_objective.py` and `optimize_layout.py` all read.

`iter2_weights.json` gains `safe_to_minimise: false` and `pinned_non_negative`, so the render-diff consumer cannot quote the weights without also seeing what they may be used for. The weights themselves are byte-identical.

Closes #1588

## Test plan

- [x] `pytest` passes: 45014 passed, 137 skipped, 46 xfailed
- [x] `prek run --all-files` clean, including ruff format and mypy
- [x] New: `tests/test_objective_safety.py` (15 tests) - the sentinel reads zero on a real single-line layout, the admissibility table checked against every committed vector, and growth monotonicity through the real engine with the unconstrained arm kept as a live counter-example so the probe is known to catch an unsafe objective
- [x] New in `tests/test_layout_preference_fit.py`: the coverage collapse, `safe_min` matching `safe`, no safe arm beating the hand-binned weights, and the bend control matching the fitted arm's precision
- [ ] Render-preview verdict: no engine code touched, so no visual change expected

Generated with Claude Code
