### PR TITLE
docs: clarify entry hints share one approach direction, unlike exit

### DIFF
--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -348,7 +348,7 @@ These go inside `subgraph` blocks.
 
 Entry/exit hints tell the layout engine which side of the section box lines should enter or leave from. Most of the time you can **omit these entirely** and let the auto-layout engine figure it out.
 
-Exit hints support per-line divergence: they're useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others). Entry hints don't, since a section has a single approach direction; every line entering it must arrive from the same side, because routed lines carry no arrowheads and mixed entry sides would leave the flow direction ambiguous. `entry: <side> | <lines>` sets that one shared side for the whole section, it doesn't carve out an independent side for just the listed lines. If a line's natural predecessor placement would approach from a different side, reposition the predecessor's grid column so every line enters from the same edge, or split the section into two.
+Exit hints support per-line divergence: they're useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others). Entry hints don't - a section has a single entry side shared by every line entering it. `entry: <side> | <lines>` sets that one shared side; it doesn't give the listed lines an independent side from the rest.
 
 ## CLI flags and directive precedence
 

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -348,7 +348,7 @@ These go inside `subgraph` blocks.
 
 Entry/exit hints tell the layout engine which side of the section box lines should enter or leave from. Most of the time you can **omit these entirely** and let the auto-layout engine figure it out.
 
-Exit hints support per-line divergence: they're useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others). Entry hints don't - a section has a single entry side shared by every line entering it. `entry: <side> | <lines>` sets that one shared side; it doesn't give the listed lines an independent side from the rest.
+Exit hints can diverge per line - some lines can leave right, others bottom, in the same section. Entry can't: every line entering a section arrives from the same one side. That's deliberate, routing is complicated enough with a single entry side, without also handling lines approaching from different ones. `entry: <side> | <lines>` sets that one shared side for the section; it doesn't give the listed lines a side of their own.
 
 ## CLI flags and directive precedence
 

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -346,7 +346,9 @@ These go inside `subgraph` blocks.
 | `%%metro exit: <side> \| <lines>`  | Exit port hint. Sides: `left`, `right`, `top`, `bottom`  |
 | `%%metro direction: <dir>`         | Internal flow direction: `LR`, `RL`, or `TB`             |
 
-Entry/exit hints tell the layout engine which side of the section box lines should enter or leave from. Most of the time you can **omit these entirely** and let the auto-layout engine figure it out. They are useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others).
+Entry/exit hints tell the layout engine which side of the section box lines should enter or leave from. Most of the time you can **omit these entirely** and let the auto-layout engine figure it out.
+
+Exit hints support per-line divergence: they're useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others). Entry hints don't, since a section has a single approach direction; every line entering it must arrive from the same side, because routed lines carry no arrowheads and mixed entry sides would leave the flow direction ambiguous. `entry: <side> | <lines>` sets that one shared side for the whole section, it doesn't carve out an independent side for just the listed lines. If a line's natural predecessor placement would approach from a different side, reposition the predecessor's grid column so every line enters from the same edge, or split the section into two.
 
 ## CLI flags and directive precedence
 


### PR DESCRIPTION
## Summary
- The Section directives docs described entry and exit hints together as if both support per-line divergent sides. Only exit does — a section has a single entry approach direction, so `entry: <side> | <lines>` sets one shared side for the whole section rather than an independent side for the listed lines.
- Clarifies that constraint and what to do instead (reposition the predecessor's grid column, or split the section).

Prompted by #1629, which was closed as working-as-intended but highlighted that the docs read as if entry supported the same per-line flexibility as exit.

## Test plan
- [x] Docs-only change; pre-commit hooks (prettier, whitespace/EOF) passed on commit.