### PR TITLE
Overhaul the browser playground

### DIFF
--- a/website/playground-tests/playground.spec.js
+++ b/website/playground-tests/playground.spec.js
@@ -23,6 +23,9 @@ test.beforeAll(async ({ browser }) => {
   page = await browser.newPage();
   await page.goto("/harness.html");
   await waitReady(page);
+  if (await page.locator("#welcome-modal").isVisible()) {
+    await page.locator("#welcome-new").click();
+  }
 });
 
 test.afterAll(async () => {
@@ -53,6 +56,23 @@ test("boots and renders the seed map", async () => {
   await expect(page.locator("#error")).toBeHidden();
 });
 
+test("standalone harness fills the browser viewport", async () => {
+  const dimensions = await page.evaluate(() => ({
+    appHeight: document.querySelector(".nfm-playground").getBoundingClientRect()
+      .height,
+    viewportHeight: window.innerHeight,
+  }));
+  expect(dimensions.appHeight).toBeGreaterThanOrEqual(
+    dimensions.viewportHeight - 1,
+  );
+});
+
+test("renderer startup message does not show the obsolete download warning", async () => {
+  await expect(page.locator("body")).not.toContainText(
+    "First load fetches the WASM runtime",
+  );
+});
+
 test("live edit re-renders with the new station", async () => {
   await expect(
     page.locator('#preview [data-station-id="brandnew"]'),
@@ -77,14 +97,10 @@ test("animate toggle adds motion elements", async () => {
   await expect(balls).toHaveCount(0);
 });
 
-test("advanced options are collapsed by default and toggle open", async () => {
-  // Progressive disclosure: power-user knobs are hidden until requested.
-  await expect(page.locator("#advanced")).not.toHaveAttribute("open", /.*/);
+test("layout options are disclosed in their dedicated control panel", async () => {
   await expect(page.locator("#opt-line-spread")).toBeHidden();
-  await page.locator("#advanced > summary").click();
+  await openAdvanced();
   await expect(page.locator("#opt-line-spread")).toBeVisible();
-  await page.locator("#advanced > summary").click();
-  await expect(page.locator("#opt-line-spread")).toBeHidden();
 });
 
 test("directional toggle adds chevron markers", async () => {
@@ -278,6 +294,7 @@ test("syntax error surfaces inline and keeps the last good render", async () => 
     );
   });
   await expect(page.locator("#error")).toBeVisible();
+  await expect(page.locator("#error strong")).toHaveText("Source error");
   // Preview is untouched: the broken edit did not blank it.
   expect(await page.locator("#preview").innerHTML()).toBe(good);
 });
@@ -399,12 +416,6 @@ test("example dropdown loads a chosen example and renders it", async () => {
     .toBeGreaterThan(0);
   // Action menu resets to its placeholder after loading.
   await expect(select).toHaveValue("");
-
-  // A topology fixture (only in the render diff, not examples/*.mmd) loads too.
-  await select.selectOption("single_section");
-  await expect
-    .poll(async () => page.evaluate(() => window.__nfMetro.getValue()))
-    .toContain("graph");
 
   // The starter entry is always available even without the manifest.
   await select.selectOption("__seed__");
@@ -687,4 +698,99 @@ test("the line panel offers add and delete on each edge", async () => {
   await expect(page.locator(".prop-edge button.del").first()).toBeVisible();
   await page.locator(".prop-edge button.add").first().click();
   expect(await getValue()).toContain("node1");
+});
+
+test("rendering runs off the main browser thread", async () => {
+  const elapsed = await page.evaluate(async () => {
+    const started = performance.now();
+    window.__nfMetro.render();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return performance.now() - started;
+  });
+  expect(elapsed).toBeLessThan(100);
+});
+
+test("the example picker exposes a curated set", async () => {
+  const options = page.locator("#example-select option");
+  await expect.poll(async () => options.count()).toBeGreaterThan(2);
+  expect(await options.count()).toBeLessThanOrEqual(12);
+});
+
+test("opening a metro source file replaces the document", async () => {
+  const source =
+    "%%metro title: Opened File\n%%metro line: a | A | #f00\n" +
+    "graph LR\n  one[One] -->|a| two[Two]\n";
+  await page.locator("#file-open").setInputFiles({
+    name: "opened.mmd",
+    mimeType: "text/plain",
+    buffer: Buffer.from(source),
+  });
+  await expect
+    .poll(() => page.evaluate(() => window.__nfMetro.getValue()))
+    .toContain("Opened File");
+  await expect(
+    page.locator('#preview [data-station-id="one"]').first(),
+  ).toBeVisible();
+});
+
+test("a local draft survives a page reload", async () => {
+  const source =
+    "%%metro title: Recovered Draft\n%%metro line: a | A | #f00\n" +
+    "graph LR\n  saved[Saved] -->|a| restored[Restored]\n";
+  await page.evaluate((value) => window.__nfMetro.setValue(value), source);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => localStorage.getItem("nf-metro-playground-draft-v2") || "",
+      ),
+    )
+    .toContain("Recovered Draft");
+  await page.evaluate(() => history.replaceState(null, "", location.pathname));
+  await page.reload();
+  await waitReady(page);
+  await expect
+    .poll(() => page.evaluate(() => window.__nfMetro.getValue()))
+    .toContain("Recovered Draft");
+  await expect(
+    page.locator('#preview [data-station-id="saved"]').first(),
+  ).toBeVisible();
+});
+
+test("replaced documents remain available as recent maps", async () => {
+  await page.evaluate(() => document.getElementById("btn-new").click());
+  await expect
+    .poll(async () => page.locator("#recent-select option").count())
+    .toBeGreaterThan(1);
+});
+
+test("source completion exposes directives and graph snippets", async () => {
+  await page.evaluate(() => window.__nfMetro.complete());
+  await expect(page.locator(".CodeMirror-hints")).toBeVisible();
+  await expect(page.locator(".CodeMirror-hint").first()).toContainText("metro");
+  await page.keyboard.press("Escape");
+});
+
+test("the command palette filters and runs keyboard-first actions", async () => {
+  await page.keyboard.press("Control+k");
+  await expect(page.locator("#command-modal")).toBeVisible();
+  await page.locator("#command-search").fill("layout controls");
+  await expect(page.locator(".command-item")).toHaveCount(1);
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#command-modal")).toBeHidden();
+});
+
+test("mobile switches between full-height source and preview views", async () => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.locator('.mobile-view[data-view="source"]').click();
+  await expect(page.locator("#editor-pane")).toBeVisible();
+  await expect(page.locator("#preview-pane")).toBeHidden();
+  await page.locator('.mobile-view[data-view="preview"]').click();
+  await expect(page.locator("#editor-pane")).toBeHidden();
+  await expect(page.locator("#preview-pane")).toBeVisible();
+  const sizes = await page.evaluate(() => [
+    innerWidth,
+    document.body.scrollWidth,
+  ]);
+  expect(sizes[1]).toBeLessThanOrEqual(sizes[0]);
+  await page.setViewportSize({ width: 1280, height: 720 });
 });

--- a/website/public/playground/app.js
+++ b/website/public/playground/app.js
@@ -1,9 +1,9 @@
 "use strict";
 
-// Pinned so the install path is reproducible; bump deliberately.
-const PYODIDE_VERSION = "v0.27.2";
-
 const REPO = "seqeralabs/nf-metro";
+const DRAFT_KEY = "nf-metro-playground-draft-v2";
+const RECENTS_KEY = "nf-metro-playground-recents-v1";
+const WELCOME_KEY = "nf-metro-playground-welcome-v1";
 
 const SEED = `%%metro title: Example Pipeline
 %%metro line: qc | QC | #2dd4bf
@@ -46,93 +46,39 @@ const SAMPLE_NEXTFLOW_DAG = `flowchart TB
     v3 --> v4
 `;
 
-// Glue defined inside the Pyodide runtime: returns a JSON envelope so a render
-// error surfaces as data rather than a thrown PythonError to unwind in JS.
-//
-// Layout cache: parse+compute_layout is expensive (~200-500ms). We cache the
-// settled MetroGraph keyed on (normalised mmd + geometry options). Brand, mode,
-// debug, animate, and directional are render-only - they don't affect station
-// coordinates, so changing them skips layout and only re-runs render_svg.
-// The style: and mode: directives are stripped before hashing so toggling brand
-// or render mode doesn't bust the geometry cache.
-//
-// permissive is always forced on (see currentOptions()): a guard failure
-// downgrades to a PermissiveGuardWarning and the render proceeds best-effort,
-// instead of the whole editor going blank on one bad topology. Warnings are
-// collected per-call (never accumulated onto the cached graph) and returned
-// alongside the svg so the UI can show both.
-const PY_GLUE = `
-import hashlib
-import json
-import re as _re
-import warnings
-from nf_metro.api import prepare_graph, resolve_theme
-from nf_metro.convert import convert_nextflow_dag
-from nf_metro.parser.model import PermissiveGuardWarning, split_guard_warnings
-from nf_metro.render import render_svg
-
-_cached_graph = None
-_cached_key = None
-_RENDER_ONLY = frozenset({"animate", "directional"})
-_STYLE_RE = _re.compile(r"^\\s*%%metro\\s+(?:style|mode):.*$", _re.MULTILINE)
-
-def nfm_render(mmd, opts_json):
-    global _cached_graph, _cached_key
-    opts = json.loads(opts_json)
-    all_layout = {k: v for k, v in (opts.get("layout_options") or {}).items() if v is not None}
-
-    layout_geom = {k: v for k, v in all_layout.items() if k not in _RENDER_ONLY}
-    render_only = {k: v for k, v in all_layout.items() if k in _RENDER_ONLY}
-
-    mmd_norm = _STYLE_RE.sub("", mmd).strip()
-    cache_key = hashlib.md5((mmd_norm + "\\x00" + json.dumps(layout_geom, sort_keys=True)).encode()).hexdigest()
-
-    svg = None
-    error = None
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.filterwarnings("always", category=PermissiveGuardWarning)
-        try:
-            if cache_key != _cached_key:
-                graph = prepare_graph(mmd, layout_options=layout_geom)
-                _cached_graph = graph
-                _cached_key = cache_key
-            else:
-                graph = _cached_graph
-
-            for k, v in render_only.items():
-                setattr(graph, k, bool(v))
-
-            theme_obj = resolve_theme(opts.get("theme") or None, graph, mode=opts.get("mode") or None)
-            svg = render_svg(
-                graph,
-                theme_obj,
-                debug=bool(opts.get("debug")),
-                responsive=True,
-                font_portability="embed",
-                self_color_scheme=False,
-            )
-        except Exception as e:
-            error = f"{type(e).__name__}: {e}"
-
-    guard_warnings = [str(w.message) for w in split_guard_warnings(caught)[0]]
-    if svg is not None:
-        return json.dumps({"ok": True, "svg": svg, "warnings": guard_warnings})
-    return json.dumps({"ok": False, "error": error, "warnings": guard_warnings})
-
-def nfm_convert(nextflow_dag):
-    try:
-        return json.dumps({"ok": True, "mmd": convert_nextflow_dag(nextflow_dag)})
-    except Exception as e:
-        return json.dumps({"ok": False, "error": f"{type(e).__name__}: {e}"})
-`;
+const SOURCE_COMPLETIONS = [
+  ["%%metro title: ", "Map title"],
+  ["%%metro line: id | Name | #19b7a5", "Define a route"],
+  ["%%metro style: nfcore", "Map brand"],
+  ["%%metro mode: light", "Light or dark output"],
+  ["%%metro direction: LR", "Section direction"],
+  ["%%metro grid: section | 0,0", "Place a section"],
+  ["%%metro file: station | FORMAT", "File terminus"],
+  ["%%metro files: station | FORMAT", "Multiple-file terminus"],
+  ["%%metro dir: station | Results", "Directory terminus"],
+  ["%%metro line_spread: rails", "Parallel route rails"],
+  ["%%metro animate: true", "Animated route markers"],
+  ["%%metro directional: true", "Direction chevrons"],
+  ["subgraph section_id [Section name]", "Start a section"],
+  ["station_id[Station label]", "Add a station"],
+  ["source -->|line_id| target", "Connect stations"],
+  ["end", "End a section"],
+].map(([text, detail]) => ({ text, displayText: `${text}  -  ${detail}` }));
 
 const el = (id) => document.getElementById(id);
 let editor = null;
-let pyRender = null;
-let pyConvert = null;
+let renderWorker = null;
+let workerReady = false;
+let workerRequestId = 0;
+let bootTimeout = null;
+let latestRenderId = 0;
+let queuedRender = null;
+const workerRequests = new Map();
 let lastSvg = "";
 let nfMetroVersion = "";
 let buildSha = "";
+let draftTimer = null;
+let lastSavedSource = "";
 const examples = {};
 
 /* ------------------------------- editor -------------------------------- */
@@ -156,12 +102,23 @@ function initEditor() {
     lineNumbers: true,
     lineWrapping: false,
     theme: "default",
+    gutters: ["CodeMirror-linenumbers", "nfm-diagnostics"],
+    extraKeys: {
+      "Ctrl-Space": showSourceCompletions,
+      "Cmd-Space": showSourceCompletions,
+    },
   });
-  editor.setValue(loadFromHash() || SEED);
+  editor.setValue(loadInitialSource());
+  lastSavedSource = editor.getValue();
   loadFromHashGz().then((src) => {
     if (src != null) editor.setValue(src);
   });
-  editor.on("change", debounce(doRender, 300));
+  const renderAfterChange = debounce(doRender, 300);
+  editor.on("change", () => {
+    renderAfterChange();
+    scheduleDraftSave();
+    updateDocumentState();
+  });
 
   // CodeMirror measures gutter and line geometry once at creation and never
   // re-measures when its container resizes; refresh() re-runs that measurement.
@@ -175,6 +132,7 @@ function initEditor() {
     getValue: () => editor.getValue(),
     setValue: (v) => editor.setValue(v),
     render: doRender,
+    complete: showSourceCompletions,
     setMode,
     getMode: () => editMode,
     select: setSelection,
@@ -194,50 +152,246 @@ function initEditor() {
   };
 }
 
+function showSourceCompletions(instance = editor) {
+  const cursor = instance.getCursor();
+  const line = instance.getLine(cursor.line);
+  const start = line.search(/\S|$/);
+  const query = line.slice(start, cursor.ch).toLowerCase();
+  const list = SOURCE_COMPLETIONS.filter((item) =>
+    item.text.toLowerCase().includes(query),
+  );
+  CodeMirror.showHint(instance, () => ({
+    from: CodeMirror.Pos(cursor.line, start),
+    to: cursor,
+    list: list.length ? list : SOURCE_COMPLETIONS,
+  }));
+}
+
+/* -------------------------- local documents --------------------------- */
+
+function storedJson(key, fallback) {
+  try {
+    return JSON.parse(localStorage.getItem(key)) || fallback;
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function loadInitialSource() {
+  const shared = loadFromHash();
+  if (shared != null) return shared;
+  const draft = storedJson(DRAFT_KEY, null);
+  return draft && draft.source ? draft.source : SEED;
+}
+
+function mapTitle(source = editor?.getValue() || "") {
+  const match = source.match(/^\s*%%metro\s+title:\s*(.+)$/m);
+  return match ? match[1].trim() : "Untitled map";
+}
+
+function updateDocumentState() {
+  if (!editor) return;
+  el("document-name").textContent = mapTitle();
+  const changed = editor.getValue() !== lastSavedSource;
+  el("draft-status").textContent = changed
+    ? "Saving local draft…"
+    : "Saved locally";
+  el("route-source").classList.toggle("active", changed);
+}
+
+function saveDraft() {
+  const source = editor.getValue();
+  try {
+    localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({
+        source,
+        title: mapTitle(source),
+        updatedAt: Date.now(),
+      }),
+    );
+    lastSavedSource = source;
+    updateDocumentState();
+  } catch (_) {
+    el("draft-status").textContent = "Local saving unavailable";
+  }
+}
+
+function scheduleDraftSave() {
+  clearTimeout(draftTimer);
+  draftTimer = setTimeout(saveDraft, 450);
+}
+
+function recentDocuments() {
+  return storedJson(RECENTS_KEY, []);
+}
+
+function archiveSource(source = editor.getValue()) {
+  if (!source.trim() || source === SEED) return;
+  const recents = recentDocuments().filter((entry) => entry.source !== source);
+  recents.unshift({
+    id: String(Date.now()),
+    title: mapTitle(source),
+    source,
+    updatedAt: Date.now(),
+  });
+  try {
+    localStorage.setItem(RECENTS_KEY, JSON.stringify(recents.slice(0, 8)));
+  } catch (_) {}
+  refreshRecents();
+}
+
+function refreshRecents() {
+  const select = el("recent-select");
+  if (!select) return;
+  select.replaceChildren(new Option("Choose…", ""));
+  recentDocuments().forEach((entry) => {
+    const option = new Option(entry.title, entry.id);
+    option.title = new Date(entry.updatedAt).toLocaleString();
+    select.append(option);
+  });
+}
+
+function loadRecent(id) {
+  const entry = recentDocuments().find((item) => item.id === id);
+  if (!entry) return;
+  archiveSource();
+  editor.setValue(entry.source);
+  el("recent-select").value = "";
+  toast(`Opened ${entry.title}`);
+}
+
+function replaceDocument(source, message) {
+  archiveSource();
+  editor.setValue(source);
+  editor.clearHistory();
+  saveDraft();
+  showMobileView("source");
+  if (message) toast(message);
+}
+
+function newDocument() {
+  if (
+    editor.getValue() !== lastSavedSource &&
+    !confirm("Start a new map? Your current work is saved in Recent maps.")
+  )
+    return;
+  replaceDocument(SEED, "Started a new map");
+}
+
+async function openSourceFile(file) {
+  if (!file) return;
+  const source = await file.text();
+  if (
+    /^\s*(?:flowchart|graph)\s+(?:TB|TD)\b/m.test(source) &&
+    !source.includes("%%metro")
+  ) {
+    if (!workerReady) {
+      toast("The DAG importer is still loading");
+      return;
+    }
+    setRenderStatus("Converting Nextflow DAG", "loading");
+    const result = await workerCall("convert", { source });
+    if (!result.ok) {
+      showError(`Conversion failed: ${result.error}`);
+      return;
+    }
+    replaceDocument(result.mmd, `Imported ${file.name}`);
+    return;
+  }
+  replaceDocument(source, `Opened ${file.name}`);
+}
+
+function setRenderStatus(message, state) {
+  const status = el("render-status");
+  if (!status) return;
+  status.dataset.state = state;
+  const text = status.querySelector(".status-text");
+  if (text) text.textContent = message;
+  else
+    status.replaceChildren(
+      Object.assign(document.createElement("span"), {
+        className: "status-dot",
+      }),
+      document.createTextNode(message),
+    );
+}
+
 /* --------------------------------- boot -------------------------------- */
 
 function setBootMsg(msg) {
   el("boot-msg").textContent = msg;
+  setRenderStatus(msg, "loading");
 }
 
-async function resolveWheel() {
-  // Prefer a dev wheel shipped alongside the page (built from the current
-  // source); fall back to the released package on PyPI.
-  try {
-    const resp = await fetch("wheels/index.json", { cache: "no-store" });
-    if (resp.ok) {
-      const { wheel } = await resp.json();
-      if (wheel) return new URL("wheels/" + wheel, location.href).href;
+function showBootFailure(message) {
+  clearTimeout(bootTimeout);
+  setBootMsg(message);
+  setRenderStatus("Renderer unavailable", "error");
+  el("boot").querySelector(".spinner").classList.add("hidden");
+  el("boot-retry").classList.remove("hidden");
+}
+
+function workerCall(type, payload = {}) {
+  return new Promise((resolve, reject) => {
+    const id = ++workerRequestId;
+    workerRequests.set(id, { resolve, reject });
+    renderWorker.postMessage({ type, id, ...payload });
+  });
+}
+
+function boot() {
+  clearTimeout(bootTimeout);
+  if (renderWorker) renderWorker.terminate();
+  workerReady = false;
+  el("boot").classList.remove("hidden");
+  el("boot").querySelector(".spinner").classList.remove("hidden");
+  el("boot-retry").classList.add("hidden");
+  setBootMsg("Loading the browser runtime");
+  renderWorker = new Worker("worker.js");
+  renderWorker.onmessage = ({ data }) => {
+    if (data.type === "progress") {
+      setBootMsg(data.message);
+      return;
     }
-  } catch (_) {
-    /* no dev wheel; use PyPI */
-  }
-  return "nf-metro";
-}
-
-async function boot() {
-  try {
-    setBootMsg("Starting Python runtime…");
-    const pyodide = await loadPyodide({
-      indexURL: `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full/`,
-    });
-    setBootMsg("Installing nf-metro…");
-    await pyodide.loadPackage("micropip");
-    const micropip = pyodide.pyimport("micropip");
-    await micropip.install(await resolveWheel());
-    pyodide.runPython(PY_GLUE);
-    pyRender = pyodide.globals.get("nfm_render");
-    pyConvert = pyodide.globals.get("nfm_convert");
-    nfMetroVersion = pyodide.runPython("import nf_metro; nf_metro.__version__");
-    el("boot").classList.add("hidden");
-    doRender();
-    // Readiness means the runtime is up, independent of whether the first
-    // render happened to succeed.
-    window.__nfMetroReady = true;
-  } catch (err) {
-    setBootMsg("Failed to start: " + err);
-    el("boot").querySelector(".spinner").classList.add("hidden");
-  }
+    if (data.type === "ready") {
+      clearTimeout(bootTimeout);
+      workerReady = true;
+      nfMetroVersion = data.version;
+      el("runtime-version").textContent = `nf-metro ${nfMetroVersion}`;
+      setRenderStatus("Renderer ready", "ready");
+      el("route-layout").classList.add("complete");
+      showWelcomeIfNeeded();
+      el("boot").classList.add("hidden");
+      doRender();
+      window.__nfMetroReady = true;
+      return;
+    }
+    if (data.type === "boot-error") {
+      showBootFailure(`Renderer failed to start: ${data.error}`);
+      return;
+    }
+    if (data.type === "render-result") {
+      handleRenderResult(data);
+      return;
+    }
+    const pending = workerRequests.get(data.id);
+    if (!pending) return;
+    workerRequests.delete(data.id);
+    if (data.type === "worker-error") pending.reject(new Error(data.error));
+    else pending.resolve(data.result);
+  };
+  renderWorker.onerror = (event) => {
+    showBootFailure(`Renderer failed to start: ${event.message}`);
+  };
+  bootTimeout = setTimeout(
+    () =>
+      showBootFailure(
+        "Renderer startup timed out. Check your connection and retry.",
+      ),
+    90000,
+  );
+  renderWorker.postMessage({ type: "boot" });
 }
 
 /* -------------------------------- render ------------------------------- */
@@ -260,60 +414,105 @@ function currentOptions() {
   };
 }
 
-function showError(msg) {
+function diagnosticPosition(message) {
+  const match = String(message || "").match(
+    /line\s+(\d+)(?:[, :] +column\s+(\d+))?/i,
+  );
+  if (!match) return null;
+  return {
+    line: Math.max(0, Number(match[1]) - 1),
+    ch: Math.max(0, Number(match[2] || 1) - 1),
+  };
+}
+
+function clearDiagnosticMarker() {
+  editor.clearGutter("nfm-diagnostics");
+}
+
+function showError(msg, severity = "error") {
   const box = el("error");
+  clearDiagnosticMarker();
   if (!msg) {
     box.classList.add("hidden");
     box.textContent = "";
+    box.dataset.severity = "";
   } else {
-    box.textContent = msg;
+    box.replaceChildren();
+    box.dataset.severity = severity;
+    const label = document.createElement("strong");
+    label.textContent =
+      severity === "warning" ? "Layout warning" : "Source error";
+    const text = document.createElement("span");
+    text.textContent = msg;
+    box.append(label, text);
+    const position = diagnosticPosition(msg);
+    if (position) {
+      const marker = document.createElement("span");
+      marker.className = `diagnostic-marker ${severity}`;
+      marker.textContent = severity === "warning" ? "!" : "×";
+      marker.title = severity === "warning" ? "Layout warning" : "Source error";
+      editor.setGutterMarker(position.line, "nfm-diagnostics", marker);
+      const jump = document.createElement("button");
+      jump.className = "diagnostic-jump";
+      jump.textContent = `Go to line ${position.line + 1}`;
+      jump.addEventListener("click", () => {
+        editor.setCursor(position);
+        editor.focus();
+      });
+      box.append(jump);
+    }
     box.classList.remove("hidden");
   }
 }
 
 function doRender() {
-  if (!pyRender) return;
-  // Snapshot inputs before the setTimeout so we render the state at the moment
-  // doRender fired, not what the editor contains when the callback runs.
-  const mmd = editor.getValue();
-  const optsJson = JSON.stringify(currentOptions());
-  // Mark the preview as rendering and yield one paint cycle so the browser can
-  // show the dimmed state before the synchronous Python call blocks the thread.
+  queuedRender = {
+    mmd: editor.getValue(),
+    options: JSON.stringify(currentOptions()),
+  };
+  if (!workerReady) return;
+  const id = ++workerRequestId;
+  latestRenderId = id;
+  const payload = queuedRender;
+  queuedRender = null;
   el("preview").classList.add("rendering");
-  setTimeout(() => {
-    let res;
-    try {
-      res = JSON.parse(pyRender(mmd, optsJson));
-    } catch (err) {
-      el("preview").classList.remove("rendering");
-      showError("Render runtime error: " + err);
-      return;
-    }
-    el("preview").classList.remove("rendering");
-    // permissive mode means a guard failure can still hand back an svg (of the
-    // defective geometry) alongside the warning(s) it downgraded, so the two
-    // are reported independently rather than one replacing the other.
-    if (res.svg) {
-      lastSvg = res.svg;
-      el("preview").innerHTML = res.svg;
-      applyZoom();
-    }
-    const warnings =
-      res.warnings && res.warnings.length ? res.warnings.join("\n\n") : "";
-    if (!res.ok) {
-      // No svg at all (or a fatal error on top of any downgraded guards):
-      // keep the last good render visible and report everything we know.
-      const parts = warnings ? [warnings, res.error] : [res.error];
-      showError(friendlyRenderError(parts.join("\n\n")));
-    } else if (warnings) {
-      showError(friendlyRenderError(warnings));
-    } else {
-      showError(null);
-    }
-    refreshLineColors();
-    syncDirectiveControls();
-    reapplySelection();
-  }, 0);
+  el("stale-preview").classList.toggle("hidden", !lastSvg);
+  setRenderStatus("Rendering map", "loading");
+  el("route-layout").classList.add("active");
+  renderWorker.postMessage({ type: "render", id, ...payload });
+  return id;
+}
+
+function handleRenderResult({ id, result: res, duration }) {
+  if (id !== latestRenderId) return;
+  el("preview").classList.remove("rendering");
+  el("stale-preview").classList.add("hidden");
+  el("route-layout").classList.remove("active");
+  if (res.svg) {
+    lastSvg = res.svg;
+    el("preview").innerHTML = res.svg;
+    applyZoom();
+  }
+  const warnings =
+    res.warnings && res.warnings.length ? res.warnings.join("\n\n") : "";
+  if (!res.ok) {
+    const parts = warnings ? [warnings, res.error] : [res.error];
+    showError(friendlyRenderError(parts.join("\n\n")), "error");
+    setRenderStatus(`Render failed after ${duration} ms`, "error");
+    el("route-layout").classList.add("error");
+  } else if (warnings) {
+    showError(friendlyRenderError(warnings), "warning");
+    setRenderStatus(`Rendered with warnings in ${duration} ms`, "warning");
+    el("route-layout").classList.add("warning");
+  } else {
+    showError(null);
+    setRenderStatus(`Rendered in ${duration} ms`, "ready");
+    el("route-layout").classList.remove("error", "warning");
+    el("route-layout").classList.add("complete");
+  }
+  refreshLineColors();
+  syncDirectiveControls();
+  reapplySelection();
 }
 
 /* --------------------------------- zoom -------------------------------- */
@@ -1015,6 +1214,7 @@ function selectorFor(sel) {
 
 function setSelection(sel) {
   selection = sel;
+  if (sel) showControlPanel("inspect");
   highlightSelection();
   renderPropPanel();
   if (sel && sel.kind === "station") jumpToStation(sel.id);
@@ -1506,6 +1706,7 @@ function exportSvg() {
   if (!lastSvg) return;
   const svg = pinColorScheme(lastSvg, modeFromSource());
   downloadBlob(new Blob([svg], { type: "image/svg+xml" }), "metro_map.svg");
+  markExportComplete();
 }
 
 function svgWithIntrinsicSize(svg) {
@@ -1546,11 +1747,28 @@ async function exportPng() {
     );
     if (!blob) throw new Error("canvas produced no image");
     downloadBlob(blob, "metro_map.png");
+    markExportComplete();
   } catch (err) {
     toast("PNG export failed: " + err.message);
   } finally {
     URL.revokeObjectURL(url);
   }
+}
+
+function exportSourceFile() {
+  const source = editor.getValue();
+  const name =
+    mapTitle(source)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "") || "metro-map";
+  downloadBlob(new Blob([source], { type: "text/plain" }), `${name}.mmd`);
+  saveDraft();
+  markExportComplete();
+}
+
+function markExportComplete() {
+  el("route-export").classList.add("complete");
 }
 
 /* ------------------------------- sharing ------------------------------- */
@@ -1639,6 +1857,7 @@ async function compressedShareUrl() {
 async function shareLink() {
   const url = await compressedShareUrl();
   history.replaceState(null, "", url);
+  markExportComplete();
   try {
     await navigator.clipboard.writeText(url);
     toast("Share link copied to clipboard");
@@ -1739,14 +1958,19 @@ function closeConvert() {
   el("convert-modal").classList.add("hidden");
 }
 
-function submitConvert() {
+async function submitConvert() {
   const dag = el("convert-text").value;
-  if (!dag.trim() || !pyConvert) return;
+  if (!dag.trim() || !workerReady) return;
+  el("convert-submit").disabled = true;
+  el("convert-submit").textContent = "Converting…";
   let res;
   try {
-    res = JSON.parse(pyConvert(dag));
+    res = await workerCall("convert", { source: dag });
   } catch (err) {
     res = { ok: false, error: String(err) };
+  } finally {
+    el("convert-submit").disabled = false;
+    el("convert-submit").textContent = "Convert";
   }
   if (!res.ok) {
     const box = el("convert-error");
@@ -1875,17 +2099,41 @@ async function loadExamples() {
     return; // no manifest shipped; the starter remains available
   }
   const select = el("example-select");
-  groups.forEach(({ label, entries }) => {
+  const available = new Map(
+    groups
+      .flatMap(({ entries }) => entries)
+      .map((entry) => [entry.name, entry.mmd]),
+  );
+  const curated = [
+    ["Start here", ["simple_pipeline", "rnaseq_auto", "rnaseq_sections"]],
+    [
+      "Pipeline shapes",
+      [
+        "fanout_bundle_plus_spurs",
+        "folded_corridor_distinct_lanes",
+        "cross_track_interchange",
+      ],
+    ],
+    [
+      "Presentation",
+      ["directional_flow", "line_spread", "marker_styles", "file_icons"],
+    ],
+  ];
+  curated.forEach(([label, names]) => {
     const optgroup = document.createElement("optgroup");
     optgroup.label = label;
-    entries.forEach(({ name, mmd }) => {
+    names.forEach((name) => {
+      const mmd = available.get(name);
+      if (mmd == null) return;
       examples[name] = mmd;
       const opt = document.createElement("option");
       opt.value = name;
-      opt.textContent = name;
+      opt.textContent = name
+        .replaceAll("_", " ")
+        .replace(/\b\w/g, (letter) => letter.toUpperCase());
       optgroup.append(opt);
     });
-    select.append(optgroup);
+    if (optgroup.children.length) select.append(optgroup);
   });
 }
 
@@ -1917,16 +2165,244 @@ async function loadBuildInfo() {
 function loadExample(value) {
   if (!value) return;
   const mmd = value === "__seed__" ? SEED : examples[value];
-  if (mmd != null) editor.setValue(mmd);
+  if (mmd != null) replaceDocument(mmd, "Loaded example");
   // The dropdown is an action menu, not a state mirror: reset to the
   // placeholder so re-picking the same entry fires `change` again.
   el("example-select").value = "";
 }
 
+function closeWelcome() {
+  el("welcome-modal")?.classList.add("hidden");
+  try {
+    localStorage.setItem(WELCOME_KEY, "seen");
+  } catch (_) {}
+}
+
+function showWelcomeIfNeeded() {
+  if (new URLSearchParams(location.search).has("skip-welcome")) return;
+  let seen = false;
+  try {
+    seen = localStorage.getItem(WELCOME_KEY) === "seen";
+  } catch (_) {}
+  if (!seen && !location.hash) {
+    const draft = storedJson(DRAFT_KEY, null);
+    el("welcome-continue").classList.toggle(
+      "hidden",
+      !draft?.source || draft.source === SEED,
+    );
+    el("welcome-modal").classList.remove("hidden");
+    el("welcome-import").focus();
+  }
+}
+
+function showControlPanel(name) {
+  document.querySelectorAll(".preview-tab").forEach((button) => {
+    const active = button.dataset.panel === name;
+    button.classList.toggle("active", active);
+    button.setAttribute("aria-selected", String(active));
+  });
+  document.querySelectorAll(".control-panel").forEach((panel) => {
+    const active = panel.id === `panel-${name}`;
+    panel.classList.toggle("active", active);
+    panel.hidden = !active;
+  });
+  if (name === "layout") el("advanced").open = true;
+}
+
+function showMobileView(view) {
+  document.querySelectorAll(".mobile-view").forEach((button) => {
+    const active = button.dataset.view === view;
+    button.classList.toggle("active", active);
+    button.setAttribute("aria-pressed", String(active));
+  });
+  el("split").dataset.mobileView = view;
+  if (view === "source") setTimeout(() => editor.refresh(), 0);
+}
+
+function wireFileDrop() {
+  const target = el("drop-target");
+  ["dragenter", "dragover"].forEach((type) =>
+    target.addEventListener(type, (event) => {
+      event.preventDefault();
+      el("drop-invitation").classList.remove("hidden");
+    }),
+  );
+  ["dragleave", "drop"].forEach((type) =>
+    target.addEventListener(type, (event) => {
+      event.preventDefault();
+      el("drop-invitation").classList.add("hidden");
+    }),
+  );
+  target.addEventListener("drop", (event) =>
+    openSourceFile(event.dataTransfer.files[0]),
+  );
+}
+
+function cycleFocusInModal(event) {
+  if (event.key !== "Tab") return;
+  const modal = event.currentTarget;
+  const focusable = [
+    ...modal.querySelectorAll("button, input, textarea, select, a[href]"),
+  ].filter((node) => !node.disabled && !node.classList.contains("hidden"));
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable.at(-1);
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+let commandSelection = 0;
+
+function commandActions() {
+  return [
+    ["Import a Nextflow DAG", "Document", openConvert],
+    ["Open a map file", "Document", () => el("file-open").click()],
+    ["Start a new map", "Document", newDocument],
+    [
+      "Show source completions",
+      "Source",
+      () => {
+        closeCommands();
+        editor.focus();
+        showSourceCompletions();
+      },
+    ],
+    ["Insert a section block", "Source", () => insertSnippet("btn-section")],
+    ["Insert a line", "Source", () => insertSnippet("btn-line")],
+    ["Insert an edge", "Source", () => insertSnippet("btn-edge")],
+    ["Undo source edit", "Source", () => editor.undo()],
+    ["Redo source edit", "Source", () => editor.redo()],
+    ["Open style controls", "Preview", () => showControlPanel("style")],
+    ["Open layout controls", "Preview", () => showControlPanel("layout")],
+    ["Inspect the map", "Preview", () => showControlPanel("inspect")],
+    ["Fit map to view", "Preview", zoomFit],
+    ["Share this map", "Export", shareLink],
+    ["Download SVG", "Export", exportSvg],
+    ["Download PNG", "Export", exportPng],
+    ["Download metro source", "Export", exportSourceFile],
+    ["Report a problem", "Help", openReport],
+  ].map(([label, group, run]) => ({ label, group, run }));
+}
+
+function visibleCommands() {
+  const query = el("command-search").value.trim().toLowerCase();
+  return commandActions().filter(({ label, group }) =>
+    `${label} ${group}`.toLowerCase().includes(query),
+  );
+}
+
+function renderCommands() {
+  const list = el("command-list");
+  const actions = visibleCommands();
+  commandSelection = Math.min(
+    commandSelection,
+    Math.max(0, actions.length - 1),
+  );
+  list.replaceChildren();
+  actions.forEach((action, index) => {
+    const button = document.createElement("button");
+    button.className = `command-item${index === commandSelection ? " selected" : ""}`;
+    button.setAttribute("role", "option");
+    button.setAttribute("aria-selected", String(index === commandSelection));
+    button.append(
+      document.createTextNode(action.label),
+      Object.assign(document.createElement("span"), {
+        textContent: action.group,
+      }),
+    );
+    button.addEventListener("mouseenter", () => {
+      commandSelection = index;
+      renderCommands();
+    });
+    button.addEventListener("click", () => runCommand(action));
+    list.append(button);
+  });
+}
+
+function runCommand(action = visibleCommands()[commandSelection]) {
+  if (!action) return;
+  closeCommands();
+  action.run();
+}
+
+function openCommands() {
+  commandSelection = 0;
+  el("command-search").value = "";
+  renderCommands();
+  el("command-modal").classList.remove("hidden");
+  el("command-search").focus();
+}
+
+function closeCommands() {
+  el("command-modal").classList.add("hidden");
+}
+
+function handleCommandKeys(event) {
+  const actions = visibleCommands();
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    commandSelection = Math.min(actions.length - 1, commandSelection + 1);
+    renderCommands();
+  } else if (event.key === "ArrowUp") {
+    event.preventDefault();
+    commandSelection = Math.max(0, commandSelection - 1);
+    renderCommands();
+  } else if (event.key === "Enter") {
+    event.preventDefault();
+    runCommand(actions[commandSelection]);
+  } else if (event.key === "Escape") {
+    event.preventDefault();
+    closeCommands();
+  }
+}
+
 function wireControls() {
+  refreshRecents();
+  updateDocumentState();
+  showMobileView("source");
   el("example-select").addEventListener("change", (e) =>
     loadExample(e.target.value),
   );
+  el("recent-select").addEventListener("change", (e) =>
+    loadRecent(e.target.value),
+  );
+  el("btn-new").addEventListener("click", newDocument);
+  el("btn-open").addEventListener("click", () => el("file-open").click());
+  el("file-open").addEventListener("change", (event) => {
+    openSourceFile(event.target.files[0]);
+    event.target.value = "";
+  });
+  el("btn-undo").addEventListener("click", () => editor.undo());
+  el("btn-redo").addEventListener("click", () => editor.redo());
+  el("btn-commands").addEventListener("click", openCommands);
+  el("boot-retry").addEventListener("click", boot);
+  el("command-search").addEventListener("input", () => {
+    commandSelection = 0;
+    renderCommands();
+  });
+  el("command-search").addEventListener("keydown", handleCommandKeys);
+  el("command-modal").addEventListener("click", (event) => {
+    if (event.target === el("command-modal")) closeCommands();
+  });
+  document
+    .querySelectorAll(".preview-tab")
+    .forEach((button) =>
+      button.addEventListener("click", () =>
+        showControlPanel(button.dataset.panel),
+      ),
+    );
+  document
+    .querySelectorAll(".mobile-view")
+    .forEach((button) =>
+      button.addEventListener("click", () =>
+        showMobileView(button.dataset.view),
+      ),
+    );
   el("opt-theme").addEventListener("change", (e) =>
     setThemeDirective(e.target.value),
   );
@@ -1981,13 +2457,46 @@ function wireControls() {
     if (e.target === el("logo-modal")) closeLogo();
   });
 
+  el("welcome-import").addEventListener("click", () => {
+    closeWelcome();
+    openConvert();
+  });
+  el("welcome-new").addEventListener("click", () => {
+    closeWelcome();
+    replaceDocument(SEED, "Started a simple map");
+  });
+  el("welcome-example").addEventListener("click", () => {
+    closeWelcome();
+    el("example-select").focus();
+  });
+  el("welcome-continue").addEventListener("click", closeWelcome);
+
+  document
+    .querySelectorAll(".modal-overlay")
+    .forEach((modal) => modal.addEventListener("keydown", cycleFocusInModal));
+
   document.addEventListener("keydown", (e) => {
-    if (e.key !== "Escape") return;
-    if (!el("report-modal").classList.contains("hidden")) closeReport();
-    if (!el("convert-modal").classList.contains("hidden")) closeConvert();
-    if (!el("logo-modal").classList.contains("hidden")) closeLogo();
+    if (e.key === "Escape") {
+      if (!el("command-modal").classList.contains("hidden")) closeCommands();
+      if (!el("report-modal").classList.contains("hidden")) closeReport();
+      if (!el("convert-modal").classList.contains("hidden")) closeConvert();
+      if (!el("logo-modal").classList.contains("hidden")) closeLogo();
+      return;
+    }
+    if (!(e.metaKey || e.ctrlKey)) return;
+    if (e.key.toLowerCase() === "k") {
+      e.preventDefault();
+      openCommands();
+    } else if (e.key.toLowerCase() === "s") {
+      e.preventDefault();
+      exportSourceFile();
+    } else if (e.key.toLowerCase() === "o") {
+      e.preventDefault();
+      el("file-open").click();
+    }
   });
 
+  wireFileDrop();
   wireEditTools();
 }
 
@@ -2031,4 +2540,7 @@ initEditor();
 wireControls();
 loadExamples();
 loadBuildInfo();
+window.addEventListener("pagehide", () => {
+  if (editor) saveDraft();
+});
 boot();

--- a/website/public/playground/harness.html
+++ b/website/public/playground/harness.html
@@ -15,6 +15,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/show-hint.min.css"
+    />
     <link rel="stylesheet" href="style.css" />
     <style>
       /* Replicate the Starlight layout overrides for the standalone harness */
@@ -26,6 +30,8 @@
         flex-direction: column;
       }
       .nfm-playground {
+        display: flex;
+        flex-direction: column;
         flex: 1;
         min-height: 0;
       }
@@ -33,6 +39,28 @@
   </head>
   <body>
     <div class="nfm-playground">
+      <div class="hidden" aria-hidden="true">
+        <span id="route-source"></span><span id="route-layout"></span
+        ><span id="route-export"></span> <span id="runtime-version"></span
+        ><span id="draft-status"></span><span id="document-name"></span>
+        <span id="render-status"><span class="status-dot"></span></span>
+        <button id="btn-new"></button><button id="btn-open"></button>
+        <input id="file-open" type="file" />
+        <button id="btn-undo"></button><button id="btn-redo"></button>
+        <button id="btn-commands"></button>
+      </div>
+      <nav class="mobile-view-switch" aria-label="Playground view">
+        <button
+          class="mobile-view active"
+          data-view="source"
+          aria-pressed="true"
+        >
+          Source
+        </button>
+        <button class="mobile-view" data-view="preview" aria-pressed="false">
+          Preview
+        </button>
+      </nav>
       <main id="split">
         <section id="editor-pane">
           <div class="pane-toolbar">
@@ -43,6 +71,12 @@
                 <option value="__seed__">Starter pipeline</option>
               </select>
             </label>
+            <label
+              >Recent
+              <select id="recent-select">
+                <option value="">Choose…</option>
+              </select></label
+            >
             <button
               id="btn-convert"
               title="Convert a Nextflow -with-dag Mermaid into a metro map"
@@ -247,7 +281,11 @@
             >
           </div>
 
-          <div id="preview"></div>
+          <div id="drop-target">
+            <div id="stale-preview" class="hidden"></div>
+            <div id="preview"></div>
+            <div id="drop-invitation" class="hidden"></div>
+          </div>
 
           <div id="zoom-controls">
             <button id="zoom-out" title="Zoom out" aria-label="Zoom out">
@@ -280,16 +318,48 @@
 
           <div id="boot" class="overlay">
             <div class="spinner"></div>
-            <p id="boot-msg">Starting Python runtime…</p>
+            <p id="boot-msg">Loading the browser runtime</p>
             <p class="muted small">
-              First load fetches the WASM runtime (~10&nbsp;MB); subsequent
-              loads are cached.
+              Editing stays responsive while the renderer starts. The runtime is
+              cached after the first visit.
             </p>
+            <button id="boot-retry" class="hidden">Retry renderer</button>
           </div>
         </section>
       </main>
 
       <div id="toast" class="hidden"></div>
+
+      <div
+        id="command-modal"
+        class="modal-overlay hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="command-title"
+      >
+        <div class="modal">
+          <h2 id="command-title">Commands</h2>
+          <label for="command-search">Search actions</label>
+          <input id="command-search" type="search" />
+          <div id="command-list" role="listbox"></div>
+        </div>
+      </div>
+
+      <div
+        id="welcome-modal"
+        class="modal-overlay hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="welcome-title"
+      >
+        <div class="modal">
+          <h2 id="welcome-title">Where do you want to start?</h2>
+          <button id="welcome-import">Import a Nextflow DAG</button>
+          <button id="welcome-new">Start a simple map</button>
+          <button id="welcome-example">Explore examples</button>
+          <button id="welcome-continue">Continue with recovered draft</button>
+        </div>
+      </div>
 
       <div
         id="report-modal"
@@ -397,7 +467,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/mode/simple.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/show-hint.min.js"></script>
     <script src="app.js"></script>
     <script>
       if ("serviceWorker" in navigator) {

--- a/website/public/playground/style.css
+++ b/website/public/playground/style.css
@@ -329,6 +329,13 @@ button:disabled {
 #preview-pane {
   background: var(--bg);
 }
+#drop-target {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
 #preview {
   flex: 1;
   overflow: auto;
@@ -734,13 +741,39 @@ button:disabled {
   border: 1px solid var(--border);
 }
 
+.mobile-view-switch {
+  display: none;
+}
+
 @media (max-width: 720px) {
+  .mobile-view-switch {
+    min-height: 43px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+    padding: 5px;
+    background: var(--panel);
+    border-bottom: 1px solid var(--border);
+  }
+  .mobile-view {
+    border: 0;
+    min-height: 32px;
+    background: transparent;
+    color: var(--muted);
+  }
+  .mobile-view.active {
+    background: var(--panel-2);
+    color: var(--accent);
+  }
   #split {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr 1fr;
+    grid-template-rows: minmax(0, 1fr);
+  }
+  #split[data-mobile-view="source"] #preview-pane,
+  #split[data-mobile-view="preview"] #editor-pane {
+    display: none;
   }
   #editor-pane {
     border-right: none;
-    border-bottom: 1px solid var(--border);
   }
 }

--- a/website/public/playground/sw.js
+++ b/website/public/playground/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-// Keep in sync with PYODIDE_VERSION in app.js. Bumping this constant
+// Keep in sync with PYODIDE_VERSION in worker.js. Bumping this constant
 // changes the cache name, which causes the activate handler to evict all
 // assets from the previous version.
 const PYODIDE_VERSION = "v0.27.2";

--- a/website/public/playground/worker.js
+++ b/website/public/playground/worker.js
@@ -1,0 +1,143 @@
+"use strict";
+
+const PYODIDE_VERSION = "v0.27.2";
+
+const PY_GLUE = `
+import hashlib
+import json
+import re as _re
+import warnings
+from nf_metro.api import prepare_graph, resolve_theme
+from nf_metro.convert import convert_nextflow_dag
+from nf_metro.parser.model import PermissiveGuardWarning, split_guard_warnings
+from nf_metro.render import render_svg
+
+_cached_graph = None
+_cached_key = None
+_RENDER_ONLY = frozenset({"animate", "directional"})
+_STYLE_RE = _re.compile(r"^\\s*%%metro\\s+(?:style|mode):.*$", _re.MULTILINE)
+
+def nfm_render(mmd, opts_json):
+    global _cached_graph, _cached_key
+    opts = json.loads(opts_json)
+    all_layout = {k: v for k, v in (opts.get("layout_options") or {}).items() if v is not None}
+
+    layout_geom = {k: v for k, v in all_layout.items() if k not in _RENDER_ONLY}
+    render_only = {k: v for k, v in all_layout.items() if k in _RENDER_ONLY}
+
+    mmd_norm = _STYLE_RE.sub("", mmd).strip()
+    cache_key = hashlib.md5((mmd_norm + "\\x00" + json.dumps(layout_geom, sort_keys=True)).encode()).hexdigest()
+
+    svg = None
+    error = None
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.filterwarnings("always", category=PermissiveGuardWarning)
+        try:
+            if cache_key != _cached_key:
+                graph = prepare_graph(mmd, layout_options=layout_geom)
+                _cached_graph = graph
+                _cached_key = cache_key
+            else:
+                graph = _cached_graph
+
+            for k, v in render_only.items():
+                setattr(graph, k, bool(v))
+
+            theme_obj = resolve_theme(opts.get("theme") or None, graph, mode=opts.get("mode") or None)
+            svg = render_svg(
+                graph,
+                theme_obj,
+                debug=bool(opts.get("debug")),
+                responsive=True,
+                font_portability="embed",
+                self_color_scheme=False,
+            )
+        except Exception as e:
+            error = f"{type(e).__name__}: {e}"
+
+    guard_warnings = [str(w.message) for w in split_guard_warnings(caught)[0]]
+    if svg is not None:
+        return json.dumps({"ok": True, "svg": svg, "warnings": guard_warnings})
+    return json.dumps({"ok": False, "error": error, "warnings": guard_warnings})
+
+def nfm_convert(nextflow_dag):
+    try:
+        return json.dumps({"ok": True, "mmd": convert_nextflow_dag(nextflow_dag)})
+    except Exception as e:
+        return json.dumps({"ok": False, "error": f"{type(e).__name__}: {e}"})
+`;
+
+let pyodide;
+let pyRender;
+let pyConvert;
+
+function progress(message, stage) {
+  postMessage({ type: "progress", message, stage });
+}
+
+async function resolveWheel() {
+  try {
+    const response = await fetch("wheels/index.json", { cache: "no-store" });
+    if (response.ok) {
+      const { wheel } = await response.json();
+      if (wheel) return new URL(`wheels/${wheel}`, self.location.href).href;
+    }
+  } catch (_) {
+    // A deployed release can fall back to PyPI when no development wheel exists.
+  }
+  return "nf-metro";
+}
+
+async function boot() {
+  progress("Loading the browser runtime", "runtime");
+  importScripts(
+    `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full/pyodide.js`,
+  );
+  pyodide = await loadPyodide({
+    indexURL: `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full/`,
+  });
+  progress("Installing nf-metro", "package");
+  await pyodide.loadPackage("micropip");
+  const micropip = pyodide.pyimport("micropip");
+  await micropip.install(await resolveWheel());
+  pyodide.runPython(PY_GLUE);
+  pyRender = pyodide.globals.get("nfm_render");
+  pyConvert = pyodide.globals.get("nfm_convert");
+  const version = pyodide.runPython("import nf_metro; nf_metro.__version__");
+  postMessage({ type: "ready", version });
+}
+
+self.onmessage = async ({ data }) => {
+  const { type, id } = data;
+  try {
+    if (type === "boot") {
+      await boot();
+      return;
+    }
+    if (type === "render") {
+      const started = performance.now();
+      const result = JSON.parse(pyRender(data.mmd, data.options));
+      postMessage({
+        type: "render-result",
+        id,
+        result,
+        duration: Math.round(performance.now() - started),
+      });
+      return;
+    }
+    if (type === "convert") {
+      postMessage({
+        type: "convert-result",
+        id,
+        result: JSON.parse(pyConvert(data.source)),
+      });
+    }
+  } catch (error) {
+    postMessage({
+      type: type === "boot" ? "boot-error" : "worker-error",
+      id,
+      operation: type,
+      error: String(error),
+    });
+  }
+};

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -34,219 +34,171 @@ import { base } from "../site";
           href: "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css",
         },
       },
+      {
+        tag: "link",
+        attrs: {
+          rel: "stylesheet",
+          href: "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/show-hint.min.css",
+        },
+      },
     ],
   }}
 >
   <div class="nfm-playground not-content">
+    <header class="app-command-bar">
+      <div class="route-strip" aria-label="Map workflow">
+        <span id="route-source" class="route-stop complete">
+          <span class="route-dot"></span><span>Source</span>
+        </span>
+        <span id="route-layout" class="route-stop">
+          <span class="route-dot"></span><span>Layout</span>
+        </span>
+        <span id="route-export" class="route-stop">
+          <span class="route-dot"></span><span>Export</span>
+        </span>
+      </div>
+      <div class="document-actions">
+        <button id="btn-new" title="Start a new map">New</button>
+        <button id="btn-open" title="Open a .mmd or Nextflow DAG file">Open</button>
+        <input id="file-open" class="hidden" type="file" accept=".mmd,.mermaid,.txt,text/plain" />
+        <button id="btn-convert" class="primary" title="Convert a Nextflow -with-dag Mermaid into a metro map">
+          Import DAG
+        </button>
+        <span class="command-sep"></span>
+        <button id="btn-share">Share</button>
+        <button id="btn-svg">SVG</button>
+        <button id="btn-png">PNG</button>
+        <button id="btn-copy-source" title="Copy the metro source">Copy source</button>
+        <button id="btn-commands" title="Open commands (Ctrl or Command + K)">Commands</button>
+      </div>
+      <div class="app-meta">
+        <span id="draft-status">Local draft</span>
+        <a id="build-hint" class="build-hint hidden" target="_blank" rel="noopener"></a>
+      </div>
+    </header>
+
+    <nav class="mobile-view-switch" aria-label="Playground view">
+      <button class="mobile-view active" data-view="source" aria-pressed="true">Source</button>
+      <button class="mobile-view" data-view="preview" aria-pressed="false">Preview</button>
+    </nav>
+
     <main id="split">
       <section id="editor-pane">
-        <div class="pane-toolbar">
-          <label
-            >Load
+        <div class="pane-heading">
+          <div>
+            <span class="pane-kicker">Source</span>
+            <strong id="document-name">Example Pipeline</strong>
+          </div>
+          <div class="history-actions">
+            <button id="btn-undo" title="Undo (Ctrl or Command + Z)">Undo</button>
+            <button id="btn-redo" title="Redo (Ctrl or Command + Shift + Z)">Redo</button>
+          </div>
+        </div>
+        <div class="pane-toolbar source-toolbar">
+          <label>Example
             <select id="example-select">
-              <option value="" selected>example…</option>
+              <option value="" selected>Choose…</option>
               <option value="__seed__">Starter pipeline</option>
             </select>
           </label>
-          <button
-            id="btn-convert"
-            title="Convert a Nextflow -with-dag Mermaid into a metro map"
-          >
-            Import Nextflow DAG
-          </button>
+          <label>Recent
+            <select id="recent-select"><option value="" selected>Choose…</option></select>
+          </label>
           <span class="sep"></span>
-          <span class="group-label">Insert</span>
+          <span class="group-label">Insert source</span>
           <button id="btn-section" title="Insert a section block">
-            + Section
+            Section block
           </button>
-          <button id="btn-line" title="Insert a line definition">+ Line</button>
-          <button id="btn-edge" title="Insert an edge">+ Edge</button>
-          <button
-            id="btn-logo"
-            title="Attach a logo image (embedded inline, since the playground can't read files from disk)"
-          >
-            + Logo
-          </button>
-          <span class="sep"></span>
-          <span class="group-label">Lines</span>
-          <div id="line-colors" class="swatches"></div>
+          <button id="btn-line" title="Insert a line definition">Line</button>
+          <button id="btn-edge" title="Insert an edge">Edge</button>
+          <button id="btn-logo" title="Attach a logo image">Logo</button>
+          <a class="source-help" href={`${base}guide/`} target="_blank">Syntax guide ↗</a>
         </div>
         <textarea id="editor"></textarea>
         <div id="error" class="hidden" role="alert"></div>
       </section>
 
       <section id="preview-pane">
-        <div class="pane-toolbar">
-          <label
-            >Brand
-            <select id="opt-theme">
-              <option value="nfcore">nf-core</option>
-              <option value="seqera">Seqera</option>
-            </select>
-          </label>
-          <label
-            >Mode
-            <select id="opt-mode">
-              <option value="dark">dark</option>
-              <option value="light">light</option>
-            </select>
-          </label>
-          <label class="check"
-            ><input type="checkbox" id="opt-animate" /> Animate</label
-          >
-          <label class="check"
-            ><input type="checkbox" id="opt-directional" /> Chevrons</label
-          >
-          <label class="check"
-            ><input type="checkbox" id="opt-debug" /> Debug</label
-          >
-          <label class="check"
-            ><input type="checkbox" id="opt-center-ports" /> Centre ports</label
-          >
-          <label
-            >Line gap
-            <input
-              type="number"
-              id="opt-track-gap"
-              min="0"
-              max="3"
-              step="0.5"
-              placeholder="1.0"
-            />
-          </label>
-        </div>
-
-        <div class="pane-toolbar">
-          <span class="group-label">Export</span>
-          <button id="btn-svg">SVG</button>
-          <button id="btn-png">PNG</button>
-          <button id="btn-share">Share link</button>
-          <button id="btn-copy-source">Copy source</button>
-          <div class="toolbar-right">
-            <a id="build-hint" class="muted small build-hint hidden"
-              target="_blank" rel="noopener"></a>
-            <button
-              id="btn-report"
-              class="report-btn"
-              title="Report a bug with this map"
-            >
-              Report a bug
-            </button>
+        <div class="pane-heading preview-heading">
+          <div>
+            <span class="pane-kicker">Preview</span>
+            <strong>Rendered map</strong>
+          </div>
+          <div class="preview-tabs" role="tablist" aria-label="Preview controls">
+            <button class="preview-tab active" data-panel="style" role="tab" aria-selected="true">Style</button>
+            <button class="preview-tab" data-panel="layout" role="tab" aria-selected="false">Layout</button>
+            <button class="preview-tab" data-panel="inspect" role="tab" aria-selected="false">Edit</button>
           </div>
         </div>
 
-        <details id="advanced" class="advanced">
-          <summary>Advanced options</summary>
-          <div class="pane-toolbar advanced-controls">
-            <span class="group-label">Layout</span>
-            <label
-              >Line spread
-              <select id="opt-line-spread">
-                <option value="">auto</option>
-                <option value="bundle">bundle</option>
-                <option value="centered">centered</option>
-                <option value="rails">rails</option>
+        <div class="preview-control-rail" aria-label="Preview controls">
+        <div id="panel-style" class="control-panel active">
+          <div class="control-row">
+            <span class="control-title">Style</span>
+            <label>Brand
+              <select id="opt-theme">
+                <option value="nfcore">nf-core</option>
+                <option value="seqera">Seqera</option>
               </select>
             </label>
-            <label
-              >Diamonds
-              <select id="opt-diamond-style">
-                <option value="">auto</option>
-                <option value="straight">straight</option>
-                <option value="symmetric">symmetric</option>
+            <label>Mode
+              <select id="opt-mode">
+                <option value="dark">dark</option>
+                <option value="light">light</option>
               </select>
             </label>
-            <label
-              >Line order
-              <select id="opt-line-order">
-                <option value="">auto</option>
-                <option value="definition">definition</option>
-                <option value="span">span</option>
-              </select>
-            </label>
-            <label class="check"
-              ><input type="checkbox" id="opt-compact-offsets" /> Compact offsets</label
-            >
-            <label
-              >Font scale
-              <input
-                type="number"
-                id="opt-font-scale"
-                min="0.1"
-                step="0.1"
-                placeholder="1.0"
-              />
-            </label>
-            <label
-              >Fold cols
-              <input
-                type="number"
-                id="opt-fold-threshold"
-                min="1"
-                step="1"
-                placeholder="auto"
-              />
-            </label>
-            <label
-              >X-spacing
-              <input
-                type="number"
-                id="opt-x-spacing"
-                min="1"
-                step="10"
-                placeholder="auto"
-              />
-            </label>
-            <label
-              >Y-spacing
-              <input
-                type="number"
-                id="opt-y-spacing"
-                min="1"
-                step="10"
-                placeholder="auto"
-              />
-            </label>
+            <label class="check"><input type="checkbox" id="opt-animate" /> Animate</label>
+            <label class="check"><input type="checkbox" id="opt-directional" /> Chevrons</label>
+            <span class="sep"></span>
+            <span class="group-label">Lines</span>
+            <div id="line-colors" class="swatches"></div>
           </div>
-        </details>
-
-        <div class="pane-toolbar edit-toolbar">
-          <span class="group-label">Edit map</span>
-          <button
-            class="mode-btn"
-            data-mode="select"
-            aria-pressed="true"
-            title="Select an element to inspect or edit it"
-          >
-            Select
-          </button>
-          <button
-            class="mode-btn"
-            data-mode="add-station"
-            aria-pressed="false"
-            title="Click a section to add a station to it"
-          >
-            + Station
-          </button>
-          <button
-            class="mode-btn"
-            data-mode="add-edge"
-            aria-pressed="false"
-            title="Click a source station, then a target, to connect them"
-          >
-            Connect
-          </button>
-          <span class="sep"></span>
-          <button id="btn-add-section" title="Add a new section">
-            + Section
-          </button>
-          <span class="sep"></span>
-          <span id="edit-hint" class="muted small"
-            >Click an element to select it.</span
-          >
         </div>
 
-        <div id="preview"></div>
+        <div id="panel-layout" class="control-panel" hidden>
+          <details id="advanced" class="advanced" open>
+            <summary>Layout controls</summary>
+            <div class="control-row advanced-controls">
+              <span class="control-title">Layout</span>
+              <label>Line spread
+                <select id="opt-line-spread"><option value="">auto</option><option value="bundle">bundle</option><option value="centered">centered</option><option value="rails">rails</option></select>
+              </label>
+              <label>Diamonds
+                <select id="opt-diamond-style"><option value="">auto</option><option value="straight">straight</option><option value="symmetric">symmetric</option></select>
+              </label>
+              <label>Line order
+                <select id="opt-line-order"><option value="">auto</option><option value="definition">definition</option><option value="span">span</option></select>
+              </label>
+              <label class="check"><input type="checkbox" id="opt-compact-offsets" /> Compact offsets</label>
+              <label class="check"><input type="checkbox" id="opt-center-ports" /> Centre ports</label>
+              <label class="check"><input type="checkbox" id="opt-debug" /> Debug geometry</label>
+              <label>Line gap <input type="number" id="opt-track-gap" min="0" max="3" step="0.5" placeholder="1.0" /></label>
+              <label>Font scale <input type="number" id="opt-font-scale" min="0.1" step="0.1" placeholder="1.0" /></label>
+              <label>Fold cols <input type="number" id="opt-fold-threshold" min="1" step="1" placeholder="auto" /></label>
+              <label>X-spacing <input type="number" id="opt-x-spacing" min="1" step="10" placeholder="auto" /></label>
+              <label>Y-spacing <input type="number" id="opt-y-spacing" min="1" step="10" placeholder="auto" /></label>
+            </div>
+          </details>
+        </div>
+
+        <div id="panel-inspect" class="control-panel" hidden>
+          <div class="control-row edit-toolbar">
+            <span class="control-title">Edit map</span>
+            <button class="mode-btn" data-mode="select" aria-pressed="true" title="Select an element to inspect or edit it">Select</button>
+            <button class="mode-btn" data-mode="add-station" aria-pressed="false" title="Click a section to add a station to it">Add station</button>
+            <button class="mode-btn" data-mode="add-edge" aria-pressed="false" title="Click a source station, then a target, to connect them">Connect</button>
+            <button id="btn-add-section" title="Add a new section">Add section</button>
+            <span class="sep"></span>
+            <span id="edit-hint" class="muted small">Click an element to select it.</span>
+          </div>
+        </div>
+        </div>
+
+        <div class="canvas-shell" id="drop-target">
+          <div id="stale-preview" class="stale-preview hidden">Showing the previous render</div>
+          <div id="preview"></div>
+          <div class="drop-invitation hidden" id="drop-invitation">Drop a .mmd file or Nextflow DAG</div>
+        </div>
 
         <div id="zoom-controls">
           <button id="zoom-out" title="Zoom out" aria-label="Zoom out">
@@ -280,16 +232,55 @@ import { base } from "../site";
 
         <div id="boot" class="overlay">
           <div class="spinner"></div>
-          <p id="boot-msg">Starting Python runtime…</p>
+          <p id="boot-msg">Loading the browser runtime</p>
           <p class="muted small">
-            First load fetches the WASM runtime (~10&nbsp;MB); subsequent loads
-            are cached.
+            Editing stays responsive while the renderer starts. The runtime is cached after the first visit.
           </p>
+          <button id="boot-retry" class="hidden">Retry renderer</button>
         </div>
       </section>
     </main>
 
+    <footer class="status-bar" aria-live="polite">
+      <span id="render-status" data-state="loading"><span class="status-dot"></span>Renderer starting</span>
+      <span id="runtime-version">Browser renderer</span>
+      <button id="btn-report" class="status-action" title="Report a bug with this map">Report a problem</button>
+    </footer>
+
     <div id="toast" class="hidden"></div>
+
+    <div id="command-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="command-title">
+      <div class="modal command-modal">
+        <h2 id="command-title">Commands</h2>
+        <label class="command-search-label" for="command-search">Search actions</label>
+        <input id="command-search" class="command-search" type="search" autocomplete="off" placeholder="Type a command…" />
+        <div id="command-list" class="command-list" role="listbox"></div>
+        <p class="command-hint">↑↓ choose · Enter run · Esc close</p>
+      </div>
+    </div>
+
+    <div id="welcome-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="welcome-title">
+      <div class="modal welcome-modal">
+        <p class="modal-kicker">nf-metro playground</p>
+        <h2 id="welcome-title">Where do you want to start?</h2>
+        <p class="muted">Build a publishable pipeline map without installing anything. Your work stays in this browser unless you share or download it.</p>
+        <div class="start-options">
+          <button id="welcome-import" class="start-option primary-option">
+            <strong>Import a Nextflow DAG</strong>
+            <span>Convert a <code>-with-dag</code> Mermaid file into an editable metro map.</span>
+          </button>
+          <button id="welcome-new" class="start-option">
+            <strong>Start a simple map</strong>
+            <span>Use a small, working pipeline and edit the source or canvas.</span>
+          </button>
+          <button id="welcome-example" class="start-option">
+            <strong>Explore examples</strong>
+            <span>Choose from a curated set of common pipeline shapes.</span>
+          </button>
+        </div>
+        <button id="welcome-continue" class="welcome-continue">Continue with the recovered draft</button>
+      </div>
+    </div>
 
     <div
       id="report-modal"
@@ -391,8 +382,8 @@ import { base } from "../site";
 
   <!--
     CDN scripts and app.js are loaded as inline (unprocessed) script tags so
-    Vite does not try to bundle them. CodeMirror 5 and Pyodide expose globals
-    (CodeMirror, loadPyodide) that app.js depends on; load order matters.
+    Vite does not try to bundle them. CodeMirror exposes the editor globals;
+    Pyodide is loaded independently inside worker.js.
   -->
   <script
     is:inline
@@ -404,7 +395,8 @@ import { base } from "../site";
   ></script>
   <script
     is:inline
-    src="https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"></script>
+    src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/show-hint.min.js"
+  ></script>
   <!--
     app.js lives in public/playground/ and is served at /playground/app.js.
     Its relative fetch calls (wheels/index.json, examples.json) resolve against
@@ -519,15 +511,15 @@ import { base } from "../site";
   /* Custom properties and flex fill */
   .nfm-playground {
     color-scheme: dark;
-    --pg-bg: #0b0e14;
-    --pg-panel: #11161f;
-    --pg-panel-2: #161c27;
-    --pg-border: #232b39;
-    --pg-text: #c9d1d9;
-    --pg-muted: #7d8794;
-    --pg-accent: #2dd4bf;
-    --pg-accent-press: #14b8a6;
-    --pg-danger: #f0716f;
+    --pg-bg: #0b1320;
+    --pg-panel: #111b2a;
+    --pg-panel-2: #172437;
+    --pg-border: #2a394d;
+    --pg-text: #e5ebf2;
+    --pg-muted: #8e9bae;
+    --pg-accent: #19b7a5;
+    --pg-accent-press: #129887;
+    --pg-danger: #d95d57;
     --pg-danger-bg: #2a1414;
 
     /* Expose the short names used throughout app.js-generated HTML */
@@ -566,15 +558,15 @@ import { base } from "../site";
   */
   :root[data-theme="light"] .nfm-playground {
     color-scheme: light;
-    --pg-bg: #ffffff;
-    --pg-panel: #f6f7f9;
-    --pg-panel-2: #eceef1;
-    --pg-border: #d8dde4;
-    --pg-text: #1f2530;
-    --pg-muted: #5a6472;
-    --pg-accent: #0d9488;
+    --pg-bg: #f7f9fc;
+    --pg-panel: #ffffff;
+    --pg-panel-2: #edf2f7;
+    --pg-border: #dbe2ea;
+    --pg-text: #172234;
+    --pg-muted: #5c6879;
+    --pg-accent: #0b8f82;
     --pg-accent-press: #0f766e;
-    --pg-danger: #c0392b;
+    --pg-danger: #b84742;
     --pg-danger-bg: #fdeaea;
   }
 
@@ -1230,14 +1222,472 @@ import { base } from "../site";
     border: 1px solid var(--border);
   }
 
+  /* Playground information architecture */
+  .app-command-bar {
+    min-height: 54px;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 18px;
+    padding: 7px 12px;
+    background: color-mix(in srgb, var(--panel) 92%, var(--accent));
+    border-bottom: 1px solid var(--border);
+  }
+  .route-strip {
+    display: flex;
+    align-items: center;
+    min-width: 262px;
+  }
+  .route-stop {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--muted);
+    font-family: "Degular", "Arial Narrow", sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+  }
+  .route-stop:not(:last-child)::after {
+    content: "";
+    width: 42px;
+    height: 3px;
+    margin: 0 7px;
+    border-radius: 3px;
+    background: var(--border);
+  }
+  .route-dot {
+    width: 11px;
+    height: 11px;
+    border: 2px solid var(--muted);
+    border-radius: 50%;
+    background: var(--panel);
+  }
+  .route-stop.complete,
+  .route-stop.active {
+    color: var(--text);
+  }
+  .route-stop.complete .route-dot {
+    border-color: #19b7a5;
+    background: #19b7a5;
+    box-shadow: 0 0 0 3px color-mix(in srgb, #19b7a5 18%, transparent);
+  }
+  .route-stop.active .route-dot {
+    border-color: #8b6fcf;
+    animation: route-pulse 1.2s ease-in-out infinite;
+  }
+  .route-stop.warning .route-dot {
+    border-color: #d9a441;
+    background: #d9a441;
+  }
+  .route-stop.error .route-dot {
+    border-color: var(--danger);
+    background: var(--danger);
+  }
+  @keyframes route-pulse {
+    50% { box-shadow: 0 0 0 5px color-mix(in srgb, #8b6fcf 20%, transparent); }
+  }
+  .document-actions,
+  .history-actions,
+  .preview-tabs {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .document-actions {
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .document-actions::-webkit-scrollbar { display: none; }
+  .command-sep {
+    width: 1px;
+    height: 24px;
+    flex: 0 0 auto;
+    margin: 0 3px;
+    background: var(--border);
+  }
+  .nfm-playground button.primary {
+    border-color: #19b7a5;
+    background: #19b7a5;
+    color: #061511;
+    font-weight: 650;
+  }
+  .app-meta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--muted);
+    font: 11px/1.2 "SF Mono", Menlo, monospace;
+    white-space: nowrap;
+  }
+  .mobile-view-switch { display: none; }
+  .pane-heading {
+    min-height: 51px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 7px 12px;
+    background: var(--panel);
+    border-bottom: 1px solid var(--border);
+  }
+  .pane-heading > div:first-child {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .pane-heading strong {
+    overflow: hidden;
+    color: var(--text);
+    font: 600 15px/1.15 "Degular", "Arial Narrow", sans-serif;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pane-kicker {
+    color: var(--accent);
+    font: 700 10px/1.1 "SF Mono", Menlo, monospace;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  .history-actions button { padding: 3px 7px; color: var(--muted); }
+  .source-help {
+    margin-left: auto;
+    color: var(--muted);
+    font-size: 11px;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .source-help:hover { color: var(--accent); }
+  .preview-tabs {
+    padding: 3px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg);
+  }
+  .nfm-playground .preview-tab {
+    border: 0;
+    padding: 4px 9px;
+    background: transparent;
+  }
+  .nfm-playground .preview-tab.active {
+    background: var(--panel-2);
+    color: var(--accent);
+  }
+  .control-panel {
+    min-height: 48px;
+    background: var(--panel);
+    border-right: 1px solid var(--border);
+  }
+  .preview-control-rail {
+    display: block;
+    flex: 0 0 auto;
+    border-bottom: 1px solid var(--border);
+    background: var(--panel);
+  }
+  .preview-control-rail .control-panel {
+    border-right: 0;
+    border-bottom: 0;
+  }
+  .preview-control-rail .control-panel[hidden] { display: none; }
+  .preview-control-rail .control-row {
+    flex-wrap: wrap;
+    min-height: 44px;
+    padding-block: 5px;
+  }
+  .control-title {
+    color: var(--accent);
+    font: 700 10px/1 "SF Mono", Menlo, monospace;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .control-row {
+    min-height: 48px;
+    display: flex;
+    align-items: center;
+    gap: 8px 12px;
+    flex-wrap: wrap;
+    padding: 7px 12px;
+  }
+  .control-row label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--muted);
+    font-size: 12px;
+    white-space: nowrap;
+  }
+  .control-row.edit-toolbar { border: 0; }
+  .advanced { border: 0; }
+  .advanced > summary { display: none; }
+  .canvas-shell {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    background-color: var(--bg);
+    background-image: radial-gradient(circle, color-mix(in srgb, var(--border) 48%, transparent) 0.7px, transparent 0.8px);
+    background-size: 18px 18px;
+  }
+  .canvas-shell #preview { width: 100%; height: 100%; }
+  .stale-preview {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    z-index: 8;
+    transform: translateX(-50%);
+    padding: 4px 9px;
+    border: 1px solid #d9a441;
+    border-radius: 999px;
+    background: var(--panel);
+    color: #d9a441;
+    font-size: 11px;
+  }
+  .drop-invitation {
+    position: absolute;
+    inset: 14px;
+    z-index: 20;
+    display: grid;
+    place-items: center;
+    border: 2px dashed var(--accent);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--panel) 92%, transparent);
+    color: var(--text);
+    font: 600 16px "Degular", sans-serif;
+    pointer-events: none;
+  }
+  .status-bar {
+    min-height: 29px;
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 4px 12px;
+    border-top: 1px solid var(--border);
+    background: var(--panel);
+    color: var(--muted);
+    font: 11px/1 "SF Mono", Menlo, monospace;
+  }
+  #render-status { display: inline-flex; align-items: center; gap: 7px; color: var(--text); }
+  .status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--muted);
+  }
+  #render-status[data-state="loading"] .status-dot { background: #8b6fcf; }
+  #render-status[data-state="ready"] .status-dot { background: #19b7a5; }
+  #render-status[data-state="warning"] .status-dot { background: #d9a441; }
+  #render-status[data-state="error"] .status-dot { background: var(--danger); }
+  .nfm-playground button.status-action {
+    margin-left: auto;
+    border: 0;
+    padding: 2px 4px;
+    background: transparent;
+    color: var(--muted);
+    font-size: 11px;
+  }
+  #error {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 9px;
+    max-height: 34%;
+  }
+  #error[data-severity="warning"] {
+    border-color: #d9a441;
+    background: color-mix(in srgb, #d9a441 12%, var(--panel));
+    color: #d9a441;
+  }
+  #error strong { font-family: system-ui, sans-serif; white-space: nowrap; }
+  #error span { min-width: 0; }
+  .nfm-playground button.diagnostic-jump {
+    border-color: currentColor;
+    background: transparent;
+    color: inherit;
+    white-space: nowrap;
+  }
+  .diagnostic-marker {
+    display: grid;
+    width: 15px;
+    height: 15px;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--danger);
+    color: white;
+    font: 700 10px/1 system-ui;
+  }
+  .diagnostic-marker.warning { background: #d9a441; color: #1a1200; }
+  .welcome-modal { width: min(720px, 100%); }
+  .command-modal { width: min(520px, 100%); padding: 14px; }
+  .command-search-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+  }
+  .nfm-playground .command-search {
+    width: 100%;
+    margin-top: 7px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: var(--bg);
+    color: var(--text);
+    font: 13px "SF Mono", Menlo, monospace;
+  }
+  .command-list {
+    max-height: 310px;
+    margin-top: 8px;
+    overflow: auto;
+  }
+  .nfm-playground .command-item {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    border: 0;
+    padding: 8px 10px;
+    background: transparent;
+    text-align: left;
+  }
+  .nfm-playground .command-item.selected { background: var(--panel-2); }
+  .command-item span { color: var(--muted); font-size: 11px; }
+  .command-hint {
+    margin: 8px 2px 0 !important;
+    color: var(--muted);
+    font: 10px "SF Mono", Menlo, monospace;
+  }
+  html:has(#split) .CodeMirror-hints {
+    z-index: 40;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 8px;
+    background: var(--sl-color-bg-nav);
+    color: var(--sl-color-text);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.32);
+    font: 12px "SF Mono", Menlo, monospace;
+  }
+  html:has(#split) .CodeMirror-hint { padding: 5px 8px; }
+  html:has(#split) li.CodeMirror-hint-active { background: var(--sl-color-accent); color: white; }
+  .modal-kicker {
+    color: var(--accent);
+    font: 700 10px/1 "SF Mono", Menlo, monospace;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  .start-options {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 18px;
+  }
+  .nfm-playground .start-option {
+    min-height: 142px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 9px;
+    padding: 16px;
+    text-align: left;
+  }
+  .start-option strong { font: 600 17px/1.1 "Degular", sans-serif; }
+  .start-option span { color: var(--muted); font-size: 12px; line-height: 1.45; }
+  .nfm-playground .start-option.primary-option {
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 10%, var(--panel-2));
+  }
+  .nfm-playground .welcome-continue {
+    display: block;
+    margin: 14px auto 0;
+    border: 0;
+    background: transparent;
+    color: var(--muted);
+    text-decoration: underline;
+  }
+  .nfm-playground button:focus-visible,
+  .nfm-playground select:focus-visible,
+  .nfm-playground input:focus-visible,
+  .nfm-playground textarea:focus-visible,
+  .nfm-playground summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .route-stop.active .route-dot,
+    .spinner { animation: none; }
+  }
+
+  @media (max-width: 900px) {
+    .route-strip { min-width: auto; }
+    .route-stop span:last-child { display: none; }
+    .route-stop:not(:last-child)::after { width: 22px; }
+    .app-meta { display: none; }
+  }
+
   @media (max-width: 720px) {
+    .app-command-bar {
+      min-height: 51px;
+      display: flex;
+      gap: 10px;
+      padding: 6px 8px;
+    }
+    .route-strip { flex: 0 0 auto; }
+    .route-stop:not(:last-child)::after { width: 11px; margin-inline: 4px; }
+    .document-actions { flex: 1; }
+    .document-actions button { min-height: 38px; white-space: nowrap; }
+    .document-actions .command-sep,
+    #btn-copy-source { display: none; }
+    .mobile-view-switch {
+      min-height: 43px;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 4px;
+      padding: 5px;
+      border-bottom: 1px solid var(--border);
+      background: var(--panel);
+    }
+    .nfm-playground .mobile-view {
+      min-height: 32px;
+      border: 0;
+      background: transparent;
+      color: var(--muted);
+    }
+    .nfm-playground .mobile-view.active {
+      background: var(--panel-2);
+      color: var(--accent);
+    }
     #split {
       grid-template-columns: 1fr;
-      grid-template-rows: 1fr 1fr;
+      grid-template-rows: minmax(0, 1fr);
     }
-    #editor-pane {
-      border-right: none;
-      border-bottom: 1px solid var(--border);
+    #split[data-mobile-view="source"] #preview-pane,
+    #split[data-mobile-view="preview"] #editor-pane { display: none; }
+    #editor-pane { border-right: 0; }
+    .pane-heading { min-height: 49px; }
+    .source-toolbar,
+    .control-row {
+      min-height: 49px;
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      scrollbar-width: none;
     }
+    .source-toolbar::-webkit-scrollbar,
+    .control-row::-webkit-scrollbar { display: none; }
+    .preview-heading { align-items: center; }
+    .preview-heading > div:first-child { display: none; }
+    .preview-tabs { width: 100%; }
+    .preview-tab { flex: 1; min-height: 34px; }
+    .control-panel { min-height: 49px; }
+    .advanced .advanced-controls { flex-wrap: nowrap; }
+    .start-options { grid-template-columns: 1fr; }
+    .nfm-playground .start-option { min-height: 96px; }
+    .modal-overlay { padding: 12px; }
+    .welcome-modal { max-height: calc(100vh - 24px); overflow: auto; }
+    .status-bar { padding-inline: 9px; }
+    #runtime-version { display: none; }
+    #error { grid-template-columns: 1fr; }
   }
 </style>


### PR DESCRIPTION
## Summary

- reshape the playground into a full-height, contextual editor with source controls beside the editor and Style, Layout, and Edit controls beside the rendered map
- add local draft recovery, recent maps, file and Nextflow DAG import, source completion, command search, diagnostics, direct map editing, responsive pane switching, and improved export and sharing workflows
- move Pyodide and nf-metro rendering into a Web Worker so editing remains responsive, with visible startup progress, timeout recovery, and retry support
- keep the implementation fully static and GitHub Pages compatible, including service-worker caching for the browser runtime and wheel
- expand the Playwright suite to cover the new workflows, worker rendering, and full-height layout

## Verification

- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `prek run prettier --all-files`
- `npm run build` in `website/` (309 pages built, internal links valid)
- Playwright playground suite (49 passed)
- desktop and mobile visual checks against the local Astro route