### PR TITLE
Fix deployed playground startup

### DIFF
--- a/tests/test_playground_dom_contract.py
+++ b/tests/test_playground_dom_contract.py
@@ -1,0 +1,41 @@
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+APP_PATH = ROOT / "website/public/playground/app.js"
+MARKUP_PATHS = [
+    ROOT / "website/src/pages/playground.astro",
+    ROOT / "website/public/playground/harness.html",
+]
+
+
+def _block(source: str, name: str) -> str:
+    match = re.search(rf"const {name} = \[(.*?)\];", source, re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def _required_element_ids(source: str) -> set[str]:
+    direct_ids = set(re.findall(r'\bel\("([^"]+)"\)', source)) - {"btn-theme"}
+    directive_ids = set(
+        re.findall(r'\["([^"]+)",', _block(source, "DIRECTIVE_CONTROLS"))
+    )
+    snippet_match = re.search(r"const SNIPPETS = \{(.*?)\n\};", source, re.DOTALL)
+    assert snippet_match is not None
+    snippet_ids = set(
+        re.findall(r'^\s*"([^"]+)":', snippet_match.group(1), re.MULTILINE)
+    )
+    return direct_ids | directive_ids | snippet_ids
+
+
+@pytest.mark.parametrize("markup_path", MARKUP_PATHS, ids=lambda path: path.name)
+def test_playground_markup_provides_required_elements(markup_path: Path) -> None:
+    required_ids = _required_element_ids(APP_PATH.read_text())
+    markup_ids = set(re.findall(r'\bid="([^"]+)"', markup_path.read_text()))
+
+    assert required_ids <= markup_ids, (
+        f"{markup_path.name} lacks required element IDs: "
+        f"{sorted(required_ids - markup_ids)}"
+    )

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -174,6 +174,7 @@ import { base } from "../site";
               <label class="check"><input type="checkbox" id="opt-debug" /> Debug geometry</label>
               <label>Line gap <input type="number" id="opt-track-gap" min="0" max="3" step="0.5" placeholder="1.0" /></label>
               <label>Font scale <input type="number" id="opt-font-scale" min="0.1" step="0.1" placeholder="1.0" /></label>
+              <label>Stroke scale <input type="number" id="opt-stroke-scale" min="0.1" step="0.1" placeholder="1.0" /></label>
               <label>Fold cols <input type="number" id="opt-fold-threshold" min="1" step="1" placeholder="auto" /></label>
               <label>X-spacing <input type="number" id="opt-x-spacing" min="1" step="10" placeholder="auto" /></label>
               <label>Y-spacing <input type="number" id="opt-y-spacing" min="1" step="10" placeholder="auto" /></label>


### PR DESCRIPTION
## Summary

- restore the missing Stroke scale input required by the playground control wiring
- prevent the Astro page and standalone test harness from drifting by checking both against every required `app.js` element ID

The missing element caused `wireControls()` to throw before `boot()`, leaving the deployed page permanently on “Loading the browser runtime” without creating the Worker.

## Verification

- fresh real-Astro browser boot rendered successfully in 4.35 seconds
- DOM contract tests: 2 passed
- playground Playwright suite: 49 passed
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `prek run prettier --all-files`
- production Astro build: 322 pages built, internal links valid
- commit hooks: Ruff, Prettier, and mypy passed