### PR TITLE
refactor(parser): resolve routes from RouteTopology

### DIFF
--- a/docs/dev/parser.mdx
+++ b/docs/dev/parser.mdx
@@ -282,10 +282,11 @@ runs a post-parse sequence (only when the graph has sections):
    through each synthetic convergence edge.
 6. `resolve_section_endpoints` - classify connectors and settle their entry
    and exit sides once, before ports exist.
-7. Build the immutable `RouteTopology` observation described below.
-8. `_resolve_sections` - consume the same endpoint resolution in the core
-   rewrite (below).
-9. `_insert_bypass_stations`.
+7. Build the immutable `RouteTopology` described below.
+8. `_resolve_sections` - create ports and junctions from that topology, using
+   the endpoint result for current edge endpoints and compatibility order.
+9. `_insert_bypass_stations` - split any required exit legs and update their
+   connector traces.
 
 Finally the parser applies pending terminus icons, `off_track` marks,
 and per-station markers that were buffered during the statement scan.
@@ -302,15 +303,16 @@ chains. It is split into three helpers:
 - `_classify_edges` - split edges into internal (both endpoints in one
   section) and inter-section, and populate each section's
   `internal_edges`.
-- `_create_ports_and_junctions` - create `Port` objects and rewrite each
-  inter-section edge into a chain: `source -> exit_port -> entry_port ->
-target`. The design rule is **one exit port per source section** (all
-  lines leave together for consistent ordering) and **one entry port per
-  target section per side**; junction stations handle fan-out to multiple
-  target sections.
+- `_create_ports_and_junctions` - create `Port` objects from topology endpoint
+  groups and rewrite each inter-section edge into a chain:
+  `source -> exit_port -> entry_port -> target`. The design rule is **one exit
+  port per source section and side** and **one entry port per target section
+  and side**. Lines sharing a boundary leave together for consistent ordering.
+  Topology divergence groups decide where fan-out junctions are required.
 
-After ports and junctions exist, `_insert_merge_junctions` adds merge
-junctions and `_assign_section_numbers` numbers any unnumbered sections.
+After ports and fan junctions exist, topology convergence groups decide where
+merge junctions are required. `_assign_section_numbers` then numbers any
+unnumbered sections.
 
 The result is a `MetroGraph` whose edges all live within a section or
 run port-to-port, ready for the layout stage.
@@ -324,9 +326,11 @@ authored connector through interchange and terminus-convergence rewrites, but
 is never stored on `MetroGraph` or `Edge`.
 
 After terminus convergence, `resolve_section_endpoints` settles every boundary
-side on the production graph. The topology builder and `_resolve_sections`
-consume that one result, so observation and resolution cannot choose different
-sides. The result is transient and is not retained by the resolved graph.
+side on the production graph. It retains the current edge endpoints and their
+encounter order. The topology builder uses those boundary facts to describe
+the semantic groups. `_resolve_sections` then creates ports and junctions from
+the topology, while the boundary result preserves the current edge endpoints
+and output order.
 
 The topology contains one connected `LineNetwork` per line component, exact
 endpoint `BundleRun`s, cross-section connectors, resolved endpoint groups,
@@ -339,8 +343,16 @@ All records are frozen and contain only scalar values, `PortSide` values, and
 tuples. They retain no `MetroGraph`, station, section, edge, mutable container,
 or NetworkX object. Top-level and nested collections have explicit canonical
 ordering, so the same input produces the same topology under every hash seed.
-`RouteTopology` is parser observation state and is excluded from `RenderPlan`;
-clearing it cannot change plan, SVG, HTML, manifest, or layout output.
+The resolver also records a `RouteResolutionTrace`. It maps endpoint groups to
+ports, fan and merge groups to junctions, and each authored connector to its
+ordered final edge paths. Most connectors have one path. A connector can have
+several when one exit leg needs parallel bypass helpers. The records use scalar
+ids and tuples, so duplicate authored connectors can safely share paths. Bypass
+insertion updates the affected paths when it splits an exit leg.
+
+`RouteTopology` and `RouteResolutionTrace` are parser metadata and are excluded
+from `RenderPlan`. Clearing them cannot change plan, SVG, HTML, manifest, or
+layout output.
 
 ## Adding things
 

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -46,6 +46,7 @@ from nf_metro.parser.resolve import (
 )
 from nf_metro.parser.route_topology import (
     AuthoredEdgeLineage,
+    RouteResolutionTrace,
     build_route_topology,
     capture_authored_routes,
 )
@@ -328,14 +329,17 @@ def _infer_layout(graph: MetroGraph, max_station_columns: int | None) -> None:
                 graph._fold_threshold_effective = eff_cols
                 graph._fold_compressed_sections = relocated
         _insert_terminus_convergence_stations(graph, authored_lineage)
-        endpoint_resolution = resolve_section_endpoints(graph)
+        endpoint_resolution = resolve_section_endpoints(graph, authored_lineage)
         graph.route_topology = build_route_topology(
             authored_capture, authored_lineage, endpoint_resolution
         )
-        _resolve_sections(graph, endpoint_resolution)
-        _insert_bypass_stations(graph)
+        graph.route_resolution = _resolve_sections(
+            graph, endpoint_resolution, graph.route_topology
+        )
+        graph.route_resolution = _insert_bypass_stations(graph, graph.route_resolution)
     else:
         graph.route_topology = build_route_topology(authored_capture, authored_lineage)
+        graph.route_resolution = RouteResolutionTrace()
 
 
 def _apply_pending_metadata(graph: MetroGraph) -> None:

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Literal, TypedDict
 from nf_metro.errors import NfMetroError
 
 if TYPE_CHECKING:
-    from nf_metro.parser.route_topology import RouteTopology
+    from nf_metro.parser.route_topology import RouteResolutionTrace, RouteTopology
 
 
 class RowGridInfo(TypedDict):
@@ -453,6 +453,9 @@ class MetroGraph:
     ports: dict[str, Port] = field(default_factory=dict)
     junctions: list[str] = field(default_factory=list)
     route_topology: RouteTopology | None = field(
+        default=None, compare=False, repr=False
+    )
+    route_resolution: RouteResolutionTrace | None = field(
         default=None, compare=False, repr=False
     )
     groups: list[StationGroup] = field(default_factory=list)

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import networkx as nx
 
@@ -24,7 +24,23 @@ from nf_metro.parser.model import (
     Section,
     Station,
 )
-from nf_metro.parser.route_topology import AuthoredEdgeKey, AuthoredEdgeLineage
+from nf_metro.parser.route_topology import (
+    AuthoredEdgeKey,
+    AuthoredEdgeLineage,
+    ConnectorId,
+    ConvergenceId,
+    DivergenceGroup,
+    DivergenceId,
+    EndpointGroupId,
+    ResolvedConnector,
+    ResolvedConvergence,
+    ResolvedDivergence,
+    ResolvedEdge,
+    ResolvedEndpointPort,
+    RouteConnector,
+    RouteResolutionTrace,
+    RouteTopology,
+)
 
 
 def _remove_empty_sections(graph: MetroGraph) -> None:
@@ -350,7 +366,33 @@ def _insert_terminus_convergence_stations(
         graph.add_edge(edge)
 
 
-def _insert_bypass_stations(graph: MetroGraph) -> None:
+def _expand_resolved_paths(
+    edge_paths: tuple[tuple[ResolvedEdge, ...], ...],
+    replacements: dict[ResolvedEdge, list[tuple[ResolvedEdge, ...]]],
+) -> tuple[tuple[ResolvedEdge, ...], ...]:
+    """Expand connector paths across edges replaced by parallel bypass paths."""
+    expanded_paths: list[tuple[ResolvedEdge, ...]] = []
+    changed = False
+    for path in edge_paths:
+        variants: list[tuple[ResolvedEdge, ...]] = [()]
+        for edge in path:
+            replacement_paths = replacements.get(edge)
+            if replacement_paths is None:
+                replacement_paths = [(edge,)]
+            else:
+                changed = True
+            variants = [
+                prefix + replacement
+                for prefix in variants
+                for replacement in replacement_paths
+            ]
+        expanded_paths.extend(variants)
+    return tuple(expanded_paths) if changed else edge_paths
+
+
+def _insert_bypass_stations(
+    graph: MetroGraph, route_resolution: RouteResolutionTrace
+) -> RouteResolutionTrace:
     """Insert virtual stations so non-consumed lines bypass intermediate stops.
 
     When a station S sits in the layer-path between an in-section
@@ -402,7 +444,7 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
       (L)``.
     """
     if not graph.sections:
-        return
+        return route_resolution
 
     pending_terminus_ids: set[str] = set(graph._pending_terminus.keys())
 
@@ -413,6 +455,7 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
     new_stations: list[Station] = []
     new_edges: list[Edge] = []
     edges_to_remove: set[int] = set()
+    bypass_replacements: dict[ResolvedEdge, list[tuple[ResolvedEdge, ...]]] = {}
     bypass_count = 0
 
     for section in graph.sections.values():
@@ -441,15 +484,19 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
                 )
                 for idx, edge in bypass_edges:
                     edges_to_remove.add(idx)
-                    new_edges.append(
-                        Edge(source=edge.source, target=v_id, line_id=edge.line_id)
-                    )
-                    new_edges.append(
-                        Edge(source=v_id, target=edge.target, line_id=edge.line_id)
+                    first = Edge(source=edge.source, target=v_id, line_id=edge.line_id)
+                    second = Edge(source=v_id, target=edge.target, line_id=edge.line_id)
+                    new_edges.extend((first, second))
+                    replaced = ResolvedEdge(edge.source, edge.target, edge.line_id)
+                    bypass_replacements.setdefault(replaced, []).append(
+                        (
+                            ResolvedEdge(first.source, first.target, first.line_id),
+                            ResolvedEdge(second.source, second.target, second.line_id),
+                        )
                     )
 
     if not new_stations:
-        return
+        return route_resolution
 
     for st in new_stations:
         graph.register_station(st)
@@ -460,6 +507,21 @@ def _insert_bypass_stations(graph: MetroGraph) -> None:
         )
     for edge in new_edges:
         graph.add_edge(edge)
+
+    shared_paths: dict[
+        tuple[tuple[ResolvedEdge, ...], ...],
+        tuple[tuple[ResolvedEdge, ...], ...],
+    ] = {}
+    connectors: list[ResolvedConnector] = []
+    for item in route_resolution.connectors:
+        paths = _expand_resolved_paths(item.edge_paths, bypass_replacements)
+        paths = shared_paths.setdefault(paths, paths)
+        connectors.append(
+            item
+            if paths is item.edge_paths
+            else ResolvedConnector(item.connector_id, paths)
+        )
+    return replace(route_resolution, connectors=tuple(connectors))
 
 
 def _section_topo_layers(graph: MetroGraph, section_ids: set[str]) -> dict[str, int]:
@@ -609,45 +671,42 @@ class ResolvedConnectorEndpoint:
     target_section: str
     exit_side: PortSide
     entry_side: PortSide
+    connector_ids: tuple[ConnectorId, ...]
 
 
 @dataclass(slots=True)
 class SectionEndpointResolution:
-    """Pre-port edge classification and boundary grouping for section resolve."""
+    """Pre-port edge classification and current boundary endpoints."""
 
     internal_edges: list[Edge]
     inter_section_edges: list[Edge]
     connectors: tuple[ResolvedConnectorEndpoint, ...]
-    entry_side_for_line: dict[tuple[str, str], PortSide]
-    exit_sides: dict[tuple[str, str], set[PortSide]]
-    exit_group_edges: dict[tuple[str, PortSide], list[Edge]]
-    entry_group_edges: dict[tuple[str, PortSide], list[Edge]]
 
 
-def resolve_section_endpoints(graph: MetroGraph) -> SectionEndpointResolution:
+def resolve_section_endpoints(
+    graph: MetroGraph, lineage: AuthoredEdgeLineage
+) -> SectionEndpointResolution:
     """Resolve inter-section endpoint sides once, before creating synthetic ports."""
     internal_edges, inter_section_edges = _classify_edges(graph)
     _reside_folded_flow_ports_to_grid(graph, inter_section_edges)
     _reanchor_flow_axis_ports(graph, inter_section_edges)
     entry_side_for_line = _build_entry_side_mapping(graph, inter_section_edges)
     exit_sides = _build_exit_side_mapping(graph)
-    connectors, exit_group_edges, entry_group_edges = _group_inter_section_edges(
-        graph, inter_section_edges, entry_side_for_line, exit_sides
+    connectors = _group_inter_section_edges(
+        graph, inter_section_edges, entry_side_for_line, exit_sides, lineage
     )
     return SectionEndpointResolution(
         internal_edges=internal_edges,
         inter_section_edges=inter_section_edges,
         connectors=connectors,
-        entry_side_for_line=entry_side_for_line,
-        exit_sides=exit_sides,
-        exit_group_edges=exit_group_edges,
-        entry_group_edges=entry_group_edges,
     )
 
 
 def _resolve_sections(
-    graph: MetroGraph, resolution: SectionEndpointResolution | None = None
-) -> None:
+    graph: MetroGraph,
+    resolution: SectionEndpointResolution,
+    topology: RouteTopology,
+) -> RouteResolutionTrace:
     """Post-parse: classify edges, create ports, rewrite inter-section edges.
 
     Key design: ONE exit port per source section. All lines leaving a section
@@ -655,14 +714,13 @@ def _resolve_sections(
     to multiple target sections. ONE entry port per target section per side
     (side from hints or LEFT default).
     """
-    if resolution is None:
-        resolution = resolve_section_endpoints(graph)
-
     if resolution.inter_section_edges:
-        _create_ports_and_junctions(graph, resolution)
-        _insert_merge_junctions(graph)
+        trace = _create_ports_and_junctions(graph, resolution, topology)
+    else:
+        trace = RouteResolutionTrace()
 
     _assign_section_numbers(graph)
+    return trace
 
 
 _LEADING_SIDE = {
@@ -1239,15 +1297,10 @@ def _group_inter_section_edges(
     inter_section_edges: list[Edge],
     entry_side_for_line: dict[tuple[str, str], PortSide],
     exit_sides: dict[tuple[str, str], set[PortSide]],
-) -> tuple[
-    tuple[ResolvedConnectorEndpoint, ...],
-    dict[tuple[str, PortSide], list[Edge]],
-    dict[tuple[str, PortSide], list[Edge]],
-]:
-    """Resolve and group inter-section edges by their section-boundary sides."""
+    lineage: AuthoredEdgeLineage,
+) -> tuple[ResolvedConnectorEndpoint, ...]:
+    """Resolve current inter-section endpoints and their authored identities."""
     connectors: list[ResolvedConnectorEndpoint] = []
-    exit_group_edges: dict[tuple[str, PortSide], list[Edge]] = {}
-    entry_group_edges: dict[tuple[str, PortSide], list[Edge]] = {}
 
     for edge in inter_section_edges:
         src_sec = graph.section_for_station(edge.source)
@@ -1267,19 +1320,21 @@ def _group_inter_section_edges(
                 target_section=tgt_sec,
                 exit_side=exit_side,
                 entry_side=entry_side,
+                connector_ids=tuple(key.id for key in lineage.origins(edge)),
             )
         )
-        exit_group_edges.setdefault((src_sec, exit_side), []).append(edge)
-        entry_group_edges.setdefault((tgt_sec, entry_side), []).append(edge)
 
-    return tuple(connectors), exit_group_edges, entry_group_edges
+    return tuple(connectors)
 
 
 def _create_port_stations(
     graph: MetroGraph,
-    exit_group_edges: dict[tuple[str, PortSide], list[Edge]],
-    entry_group_edges: dict[tuple[str, PortSide], list[Edge]],
-) -> tuple[dict[tuple[str, PortSide], str], dict[tuple[str, PortSide], str], int]:
+    topology: RouteTopology,
+) -> tuple[
+    dict[EndpointGroupId, str],
+    dict[EndpointGroupId, str],
+    int,
+]:
     """Create exit and entry port stations on the graph.
 
     A section gets one exit port per side it leaves by, so a line declared on
@@ -1287,54 +1342,120 @@ def _create_port_stations(
     each.  Returns (exit_port_map, entry_port_map, next_port_counter).
     """
     port_counter = 0
-    exit_port_map: dict[tuple[str, PortSide], str] = {}
+    exit_port_map: dict[EndpointGroupId, str] = {}
 
-    for sec_id, side in exit_group_edges:
-        port_id = f"{sec_id}__exit_{side.value}_{port_counter}"
+    for group in topology.exit_groups:
+        port_id = f"{group.section_id}__exit_{group.side.value}_{port_counter}"
         port = Port(
             id=port_id,
-            section_id=sec_id,
-            side=side,
+            section_id=group.section_id,
+            side=group.side,
             is_entry=False,
         )
         graph.add_port(port)
-        exit_port_map[(sec_id, side)] = port_id
+        exit_port_map[group.id] = port_id
         port_counter += 1
 
-    entry_port_map: dict[tuple[str, PortSide], str] = {}
+    entry_port_map: dict[EndpointGroupId, str] = {}
 
-    for sec_id, side in entry_group_edges:
-        port_id = f"{sec_id}__entry_{side.value}_{port_counter}"
+    for group in topology.entry_groups:
+        port_id = f"{group.section_id}__entry_{group.side.value}_{port_counter}"
         port = Port(
             id=port_id,
-            section_id=sec_id,
-            side=side,
+            section_id=group.section_id,
+            side=group.side,
             is_entry=True,
         )
         graph.add_port(port)
-        entry_port_map[(sec_id, side)] = port_id
+        entry_port_map[group.id] = port_id
         port_counter += 1
 
     return exit_port_map, entry_port_map, port_counter
 
 
+@dataclass(slots=True)
+class _BoundaryRewriteState:
+    """Mutable resolver state indexed by immutable topology identities."""
+
+    exit_ports: dict[EndpointGroupId, str]
+    entry_ports: dict[EndpointGroupId, str]
+    connectors: dict[ConnectorId, RouteConnector]
+    divergences_by_exit: dict[EndpointGroupId, DivergenceGroup]
+    connector_paths: dict[ConnectorId, list[list[ResolvedEdge]]]
+    divergence_junctions: dict[DivergenceId, str]
+    fan_edge_order: list[tuple[ResolvedEdge, DivergenceId, EndpointGroupId]]
+
+    def replace_connector_edge(
+        self,
+        connector_ids: tuple[ConnectorId, ...],
+        old_edge: ResolvedEdge,
+        replacement: tuple[ResolvedEdge, ...],
+    ) -> None:
+        """Replace one resolved edge in every named connector path."""
+        for connector_id in connector_ids:
+            replaced = False
+            for path in self.connector_paths[connector_id]:
+                for index, edge in enumerate(path):
+                    if edge != old_edge:
+                        continue
+                    path[index : index + 1] = replacement
+                    replaced = True
+            if not replaced:
+                raise ValueError("connector path is missing its convergence edge")
+
+
 def _rewrite_edges_with_junctions(
     graph: MetroGraph,
     resolution: SectionEndpointResolution,
-    exit_port_map: dict[tuple[str, PortSide], str],
-    entry_port_map: dict[tuple[str, PortSide], str],
+    topology: RouteTopology,
+    exit_port_map: dict[EndpointGroupId, str],
+    entry_port_map: dict[EndpointGroupId, str],
     port_counter: int,
-) -> None:
+) -> _BoundaryRewriteState:
     """Rewrite inter-section edges into 3-part chains with junctions."""
     new_edges: list[Edge] = list(resolution.internal_edges)
+    state = _BoundaryRewriteState(
+        exit_ports=exit_port_map,
+        entry_ports=entry_port_map,
+        connectors={connector.id: connector for connector in topology.connectors},
+        divergences_by_exit={
+            divergence.exit_group_id: divergence for divergence in topology.divergences
+        },
+        connector_paths={},
+        divergence_junctions={},
+        fan_edge_order=[],
+    )
+    connectors_by_id = state.connectors
+    divergence_by_exit = state.divergences_by_exit
+    boundary_groups: dict[
+        EndpointGroupId,
+        dict[EndpointGroupId, list[ResolvedConnectorEndpoint]],
+    ] = {}
 
-    # Group by exit port to detect fan-outs
-    exit_fan: dict[str, dict[str, list[Edge]]] = {}
-
-    for connector in resolution.connectors:
-        edge = connector.edge
-        exit_port_id = exit_port_map[(connector.source_section, connector.exit_side)]
-        entry_port_id = entry_port_map[(connector.target_section, connector.entry_side)]
+    for endpoint in resolution.connectors:
+        connector_ids = endpoint.connector_ids
+        if not connector_ids:
+            raise ValueError("boundary connector has no authored topology identity")
+        try:
+            topology_connectors = [connectors_by_id[item] for item in connector_ids]
+        except KeyError as error:
+            raise ValueError(
+                "boundary connector lineage is absent from RouteTopology"
+            ) from error
+        exit_group_ids = {item.exit_group_id for item in topology_connectors}
+        entry_group_ids = {item.entry_group_id for item in topology_connectors}
+        line_ids = {item.line_id for item in topology_connectors}
+        if (
+            len(exit_group_ids) != 1
+            or len(entry_group_ids) != 1
+            or line_ids != {endpoint.edge.line_id}
+        ):
+            raise ValueError("boundary connector lineage disagrees with RouteTopology")
+        exit_group_id = next(iter(exit_group_ids))
+        entry_group_id = next(iter(entry_group_ids))
+        exit_port_id = exit_port_map[exit_group_id]
+        entry_port_id = entry_port_map[entry_group_id]
+        edge = endpoint.edge
 
         new_edges.append(
             Edge(source=edge.source, target=exit_port_id, line_id=edge.line_id)
@@ -1342,13 +1463,21 @@ def _rewrite_edges_with_junctions(
         new_edges.append(
             Edge(source=entry_port_id, target=edge.target, line_id=edge.line_id)
         )
+        boundary_groups.setdefault(exit_group_id, {}).setdefault(
+            entry_group_id, []
+        ).append(endpoint)
 
-        exit_fan.setdefault(exit_port_id, {}).setdefault(entry_port_id, []).append(edge)
-
-    for exit_port_id, entry_targets in exit_fan.items():
-        if len(entry_targets) <= 1:
-            for entry_port_id, edges in entry_targets.items():
-                for edge in edges:
+    fan_edge_metadata: dict[ResolvedEdge, tuple[DivergenceId, EndpointGroupId]] = {}
+    for exit_group_id, entry_targets in boundary_groups.items():
+        exit_port_id = exit_port_map[exit_group_id]
+        divergence = divergence_by_exit.get(exit_group_id)
+        if divergence is None:
+            if len(entry_targets) != 1:
+                raise ValueError("resolved fan-out is absent from RouteTopology")
+            for entry_group_id, endpoints in entry_targets.items():
+                entry_port_id = entry_port_map[entry_group_id]
+                for endpoint in endpoints:
+                    edge = endpoint.edge
                     new_edges.append(
                         Edge(
                             source=exit_port_id,
@@ -1356,24 +1485,37 @@ def _rewrite_edges_with_junctions(
                             line_id=edge.line_id,
                         )
                     )
+                    path = [
+                        ResolvedEdge(edge.source, exit_port_id, edge.line_id),
+                        ResolvedEdge(exit_port_id, entry_port_id, edge.line_id),
+                        ResolvedEdge(entry_port_id, edge.target, edge.line_id),
+                    ]
+                    for connector_id in endpoint.connector_ids:
+                        state.connector_paths[connector_id] = [path.copy()]
         else:
+            if len(entry_targets) <= 1 or set(divergence.entry_group_ids) != set(
+                entry_targets
+            ):
+                raise ValueError("resolved fan-out disagrees with RouteTopology")
             junction_id = f"__junction_{port_counter}"
             port_counter += 1
             junction = Station(id=junction_id, label="", is_port=True, section_id=None)
             graph.add_station(junction)
             graph.add_junction(junction_id)
+            state.divergence_junctions[divergence.id] = junction_id
 
-            all_line_ids_set: set[str] = set()
-            for edges in entry_targets.values():
-                for edge in edges:
-                    all_line_ids_set.add(edge.line_id)
-            for lid in sorted(all_line_ids_set):
+            fan_line_ids = sorted(
+                {connectors_by_id[item].line_id for item in divergence.connector_ids}
+            )
+            for lid in fan_line_ids:
                 new_edges.append(
                     Edge(source=exit_port_id, target=junction_id, line_id=lid)
                 )
 
-            for entry_port_id, edges in entry_targets.items():
-                for edge in edges:
+            for entry_group_id, endpoints in entry_targets.items():
+                entry_port_id = entry_port_map[entry_group_id]
+                for endpoint in endpoints:
+                    edge = endpoint.edge
                     new_edges.append(
                         Edge(
                             source=junction_id,
@@ -1381,6 +1523,18 @@ def _rewrite_edges_with_junctions(
                             line_id=edge.line_id,
                         )
                     )
+                    middle = ResolvedEdge(junction_id, entry_port_id, edge.line_id)
+                    fan_edge_metadata.setdefault(
+                        middle, (divergence.id, entry_group_id)
+                    )
+                    path = [
+                        ResolvedEdge(edge.source, exit_port_id, edge.line_id),
+                        ResolvedEdge(exit_port_id, junction_id, edge.line_id),
+                        middle,
+                        ResolvedEdge(entry_port_id, edge.target, edge.line_id),
+                    ]
+                    for connector_id in endpoint.connector_ids:
+                        state.connector_paths[connector_id] = [path.copy()]
 
     # Deduplicate edges by (source, target, line_id) - multiple original
     # inter-section edges targeting different stations in the same section
@@ -1393,31 +1547,78 @@ def _rewrite_edges_with_junctions(
             seen.add(key)
             deduped.append(edge)
     graph.replace_edges(deduped)
+    state.fan_edge_order = [
+        (ResolvedEdge(edge.source, edge.target, edge.line_id), *fan_edge_metadata[key])
+        for edge in deduped
+        if (key := ResolvedEdge(edge.source, edge.target, edge.line_id))
+        in fan_edge_metadata
+    ]
+    if set(state.connector_paths) != set(connectors_by_id):
+        raise ValueError("not every topology connector resolved to a synthetic chain")
+    return state
 
 
 def _create_ports_and_junctions(
     graph: MetroGraph,
     resolution: SectionEndpointResolution,
-) -> None:
+    topology: RouteTopology,
+) -> RouteResolutionTrace:
     """Create exit/entry ports and junctions, rewrite inter-section edges.
 
     Creates one exit port per (source_section, exit_side), one entry port per
     (target_section, entry_side), and inserts junction stations where an exit
     port fans out to multiple entry ports.
     """
-    exit_port_map, entry_port_map, port_counter = _create_port_stations(
-        graph, resolution.exit_group_edges, resolution.entry_group_edges
-    )
-    _rewrite_edges_with_junctions(
+    exit_port_map, entry_port_map, port_counter = _create_port_stations(graph, topology)
+    state = _rewrite_edges_with_junctions(
         graph,
         resolution,
+        topology,
         exit_port_map,
         entry_port_map,
         port_counter,
     )
+    convergence_junctions = _insert_merge_junctions(graph, topology, state)
+    frozen_paths: dict[
+        tuple[tuple[ResolvedEdge, ...], ...],
+        tuple[tuple[ResolvedEdge, ...], ...],
+    ] = {}
+
+    def connector_paths(
+        connector_id: ConnectorId,
+    ) -> tuple[tuple[ResolvedEdge, ...], ...]:
+        paths = tuple(tuple(path) for path in state.connector_paths[connector_id])
+        return frozen_paths.setdefault(paths, paths)
+
+    return RouteResolutionTrace(
+        connectors=tuple(
+            ResolvedConnector(connector.id, connector_paths(connector.id))
+            for connector in topology.connectors
+        ),
+        exit_ports=tuple(
+            ResolvedEndpointPort(group.id, exit_port_map[group.id])
+            for group in topology.exit_groups
+        ),
+        entry_ports=tuple(
+            ResolvedEndpointPort(group.id, entry_port_map[group.id])
+            for group in topology.entry_groups
+        ),
+        divergences=tuple(
+            ResolvedDivergence(group.id, state.divergence_junctions[group.id])
+            for group in topology.divergences
+        ),
+        convergences=tuple(
+            ResolvedConvergence(group.id, convergence_junctions[group.id])
+            for group in topology.convergences
+        ),
+    )
 
 
-def _insert_merge_junctions(graph: MetroGraph) -> None:
+def _insert_merge_junctions(
+    graph: MetroGraph,
+    topology: RouteTopology,
+    state: _BoundaryRewriteState,
+) -> dict[ConvergenceId, str]:
     """Insert merge junctions where multiple same-line edges converge on one entry port.
 
     After _create_ports_and_junctions, multiple inter-section edges of the same
@@ -1432,30 +1633,33 @@ def _insert_merge_junctions(graph: MetroGraph) -> None:
     _resolve_section_col() in routing correctly resolves its column for bypass
     detection.
     """
-    # Find edges from fan-out junctions targeting entry ports, grouped
-    # by (entry_port_id, line_id).  Only junction sources are counted -
-    # exit port sources route fine as normal L-shapes and shouldn't be
-    # merged (merging disrupts exit port positioning).
-    convergent: dict[tuple[str, str], list[Edge]] = {}
-    for edge in graph.edges:
-        tgt_port = graph.ports.get(edge.target)
-        if not tgt_port or not tgt_port.is_entry:
-            continue
-        if edge.source not in graph.junctions:
-            continue
-        key = (edge.target, edge.line_id)
-        convergent.setdefault(key, []).append(edge)
+    convergence_by_key = {
+        (group.entry_group_id, group.line_id): group for group in topology.convergences
+    }
+    ordered_groups: dict[
+        tuple[EndpointGroupId, str],
+        list[tuple[ResolvedEdge, DivergenceId]],
+    ] = {}
+    for edge, divergence_id, entry_group_id in state.fan_edge_order:
+        key = (entry_group_id, edge.line_id)
+        if key in convergence_by_key:
+            ordered_groups.setdefault(key, []).append((edge, divergence_id))
 
-    # Only process groups with N>1 convergent edges
-    merge_groups = {k: v for k, v in convergent.items() if len(v) > 1}
-    if not merge_groups:
-        return
+    if set(ordered_groups) != set(convergence_by_key):
+        raise ValueError("resolved merge groups disagree with RouteTopology")
 
     counter = len(graph.junctions)
     edges_to_remove: set[tuple[str, str, str]] = set()
     new_edges: list[Edge] = []
+    convergence_junctions: dict[ConvergenceId, str] = {}
 
-    for (entry_port_id, line_id), edges in merge_groups.items():
+    for (entry_group_id, line_id), edges in ordered_groups.items():
+        convergence = convergence_by_key[(entry_group_id, line_id)]
+        if {divergence_id for _, divergence_id in edges} != set(
+            convergence.divergence_ids
+        ):
+            raise ValueError("resolved merge membership disagrees with RouteTopology")
+        entry_port_id = state.entry_ports[entry_group_id]
         entry_port = graph.ports[entry_port_id]
         merge_id = f"__merge_{counter}"
         counter += 1
@@ -1468,10 +1672,10 @@ def _insert_merge_junctions(graph: MetroGraph) -> None:
         )
         graph.add_station(merge_station)
         graph.add_junction(merge_id)
+        convergence_junctions[convergence.id] = merge_id
 
-        # Rewrite: each source -> merge junction
-        for edge in edges:
-            edges_to_remove.add((edge.source, edge.target, edge.line_id))
+        for edge, _divergence_id in edges:
+            edges_to_remove.add(edge)
             new_edges.append(Edge(source=edge.source, target=merge_id, line_id=line_id))
 
         # One edge: merge junction -> entry port
@@ -1482,3 +1686,19 @@ def _insert_merge_junctions(graph: MetroGraph) -> None:
         e for e in graph.edges if (e.source, e.target, e.line_id) not in edges_to_remove
     ]
     graph.replace_edges(kept + new_edges)
+
+    for convergence in topology.convergences:
+        merge_id = convergence_junctions[convergence.id]
+        entry_port_id = state.entry_ports[convergence.entry_group_id]
+        for connector_id in convergence.connector_ids:
+            connector = state.connectors[connector_id]
+            divergence = state.divergences_by_exit[connector.exit_group_id]
+            junction_id = state.divergence_junctions[divergence.id]
+            old_edge = ResolvedEdge(junction_id, entry_port_id, convergence.line_id)
+            replacement = (
+                ResolvedEdge(junction_id, merge_id, convergence.line_id),
+                ResolvedEdge(merge_id, entry_port_id, convergence.line_id),
+            )
+            state.replace_connector_edge((connector_id,), old_edge, replacement)
+
+    return convergence_junctions

--- a/src/nf_metro/parser/route_topology.py
+++ b/src/nf_metro/parser/route_topology.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NewType
+from typing import TYPE_CHECKING, NamedTuple, NewType
 
 import networkx as nx
 
@@ -21,6 +21,14 @@ BundleId = NewType("BundleId", str)
 EndpointGroupId = NewType("EndpointGroupId", str)
 DivergenceId = NewType("DivergenceId", str)
 ConvergenceId = NewType("ConvergenceId", str)
+
+
+class ResolvedEdge(NamedTuple):
+    """One final graph edge in an authored connector's resolved path."""
+
+    source: str
+    target: str
+    line_id: str
 
 
 def _route_id(kind: str, *parts: object) -> str:
@@ -239,6 +247,49 @@ class RouteTopology:
     entry_groups: tuple[EndpointGroup, ...]
     divergences: tuple[DivergenceGroup, ...]
     convergences: tuple[ConvergenceGroup, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedEndpointPort:
+    """Synthetic port created for one topology endpoint group."""
+
+    group_id: EndpointGroupId
+    port_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedDivergence:
+    """Synthetic junction created for one topology divergence."""
+
+    group_id: DivergenceId
+    junction_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedConvergence:
+    """Synthetic junction created for one topology convergence."""
+
+    group_id: ConvergenceId
+    junction_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedConnector:
+    """Final ordered graph-edge paths for one authored connector."""
+
+    connector_id: ConnectorId
+    edge_paths: tuple[tuple[ResolvedEdge, ...], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RouteResolutionTrace:
+    """Immutable mapping from authored topology to resolved synthetic ids."""
+
+    connectors: tuple[ResolvedConnector, ...] = ()
+    exit_ports: tuple[ResolvedEndpointPort, ...] = ()
+    entry_ports: tuple[ResolvedEndpointPort, ...] = ()
+    divergences: tuple[ResolvedDivergence, ...] = ()
+    convergences: tuple[ResolvedConvergence, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nf_metro/render/plan.py
+++ b/src/nf_metro/render/plan.py
@@ -207,6 +207,7 @@ class RenderPlan:
 
 
 _RENDER_GRAPH_EXCLUDED_FIELDS = {
+    "route_resolution",
     "route_topology",
     "_station_lines_cache",
     "_edges_from_cache",

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -688,6 +688,18 @@ def _settle_render_geometry(
     return station_offsets, routes, labels
 
 
+def _copy_graph_for_render(source_graph: MetroGraph) -> MetroGraph:
+    """Copy mutable render state while sharing frozen parser metadata."""
+    immutable_metadata = (
+        source_graph.route_topology,
+        source_graph.route_resolution,
+    )
+    return copy.deepcopy(
+        source_graph,
+        {id(value): value for value in immutable_metadata if value is not None},
+    )
+
+
 def _build_render_plan_scaled(
     source_graph: MetroGraph,
     theme: Theme,
@@ -701,7 +713,7 @@ def _build_render_plan_scaled(
     bare: bool = False,
 ) -> RenderPlan:
     """Finish render geometry on a private graph copy and freeze the result."""
-    graph = copy.deepcopy(source_graph)
+    graph = _copy_graph_for_render(source_graph)
     effective_legend_position = (
         legend_position if legend_position is not None else graph.legend_position
     )

--- a/tests/test_render_plan.py
+++ b/tests/test_render_plan.py
@@ -17,7 +17,12 @@ from nf_metro.render.plan import (
     contains_mutable_model_reference,
     thaw_render_value,
 )
-from nf_metro.render.svg import build_render_plan, emit_render_plan, render_svg
+from nf_metro.render.svg import (
+    _copy_graph_for_render,
+    build_render_plan,
+    emit_render_plan,
+    render_svg,
+)
 
 ROOT = Path(__file__).parents[1]
 
@@ -72,6 +77,18 @@ def test_render_plan_is_deeply_immutable_and_has_no_mutable_models() -> None:
         plan.graph.stations["new"] = object()  # type: ignore[index]
 
 
+def test_render_copy_shares_only_frozen_route_metadata() -> None:
+    source = ROOT / "examples" / "guide" / "03b_fan_in_merge.mmd"
+    graph = prepare_graph(source.read_text(), source_dir=str(source.parent))
+
+    copied = _copy_graph_for_render(graph)
+
+    assert copied is not graph
+    assert copied.stations is not graph.stations
+    assert copied.route_topology is graph.route_topology
+    assert copied.route_resolution is graph.route_resolution
+
+
 def test_repeated_plan_emission_is_byte_identical() -> None:
     _graph, plan = _plan("examples/topologies/fold_double.mmd")
     before = repr(plan)
@@ -104,13 +121,15 @@ def test_repeated_html_emission_is_byte_identical() -> None:
         "examples/guide/03b_fan_in_merge.mmd",
     ],
 )
-def test_route_topology_is_excluded_from_render_artifacts(path: str) -> None:
+def test_route_metadata_is_excluded_from_render_artifacts(path: str) -> None:
     graph, observed = _plan(path)
     graph.route_topology = None
+    graph.route_resolution = None
     baseline = build_render_plan(graph, resolve_theme(None, graph))
 
     assert observed == baseline
     assert not hasattr(observed.graph, "route_topology")
+    assert not hasattr(observed.graph, "route_resolution")
     assert emit_render_plan(observed) == emit_render_plan(baseline)
     assert emit_render_plan_html(observed) == emit_render_plan_html(baseline)
 

--- a/tests/test_route_topology.py
+++ b/tests/test_route_topology.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import os
 import subprocess
 import sys
@@ -22,9 +23,10 @@ from nf_metro.parser.model import (
     is_bypass_v,
     is_converge_junction,
 )
-from nf_metro.parser.resolve import resolve_section_endpoints
+from nf_metro.parser.resolve import _resolve_sections, resolve_section_endpoints
 from nf_metro.parser.route_topology import (
     AuthoredEdgeLineage,
+    ConnectorId,
     RouteTopology,
     build_route_topology,
     capture_authored_routes,
@@ -45,6 +47,29 @@ def _parse(text: str) -> MetroGraph:
     return graph
 
 
+def test_direct_connector_records_its_resolved_synthetic_chain() -> None:
+    graph = _parse(_two_section_text("    a -->|red| b\n"))
+    topology = graph.route_topology
+    resolution = graph.route_resolution
+    assert topology is not None and resolution is not None
+
+    connector = topology.connectors[0]
+    connector_resolution = resolution.connectors[0]
+    exit_port = resolution.exit_ports[0]
+    entry_port = resolution.entry_ports[0]
+
+    assert connector_resolution.connector_id == connector.id
+    assert exit_port.group_id == connector.exit_group_id
+    assert entry_port.group_id == connector.entry_group_id
+    assert connector_resolution.edge_paths == (
+        (
+            ("a", exit_port.port_id, "red"),
+            (exit_port.port_id, entry_port.port_id, "red"),
+            (entry_port.port_id, "b", "red"),
+        ),
+    )
+
+
 def _two_section_text(edges: str, *, extra: str = "") -> str:
     return f"""\
 %%metro line: red | Red | #f00
@@ -61,10 +86,10 @@ def _two_section_text(edges: str, *, extra: str = "") -> str:
 
 
 def test_connector_identity_preserves_multiline_order_and_exact_duplicates() -> None:
-    topology = _parse(
-        _two_section_text("    a -->|red,blue| b\n    a -->|red| b\n")
-    ).route_topology
-    assert topology is not None
+    graph = _parse(_two_section_text("    a -->|red,blue| b\n    a -->|red| b\n"))
+    topology = graph.route_topology
+    resolution = graph.route_resolution
+    assert topology is not None and resolution is not None
 
     assert [
         (connector.source, connector.target, connector.line_id)
@@ -80,6 +105,96 @@ def test_connector_identity_preserves_multiline_order_and_exact_duplicates() -> 
         connector.id for connector in topology.connectors
     )
     assert topology.bundles[0].line_ids == ("red", "blue")
+    assert [item.connector_id for item in resolution.connectors] == [
+        connector.id for connector in topology.connectors
+    ]
+    assert resolution.connectors[0].edge_paths == resolution.connectors[2].edge_paths
+    assert resolution.connectors[0].edge_paths is resolution.connectors[2].edge_paths
+
+
+def test_one_to_many_fanout_maps_to_one_topology_divergence() -> None:
+    graph = _parse(
+        """\
+%%metro line: red | Red | #f00
+graph LR
+    subgraph source [Source]
+        a[A]
+    end
+    subgraph first [First]
+        b[B]
+    end
+    subgraph second [Second]
+        c[C]
+    end
+    a -->|red| b
+    a -->|red| c
+"""
+    )
+    topology = graph.route_topology
+    resolution = graph.route_resolution
+    assert topology is not None and resolution is not None
+    assert len(topology.divergences) == len(resolution.divergences) == 1
+    assert not topology.convergences
+
+    divergence = topology.divergences[0]
+    fan = resolution.divergences[0]
+    exit_port = next(
+        item
+        for item in resolution.exit_ports
+        if item.group_id == divergence.exit_group_id
+    )
+    assert fan.group_id == divergence.id
+    assert fan.junction_id in graph.junctions
+    for connector in resolution.connectors:
+        assert (
+            exit_port.port_id,
+            fan.junction_id,
+            next(
+                item.line_id
+                for item in topology.connectors
+                if item.id == connector.connector_id
+            ),
+        ) in connector.edge_paths[0]
+
+
+def test_fanout_and_merge_groups_map_to_their_junctions() -> None:
+    graph = _parse((ROOT / "examples" / "guide" / "03b_fan_in_merge.mmd").read_text())
+    topology = graph.route_topology
+    resolution = graph.route_resolution
+    assert topology is not None and resolution is not None
+    assert topology.divergences and topology.convergences
+
+    fan_by_group = {item.group_id: item.junction_id for item in resolution.divergences}
+    merge_by_group = {
+        item.group_id: item.junction_id for item in resolution.convergences
+    }
+    connector_traces = {
+        item.connector_id: item.edge_paths for item in resolution.connectors
+    }
+    entry_ports = {item.group_id: item.port_id for item in resolution.entry_ports}
+
+    for convergence in topology.convergences:
+        merge_id = merge_by_group[convergence.id]
+        entry_port_id = entry_ports[convergence.entry_group_id]
+        assert merge_id in graph.junctions
+        for connector_id in convergence.connector_ids:
+            connector = next(
+                item for item in topology.connectors if item.id == connector_id
+            )
+            fan_id = fan_by_group[
+                next(
+                    item.id
+                    for item in topology.divergences
+                    if item.exit_group_id == connector.exit_group_id
+                )
+            ]
+            paths = connector_traces[connector_id]
+            assert any(
+                (fan_id, merge_id, convergence.line_id) in path for path in paths
+            )
+            assert any(
+                (merge_id, entry_port_id, convergence.line_id) in path for path in paths
+            )
 
 
 def test_line_networks_are_stable_connected_components() -> None:
@@ -146,7 +261,7 @@ def test_programmatic_duplicate_edges_get_stable_unique_identities() -> None:
     )
     capture = capture_authored_routes(graph)
     lineage = AuthoredEdgeLineage.from_capture(graph.edges, capture)
-    resolution = resolve_section_endpoints(graph)
+    resolution = resolve_section_endpoints(graph, lineage)
 
     topology = build_route_topology(capture, lineage, resolution)
 
@@ -156,6 +271,18 @@ def test_programmatic_duplicate_edges_get_stable_unique_identities() -> None:
     ]
     assert len({connector.id for connector in topology.connectors}) == 2
     assert all(connector.source_line is None for connector in topology.connectors)
+
+    corrupted_endpoint = dataclasses.replace(
+        resolution.connectors[0],
+        connector_ids=resolution.connectors[0].connector_ids
+        + (ConnectorId("missing"),),
+    )
+    corrupted_resolution = dataclasses.replace(
+        resolution,
+        connectors=(corrupted_endpoint,),
+    )
+    with pytest.raises(ValueError, match="absent from RouteTopology"):
+        _resolve_sections(graph, corrupted_resolution, topology)
 
 
 def test_terminus_topology_uses_the_resolvers_reanchored_entry_side() -> None:
@@ -193,7 +320,7 @@ graph LR
 
 
 def test_duplicate_terminus_connectors_survive_many_to_one_lineage() -> None:
-    topology = _parse(
+    graph = _parse(
         """\
 %%metro line: red | Red | #f00
 %%metro file: output | Results
@@ -209,8 +336,10 @@ graph LR
     a -->|red| output
     a -->|red| output
 """
-    ).route_topology
-    assert topology is not None
+    )
+    topology = graph.route_topology
+    resolution = graph.route_resolution
+    assert topology is not None and resolution is not None
 
     connectors = [
         connector
@@ -221,6 +350,45 @@ graph LR
     assert [connector.duplicate_ordinal for connector in connectors] == [0, 1]
     assert len({connector.id for connector in connectors}) == 2
     assert connectors[0].entry_group_id == connectors[1].entry_group_id
+    traces = {item.connector_id: item.edge_paths for item in resolution.connectors}
+    assert traces[connectors[0].id] == traces[connectors[1].id]
+
+
+def test_repeated_bypasses_record_every_parallel_resolved_path() -> None:
+    graph = _parse(
+        """\
+%%metro line: red | Red | #f00
+%%metro line: blue | Blue | #00f
+graph LR
+    subgraph s [S]
+        p[P]
+        a[A]
+        b[B]
+        q[Q]
+        p -->|red| a
+        a -->|red| b
+        b -->|red| q
+    end
+    subgraph t [T]
+        z[Z]
+    end
+    p -->|blue| z
+"""
+    )
+    resolution = graph.route_resolution
+    assert resolution is not None
+    paths = resolution.connectors[0].edge_paths
+
+    assert len(paths) == 3
+    assert {path[0].target for path in paths} == {
+        "__bypass_a_p_1",
+        "__bypass_b_p_2",
+        "__bypass_q_p_3",
+    }
+    for path in paths:
+        assert path[0].source == "p"
+        assert path[-1].target == "z"
+        assert all(left.target == right.source for left, right in zip(path, path[1:]))
 
 
 def test_topology_records_are_deeply_immutable_and_detached() -> None:
@@ -244,7 +412,13 @@ def test_topology_records_are_deeply_immutable_and_detached() -> None:
             for item in value:
                 visit(item)
 
+    resolution = graph.route_resolution
+    assert resolution is not None
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        resolution.connectors = ()  # type: ignore[misc]
+
     visit(topology)
+    visit(resolution)
     assert [field.name for field in dataclasses.fields(Edge)] == [
         "source",
         "target",
@@ -499,14 +673,65 @@ def _predicted_shapes(
     return exit_groups, entry_groups, fan_groups, merge_groups
 
 
-@pytest.mark.parametrize(
-    "path", CORPUS, ids=lambda path: path.relative_to(ROOT).as_posix()
-)
-def test_corpus_topology_shapes_match_final_resolver(path: Path) -> None:
-    graph = parse_metro_mermaid(path.read_text())
-    topology = graph.route_topology
-    assert topology is not None
-    assert _predicted_shapes(topology) == _actual_shapes(graph)
+def test_corpus_topology_shapes_match_byte_identical_resolved_graphs() -> None:
+    digest = hashlib.sha256()
+    saw_bypass_path = False
+    for path in CORPUS:
+        graph = parse_metro_mermaid(path.read_text())
+        topology = graph.route_topology
+        resolution = graph.route_resolution
+        assert topology is not None and resolution is not None
+        assert _predicted_shapes(topology) == _actual_shapes(graph), path
+        assert tuple(item.connector_id for item in resolution.connectors) == tuple(
+            item.id for item in topology.connectors
+        ), path
+        assert tuple(item.group_id for item in resolution.exit_ports) == tuple(
+            item.id for item in topology.exit_groups
+        ), path
+        assert tuple(item.group_id for item in resolution.entry_ports) == tuple(
+            item.id for item in topology.entry_groups
+        ), path
+        assert {item.group_id for item in resolution.divergences} == {
+            item.id for item in topology.divergences
+        }, path
+        assert {item.group_id for item in resolution.convergences} == {
+            item.id for item in topology.convergences
+        }, path
+
+        final_edges = {(edge.source, edge.target, edge.line_id) for edge in graph.edges}
+        connector_by_id = {item.id: item for item in topology.connectors}
+        for connector in resolution.connectors:
+            authored = connector_by_id[connector.connector_id]
+            assert connector.edge_paths, (path, connector)
+            for edge_path in connector.edge_paths:
+                assert edge_path, (path, connector)
+                assert all(edge.line_id == authored.line_id for edge in edge_path)
+                assert all(
+                    left.target == right.source
+                    for left, right in zip(edge_path, edge_path[1:])
+                ), (path, connector)
+                assert set(edge_path) <= final_edges, (path, connector)
+                saw_bypass_path |= any(
+                    is_bypass_v(edge.source) or is_bypass_v(edge.target)
+                    for edge in edge_path
+                )
+
+        digest.update(path.relative_to(ROOT).as_posix().encode())
+        digest.update(
+            repr(
+                (
+                    tuple(graph.stations.items()),
+                    tuple(graph.ports.items()),
+                    tuple(graph.junctions),
+                    tuple(graph.edges),
+                )
+            ).encode()
+        )
+
+    assert digest.hexdigest() == (
+        "439e432f93c93c7e6526e778f99a4ecfa20e9cbe4546943444c3dec856b2da4f"
+    )
+    assert saw_bypass_path
 
 
 def test_route_topology_is_hash_seed_deterministic() -> None:
@@ -515,7 +740,8 @@ def test_route_topology_is_hash_seed_deterministic() -> None:
         "from pathlib import Path; "
         "from nf_metro.parser.mermaid import parse_metro_mermaid; "
         f"p=Path({str(fixture)!r}); "
-        "print(repr(parse_metro_mermaid(p.read_text()).route_topology))"
+        "g=parse_metro_mermaid(p.read_text()); "
+        "print(repr((g.route_topology,g.route_resolution)))"
     )
     outputs = []
     for seed in ("1", "7", "41"):


### PR DESCRIPTION
## Why

The parser already had an immutable description of authored route topology, but port and junction creation still rebuilt the same grouping from mutable edges. That duplication made the two descriptions liable to drift and left later routing work without a reliable link from an authored connector to its resolved graph paths.

## What this changes

- Creates exit ports, entry ports, fan junctions, and merge junctions from `RouteTopology` groups.
- Retains a frozen `RouteResolutionTrace` that maps topology ids to ports, junctions, and each connector's final edge path or paths, including terminus, merge, and bypass rewrites.
- Keeps this parser metadata out of render plans and avoids copying it during rendering.

## Compatibility and review

This is intended to produce no visual change. Existing boundary encounter order, synthetic ids, edge emission order, and first-wins deduplication are preserved. A 340-file corpus ratchet confirms the complete ordered parsed graph is unchanged, alongside focused direct, multi-line, fan-out, merge, duplicate-lineage, parallel-bypass, render-plan, formatting, lint, and type checks.

Please use the CI render comparison as the visual review gate.

Closes #1642
