### PR TITLE
Make layout and routing deterministic across hash seeds

### DIFF
--- a/docs/dev/determinism.mdx
+++ b/docs/dev/determinism.mdx
@@ -1,0 +1,71 @@
+---
+title: "Determinism"
+description: Canonical ordering rules and the cross-process render oracle.
+sidebar:
+  order: 9
+---
+
+nf-metro treats output ordering as part of its render contract. The same source,
+options, and dependency versions must produce the same settled graph, render
+plan, SVG bytes, exception, and ordered validation findings in fresh Python
+processes. `PYTHONHASHSEED` must not affect any of those results.
+
+## Semantic ranks
+
+When several graph elements are equally valid candidates, code must resolve the
+tie with a rank owned by the model or by geometry:
+
+- Sections use declaration order from `MetroGraph.sections`.
+- Stations use declaration order from `MetroGraph.stations`, or the local
+  `Section.station_ids` order when a decision is section-local.
+- Edges use `MetroGraph.edges` order unless the decision has a more specific
+  spatial key.
+- Lines use declaration order from `MetroGraph.lines` when lane priority
+  matters. Lexical line order is suitable only for stable presentation or set
+  identity, not lane preference.
+- Ports and junctions use their ordered model collections. Their construction
+  order follows the ordered connector rewrite that created them.
+- Spatial decisions sort by the relevant coordinates first and append the
+  matching semantic rank as the final tie-breaker.
+
+NetworkX insertion order and Python set iteration order are implementation
+details, not semantic ranks. Graph views therefore receive ordered node and edge
+sequences, and topological traversals use the applicable model rank when the
+traversal can affect coordinates.
+
+## Safe unordered values
+
+Sets and frozensets remain useful for membership, equality, aggregation, and
+mathematically commutative reductions. Iteration over a multi-member unordered
+value must not choose a branch, assign a position, overwrite an earlier result,
+or determine which invariant is reported first.
+
+`next(iter(value))` is valid only after a cardinality check proves that `value`
+has exactly one member. Otherwise, traverse an ordered model collection or sort
+with an explicit semantic key.
+
+These rules apply across parser rewrites, auto-layout, section and station
+placement, route dispatch, lane offsets, normalization, validation, and bridge
+placement. Bridge crossing graphs use ordered route indices and explicitly sort
+component members before choosing bridge geometry.
+
+## Cross-process oracle
+
+`tests/hash_seed_oracle.py` launches a fresh interpreter for each hash seed. It
+compares the complete semantic state of the settled `MetroGraph`, including its
+route topology and resolution trace, while excluding only lazy lookup caches. It
+also compares the complete `RenderPlan`, exact emitted SVG bytes, exception
+phase (`prepare`, `plan`, `emit`, or `validate`), class and message, and ordered
+validation findings. The oracle does not normalize SVG or discard ordered
+fields.
+
+The regression suite freezes the generated issue fixtures by source SHA-256 and
+runs them under hash seeds `0`, `1`, `2`, `5`, `43`, and a literal random seed. The
+fixed seeds make failures reproducible; the random run checks an additional
+interpreter-selected ordering. A representative corpus test covers production
+pipelines and difficult topology families. A reproducible full-corpus check is
+also available for broader investigations:
+
+```bash
+PYTHONPATH=src:tests python tests/hash_seed_oracle.py --check-example-corpus
+```

--- a/docs/how-its-built.mdx
+++ b/docs/how-its-built.mdx
@@ -111,6 +111,7 @@ The `docs/dev/` tree covers the internals in detail:
 - [`inter_section_dispatch.mdx`](/nf-metro/dev/inter_section_dispatch/) - the dispatch table for inter-section routes
 - [`routing_gate_coverage.md`](/nf-metro/dev/routing_gate_coverage/) - which handler arms are covered by corpus tests
 - [`parser.mdx`](/nf-metro/dev/parser/) - the Lark grammar and post-parse rewrites
+- [`determinism.mdx`](/nf-metro/dev/determinism/) - canonical ordering rules and the cross-process oracle
 - [`testing.md`](/nf-metro/dev/testing/) - test structure and validation layers in detail
 
 The `CONTRACT.md` at [`src/nf_metro/layout/CONTRACT.md`](https://github.com/seqeralabs/nf-metro/blob/main/src/nf_metro/layout/CONTRACT.md) is the per-phase lifecycle specification: what each phase receives, modifies, and guarantees.

--- a/src/nf_metro/graph_views.py
+++ b/src/nf_metro/graph_views.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import networkx as nx
 
-from nf_metro.parser.model import MetroGraph
+if TYPE_CHECKING:
+    from nf_metro.parser.model import MetroGraph
 
 
 def directed_graph(
@@ -17,6 +19,25 @@ def directed_graph(
     graph.add_nodes_from(nodes)
     graph.add_edges_from(edges)
     return graph
+
+
+def longest_path_layers(
+    graph: nx.DiGraph[str], node_order: Iterable[str]
+) -> dict[str, int]:
+    """Return longest-path layers in the supplied semantic node order."""
+    ordered_nodes = tuple(node_order)
+    rank = {node: index for index, node in enumerate(ordered_nodes)}
+    topological_order = nx.lexicographical_topological_sort(graph, key=rank.__getitem__)
+    layers: dict[str, int] = {}
+    for node in topological_order:
+        layers[node] = (
+            max(
+                (layers[predecessor] for predecessor in graph.predecessors(node)),
+                default=-1,
+            )
+            + 1
+        )
+    return layers
 
 
 def line_graphs(graph: MetroGraph) -> dict[str, nx.DiGraph[str]]:

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -15,6 +15,9 @@ from collections import defaultdict, deque
 from collections.abc import Callable
 from collections.abc import Set as AbstractSet
 
+import networkx as nx
+
+from nf_metro.graph_views import directed_graph, longest_path_layers
 from nf_metro.layout.geometry import AxisFrame
 from nf_metro.layout.layers import assign_layers
 from nf_metro.parser.model import (
@@ -304,37 +307,37 @@ def _internal_station_depths(
     than falling back to a distorted station-count estimate.
     """
     section = graph.sections[section_id]
-    station_ids = set(section.station_ids)
-
-    adj: dict[str, set[str]] = defaultdict(set)
-    has_pred: set[str] = set()
-    for edge in graph.edges:
-        if edge.source in station_ids and edge.target in station_ids:
-            adj[edge.source].add(edge.target)
-            has_pred.add(edge.target)
-
-    if not adj:
+    station_ids = list(section.station_ids)
+    station_set = set(station_ids)
+    station_graph = directed_graph(
+        station_ids,
+        (
+            (edge.source, edge.target)
+            for edge in graph.edges
+            if edge.source in station_set and edge.target in station_set
+        ),
+    )
+    if station_graph.number_of_edges() == 0:
         return None
-    roots = station_ids - has_pred
-    if not roots:
+    try:
+        return longest_path_layers(station_graph, station_ids)
+    except nx.NetworkXUnfeasible as exc:
         raise CyclicGraphError(
             f"Section '{section_id}' has cyclic internal edges: "
-            f"{', '.join(sorted(station_ids))}"
-        )
+            f"{', '.join(station_ids)}"
+        ) from exc
 
-    depth: dict[str, int] = {sid: 0 for sid in station_ids}
-    queue: deque[str] = deque(roots)
-    visited: set[str] = set()
-    while queue:
-        node = queue.popleft()
-        if node in visited:
-            continue
-        visited.add(node)
-        for succ in adj.get(node, set()):
-            if depth[node] + 1 > depth[succ]:
-                depth[succ] = depth[node] + 1
-            queue.append(succ)
-    return depth
+
+def _estimate_section_shape(graph: MetroGraph, section_id: str) -> tuple[int, int]:
+    """Estimate a section's horizontal layers and widest vertical layer."""
+    depth = _internal_station_depths(graph, section_id)
+    if depth is None:
+        station_count = max(len(graph.sections[section_id].station_ids), 1)
+        return station_count, station_count
+    per_layer: dict[int, int] = defaultdict(int)
+    for station_depth in depth.values():
+        per_layer[station_depth] += 1
+    return max(depth.values()) + 1, max(per_layer.values())
 
 
 def _estimate_section_layers(graph: MetroGraph, section_id: str) -> int:
@@ -343,26 +346,8 @@ def _estimate_section_layers(graph: MetroGraph, section_id: str) -> int:
     Computes the longest path through internal edges via topological DP.
     Returns at least 1.
     """
-    depth = _internal_station_depths(graph, section_id)
-    if depth is None:
-        return max(len(graph.sections[section_id].station_ids), 1)
-    return max(depth.values()) + 1  # +1: convert 0-indexed depth to layer count
-
-
-def _estimate_section_height(graph: MetroGraph, section_id: str) -> int:
-    """Estimate a section's vertical extent as its widest internal layer.
-
-    Counts the stations sharing the busiest longest-path depth (the broadest
-    fan), the orthogonal counterpart to ``_estimate_section_layers``. Returns
-    at least 1.
-    """
-    depth = _internal_station_depths(graph, section_id)
-    if depth is None:
-        return max(len(graph.sections[section_id].station_ids), 1)
-    per_layer: dict[int, int] = defaultdict(int)
-    for d in depth.values():
-        per_layer[d] += 1
-    return max(per_layer.values())
+    layers, _height = _estimate_section_shape(graph, section_id)
+    return layers
 
 
 # A section qualifies as a tall anchor when its fan is at least this many
@@ -396,8 +381,9 @@ def _detect_tall_anchor_chain(graph: MetroGraph) -> str | None:
     if len(sources) != 1 or len(sinks) != 1:
         return None
 
-    heights = {s: _estimate_section_height(graph, s) for s in section_ids}
-    widths = {s: _estimate_section_layers(graph, s) for s in section_ids}
+    shapes = {sid: _estimate_section_shape(graph, sid) for sid in section_ids}
+    widths = {sid: shape[0] for sid, shape in shapes.items()}
+    heights = {sid: shape[1] for sid, shape in shapes.items()}
     anchor = max(section_ids, key=lambda s: heights[s])
 
     if heights[anchor] < TALL_ANCHOR_MIN_HEIGHT:
@@ -480,41 +466,22 @@ def _place_with_tall_anchor(
     return set(), set(), set()
 
 
-def _bfs_section_columns(
+def _topological_section_columns(
     section_ids: list[str], successors: dict[str, set[str]]
 ) -> dict[str, int]:
     """Longest-path topo column per section (disconnected sections get 0)."""
+    rank = {sid: index for index, sid in enumerate(section_ids)}
     all_sections = set(section_ids)
-    in_degree: dict[str, int] = {sid: 0 for sid in section_ids}
-    adj: dict[str, list[str]] = {sid: [] for sid in section_ids}
-
-    for src, targets in successors.items():
-        for tgt in targets:
-            if src in all_sections and tgt in all_sections:
-                adj[src].append(tgt)
-                in_degree[tgt] += 1
-
-    col_assign: dict[str, int] = {}
-    queue: deque[str] = deque()
-    for sid in section_ids:
-        if in_degree[sid] == 0:
-            queue.append(sid)
-            col_assign[sid] = 0
-
-    while queue:
-        sid = queue.popleft()
-        for tgt in adj[sid]:
-            new_col = col_assign[sid] + 1
-            if tgt not in col_assign or new_col > col_assign[tgt]:
-                col_assign[tgt] = new_col
-            in_degree[tgt] -= 1
-            if in_degree[tgt] == 0:
-                queue.append(tgt)
-
-    for sid in section_ids:
-        if sid not in col_assign:
-            col_assign[sid] = 0
-    return col_assign
+    edges = [
+        (source, target)
+        for source in section_ids
+        for target in sorted(
+            successors.get(source, ()), key=lambda sid: rank.get(sid, len(rank))
+        )
+        if target in all_sections
+    ]
+    section_graph = directed_graph(section_ids, edges)
+    return longest_path_layers(section_graph, section_ids)
 
 
 def _pack_topo_columns(
@@ -692,7 +659,7 @@ def _assign_grid_positions(
     """
     section_ids = list(graph.sections.keys())
 
-    col_assign = _bfs_section_columns(section_ids, successors)
+    col_assign = _topological_section_columns(section_ids, successors)
 
     # Skip sections already in grid_overrides
     auto_sections = {sid for sid in section_ids if sid not in graph.grid_overrides}
@@ -740,6 +707,7 @@ def _assign_grid_positions(
             col_groups,
             successors,
             predecessors,
+            section_rank={sid: index for index, sid in enumerate(section_ids)},
         )
         if convergence_result is not None:
             return _place_with_convergence(
@@ -791,6 +759,8 @@ def _detect_convergence_split(
     col_groups: dict[int, list[str]],
     successors: dict[str, set[str]],
     predecessors: dict[str, set[str]],
+    *,
+    section_rank: dict[str, int],
 ) -> set[str] | None:
     """Detect a convergence section and return the set of sections for a return row.
 
@@ -802,7 +772,7 @@ def _detect_convergence_split(
     # Skip terminal sections (no successors) - they are sinks that collect
     # from many upstream sections and don't benefit from a return row.
     convergence_sid = None
-    for sid in sorted(col_assign, key=lambda s: col_assign[s]):
+    for sid in sorted(col_assign, key=lambda sid: (col_assign[sid], section_rank[sid])):
         if not successors.get(sid):
             continue
         pred_cols = set()
@@ -817,9 +787,7 @@ def _detect_convergence_split(
         return None
 
     # Migration below tests membership against this frozen base, never the set
-    # it is growing: ``col_assign``'s key order derives from a BFS over
-    # set-valued successor maps and so varies with ``PYTHONHASHSEED``, so an
-    # order-dependent inclusion would make grid placement hash-seed dependent.
+    # it is growing, so candidate eligibility cannot depend on earlier additions.
     base_return_set = frozenset(
         {convergence_sid} | _transitive_successors(convergence_sid, successors)
     )
@@ -911,7 +879,10 @@ def _place_with_convergence(
     # whenever a row-0 column held 2+ sections (issue #484).
     return_row = row0_height
     # Sort by topo col ascending: lowest topo col = rightmost on return row
-    return_sids = sorted(return_set, key=lambda s: col_assign[s])
+    section_rank = {sid: index for index, sid in enumerate(graph.sections)}
+    return_sids = sorted(
+        return_set, key=lambda sid: (col_assign[sid], section_rank[sid])
+    )
     grid_col = max_row0_col
     for sid in return_sids:
         folded[sid] = (grid_col, return_row)
@@ -1034,11 +1005,11 @@ def _adjust_explicit_tb_sections(
     span so that lines exit downward naturally.
     """
     # Find explicit TB sections that aren't already handled as fold sections
-    explicit_tb = {
+    explicit_tb = [
         sid
         for sid, sec in graph.sections.items()
         if sec.direction == "TB" and sid not in fold_sections and sec.grid_col >= 0
-    }
+    ]
     if not explicit_tb:
         return
 
@@ -1083,7 +1054,11 @@ def _adjust_explicit_tb_sections(
                     tb_sec.grid_col_span,
                 )
 
-        # Move successors from the top of the span to the bottom
+    successor_rows: dict[str, int] = {}
+    for tb_sid in explicit_tb:
+        tb_sec = graph.sections[tb_sid]
+        tb_col = tb_sec.grid_col
+        tb_row = tb_sec.grid_row
         if tb_sec.grid_row_span > 1:
             bottom_row = tb_row + tb_sec.grid_row_span - 1
             for succ_id in successors.get(tb_sid, set()):
@@ -1093,13 +1068,19 @@ def _adjust_explicit_tb_sections(
                 # Only adjust auto-placed successors in columns to the right
                 if succ.grid_col <= tb_col:
                     continue
-                succ.grid_row = bottom_row
-                graph.grid_overrides[succ_id] = (
-                    succ.grid_col,
-                    bottom_row,
-                    succ.grid_row_span,
-                    succ.grid_col_span,
+                successor_rows[succ_id] = max(
+                    successor_rows.get(succ_id, bottom_row), bottom_row
                 )
+
+    for succ_id, target_row in successor_rows.items():
+        succ = graph.sections[succ_id]
+        succ.grid_row = target_row
+        graph.grid_overrides[succ_id] = (
+            succ.grid_col,
+            target_row,
+            succ.grid_row_span,
+            succ.grid_col_span,
+        )
 
 
 def _optimize_colspans(
@@ -1646,6 +1627,14 @@ def _neighbour_side_votes(
     return votes
 
 
+_FOLD_EXIT_TIE_PRIORITY = (
+    PortSide.LEFT,
+    PortSide.RIGHT,
+    PortSide.TOP,
+    PortSide.BOTTOM,
+)
+
+
 def _compute_fold_exit_side(
     graph: MetroGraph,
     sec_id: str,
@@ -1671,7 +1660,10 @@ def _compute_fold_exit_side(
     if not side_votes:
         return PortSide.BOTTOM
 
-    dominant = max(side_votes, key=lambda s: side_votes[s])
+    best_vote = max(side_votes.values())
+    dominant = next(
+        side for side in _FOLD_EXIT_TIE_PRIORITY if side_votes.get(side) == best_vote
+    )
 
     # Override for multi-row spans: if all successors are below the fold
     # span, use BOTTOM exit so lines continue their vertical flow.

--- a/src/nf_metro/layout/layers.py
+++ b/src/nf_metro/layout/layers.py
@@ -10,6 +10,7 @@ __all__ = ["assign_layers", "build_station_digraph"]
 
 import networkx as nx
 
+from nf_metro.graph_views import longest_path_layers
 from nf_metro.parser.model import MetroGraph
 
 
@@ -39,15 +40,4 @@ def assign_layers(graph: MetroGraph) -> dict[str, int]:
     """
     G = build_station_digraph(graph)
 
-    # Topological sort (will raise if cycles exist)
-    topo_order = list(nx.topological_sort(G))
-
-    layers: dict[str, int] = {}
-    for node in topo_order:
-        preds = list(G.predecessors(node))
-        if not preds:
-            layers[node] = 0
-        else:
-            layers[node] = max(layers[p] for p in preds) + 1
-
-    return layers
+    return longest_path_layers(G, graph.stations)

--- a/src/nf_metro/layout/phases/canvas.py
+++ b/src/nf_metro/layout/phases/canvas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from nf_metro.graph_views import directed_graph
 from nf_metro.layout.constants import (
     TITLE_BAND_CLEARANCE,
     TITLE_BAND_OVERLAP_FLOOR,
@@ -25,15 +26,20 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
     """
     from collections import deque
 
-    import networkx as nx
-
-    dag: nx.DiGraph[str] = nx.DiGraph()
-    for sid in graph.sections:
-        dag.add_node(sid)
-    if graph.section_dag:
-        for src, tgt in graph.section_dag.section_edges:
-            if src in graph.sections and tgt in graph.sections:
-                dag.add_edge(src, tgt)
+    section_rank = {sid: rank for rank, sid in enumerate(graph.sections)}
+    section_edges = (
+        sorted(
+            (
+                (src, tgt)
+                for src, tgt in graph.section_dag.section_edges
+                if src in graph.sections and tgt in graph.sections
+            ),
+            key=lambda edge: (section_rank[edge[0]], section_rank[edge[1]]),
+        )
+        if graph.section_dag
+        else []
+    )
+    dag = directed_graph(graph.sections, section_edges)
 
     secs = graph.sections
 
@@ -61,7 +67,7 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
 
     while q:
         node = q.popleft()
-        for succ in dag.successors(node):
+        for succ in sorted(dag.successors(node), key=section_rank.__getitem__):
             new_depth = sweep[node]
             if _is_direction_change(node, succ):
                 new_depth = sweep[node] + 1
@@ -77,12 +83,15 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
     # ordered by the topmost grid_row so top flows come first.
     from nf_metro.layout.section_placement import _weakly_connected_components
 
-    section_edges = graph.section_dag.section_edges if graph.section_dag else set()
+    component_edges = graph.section_dag.section_edges if graph.section_dag else set()
     comp_idx: dict[str, int] = {}
     for rank, comp in enumerate(
         sorted(
-            _weakly_connected_components(graph, section_edges),
-            key=lambda c: min(graph.sections[sid].grid_row for sid in c),
+            _weakly_connected_components(graph, component_edges),
+            key=lambda component: (
+                min(graph.sections[sid].grid_row for sid in component),
+                min(section_rank[sid] for sid in component),
+            ),
         )
     ):
         for sid in comp:
@@ -98,10 +107,10 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
         elif sw not in sweep_is_rl and s.direction == "LR":
             sweep_is_rl[sw] = False
 
-    def _sort_key(s: Section) -> tuple[int, int, int, int]:
+    def _sort_key(s: Section) -> tuple[int, int, int, int, int]:
         sw = sweep[s.id]
         col = -s.grid_col if sweep_is_rl.get(sw, False) else s.grid_col
-        return (comp_idx.get(s.id, 0), sw, col, s.grid_row)
+        return (comp_idx.get(s.id, 0), sw, col, s.grid_row, section_rank[s.id])
 
     sorted_sections = sorted(graph.sections.values(), key=_sort_key)
     for i, section in enumerate(sorted_sections, start=1):

--- a/src/nf_metro/layout/routing/context.py
+++ b/src/nf_metro/layout/routing/context.py
@@ -252,7 +252,7 @@ def _classify_merge_edges(
     trunk_source: dict[str, str] = {}
     trunk_by: dict[str, float] = {}
 
-    for mjid in junctions:
+    for mjid in entry_port_for:
         mst = graph.stations.get(mjid)
         if not mst:
             continue

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -86,6 +86,7 @@ class _OffsetCtx:
     # Pre-computed per-station inbound/outbound line sets
     inbound: dict[str, set[str]] = field(default_factory=dict)
     outbound: dict[str, set[str]] = field(default_factory=dict)
+    station_rank: dict[str, int] = field(default_factory=dict)
     # Section -> flat-frame component root, populated by section-local re-indexing
     frame_roots: dict[str, str] = field(default_factory=dict)
 
@@ -125,6 +126,7 @@ def _build_offset_ctx(graph: MetroGraph, offset_step: float) -> _OffsetCtx:
         lr_rl_sections=lr_rl_sections,
         inbound=inbound,
         outbound=outbound,
+        station_rank={sid: rank for rank, sid in enumerate(graph.stations)},
     )
 
 
@@ -1183,7 +1185,7 @@ def _propagate_exit_offsets_to_hubs(
     if len(feeder_ids) < 2:
         return
     hub_candidates = {edge.source for fid in feeder_ids for edge in graph.edges_to(fid)}
-    for hub_id in hub_candidates:
+    for hub_id in sorted(hub_candidates, key=ctx.station_rank.__getitem__):
         overlap = [lid for lid in graph.station_lines(hub_id) if lid in offs]
         if len(overlap) < 2 or _hub_copy_would_desync_trunk_row(
             ctx, hub_id, overlap, offs
@@ -1255,6 +1257,7 @@ def _exit_trunk_feeder(
     graph: MetroGraph,
     line_feeders: dict[str, list[tuple[str, float]]],
     port_lines: set[str],
+    station_rank: dict[str, int],
 ) -> str | None:
     """The feeder that carries the whole exit bundle out on one row, or None.
 
@@ -1273,23 +1276,23 @@ def _exit_trunk_feeder(
     for lid, entries in line_feeders.items():
         for fid, _ in entries:
             feeder_port_lines.setdefault(fid, set()).add(lid)
-    trunk_feeder_id = next(
-        (sid for sid in all_feeders if port_lines.issubset(graph.station_lines(sid))),
-        None,
-    )
-    if trunk_feeder_id is None or port_lines.issubset(
-        feeder_port_lines.get(trunk_feeder_id, set())
-    ):
-        return trunk_feeder_id
-    trunk_y = graph.stations[trunk_feeder_id].y
-    unforwarded_ys = {
-        y
-        for lid in port_lines - feeder_port_lines.get(trunk_feeder_id, set())
-        for _, y in line_feeders[lid]
-    }
-    if any(abs(y - trunk_y) > _SAME_Y_TOLERANCE for y in unforwarded_ys):
-        return None
-    return trunk_feeder_id
+    ordered_feeders = sorted(all_feeders, key=station_rank.__getitem__)
+    for feeder_id in ordered_feeders:
+        if port_lines.issubset(feeder_port_lines.get(feeder_id, set())):
+            return feeder_id
+
+    for feeder_id in ordered_feeders:
+        if not port_lines.issubset(graph.station_lines(feeder_id)):
+            continue
+        trunk_y = graph.stations[feeder_id].y
+        unforwarded_ys = {
+            y
+            for lid in port_lines - feeder_port_lines.get(feeder_id, set())
+            for _, y in line_feeders[lid]
+        }
+        if all(abs(y - trunk_y) <= _SAME_Y_TOLERANCE for y in unforwarded_ys):
+            return feeder_id
+    return None
 
 
 def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
@@ -1393,7 +1396,9 @@ def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
                 _propagate_exit_offsets_to_hubs(ctx, port_id, inherited)
                 continue
 
-        trunk_feeder_id = _exit_trunk_feeder(graph, line_feeders, port_lines)
+        trunk_feeder_id = _exit_trunk_feeder(
+            graph, line_feeders, port_lines, ctx.station_rank
+        )
         if trunk_feeder_id is not None:
             trunk_y = graph.stations[trunk_feeder_id].y
             line_avg_y = {lid: trunk_y for lid in line_feeders}
@@ -2216,7 +2221,7 @@ def _propagate_touched_exit_ports_to_entries(
     be wrong, not merely redundant.
     """
     graph = ctx.graph
-    for sid in touched:
+    for sid in sorted(touched, key=ctx.station_rank.__getitem__):
         src_port = graph.ports.get(sid)
         if src_port is None or src_port.is_entry:
             continue
@@ -2240,7 +2245,7 @@ def _propagate_touched_exit_ports_to_entries(
 
 def _seed_compaction(ctx: _OffsetCtx, seed_sid: str) -> dict[str, float] | None:
     """Target offsets that pack the seed's lines into consecutive slots, or None."""
-    seed_lines = ctx.graph.station_lines(seed_sid)
+    seed_lines = ctx.graph.station_lines_ordered(seed_sid)
     if len(seed_lines) < 2:
         return None
 
@@ -2271,12 +2276,12 @@ def _anchored_seed_compaction(
     into the free slots immediately below and above it instead.
     """
     graph = ctx.graph
-    seed_lines = graph.station_lines(seed_sid)
+    seed_lines = graph.station_lines_ordered(seed_sid)
     if len(seed_lines) < 2:
         return None
 
     current = {lid: ctx.offsets.get((seed_sid, lid), 0.0) for lid in seed_lines}
-    fixed_here = fixed & set(seed_lines)
+    fixed_here = [lid for lid in seed_lines if lid in fixed]
     movable = [lid for lid in seed_lines if lid not in fixed_here]
     if not fixed_here or not movable:
         return None
@@ -2328,12 +2333,12 @@ def _compact_one_seed(
     compacted = _seed_compaction(ctx, seed_sid)
     if compacted is None:
         return set()
-    changed_lids = {
+    changed_lids = [
         lid
-        for lid in ctx.graph.station_lines(seed_sid)
+        for lid in ctx.graph.station_lines_ordered(seed_sid)
         if abs(compacted[lid] - ctx.offsets.get((seed_sid, lid), 0.0))
         > _OFFSET_EQ_TOLERANCE
-    }
+    ]
 
     pending = _propagate_compaction(
         ctx,
@@ -2377,7 +2382,7 @@ def _compact_one_seed_with_retry(
     :func:`_propagate_compaction`.
     """
     graph = ctx.graph
-    seed_lines = graph.station_lines(seed_sid)
+    seed_lines = graph.station_lines_ordered(seed_sid)
     fixed: set[str] = set()
     for _ in range(len(seed_lines)):
         compacted = (
@@ -2387,12 +2392,12 @@ def _compact_one_seed_with_retry(
         )
         if compacted is None:
             return set()
-        changed_lids = {
+        changed_lids = [
             lid
             for lid in seed_lines
             if abs(compacted[lid] - ctx.offsets.get((seed_sid, lid), 0.0))
             > _OFFSET_EQ_TOLERANCE
-        }
+        ]
         if not changed_lids:
             return set()
 
@@ -2462,7 +2467,7 @@ def _propagate_compaction(
     sec_id: str,
     seed_sid: str,
     compacted: dict[str, float],
-    changed_lids: set[str],
+    changed_lids: Sequence[str],
     n_sec_stations: int,
     *,
     mover: str | None = None,

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, replace
 
 import networkx as nx
 
+from nf_metro.graph_views import directed_graph, longest_path_layers
 from nf_metro.parser.model import (
     BYPASS_V_PREFIX,
     CONVERGE_PREFIX,
@@ -526,21 +527,19 @@ def _insert_bypass_stations(
 
 def _section_topo_layers(graph: MetroGraph, section_ids: set[str]) -> dict[str, int]:
     """Longest-path layer index for the in-section subgraph (empty if cyclic)."""
-    sub: nx.DiGraph[str] = nx.DiGraph()
-    for sid in section_ids:
-        sub.add_node(sid)
-    for edge in graph.edges:
-        if edge.source in section_ids and edge.target in section_ids:
-            sub.add_edge(edge.source, edge.target)
+    station_ids = [sid for sid in graph.stations if sid in section_ids]
+    section_graph = directed_graph(
+        station_ids,
+        (
+            (edge.source, edge.target)
+            for edge in graph.edges
+            if edge.source in section_ids and edge.target in section_ids
+        ),
+    )
     try:
-        topo = list(nx.topological_sort(sub))
+        return longest_path_layers(section_graph, station_ids)
     except nx.NetworkXUnfeasible:
         return {}
-    layers: dict[str, int] = {}
-    for node in topo:
-        preds = list(sub.predecessors(node))
-        layers[node] = max((layers[p] for p in preds), default=-1) + 1 if preds else 0
-    return layers
 
 
 @dataclass
@@ -787,20 +786,20 @@ def _section_flow_ranks(section: Section) -> dict[str, int]:
     flow-sink end (trailing edge).  Returns an empty dict if the internal
     edges form a cycle.
     """
-    g: nx.DiGraph[str] = nx.DiGraph()
-    g.add_nodes_from(section.station_ids)
-    for e in section.internal_edges:
-        if e.source in g and e.target in g:
-            g.add_edge(e.source, e.target)
+    station_ids = list(section.station_ids)
+    station_set = set(station_ids)
+    section_graph = directed_graph(
+        station_ids,
+        (
+            (edge.source, edge.target)
+            for edge in section.internal_edges
+            if edge.source in station_set and edge.target in station_set
+        ),
+    )
     try:
-        order = list(nx.topological_sort(g))
+        return longest_path_layers(section_graph, station_ids)
     except nx.NetworkXUnfeasible:
         return {}
-    ranks: dict[str, int] = {}
-    for node in order:
-        preds = list(g.predecessors(node))
-        ranks[node] = max((ranks[p] for p in preds), default=-1) + 1
-    return ranks
 
 
 def _port_fold_target(

--- a/tests/fixtures/hash_seed_determinism/seed_15.mmd
+++ b/tests/fixtures/hash_seed_determinism/seed_15.mmd
@@ -1,0 +1,90 @@
+%%metro title: Candidate recovery fuzz
+%%metro line: l0 | Line 1 | #3779b1
+%%metro line: l1 | Line 2 | #6ef362
+%%metro line: l2 | Line 3 | #a66d13
+graph LR
+    subgraph s0 [Section 0]
+        n0_0[N0.0]
+    end
+    subgraph s1 [Section 1]
+        n1_0[N1.0]
+        n1_1[N1.1]
+        n1_0 -->|l2| n1_1
+    end
+    subgraph s2 [Section 2]
+        n2_0[N2.0]
+        n2_1[N2.1]
+        n2_0 -->|l1| n2_1
+    end
+    subgraph s3 [Section 3]
+        n3_0[N3.0]
+    end
+    subgraph s4 [Section 4]
+        n4_0[N4.0]
+    end
+    subgraph s5 [Section 5]
+        n5_0[N5.0]
+        n5_1[N5.1]
+        n5_0 -->|l1| n5_1
+    end
+    subgraph s6 [Section 6]
+        n6_0[N6.0]
+        n6_1[N6.1]
+        n6_0 -->|l1| n6_1
+        n6_2[N6.2]
+        n6_1 -->|l0| n6_2
+    end
+    subgraph s7 [Section 7]
+        n7_0[N7.0]
+        n7_1[N7.1]
+        n7_0 -->|l2| n7_1
+    end
+    subgraph s8 [Section 8]
+        n8_0[N8.0]
+    end
+    subgraph s9 [Section 9]
+        n9_0[N9.0]
+        n9_1[N9.1]
+        n9_0 -->|l2| n9_1
+        n9_2[N9.2]
+        n9_1 -->|l1| n9_2
+    end
+    subgraph s10 [Section 10]
+        n10_0[N10.0]
+        n10_1[N10.1]
+        n10_0 -->|l2| n10_1
+        n10_2[N10.2]
+        n10_1 -->|l1| n10_2
+        n10_3[N10.3]
+        n10_2 -->|l1| n10_3
+    end
+    n0_0 -->|l1| n1_0
+    n0_0 -->|l0| n4_0
+    n1_1 -->|l0| n2_0
+    n1_1 -->|l1| n2_0
+    n1_1 -->|l0| n3_0
+    n1_1 -->|l1| n4_0
+    n1_1 -->|l0| n6_0
+    n1_1 -->|l2| n9_0
+    n2_1 -->|l0| n4_0
+    n2_1 -->|l0| n5_0
+    n2_1 -->|l1| n8_0
+    n3_0 -->|l2| n5_0
+    n3_0 -->|l2| n6_0
+    n4_0 -->|l1| n6_0
+    n4_0 -->|l0| n8_0
+    n4_0 -->|l1| n8_0
+    n4_0 -->|l2| n8_0
+    n5_1 -->|l0| n6_0
+    n5_1 -->|l0| n9_0
+    n6_2 -->|l1| n7_0
+    n6_2 -->|l0| n10_0
+    n7_1 -->|l0| n8_0
+    n7_1 -->|l2| n8_0
+    n7_1 -->|l0| n9_0
+    n7_1 -->|l1| n9_0
+    n8_0 -->|l0| n10_0
+    n8_0 -->|l1| n10_0
+    n9_2 -->|l0| n10_0
+    n9_2 -->|l1| n10_0
+    n9_2 -->|l2| n10_0

--- a/tests/fixtures/hash_seed_determinism/seed_41.mmd
+++ b/tests/fixtures/hash_seed_determinism/seed_41.mmd
@@ -1,0 +1,133 @@
+%%metro title: Candidate recovery fuzz
+%%metro line: l0 | Line 1 | #3779b1
+%%metro line: l1 | Line 2 | #6ef362
+%%metro line: l2 | Line 3 | #a66d13
+%%metro line: l3 | Line 4 | #dde6c4
+%%metro line: l4 | Line 5 | #156075
+graph LR
+    subgraph s0 [Section 0]
+        n0_0[N0.0]
+        n0_1[N0.1]
+        n0_0 -->|l0| n0_1
+    end
+    subgraph s1 [Section 1]
+        n1_0[N1.0]
+        n1_1[N1.1]
+        n1_0 -->|l0| n1_1
+    end
+    subgraph s2 [Section 2]
+        n2_0[N2.0]
+        n2_1[N2.1]
+        n2_0 -->|l4| n2_1
+        n2_2[N2.2]
+        n2_1 -->|l4| n2_2
+        n2_3[N2.3]
+        n2_2 -->|l2| n2_3
+    end
+    subgraph s3 [Section 3]
+        n3_0[N3.0]
+        n3_1[N3.1]
+        n3_0 -->|l1| n3_1
+        n3_2[N3.2]
+        n3_1 -->|l3| n3_2
+    end
+    subgraph s4 [Section 4]
+        n4_0[N4.0]
+        n4_1[N4.1]
+        n4_0 -->|l2| n4_1
+        n4_2[N4.2]
+        n4_1 -->|l2| n4_2
+    end
+    subgraph s5 [Section 5]
+        n5_0[N5.0]
+        n5_1[N5.1]
+        n5_0 -->|l1| n5_1
+        n5_2[N5.2]
+        n5_1 -->|l2| n5_2
+        n5_3[N5.3]
+        n5_2 -->|l3| n5_3
+    end
+    subgraph s6 [Section 6]
+        n6_0[N6.0]
+    end
+    subgraph s7 [Section 7]
+        n7_0[N7.0]
+        n7_1[N7.1]
+        n7_0 -->|l4| n7_1
+    end
+    subgraph s8 [Section 8]
+        n8_0[N8.0]
+    end
+    subgraph s9 [Section 9]
+        n9_0[N9.0]
+        n9_1[N9.1]
+        n9_0 -->|l1| n9_1
+        n9_2[N9.2]
+        n9_1 -->|l0| n9_2
+        n9_3[N9.3]
+        n9_2 -->|l2| n9_3
+    end
+    subgraph s10 [Section 10]
+        n10_0[N10.0]
+        n10_1[N10.1]
+        n10_0 -->|l4| n10_1
+    end
+    subgraph s11 [Section 11]
+        n11_0[N11.0]
+        n11_1[N11.1]
+        n11_0 -->|l4| n11_1
+    end
+    subgraph s12 [Section 12]
+        n12_0[N12.0]
+        n12_1[N12.1]
+        n12_0 -->|l3| n12_1
+        n12_2[N12.2]
+        n12_1 -->|l2| n12_2
+    end
+    subgraph s13 [Section 13]
+        n13_0[N13.0]
+        n13_1[N13.1]
+        n13_0 -->|l3| n13_1
+    end
+    n0_1 -->|l4| n1_0
+    n0_1 -->|l0| n2_0
+    n1_1 -->|l0| n5_0
+    n1_1 -->|l4| n5_0
+    n1_1 -->|l2| n12_0
+    n2_3 -->|l0| n3_0
+    n2_3 -->|l0| n4_0
+    n2_3 -->|l0| n9_0
+    n2_3 -->|l2| n10_0
+    n2_3 -->|l3| n10_0
+    n2_3 -->|l1| n13_0
+    n3_2 -->|l0| n4_0
+    n3_2 -->|l1| n4_0
+    n3_2 -->|l2| n4_0
+    n3_2 -->|l3| n4_0
+    n3_2 -->|l3| n6_0
+    n3_2 -->|l4| n7_0
+    n3_2 -->|l0| n8_0
+    n4_2 -->|l1| n9_0
+    n4_2 -->|l0| n12_0
+    n4_2 -->|l1| n12_0
+    n4_2 -->|l0| n13_0
+    n5_3 -->|l1| n6_0
+    n6_0 -->|l0| n10_0
+    n7_1 -->|l2| n11_0
+    n7_1 -->|l1| n12_0
+    n8_0 -->|l2| n11_0
+    n8_0 -->|l4| n12_0
+    n8_0 -->|l4| n13_0
+    n9_3 -->|l1| n10_0
+    n9_3 -->|l2| n10_0
+    n10_1 -->|l2| n11_0
+    n10_1 -->|l3| n11_0
+    n10_1 -->|l0| n12_0
+    n10_1 -->|l2| n12_0
+    n10_1 -->|l0| n13_0
+    n10_1 -->|l3| n13_0
+    n11_1 -->|l0| n12_0
+    n11_1 -->|l3| n12_0
+    n11_1 -->|l4| n12_0
+    n11_1 -->|l3| n13_0
+    n11_1 -->|l4| n13_0

--- a/tests/fixtures/hash_seed_determinism/seed_72.mmd
+++ b/tests/fixtures/hash_seed_determinism/seed_72.mmd
@@ -1,0 +1,81 @@
+%%metro title: Candidate recovery fuzz
+%%metro line: l0 | Line 1 | #3779b1
+%%metro line: l1 | Line 2 | #6ef362
+%%metro line: l2 | Line 3 | #a66d13
+%%metro line: l3 | Line 4 | #dde6c4
+%%metro line: l4 | Line 5 | #156075
+%%metro line: l5 | Line 6 | #4cda26
+%%metro line: l6 | Line 7 | #8453d7
+graph LR
+    subgraph s0 [Section 0]
+        n0_0[N0.0]
+        n0_1[N0.1]
+        n0_0 -->|l3| n0_1
+    end
+    subgraph s1 [Section 1]
+        n1_0[N1.0]
+        n1_1[N1.1]
+        n1_0 -->|l4| n1_1
+        n1_2[N1.2]
+        n1_1 -->|l6| n1_2
+    end
+    subgraph s2 [Section 2]
+        n2_0[N2.0]
+        n2_1[N2.1]
+        n2_0 -->|l3| n2_1
+        n2_2[N2.2]
+        n2_1 -->|l1| n2_2
+    end
+    subgraph s3 [Section 3]
+        n3_0[N3.0]
+        n3_1[N3.1]
+        n3_0 -->|l0| n3_1
+        n3_2[N3.2]
+        n3_1 -->|l6| n3_2
+    end
+    subgraph s4 [Section 4]
+        n4_0[N4.0]
+        n4_1[N4.1]
+        n4_0 -->|l6| n4_1
+    end
+    subgraph s5 [Section 5]
+        n5_0[N5.0]
+        n5_1[N5.1]
+        n5_0 -->|l3| n5_1
+        n5_2[N5.2]
+        n5_1 -->|l4| n5_2
+    end
+    subgraph s6 [Section 6]
+        n6_0[N6.0]
+        n6_1[N6.1]
+        n6_0 -->|l5| n6_1
+    end
+    subgraph s7 [Section 7]
+        n7_0[N7.0]
+        n7_1[N7.1]
+        n7_0 -->|l0| n7_1
+        n7_2[N7.2]
+        n7_1 -->|l2| n7_2
+        n7_3[N7.3]
+        n7_2 -->|l3| n7_3
+    end
+    subgraph s8 [Section 8]
+        n8_0[N8.0]
+        n8_1[N8.1]
+        n8_0 -->|l2| n8_1
+    end
+    n0_1 -->|l5| n1_0
+    n0_1 -->|l3| n2_0
+    n0_1 -->|l3| n3_0
+    n0_1 -->|l6| n4_0
+    n0_1 -->|l0| n7_0
+    n2_2 -->|l0| n5_0
+    n2_2 -->|l3| n5_0
+    n2_2 -->|l6| n7_0
+    n3_2 -->|l0| n4_0
+    n5_2 -->|l2| n6_0
+    n5_2 -->|l3| n6_0
+    n5_2 -->|l1| n7_0
+    n6_1 -->|l2| n8_0
+    n7_3 -->|l2| n8_0
+    n7_3 -->|l6| n8_0

--- a/tests/fixtures/hash_seed_determinism/seed_77.mmd
+++ b/tests/fixtures/hash_seed_determinism/seed_77.mmd
@@ -1,0 +1,159 @@
+%%metro title: Candidate recovery fuzz
+%%metro line: l0 | Line 1 | #3779b1
+%%metro line: l1 | Line 2 | #6ef362
+%%metro line: l2 | Line 3 | #a66d13
+%%metro line: l3 | Line 4 | #dde6c4
+%%metro line: l4 | Line 5 | #156075
+graph LR
+    subgraph s0 [Section 0]
+        n0_0[N0.0]
+        n0_1[N0.1]
+        n0_0 -->|l4| n0_1
+        n0_2[N0.2]
+        n0_1 -->|l1| n0_2
+    end
+    subgraph s1 [Section 1]
+        n1_0[N1.0]
+        n1_1[N1.1]
+        n1_0 -->|l0| n1_1
+    end
+    subgraph s2 [Section 2]
+        n2_0[N2.0]
+        n2_1[N2.1]
+        n2_0 -->|l3| n2_1
+    end
+    subgraph s3 [Section 3]
+        n3_0[N3.0]
+        n3_1[N3.1]
+        n3_0 -->|l1| n3_1
+    end
+    subgraph s4 [Section 4]
+        n4_0[N4.0]
+    end
+    subgraph s5 [Section 5]
+        n5_0[N5.0]
+        n5_1[N5.1]
+        n5_0 -->|l0| n5_1
+        n5_2[N5.2]
+        n5_1 -->|l3| n5_2
+    end
+    subgraph s6 [Section 6]
+        n6_0[N6.0]
+        n6_1[N6.1]
+        n6_0 -->|l2| n6_1
+        n6_2[N6.2]
+        n6_1 -->|l3| n6_2
+        n6_3[N6.3]
+        n6_2 -->|l3| n6_3
+    end
+    subgraph s7 [Section 7]
+        n7_0[N7.0]
+        n7_1[N7.1]
+        n7_0 -->|l4| n7_1
+    end
+    subgraph s8 [Section 8]
+        n8_0[N8.0]
+        n8_1[N8.1]
+        n8_0 -->|l3| n8_1
+    end
+    subgraph s9 [Section 9]
+        n9_0[N9.0]
+    end
+    subgraph s10 [Section 10]
+        n10_0[N10.0]
+        n10_1[N10.1]
+        n10_0 -->|l1| n10_1
+        n10_2[N10.2]
+        n10_1 -->|l3| n10_2
+    end
+    subgraph s11 [Section 11]
+        n11_0[N11.0]
+    end
+    subgraph s12 [Section 12]
+        n12_0[N12.0]
+        n12_1[N12.1]
+        n12_0 -->|l2| n12_1
+        n12_2[N12.2]
+        n12_1 -->|l2| n12_2
+        n12_3[N12.3]
+        n12_2 -->|l0| n12_3
+    end
+    subgraph s13 [Section 13]
+        n13_0[N13.0]
+        n13_1[N13.1]
+        n13_0 -->|l4| n13_1
+    end
+    subgraph s14 [Section 14]
+        n14_0[N14.0]
+        n14_1[N14.1]
+        n14_0 -->|l2| n14_1
+    end
+    subgraph s15 [Section 15]
+        n15_0[N15.0]
+        n15_1[N15.1]
+        n15_0 -->|l2| n15_1
+        n15_2[N15.2]
+        n15_1 -->|l1| n15_2
+        n15_3[N15.3]
+        n15_2 -->|l2| n15_3
+    end
+    subgraph s16 [Section 16]
+        n16_0[N16.0]
+        n16_1[N16.1]
+        n16_0 -->|l2| n16_1
+    end
+    subgraph s17 [Section 17]
+        n17_0[N17.0]
+        n17_1[N17.1]
+        n17_0 -->|l3| n17_1
+        n17_2[N17.2]
+        n17_1 -->|l4| n17_2
+    end
+    subgraph s18 [Section 18]
+        n18_0[N18.0]
+        n18_1[N18.1]
+        n18_0 -->|l3| n18_1
+        n18_2[N18.2]
+        n18_1 -->|l4| n18_2
+    end
+    subgraph s19 [Section 19]
+        n19_0[N19.0]
+    end
+    n0_2 -->|l4| n1_0
+    n0_2 -->|l0| n5_0
+    n0_2 -->|l2| n16_0
+    n1_1 -->|l0| n2_0
+    n1_1 -->|l1| n2_0
+    n1_1 -->|l4| n2_0
+    n1_1 -->|l1| n3_0
+    n1_1 -->|l1| n4_0
+    n2_1 -->|l4| n6_0
+    n2_1 -->|l0| n8_0
+    n2_1 -->|l1| n8_0
+    n3_1 -->|l2| n8_0
+    n3_1 -->|l4| n19_0
+    n4_0 -->|l1| n9_0
+    n4_0 -->|l0| n17_0
+    n5_2 -->|l4| n7_0
+    n6_3 -->|l4| n7_0
+    n6_3 -->|l4| n11_0
+    n7_1 -->|l0| n8_0
+    n7_1 -->|l3| n9_0
+    n7_1 -->|l0| n10_0
+    n7_1 -->|l4| n18_0
+    n10_2 -->|l0| n12_0
+    n11_0 -->|l3| n14_0
+    n11_0 -->|l0| n18_0
+    n11_0 -->|l4| n18_0
+    n12_3 -->|l0| n13_0
+    n12_3 -->|l3| n17_0
+    n13_1 -->|l4| n16_0
+    n13_1 -->|l0| n18_0
+    n13_1 -->|l3| n18_0
+    n14_1 -->|l0| n15_0
+    n15_3 -->|l1| n16_0
+    n17_2 -->|l4| n18_0
+    n17_2 -->|l2| n19_0
+    n18_2 -->|l0| n19_0
+    n18_2 -->|l1| n19_0
+    n18_2 -->|l3| n19_0

--- a/tests/hash_seed_oracle.py
+++ b/tests/hash_seed_oracle.py
@@ -1,0 +1,310 @@
+"""Cross-process oracle for settled render determinism."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import warnings
+from collections.abc import Mapping, Sequence
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+from nf_metro.api import prepare_graph, resolve_theme
+from nf_metro.parser.model import MetroGraph
+from nf_metro.render.plan import FrozenMap, FrozenRecord, freeze_render_value
+from nf_metro.render.svg import build_render_plan, emit_render_plan
+from nf_metro.render.validate import validate_render
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_HASH_SEEDS = ("0", "1", "2", "5", "43", "random")
+_SETTLED_GRAPH_CACHE_FIELDS = {
+    "_station_lines_cache",
+    "_edges_from_cache",
+    "_edges_to_cache",
+    "_junction_ids_cache",
+}
+
+
+ExceptionObservation = TypedDict(
+    "ExceptionObservation",
+    {
+        "phase": str,
+        "class": str,
+        "qualified_class": str,
+        "message": str,
+    },
+)
+
+
+class Observation(TypedDict):
+    outcome: Literal["success", "exception"]
+    exception: ExceptionObservation | None
+    settled_graph_sha256: str | None
+    render_plan_sha256: str | None
+    svg_sha256: str | None
+    svg_length: int | None
+    findings: Any
+    findings_sha256: str | None
+
+
+def _stable_value(value: Any) -> Any:
+    """Return JSON-safe data without discarding semantically ordered fields."""
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    if isinstance(value, Enum):
+        return {"enum": f"{type(value).__name__}.{value.name}"}
+    if isinstance(value, FrozenMap):
+        return {
+            "map": [
+                [_stable_value(key), _stable_value(item)] for key, item in value.entries
+            ]
+        }
+    if isinstance(value, FrozenRecord):
+        return {"record": value.kind, "values": _stable_value(value.values)}
+    if is_dataclass(value):
+        return {
+            "record": type(value).__name__,
+            "values": [
+                [field.name, _stable_value(getattr(value, field.name))]
+                for field in fields(value)
+            ],
+        }
+    if isinstance(value, Mapping):
+        return {
+            "map": [
+                [_stable_value(key), _stable_value(item)] for key, item in value.items()
+            ]
+        }
+    if isinstance(value, (list, tuple)):
+        return [_stable_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        members = [_stable_value(item) for item in value]
+        return {
+            "set": sorted(
+                members,
+                key=lambda item: json.dumps(
+                    item, sort_keys=True, separators=(",", ":")
+                ),
+            )
+        }
+    raise TypeError(f"cannot serialise {type(value).__name__}")
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        _stable_value(value), sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _freeze_settled_graph(graph: MetroGraph) -> FrozenRecord:
+    """Freeze semantic graph state while excluding lazy lookup caches."""
+    return FrozenRecord(
+        type(graph).__name__,
+        FrozenMap(
+            tuple(
+                (field.name, freeze_render_value(getattr(graph, field.name)))
+                for field in fields(graph)
+                if field.name not in _SETTLED_GRAPH_CACHE_FIELDS
+            )
+        ),
+    )
+
+
+def _exception(exc: Exception, phase: str) -> ExceptionObservation:
+    return {
+        "phase": phase,
+        "class": type(exc).__name__,
+        "qualified_class": f"{type(exc).__module__}.{type(exc).__qualname__}",
+        "message": str(exc),
+    }
+
+
+def _observation(
+    *,
+    exception: ExceptionObservation | None,
+    graph_digest: str | None,
+    plan_digest: str | None,
+    svg: str | None,
+    findings: Any = None,
+) -> Observation:
+    svg_bytes = svg.encode() if svg is not None else None
+    return {
+        "outcome": "success" if exception is None else "exception",
+        "exception": exception,
+        "settled_graph_sha256": graph_digest,
+        "render_plan_sha256": plan_digest,
+        "svg_sha256": (
+            hashlib.sha256(svg_bytes).hexdigest() if svg_bytes is not None else None
+        ),
+        "svg_length": len(svg_bytes) if svg_bytes is not None else None,
+        "findings": _stable_value(findings) if findings is not None else None,
+        "findings_sha256": _digest(findings) if findings is not None else None,
+    }
+
+
+def observe_path(path: Path) -> Observation:
+    """Observe the complete settled/rendered state for one source file."""
+    text = path.read_text()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try:
+            graph = prepare_graph(text, source_dir=str(path.parent))
+        except Exception as exc:  # noqa: BLE001 - the outcome is oracle data
+            return _observation(
+                exception=_exception(exc, "prepare"),
+                graph_digest=None,
+                plan_digest=None,
+                svg=None,
+            )
+
+        graph_digest = _digest(_freeze_settled_graph(graph))
+        try:
+            plan = build_render_plan(graph, resolve_theme(None, graph))
+        except Exception as exc:  # noqa: BLE001 - the outcome is oracle data
+            return _observation(
+                exception=_exception(exc, "plan"),
+                graph_digest=graph_digest,
+                plan_digest=None,
+                svg=None,
+            )
+
+        plan_digest = _digest(plan)
+        try:
+            svg = emit_render_plan(plan)
+        except Exception as exc:  # noqa: BLE001 - the outcome is oracle data
+            return _observation(
+                exception=_exception(exc, "emit"),
+                graph_digest=graph_digest,
+                plan_digest=plan_digest,
+                svg=None,
+            )
+
+        try:
+            findings = validate_render(svg, plan=plan)
+        except Exception as exc:  # noqa: BLE001 - the outcome is oracle data
+            return _observation(
+                exception=_exception(exc, "validate"),
+                graph_digest=graph_digest,
+                plan_digest=plan_digest,
+                svg=svg,
+            )
+        return _observation(
+            exception=None,
+            graph_digest=graph_digest,
+            plan_digest=plan_digest,
+            svg=svg,
+            findings=findings,
+        )
+
+
+def _path_key(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(ROOT))
+    except ValueError:
+        return str(resolved)
+
+
+def observe_paths(paths: Sequence[Path]) -> dict[str, Observation]:
+    """Observe several sources in one interpreter, keyed by stable path."""
+    return {_path_key(path): observe_path(path) for path in paths}
+
+
+def observe_paths_across_hash_seeds(
+    paths: Sequence[Path],
+    hash_seeds: tuple[str, ...] = DEFAULT_HASH_SEEDS,
+) -> dict[str, dict[str, Observation]]:
+    """Observe all paths in one fresh interpreter per requested hash seed."""
+    resolved_paths = tuple(path.resolve() for path in paths)
+    python_path = os.pathsep.join((str(ROOT / "src"), str(ROOT / "tests")))
+    observations: dict[str, dict[str, Observation]] = {}
+    for hash_seed in hash_seeds:
+        env = dict(os.environ)
+        env["PYTHONHASHSEED"] = hash_seed
+        env["PYTHONPATH"] = python_path
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                *(str(path) for path in resolved_paths),
+            ],
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        observations[hash_seed] = json.loads(result.stdout)
+    return observations
+
+
+def observe_across_hash_seeds(
+    path: Path,
+    hash_seeds: tuple[str, ...] = DEFAULT_HASH_SEEDS,
+) -> dict[str, Observation]:
+    """Observe one path in a fresh interpreter for every requested hash seed."""
+    key = _path_key(path)
+    batches = observe_paths_across_hash_seeds((path,), hash_seeds)
+    return {seed: observations[key] for seed, observations in batches.items()}
+
+
+def observation_differences(
+    batches: dict[str, dict[str, Observation]],
+) -> dict[str, dict[str, dict[str, dict[str, Any]]]]:
+    """Return only fields that differ from the hash-seed-zero observation."""
+    baseline = batches["0"]
+    differences: dict[str, dict[str, dict[str, dict[str, Any]]]] = {}
+    for seed, observations in batches.items():
+        if seed == "0":
+            continue
+        for path in sorted(set(baseline) | set(observations)):
+            expected = baseline.get(path, {})
+            observed = observations.get(path, {})
+            fields = {
+                field: {
+                    "baseline": expected.get(field),
+                    "observed": observed.get(field),
+                }
+                for field in sorted(set(expected) | set(observed))
+                if expected.get(field) != observed.get(field)
+            }
+            if fields:
+                differences.setdefault(seed, {})[path] = fields
+    return differences
+
+
+def _assert_batches_identical(batches: dict[str, dict[str, Observation]]) -> None:
+    differences = observation_differences(batches)
+    if differences:
+        raise SystemExit(
+            "hash-seed differences: "
+            + json.dumps(differences, sort_keys=True, separators=(",", ":"))
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", type=Path)
+    parser.add_argument(
+        "--check-example-corpus",
+        action="store_true",
+        help="compare every committed example under the standard hash seeds",
+    )
+    args = parser.parse_args()
+    if args.check_example_corpus:
+        corpus_paths = sorted((ROOT / "examples").rglob("*.mmd"))
+        corpus_batches = observe_paths_across_hash_seeds(corpus_paths)
+        _assert_batches_identical(corpus_batches)
+        print(f"{len(corpus_paths)} example sources are hash-seed deterministic")
+    else:
+        if not args.paths:
+            parser.error("provide at least one path")
+        observations = observe_paths(args.paths)
+        print(json.dumps(observations, sort_keys=True, separators=(",", ":")))

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -6,8 +6,10 @@ from pathlib import Path
 import pytest
 
 from nf_metro.layout.auto_layout import (
+    _adjust_explicit_tb_sections,
     _assign_grid_positions,
     _build_section_dag,
+    _compute_fold_exit_side,
     _infer_directions,
     _infer_port_sides,
     infer_section_layout,
@@ -23,6 +25,58 @@ from nf_metro.parser.model import (
 )
 
 EXAMPLES = Path(__file__).parent.parent / "examples"
+
+
+def test_fold_exit_tie_prefers_leftward_return() -> None:
+    graph = MetroGraph(
+        sections={
+            "fold": Section("fold", "Fold", grid_col=1, grid_row=0),
+            "left": Section("left", "Left", grid_col=0, grid_row=0),
+            "right": Section("right", "Right", grid_col=2, grid_row=0),
+        }
+    )
+    successors = {"fold": {"left", "right"}}
+    edge_lines = {
+        ("fold", "left"): {"left_line"},
+        ("fold", "right"): {"right_line"},
+    }
+
+    assert (
+        _compute_fold_exit_side(graph, "fold", successors, edge_lines) is PortSide.LEFT
+    )
+
+
+@pytest.mark.parametrize(
+    "section_order",
+    [
+        ("a", "b", "c"),
+        ("b", "a", "c"),
+    ],
+)
+def test_explicit_tb_shared_successor_uses_deepest_required_row(
+    section_order: tuple[str, ...],
+) -> None:
+    sections = {
+        "a": Section("a", "a", direction="TB", grid_col=0, grid_row=0, grid_row_span=2),
+        "b": Section("b", "b", direction="TB", grid_col=1, grid_row=0, grid_row_span=3),
+        "c": Section("c", "c", grid_col=2, grid_row=0),
+    }
+    graph = MetroGraph(
+        sections={sid: sections[sid] for sid in section_order},
+        grid_overrides={
+            "a": (0, 0, 2, 1),
+            "b": (1, 0, 3, 1),
+            "c": (2, 0, 1, 1),
+        },
+    )
+
+    _adjust_explicit_tb_sections(
+        graph,
+        successors={"a": {"c"}, "b": {"c"}},
+        fold_sections=set(),
+    )
+
+    assert graph.sections["c"].grid_row == 2
 
 
 def _make_graph_with_sections(

--- a/tests/test_exit_trunk_feeder.py
+++ b/tests/test_exit_trunk_feeder.py
@@ -1,0 +1,37 @@
+"""Selection tests for shared-row exit bundle feeders."""
+
+from nf_metro.layout.routing.offsets import _exit_trunk_feeder
+from nf_metro.parser.model import Edge, MetroGraph, MetroLine, Station
+
+
+def test_direct_trunk_wins_over_earlier_partial_candidate() -> None:
+    graph = MetroGraph(
+        lines={
+            "first": MetroLine("first", "First", "#111111"),
+            "second": MetroLine("second", "Second", "#222222"),
+        },
+        stations={
+            "partial": Station("partial", "Partial", y=0.0),
+            "trunk": Station("trunk", "Trunk", y=10.0),
+            "other": Station("other", "Other", y=20.0),
+            "upstream": Station("upstream", "Upstream"),
+            "port": Station("port", "Port", is_port=True),
+        },
+        edges=[
+            Edge("upstream", "partial", "second"),
+            Edge("partial", "port", "first"),
+            Edge("trunk", "port", "first"),
+            Edge("trunk", "port", "second"),
+            Edge("other", "port", "second"),
+        ],
+    )
+    line_feeders = {
+        "first": [("partial", 0.0), ("trunk", 10.0)],
+        "second": [("trunk", 10.0), ("other", 20.0)],
+    }
+
+    station_rank = {sid: rank for rank, sid in enumerate(graph.stations)}
+    assert (
+        _exit_trunk_feeder(graph, line_feeders, {"first", "second"}, station_rank)
+        == "trunk"
+    )

--- a/tests/test_hash_seed_determinism.py
+++ b/tests/test_hash_seed_determinism.py
@@ -1,0 +1,74 @@
+"""Identical input must settle and render identically across hash seeds."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from hash_seed_oracle import (
+    _freeze_settled_graph,
+    observation_differences,
+    observe_paths_across_hash_seeds,
+)
+
+from nf_metro.parser.model import MetroGraph
+
+ROOT = Path(__file__).resolve().parents[1]
+REGRESSIONS = ROOT / "tests" / "fixtures" / "hash_seed_determinism"
+
+FROZEN_SOURCE_SHA256 = {
+    "seed_15.mmd": "c0f514bcd7109a8c5b83e8aa1b8964feee5f759b0ffaef0b0d66c0b7f716b49b",
+    "seed_41.mmd": "aa7240e9a8bca5309a8435c06eeb3a1fdde4fc5f63a0647866a14a5ac9680a1b",
+    "seed_72.mmd": "2aa378b381e1af863cfe82b6b1f492cf28a3899650787430ec00f597138dcc35",
+    "seed_77.mmd": "600d869e312cd7afd4f7ccee8cc533f1a81c47f69f4e393d48059c2655fe8397",
+}
+
+REPRESENTATIVE_CORPUS = (
+    "examples/rnaseq_auto.mmd",
+    "examples/variant_calling.mmd",
+    "examples/topologies/convergence_fold_diamond.mmd",
+    "examples/topologies/fan_in_merge.mmd",
+    "examples/topologies/lr_to_tb_top_two_lines.mmd",
+    "examples/topologies/packed_cell_cellmate_bypass.mmd",
+    "examples/topologies/u_turn_fold.mmd",
+    "examples/topologies/wide_fan_out.mmd",
+)
+
+
+def _assert_identical(paths: tuple[Path, ...]) -> None:
+    observations = observe_paths_across_hash_seeds(paths)
+    differences = observation_differences(observations)
+    assert not differences, json.dumps(differences, indent=2, sort_keys=True)
+
+
+def test_settled_graph_snapshot_includes_semantic_route_state() -> None:
+    field_names = {
+        name for name, _value in _freeze_settled_graph(MetroGraph()).values.entries
+    }
+    assert {"route_topology", "route_resolution"} <= field_names
+    assert (
+        not {
+            "_station_lines_cache",
+            "_edges_from_cache",
+            "_edges_to_cache",
+            "_junction_ids_cache",
+        }
+        & field_names
+    )
+
+
+@pytest.mark.parametrize("name", sorted(FROZEN_SOURCE_SHA256))
+def test_frozen_regression_source_bytes(name: str) -> None:
+    assert (
+        hashlib.sha256((REGRESSIONS / name).read_bytes()).hexdigest()
+        == (FROZEN_SOURCE_SHA256[name])
+    )
+
+
+def test_regressions_and_representative_corpus_are_hash_seed_deterministic() -> None:
+    paths = tuple(REGRESSIONS / name for name in sorted(FROZEN_SOURCE_SHA256)) + tuple(
+        ROOT / relative_path for relative_path in REPRESENTATIVE_CORPUS
+    )
+    _assert_identical(paths)

--- a/tests/test_placement_determinism.py
+++ b/tests/test_placement_determinism.py
@@ -77,6 +77,7 @@ def test_convergence_split_excludes_cascade_only_companion():
         _col_groups(_CASCADE_COL),
         _CASCADE_SUCC,
         _predecessors(_CASCADE_SUCC),
+        section_rank={sid: rank for rank, sid in enumerate(_SECTIONS)},
     )
     assert result is not None
     assert "Q" not in result
@@ -90,10 +91,18 @@ def test_convergence_split_is_order_independent(order):
     groups = _col_groups(_CASCADE_COL)
 
     baseline = _detect_convergence_split(
-        _reorder(_CASCADE_COL, _SECTIONS), groups, _CASCADE_SUCC, pred
+        _reorder(_CASCADE_COL, _SECTIONS),
+        groups,
+        _CASCADE_SUCC,
+        pred,
+        section_rank={sid: rank for rank, sid in enumerate(_SECTIONS)},
     )
     permuted = _detect_convergence_split(
-        _reorder(_CASCADE_COL, order), groups, _CASCADE_SUCC, pred
+        _reorder(_CASCADE_COL, order),
+        groups,
+        _CASCADE_SUCC,
+        pred,
+        section_rank={sid: rank for rank, sid in enumerate(_SECTIONS)},
     )
     assert permuted == baseline, (
         f"return set depends on col_assign key order: {order} -> {permuted} "

--- a/tests/test_placement_stability.py
+++ b/tests/test_placement_stability.py
@@ -76,6 +76,35 @@ def _deepest_real_anchor(graph: MetroGraph, section: Section) -> tuple[str, str]
     return None
 
 
+def test_internal_station_depths_uses_longest_predecessor_path() -> None:
+    graph = parse_metro_mermaid(
+        """\
+%%metro line: main | Main | #ff0000
+graph LR
+    subgraph work [Work]
+        start[Start]
+        short[Short]
+        long_1[Long 1]
+        long_2[Long 2]
+        join[Join]
+        tail[Tail]
+        start -->|main| short
+        short -->|main| join
+        start -->|main| long_1
+        long_1 -->|main| long_2
+        long_2 -->|main| join
+        join -->|main| tail
+    end
+"""
+    )
+
+    depths = _internal_station_depths(graph, "work")
+
+    assert depths is not None
+    assert depths["join"] == 3
+    assert depths["tail"] == 4
+
+
 def _inject_leaf(text: str, section_id: str, anchor: str, line_id: str) -> str:
     """Append ``anchor -->|line_id| __stability_leaf`` inside ``section_id``.
 

--- a/tests/test_route_topology.py
+++ b/tests/test_route_topology.py
@@ -962,7 +962,7 @@ def test_corpus_topology_shapes_match_byte_identical_resolved_graphs() -> None:
         )
 
     assert digest.hexdigest() == (
-        "439e432f93c93c7e6526e778f99a4ecfa20e9cbe4546943444c3dec856b2da4f"
+        "45b7eb91af27f76dbb0c1ed78317a541aa6ae2a695fb475c8ee808ec3f2ddaf3"
     )
     assert saw_bypass_path
 


### PR DESCRIPTION
## Why

Python set iteration could change section placement, lane compaction, route geometry, and which invariant failure was reported for the same input. That makes later bounded recovery unreliable because candidate outcomes cannot be compared repeatably.

This is determinism gate 1 of #1653 and closes #1644.

## What this changes

- Uses model-owned section, station, line, and connector order whenever a layout or routing tie can affect output.
- Shares one deterministic longest-path implementation across parser and layout graph views.
- Resolves competing explicit-TB successor placement by the deepest required row, rather than whichever predecessor runs first.
- Prefers a feeder that directly carries a complete exit bundle before considering same-row fallback candidates.
- Preserves semantic line order throughout gap compaction and its retry propagation.
- Adds a cross-process oracle that compares complete settled graph state, including route topology and resolution, the render plan, raw SVG bytes, exception details, and ordered validation findings.

## Regression outcomes

The four generated sources from #1644 now have identical outcomes under fixed hash seeds 0, 1, 2, 5, and 43, plus a literal random seed:

- seed 72 completes successfully.
- seeds 15, 41, and 77 consistently raise CurveInvariantError with identical state and error details.

This gate makes outcomes reproducible. It does not attempt bounded recovery for currently invalid geometry; that is the dependent #1645 work.

## Verification

- 36 focused determinism, placement, compaction, and regression tests pass.
- Exact Ruff lint, Ruff format, and mypy commands pass.
- All 19 routing-gate coverage tests pass.
- Commit hooks pass.

Full CI and the gallery render diff are required before review. Render changes are acceptable only when the CI comparison shows they are non-detrimental.