### PR TITLE
Model authored and effective layout provenance

### DIFF
--- a/docs/dev/guard_tiers.md
+++ b/docs/dev/guard_tiers.md
@@ -209,33 +209,33 @@ rather than through the Pass C / final dispatch, so they carry no `needs` /
 `narrow_reason`. Costs are not separately measured; each is a single structural
 pass.
 
-| guard                                         | tier | role                                                                                                             |
-| --------------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------------------- |
-| `_guard_stations_within_bbox`                 | A    | Always-on postcondition: every station centre lies within its section bbox.                                      |
-| `_guard_no_negative_grid_columns`             | A    | No section sits at a negative grid column.                                                                       |
-| `_guard_explicit_grid_directions`             | A    | Explicit-grid sections skip auto direction inference; only a typed resolver reversal may replace the LR default. |
-| `_guard_no_mixed_entry_directions`            | A    | A section's incoming lines approach from a single side.                                                          |
-| `_guard_independent_components_disjoint`      | A    | Independently-stacked components do not overlap.                                                                 |
-| `_guard_no_same_row_backward_feed`            | A    | A same-row inter-section edge does not run against source flow.                                                  |
-| `_guard_anchors_frozen_during_placement`      | B    | Content placement leaves resolved anchors fixed.                                                                 |
-| `_guard_bypass_v_flat_visible`                | B    | Every bypass V keeps a visible horizontal run through its X.                                                     |
-| `_guard_centered_line_spread_balanced`        | B    | A `centered` section's weave balances about its trunk.                                                           |
-| `_guard_file_icon_no_name_label`              | B    | A file-icon station gets no separate node-name label.                                                            |
-| `_guard_interchange_bar_clears_non_members`   | B    | An interchange bar does not cross a non-member station.                                                          |
-| `_guard_no_diagonal_strikes_horizontal_label` | B    | No foreign fan diagonal rakes a stacked station's name.                                                          |
-| `_guard_no_label_overlap`                     | B    | No station label overlaps another label or a marker.                                                             |
-| `_guard_no_line_crosses_file_icon`            | B    | No rendered line passes through a file/terminus icon.                                                            |
-| `_guard_no_line_strikes_label`                | B    | No rendered line strikes through a station label.                                                                |
-| `_guard_no_wrapped_label_trunk_strike`        | B    | No wrapped label overruns a foreign horizontal trunk.                                                            |
-| `_guard_off_track_consumer_on_trunk`          | B    | An off-track input's straight-through consumer stays on trunk (`#650`).                                          |
-| `_guard_off_track_input_column_stack`         | B    | Single-trunk off-track inputs hug their consumer column (`#651`).                                                |
-| `_guard_off_track_not_hub`                    | B    | No off-track station has edges on both sides (`#1295`).                                                          |
-| `_guard_rail_above_label_band`                | B    | A rail section reserves room above its top rail for labels.                                                      |
-| `_guard_rail_one_station_per_column`          | B    | Rails place one distinct station per column.                                                                     |
-| `_guard_rail_stations_seat_on_rails`          | B    | Rail stations seat on their lines' fixed rails.                                                                  |
-| `_guard_single_trunk_off_track_step`          | B    | Single-trunk sections lift off-track stations by the base pitch (`#580`).                                        |
-| `_guard_tall_anchor_stack_well_formed`        | B    | A tall-anchor vertical stack keeps its downstream chain intact.                                                  |
-| `_guard_tb_top_entry_drop_hugs_top`           | B    | A clean TB TOP-entry drop seats its first station at the top.                                                    |
+| guard                                         | tier | role                                                                        |
+| --------------------------------------------- | ---- | --------------------------------------------------------------------------- |
+| `_guard_stations_within_bbox`                 | A    | Always-on postcondition: every station centre lies within its section bbox. |
+| `_guard_no_negative_grid_columns`             | A    | No section sits at a negative grid column.                                  |
+| `_guard_explicit_grid_directions`             | A    | Explicit-grid sections retain direction unless resolution reverses it.      |
+| `_guard_no_mixed_entry_directions`            | A    | A section's incoming lines approach from a single side.                     |
+| `_guard_independent_components_disjoint`      | A    | Independently-stacked components do not overlap.                            |
+| `_guard_no_same_row_backward_feed`            | A    | A same-row inter-section edge does not run against source flow.             |
+| `_guard_anchors_frozen_during_placement`      | B    | Content placement leaves resolved anchors fixed.                            |
+| `_guard_bypass_v_flat_visible`                | B    | Every bypass V keeps a visible horizontal run through its X.                |
+| `_guard_centered_line_spread_balanced`        | B    | A `centered` section's weave balances about its trunk.                      |
+| `_guard_file_icon_no_name_label`              | B    | A file-icon station gets no separate node-name label.                       |
+| `_guard_interchange_bar_clears_non_members`   | B    | An interchange bar does not cross a non-member station.                     |
+| `_guard_no_diagonal_strikes_horizontal_label` | B    | No foreign fan diagonal rakes a stacked station's name.                     |
+| `_guard_no_label_overlap`                     | B    | No station label overlaps another label or a marker.                        |
+| `_guard_no_line_crosses_file_icon`            | B    | No rendered line passes through a file/terminus icon.                       |
+| `_guard_no_line_strikes_label`                | B    | No rendered line strikes through a station label.                           |
+| `_guard_no_wrapped_label_trunk_strike`        | B    | No wrapped label overruns a foreign horizontal trunk.                       |
+| `_guard_off_track_consumer_on_trunk`          | B    | An off-track input's straight-through consumer stays on trunk (`#650`).     |
+| `_guard_off_track_input_column_stack`         | B    | Single-trunk off-track inputs hug their consumer column (`#651`).           |
+| `_guard_off_track_not_hub`                    | B    | No off-track station has edges on both sides (`#1295`).                     |
+| `_guard_rail_above_label_band`                | B    | A rail section reserves room above its top rail for labels.                 |
+| `_guard_rail_one_station_per_column`          | B    | Rails place one distinct station per column.                                |
+| `_guard_rail_stations_seat_on_rails`          | B    | Rail stations seat on their lines' fixed rails.                             |
+| `_guard_single_trunk_off_track_step`          | B    | Single-trunk sections lift off-track stations by the base pitch (`#580`).   |
+| `_guard_tall_anchor_stack_well_formed`        | B    | A tall-anchor vertical stack keeps its downstream chain intact.             |
+| `_guard_tb_top_entry_drop_hugs_top`           | B    | A clean TB TOP-entry drop seats its first station at the top.               |
 
 ## Consolidation
 

--- a/docs/dev/guard_tiers.md
+++ b/docs/dev/guard_tiers.md
@@ -209,33 +209,33 @@ rather than through the Pass C / final dispatch, so they carry no `needs` /
 `narrow_reason`. Costs are not separately measured; each is a single structural
 pass.
 
-| guard                                         | tier | role                                                                        |
-| --------------------------------------------- | ---- | --------------------------------------------------------------------------- |
-| `_guard_stations_within_bbox`                 | A    | Always-on postcondition: every station centre lies within its section bbox. |
-| `_guard_no_negative_grid_columns`             | A    | No section sits at a negative grid column.                                  |
-| `_guard_explicit_grid_directions`             | A    | Explicit-grid sections keep the LR default unless they declare a direction. |
-| `_guard_no_mixed_entry_directions`            | A    | A section's incoming lines approach from a single side.                     |
-| `_guard_independent_components_disjoint`      | A    | Independently-stacked components do not overlap.                            |
-| `_guard_no_same_row_backward_feed`            | A    | A same-row inter-section edge does not run against source flow.             |
-| `_guard_anchors_frozen_during_placement`      | B    | Content placement leaves resolved anchors fixed.                            |
-| `_guard_bypass_v_flat_visible`                | B    | Every bypass V keeps a visible horizontal run through its X.                |
-| `_guard_centered_line_spread_balanced`        | B    | A `centered` section's weave balances about its trunk.                      |
-| `_guard_file_icon_no_name_label`              | B    | A file-icon station gets no separate node-name label.                       |
-| `_guard_interchange_bar_clears_non_members`   | B    | An interchange bar does not cross a non-member station.                     |
-| `_guard_no_diagonal_strikes_horizontal_label` | B    | No foreign fan diagonal rakes a stacked station's name.                     |
-| `_guard_no_label_overlap`                     | B    | No station label overlaps another label or a marker.                        |
-| `_guard_no_line_crosses_file_icon`            | B    | No rendered line passes through a file/terminus icon.                       |
-| `_guard_no_line_strikes_label`                | B    | No rendered line strikes through a station label.                           |
-| `_guard_no_wrapped_label_trunk_strike`        | B    | No wrapped label overruns a foreign horizontal trunk.                       |
-| `_guard_off_track_consumer_on_trunk`          | B    | An off-track input's straight-through consumer stays on trunk (`#650`).     |
-| `_guard_off_track_input_column_stack`         | B    | Single-trunk off-track inputs hug their consumer column (`#651`).           |
-| `_guard_off_track_not_hub`                    | B    | No off-track station has edges on both sides (`#1295`).                     |
-| `_guard_rail_above_label_band`                | B    | A rail section reserves room above its top rail for labels.                 |
-| `_guard_rail_one_station_per_column`          | B    | Rails place one distinct station per column.                                |
-| `_guard_rail_stations_seat_on_rails`          | B    | Rail stations seat on their lines' fixed rails.                             |
-| `_guard_single_trunk_off_track_step`          | B    | Single-trunk sections lift off-track stations by the base pitch (`#580`).   |
-| `_guard_tall_anchor_stack_well_formed`        | B    | A tall-anchor vertical stack keeps its downstream chain intact.             |
-| `_guard_tb_top_entry_drop_hugs_top`           | B    | A clean TB TOP-entry drop seats its first station at the top.               |
+| guard                                         | tier | role                                                                                                             |
+| --------------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------------------- |
+| `_guard_stations_within_bbox`                 | A    | Always-on postcondition: every station centre lies within its section bbox.                                      |
+| `_guard_no_negative_grid_columns`             | A    | No section sits at a negative grid column.                                                                       |
+| `_guard_explicit_grid_directions`             | A    | Explicit-grid sections skip auto direction inference; only a typed resolver reversal may replace the LR default. |
+| `_guard_no_mixed_entry_directions`            | A    | A section's incoming lines approach from a single side.                                                          |
+| `_guard_independent_components_disjoint`      | A    | Independently-stacked components do not overlap.                                                                 |
+| `_guard_no_same_row_backward_feed`            | A    | A same-row inter-section edge does not run against source flow.                                                  |
+| `_guard_anchors_frozen_during_placement`      | B    | Content placement leaves resolved anchors fixed.                                                                 |
+| `_guard_bypass_v_flat_visible`                | B    | Every bypass V keeps a visible horizontal run through its X.                                                     |
+| `_guard_centered_line_spread_balanced`        | B    | A `centered` section's weave balances about its trunk.                                                           |
+| `_guard_file_icon_no_name_label`              | B    | A file-icon station gets no separate node-name label.                                                            |
+| `_guard_interchange_bar_clears_non_members`   | B    | An interchange bar does not cross a non-member station.                                                          |
+| `_guard_no_diagonal_strikes_horizontal_label` | B    | No foreign fan diagonal rakes a stacked station's name.                                                          |
+| `_guard_no_label_overlap`                     | B    | No station label overlaps another label or a marker.                                                             |
+| `_guard_no_line_crosses_file_icon`            | B    | No rendered line passes through a file/terminus icon.                                                            |
+| `_guard_no_line_strikes_label`                | B    | No rendered line strikes through a station label.                                                                |
+| `_guard_no_wrapped_label_trunk_strike`        | B    | No wrapped label overruns a foreign horizontal trunk.                                                            |
+| `_guard_off_track_consumer_on_trunk`          | B    | An off-track input's straight-through consumer stays on trunk (`#650`).                                          |
+| `_guard_off_track_input_column_stack`         | B    | Single-trunk off-track inputs hug their consumer column (`#651`).                                                |
+| `_guard_off_track_not_hub`                    | B    | No off-track station has edges on both sides (`#1295`).                                                          |
+| `_guard_rail_above_label_band`                | B    | A rail section reserves room above its top rail for labels.                                                      |
+| `_guard_rail_one_station_per_column`          | B    | Rails place one distinct station per column.                                                                     |
+| `_guard_rail_stations_seat_on_rails`          | B    | Rail stations seat on their lines' fixed rails.                                                                  |
+| `_guard_single_trunk_off_track_step`          | B    | Single-trunk sections lift off-track stations by the base pitch (`#580`).                                        |
+| `_guard_tall_anchor_stack_well_formed`        | B    | A tall-anchor vertical stack keeps its downstream chain intact.                                                  |
+| `_guard_tb_top_entry_drop_hugs_top`           | B    | A clean TB TOP-entry drop seats its first station at the top.                                                    |
 
 ## Consolidation
 

--- a/docs/dev/layout_pipeline.mdx
+++ b/docs/dev/layout_pipeline.mdx
@@ -17,6 +17,12 @@ postconditions, invariants preserved, related tests), see
 For the source itself, the orchestrator is `_compute_section_layout`
 in `src/nf_metro/layout/engine.py`.
 
+The parser also attaches typed layout provenance to the graph before this
+pipeline starts. Layout passes use its effective decisions to distinguish an
+authored choice from an engine choice and to tell whether a choice may be
+inferred again. The [parser guide's provenance section](/nf-metro/dev/parser/#layout-decision-provenance)
+describes the snapshot, decision states, and connector endpoint keys.
+
 ## What "layout" means here
 
 Parsing produces a `MetroGraph` with sections, stations, edges, lines,

--- a/docs/dev/parser.mdx
+++ b/docs/dev/parser.mdx
@@ -136,6 +136,13 @@ Three steps:
    closes it, and the nodes/edges/directives in between are attached to
    it.
 
+Before auto-layout or resolver rewrites begin, the parser freezes the accepted
+layout input in `graph.layout_provenance.authored`. This snapshot contains the
+authored grid cells, section directions, entry and exit hints, connector-side
+choices, and both possible fold-threshold inputs. It is immutable, so later
+inference cannot make an authored value look inferred or make an inferred value
+look authored.
+
 Because the appliers receive structured fields, the driver stays a thin
 dispatch: a `_Node` registers a station, an `_Edge` registers one edge
 per line id (declaring any inline-shaped endpoints), a `_Directive` is
@@ -354,7 +361,33 @@ insertion updates the affected paths when it splits an exit leg.
 routing run. They identify the authored fan, merge, and endpoint group behind
 each resolver-created port or junction. They are excluded from `RenderPlan`
 because that plan is created only after geometry has settled and needs no parser
-provenance to render SVG, HTML, or a manifest.
+provenance to render SVG, HTML, or a manifest. `LayoutProvenance` is excluded
+for the same reason.
+
+### Layout decision provenance
+
+`LayoutProvenance` keeps two views of layout intent:
+
+- `authored` is the frozen pre-inference snapshot described above.
+- `grids`, `directions`, `connector_sides`, and `fold_threshold_decision`
+  describe the effective values the engine uses.
+
+Each effective decision answers three separate questions: who selected the
+value, whether another inference pass may replace it, and why it was selected.
+The compact states shown by `nf-metro info --verbose` and `nf-metro explain`
+are `authored`, `inferred`, and `inferred-then-pinned`. A value can therefore be
+engine-selected and locked without being misreported as authored.
+
+Grid and direction decisions are keyed by section id. Port-side decisions are
+keyed by the semantic `ConnectorId` plus `entry` or `exit`, so two lines sharing
+one visible port can retain different histories. If resolution changes an
+authored side, the effective decision records the new side and retains the
+original authored options.
+
+The fold threshold follows caller, directive, then default precedence. The
+snapshot retains the caller and directive values separately, while the
+effective decision records the selected source. Rendering reads this typed
+decision when it reports an unsafe fold threshold.
 
 ## Adding things
 

--- a/src/nf_metro/explain.py
+++ b/src/nf_metro/explain.py
@@ -21,6 +21,11 @@ if TYPE_CHECKING:
     from nf_metro.parser.model import MetroGraph, Section
 
 from nf_metro.introspect import station_kind
+from nf_metro.parser.provenance import (
+    ConnectorEndpointRole,
+    DecisionReason,
+    EffectiveDecision,
+)
 
 __all__ = ["build_explain", "format_explain_json", "format_explain_text"]
 
@@ -34,6 +39,7 @@ _A_BYPASS = "bypass"
 
 # Source labels
 _SRC_INFERRED = "inferred"
+_SRC_INFERRED_PINNED = "inferred-then-pinned"
 _SRC_SYNTHETIC = "synthetic"
 
 _ASPECT_ORDER = [_A_LAYOUT, _A_DIRECTION, _A_ENTRY, _A_EXIT, _A_JUNCTION, _A_BYPASS]
@@ -83,7 +89,9 @@ def build_explain(
     if station_filter:
         decisions = [d for d in decisions if d.get("subject") == station_filter]
 
-    inferred = sum(1 for d in decisions if d["source"] == _SRC_INFERRED)
+    inferred = sum(
+        1 for d in decisions if d["source"] in (_SRC_INFERRED, _SRC_INFERRED_PINNED)
+    )
     synthetic = sum(1 for d in decisions if d["source"] == _SRC_SYNTHETIC)
 
     return {
@@ -150,7 +158,9 @@ def format_explain_text(data: dict[str, Any]) -> str:
             elif aspect in (_A_JUNCTION, _A_BYPASS):
                 out.append(f"  {subject}: {detail}")
             else:
-                out.append(f"  [{subject}] -> {decision}: {detail}")
+                state = d.get("state")
+                state_suffix = f" [{state}]" if state else ""
+                out.append(f"  [{subject}] -> {decision}{state_suffix}: {detail}")
 
     return "\n".join(out)
 
@@ -169,8 +179,9 @@ def _decision(
     rule: str,
     detail: str,
     sections: list[str],
+    provenance: EffectiveDecision[Any] | None = None,
 ) -> dict[str, Any]:
-    return {
+    result: dict[str, Any] = {
         "subject": subject,
         "subject_type": subject_type,
         "aspect": aspect,
@@ -180,6 +191,19 @@ def _decision(
         "detail": detail,
         "sections": sections,
     }
+    if provenance is not None:
+        result.update(
+            {
+                "state": provenance.state.value,
+                "locked": provenance.is_reinference_locked,
+                "provenance_reason": provenance.reason.value,
+                "authored_values": [
+                    value.value if hasattr(value, "value") else value
+                    for value in provenance.authored_values
+                ],
+            }
+        )
+    return result
 
 
 def _add_layout_decisions(
@@ -200,11 +224,12 @@ def _add_layout_decisions(
         return
 
     if not any(
-        row > 0 and sid not in graph._explicit_grid for sid, row in sid_rows.items()
+        row > 0 and not graph.layout_provenance.author_owns_grid(sid)
+        for sid, row in sid_rows.items()
     ):
         return
 
-    threshold = graph.fold_threshold if graph.fold_threshold is not None else 15
+    threshold = graph.layout_provenance.effective_fold_threshold
     n_rows = len(rows)
     section_list = ", ".join(
         f"row {r}: [{', '.join(sorted(sids))}]" for r, sids in sorted(rows.items())
@@ -235,24 +260,44 @@ def _add_direction_decisions(
 ) -> None:
     """Emit a direction decision for each section whose direction was inferred."""
     for sec_id, section in graph.sections.items():
-        if sec_id in graph._explicit_directions:
-            continue
-        # Sections with explicit grids are skipped by _infer_directions;
-        # their direction keeps the LR default without inference running.
-        if sec_id in graph._explicit_grid:
+        provenance = graph.layout_provenance.direction_decision(sec_id)
+        if provenance is None or provenance.is_author_owned:
             continue
 
-        rule, detail = _explain_direction(graph, sec_id, section, dag_succs, dag_preds)
+        if provenance.reason is DecisionReason.TALL_ANCHOR_DIRECTION:
+            rule = provenance.reason.value
+            detail = (
+                "The tall-anchor packer selected horizontal flow and locked it "
+                "so later direction inference cannot rotate the stacked chain."
+            )
+        elif provenance.reason is DecisionReason.FLOW_REORIENTED_DIRECTION:
+            rule = provenance.reason.value
+            detail = (
+                "Endpoint resolution reversed the inferred horizontal flow and "
+                "locked it so the port remains beside its connecting station."
+            )
+        elif provenance.reason is DecisionReason.EXPLICIT_GRID_DEFAULT_DIRECTION:
+            rule = provenance.reason.value
+            detail = (
+                "The section keeps the horizontal default because its grid cell "
+                "is author-owned, so the initial geometry inference does not "
+                "derive a direction from neighbouring cells."
+            )
+        else:
+            rule, detail = _explain_direction(
+                graph, sec_id, section, dag_succs, dag_preds
+            )
         decisions.append(
             _decision(
                 sec_id,
                 "section",
                 _A_DIRECTION,
                 section.direction,
-                _SRC_INFERRED,
+                provenance.state.value,
                 rule,
                 detail,
                 [sec_id],
+                provenance,
             )
         )
 
@@ -262,37 +307,72 @@ def _add_port_decisions(
     dag_preds: dict[str, set[str]],
     decisions: list[dict[str, Any]],
 ) -> None:
-    """Emit entry/exit side decisions for sections whose port sides were inferred."""
-    for sec_id, section in graph.sections.items():
-        if sec_id not in graph._explicit_entry and section.entry_hints:
-            sides = sorted({s.value for s, _ in section.entry_hints})
-            rule, detail = _explain_entry_side(graph, sec_id, section, dag_preds, sides)
-            decisions.append(
-                _decision(
-                    sec_id,
-                    "section",
-                    _A_ENTRY,
-                    ", ".join(sides),
-                    _SRC_INFERRED,
-                    rule,
-                    detail,
-                    [sec_id],
-                )
-            )
+    """Emit each engine-owned connector-side decision independently."""
+    topology = graph.route_topology
+    if topology is None:
+        return
 
-        if sec_id not in graph._explicit_exit and section.exit_hints:
-            sides = sorted({s.value for s, _ in section.exit_hints})
-            rule, detail = _explain_exit_side(section, sides)
+    for connector in topology.connectors:
+        for role, sec_id, aspect in (
+            (
+                ConnectorEndpointRole.EXIT,
+                connector.source_section,
+                _A_EXIT,
+            ),
+            (
+                ConnectorEndpointRole.ENTRY,
+                connector.target_section,
+                _A_ENTRY,
+            ),
+        ):
+            endpoint = graph.layout_provenance.endpoint_key(connector.id, role)
+            provenance = graph.layout_provenance.endpoint_decision(endpoint)
+            if provenance is None or provenance.is_author_owned:
+                continue
+
+            section = graph.sections[sec_id]
+            side = provenance.value.value
+            if provenance.reason in (
+                DecisionReason.FOLD_RELOCATED_SIDE,
+                DecisionReason.FLOW_REANCHORED_SIDE,
+                DecisionReason.RESOLUTION_SIDE_SELECTION,
+            ):
+                authored = ", ".join(
+                    value.value for value in provenance.authored_values
+                )
+                original = authored or "an inferred side"
+                rule = provenance.reason.value
+                detail = (
+                    f"Connector {connector.line_id} ({connector.source} -> "
+                    f"{connector.target}) uses {side.upper()} after endpoint "
+                    f"resolution replaced {original.upper()}; the effective side "
+                    "is engine-owned."
+                )
+            elif role is ConnectorEndpointRole.ENTRY:
+                rule, detail = _explain_entry_side(
+                    graph, sec_id, section, dag_preds, [side]
+                )
+                detail = (
+                    f"Connector {connector.line_id} ({connector.source} -> "
+                    f"{connector.target}): {detail}"
+                )
+            else:
+                rule, detail = _explain_exit_side(section, [side])
+                detail = (
+                    f"Connector {connector.line_id} ({connector.source} -> "
+                    f"{connector.target}): {detail}"
+                )
             decisions.append(
                 _decision(
                     sec_id,
                     "section",
-                    _A_EXIT,
-                    ", ".join(sides),
-                    _SRC_INFERRED,
+                    aspect,
+                    side,
+                    provenance.state.value,
                     rule,
                     detail,
                     [sec_id],
+                    provenance,
                 )
             )
 

--- a/src/nf_metro/introspect.py
+++ b/src/nf_metro/introspect.py
@@ -31,6 +31,7 @@ from nf_metro.parser.route_topology import build_route_topology_query
 
 if TYPE_CHECKING:
     from nf_metro.parser.model import MetroGraph
+    from nf_metro.parser.route_topology import RouteConnector
 
 __all__ = ["build_info", "format_info_json", "format_info_text", "station_kind"]
 
@@ -60,33 +61,19 @@ def _decision_info(decision: EffectiveDecision[Any] | None) -> dict[str, Any] | 
 
 def _connector_side_info(
     graph: MetroGraph,
-    section_id: str,
+    connector: RouteConnector,
     role: ConnectorEndpointRole,
-) -> list[dict[str, Any]]:
-    topology = graph.route_topology
-    if topology is None:
-        return []
-    records: list[dict[str, Any]] = []
-    for connector in topology.connectors:
-        endpoint_section = (
-            connector.source_section
-            if role is ConnectorEndpointRole.EXIT
-            else connector.target_section
-        )
-        if endpoint_section != section_id:
-            continue
-        endpoint = graph.layout_provenance.endpoint_key(connector.id, role)
-        decision = graph.layout_provenance.endpoint_decision(endpoint)
-        records.append(
-            {
-                "connector_id": str(connector.id),
-                "line_id": connector.line_id,
-                "source": connector.source,
-                "target": connector.target,
-                "provenance": _decision_info(decision),
-            }
-        )
-    return records
+) -> dict[str, Any]:
+    endpoint = graph.layout_provenance.endpoint_key(connector.id, role)
+    return {
+        "connector_id": str(connector.id),
+        "line_id": connector.line_id,
+        "source": connector.source,
+        "target": connector.target,
+        "provenance": _decision_info(
+            graph.layout_provenance.endpoint_decision(endpoint)
+        ),
+    }
 
 
 def _inferred_summary(records: list[dict[str, Any]]) -> bool | None:
@@ -96,7 +83,7 @@ def _inferred_summary(records: list[dict[str, Any]]) -> bool | None:
         if record["provenance"] is not None
     }
     if not ownership:
-        return True
+        return None
     if len(ownership) > 1:
         return None
     return not next(iter(ownership))
@@ -132,6 +119,17 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
     parser emits these via :mod:`warnings`); pass ``None`` for none.
     """
     real_sections = graph.real_sections
+    topology_query = build_route_topology_query(graph)
+    connector_sides: dict[tuple[str, ConnectorEndpointRole], list[dict[str, Any]]] = {}
+    if topology_query is not None:
+        for connector in topology_query.connectors:
+            for section_id, role in (
+                (connector.source_section, ConnectorEndpointRole.EXIT),
+                (connector.target_section, ConnectorEndpointRole.ENTRY),
+            ):
+                connector_sides.setdefault((section_id, role), []).append(
+                    _connector_side_info(graph, connector, role)
+                )
 
     lines = []
     for lid, line in graph.lines.items():
@@ -154,8 +152,8 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
     for sid, sec in graph.sections.items():
         direction = graph.layout_provenance.direction_decision(sid)
         grid = graph.layout_provenance.grid_decision(sid)
-        entry_sides = _connector_side_info(graph, sid, ConnectorEndpointRole.ENTRY)
-        exit_sides = _connector_side_info(graph, sid, ConnectorEndpointRole.EXIT)
+        entry_sides = connector_sides.get((sid, ConnectorEndpointRole.ENTRY), [])
+        exit_sides = connector_sides.get((sid, ConnectorEndpointRole.EXIT), [])
         sections.append(
             {
                 "id": sid,
@@ -203,7 +201,6 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
         )
 
     ports = []
-    topology_query = build_route_topology_query(graph)
     for pid, port in graph.ports.items():
         role = (
             ConnectorEndpointRole.ENTRY if port.is_entry else ConnectorEndpointRole.EXIT

--- a/src/nf_metro/introspect.py
+++ b/src/nf_metro/introspect.py
@@ -23,7 +23,11 @@ resolution internally; no full layout pass is required.
 from __future__ import annotations
 
 import json
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal
+
+from nf_metro.parser.provenance import ConnectorEndpointRole, EffectiveDecision
+from nf_metro.parser.route_topology import build_route_topology_query
 
 if TYPE_CHECKING:
     from nf_metro.parser.model import MetroGraph
@@ -31,6 +35,71 @@ if TYPE_CHECKING:
 __all__ = ["build_info", "format_info_json", "format_info_text", "station_kind"]
 
 StationKind = Literal["station", "junction", "port", "bypass", "hidden", "unknown"]
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    return value
+
+
+def _decision_info(decision: EffectiveDecision[Any] | None) -> dict[str, Any] | None:
+    if decision is None:
+        return None
+    return {
+        "value": _json_value(decision.value),
+        "origin": decision.origin.value,
+        "state": decision.state.value,
+        "locked": decision.is_reinference_locked,
+        "reason": decision.reason.value,
+        "authored_values": [_json_value(value) for value in decision.authored_values],
+    }
+
+
+def _connector_side_info(
+    graph: MetroGraph,
+    section_id: str,
+    role: ConnectorEndpointRole,
+) -> list[dict[str, Any]]:
+    topology = graph.route_topology
+    if topology is None:
+        return []
+    records: list[dict[str, Any]] = []
+    for connector in topology.connectors:
+        endpoint_section = (
+            connector.source_section
+            if role is ConnectorEndpointRole.EXIT
+            else connector.target_section
+        )
+        if endpoint_section != section_id:
+            continue
+        endpoint = graph.layout_provenance.endpoint_key(connector.id, role)
+        decision = graph.layout_provenance.endpoint_decision(endpoint)
+        records.append(
+            {
+                "connector_id": str(connector.id),
+                "line_id": connector.line_id,
+                "source": connector.source,
+                "target": connector.target,
+                "provenance": _decision_info(decision),
+            }
+        )
+    return records
+
+
+def _inferred_summary(records: list[dict[str, Any]]) -> bool | None:
+    ownership = {
+        record["provenance"]["origin"] == "authored"
+        for record in records
+        if record["provenance"] is not None
+    }
+    if not ownership:
+        return True
+    if len(ownership) > 1:
+        return None
+    return not next(iter(ownership))
 
 
 def station_kind(graph: MetroGraph, station_id: str) -> StationKind:
@@ -83,6 +152,10 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
 
     sections = []
     for sid, sec in graph.sections.items():
+        direction = graph.layout_provenance.direction_decision(sid)
+        grid = graph.layout_provenance.grid_decision(sid)
+        entry_sides = _connector_side_info(graph, sid, ConnectorEndpointRole.ENTRY)
+        exit_sides = _connector_side_info(graph, sid, ConnectorEndpointRole.EXIT)
         sections.append(
             {
                 "id": sid,
@@ -90,22 +163,28 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
                 "number": sec.number,
                 "n_stations": len(sec.station_ids),
                 "direction": sec.direction,
-                "direction_inferred": sid not in graph._explicit_directions,
+                "direction_inferred": (
+                    direction is None or not direction.is_author_owned
+                ),
+                "direction_provenance": _decision_info(direction),
                 "grid": {
                     "col": sec.grid_col,
                     "row": sec.grid_row,
                     "row_span": sec.grid_row_span,
                     "col_span": sec.grid_col_span,
                 },
-                "grid_inferred": sid not in graph._explicit_grid,
+                "grid_inferred": grid is None or not grid.is_author_owned,
+                "grid_provenance": _decision_info(grid),
                 "is_implicit": sec.is_implicit,
                 "stations": [
                     st for st in sec.station_ids if station_kind(graph, st) == "station"
                 ],
                 "entry_ports": list(sec.entry_ports),
                 "exit_ports": list(sec.exit_ports),
-                "entry_sides_inferred": sid not in graph._explicit_entry,
-                "exit_sides_inferred": sid not in graph._explicit_exit,
+                "entry_sides_inferred": _inferred_summary(entry_sides),
+                "exit_sides_inferred": _inferred_summary(exit_sides),
+                "entry_side_provenance": entry_sides,
+                "exit_side_provenance": exit_sides,
             }
         )
 
@@ -124,15 +203,31 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
         )
 
     ports = []
+    topology_query = build_route_topology_query(graph)
     for pid, port in graph.ports.items():
-        explicit_set = graph._explicit_entry if port.is_entry else graph._explicit_exit
+        role = (
+            ConnectorEndpointRole.ENTRY if port.is_entry else ConnectorEndpointRole.EXIT
+        )
+        side_provenance: list[dict[str, Any]] = []
+        if topology_query is not None:
+            for connector_id in topology_query.connector_ids_for_port(pid):
+                endpoint = graph.layout_provenance.endpoint_key(connector_id, role)
+                side_provenance.append(
+                    {
+                        "connector_id": str(connector_id),
+                        "provenance": _decision_info(
+                            graph.layout_provenance.endpoint_decision(endpoint)
+                        ),
+                    }
+                )
         ports.append(
             {
                 "id": pid,
                 "section_id": port.section_id,
                 "side": port.side.value,
                 "is_entry": port.is_entry,
-                "side_inferred": port.section_id not in explicit_set,
+                "side_inferred": _inferred_summary(side_provenance),
+                "side_provenance": side_provenance,
             }
         )
 
@@ -172,6 +267,9 @@ def build_info(graph: MetroGraph, warnings: list[str] | None = None) -> dict[str
         "junctions": sorted(graph.junctions),
         "section_dag": {"edges": dag_edges},
         "layout": {
+            "fold_threshold_provenance": _decision_info(
+                graph.layout_provenance.fold_threshold_decision
+            ),
             "rows": len(rows),
             "folded": len(rows) > 1,
             "sections_by_row": {
@@ -186,8 +284,10 @@ def format_info_json(info: dict[str, Any]) -> str:
     return json.dumps(info, indent=2)
 
 
-def _format_inferred(inferred: bool) -> str:
-    return "inferred" if inferred else "explicit"
+def _format_inferred(inferred: bool | None) -> str:
+    if inferred is None:
+        return "mixed"
+    return "inferred" if inferred else "authored"
 
 
 def format_info_text(info: dict[str, Any], *, verbose: bool = False) -> str:
@@ -251,11 +351,14 @@ def format_info_text(info: dict[str, Any], *, verbose: bool = False) -> str:
     out.append("")
     out.append("Sections (detail):")
     for sec in info["sections"]:
+        direction_state = sec["direction_provenance"]
+        grid_state = sec["grid_provenance"]
         tags = [
             "implicit" if sec["is_implicit"] else "explicit-box",
-            f"{sec['direction']} ({_format_inferred(sec['direction_inferred'])})",
+            f"{sec['direction']} "
+            f"({direction_state['state'] if direction_state else 'unrecorded'})",
             f"grid {sec['grid']['col']},{sec['grid']['row']} "
-            f"({_format_inferred(sec['grid_inferred'])})",
+            f"({grid_state['state'] if grid_state else 'unrecorded'})",
         ]
         out.append(f"  [{sec['number']}] {sec['name']}: {', '.join(tags)}")
         if sec["stations"]:

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -277,10 +277,11 @@ so their `PhaseFieldSpec` names a lifecycle phase (`pre-layout`, `post-layout`,
   bridged across grid columns, accumulated by the Stage 3.2 / 3.4 port
   alignment; routing's render-curve invariant reads it to relax its abort to a
   warning for those bundles.
-- `graph._fold_compressed_sections` / `graph._fold_reoriented_sections` -
-  recorded at parse/resolve time for sections a lowered fold threshold
-  relocated or whose flow direction was flipped; read by the fold-exit-side
-  guard, the render fold-abort chokepoint, and routing's exit-port offset.
+- `graph._fold_compressed_sections` - recorded at parse time for sections a
+  lowered fold threshold relocated; read by the fold-exit-side guard and the
+  render fold-abort chokepoint. A resolve-time flow reversal is recorded as a
+  `FLOW_REORIENTED_DIRECTION` decision in `graph.layout_provenance`; routing's
+  exit-port offset reads that typed reason instead of a second section set.
 - `graph._rail_y` - the per-section `{line_id: rail_y}` map produced by the
   opt-in rail-mode layout; read by the rail router, label placement, and rail
   guards, empty when rail mode is off.
@@ -1039,9 +1040,10 @@ in pipeline order.
   still has an empty band above the trunk while more siblings sit
   below than above, lift bottommost movable siblings into the empty
   top band. U-turn-safe and bbox-bounded.
-- **Gating**: Early-returns unless **both** `graph._explicit_grid` and
-  `graph.center_ports` are set (scoped to explicit-`%%metro grid:` +
-  centre-ports pipelines), so it is a no-op on auto-laid graphs.
+- **Gating**: Early-returns unless `graph.layout_provenance` contains at least
+  one author-owned grid decision and `graph.center_ports` is set (scoped to
+  explicit-`%%metro grid:` + centre-ports pipelines), so it is a no-op on
+  auto-laid graphs.
 - **Helper**: `_balance_section_content_around_trunk` (`phases/balancing.py`).
 - **Precondition**: All earlier 13-phase reshuffles done.
 - **Postcondition**: Sibling count above trunk >= sibling count below

--- a/src/nf_metro/layout/auto_layout.py
+++ b/src/nf_metro/layout/auto_layout.py
@@ -27,6 +27,7 @@ from nf_metro.parser.model import (
     Section,
     SectionDAG,
 )
+from nf_metro.parser.provenance import DecisionReason
 from nf_metro.parser.validate import CyclicGraphError
 
 
@@ -230,6 +231,7 @@ def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> No
     """
     if len(graph.sections) <= 1:
         graph.section_dag = SectionDAG(successors={}, predecessors={}, edge_lines={})
+        graph.layout_provenance.complete_section_inference(graph, set())
         return
 
     successors, predecessors, edge_lines = _build_section_dag(graph)
@@ -239,6 +241,7 @@ def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> No
 
     # Only run grid/direction/port inference if there are inter-section edges
     if not successors and not predecessors:
+        graph.layout_provenance.complete_section_inference(graph, set())
         return
 
     fold_sections, below_fold_sections, convergence_sections = _assign_grid_positions(
@@ -261,6 +264,7 @@ def infer_section_layout(graph: MetroGraph, max_station_columns: int = 15) -> No
         fold_sections,
         convergence_sections,
     )
+    graph.layout_provenance.complete_section_inference(graph, fold_sections)
 
 
 def _build_section_dag(
@@ -371,7 +375,7 @@ def _detect_tall_anchor_chain(graph: MetroGraph) -> str | None:
     # A single explicit pin is manual layout intent for the whole map; the
     # vertical-stack packer owns every section's cell, so it must not run
     # alongside hand-placed grids.
-    if graph._explicit_grid:
+    if graph.layout_provenance.has_authored_grids():
         return None
     successors, predecessors = dag.successors, dag.predecessors
     section_ids = list(graph.sections)
@@ -448,6 +452,11 @@ def _place_with_tall_anchor(
 
     for sid, (col, row, rspan, cspan) in folded.items():
         graph.grid_overrides[sid] = (col, row, rspan, cspan)
+        graph.layout_provenance.record_inferred_grid(
+            sid,
+            (col, row, rspan, cspan),
+            DecisionReason.TALL_ANCHOR_GRID,
+        )
         section = graph.sections[sid]
         section.grid_col = col
         section.grid_row = row
@@ -461,7 +470,12 @@ def _place_with_tall_anchor(
     # directions makes _infer_directions leave them LR.
     for sid in [anchor, *tail]:
         graph.sections[sid].direction = "LR"
-        graph._explicit_directions.add(sid)
+        graph.layout_provenance.record_inferred_direction(
+            sid,
+            "LR",
+            DecisionReason.TALL_ANCHOR_DIRECTION,
+            locked=True,
+        )
 
     return set(), set(), set()
 
@@ -1204,7 +1218,7 @@ def _infer_directions(
 ) -> None:
     """Infer section flow direction (LR/RL/TB/BT) from grid positions.
 
-    Only modifies sections NOT in graph._explicit_directions.
+    Only modifies sections whose effective direction is not locked.
     Fold sections are forced to TB (they bridge between row bands).
     Every other auto-gridded section is classified by
     :func:`_classify_inferred_direction`.
@@ -1216,10 +1230,10 @@ def _infer_directions(
     neighbours in mixed grids.
     """
     for sec_id, section in graph.sections.items():
-        if sec_id in graph._explicit_directions:
+        if graph.layout_provenance.direction_is_locked(sec_id):
             continue
 
-        if sec_id in graph._explicit_grid:
+        if graph.layout_provenance.author_owns_grid(sec_id):
             continue
 
         # Fold sections are always TB (vertical bridge between rows)

--- a/src/nf_metro/layout/phase_state.py
+++ b/src/nf_metro/layout/phase_state.py
@@ -230,18 +230,6 @@ PHASE_FIELD_REGISTRY: dict[str, PhaseFieldSpec] = {
             "tolerate its empty default when no fold compression occurred"
         ),
     ),
-    "_fold_reoriented_sections": PhaseFieldSpec(
-        name="_fold_reoriented_sections",
-        writer_stage=PRE_LAYOUT,
-        reader_stages=(POST_LAYOUT,),
-        enforcement=FieldEnforcement.FALLBACK,
-        why=(
-            "sections whose flow direction resolve.py flipped to keep a flow-axis "
-            "port on its consumer/producer end; routing's exit-port offset reads "
-            "the set to anchor on the feeder-bundle frame, tolerating the empty "
-            "default"
-        ),
-    ),
     "_rail_y": PhaseFieldSpec(
         name="_rail_y",
         writer_stage=RAIL_LAYOUT,

--- a/src/nf_metro/layout/phases/balancing.py
+++ b/src/nf_metro/layout/phases/balancing.py
@@ -60,7 +60,7 @@ def _snap_inter_section_port_pairs(graph: MetroGraph) -> None:
     branch below runs unconditionally because it only moves the entry
     port (not the exit), preserving the auto-layout fan-in convergence.
     """
-    explicit_grid = bool(graph._explicit_grid)
+    explicit_grid = graph.layout_provenance.has_authored_grids()
     junction_ids = graph.junction_ids
 
     for port_id, port in graph.ports.items():
@@ -199,7 +199,7 @@ def _fan_free_content_upward(
     Scoped to pipelines using explicit ``%%metro grid:`` directives so
     the auto-layout path is unaffected.
     """
-    if not graph._explicit_grid:
+    if not graph.layout_provenance.has_authored_grids():
         return
     for section in graph.sections.values():
         if section.bbox_h <= 0 or section.direction not in ("LR", "RL"):
@@ -335,7 +335,7 @@ def _fan_source_inputs_upward(graph: MetroGraph, y_spacing: float) -> None:
     path is unaffected.  U-turn risk is nil because sources have no
     upstream feeders by definition.
     """
-    if not graph._explicit_grid:
+    if not graph.layout_provenance.has_authored_grids():
         return
 
     for section in graph.sections.values():
@@ -502,7 +502,7 @@ def _balance_section_content_around_trunk(
     safety prevents lifts that would force the line to climb past the
     trunk and double back.
     """
-    if not graph._explicit_grid:
+    if not graph.layout_provenance.has_authored_grids():
         return
     if not graph.center_ports:
         return

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -105,6 +105,7 @@ from nf_metro.parser.model import (
     Station,
     is_converge_junction,
 )
+from nf_metro.parser.provenance import DecisionReason
 from nf_metro.parser.resolve import _expected_flow_side
 from nf_metro.parser.route_topology import build_route_topology_query
 
@@ -996,7 +997,11 @@ def _guard_independent_components_disjoint(graph: MetroGraph, phase: str) -> Non
         _weakly_connected_components,
     )
 
-    if not graph.sections or graph.section_dag is None or graph._explicit_grid:
+    if (
+        not graph.sections
+        or graph.section_dag is None
+        or graph.layout_provenance.has_authored_grids()
+    ):
         return
 
     components = _weakly_connected_components(graph, graph.section_dag.section_edges)
@@ -1079,19 +1084,23 @@ def _guard_no_section_overlap(graph: MetroGraph, phase: str) -> None:
 
 
 def _guard_explicit_grid_directions(graph: MetroGraph, phase: str) -> None:
-    """Explicit-grid sections keep the LR default unless they carry an
-    explicit %%metro direction.
+    """Explicit-grid sections skip auto direction inference.
 
     A section's grid position is the author's manual layout intent, not a
     flow-direction signal. Direction inference therefore skips explicit-grid
-    sections; this guard fails loudly if a future change ever lets inference
-    reorient one (e.g. by reading override-aware positions), which would
-    silently elongate serpentine-stacked maps vertically.
+    sections. Connector resolution may later reverse horizontal flow when an
+    authored port faces the section's producer; that distinct transition is
+    accepted only when its typed reason is present.
     """
     offenders = {
-        sid: graph.sections[sid].direction
-        for sid in graph._explicit_grid - graph._explicit_directions
-        if sid in graph.sections and graph.sections[sid].direction != "LR"
+        sid: section.direction
+        for sid, section in graph.sections.items()
+        if graph.layout_provenance.author_owns_grid(sid)
+        and not graph.layout_provenance.author_owns_direction(sid)
+        and section.direction != "LR"
+        and not graph.layout_provenance.direction_has_reason(
+            sid, DecisionReason.FLOW_REORIENTED_DIRECTION
+        )
     }
     if offenders:
         raise PhaseInvariantError(

--- a/src/nf_metro/layout/rail_mode.py
+++ b/src/nf_metro/layout/rail_mode.py
@@ -503,7 +503,9 @@ def _layout_section_rails(
     section.bbox_y = bbox_y
     section.bbox_w = bbox_w
     section.bbox_h = bbox_h
-    if section.direction != "LR" and section.id in graph._explicit_directions:
+    if section.direction != "LR" and graph.layout_provenance.author_owns_direction(
+        section.id
+    ):
         raise ValueError(
             f"rail-mode section {section.id!r} declares direction "
             f"{section.direction!r}; rail mode lays rails left-to-right only. "

--- a/src/nf_metro/layout/routing/offsets.py
+++ b/src/nf_metro/layout/routing/offsets.py
@@ -58,6 +58,7 @@ from nf_metro.parser.model import (
     Section,
     Station,
 )
+from nf_metro.parser.provenance import DecisionReason
 from nf_metro.parser.route_topology import (
     RouteTopologyQuery,
     build_route_topology_query,
@@ -1485,7 +1486,9 @@ def _compute_exit_port_offsets(ctx: _OffsetCtx) -> None:
         # on zero would desync the port from those feeders and leave the bundle
         # on non-adjacent slots after reconciliation.  Anchor on the feeder's
         # own offset instead so the whole bundle keeps one frame.
-        if port_obj.section_id in graph._fold_reoriented_sections:
+        if graph.layout_provenance.direction_has_reason(
+            port_obj.section_id, DecisionReason.FLOW_REORIENTED_DIRECTION
+        ):
             anchor_feeders = line_feeders.get(anchor_line)
             if anchor_feeders:
                 anchor_feeder_id = anchor_feeders[0][0]

--- a/src/nf_metro/layout/section_placement.py
+++ b/src/nf_metro/layout/section_placement.py
@@ -592,7 +592,7 @@ def place_sections(
     section_edges = graph.section_dag.section_edges
 
     components = _weakly_connected_components(graph, section_edges)
-    if len(components) <= 1 or graph._explicit_grid:
+    if len(components) <= 1 or graph.layout_provenance.has_authored_grids():
         _place_section_group(graph, section_edges, section_x_gap, section_y_gap, None)
         _reserve_over_top_headroom(graph)
         return

--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -183,10 +183,8 @@ def _parse_port_hint(
     if section:
         if is_entry:
             section.entry_hints.append((side, line_ids))
-            graph._explicit_entry.add(section_id)
         else:
             section.exit_hints.append((side, line_ids))
-            graph._explicit_exit.add(section_id)
 
 
 def _parse_grid_directive(value: str, graph: MetroGraph) -> None:
@@ -214,8 +212,9 @@ def _parse_grid_directive(value: str, graph: MetroGraph) -> None:
         _warn_malformed("grid", value, "integer col,row[,rowspan[,colspan]]")
         return
     for section_id in member_ids:
-        graph.grid_overrides[section_id] = (col, row, rowspan, colspan)
-        graph._explicit_grid.add(section_id)
+        cell = (col, row, rowspan, colspan)
+        graph.grid_overrides[section_id] = cell
+        graph.layout_provenance.record_authored_grid(section_id, cell)
     if len(member_ids) > 1:
         graph.cell_packs[col, row] = member_ids
 
@@ -541,7 +540,7 @@ def _apply_scoped_directive(
         direction = value.upper()
         if direction in FLOW_DIRECTIONS:
             graph.sections[section_id].direction = direction
-            graph._explicit_directions.add(section_id)
+            graph.layout_provenance.record_authored_direction(section_id, direction)
         else:
             _warn_malformed("direction", value, "LR/RL/TB/BT")
     else:

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -248,6 +248,11 @@ def _finalize_graph(
 ) -> None:
     """Validate, run the post-parse resolution, and apply buffered metadata."""
     _validate_edge_annotations(graph)
+    graph.layout_provenance.capture_authored_intent(
+        graph,
+        capture_authored_routes(graph),
+        max_station_columns,
+    )
 
     if graph.sections:
         _remove_empty_sections(graph)
@@ -326,7 +331,6 @@ def _infer_layout(graph: MetroGraph, max_station_columns: int | None) -> None:
                 if (s.grid_col, s.grid_row) != unbounded_grid.get(sid)
             }
             if relocated:
-                graph._fold_threshold_effective = eff_cols
                 graph._fold_compressed_sections = relocated
         _insert_terminus_convergence_stations(graph, authored_lineage)
         endpoint_resolution = resolve_section_endpoints(graph, authored_lineage)

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal, TypedDict
 
 from nf_metro.errors import NfMetroError
+from nf_metro.parser.provenance import LayoutProvenance
 
 if TYPE_CHECKING:
     from nf_metro.parser.route_topology import RouteResolutionTrace, RouteTopology
@@ -460,11 +461,9 @@ class MetroGraph:
     )
     groups: list[StationGroup] = field(default_factory=list)
     grid_overrides: dict[str, tuple[int, int, int, int]] = field(default_factory=dict)
-    # Section IDs that received an explicit %%metro grid: directive (i.e.
-    # the user laid out the grid manually, as opposed to auto_layout
-    # filling in the placement).  Used to gate alignment polish passes
-    # that would distort auto-layout pipelines.
-    _explicit_grid: set[str] = field(default_factory=set)
+    layout_provenance: LayoutProvenance = field(
+        default_factory=LayoutProvenance, repr=False
+    )
     # Multi-section grid cells: a ``%%metro grid:`` directive may name several
     # comma-separated sections that share one cell.  Keyed by (col, row); each
     # value is the listed-order member ids, which pack side-by-side along the
@@ -566,19 +565,6 @@ class MetroGraph:
     marker_legend: list[MarkerLegendEntry] = field(default_factory=list)
     # Section dependency graph (populated by auto_layout)
     section_dag: SectionDAG | None = None
-    # Section IDs that had explicit %%metro direction: directives
-    _explicit_directions: set[str] = field(default_factory=set)
-    # Section IDs whose flow direction was flipped at resolve time to keep a
-    # flow-axis port on its consumer/producer's end (see resolve.py
-    # _reanchor_flow_axis_ports).  Their exit-port offsets anchor on the
-    # feeder bundle frame rather than re-centring on zero.
-    _fold_reoriented_sections: set[str] = field(default_factory=set, repr=False)
-    # Section IDs whose entry/exit port sides were author-specified via
-    # %%metro entry:/exit: directives (tracked separately because auto_layout
-    # fills entry_hints/exit_hints for sections that have none, so the hint
-    # list alone cannot tell an author side from an inferred one).
-    _explicit_entry: set[str] = field(default_factory=set)
-    _explicit_exit: set[str] = field(default_factory=set)
     # Section IDs whose perpendicular (TOP/BOTTOM) connection had to be bridged
     # across grid columns because its feeding source sits outside the section's
     # own column.  The run/trunk is held on the section's column (in-bbox) and
@@ -587,12 +573,9 @@ class MetroGraph:
     # render-curve invariants, so their presence relaxes that check to a
     # warning instead of a hard render abort.
     _cross_column_perp_bridges: set[str] = field(default_factory=set, repr=False)
-    # Effective row-wrap width when the author set one (--fold-threshold or
-    # %%metro fold_threshold), plus the auto-laid sections whose grid cell that
-    # width shifted versus the unbounded layout.  A non-empty set means the
-    # user-chosen threshold compressed the section grid; the render chokepoint
-    # uses it to reframe a fold-induced routing abort as FoldThresholdError.
-    _fold_threshold_effective: int | None = None
+    # Auto-laid sections whose grid cell a caller- or directive-supplied fold
+    # threshold shifted versus the unbounded layout. A non-empty set lets the
+    # render chokepoint reframe a fold-induced routing abort.
     _fold_compressed_sections: set[str] = field(default_factory=set, repr=False)
     # Pending terminus designations: station_id ->
     # list of (label, icon_type, name, banner)

--- a/src/nf_metro/parser/provenance.py
+++ b/src/nf_metro/parser/provenance.py
@@ -1,0 +1,501 @@
+"""Typed provenance for authored and effective layout commitments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from nf_metro.parser.model import MetroGraph, PortSide
+    from nf_metro.parser.route_topology import AuthoredRouteCapture, ConnectorId
+
+T = TypeVar("T")
+GridCell = tuple[int, int, int, int]
+
+
+class DecisionOrigin(str, Enum):
+    """Who selected an effective layout value."""
+
+    AUTHORED = "authored"
+    INFERRED = "inferred"
+
+
+class DecisionState(str, Enum):
+    """User-facing state derived from origin and re-inference locking."""
+
+    AUTHORED = "authored"
+    INFERRED = "inferred"
+    INFERRED_THEN_PINNED = "inferred-then-pinned"
+
+
+class DecisionReason(str, Enum):
+    """Stable causes for effective layout decisions and transitions."""
+
+    AUTHOR_DIRECTIVE = "author-directive"
+    CALLER_FOLD_THRESHOLD = "caller-fold-threshold"
+    DEFAULT_FOLD_THRESHOLD = "default-fold-threshold"
+    AUTO_GRID = "auto-grid"
+    AUTO_DIRECTION = "auto-direction"
+    EXPLICIT_GRID_DEFAULT_DIRECTION = "explicit-grid-default-direction"
+    TALL_ANCHOR_GRID = "tall-anchor-grid"
+    TALL_ANCHOR_DIRECTION = "tall-anchor-direction"
+    FOLD_BRIDGE_DIRECTION = "fold-bridge-direction"
+    FLOW_REORIENTED_DIRECTION = "flow-reoriented-direction"
+    AUTO_ENTRY_SIDE = "auto-entry-side"
+    AUTO_EXIT_SIDE = "auto-exit-side"
+    SHARED_CONNECTOR_ENTRY_SIDE = "shared-connector-entry-side"
+    RESOLUTION_SIDE_SELECTION = "resolution-side-selection"
+    FOLD_RELOCATED_SIDE = "fold-relocated-side"
+    FLOW_REANCHORED_SIDE = "flow-reanchored-side"
+
+
+class FoldThresholdSource(str, Enum):
+    """Precedence source that supplied the effective fold threshold."""
+
+    CALLER = "caller"
+    DIRECTIVE = "directive"
+    DEFAULT = "default"
+
+
+class ConnectorEndpointRole(str, Enum):
+    """Which section boundary of a semantic connector is described."""
+
+    EXIT = "exit"
+    ENTRY = "entry"
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveDecision(Generic[T]):
+    """One effective value with independent ownership and lock state."""
+
+    value: T
+    origin: DecisionOrigin
+    locked: bool
+    reason: DecisionReason
+    authored_values: tuple[T, ...] = ()
+
+    @property
+    def is_author_owned(self) -> bool:
+        """Whether the author selected this exact effective commitment."""
+        return self.origin is DecisionOrigin.AUTHORED
+
+    @property
+    def is_reinference_locked(self) -> bool:
+        """Whether a later inference pass must preserve this effective value."""
+        return self.locked
+
+    @property
+    def state(self) -> DecisionState:
+        """Return the compact author-facing state for this decision."""
+        if self.origin is DecisionOrigin.AUTHORED:
+            return DecisionState.AUTHORED
+        if self.locked:
+            return DecisionState.INFERRED_THEN_PINNED
+        return DecisionState.INFERRED
+
+
+@dataclass(frozen=True, slots=True)
+class SectionIntent(Generic[T]):
+    """One authored section-level layout value."""
+
+    section_id: str
+    value: T
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorEndpointKey:
+    """Stable identity of one semantic connector boundary."""
+
+    connector_id: ConnectorId
+    role: ConnectorEndpointRole
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorSideIntent:
+    """One authored side option for a semantic connector boundary."""
+
+    endpoint: ConnectorEndpointKey
+    value: PortSide
+
+
+@dataclass(frozen=True, slots=True)
+class PortHintIntent:
+    """One entry or exit directive exactly as accepted by the parser."""
+
+    section_id: str
+    role: ConnectorEndpointRole
+    side: PortSide
+    line_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FoldThresholdIntent:
+    """Authored threshold inputs and the precedence-selected source."""
+
+    directive_value: int | None
+    caller_value: int | None
+    selected_value: int
+    selected_source: FoldThresholdSource
+
+
+@dataclass(frozen=True, slots=True)
+class AuthoredLayoutIntent:
+    """Immutable pre-inference snapshot of accepted author layout input."""
+
+    grids: tuple[SectionIntent[GridCell], ...]
+    directions: tuple[SectionIntent[str], ...]
+    port_hints: tuple[PortHintIntent, ...]
+    connector_sides: tuple[ConnectorSideIntent, ...]
+    fold_threshold: FoldThresholdIntent
+
+    def endpoint_values(self, endpoint: ConnectorEndpointKey) -> tuple[PortSide, ...]:
+        """Return authored side options for *endpoint* in source order."""
+        return tuple(
+            item.value for item in self.connector_sides if item.endpoint == endpoint
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointSideSelection:
+    """A typed side selected while connector endpoints are resolved."""
+
+    side: PortSide
+    origin: DecisionOrigin
+    locked: bool
+    reason: DecisionReason
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointSideTransition:
+    """A resolver mutation applied to a set of line-specific endpoints."""
+
+    section_id: str
+    role: ConnectorEndpointRole
+    line_ids: tuple[str, ...]
+    previous: PortSide
+    effective: PortSide
+    reason: DecisionReason
+
+
+@dataclass(slots=True)
+class LayoutProvenance:
+    """Authored snapshot and effective layout decisions for one graph."""
+
+    authored: AuthoredLayoutIntent | None = None
+    grids: dict[str, EffectiveDecision[GridCell]] = field(default_factory=dict)
+    directions: dict[str, EffectiveDecision[str]] = field(default_factory=dict)
+    connector_sides: dict[ConnectorEndpointKey, EffectiveDecision[PortSide]] = field(
+        default_factory=dict
+    )
+    fold_threshold_decision: EffectiveDecision[int] | None = None
+
+    def record_authored_grid(self, section_id: str, value: GridCell) -> None:
+        """Record an accepted ``grid:`` directive."""
+        self.grids[section_id] = EffectiveDecision(
+            value,
+            DecisionOrigin.AUTHORED,
+            True,
+            DecisionReason.AUTHOR_DIRECTIVE,
+            (value,),
+        )
+
+    def record_authored_direction(self, section_id: str, value: str) -> None:
+        """Record an accepted ``direction:`` directive."""
+        self.directions[section_id] = EffectiveDecision(
+            value,
+            DecisionOrigin.AUTHORED,
+            True,
+            DecisionReason.AUTHOR_DIRECTIVE,
+            (value,),
+        )
+
+    def capture_authored_intent(
+        self,
+        graph: MetroGraph,
+        routes: AuthoredRouteCapture,
+        caller_fold_threshold: int | None,
+    ) -> None:
+        """Freeze accepted layout input before any graph rewrite or inference."""
+        if self.authored is not None:
+            raise RuntimeError("authored layout intent has already been captured")
+
+        section_rank = {sid: rank for rank, sid in enumerate(graph.sections)}
+        trailing_rank = len(section_rank)
+        grids = tuple(
+            SectionIntent(section_id, decision.value)
+            for section_id, decision in sorted(
+                self.grids.items(),
+                key=lambda item: (section_rank.get(item[0], trailing_rank), item[0]),
+            )
+            if decision.origin is DecisionOrigin.AUTHORED
+        )
+        directions = tuple(
+            SectionIntent(section_id, decision.value)
+            for section_id, decision in sorted(
+                self.directions.items(),
+                key=lambda item: (section_rank.get(item[0], trailing_rank), item[0]),
+            )
+            if decision.origin is DecisionOrigin.AUTHORED
+        )
+
+        port_hints: list[PortHintIntent] = []
+        for section_id, section in graph.sections.items():
+            for role, hints in (
+                (ConnectorEndpointRole.EXIT, section.exit_hints),
+                (ConnectorEndpointRole.ENTRY, section.entry_hints),
+            ):
+                port_hints.extend(
+                    PortHintIntent(section_id, role, side, tuple(line_ids))
+                    for side, line_ids in hints
+                )
+
+        connector_sides: list[ConnectorSideIntent] = []
+        for fact in routes.edges:
+            if (
+                fact.source_section is None
+                or fact.target_section is None
+                or fact.source_section == fact.target_section
+            ):
+                continue
+            for role, section_id in (
+                (ConnectorEndpointRole.EXIT, fact.source_section),
+                (ConnectorEndpointRole.ENTRY, fact.target_section),
+            ):
+                endpoint_section = graph.sections.get(section_id)
+                if endpoint_section is None:
+                    continue
+                hints = (
+                    endpoint_section.exit_hints
+                    if role is ConnectorEndpointRole.EXIT
+                    else endpoint_section.entry_hints
+                )
+                endpoint = ConnectorEndpointKey(fact.key.id, role)
+                for side, line_ids in hints:
+                    if fact.key.line_id in line_ids:
+                        connector_sides.append(ConnectorSideIntent(endpoint, side))
+
+        directive = graph.fold_threshold
+        if caller_fold_threshold is not None:
+            selected_value = caller_fold_threshold
+            source = FoldThresholdSource.CALLER
+            fold_decision = EffectiveDecision(
+                selected_value,
+                DecisionOrigin.AUTHORED,
+                True,
+                DecisionReason.CALLER_FOLD_THRESHOLD,
+                (selected_value,),
+            )
+        elif directive is not None:
+            selected_value = directive
+            source = FoldThresholdSource.DIRECTIVE
+            fold_decision = EffectiveDecision(
+                selected_value,
+                DecisionOrigin.AUTHORED,
+                True,
+                DecisionReason.AUTHOR_DIRECTIVE,
+                (selected_value,),
+            )
+        else:
+            selected_value = 15
+            source = FoldThresholdSource.DEFAULT
+            fold_decision = EffectiveDecision(
+                selected_value,
+                DecisionOrigin.INFERRED,
+                False,
+                DecisionReason.DEFAULT_FOLD_THRESHOLD,
+            )
+
+        self.authored = AuthoredLayoutIntent(
+            grids=grids,
+            directions=directions,
+            port_hints=tuple(port_hints),
+            connector_sides=tuple(connector_sides),
+            fold_threshold=FoldThresholdIntent(
+                directive_value=directive,
+                caller_value=caller_fold_threshold,
+                selected_value=selected_value,
+                selected_source=source,
+            ),
+        )
+        self.fold_threshold_decision = fold_decision
+
+    @staticmethod
+    def endpoint_key(
+        connector_id: ConnectorId, role: ConnectorEndpointRole
+    ) -> ConnectorEndpointKey:
+        """Build the canonical key for one connector boundary."""
+        return ConnectorEndpointKey(connector_id, role)
+
+    def authored_endpoint_values(
+        self, endpoint: ConnectorEndpointKey
+    ) -> tuple[PortSide, ...]:
+        """Return the snapshot's authored side options for *endpoint*."""
+        if self.authored is None:
+            return ()
+        return self.authored.endpoint_values(endpoint)
+
+    def record_inferred_grid(
+        self,
+        section_id: str,
+        value: GridCell,
+        reason: DecisionReason = DecisionReason.AUTO_GRID,
+        *,
+        locked: bool = False,
+    ) -> None:
+        """Record an engine-selected grid cell unless the author owns it."""
+        current = self.grids.get(section_id)
+        if current is not None and current.is_author_owned:
+            if current.value != value:
+                raise ValueError(
+                    f"cannot replace author-owned grid for {section_id!r}: "
+                    f"{current.value!r} -> {value!r}"
+                )
+            return
+        authored_values = current.authored_values if current is not None else ()
+        self.grids[section_id] = EffectiveDecision(
+            value, DecisionOrigin.INFERRED, locked, reason, authored_values
+        )
+
+    def record_inferred_direction(
+        self,
+        section_id: str,
+        value: str,
+        reason: DecisionReason = DecisionReason.AUTO_DIRECTION,
+        *,
+        locked: bool = False,
+    ) -> None:
+        """Record an engine-selected direction and its lock state."""
+        current = self.directions.get(section_id)
+        if current is not None and current.is_author_owned:
+            if current.value != value:
+                raise ValueError(
+                    f"cannot replace author-owned direction for {section_id!r}: "
+                    f"{current.value!r} -> {value!r}"
+                )
+            return
+        authored_values = current.authored_values if current is not None else ()
+        self.directions[section_id] = EffectiveDecision(
+            value, DecisionOrigin.INFERRED, locked, reason, authored_values
+        )
+
+    def record_endpoint_selection(
+        self,
+        endpoint: ConnectorEndpointKey,
+        selection: EndpointSideSelection,
+    ) -> None:
+        """Record the typed resolver selection for one connector boundary."""
+        authored_values = self.authored_endpoint_values(endpoint)
+        origin = selection.origin
+        locked = selection.locked
+        reason = selection.reason
+        authored_matches = bool(authored_values) and all(
+            value is selection.side for value in authored_values
+        )
+        if origin is DecisionOrigin.AUTHORED and not authored_matches:
+            origin = DecisionOrigin.INFERRED
+            locked = False
+            reason = DecisionReason.RESOLUTION_SIDE_SELECTION
+        self.connector_sides[endpoint] = EffectiveDecision(
+            selection.side, origin, locked, reason, authored_values
+        )
+
+    def grid_decision(self, section_id: str) -> EffectiveDecision[GridCell] | None:
+        return self.grids.get(section_id)
+
+    def direction_decision(self, section_id: str) -> EffectiveDecision[str] | None:
+        return self.directions.get(section_id)
+
+    def endpoint_decision(
+        self, endpoint: ConnectorEndpointKey
+    ) -> EffectiveDecision[PortSide] | None:
+        return self.connector_sides.get(endpoint)
+
+    @property
+    def effective_fold_threshold(self) -> int:
+        """Return the selected threshold after caller/directive precedence."""
+        if self.fold_threshold_decision is None:
+            return 15
+        return self.fold_threshold_decision.value
+
+    def author_owns_grid(self, section_id: str) -> bool:
+        decision = self.grid_decision(section_id)
+        return decision is not None and decision.is_author_owned
+
+    def has_authored_grids(self) -> bool:
+        """Whether any effective grid commitment is author-owned."""
+        return any(decision.is_author_owned for decision in self.grids.values())
+
+    def grid_is_locked(self, section_id: str) -> bool:
+        decision = self.grid_decision(section_id)
+        return decision is not None and decision.is_reinference_locked
+
+    def author_owns_direction(self, section_id: str) -> bool:
+        decision = self.direction_decision(section_id)
+        return decision is not None and decision.is_author_owned
+
+    def direction_is_locked(self, section_id: str) -> bool:
+        decision = self.direction_decision(section_id)
+        return decision is not None and decision.is_reinference_locked
+
+    def direction_has_reason(self, section_id: str, reason: DecisionReason) -> bool:
+        decision = self.direction_decision(section_id)
+        return decision is not None and decision.reason is reason
+
+    def complete_section_inference(
+        self,
+        graph: MetroGraph,
+        fold_sections: set[str],
+    ) -> None:
+        """Record all effective grid and direction decisions in section order."""
+        for section_id, section in graph.sections.items():
+            if section_id in graph.grid_overrides:
+                current_grid = self.grid_decision(section_id)
+                if current_grid is None:
+                    self.record_inferred_grid(
+                        section_id, graph.grid_overrides[section_id]
+                    )
+
+            current_direction = self.direction_decision(section_id)
+            if current_direction is not None:
+                continue
+            if self.author_owns_grid(section_id):
+                self.record_inferred_direction(
+                    section_id,
+                    section.direction,
+                    DecisionReason.EXPLICIT_GRID_DEFAULT_DIRECTION,
+                )
+            else:
+                reason = (
+                    DecisionReason.FOLD_BRIDGE_DIRECTION
+                    if section_id in fold_sections
+                    else DecisionReason.AUTO_DIRECTION
+                )
+                self.record_inferred_direction(section_id, section.direction, reason)
+
+    def validate_complete(self, graph: MetroGraph) -> None:
+        """Raise when an effective layout commitment lacks typed provenance."""
+        if self.authored is None or self.fold_threshold_decision is None:
+            raise ValueError("layout provenance was not captured before inference")
+        missing_directions = [
+            sid for sid in graph.sections if sid not in self.directions
+        ]
+        missing_grids = [
+            sid
+            for sid in graph.grid_overrides
+            if sid in graph.sections and sid not in self.grids
+        ]
+        missing_endpoints: list[ConnectorEndpointKey] = []
+        topology = graph.route_topology
+        if topology is not None:
+            for connector in topology.connectors:
+                for role in ConnectorEndpointRole:
+                    endpoint = ConnectorEndpointKey(connector.id, role)
+                    if endpoint not in self.connector_sides:
+                        missing_endpoints.append(endpoint)
+        if missing_directions or missing_grids or missing_endpoints:
+            raise ValueError(
+                "incomplete layout provenance: "
+                f"directions={missing_directions}, grids={missing_grids}, "
+                f"connector_endpoints={missing_endpoints}"
+            )

--- a/src/nf_metro/parser/provenance.py
+++ b/src/nf_metro/parser/provenance.py
@@ -155,6 +155,33 @@ class AuthoredLayoutIntent:
             item.value for item in self.connector_sides if item.endpoint == endpoint
         )
 
+    def endpoint_values_index(
+        self,
+    ) -> dict[ConnectorEndpointKey, tuple[PortSide, ...]]:
+        """Index authored side options by semantic connector endpoint."""
+        values: dict[ConnectorEndpointKey, list[PortSide]] = {}
+        for item in self.connector_sides:
+            values.setdefault(item.endpoint, []).append(item.value)
+        return {endpoint: tuple(sides) for endpoint, sides in values.items()}
+
+    def port_hint_index(
+        self,
+    ) -> dict[tuple[str, ConnectorEndpointRole, str], tuple[PortSide, ...]]:
+        """Index authored side options by section, endpoint role, and line."""
+        return _index_port_hints(self.port_hints)
+
+
+def _index_port_hints(
+    port_hints: tuple[PortHintIntent, ...] | list[PortHintIntent],
+) -> dict[tuple[str, ConnectorEndpointRole, str], tuple[PortSide, ...]]:
+    values: dict[tuple[str, ConnectorEndpointRole, str], list[PortSide]] = {}
+    for hint in port_hints:
+        for line_id in hint.line_ids:
+            values.setdefault((hint.section_id, hint.role, line_id), []).append(
+                hint.side
+            )
+    return {key: tuple(sides) for key, sides in values.items()}
+
 
 @dataclass(frozen=True, slots=True)
 class EndpointSideSelection:
@@ -220,23 +247,17 @@ class LayoutProvenance:
         if self.authored is not None:
             raise RuntimeError("authored layout intent has already been captured")
 
-        section_rank = {sid: rank for rank, sid in enumerate(graph.sections)}
-        trailing_rank = len(section_rank)
         grids = tuple(
-            SectionIntent(section_id, decision.value)
-            for section_id, decision in sorted(
-                self.grids.items(),
-                key=lambda item: (section_rank.get(item[0], trailing_rank), item[0]),
-            )
-            if decision.origin is DecisionOrigin.AUTHORED
+            SectionIntent(section_id, grid_decision.value)
+            for section_id in routes.section_ids
+            if (grid_decision := self.grids.get(section_id)) is not None
+            and grid_decision.origin is DecisionOrigin.AUTHORED
         )
         directions = tuple(
-            SectionIntent(section_id, decision.value)
-            for section_id, decision in sorted(
-                self.directions.items(),
-                key=lambda item: (section_rank.get(item[0], trailing_rank), item[0]),
-            )
-            if decision.origin is DecisionOrigin.AUTHORED
+            SectionIntent(section_id, direction_decision.value)
+            for section_id in routes.section_ids
+            if (direction_decision := self.directions.get(section_id)) is not None
+            and direction_decision.origin is DecisionOrigin.AUTHORED
         )
 
         port_hints: list[PortHintIntent] = []
@@ -250,6 +271,7 @@ class LayoutProvenance:
                     for side, line_ids in hints
                 )
 
+        hint_index = _index_port_hints(port_hints)
         connector_sides: list[ConnectorSideIntent] = []
         for fact in routes.edges:
             if (
@@ -262,18 +284,11 @@ class LayoutProvenance:
                 (ConnectorEndpointRole.EXIT, fact.source_section),
                 (ConnectorEndpointRole.ENTRY, fact.target_section),
             ):
-                endpoint_section = graph.sections.get(section_id)
-                if endpoint_section is None:
-                    continue
-                hints = (
-                    endpoint_section.exit_hints
-                    if role is ConnectorEndpointRole.EXIT
-                    else endpoint_section.entry_hints
-                )
                 endpoint = ConnectorEndpointKey(fact.key.id, role)
-                for side, line_ids in hints:
-                    if fact.key.line_id in line_ids:
-                        connector_sides.append(ConnectorSideIntent(endpoint, side))
+                connector_sides.extend(
+                    ConnectorSideIntent(endpoint, side)
+                    for side in hint_index.get((section_id, role, fact.key.line_id), ())
+                )
 
         directive = graph.fold_threshold
         if caller_fold_threshold is not None:
@@ -383,9 +398,9 @@ class LayoutProvenance:
         self,
         endpoint: ConnectorEndpointKey,
         selection: EndpointSideSelection,
+        authored_values: tuple[PortSide, ...],
     ) -> None:
         """Record the typed resolver selection for one connector boundary."""
-        authored_values = self.authored_endpoint_values(endpoint)
         origin = selection.origin
         locked = selection.locked
         reason = selection.reason

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -26,6 +26,7 @@ from nf_metro.parser.model import (
     Station,
 )
 from nf_metro.parser.provenance import (
+    ConnectorEndpointKey,
     ConnectorEndpointRole,
     DecisionOrigin,
     DecisionReason,
@@ -706,8 +707,9 @@ def resolve_section_endpoints(
         *_reside_folded_flow_ports_to_grid(graph, inter_section_edges),
         *_reanchor_flow_axis_ports(graph, inter_section_edges),
     ]
+    provenance = _build_endpoint_provenance_context(graph, transitions)
     entry_side_for_line = _build_entry_side_mapping(
-        graph, inter_section_edges, transitions
+        graph, inter_section_edges, provenance
     )
     exit_sides = _build_exit_side_mapping(graph)
     connectors = _group_inter_section_edges(
@@ -716,7 +718,7 @@ def resolve_section_endpoints(
         entry_side_for_line,
         exit_sides,
         lineage,
-        transitions,
+        provenance,
     )
     return SectionEndpointResolution(
         internal_edges=internal_edges,
@@ -1185,58 +1187,56 @@ def _dominant_entry_side(graph: MetroGraph, sec_id: str) -> PortSide | None:
     return _priority_side({s for s, count in votes.items() if count == best})
 
 
-def _authored_line_sides(
+_LineEndpointKey = tuple[str, ConnectorEndpointRole, str]
+
+
+@dataclass(frozen=True, slots=True)
+class _EndpointProvenanceContext:
+    """Resolver-local indexes for classifying endpoint decisions."""
+
+    authored_line_sides: dict[_LineEndpointKey, tuple[PortSide, ...]]
+    authored_endpoint_values: dict[ConnectorEndpointKey, tuple[PortSide, ...]]
+    transition_reasons: dict[_LineEndpointKey, DecisionReason]
+
+
+def _build_endpoint_provenance_context(
     graph: MetroGraph,
-    section_id: str,
-    role: ConnectorEndpointRole,
-    line_id: str,
-) -> tuple[PortSide, ...]:
-    """Authored side options for one section/role/line in source order."""
+    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition],
+) -> _EndpointProvenanceContext:
     authored = graph.layout_provenance.authored
-    if authored is None:
-        return ()
-    return tuple(
-        hint.side
-        for hint in authored.port_hints
-        if hint.section_id == section_id
-        and hint.role is role
-        and line_id in hint.line_ids
+    authored_line_sides = authored.port_hint_index() if authored is not None else {}
+    authored_endpoint_values = (
+        authored.endpoint_values_index() if authored is not None else {}
+    )
+    transition_reasons: dict[_LineEndpointKey, DecisionReason] = {}
+    for transition in transitions:
+        for line_id in transition.line_ids:
+            transition_reasons[(transition.section_id, transition.role, line_id)] = (
+                transition.reason
+            )
+    return _EndpointProvenanceContext(
+        authored_line_sides,
+        authored_endpoint_values,
+        transition_reasons,
     )
 
 
-def _transition_reason(
-    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition],
-    section_id: str,
-    role: ConnectorEndpointRole,
-    line_id: str,
-) -> DecisionReason | None:
-    """Return the last resolver transition affecting one line endpoint."""
-    for transition in reversed(transitions):
-        if (
-            transition.section_id == section_id
-            and transition.role is role
-            and line_id in transition.line_ids
-        ):
-            return transition.reason
-    return None
-
-
 def _endpoint_selection(
-    graph: MetroGraph,
+    provenance: _EndpointProvenanceContext,
     section_id: str,
     role: ConnectorEndpointRole,
     line_id: str,
     side: PortSide,
-    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition],
     *,
     shared_connector: bool = False,
 ) -> EndpointSideSelection:
     """Classify a resolved side without inferring ownership from hint presence."""
-    transition = _transition_reason(transitions, section_id, role, line_id)
+    key = (section_id, role, line_id)
+    transition = provenance.transition_reasons.get(key)
     if transition is not None:
         return EndpointSideSelection(side, DecisionOrigin.INFERRED, True, transition)
 
-    authored = _authored_line_sides(graph, section_id, role, line_id)
+    authored = provenance.authored_line_sides.get(key, ())
     if authored and all(value is side for value in authored):
         return EndpointSideSelection(
             side,
@@ -1273,7 +1273,7 @@ def _endpoint_selection(
 def _build_entry_side_mapping(
     graph: MetroGraph,
     inter_section_edges: list[Edge],
-    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition] = (),
+    provenance: _EndpointProvenanceContext | None = None,
 ) -> dict[tuple[str, str], EndpointSideSelection]:
     """Build a per-line entry side lookup from hints and feed geometry.
 
@@ -1295,6 +1295,8 @@ def _build_entry_side_mapping(
     downstream by ``_guard_no_mixed_entry_directions``.  Returns dict mapping
     (section_id, line_id) -> PortSide.
     """
+    if provenance is None:
+        provenance = _build_endpoint_provenance_context(graph, ())
     dag = graph.section_dag
     connectors_by_line: dict[tuple[str, str], set[tuple[str, str]]] = defaultdict(set)
     for edge in inter_section_edges:
@@ -1333,12 +1335,11 @@ def _build_entry_side_mapping(
             )
             if side is not None:
                 entry_side_for_line[(sec_id, lid)] = _endpoint_selection(
-                    graph,
+                    provenance,
                     sec_id,
                     ConnectorEndpointRole.ENTRY,
                     lid,
                     side,
-                    transitions,
                     shared_connector=shares_hinted_connector
                     and lid not in hinted_lines,
                 )
@@ -1406,7 +1407,7 @@ def _exit_side_for_edge(
     tgt_sec: str,
     exit_sides: dict[tuple[str, str], set[PortSide]],
     entry_side_for_line: dict[tuple[str, str], EndpointSideSelection],
-    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition] = (),
+    provenance: _EndpointProvenanceContext,
 ) -> EndpointSideSelection:
     """Choose the exit side an inter-section edge leaves its source by.
 
@@ -1423,12 +1424,11 @@ def _exit_side_for_edge(
     sides = exit_sides.get((src_sec, edge.line_id))
     if not sides:
         return _endpoint_selection(
-            graph,
+            provenance,
             src_sec,
             ConnectorEndpointRole.EXIT,
             edge.line_id,
             PortSide.RIGHT,
-            transitions,
         )
 
     entry_selection = entry_side_for_line.get((tgt_sec, edge.line_id))
@@ -1459,12 +1459,11 @@ def _exit_side_for_edge(
         )
 
     return _endpoint_selection(
-        graph,
+        provenance,
         src_sec,
         ConnectorEndpointRole.EXIT,
         edge.line_id,
         selected,
-        transitions,
     )
 
 
@@ -1474,7 +1473,7 @@ def _group_inter_section_edges(
     entry_side_for_line: dict[tuple[str, str], EndpointSideSelection],
     exit_sides: dict[tuple[str, str], set[PortSide]],
     lineage: AuthoredEdgeLineage,
-    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition] = (),
+    provenance: _EndpointProvenanceContext,
 ) -> tuple[ResolvedConnectorEndpoint, ...]:
     """Resolve current inter-section endpoints and their authored identities."""
     connectors: list[ResolvedConnectorEndpoint] = []
@@ -1485,17 +1484,15 @@ def _group_inter_section_edges(
         # _classify_edges only files an edge as inter-section when both
         # endpoints resolve to a section, so neither lookup is None here.
         assert src_sec is not None and tgt_sec is not None
-        entry_selection = entry_side_for_line.get(
-            (tgt_sec, edge.line_id),
-            _endpoint_selection(
-                graph,
+        entry_selection = entry_side_for_line.get((tgt_sec, edge.line_id))
+        if entry_selection is None:
+            entry_selection = _endpoint_selection(
+                provenance,
                 tgt_sec,
                 ConnectorEndpointRole.ENTRY,
                 edge.line_id,
                 PortSide.LEFT,
-                transitions,
-            ),
-        )
+            )
         exit_selection = _exit_side_for_edge(
             graph,
             edge,
@@ -1503,22 +1500,26 @@ def _group_inter_section_edges(
             tgt_sec,
             exit_sides,
             entry_side_for_line,
-            transitions,
+            provenance,
         )
 
         connector_ids = tuple(key.id for key in lineage.origins(edge))
         for connector_id in connector_ids:
-            graph.layout_provenance.record_endpoint_selection(
-                graph.layout_provenance.endpoint_key(
-                    connector_id, ConnectorEndpointRole.EXIT
-                ),
-                exit_selection,
+            exit_endpoint = graph.layout_provenance.endpoint_key(
+                connector_id, ConnectorEndpointRole.EXIT
             )
             graph.layout_provenance.record_endpoint_selection(
-                graph.layout_provenance.endpoint_key(
-                    connector_id, ConnectorEndpointRole.ENTRY
-                ),
+                exit_endpoint,
+                exit_selection,
+                provenance.authored_endpoint_values.get(exit_endpoint, ()),
+            )
+            entry_endpoint = graph.layout_provenance.endpoint_key(
+                connector_id, ConnectorEndpointRole.ENTRY
+            )
+            graph.layout_provenance.record_endpoint_selection(
+                entry_endpoint,
                 entry_selection,
+                provenance.authored_endpoint_values.get(entry_endpoint, ()),
             )
 
         connectors.append(

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -25,6 +25,13 @@ from nf_metro.parser.model import (
     Section,
     Station,
 )
+from nf_metro.parser.provenance import (
+    ConnectorEndpointRole,
+    DecisionOrigin,
+    DecisionReason,
+    EndpointSideSelection,
+    EndpointSideTransition,
+)
 from nf_metro.parser.route_topology import (
     AuthoredEdgeKey,
     AuthoredEdgeLineage,
@@ -668,9 +675,17 @@ class ResolvedConnectorEndpoint:
     edge: Edge
     source_section: str
     target_section: str
-    exit_side: PortSide
-    entry_side: PortSide
+    exit_selection: EndpointSideSelection
+    entry_selection: EndpointSideSelection
     connector_ids: tuple[ConnectorId, ...]
+
+    @property
+    def exit_side(self) -> PortSide:
+        return self.exit_selection.side
+
+    @property
+    def entry_side(self) -> PortSide:
+        return self.entry_selection.side
 
 
 @dataclass(slots=True)
@@ -687,12 +702,21 @@ def resolve_section_endpoints(
 ) -> SectionEndpointResolution:
     """Resolve inter-section endpoint sides once, before creating synthetic ports."""
     internal_edges, inter_section_edges = _classify_edges(graph)
-    _reside_folded_flow_ports_to_grid(graph, inter_section_edges)
-    _reanchor_flow_axis_ports(graph, inter_section_edges)
-    entry_side_for_line = _build_entry_side_mapping(graph, inter_section_edges)
+    transitions = [
+        *_reside_folded_flow_ports_to_grid(graph, inter_section_edges),
+        *_reanchor_flow_axis_ports(graph, inter_section_edges),
+    ]
+    entry_side_for_line = _build_entry_side_mapping(
+        graph, inter_section_edges, transitions
+    )
     exit_sides = _build_exit_side_mapping(graph)
     connectors = _group_inter_section_edges(
-        graph, inter_section_edges, entry_side_for_line, exit_sides, lineage
+        graph,
+        inter_section_edges,
+        entry_side_for_line,
+        exit_sides,
+        lineage,
+        transitions,
     )
     return SectionEndpointResolution(
         internal_edges=internal_edges,
@@ -850,7 +874,7 @@ def _expected_flow_side(cols: set[int], col: int) -> PortSide | None:
 
 def _reside_folded_flow_ports_to_grid(
     graph: MetroGraph, inter_section_edges: list[Edge]
-) -> None:
+) -> tuple[EndpointSideTransition, ...]:
     """Turn a fold-relocated section's flow-axis port toward its connecting sections.
 
     A lowered fold threshold relocates sections onto a return row, which can
@@ -865,7 +889,9 @@ def _reside_folded_flow_ports_to_grid(
     """
     relocated = graph._fold_compressed_sections
     if not relocated:
-        return
+        return ()
+
+    transitions: list[EndpointSideTransition] = []
 
     exit_cols: dict[tuple[str, str], set[int]] = defaultdict(set)
     entry_cols: dict[tuple[str, str], set[int]] = defaultdict(set)
@@ -894,6 +920,20 @@ def _reside_folded_flow_ports_to_grid(
                 if target is None or side == target:
                     continue
                 hints[idx] = (target, lines)
+                transitions.append(
+                    EndpointSideTransition(
+                        section_id=sec_id,
+                        role=(
+                            ConnectorEndpointRole.ENTRY
+                            if is_entry
+                            else ConnectorEndpointRole.EXIT
+                        ),
+                        line_ids=tuple(lines),
+                        previous=side,
+                        effective=target,
+                        reason=DecisionReason.FOLD_RELOCATED_SIDE,
+                    )
+                )
                 warnings.warn(
                     f"Section '{sec_id}': {'entry' if is_entry else 'exit'} port "
                     f"declared on {side.value} but the fold placed its connecting "
@@ -902,11 +942,12 @@ def _reside_folded_flow_ports_to_grid(
                     f"section.",
                     stacklevel=2,
                 )
+    return tuple(transitions)
 
 
 def _reanchor_flow_axis_ports(
     graph: MetroGraph, inter_section_edges: list[Edge]
-) -> None:
+) -> tuple[EndpointSideTransition, ...]:
     """Keep a flow-axis entry/exit port on the same end as its consumer/producer.
 
     A LEFT/RIGHT (LR/RL) or TOP/BOTTOM (TB) port lies on the section's flow
@@ -920,6 +961,7 @@ def _reanchor_flow_axis_ports(
     the offending port moved to its connecting station's own edge.  Ports that
     run with the flow, and cross-axis ports, are left alone.
     """
+    transitions: list[EndpointSideTransition] = []
     consumers: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
     producers: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
     # The flow-axis side each endpoint's connecting section sits on, so a port's
@@ -1005,7 +1047,7 @@ def _reanchor_flow_axis_ports(
         # block re-orientation.
         if (
             section.direction in _HORIZONTAL_FLOW_REVERSAL
-            and sec_id not in graph._explicit_directions
+            and not graph.layout_provenance.direction_is_locked(sec_id)
             and not with_flow
         ):
             new_dir = _HORIZONTAL_FLOW_REVERSAL[section.direction]
@@ -1016,12 +1058,30 @@ def _reanchor_flow_axis_ports(
                 stacklevel=2,
             )
             section.direction = new_dir
-            graph._explicit_directions.add(sec_id)
-            graph._fold_reoriented_sections.add(sec_id)
+            graph.layout_provenance.record_inferred_direction(
+                sec_id,
+                new_dir,
+                DecisionReason.FLOW_REORIENTED_DIRECTION,
+                locked=True,
+            )
         else:
             for hints, idx, target in folds:
                 side, lines = hints[idx]
                 hints[idx] = (target, lines)
+                transitions.append(
+                    EndpointSideTransition(
+                        section_id=sec_id,
+                        role=(
+                            ConnectorEndpointRole.ENTRY
+                            if hints is section.entry_hints
+                            else ConnectorEndpointRole.EXIT
+                        ),
+                        line_ids=tuple(lines),
+                        previous=side,
+                        effective=target,
+                        reason=DecisionReason.FLOW_REANCHORED_SIDE,
+                    )
+                )
                 warnings.warn(
                     f"Section '{sec_id}': port declared on {side.value} but its "
                     f"connecting station sits at the {target.value} end; "
@@ -1029,6 +1089,7 @@ def _reanchor_flow_axis_ports(
                     f"back through the section's other stations.",
                     stacklevel=2,
                 )
+    return tuple(transitions)
 
 
 def _assign_section_numbers(graph: MetroGraph) -> None:
@@ -1124,9 +1185,96 @@ def _dominant_entry_side(graph: MetroGraph, sec_id: str) -> PortSide | None:
     return _priority_side({s for s, count in votes.items() if count == best})
 
 
+def _authored_line_sides(
+    graph: MetroGraph,
+    section_id: str,
+    role: ConnectorEndpointRole,
+    line_id: str,
+) -> tuple[PortSide, ...]:
+    """Authored side options for one section/role/line in source order."""
+    authored = graph.layout_provenance.authored
+    if authored is None:
+        return ()
+    return tuple(
+        hint.side
+        for hint in authored.port_hints
+        if hint.section_id == section_id
+        and hint.role is role
+        and line_id in hint.line_ids
+    )
+
+
+def _transition_reason(
+    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition],
+    section_id: str,
+    role: ConnectorEndpointRole,
+    line_id: str,
+) -> DecisionReason | None:
+    """Return the last resolver transition affecting one line endpoint."""
+    for transition in reversed(transitions):
+        if (
+            transition.section_id == section_id
+            and transition.role is role
+            and line_id in transition.line_ids
+        ):
+            return transition.reason
+    return None
+
+
+def _endpoint_selection(
+    graph: MetroGraph,
+    section_id: str,
+    role: ConnectorEndpointRole,
+    line_id: str,
+    side: PortSide,
+    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition],
+    *,
+    shared_connector: bool = False,
+) -> EndpointSideSelection:
+    """Classify a resolved side without inferring ownership from hint presence."""
+    transition = _transition_reason(transitions, section_id, role, line_id)
+    if transition is not None:
+        return EndpointSideSelection(side, DecisionOrigin.INFERRED, True, transition)
+
+    authored = _authored_line_sides(graph, section_id, role, line_id)
+    if authored and all(value is side for value in authored):
+        return EndpointSideSelection(
+            side,
+            DecisionOrigin.AUTHORED,
+            True,
+            DecisionReason.AUTHOR_DIRECTIVE,
+        )
+    if authored:
+        return EndpointSideSelection(
+            side,
+            DecisionOrigin.INFERRED,
+            False,
+            DecisionReason.RESOLUTION_SIDE_SELECTION,
+        )
+    if shared_connector:
+        return EndpointSideSelection(
+            side,
+            DecisionOrigin.INFERRED,
+            False,
+            DecisionReason.SHARED_CONNECTOR_ENTRY_SIDE,
+        )
+    return EndpointSideSelection(
+        side,
+        DecisionOrigin.INFERRED,
+        False,
+        (
+            DecisionReason.AUTO_ENTRY_SIDE
+            if role is ConnectorEndpointRole.ENTRY
+            else DecisionReason.AUTO_EXIT_SIDE
+        ),
+    )
+
+
 def _build_entry_side_mapping(
-    graph: MetroGraph, inter_section_edges: list[Edge]
-) -> dict[tuple[str, str], PortSide]:
+    graph: MetroGraph,
+    inter_section_edges: list[Edge],
+    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition] = (),
+) -> dict[tuple[str, str], EndpointSideSelection]:
     """Build a per-line entry side lookup from hints and feed geometry.
 
     A line resolves to one entry side:
@@ -1154,7 +1302,7 @@ def _build_entry_side_mapping(
         if tgt_sec is not None:
             connectors_by_line[(tgt_sec, edge.line_id)].add((edge.source, edge.target))
 
-    entry_side_for_line: dict[tuple[str, str], PortSide] = {}
+    entry_side_for_line: dict[tuple[str, str], EndpointSideSelection] = {}
     for sec_id, section in graph.sections.items():
         incoming: set[str] = set()
         if dag is not None:
@@ -1175,7 +1323,7 @@ def _build_entry_side_mapping(
             hinted_connectors.update(connectors_by_line.get((sec_id, lid), set()))
 
         for lid in incoming:
-            shares_hinted_connector = hinted_side is not None and (
+            shares_hinted_connector = hinted_side is not None and bool(
                 connectors_by_line.get((sec_id, lid), set()) & hinted_connectors
             )
             side = (
@@ -1184,7 +1332,16 @@ def _build_entry_side_mapping(
                 else dominant
             )
             if side is not None:
-                entry_side_for_line[(sec_id, lid)] = side
+                entry_side_for_line[(sec_id, lid)] = _endpoint_selection(
+                    graph,
+                    sec_id,
+                    ConnectorEndpointRole.ENTRY,
+                    lid,
+                    side,
+                    transitions,
+                    shared_connector=shares_hinted_connector
+                    and lid not in hinted_lines,
+                )
     return entry_side_for_line
 
 
@@ -1248,8 +1405,9 @@ def _exit_side_for_edge(
     src_sec: str,
     tgt_sec: str,
     exit_sides: dict[tuple[str, str], set[PortSide]],
-    entry_side_for_line: dict[tuple[str, str], PortSide],
-) -> PortSide:
+    entry_side_for_line: dict[tuple[str, str], EndpointSideSelection],
+    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition] = (),
+) -> EndpointSideSelection:
     """Choose the exit side an inter-section edge leaves its source by.
 
     A perpendicular (TOP/BOTTOM) exit forms a clean vertical drop only when it
@@ -1264,9 +1422,17 @@ def _exit_side_for_edge(
 
     sides = exit_sides.get((src_sec, edge.line_id))
     if not sides:
-        return PortSide.RIGHT
+        return _endpoint_selection(
+            graph,
+            src_sec,
+            ConnectorEndpointRole.EXIT,
+            edge.line_id,
+            PortSide.RIGHT,
+            transitions,
+        )
 
-    entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
+    entry_selection = entry_side_for_line.get((tgt_sec, edge.line_id))
+    entry_side = entry_selection.side if entry_selection is not None else PortSide.LEFT
 
     preferred: PortSide | None
     if len(sides) == 1:
@@ -1285,18 +1451,30 @@ def _exit_side_for_edge(
         preferred = geo if geo in sides else None
 
     if preferred in _PERP_DROP_PAIR and _PERP_DROP_PAIR[preferred] == entry_side:
-        return preferred
+        selected = preferred
+    else:
+        section_sides = {s for s, _ in graph.sections[src_sec].exit_hints}
+        selected = (
+            next(iter(section_sides)) if len(section_sides) == 1 else PortSide.RIGHT
+        )
 
-    section_sides = {s for s, _ in graph.sections[src_sec].exit_hints}
-    return next(iter(section_sides)) if len(section_sides) == 1 else PortSide.RIGHT
+    return _endpoint_selection(
+        graph,
+        src_sec,
+        ConnectorEndpointRole.EXIT,
+        edge.line_id,
+        selected,
+        transitions,
+    )
 
 
 def _group_inter_section_edges(
     graph: MetroGraph,
     inter_section_edges: list[Edge],
-    entry_side_for_line: dict[tuple[str, str], PortSide],
+    entry_side_for_line: dict[tuple[str, str], EndpointSideSelection],
     exit_sides: dict[tuple[str, str], set[PortSide]],
     lineage: AuthoredEdgeLineage,
+    transitions: tuple[EndpointSideTransition, ...] | list[EndpointSideTransition] = (),
 ) -> tuple[ResolvedConnectorEndpoint, ...]:
     """Resolve current inter-section endpoints and their authored identities."""
     connectors: list[ResolvedConnectorEndpoint] = []
@@ -1307,19 +1485,50 @@ def _group_inter_section_edges(
         # _classify_edges only files an edge as inter-section when both
         # endpoints resolve to a section, so neither lookup is None here.
         assert src_sec is not None and tgt_sec is not None
-        entry_side = entry_side_for_line.get((tgt_sec, edge.line_id), PortSide.LEFT)
-        exit_side = _exit_side_for_edge(
-            graph, edge, src_sec, tgt_sec, exit_sides, entry_side_for_line
+        entry_selection = entry_side_for_line.get(
+            (tgt_sec, edge.line_id),
+            _endpoint_selection(
+                graph,
+                tgt_sec,
+                ConnectorEndpointRole.ENTRY,
+                edge.line_id,
+                PortSide.LEFT,
+                transitions,
+            ),
         )
+        exit_selection = _exit_side_for_edge(
+            graph,
+            edge,
+            src_sec,
+            tgt_sec,
+            exit_sides,
+            entry_side_for_line,
+            transitions,
+        )
+
+        connector_ids = tuple(key.id for key in lineage.origins(edge))
+        for connector_id in connector_ids:
+            graph.layout_provenance.record_endpoint_selection(
+                graph.layout_provenance.endpoint_key(
+                    connector_id, ConnectorEndpointRole.EXIT
+                ),
+                exit_selection,
+            )
+            graph.layout_provenance.record_endpoint_selection(
+                graph.layout_provenance.endpoint_key(
+                    connector_id, ConnectorEndpointRole.ENTRY
+                ),
+                entry_selection,
+            )
 
         connectors.append(
             ResolvedConnectorEndpoint(
                 edge=edge,
                 source_section=src_sec,
                 target_section=tgt_sec,
-                exit_side=exit_side,
-                entry_side=entry_side,
-                connector_ids=tuple(key.id for key in lineage.origins(edge)),
+                exit_selection=exit_selection,
+                entry_selection=entry_selection,
+                connector_ids=connector_ids,
             )
         )
 

--- a/src/nf_metro/render/plan.py
+++ b/src/nf_metro/render/plan.py
@@ -207,6 +207,7 @@ class RenderPlan:
 
 
 _RENDER_GRAPH_EXCLUDED_FIELDS = {
+    "layout_provenance",
     "route_resolution",
     "route_topology",
     "_station_lines_cache",

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -564,7 +564,8 @@ def _fold_threshold_error(graph: MetroGraph) -> FoldThresholdError | None:
         return None
     sections = ", ".join(sorted(relocated))
     return FoldThresholdError(
-        f"fold_threshold={graph._fold_threshold_effective} is too small for "
+        f"fold_threshold={graph.layout_provenance.effective_fold_threshold} "
+        "is too small for "
         f"this map: it folds section(s) {sections} into a tighter grid than "
         f"their natural layout, leaving the router no room to separate the "
         f"bundle curves. Raise --fold-threshold (or the %%metro fold_threshold "

--- a/tests/orientation_transform.py
+++ b/tests/orientation_transform.py
@@ -169,16 +169,19 @@ def transformable_reason(graph: MetroGraph) -> str | None:
     from the rotated source, and inference answering differently is not the
     engine laying one geometry out two ways.
 
-    ``resolve`` adds a fold-reoriented section to ``_explicit_directions``, so
-    those are subtracted to leave author-declared flows only.
+    Effective directions carry independent author-ownership and lock state, so
+    a resolve-time pin never makes an inferred direction transformable.
     """
     sections = set(graph.sections)
     if len(sections) < 2:
         return "single section: every transform is the identity"
-    authored = graph._explicit_directions - graph._fold_reoriented_sections
+    authored = {
+        sid for sid in sections if graph.layout_provenance.author_owns_direction(sid)
+    }
     if inferred := sections - authored:
         return f"inferred flow direction: {sorted(inferred)}"
-    if ungridded := sections - graph._explicit_grid:
+    gridded = {sid for sid in sections if graph.layout_provenance.author_owns_grid(sid)}
+    if ungridded := sections - gridded:
         return f"inferred grid cell: {sorted(ungridded)}"
     return None
 

--- a/tests/test_auto_layout.py
+++ b/tests/test_auto_layout.py
@@ -286,7 +286,7 @@ def test_direction_explicit_preserved():
         [("sec1_s1", "sec1", "sec2_s1", "sec2", "main")],
     )
     graph.sections["sec1"].direction = "TB"
-    graph._explicit_directions.add("sec1")
+    graph.layout_provenance.record_authored_direction("sec1", "TB")
 
     successors, predecessors, _ = _build_section_dag(graph)
     _assign_grid_positions(graph, successors, predecessors, max_station_columns=100)
@@ -310,7 +310,7 @@ def test_explicit_grid_section_keeps_lr_against_auto_successor_below():
     )
     # 'manual' is explicitly gridded; 'downstream' is left to auto-layout.
     graph.grid_overrides["manual"] = (0, 0, 1, 1)
-    graph._explicit_grid.add("manual")
+    graph.layout_provenance.record_authored_grid("manual", (0, 0, 1, 1))
 
     successors, predecessors, _ = _build_section_dag(graph)
     _assign_grid_positions(graph, successors, predecessors, max_station_columns=100)
@@ -339,7 +339,12 @@ def test_explicit_grid_sections_default_lr(fixture):
     text = (EXAMPLES / fixture).read_text()
     graph = parse_metro_mermaid(text)
 
-    explicit = graph._explicit_grid - graph._explicit_directions
+    explicit = {
+        sid
+        for sid in graph.sections
+        if graph.layout_provenance.author_owns_grid(sid)
+        and not graph.layout_provenance.author_owns_direction(sid)
+    }
     assert explicit, f"{fixture} has no explicit-grid sections to check"
     for sec_id in explicit:
         assert graph.sections[sec_id].direction == "LR", (

--- a/tests/test_entry_side_inference.py
+++ b/tests/test_entry_side_inference.py
@@ -77,8 +77,8 @@ def test_build_mapping_shares_one_side_across_a_sections_lines() -> None:
     _, inter_section_edges = resolve._classify_edges(graph)
     mapping = resolve._build_entry_side_mapping(graph, inter_section_edges)
     by_section: dict[str, set[PortSide]] = {}
-    for (sec_id, _line), side in mapping.items():
-        by_section.setdefault(sec_id, set()).add(side)
+    for (sec_id, _line), selection in mapping.items():
+        by_section.setdefault(sec_id, set()).add(selection.side)
     for sec_id, sides in by_section.items():
         assert len(sides) == 1, f"{sec_id} resolved to multiple entry sides: {sides}"
 
@@ -100,7 +100,9 @@ def test_conflicting_side_hints_collapse_to_one_fed_hinted_side_and_warn() -> No
         )
         _, inter_section_edges = resolve._classify_edges(graph)
         mapping = resolve._build_entry_side_mapping(graph, inter_section_edges)
-    sec_g_sides = {side for (sec, _line), side in mapping.items() if sec == "sec_g"}
+    sec_g_sides = {
+        selection.side for (sec, _line), selection in mapping.items() if sec == "sec_g"
+    }
     assert sec_g_sides == {PortSide.LEFT}, f"sec_g resolved to {sec_g_sides}"
     assert any("sec_g" in str(w.message) and "TOP" in str(w.message) for w in caught), (
         "no warning naming the dropped sec_g TOP hint"

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -46,7 +46,7 @@ def test_explain_decision_schema():
     }
     for d in data["decisions"]:
         assert required <= set(d), f"Decision missing keys: {d}"
-        assert d["source"] in ("inferred", "synthetic")
+        assert d["source"] in ("inferred", "inferred-then-pinned", "synthetic")
         assert d["subject_type"] in ("section", "station", "layout")
 
 
@@ -106,24 +106,32 @@ def test_explain_explicit_direction_not_reported():
     }
     # rnaseq_sections.mmd has two explicit direction directives; check none of
     # those sections show up as inferred.
-    for sid in graph._explicit_directions:
+    for sid in graph.sections:
+        if not graph.layout_provenance.author_owns_direction(sid):
+            continue
         assert sid not in inferred_dir_subjects, (
             f"Section {sid!r} has an explicit direction but appeared as inferred"
         )
 
 
-def test_explain_explicit_grid_sections_skipped_in_directions():
-    """Sections in _explicit_grid do not appear in direction decisions."""
+def test_explain_explicit_grid_default_has_truthful_inferred_provenance():
+    """An author-owned grid does not falsely make its LR default authored."""
     graph = parse_metro_mermaid(DA_MMD.read_text())
     data = build_explain(graph)
 
-    dir_subjects = {
-        d["subject"] for d in data["decisions"] if d["aspect"] == "direction"
+    directions = {
+        d["subject"]: d for d in data["decisions"] if d["aspect"] == "direction"
     }
-    for sid in graph._explicit_grid:
-        assert sid not in dir_subjects, (
-            f"Explicitly-gridded section {sid!r} appeared in direction decisions"
-        )
+    inferred_defaults = {
+        sid
+        for sid in graph.sections
+        if graph.layout_provenance.author_owns_grid(sid)
+        and not graph.layout_provenance.author_owns_direction(sid)
+    }
+    assert inferred_defaults
+    for sid in inferred_defaults:
+        assert directions[sid]["source"] == "inferred"
+        assert directions[sid]["rule"] == "explicit-grid-default-direction"
 
 
 def test_explain_fan_out_junction():
@@ -168,6 +176,35 @@ def test_explain_port_sides_inferred():
     assert entry_sides.get("qc_report") == "vertical-drop"
     # genome_align is LR -> flow-aligned LEFT entry
     assert entry_sides.get("genome_align") == "flow-aligned-entry"
+
+
+def test_explain_keeps_inferred_connector_in_partially_hinted_section():
+    graph = parse_metro_mermaid(
+        """\
+%%metro line: a | A | #ff0000
+%%metro line: b | B | #0000ff
+%%metro grid: source | 0,0
+%%metro grid: target | 1,0
+graph LR
+    subgraph source [Source]
+        s1[S1]
+    end
+    subgraph target [Target]
+        %%metro entry: top | a
+        t1[T1]
+    end
+    s1 -->|a,b| t1
+"""
+    )
+    entries = [
+        decision
+        for decision in build_explain(graph)["decisions"]
+        if decision["aspect"] == "entry_side"
+    ]
+
+    assert len(entries) == 1
+    assert "Connector b" in entries[0]["detail"]
+    assert entries[0]["provenance_reason"] == "shared-connector-entry-side"
 
 
 def test_explain_no_decisions_single_section(tmp_path):

--- a/tests/test_grid_alignment.py
+++ b/tests/test_grid_alignment.py
@@ -453,5 +453,4 @@ class TestInterSectionPortSnap:
     def test_auto_layout_unaffected(self):
         """The snap stays off for purely auto-layout pipelines."""
         g = _load("variant_calling_tuned")
-        # Without any %%metro grid: directive, no explicit_grid entries.
-        assert not g._explicit_grid
+        assert not g.layout_provenance.has_authored_grids()

--- a/tests/test_hash_seed_determinism.py
+++ b/tests/test_hash_seed_determinism.py
@@ -47,7 +47,7 @@ def test_settled_graph_snapshot_includes_semantic_route_state() -> None:
     field_names = {
         name for name, _value in _freeze_settled_graph(MetroGraph()).values.entries
     }
-    assert {"route_topology", "route_resolution"} <= field_names
+    assert {"route_topology", "route_resolution", "layout_provenance"} <= field_names
     assert (
         not {
             "_station_lines_cache",

--- a/tests/test_independent_components.py
+++ b/tests/test_independent_components.py
@@ -202,7 +202,7 @@ def test_explicit_grid_keeps_shared_grid() -> None:
     """
     text = (EXAMPLES_DIR / "topologies" / "self_crossing_bridge.mmd").read_text()
     g = parse_metro_mermaid(text)
-    assert g._explicit_grid  # author pinned positions
+    assert g.layout_provenance.has_authored_grids()
     comps = _weakly_connected_components(g, g.section_dag.section_edges)
     assert len(comps) == 2
     # Layout still succeeds and respects the explicit interleaving: the

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -135,18 +135,54 @@ def test_explicit_directives_reported_as_explicit() -> None:
     # A section without a direction: directive keeps the inferred default.
     assert sections["preprocessing"]["direction_inferred"] is True
 
-    # preprocessing writes an explicit exit: but no entry: directive.
-    assert sections["preprocessing"]["exit_sides_inferred"] is False
+    # preprocessing has authored right and bottom exit hints. Resolution keeps
+    # the right hints and selects right for the bottom-hinted connectors.
+    assert sections["preprocessing"]["exit_sides_inferred"] is None
     assert sections["preprocessing"]["entry_sides_inferred"] is True
 
 
 def test_port_side_inferred_tracks_section_directive() -> None:
-    """A port's side_inferred mirrors whether its section authored that side."""
+    """A port's summary is derived from its connector endpoint records."""
     graph = _graph("rnaseq_sections.mmd")
     info = build_info(graph)
     for port in info["ports"]:
-        explicit = graph._explicit_entry if port["is_entry"] else graph._explicit_exit
-        assert port["side_inferred"] is (port["section_id"] not in explicit)
+        origins = {item["provenance"]["origin"] for item in port["side_provenance"]}
+        expected = None if len(origins) > 1 else origins != {"authored"}
+        assert port["side_inferred"] is expected
+
+
+def test_partially_hinted_port_reports_connector_specific_provenance() -> None:
+    graph = parse_metro_mermaid(
+        """\
+%%metro line: a | A | #ff0000
+%%metro line: b | B | #0000ff
+%%metro grid: source | 0,0
+%%metro grid: target | 1,0
+graph LR
+    subgraph source [Source]
+        s1[S1]
+    end
+    subgraph target [Target]
+        %%metro entry: top | a
+        t1[T1]
+    end
+    s1 -->|a,b| t1
+"""
+    )
+    target = next(
+        section
+        for section in build_info(graph)["sections"]
+        if section["id"] == "target"
+    )
+    by_line = {
+        record["line_id"]: record["provenance"]
+        for record in target["entry_side_provenance"]
+    }
+
+    assert target["entry_sides_inferred"] is None
+    assert by_line["a"]["state"] == "authored"
+    assert by_line["b"]["state"] == "inferred"
+    assert by_line["b"]["reason"] == "shared-connector-entry-side"
 
 
 def test_warnings_passed_through() -> None:

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -112,10 +112,39 @@ def test_inferred_when_no_directives() -> None:
     for sec in info["sections"]:
         assert sec["direction_inferred"] is True
         assert sec["grid_inferred"] is True
-        assert sec["entry_sides_inferred"] is True
-        assert sec["exit_sides_inferred"] is True
+        assert sec["entry_sides_inferred"] is (
+            True if sec["entry_side_provenance"] else None
+        )
+        assert sec["exit_sides_inferred"] is (
+            True if sec["exit_side_provenance"] else None
+        )
     for port in info["ports"]:
         assert port["side_inferred"] is True
+
+
+def test_sections_without_connector_endpoints_report_no_side_ownership() -> None:
+    graph = parse_metro_mermaid(
+        """\
+%%metro line: a | A | #ff0000
+graph LR
+    subgraph source [Source]
+        %%metro entry: top | a
+        s1[S1]
+    end
+    subgraph target [Target]
+        t1[T1]
+    end
+    s1 -->|a| t1
+"""
+    )
+    sections = {item["id"]: item for item in build_info(graph)["sections"]}
+
+    assert sections["source"]["entry_side_provenance"] == []
+    assert sections["source"]["entry_sides_inferred"] is None
+    assert sections["source"]["exit_sides_inferred"] is True
+    assert sections["target"]["entry_sides_inferred"] is True
+    assert sections["target"]["exit_side_provenance"] == []
+    assert sections["target"]["exit_sides_inferred"] is None
 
 
 def test_explicit_directives_reported_as_explicit() -> None:
@@ -138,7 +167,7 @@ def test_explicit_directives_reported_as_explicit() -> None:
     # preprocessing has authored right and bottom exit hints. Resolution keeps
     # the right hints and selects right for the bottom-hinted connectors.
     assert sections["preprocessing"]["exit_sides_inferred"] is None
-    assert sections["preprocessing"]["entry_sides_inferred"] is True
+    assert sections["preprocessing"]["entry_sides_inferred"] is None
 
 
 def test_port_side_inferred_tracks_section_directive() -> None:

--- a/tests/test_layout_provenance.py
+++ b/tests/test_layout_provenance.py
@@ -1,0 +1,277 @@
+"""Authored layout intent and effective engine decisions stay distinct."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, fields
+from pathlib import Path
+
+import pytest
+
+from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph, PortSide
+from nf_metro.parser.provenance import (
+    ConnectorEndpointKey,
+    ConnectorEndpointRole,
+    DecisionOrigin,
+    DecisionReason,
+    DecisionState,
+    FoldThresholdSource,
+)
+from nf_metro.render.svg import _fold_threshold_error
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+AUTHORED_SOURCE = """\
+%%metro title: Authored provenance
+%%metro line: a | A | #ff0000
+%%metro fold_threshold: 9
+%%metro grid: source | 2,3,2,1
+%%metro grid: target | 3,3
+graph LR
+    subgraph source [Source]
+        %%metro direction: TB
+        %%metro exit: bottom | a
+        s1[S1]
+    end
+    subgraph target [Target]
+        %%metro direction: LR
+        %%metro entry: top | a
+        t1[T1]
+    end
+    s1 -->|a| t1
+"""
+
+
+def _connector(graph, source: str, target: str, line_id: str):
+    assert graph.route_topology is not None
+    return next(
+        connector
+        for connector in graph.route_topology.connectors
+        if connector.source == source
+        and connector.target == target
+        and connector.line_id == line_id
+    )
+
+
+def test_authored_snapshot_captures_every_layout_directive_before_inference() -> None:
+    graph = parse_metro_mermaid(AUTHORED_SOURCE)
+    provenance = graph.layout_provenance
+    authored = provenance.authored
+
+    assert authored is not None
+    assert [(item.section_id, item.value) for item in authored.grids] == [
+        ("source", (2, 3, 2, 1)),
+        ("target", (3, 3, 1, 1)),
+    ]
+    assert [(item.section_id, item.value) for item in authored.directions] == [
+        ("source", "TB"),
+        ("target", "LR"),
+    ]
+    assert authored.fold_threshold.directive_value == 9
+    assert authored.fold_threshold.caller_value is None
+    assert authored.fold_threshold.selected_source is FoldThresholdSource.DIRECTIVE
+    assert [
+        (hint.section_id, hint.role, hint.side, hint.line_ids)
+        for hint in authored.port_hints
+    ] == [
+        (
+            "source",
+            ConnectorEndpointRole.EXIT,
+            PortSide.BOTTOM,
+            ("a",),
+        ),
+        (
+            "target",
+            ConnectorEndpointRole.ENTRY,
+            PortSide.TOP,
+            ("a",),
+        ),
+    ]
+    with pytest.raises(FrozenInstanceError):
+        authored.fold_threshold.selected_value = 1  # type: ignore[misc]
+
+    connector = _connector(graph, "s1", "t1", "a")
+    exit_key = provenance.endpoint_key(connector.id, ConnectorEndpointRole.EXIT)
+    entry_key = provenance.endpoint_key(connector.id, ConnectorEndpointRole.ENTRY)
+    assert authored.endpoint_values(exit_key) == (PortSide.BOTTOM,)
+    assert authored.endpoint_values(entry_key) == (PortSide.TOP,)
+
+    for decision in (
+        provenance.grid_decision("source"),
+        provenance.direction_decision("source"),
+        provenance.endpoint_decision(exit_key),
+        provenance.endpoint_decision(entry_key),
+        provenance.fold_threshold_decision,
+    ):
+        assert decision is not None
+        assert decision.origin is DecisionOrigin.AUTHORED
+        assert decision.is_author_owned
+        assert decision.is_reinference_locked
+        assert decision.state is DecisionState.AUTHORED
+
+
+def test_caller_fold_threshold_is_preserved_separately_from_directive() -> None:
+    graph = parse_metro_mermaid(AUTHORED_SOURCE, max_station_columns=12)
+    authored = graph.layout_provenance.authored
+    decision = graph.layout_provenance.fold_threshold_decision
+
+    assert authored is not None
+    assert authored.fold_threshold.directive_value == 9
+    assert authored.fold_threshold.caller_value == 12
+    assert authored.fold_threshold.selected_source is FoldThresholdSource.CALLER
+    assert decision is not None
+    assert decision.value == 12
+    assert decision.origin is DecisionOrigin.AUTHORED
+    assert decision.is_reinference_locked
+    assert decision.state is DecisionState.AUTHORED
+    assert decision.reason is DecisionReason.CALLER_FOLD_THRESHOLD
+
+
+def test_default_fold_threshold_is_inferred_and_unlocked() -> None:
+    source = AUTHORED_SOURCE.replace("%%metro fold_threshold: 9\n", "")
+    graph = parse_metro_mermaid(source)
+    decision = graph.layout_provenance.fold_threshold_decision
+
+    assert decision is not None
+    assert decision.value == 15
+    assert decision.origin is DecisionOrigin.INFERRED
+    assert not decision.is_reinference_locked
+    assert decision.reason is DecisionReason.DEFAULT_FOLD_THRESHOLD
+
+
+def test_partially_hinted_entry_tracks_each_semantic_connector() -> None:
+    graph = parse_metro_mermaid(
+        """\
+%%metro line: a | A | #ff0000
+%%metro line: b | B | #0000ff
+%%metro grid: source | 0,0
+%%metro grid: target | 1,0
+graph LR
+    subgraph source [Source]
+        s1[S1]
+    end
+    subgraph target [Target]
+        %%metro entry: top | a
+        t1[T1]
+    end
+    s1 -->|a,b| t1
+"""
+    )
+    provenance = graph.layout_provenance
+    authored_connector = _connector(graph, "s1", "t1", "a")
+    inferred_connector = _connector(graph, "s1", "t1", "b")
+    authored_key = provenance.endpoint_key(
+        authored_connector.id, ConnectorEndpointRole.ENTRY
+    )
+    inferred_key = provenance.endpoint_key(
+        inferred_connector.id, ConnectorEndpointRole.ENTRY
+    )
+
+    authored = provenance.endpoint_decision(authored_key)
+    inferred = provenance.endpoint_decision(inferred_key)
+    assert authored is not None and inferred is not None
+    assert authored.value is PortSide.TOP
+    assert authored.is_author_owned
+    assert inferred.value is PortSide.TOP
+    assert not inferred.is_author_owned
+    assert inferred.state is DecisionState.INFERRED
+    assert inferred.reason is DecisionReason.SHARED_CONNECTOR_ENTRY_SIDE
+    assert authored_key != inferred_key
+
+
+def test_repeated_identical_hints_remain_author_owned() -> None:
+    source = AUTHORED_SOURCE.replace(
+        "        %%metro entry: top | a\n",
+        "        %%metro entry: top | a\n        %%metro entry: top | a\n",
+    )
+    graph = parse_metro_mermaid(source)
+    connector = _connector(graph, "s1", "t1", "a")
+    endpoint = graph.layout_provenance.endpoint_key(
+        connector.id, ConnectorEndpointRole.ENTRY
+    )
+    decision = graph.layout_provenance.endpoint_decision(endpoint)
+
+    assert decision is not None
+    assert decision.is_author_owned
+    assert decision.authored_values == (PortSide.TOP, PortSide.TOP)
+
+
+def test_tall_anchor_directions_are_inferred_then_pinned() -> None:
+    graph = parse_metro_mermaid((EXAMPLES / "genomic_pipeline.mmd").read_text())
+
+    for section_id in ("variant_calling", "post_vc", "annotation", "reporting"):
+        decision = graph.layout_provenance.direction_decision(section_id)
+        assert decision is not None
+        assert decision.value == "LR"
+        assert decision.origin is DecisionOrigin.INFERRED
+        assert not decision.is_author_owned
+        assert decision.is_reinference_locked
+        assert decision.state is DecisionState.INFERRED_THEN_PINNED
+        assert decision.reason is DecisionReason.TALL_ANCHOR_DIRECTION
+
+
+def test_fold_relocation_keeps_authored_and_effective_port_sides_distinct() -> None:
+    graph = parse_metro_mermaid(
+        (EXAMPLES / "genomeassembly.mmd").read_text(), max_station_columns=5
+    )
+    provenance = graph.layout_provenance
+
+    exit_connector = _connector(graph, "yahs", "asmstats", "assemblies")
+    exit_key = provenance.endpoint_key(exit_connector.id, ConnectorEndpointRole.EXIT)
+    exit_decision = provenance.endpoint_decision(exit_key)
+    assert exit_decision is not None
+    assert exit_decision.value is PortSide.LEFT
+    assert exit_decision.authored_values == (PortSide.RIGHT,)
+    assert exit_decision.origin is DecisionOrigin.INFERRED
+    assert not exit_decision.is_author_owned
+    assert exit_decision.is_reinference_locked
+    assert exit_decision.reason is DecisionReason.FOLD_RELOCATED_SIDE
+
+    entry_connector = _connector(graph, "yahs", "asmstats", "assemblies")
+    entry_key = provenance.endpoint_key(entry_connector.id, ConnectorEndpointRole.ENTRY)
+    entry_decision = provenance.endpoint_decision(entry_key)
+    assert entry_decision is not None
+    assert entry_decision.value is PortSide.RIGHT
+    assert entry_decision.authored_values == (PortSide.LEFT,)
+    assert entry_decision.reason is DecisionReason.FOLD_RELOCATED_SIDE
+
+
+def test_fold_error_reads_the_typed_caller_threshold() -> None:
+    graph = parse_metro_mermaid(
+        (EXAMPLES / "genomeassembly.mmd").read_text(), max_station_columns=5
+    )
+    decision = graph.layout_provenance.fold_threshold_decision
+    error = _fold_threshold_error(graph)
+
+    assert decision is not None
+    assert decision.value == 5
+    assert decision.reason is DecisionReason.CALLER_FOLD_THRESHOLD
+    assert error is not None
+    assert "fold_threshold=5" in str(error)
+
+
+def test_every_effective_corpus_commitment_has_valid_provenance() -> None:
+    for path in sorted(EXAMPLES.rglob("*.mmd")):
+        graph = parse_metro_mermaid(path.read_text())
+        graph.layout_provenance.validate_complete(graph)
+        if graph.route_topology is not None:
+            assert list(graph.layout_provenance.connector_sides) == [
+                ConnectorEndpointKey(connector.id, role)
+                for connector in graph.route_topology.connectors
+                for role in ConnectorEndpointRole
+            ]
+
+
+def test_legacy_provenance_fields_are_absent() -> None:
+    names = {item.name for item in fields(MetroGraph)}
+    assert (
+        not {
+            "_explicit_grid",
+            "_explicit_directions",
+            "_explicit_entry",
+            "_explicit_exit",
+            "_fold_reoriented_sections",
+            "_fold_threshold_effective",
+        }
+        & names
+    )

--- a/tests/test_phase_state_registry.py
+++ b/tests/test_phase_state_registry.py
@@ -46,14 +46,10 @@ CONTRACT = LAYOUT_DIR / "CONTRACT.md"
 #     machinery itself.
 #   - _phase_snapshots_enabled: a per-run coordinate-snapshot flag stashed to
 #     avoid signature churn (#363), pure observation.
-#   - _explicit_grid / _explicit_directions: authoring provenance mutated by
-#     inference; owned by #681's provenance design rather than this protocol.
 _BOOKKEEPING_ALLOWLIST = {
     "_stages_completed",
     "_validate_active",
     "_phase_snapshots_enabled",
-    "_explicit_grid",
-    "_explicit_directions",
 }
 
 _COMMENT = re.compile(r"#.*$", re.MULTILINE)

--- a/tests/test_render_plan.py
+++ b/tests/test_render_plan.py
@@ -10,6 +10,7 @@ import pytest
 
 from nf_metro.api import prepare_graph, resolve_theme
 from nf_metro.parser.model import MetroGraph
+from nf_metro.parser.provenance import LayoutProvenance
 from nf_metro.render.html import emit_render_plan_html
 from nf_metro.render.manifest import read_manifest
 from nf_metro.render.plan import (
@@ -125,9 +126,11 @@ def test_route_metadata_is_excluded_from_render_artifacts(path: str) -> None:
     graph, observed = _plan(path)
     graph.route_topology = None
     graph.route_resolution = None
+    graph.layout_provenance = LayoutProvenance()
     baseline = build_render_plan(graph, resolve_theme(None, graph))
 
     assert observed == baseline
+    assert not hasattr(observed.graph, "layout_provenance")
     assert not hasattr(observed.graph, "route_topology")
     assert not hasattr(observed.graph, "route_resolution")
     assert emit_render_plan(observed) == emit_render_plan(baseline)

--- a/tests/test_reversed_flow_reorient.py
+++ b/tests/test_reversed_flow_reorient.py
@@ -9,10 +9,17 @@ re-anchor a single port and leave the flow pointing the wrong way.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
+from orientation_transform import transformable_reason
+
 from nf_metro.layout.engine import compute_layout
+from nf_metro.layout.routing import compute_station_offsets
 from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.provenance import DecisionReason, DecisionState
 
 REVERSED_FLOW = "examples/topologies/rl_entry_right_exit_left.mmd"
+MULTILINE_REVERSED_FLOW = "examples/topologies/rl_entry_runway.mmd"
 
 
 def _graph(path: str, *, validate: bool):
@@ -30,4 +37,45 @@ def test_entry_right_exit_left_reorients_to_rl() -> None:
     back), so the section resolves to RL and lays out without raising.
     """
     graph = _graph(REVERSED_FLOW, validate=True)
+    decision = graph.layout_provenance.direction_decision("mid")
+
     assert graph.sections["mid"].direction == "RL"
+    assert decision is not None
+    assert decision.state is DecisionState.INFERRED_THEN_PINNED
+    assert decision.reason is DecisionReason.FLOW_REORIENTED_DIRECTION
+    assert transformable_reason(graph) == (
+        "inferred flow direction: ['feed', 'mid', 'sink']"
+    )
+
+
+def test_routing_reads_the_reorientation_reason() -> None:
+    graph = parse_metro_mermaid(open(MULTILINE_REVERSED_FLOW).read())
+    compute_layout(graph, validate=True)
+    geometry = {
+        station_id: (station.x, station.y)
+        for station_id, station in graph.stations.items()
+    }
+    exit_port = next(
+        port_id
+        for port_id, port in graph.ports.items()
+        if port.section_id == "src_sec" and not port.is_entry
+    )
+    line_ids = graph.station_lines(exit_port)
+    offsets = compute_station_offsets(graph)
+
+    assert [offsets[(exit_port, line_id)] for line_id in line_ids] == [0.0, 4.0]
+
+    decision = graph.layout_provenance.directions["src_sec"]
+    graph.layout_provenance.directions["src_sec"] = replace(
+        decision, reason=DecisionReason.AUTO_DIRECTION
+    )
+    without_transition = compute_station_offsets(graph)
+
+    assert [without_transition[(exit_port, line_id)] for line_id in line_ids] == [
+        -4.0,
+        0.0,
+    ]
+    assert {
+        station_id: (station.x, station.y)
+        for station_id, station in graph.stations.items()
+    } == geometry

--- a/tests/test_vertical_flow_reversal.py
+++ b/tests/test_vertical_flow_reversal.py
@@ -20,6 +20,7 @@ import warnings
 import pytest
 
 from nf_metro.parser.model import Edge, MetroGraph, PortSide, Section, Station
+from nf_metro.parser.provenance import DecisionOrigin, DecisionReason, DecisionState
 from nf_metro.parser.resolve import (
     _LEADING_SIDE,
     _TRAILING_SIDE,
@@ -88,9 +89,14 @@ def test_horizontal_fold_reverses_the_section(direction: str) -> None:
     """A horizontal section's flow is reversed, leaving its port hints alone."""
     graph, messages = _resolve(direction)
     mid = graph.sections["mid"]
+    decision = graph.layout_provenance.direction_decision("mid")
 
     assert mid.direction == _REVERSED[direction]
-    assert "mid" in graph._fold_reoriented_sections
+    assert decision is not None
+    assert decision.value == _REVERSED[direction]
+    assert decision.origin is DecisionOrigin.INFERRED
+    assert decision.state is DecisionState.INFERRED_THEN_PINNED
+    assert decision.reason is DecisionReason.FLOW_REORIENTED_DIRECTION
     assert mid.entry_hints == [(_TRAILING_SIDE[direction], ["a"])]
     assert mid.exit_hints == [(_LEADING_SIDE[direction], ["a"])]
     assert any("flow re-oriented" in m for m in messages), messages
@@ -108,7 +114,9 @@ def test_vertical_fold_reanchors_the_port(direction: str) -> None:
     mid = graph.sections["mid"]
 
     assert mid.direction == direction
-    assert "mid" not in graph._fold_reoriented_sections
+    assert not graph.layout_provenance.direction_has_reason(
+        "mid", DecisionReason.FLOW_REORIENTED_DIRECTION
+    )
     assert mid.exit_hints == [(_TRAILING_SIDE[direction], ["a"])]
     assert any("re-anchored" in m for m in messages), messages
 


### PR DESCRIPTION
Closes #681

Part of #1653. This is the provenance prerequisite for #1645 and #1436.

## Why

The layout engine used the same `_explicit_*` sets for two different meanings: values authored in the input and inferred values that a later pass must not replace. Resolution could also move an authored port side while the old sets continued to describe the effective side as authored. That made diagnostics unreliable and left no safe basis for candidate layout execution.

## What this changes

- Captures an immutable snapshot of authored grids, directions, port hints, connector-side choices, and fold-threshold inputs before inference or resolver rewrites.
- Records each effective decision with independent origin, lock state, reason, and original authored values.
- Keys entry and exit provenance by semantic connector endpoint, so partially hinted lines sharing a visible port retain distinct histories.
- Migrates layout guards, balancing, section placement, routing offsets, rail mode, rendering diagnostics, `nf-metro info`, and `nf-metro explain` to typed provenance queries.
- Removes `_explicit_grid`, `_explicit_directions`, `_explicit_entry`, `_explicit_exit`, and the related fold bookkeeping as competing authorities.
- Extends deterministic serialization and corpus validation to cover the complete provenance state.

## Behaviour and review

This is an ownership-model refactor. It does not deliberately change selected layout or SVG geometry. Please use the CI render diff as the authoritative visual check.

The main review questions are:

- Does authored intent remain distinct from inferred and inferred-then-pinned decisions?
- Do fold relocation and flow reversal retain the original authored values while reporting the effective values accurately?
- Is the CI render corpus unchanged or otherwise free of detrimental visual changes?

## Verification

- 871 focused parser, layout, explanation, introspection, determinism, and render-plan tests passed; 10 skipped.
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy`
- Configured pre-commit checks, including Prettier

Full matrix CI and the render diff run on this PR.
