### PR TITLE
Keep flow exits on their carrier rows

### DIFF
--- a/docs/dev/layout_pipeline.mdx
+++ b/docs/dev/layout_pipeline.mdx
@@ -189,7 +189,9 @@ fan-out and full-bundle columns around the trunk.
   top-align after the Stage 4.5 expansions.
 - **Stage 4.8**: Align trunk Ys across same-row sections. Shifts
   shallower sections' content down so the inter-section bundle passes
-  through at a single Y per row.
+  through at a single Y per row, then restores carrier-owned exits to
+  their internal row while leaving downstream entries on their consumer
+  row. Any level change therefore happens in the inter-section corridor.
 - **Stages 4.9 to 4.10**: Redistribute fan-out siblings and full-bundle
   columns symmetrically around the trunk. Both gated on `center_ports`.
 

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -670,13 +670,18 @@ in pipeline order.
 ### Stage 4.8: align row trunk Ys
 - **Purpose**: Within each row, shift content downward in shallower
   sections so the inter-section trunk bundle passes through at a
-  single Y. Bbox tops preserved (heights grow downward).
-- **Helper**: `_align_row_trunk_ys` (`phases/row_align.py`).
+  single Y, then seat each eligible flow exit on its internal carrier
+  row so the level change occurs in the inter-section corridor.
+- **Helpers**: `_align_row_trunk_ys` (`phases/row_align.py`), then
+  `_reconcile_flow_exit_carrier_anchors` (`phases/ports.py`).
 - **Precondition**: Stage 4.7 done.
 - **Postcondition**: For sections in a row's contiguous column run,
-  the trunk Y is the row's deepest pre-pass trunk Y. Row-spanning
+  the trunk Y is the row's deepest pre-pass trunk Y. A non-fold LR/RL
+  exit selected by `flow_exit_carrier_anchor` shares its carrier Y;
+  its downstream entry remains on the consumer row. Row-spanning
   sections are skipped.
-- **Invariants preserved**: Bbox tops. Row-spanning sections.
+- **Invariants preserved**: Bbox tops, downstream entry coordinates,
+  perpendicular exits, and row-spanning sections.
 - **Lifecycle:** invariant - the per-row trunk Y is consistent at the
   final boundary (`test_row_trunk_marker_cy_consistent`).
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -265,6 +265,7 @@ from nf_metro.layout.phases.ports import (  # noqa: F401
     _push_ports_from_termini,
     _push_termini_from_port,
     _realign_fold_lr_exit_ports,
+    _reconcile_flow_exit_carrier_anchors,
     _resolve_downstream_entry_y,
     _resolve_tb_exit_y,
     _set_port_x,
@@ -1553,6 +1554,9 @@ def _compute_section_layout(
     # content downward in shallower sections so the inter-section bundle
     # passes through at a single Y per row.  Bbox tops are preserved.
     _align_row_trunk_ys(graph)
+    # Carrier eligibility needs final boundary X coordinates for its corridor
+    # check and final carrier Ys after row-trunk alignment.
+    _reconcile_flow_exit_carrier_anchors(graph)
     _snap(graph, "4.8")
 
     # The trunk anchors (LR/RL port Ys) are now resolved.  The phases below

--- a/src/nf_metro/layout/phases/_common.py
+++ b/src/nf_metro/layout/phases/_common.py
@@ -1851,6 +1851,8 @@ def flow_exit_carrier_anchor(
     exit_port_id: str,
     section: Section,
     junction_ids: set[str],
+    *,
+    divergence_sources: Mapping[str, str] | None = None,
 ) -> tuple[float, list[str]] | None:
     """Carrier row a flow-aligned exit should anchor to, with its carriers.
 
@@ -1876,9 +1878,13 @@ def flow_exit_carrier_anchor(
     section, a merge junction on the far side, or a corridor blocked by another
     station also keep the downstream-aligned placement.
     """
+    port = graph.ports.get(exit_port_id)
+    if port is None or port.side not in (PortSide.LEFT, PortSide.RIGHT):
+        return None
     if _is_fold_section(section) or section.direction not in ("LR", "RL"):
         return None
-    divergence_sources = divergence_junction_sources(graph)
+    if divergence_sources is None:
+        divergence_sources = divergence_junction_sources(graph)
     if not _exit_anchorable_downstream(
         graph,
         exit_port_id,

--- a/src/nf_metro/layout/phases/ports.py
+++ b/src/nf_metro/layout/phases/ports.py
@@ -26,6 +26,7 @@ from nf_metro.layout.phases._common import (
     _lr_exit_aligned_target,
     dominant_value,
     exit_entry_ports_face,
+    flow_axis_exit_ports,
     flow_exit_carrier_anchor,
     iter_fold_lr_exits_short_of_target,
     perp_entry_lands_left,
@@ -38,6 +39,7 @@ from nf_metro.layout.phases.junctions import (
     _resolve_source_section_id,
     _resolve_source_xy,
 )
+from nf_metro.layout.route_topology import divergence_junction_sources
 from nf_metro.parser.model import Edge, MetroGraph, Port, PortSide, Section, Station
 
 
@@ -999,6 +1001,26 @@ def _snap_grid_group_exit_ports(graph: MetroGraph) -> None:
 
         if abs(port_st.y - target_y) >= COORD_TOLERANCE:
             _set_port_y(graph, port_id, target_y)
+
+
+def _reconcile_flow_exit_carrier_anchors(graph: MetroGraph) -> None:
+    """Set each selected flow exit port's Y coordinate to its carrier row."""
+    junction_ids = graph.junction_ids
+    divergence_sources = divergence_junction_sources(graph)
+    for section in graph.sections.values():
+        flow_exits = flow_axis_exit_ports(section, graph)
+        for port_id in section.exit_ports:
+            if port_id not in flow_exits:
+                continue
+            anchor = flow_exit_carrier_anchor(
+                graph,
+                port_id,
+                section,
+                junction_ids,
+                divergence_sources=divergence_sources,
+            )
+            if anchor is not None:
+                _set_port_y(graph, port_id, anchor[0])
 
 
 def _resolve_downstream_entry_y(

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -87,6 +87,7 @@ from nf_metro.layout.phases.bbox import (
     _section_fit_top,
 )
 from nf_metro.layout.phases.guards import (
+    _guard_flow_exit_anchored_to_carrier,
     _guard_port_station_coords_synced,
     _perp_fed_entry_consumer_y,
     _tb_top_entry_drop_overshoot,
@@ -1140,6 +1141,59 @@ def test_flow_exit_port_anchors_to_carrying_station(fixture):
             f"row y={carrier_y:.1f} (carriers {sorted(carrier_ids)}); the "
             f"boundary run will read as a diagonal instead of a clean riser"
         )
+
+
+def test_seed_72_flow_exit_reconciles_to_carrier_without_moving_consumer_entry():
+    """A carrier-anchored exit keeps its downstream entry on the consumer row."""
+    graph = _layout("hash_seed_determinism/seed_72.mmd", center_ports=False)
+
+    exit_port = graph.stations["s7__exit_left_5"]
+    carrier = graph.stations["n7_3"]
+    entry_port = graph.stations["s8__entry_right_13"]
+    consumer = graph.stations["n8_0"]
+
+    assert abs(exit_port.y - carrier.y) <= _Y_TOL
+    assert abs(entry_port.y - consumer.y) <= _Y_TOL
+    assert abs(entry_port.y - carrier.y) > _Y_TOL
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    (
+        "hash_seed_determinism/seed_15.mmd",
+        "hash_seed_determinism/seed_41.mmd",
+        "hash_seed_determinism/seed_72.mmd",
+        "hash_seed_determinism/seed_77.mmd",
+    ),
+)
+def test_hash_seed_flow_exit_carrier_anchors_are_reconciled(fixture):
+    """Every frozen recovery seed honours the shared carrier predicate."""
+    graph = _layout(fixture, center_ports=False)
+    _guard_flow_exit_anchored_to_carrier(graph, "test")
+
+
+def test_perpendicular_exit_is_not_a_flow_carrier_anchor():
+    """A horizontal section's BOTTOM exit is outside this carrier contract."""
+    graph = _layout("topologies/lr_perp_bottom_exit_side_entry.mmd")
+    junction_ids = graph.junction_ids
+    perpendicular_exits = [
+        port_id
+        for section in graph.sections.values()
+        for port_id in section.exit_ports
+        if graph.ports[port_id].side in (PortSide.TOP, PortSide.BOTTOM)
+    ]
+
+    assert perpendicular_exits
+    assert all(
+        flow_exit_carrier_anchor(
+            graph,
+            port_id,
+            graph.sections[graph.ports[port_id].section_id],
+            junction_ids,
+        )
+        is None
+        for port_id in perpendicular_exits
+    )
 
 
 def test_single_line_dual_source_exit_shares_feeder_row():


### PR DESCRIPTION
## Why

A flow-aligned exit could remain on the downstream consumer row even when its internal carrier belongs on another row. The route then climbed diagonally inside the source section instead of changing level in the inter-section corridor.

## What changes

- Reconcile eligible non-fold LR/RL exits after boundary coordinates and row trunk positions are final.
- Move only the exit to the carrier row. The downstream entry stays on its consumer row.
- Use the existing carrier predicate as the single eligibility rule, explicitly excluding perpendicular exits.
- Build semantic divergence data once for the reconciliation pass.
- Extend the Stage 4.8 contract and add regression coverage across the four deterministic seed fixtures.

## Verification

- Focused layout and contract tests: 61 passed, 40 skipped.
- Full carrier-invariant corpus before the final review tightening: 368 passed, 40 skipped.
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy`

Full CI and the CI render preview are required. The expected visual change is a horizontal carrier-to-exit run followed by a riser in the inter-section corridor wherever the shared carrier predicate applies.

Closes #1672