### PR TITLE
Add bounded candidate execution harness

### DIFF
--- a/docs/dev/candidate_execution.mdx
+++ b/docs/dev/candidate_execution.mdx
@@ -1,0 +1,88 @@
+---
+title: "Candidate execution"
+description: How nf-metro evaluates proposed layout commitments in isolated, bounded workers.
+sidebar:
+  order: 6
+---
+
+Candidate execution is an internal safety boundary for layout recovery. It can
+answer, "what would this exact set of layout commitments produce?" It does not
+generate candidates, rank them, choose one, or retry a normal render.
+
+The normal CLI and Python rendering APIs never call the executor.
+
+## What a candidate contains
+
+A candidate is an immutable set of typed commitments. It may pin section grid
+cells, section directions, a fold threshold, exact connector entry or exit
+sides, and line ordering. The request separately records caller-owned layout
+options and pins.
+
+The parser captures authored and caller provenance before it sees a candidate.
+It then validates the complete overlay at one pre-inference boundary. A
+candidate cannot replace an authored or caller-owned value. Duplicate,
+contradictory, malformed, partial, and unknown commitments are rejected before
+layout.
+
+Accepted candidate values are recorded as inferred, locked decisions. After
+layout, the executor checks the effective provenance and settled graph again.
+This catches a commitment that inference accepted but failed to honour.
+
+## One attempt
+
+Every baseline and candidate attempt starts a new Python process using the
+`spawn` start method. The worker runs these stages in order:
+
+1. The shared production preparation cascade parses the source, applies caller
+   options, resolves relative logos, and reserves the title band.
+2. Structured graph validation runs.
+3. Layout runs with stage-boundary validation enabled.
+4. The accepted commitments are checked against the settled graph.
+5. Production routing produces immutable route-system evidence.
+6. Render planning observes the final centred routing invocation used by the
+   plan.
+7. The plan is emitted with the requested theme, mode, baked mode, and SVG
+   configuration.
+8. Plan-aware artifact validation checks label strikes, marker crossings, and
+   collapsed offsets.
+
+The result keeps every completed piece of evidence. For example, an SVG
+emission failure still carries the settled graph, route plan, and RenderPlan.
+Route-plan diagnostics and artifact findings are structured rejection data,
+not text parsed from an exception.
+
+## Warnings
+
+Ordinary parser and adjustment warnings remain ordered diagnostics. Typed
+`LayoutGeometryWarning` warnings reject an attempt because they identify known
+visual damage. `PermissiveGuardWarning` inherits from that category, so a
+permissive render cannot turn a failed engine guard into an accepted candidate.
+Warning messages do not decide policy.
+
+## Limits and cleanup
+
+The coordinator enforces three independent limits: a maximum attempt count, a
+deadline for each worker, and one deadline for the complete request. The
+baseline always runs first. Candidates that cannot start because of a limit
+are returned explicitly as unattempted; they are not reported as timeouts.
+
+Workers send versioned, sequenced frames over a one-way pipe. Large evidence is
+split into small atomic frames, so receiving cannot block indefinitely after
+only part of a message arrives. The parent receives and verifies the complete
+payload before joining a successful worker. It joins before reading the exit
+code, and terminates or kills and reaps every timed-out worker.
+
+The outcome distinguishes accepted execution, validation rejection, engine
+failure, timeout, worker crash, and communication or infrastructure failure.
+It records no elapsed times, process IDs, or temporary paths.
+
+## Determinism
+
+General mapping keys are sorted by their canonical encoded key. Semantic
+tuples and lists keep their order. Sets are sorted by canonical value. Route
+plans use their own canonical serializer. The settled graph, route plan,
+RenderPlan, SVG, findings, diagnostics, and failure details must match across
+fresh interpreters with different `PYTHONHASHSEED` values.
+
+The frozen fuzz sources are determinism inputs only. Their current success or
+failure stage is not part of the executor contract.

--- a/docs/dev/determinism.mdx
+++ b/docs/dev/determinism.mdx
@@ -76,3 +76,8 @@ also available for broader investigations:
 ```bash
 PYTHONPATH=src:tests python tests/hash_seed_oracle.py --check-example-corpus
 ```
+
+Candidate execution has a separate cross-process oracle described in the
+[candidate executor guide](/nf-metro/dev/candidate_execution/). It hashes the
+complete accepted result at several hash seeds, without freezing any
+intermediate layout stage as the expected answer.

--- a/docs/dev/parser.mdx
+++ b/docs/dev/parser.mdx
@@ -147,6 +147,12 @@ applied at the established API override stage, preserving current layout
 behaviour. The snapshot is immutable, so later inference cannot make an
 authored value look inferred or make an inferred value look authored.
 
+The internal
+[candidate executor](/nf-metro/dev/candidate_execution/) applies prospective
+layout commitments through one typed overlay at this boundary. It rejects
+malformed, duplicate, unknown, or conflicting commitments before inference,
+then verifies the settled graph against the same commitments.
+
 Because the appliers receive structured fields, the driver stays a thin
 dispatch: a `_Node` registers a station, an `_Edge` registers one edge
 per line id (declaring any inline-shaped endpoints), a `_Directive` is

--- a/docs/dev/render.md
+++ b/docs/dev/render.md
@@ -20,6 +20,12 @@ which performs both steps and returns an SVG string. Callers that need to reuse
 a plan can call `build_render_plan`, `emit_render_plan`, or
 `emit_render_plan_html` directly.
 
+The internal
+[candidate executor](/nf-metro/dev/candidate_execution/) observes the route
+plan used by the final `RenderPlan`. This matters when render-time geometry
+settling causes a reroute: acceptance evidence must describe the SVG that was
+actually emitted, not an earlier routing pass.
+
 `build_render_plan` makes one deep copy of the graph. Render-specific routing,
 label placement, and section adjustments run on this private copy. This is
 safer than changing the caller's graph and trying to restore it after an error.

--- a/src/nf_metro/api.py
+++ b/src/nf_metro/api.py
@@ -22,6 +22,10 @@ from typing import Literal
 from nf_metro.layout import PhaseInvariantError, compute_layout
 from nf_metro.options import LAYOUT_OPTIONS, is_line_order
 from nf_metro.parser import parse_metro_mermaid
+from nf_metro.parser.commitments import (
+    CommitmentConflictError,
+    LayoutCommitmentOverlay,
+)
 from nf_metro.parser.directives import apply_legend_directive
 from nf_metro.parser.model import LineSpread, MetroGraph, PermissiveGuardWarning
 from nf_metro.render.font_embed import apply_font_portability
@@ -113,6 +117,23 @@ class RenderResult:
     plan: RenderPlan
 
 
+def _emit_svg_plan(graph: MetroGraph, plan: RenderPlan, cfg: RenderConfig) -> str:
+    """Emit one production SVG plan with the complete render configuration."""
+    font_portability: Literal["embed", "paths"] | None = (
+        "paths" if cfg.text_to_paths else "embed" if cfg.embed_font else None
+    )
+    with class_prefix_context(cfg.svg_class_prefix):
+        content = emit_render_plan(
+            plan,
+            animate=graph.animate,
+            responsive=cfg.responsive,
+            inject_dark_mode_css=cfg.inject_dark_mode_css,
+            self_color_scheme=cfg.self_color_scheme,
+            baked_mode=cfg.baked_mode,
+        )
+    return apply_font_portability(content, font_portability)
+
+
 def render_graph_result(
     graph: MetroGraph, theme_obj: Theme, cfg: RenderConfig
 ) -> RenderResult:
@@ -144,16 +165,7 @@ def render_graph_result(
         chrome_css=cfg.chrome_css,
         bare=cfg.bare,
     )
-    with class_prefix_context(cfg.svg_class_prefix):
-        content = emit_render_plan(
-            plan,
-            animate=graph.animate,
-            responsive=cfg.responsive,
-            inject_dark_mode_css=cfg.inject_dark_mode_css,
-            self_color_scheme=cfg.self_color_scheme,
-            baked_mode=cfg.baked_mode,
-        )
-    return RenderResult(apply_font_portability(content, font_portability), plan)
+    return RenderResult(_emit_svg_plan(graph, plan, cfg), plan)
 
 
 def render_graph(graph: MetroGraph, theme_obj: Theme, cfg: RenderConfig) -> str:
@@ -164,6 +176,86 @@ def render_graph(graph: MetroGraph, theme_obj: Theme, cfg: RenderConfig) -> str:
     without re-parsing.
     """
     return render_graph_result(graph, theme_obj, cfg).content
+
+
+def _prepare_graph_state(
+    text: str,
+    *,
+    from_nextflow: bool = False,
+    title: str | None = None,
+    line_spread: str | None = None,
+    logo: str | None = None,
+    legend: str | None = None,
+    layout_options: Mapping[str, object] | None = None,
+    source_dir: str = "",
+    bare: bool = False,
+    output_format: Literal["svg", "html"] = "svg",
+    layout_commitments: LayoutCommitmentOverlay | None = None,
+) -> MetroGraph:
+    """Run the production preparation cascade up to the layout boundary."""
+    opts = dict(layout_options or {})
+    if layout_commitments is not None:
+        for name, committed in (
+            ("fold_threshold", layout_commitments.caller.fold_threshold),
+            ("line_order", layout_commitments.caller.line_order),
+        ):
+            if committed is None:
+                continue
+            supplied = opts.get(name)
+            if supplied is not None and supplied != committed:
+                raise CommitmentConflictError(
+                    f"caller {name!r} values disagree: {supplied!r} and {committed!r}"
+                )
+            opts[name] = committed
+
+    if from_nextflow:
+        from nf_metro.convert import convert_nextflow_dag
+
+        text = convert_nextflow_dag(text, title=title or "")
+
+    fold = opts.get("fold_threshold")
+    auto_process = opts.get("auto_process")
+    process_scope = opts.get("process_scope")
+    caller_line_order = opts.get("line_order")
+    graph = parse_metro_mermaid(
+        text,
+        max_station_columns=fold if isinstance(fold, int) else None,
+        auto_process=auto_process if isinstance(auto_process, bool) else None,
+        process_scope=process_scope if isinstance(process_scope, str) else None,
+        caller_line_order=(
+            caller_line_order if is_line_order(caller_line_order) else None
+        ),
+        _layout_commitments=layout_commitments,
+    )
+
+    apply_layout_overrides(graph, opts)
+
+    if source_dir:
+        graph.source_dir = source_dir
+        for attr in ("logo_path", "logo_path_light", "logo_path_dark"):
+            raw: str = getattr(graph, attr)
+            resolved = resolve_logo_file(raw, source_dir) if raw else ""
+            if resolved:
+                setattr(graph, attr, resolved)
+    if line_spread is not None:
+        graph.line_spread = LineSpread(line_spread)
+    if logo is not None:
+        graph.logo_path = str(logo)
+    if legend is not None:
+        apply_legend_directive(legend, graph)
+    if title is not None:
+        graph.title = title
+
+    for attr in ("logo_path", "logo_path_light", "logo_path_dark"):
+        raw = getattr(graph, attr)
+        if raw and not logo_is_resolvable(raw):
+            raise ValueError(f"%%metro logo: path {raw!r} not found")
+
+    logo_in_legend = logo_certainly_shows(graph) and graph.legend_position != "none"
+    graph.reserve_title_band = output_format == "html" or (
+        not bare and not logo_in_legend
+    )
+    return graph
 
 
 def prepare_graph(
@@ -230,53 +322,17 @@ def prepare_graph(
     cycle, backward flow, or mixed entry directions raise unconditionally:
     those leave no geometry to fall back to.
     """
-    opts = layout_options or {}
-
-    if from_nextflow:
-        from nf_metro.convert import convert_nextflow_dag
-
-        text = convert_nextflow_dag(text, title=title or "")
-
-    fold = opts.get("fold_threshold")
-    auto_process = opts.get("auto_process")
-    process_scope = opts.get("process_scope")
-    caller_line_order = opts.get("line_order")
-    graph = parse_metro_mermaid(
+    graph = _prepare_graph_state(
         text,
-        max_station_columns=fold if isinstance(fold, int) else None,
-        auto_process=auto_process if isinstance(auto_process, bool) else None,
-        process_scope=process_scope if isinstance(process_scope, str) else None,
-        caller_line_order=(
-            caller_line_order if is_line_order(caller_line_order) else None
-        ),
-    )
-
-    apply_layout_overrides(graph, opts)
-
-    if source_dir:
-        graph.source_dir = source_dir
-        for attr in ("logo_path", "logo_path_light", "logo_path_dark"):
-            raw: str = getattr(graph, attr)
-            resolved = resolve_logo_file(raw, source_dir) if raw else ""
-            if resolved:
-                setattr(graph, attr, resolved)
-    if line_spread is not None:
-        graph.line_spread = LineSpread(line_spread)
-    if logo is not None:
-        graph.logo_path = str(logo)
-    if legend is not None:
-        apply_legend_directive(legend, graph)
-    if title is not None:
-        graph.title = title
-
-    for _attr in ("logo_path", "logo_path_light", "logo_path_dark"):
-        _raw: str = getattr(graph, _attr)
-        if _raw and not logo_is_resolvable(_raw):
-            raise ValueError(f"%%metro logo: path {_raw!r} not found")
-
-    logo_in_legend = logo_certainly_shows(graph) and graph.legend_position != "none"
-    graph.reserve_title_band = output_format == "html" or (
-        not bare and not logo_in_legend
+        from_nextflow=from_nextflow,
+        title=title,
+        line_spread=line_spread,
+        logo=logo,
+        legend=legend,
+        layout_options=layout_options,
+        source_dir=source_dir,
+        bare=bare,
+        output_format=output_format,
     )
 
     if graph.permissive:

--- a/src/nf_metro/candidate_executor.py
+++ b/src/nf_metro/candidate_executor.py
@@ -1,0 +1,1551 @@
+"""Bounded, policy-free execution of proposed layout commitments.
+
+This module is intentionally absent from normal rendering entry points. It
+executes a mandatory baseline and caller-supplied candidates from fresh source,
+in fresh spawned workers, and returns evidence without ranking or selecting it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import multiprocessing
+import os
+import struct
+import time
+import warnings
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, fields, is_dataclass, replace
+from enum import Enum
+from multiprocessing.connection import Connection, wait
+from typing import Any, Literal, cast
+
+from nf_metro.api import (
+    RenderConfig,
+    _emit_svg_plan,
+    _prepare_graph_state,
+    resolve_theme,
+)
+from nf_metro.layout import compute_layout
+from nf_metro.layout.route_plan import (
+    EmissionMemberId,
+    RoutePlan,
+    RoutePlanDiagnostic,
+    build_route_plan_query,
+    serialize_route_plan,
+)
+from nf_metro.layout.routing import compute_station_offsets, observe_route_edges
+from nf_metro.options import LAYOUT_OPTIONS, LayoutOption
+from nf_metro.parser import ERROR, validate_graph
+from nf_metro.parser.commitments import (
+    CommitmentConflictError,
+    CommitmentSettlementError,
+    CommitmentValidationError,
+    DirectionCommitment,
+    EndpointCommitment,
+    GridCommitment,
+    LayoutCommitmentOverlay,
+    LayoutCommitments,
+    verify_settled_commitments,
+)
+from nf_metro.parser.model import LayoutGeometryWarning, MetroGraph
+from nf_metro.parser.validate import ValidationIssue
+from nf_metro.render.plan import (
+    FrozenMap,
+    FrozenRecord,
+    RenderPlan,
+    freeze_render_value,
+)
+from nf_metro.render.svg import (
+    build_observed_render_plan,
+)
+from nf_metro.render.validate import RenderFinding, validate_render
+
+__all__ = [
+    "CandidateAttemptResult",
+    "CandidateExecutionRequest",
+    "CandidateExecutionResult",
+    "CandidateDiagnostic",
+    "CandidateEvidence",
+    "CandidateFailure",
+    "CandidateStage",
+    "CandidateStatus",
+    "AttemptKind",
+    "CanonicalEvidence",
+    "DirectionCommitment",
+    "EndpointCommitment",
+    "ExecutionLimits",
+    "GridCommitment",
+    "GraphEvidence",
+    "GraphState",
+    "LayoutCandidate",
+    "LayoutCommitments",
+    "LayoutOptionValue",
+    "LayoutOptionValues",
+    "RenderConfigSnapshot",
+    "RenderFinding",
+    "RoutePlanDiagnostic",
+    "StopReason",
+    "ValidationIssue",
+    "execute_candidates",
+]
+
+LayoutOptionScalar = str | int | float | bool
+_CACHE_FIELDS = {
+    "_station_lines_cache",
+    "_edges_from_cache",
+    "_edges_to_cache",
+    "_junction_ids_cache",
+}
+_PROTOCOL_VERSION = 1
+_MAX_FRAME_BYTES = 508
+_CHUNK_BYTES = _MAX_FRAME_BYTES - 13
+_MAX_RESULT_BYTES = 64 * 1024 * 1024
+_DRAIN_BATCH = 64
+
+
+class AttemptKind(str, Enum):
+    BASELINE = "baseline"
+    CANDIDATE = "candidate"
+
+
+class CandidateStatus(str, Enum):
+    ACCEPTED = "accepted"
+    VALIDATION_REJECTION = "validation-rejection"
+    ENGINE_FAILURE = "engine-failure"
+    TIMEOUT = "timeout"
+    WORKER_CRASH = "worker-crash"
+    INFRASTRUCTURE_FAILURE = "infrastructure-or-communication-failure"
+
+
+class CandidateStage(str, Enum):
+    REQUEST_VALIDATION = "request-validation"
+    PREPARATION = "preparation"
+    GRAPH_VALIDATION = "graph-validation"
+    LAYOUT = "layout"
+    COMMITMENT_VERIFICATION = "commitment-verification"
+    ROUTE_PLAN = "route-plan"
+    ROUTE_VALIDATION = "route-validation"
+    RENDER_PLAN = "render-plan"
+    SVG_EMISSION = "svg-emission"
+    ARTIFACT_VALIDATION = "artifact-validation"
+    COMPLETE = "complete"
+    COMMUNICATION = "communication"
+    COORDINATOR = "coordinator"
+
+
+class GraphState(str, Enum):
+    RESOLVED = "resolved"
+    PARTIAL_LAYOUT = "partial-layout"
+    SETTLED = "settled"
+
+
+class StopReason(str, Enum):
+    COMPLETE = "complete"
+    ATTEMPT_LIMIT = "attempt-limit"
+    TOTAL_DEADLINE = "total-deadline"
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutOptionValue:
+    name: str
+    value: LayoutOptionScalar
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutOptionValues:
+    items: tuple[LayoutOptionValue, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RenderConfigSnapshot:
+    debug: bool = False
+    responsive: bool = False
+    embed_font: bool = False
+    text_to_paths: bool = False
+    svg_class_prefix: str = ""
+    inject_dark_mode_css: bool = True
+    chrome_css: bool = True
+    self_color_scheme: bool = True
+    baked_mode: Literal["light", "dark"] | None = None
+    bare: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionLimits:
+    max_attempts: int = 8
+    per_attempt_timeout: float = 10.0
+    total_deadline: float = 60.0
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutCandidate:
+    id: str
+    commitments: LayoutCommitments = LayoutCommitments()
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateExecutionRequest:
+    source: str
+    source_dir: str = ""
+    from_nextflow: bool = False
+    title: str | None = None
+    line_spread: str | None = None
+    logo: str | None = None
+    legend: str | None = None
+    theme: str | None = None
+    mode: str | None = None
+    layout_options: LayoutOptionValues = LayoutOptionValues()
+    caller_pins: LayoutCommitments = LayoutCommitments()
+    render: RenderConfigSnapshot = RenderConfigSnapshot()
+    candidates: tuple[LayoutCandidate, ...] = ()
+    limits: ExecutionLimits = ExecutionLimits()
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateDiagnostic:
+    stage: CandidateStage
+    category: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalEvidence:
+    content: str
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class GraphEvidence:
+    state: GraphState
+    snapshot: CanonicalEvidence
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateEvidence:
+    graph: GraphEvidence | None = None
+    route_plan: CanonicalEvidence | None = None
+    render_plan: CanonicalEvidence | None = None
+    svg: CanonicalEvidence | None = None
+    graph_findings: tuple[ValidationIssue, ...] = ()
+    route_findings: tuple[RoutePlanDiagnostic, ...] = ()
+    artifact_findings: tuple[RenderFinding, ...] = ()
+    diagnostics: tuple[CandidateDiagnostic, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateFailure:
+    exception_type: str
+    message: str
+    infrastructure_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateAttemptResult:
+    index: int
+    kind: AttemptKind
+    candidate_id: str
+    attempted_commitments: LayoutCommitments
+    status: CandidateStatus
+    stage: CandidateStage
+    failure: CandidateFailure | None
+    evidence: CandidateEvidence
+    worker_exit_code: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateExecutionResult:
+    baseline: CandidateAttemptResult
+    attempts: tuple[CandidateAttemptResult, ...]
+    unattempted: tuple[LayoutCandidate, ...]
+    stop_reason: StopReason
+
+    @property
+    def attempt_count(self) -> int:
+        return 1 + len(self.attempts)
+
+
+class _FaultAction(str, Enum):
+    RAISE = "raise"
+    BLOCK = "block"
+    CRASH = "crash"
+    CLEAN_NO_PAYLOAD = "clean-no-payload"
+    MALFORMED_PAYLOAD = "malformed-payload"
+    PAYLOAD_THEN_CRASH = "payload-then-crash"
+    PAYLOAD_THEN_BLOCK = "payload-then-block"
+
+
+@dataclass(frozen=True, slots=True)
+class _FaultInjection:
+    action: _FaultAction
+    stage: CandidateStage = CandidateStage.PREPARATION
+
+
+class _InjectedWorkerError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class _ProductionInput:
+    source: str
+    source_dir: str
+    from_nextflow: bool
+    title: str | None
+    line_spread: str | None
+    logo: str | None
+    legend: str | None
+    theme: str | None
+    mode: str | None
+    layout_options: tuple[tuple[str, LayoutOptionScalar], ...]
+    caller_pins: LayoutCommitments
+    render: RenderConfigSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class _AttemptInput:
+    production: _ProductionInput
+    index: int
+    kind: AttemptKind
+    candidate_id: str
+    commitments: LayoutCommitments
+
+
+def _qualified_type(value: BaseException | type[BaseException]) -> str:
+    typ = value if isinstance(value, type) else type(value)
+    return f"{typ.__module__}.{typ.__qualname__}"
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode()
+
+
+def _stable_value(value: Any) -> Any:  # noqa: ANN401
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    if isinstance(value, Enum):
+        return {
+            "enum": f"{type(value).__module__}.{type(value).__qualname__}",
+            "member": value.name,
+        }
+    if isinstance(value, FrozenMap):
+        entries = [
+            [_stable_value(key), _stable_value(item)] for key, item in value.entries
+        ]
+        entries.sort(key=lambda item: _canonical_bytes(item[0]))
+        return {"map": entries}
+    if isinstance(value, FrozenRecord):
+        return {"record": value.kind, "values": _stable_value(value.values)}
+    if is_dataclass(value):
+        return {
+            "record": f"{type(value).__module__}.{type(value).__qualname__}",
+            "values": [
+                [field.name, _stable_value(getattr(value, field.name))]
+                for field in fields(value)
+            ],
+        }
+    if isinstance(value, Mapping):
+        entries = [
+            [_stable_value(key), _stable_value(item)] for key, item in value.items()
+        ]
+        entries.sort(key=lambda item: _canonical_bytes(item[0]))
+        return {"map": entries}
+    if isinstance(value, (list, tuple)):
+        return [_stable_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        members = [_stable_value(item) for item in value]
+        members.sort(key=_canonical_bytes)
+        return {"set": members}
+    raise TypeError(f"cannot serialise {type(value).__name__}")
+
+
+def _canonical_json(value: Any) -> str:  # noqa: ANN401
+    return _canonical_bytes(_stable_value(value)).decode()
+
+
+def _canonical_evidence(value: Any) -> CanonicalEvidence:  # noqa: ANN401
+    content = _canonical_json(value)
+    return CanonicalEvidence(content, hashlib.sha256(content.encode()).hexdigest())
+
+
+def _freeze_graph(graph: MetroGraph) -> FrozenRecord:
+    return FrozenRecord(
+        type(graph).__name__,
+        FrozenMap(
+            tuple(
+                (field.name, freeze_render_value(getattr(graph, field.name)))
+                for field in fields(graph)
+                if field.name not in _CACHE_FIELDS
+            )
+        ),
+    )
+
+
+def _graph_evidence(graph: MetroGraph, state: GraphState) -> GraphEvidence:
+    return GraphEvidence(state, _canonical_evidence(_freeze_graph(graph)))
+
+
+def _route_evidence(plan: RoutePlan) -> CanonicalEvidence:
+    content = serialize_route_plan(plan)
+    return CanonicalEvidence(content, hashlib.sha256(content.encode()).hexdigest())
+
+
+def _failure_result(
+    attempt: _AttemptInput,
+    status: CandidateStatus,
+    stage: CandidateStage,
+    exc: BaseException,
+    evidence: CandidateEvidence,
+    *,
+    infrastructure_code: str | None = None,
+) -> CandidateAttemptResult:
+    return CandidateAttemptResult(
+        index=attempt.index,
+        kind=attempt.kind,
+        candidate_id=attempt.candidate_id,
+        attempted_commitments=attempt.commitments,
+        status=status,
+        stage=stage,
+        failure=CandidateFailure(_qualified_type(exc), str(exc), infrastructure_code),
+        evidence=evidence,
+    )
+
+
+def _rejection_result(
+    attempt: _AttemptInput,
+    stage: CandidateStage,
+    message: str,
+    evidence: CandidateEvidence,
+    exception: type[BaseException] = CommitmentValidationError,
+) -> CandidateAttemptResult:
+    return CandidateAttemptResult(
+        index=attempt.index,
+        kind=attempt.kind,
+        candidate_id=attempt.candidate_id,
+        attempted_commitments=attempt.commitments,
+        status=CandidateStatus.VALIDATION_REJECTION,
+        stage=stage,
+        failure=CandidateFailure(_qualified_type(exception), message),
+        evidence=evidence,
+    )
+
+
+def _maybe_fault(fault: _FaultInjection | None, stage: CandidateStage) -> None:
+    if fault is None or fault.stage is not stage:
+        return
+    if fault.action is _FaultAction.RAISE:
+        raise _InjectedWorkerError(f"injected {stage.value} failure")
+    if fault.action is _FaultAction.BLOCK:
+        multiprocessing.Event().wait()
+    if fault.action is _FaultAction.CRASH:
+        os._exit(23)
+
+
+def _evaluate_attempt(
+    attempt: _AttemptInput,
+    fault: _FaultInjection | None = None,
+    announce: Callable[[CandidateStage], None] | None = None,
+) -> CandidateAttemptResult:
+    production = attempt.production
+    graph_evidence: GraphEvidence | None = None
+    route_evidence: CanonicalEvidence | None = None
+    render_evidence: CanonicalEvidence | None = None
+    svg_evidence: CanonicalEvidence | None = None
+    graph_findings: tuple[ValidationIssue, ...] = ()
+    route_findings: tuple[RoutePlanDiagnostic, ...] = ()
+    artifact_findings: tuple[RenderFinding, ...] = ()
+    diagnostics: list[CandidateDiagnostic] = []
+
+    def evidence() -> CandidateEvidence:
+        return CandidateEvidence(
+            graph=graph_evidence,
+            route_plan=route_evidence,
+            render_plan=render_evidence,
+            svg=svg_evidence,
+            graph_findings=graph_findings,
+            route_findings=route_findings,
+            artifact_findings=artifact_findings,
+            diagnostics=tuple(diagnostics),
+        )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warning_cursor = 0
+
+        def begin(stage: CandidateStage) -> None:
+            if announce is not None:
+                announce(stage)
+            _maybe_fault(fault, stage)
+
+        def collect(stage: CandidateStage) -> bool:
+            nonlocal warning_cursor
+            new = caught[warning_cursor:]
+            warning_cursor = len(caught)
+            diagnostics.extend(
+                CandidateDiagnostic(
+                    stage, _qualified_type(item.category), str(item.message)
+                )
+                for item in new
+            )
+            return any(issubclass(item.category, LayoutGeometryWarning) for item in new)
+
+        try:
+            begin(CandidateStage.PREPARATION)
+            graph = _prepare_graph_state(
+                production.source,
+                from_nextflow=production.from_nextflow,
+                title=production.title,
+                line_spread=production.line_spread,
+                logo=production.logo,
+                legend=production.legend,
+                layout_options=dict(production.layout_options),
+                source_dir=production.source_dir,
+                bare=production.render.bare,
+                output_format="svg",
+                layout_commitments=LayoutCommitmentOverlay(
+                    production.caller_pins, attempt.commitments
+                ),
+            )
+            graph.layout_provenance.validate_complete(graph)
+        except (CommitmentValidationError, CommitmentConflictError) as exc:
+            collect(CandidateStage.PREPARATION)
+            return _rejection_result(
+                attempt,
+                CandidateStage.PREPARATION,
+                str(exc),
+                evidence(),
+                type(exc),
+            )
+        except Exception as exc:  # noqa: BLE001
+            collect(CandidateStage.PREPARATION)
+            return _failure_result(
+                attempt,
+                CandidateStatus.ENGINE_FAILURE,
+                CandidateStage.PREPARATION,
+                exc,
+                evidence(),
+            )
+        if collect(CandidateStage.PREPARATION):
+            return _rejection_result(
+                attempt,
+                CandidateStage.PREPARATION,
+                "preparation emitted a typed geometry warning",
+                evidence(),
+            )
+
+        try:
+            begin(CandidateStage.GRAPH_VALIDATION)
+            issues = validate_graph(graph)
+            graph_findings = tuple(issues)
+            graph_evidence = _graph_evidence(graph, GraphState.RESOLVED)
+        except Exception as exc:  # noqa: BLE001
+            collect(CandidateStage.GRAPH_VALIDATION)
+            return _failure_result(
+                attempt,
+                CandidateStatus.ENGINE_FAILURE,
+                CandidateStage.GRAPH_VALIDATION,
+                exc,
+                evidence(),
+            )
+        if collect(CandidateStage.GRAPH_VALIDATION):
+            return _rejection_result(
+                attempt,
+                CandidateStage.GRAPH_VALIDATION,
+                "graph validation emitted a typed geometry warning",
+                evidence(),
+            )
+        if any(item.severity == ERROR for item in issues):
+            return _rejection_result(
+                attempt,
+                CandidateStage.GRAPH_VALIDATION,
+                "graph validation rejected the attempt",
+                evidence(),
+            )
+
+        try:
+            begin(CandidateStage.LAYOUT)
+            compute_layout(graph, validate=True)
+            graph_evidence = _graph_evidence(graph, GraphState.SETTLED)
+        except Exception as exc:  # noqa: BLE001
+            graph_evidence = _graph_evidence(graph, GraphState.PARTIAL_LAYOUT)
+            collect(CandidateStage.LAYOUT)
+            return _failure_result(
+                attempt,
+                CandidateStatus.ENGINE_FAILURE,
+                CandidateStage.LAYOUT,
+                exc,
+                evidence(),
+            )
+        if collect(CandidateStage.LAYOUT):
+            return _rejection_result(
+                attempt,
+                CandidateStage.LAYOUT,
+                "layout emitted a typed geometry warning",
+                evidence(),
+            )
+
+        try:
+            begin(CandidateStage.COMMITMENT_VERIFICATION)
+            verify_settled_commitments(
+                graph,
+                LayoutCommitmentOverlay(production.caller_pins, attempt.commitments),
+            )
+        except CommitmentSettlementError as exc:
+            collect(CandidateStage.COMMITMENT_VERIFICATION)
+            return _rejection_result(
+                attempt,
+                CandidateStage.COMMITMENT_VERIFICATION,
+                str(exc),
+                evidence(),
+                type(exc),
+            )
+        except Exception as exc:  # noqa: BLE001
+            collect(CandidateStage.COMMITMENT_VERIFICATION)
+            return _failure_result(
+                attempt,
+                CandidateStatus.ENGINE_FAILURE,
+                CandidateStage.COMMITMENT_VERIFICATION,
+                exc,
+                evidence(),
+            )
+        if collect(CandidateStage.COMMITMENT_VERIFICATION):
+            return _rejection_result(
+                attempt,
+                CandidateStage.COMMITMENT_VERIFICATION,
+                "commitment verification emitted a typed geometry warning",
+                evidence(),
+            )
+
+        try:
+            begin(CandidateStage.ROUTE_PLAN)
+            offsets = compute_station_offsets(graph)
+            observation = observe_route_edges(graph, station_offsets=offsets)
+            build_route_plan_query(observation.plan)
+            route_evidence = _route_evidence(observation.plan)
+            route_findings = observation.plan.diagnostics
+        except Exception as exc:  # noqa: BLE001
+            collect(CandidateStage.ROUTE_PLAN)
+            return _failure_result(
+                attempt,
+                CandidateStatus.ENGINE_FAILURE,
+                CandidateStage.ROUTE_PLAN,
+                exc,
+                evidence(),
+            )
+        if collect(CandidateStage.ROUTE_PLAN):
+            return _rejection_result(
+                attempt,
+                CandidateStage.ROUTE_PLAN,
+                "routing emitted a typed geometry warning",
+                evidence(),
+            )
+        if route_findings:
+            return _rejection_result(
+                attempt,
+                CandidateStage.ROUTE_VALIDATION,
+                "route-plan validation rejected the attempt",
+                evidence(),
+            )
+
+        try:
+            begin(CandidateStage.RENDER_PLAN)
+            theme = resolve_theme(production.theme, graph, mode=production.mode)
+            observed = build_observed_render_plan(
+                graph,
+                theme,
+                debug=production.render.debug,
+                chrome_css=production.render.chrome_css,
+                bare=production.render.bare,
+            )
+            build_route_plan_query(observed.route_plan)
+            route_evidence = _route_evidence(observed.route_plan)
+            route_findings = observed.route_plan.diagnostics
+            render_evidence = _canonical_evidence(observed.plan)
+        except Exception as exc:  # noqa: BLE001
+            collect(CandidateStage.RENDER_PLAN)
+            return _failure_result(
+                attempt,
+                CandidateStatus.ENGINE_FAILURE,
+                CandidateStage.RENDER_PLAN,
+                exc,
+                evidence(),
+            )
+        if collect(CandidateStage.RENDER_PLAN):
+            return _rejection_result(
+                attempt,
+                CandidateStage.RENDER_PLAN,
+                "render planning emitted a typed geometry warning",
+                evidence(),
+            )
+        if route_findings:
+            return _rejection_result(
+                attempt,
+                CandidateStage.ROUTE_VALIDATION,
+                "final route-plan validation rejected the attempt",
+                evidence(),
+            )
+
+        plan: RenderPlan = observed.plan
+        baked_mode = production.render.baked_mode
+        if baked_mode is None:
+            baked_mode = cast(
+                Literal["light", "dark"] | None,
+                (production.mode or graph.mode).strip() or None,
+            )
+        try:
+            begin(CandidateStage.SVG_EMISSION)
+            svg = _emit_svg_plan(
+                graph,
+                plan,
+                RenderConfig(
+                    debug=production.render.debug,
+                    responsive=production.render.responsive,
+                    embed_font=production.render.embed_font,
+                    text_to_paths=production.render.text_to_paths,
+                    svg_class_prefix=production.render.svg_class_prefix,
+                    inject_dark_mode_css=production.render.inject_dark_mode_css,
+                    chrome_css=production.render.chrome_css,
+                    self_color_scheme=production.render.self_color_scheme,
+                    baked_mode=baked_mode,
+                    bare=production.render.bare,
+                ),
+            )
+            svg_evidence = CanonicalEvidence(
+                svg, hashlib.sha256(svg.encode()).hexdigest()
+            )
+        except Exception as exc:  # noqa: BLE001
+            collect(CandidateStage.SVG_EMISSION)
+            return _failure_result(
+                attempt,
+                CandidateStatus.ENGINE_FAILURE,
+                CandidateStage.SVG_EMISSION,
+                exc,
+                evidence(),
+            )
+        if collect(CandidateStage.SVG_EMISSION):
+            return _rejection_result(
+                attempt,
+                CandidateStage.SVG_EMISSION,
+                "SVG emission produced a typed geometry warning",
+                evidence(),
+            )
+
+        try:
+            begin(CandidateStage.ARTIFACT_VALIDATION)
+            artifact_findings = tuple(validate_render(svg, plan=plan))
+        except Exception as exc:  # noqa: BLE001
+            collect(CandidateStage.ARTIFACT_VALIDATION)
+            return _failure_result(
+                attempt,
+                CandidateStatus.ENGINE_FAILURE,
+                CandidateStage.ARTIFACT_VALIDATION,
+                exc,
+                evidence(),
+            )
+        if collect(CandidateStage.ARTIFACT_VALIDATION):
+            return _rejection_result(
+                attempt,
+                CandidateStage.ARTIFACT_VALIDATION,
+                "artifact validation emitted a typed geometry warning",
+                evidence(),
+            )
+        if artifact_findings:
+            return _rejection_result(
+                attempt,
+                CandidateStage.ARTIFACT_VALIDATION,
+                "rendered-artifact validation rejected the attempt",
+                evidence(),
+            )
+
+    return CandidateAttemptResult(
+        index=attempt.index,
+        kind=attempt.kind,
+        candidate_id=attempt.candidate_id,
+        attempted_commitments=attempt.commitments,
+        status=CandidateStatus.ACCEPTED,
+        stage=CandidateStage.COMPLETE,
+        failure=None,
+        evidence=evidence(),
+    )
+
+
+def _evidence_to_wire(value: CandidateEvidence) -> dict[str, object]:
+    return {
+        "graph": None
+        if value.graph is None
+        else {
+            "state": value.graph.state.value,
+            "snapshot": vars_wire(value.graph.snapshot),
+        },
+        "route_plan": None if value.route_plan is None else vars_wire(value.route_plan),
+        "render_plan": None
+        if value.render_plan is None
+        else vars_wire(value.render_plan),
+        "svg": None if value.svg is None else vars_wire(value.svg),
+        "graph_findings": [vars_wire(item) for item in value.graph_findings],
+        "route_findings": [vars_wire(item) for item in value.route_findings],
+        "artifact_findings": [
+            {
+                "kind": item.kind,
+                "line_id": item.line_id,
+                "station_id": item.station_id,
+                "message": item.message,
+                "segment": [list(point) for point in item.segment],
+            }
+            for item in value.artifact_findings
+        ],
+        "diagnostics": [
+            {
+                "stage": item.stage.value,
+                "category": item.category,
+                "message": item.message,
+            }
+            for item in value.diagnostics
+        ],
+    }
+
+
+def vars_wire(value: Any) -> dict[str, object]:  # noqa: ANN401
+    return {field.name: getattr(value, field.name) for field in fields(value)}
+
+
+def _attempt_to_bytes(value: CandidateAttemptResult) -> bytes:
+    raw = {
+        "index": value.index,
+        "kind": value.kind.value,
+        "candidate_id": value.candidate_id,
+        "status": value.status.value,
+        "stage": value.stage.value,
+        "failure": None if value.failure is None else vars_wire(value.failure),
+        "evidence": _evidence_to_wire(value.evidence),
+    }
+    return _canonical_bytes(raw)
+
+
+def _canonical_from_wire(value: object) -> CanonicalEvidence:
+    raw = _object(value)
+    return CanonicalEvidence(str(raw["content"]), str(raw["sha256"]))
+
+
+def _evidence_from_wire(value: object) -> CandidateEvidence:
+    raw = _object(value)
+    graph_raw = raw["graph"]
+    graph = None
+    if graph_raw is not None:
+        item = _object(graph_raw)
+        graph = GraphEvidence(
+            GraphState(str(item["state"])),
+            _canonical_from_wire(item["snapshot"]),
+        )
+    route = (
+        _canonical_from_wire(raw["route_plan"])
+        if raw["route_plan"] is not None
+        else None
+    )
+    render = (
+        _canonical_from_wire(raw["render_plan"])
+        if raw["render_plan"] is not None
+        else None
+    )
+    svg = None
+    if raw["svg"] is not None:
+        svg = _canonical_from_wire(raw["svg"])
+    graph_findings = tuple(
+        ValidationIssue(
+            str(_object(item)["severity"]),
+            str(_object(item)["message"]),
+            cast(int | None, _object(item)["line"]),
+        )
+        for item in _array(raw["graph_findings"])
+    )
+    route_findings = tuple(
+        RoutePlanDiagnostic(
+            cast(EmissionMemberId | None, _object(item)["member_id"]),
+            str(_object(item)["code"]),
+            str(_object(item)["message"]),
+        )
+        for item in _array(raw["route_findings"])
+    )
+    artifact_findings = tuple(
+        RenderFinding(
+            str(_object(item)["kind"]),
+            str(_object(item)["line_id"]),
+            str(_object(item)["station_id"]),
+            str(_object(item)["message"]),
+            cast(
+                tuple[tuple[float, float], tuple[float, float]],
+                tuple(_point(point) for point in _array(_object(item)["segment"])),
+            ),
+        )
+        for item in _array(raw["artifact_findings"])
+    )
+    diagnostics = tuple(
+        CandidateDiagnostic(
+            CandidateStage(str(_object(item)["stage"])),
+            str(_object(item)["category"]),
+            str(_object(item)["message"]),
+        )
+        for item in _array(raw["diagnostics"])
+    )
+    return CandidateEvidence(
+        graph=graph,
+        route_plan=route,
+        render_plan=render,
+        svg=svg,
+        graph_findings=graph_findings,
+        route_findings=route_findings,
+        artifact_findings=artifact_findings,
+        diagnostics=diagnostics,
+    )
+
+
+def _attempt_from_bytes(value: bytes) -> CandidateAttemptResult:
+    raw = _object(json.loads(value))
+    failure = None
+    if raw["failure"] is not None:
+        item = _object(raw["failure"])
+        failure = CandidateFailure(
+            str(item["exception_type"]),
+            str(item["message"]),
+            cast(str | None, item["infrastructure_code"]),
+        )
+    return CandidateAttemptResult(
+        index=_integer(raw["index"]),
+        kind=AttemptKind(str(raw["kind"])),
+        candidate_id=str(raw["candidate_id"]),
+        attempted_commitments=LayoutCommitments(),
+        status=CandidateStatus(str(raw["status"])),
+        stage=CandidateStage(str(raw["stage"])),
+        failure=failure,
+        evidence=_evidence_from_wire(raw["evidence"]),
+    )
+
+
+def _object(value: object) -> dict[str, object]:
+    if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+        raise ValueError("wire object is malformed")
+    return value
+
+
+def _array(value: object) -> list[object]:
+    if not isinstance(value, list):
+        raise ValueError("wire array is malformed")
+    return value
+
+
+def _point(value: object) -> tuple[float, float]:
+    coordinates = _array(value)
+    if len(coordinates) != 2 or any(
+        not isinstance(coordinate, (int, float)) or isinstance(coordinate, bool)
+        for coordinate in coordinates
+    ):
+        raise ValueError("wire point is malformed")
+    return (
+        float(cast(int | float, coordinates[0])),
+        float(cast(int | float, coordinates[1])),
+    )
+
+
+def _integer(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError("wire integer is malformed")
+    return value
+
+
+def _send_control(
+    connection: Connection, sequence: int, kind: str, **payload: object
+) -> int:
+    frame = _canonical_bytes(
+        {"version": _PROTOCOL_VERSION, "sequence": sequence, "kind": kind, **payload}
+    )
+    if len(frame) > _MAX_FRAME_BYTES:
+        raise ValueError("control frame exceeds atomic protocol limit")
+    connection.send_bytes(frame)
+    return sequence + 1
+
+
+def _send_result(
+    connection: Connection, sequence: int, result: CandidateAttemptResult
+) -> int:
+    payload = _attempt_to_bytes(result)
+    if len(payload) > _MAX_RESULT_BYTES:
+        raise ValueError("candidate result exceeds protocol payload limit")
+    digest = hashlib.sha256(payload).hexdigest()
+    chunks = max(1, math.ceil(len(payload) / _CHUNK_BYTES))
+    sequence = _send_control(
+        connection,
+        sequence,
+        "result-start",
+        length=len(payload),
+        sha256=digest,
+        chunks=chunks,
+    )
+    for index in range(chunks):
+        chunk = payload[index * _CHUNK_BYTES : (index + 1) * _CHUNK_BYTES]
+        frame = b"D" + struct.pack(">QI", sequence, index) + chunk
+        if len(frame) > _MAX_FRAME_BYTES:
+            raise ValueError("data frame exceeds atomic protocol limit")
+        connection.send_bytes(frame)
+        sequence += 1
+    return _send_control(connection, sequence, "result-end")
+
+
+def _worker_entry(
+    connection: Connection,
+    attempt: _AttemptInput,
+    fault: _FaultInjection | None,
+) -> None:
+    sequence = 0
+    try:
+        if fault is not None and fault.action is _FaultAction.CLEAN_NO_PAYLOAD:
+            return
+        if fault is not None and fault.action is _FaultAction.MALFORMED_PAYLOAD:
+            connection.send_bytes(b"not-json")
+            return
+
+        def announce(stage: CandidateStage) -> None:
+            nonlocal sequence
+            sequence = _send_control(connection, sequence, "stage", stage=stage.value)
+
+        result = _evaluate_attempt(attempt, fault, announce)
+        sequence = _send_result(connection, sequence, result)
+        if fault is not None and fault.action is _FaultAction.PAYLOAD_THEN_CRASH:
+            os._exit(24)
+        if fault is not None and fault.action is _FaultAction.PAYLOAD_THEN_BLOCK:
+            multiprocessing.Event().wait()
+    finally:
+        connection.close()
+
+
+@dataclass(slots=True)
+class _ProtocolAssembler:
+    sequence: int = 0
+    stage: CandidateStage = CandidateStage.COORDINATOR
+    expected_length: int | None = None
+    expected_digest: str | None = None
+    expected_chunks: int | None = None
+    chunks: list[bytes] | None = None
+    received_length: int = 0
+    result: CandidateAttemptResult | None = None
+
+    def feed(self, frame: bytes) -> None:
+        if self.result is not None:
+            raise ValueError("protocol frame arrived after the completed result")
+        if frame.startswith(b"D"):
+            if len(frame) < 13 or self.chunks is None:
+                raise ValueError("unexpected protocol data frame")
+            sequence, index = struct.unpack(">QI", frame[1:13])
+            self._accept_sequence(sequence)
+            if index != len(self.chunks):
+                raise ValueError("out-of-order protocol chunk")
+            chunk = frame[13:]
+            assert self.expected_length is not None
+            expected_size = min(
+                _CHUNK_BYTES,
+                max(0, self.expected_length - index * _CHUNK_BYTES),
+            )
+            if len(chunk) != expected_size:
+                raise ValueError("protocol chunk length mismatch")
+            self.received_length += len(chunk)
+            if self.received_length > _MAX_RESULT_BYTES:
+                raise ValueError("protocol payload exceeds hard limit")
+            self.chunks.append(chunk)
+            return
+
+        raw = _object(json.loads(frame))
+        if raw.get("version") != _PROTOCOL_VERSION:
+            raise ValueError("unsupported protocol version")
+        sequence = raw.get("sequence")
+        if not isinstance(sequence, int) or isinstance(sequence, bool):
+            raise ValueError("protocol sequence is malformed")
+        self._accept_sequence(sequence)
+        kind = raw.get("kind")
+        if kind == "stage":
+            if self.expected_length is not None:
+                raise ValueError("stage frame interrupted a result payload")
+            self.stage = CandidateStage(str(raw["stage"]))
+            return
+        if kind == "result-start":
+            length = raw.get("length")
+            chunks = raw.get("chunks")
+            digest = raw.get("sha256")
+            if (
+                not isinstance(length, int)
+                or isinstance(length, bool)
+                or length < 0
+                or length > _MAX_RESULT_BYTES
+                or not isinstance(chunks, int)
+                or isinstance(chunks, bool)
+                or not isinstance(digest, str)
+                or len(digest) != 64
+                or any(character not in "0123456789abcdef" for character in digest)
+            ):
+                raise ValueError("result header is malformed")
+            exact_chunks = max(1, math.ceil(length / _CHUNK_BYTES))
+            if chunks != exact_chunks or self.expected_length is not None:
+                raise ValueError("result header has an invalid chunk count or state")
+            self.expected_length = length
+            self.expected_chunks = chunks
+            self.expected_digest = digest
+            self.chunks = []
+            self.received_length = 0
+            return
+        if kind == "result-end":
+            if (
+                self.chunks is None
+                or self.expected_length is None
+                or self.expected_chunks is None
+                or self.expected_digest is None
+                or len(self.chunks) != self.expected_chunks
+                or self.received_length != self.expected_length
+            ):
+                raise ValueError("result ended before every chunk arrived")
+            payload = b"".join(self.chunks)
+            if len(payload) != self.expected_length:
+                raise ValueError("result payload length mismatch")
+            if hashlib.sha256(payload).hexdigest() != self.expected_digest:
+                raise ValueError("result payload digest mismatch")
+            self.result = _attempt_from_bytes(payload)
+            return
+        raise ValueError(f"unknown protocol frame {kind!r}")
+
+    def _accept_sequence(self, sequence: int) -> None:
+        if sequence != self.sequence:
+            raise ValueError("protocol sequence gap")
+        self.sequence += 1
+
+
+def _infrastructure_result(
+    attempt: _AttemptInput,
+    stage: CandidateStage,
+    code: str,
+    message: str,
+    *,
+    exit_code: int | None = None,
+    evidence: CandidateEvidence = CandidateEvidence(),
+) -> CandidateAttemptResult:
+    return CandidateAttemptResult(
+        index=attempt.index,
+        kind=attempt.kind,
+        candidate_id=attempt.candidate_id,
+        attempted_commitments=attempt.commitments,
+        status=CandidateStatus.INFRASTRUCTURE_FAILURE,
+        stage=stage,
+        failure=CandidateFailure("worker.infrastructure", message, code),
+        evidence=evidence,
+        worker_exit_code=exit_code,
+    )
+
+
+def _bounded_reap(process: multiprocessing.Process, terminate: bool) -> int | None:
+    if process.pid is None:
+        try:
+            process.close()
+        except ValueError:
+            pass
+        return None
+    if terminate and process.is_alive():
+        process.terminate()
+    if process.pid is not None:
+        process.join(0.2)
+        if process.is_alive():
+            process.kill()
+            process.join(0.2)
+    exit_code = process.exitcode
+    try:
+        process.close()
+    except ValueError:
+        pass
+    return exit_code
+
+
+def _timeout_result(
+    attempt: _AttemptInput,
+    stage: CandidateStage,
+    message: str,
+    exit_code: int | None,
+    completed: CandidateAttemptResult | None,
+) -> CandidateAttemptResult:
+    evidence = completed.evidence if completed is not None else CandidateEvidence()
+    return CandidateAttemptResult(
+        index=attempt.index,
+        kind=attempt.kind,
+        candidate_id=attempt.candidate_id,
+        attempted_commitments=attempt.commitments,
+        status=CandidateStatus.TIMEOUT,
+        stage=stage,
+        failure=CandidateFailure(_qualified_type(TimeoutError), message),
+        evidence=evidence,
+        worker_exit_code=exit_code,
+    )
+
+
+def _crash_result(
+    attempt: _AttemptInput,
+    stage: CandidateStage,
+    exit_code: int,
+    completed: CandidateAttemptResult | None,
+) -> CandidateAttemptResult:
+    return CandidateAttemptResult(
+        index=attempt.index,
+        kind=attempt.kind,
+        candidate_id=attempt.candidate_id,
+        attempted_commitments=attempt.commitments,
+        status=CandidateStatus.WORKER_CRASH,
+        stage=stage,
+        failure=CandidateFailure(
+            "worker.nonzero-exit",
+            f"worker exited with status {exit_code}",
+            "nonzero-exit",
+        ),
+        evidence=(completed.evidence if completed is not None else CandidateEvidence()),
+        worker_exit_code=exit_code,
+    )
+
+
+def _run_one(
+    context: Any,  # noqa: ANN401
+    attempt: _AttemptInput,
+    attempt_deadline: float,
+    total_deadline: float,
+    fault: _FaultInjection | None,
+) -> CandidateAttemptResult:
+    receiver: Connection | None = None
+    sender: Connection | None = None
+    process: multiprocessing.Process | None = None
+    reaped = False
+    assembler = _ProtocolAssembler()
+    completed: CandidateAttemptResult | None = None
+
+    def reap(terminate: bool) -> int | None:
+        nonlocal reaped
+        if process is None:
+            return None
+        try:
+            return _bounded_reap(process, terminate)
+        finally:
+            reaped = True
+
+    try:
+        try:
+            receiver, sender = context.Pipe(duplex=False)
+            process = context.Process(
+                target=_worker_entry,
+                args=(sender, attempt, fault),
+            )
+            process.start()
+            sender.close()
+            sentinel = process.sentinel
+        except BaseException as exc:  # noqa: BLE001
+            exit_code = reap(terminate=True)
+            return _infrastructure_result(
+                attempt,
+                CandidateStage.COORDINATOR,
+                "spawn-failure",
+                f"{_qualified_type(exc)}: {exc}",
+                exit_code=exit_code,
+            )
+
+        while True:
+            deadline = min(attempt_deadline, total_deadline)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                exit_code = reap(terminate=True)
+                message = (
+                    "total request deadline exceeded"
+                    if total_deadline <= attempt_deadline
+                    else "per-attempt deadline exceeded"
+                )
+                return _timeout_result(
+                    attempt, assembler.stage, message, exit_code, completed
+                )
+
+            ready = wait((receiver, sentinel), timeout=remaining)
+            if not ready:
+                continue
+            pipe_eof = False
+            if receiver in ready:
+                for _ in range(_DRAIN_BATCH):
+                    if time.monotonic() >= deadline or not receiver.poll(0):
+                        break
+                    try:
+                        frame = receiver.recv_bytes(_MAX_FRAME_BYTES)
+                        assembler.feed(frame)
+                        completed = assembler.result
+                    except EOFError:
+                        pipe_eof = True
+                        break
+                    except Exception as exc:  # noqa: BLE001
+                        exit_code = reap(terminate=True)
+                        return _infrastructure_result(
+                            attempt,
+                            CandidateStage.COMMUNICATION,
+                            "invalid-payload",
+                            f"{_qualified_type(exc)}: {exc}",
+                            exit_code=exit_code,
+                            evidence=(
+                                completed.evidence
+                                if completed is not None
+                                else CandidateEvidence()
+                            ),
+                        )
+            if sentinel not in ready:
+                continue
+            if not pipe_eof and receiver.poll(0):
+                continue
+            process.join(min(0.05, remaining))
+            exit_code = process.exitcode
+            if exit_code is None:
+                continue
+            process.close()
+            reaped = True
+            if exit_code != 0:
+                return _crash_result(attempt, assembler.stage, exit_code, completed)
+            if completed is None:
+                return _infrastructure_result(
+                    attempt,
+                    CandidateStage.COMMUNICATION,
+                    "no-payload",
+                    "worker exited cleanly without a complete payload",
+                    exit_code=exit_code,
+                )
+            return replace(
+                completed,
+                index=attempt.index,
+                kind=attempt.kind,
+                candidate_id=attempt.candidate_id,
+                attempted_commitments=attempt.commitments,
+                worker_exit_code=exit_code,
+            )
+    except Exception as exc:  # noqa: BLE001
+        exit_code = reap(terminate=True)
+        return _infrastructure_result(
+            attempt,
+            CandidateStage.COORDINATOR,
+            "coordinator-failure",
+            f"{_qualified_type(exc)}: {exc}",
+            exit_code=exit_code,
+            evidence=(
+                completed.evidence if completed is not None else CandidateEvidence()
+            ),
+        )
+    finally:
+        if receiver is not None:
+            receiver.close()
+        if sender is not None and not sender.closed:
+            sender.close()
+        if process is not None and not reaped:
+            reap(terminate=True)
+
+
+def _validate_option_value(option: LayoutOption, value: object) -> bool:
+    if option.kind == "bool":
+        return isinstance(value, bool)
+    if option.kind == "int":
+        valid = isinstance(value, int) and not isinstance(value, bool)
+    elif option.kind == "float":
+        valid = (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(float(value))
+        )
+    elif option.kind == "choice":
+        return isinstance(value, str) and value in option.choices
+    else:
+        return isinstance(value, str)
+    if not valid:
+        return False
+    number = float(cast(int | float, value))
+    if option.sign == "positive" and number <= 0:
+        return False
+    if option.sign == "nonneg" and number < 0:
+        return False
+    return option.max_val is None or number <= option.max_val
+
+
+def _layout_options(
+    values: LayoutOptionValues,
+) -> tuple[tuple[str, LayoutOptionScalar], ...]:
+    if not isinstance(values.items, tuple):
+        raise ValueError("layout option values must be an immutable tuple")
+    registry = {option.name: option for option in LAYOUT_OPTIONS}
+    seen: set[str] = set()
+    result: list[tuple[str, LayoutOptionScalar]] = []
+    for item in values.items:
+        if not isinstance(item, LayoutOptionValue) or not isinstance(item.name, str):
+            raise ValueError("layout option record is malformed")
+        if item.name in seen:
+            raise ValueError(f"duplicate caller layout option {item.name!r}")
+        seen.add(item.name)
+        option = registry.get(item.name)
+        if option is None:
+            raise ValueError(f"unknown caller layout option {item.name!r}")
+        if not _validate_option_value(option, item.value):
+            raise ValueError(
+                f"invalid caller layout option {item.name!r}: {item.value!r}"
+            )
+        result.append((item.name, item.value))
+    return tuple(result)
+
+
+def _validate_request(
+    request: CandidateExecutionRequest,
+) -> tuple[tuple[str, LayoutOptionScalar], ...]:
+    if not isinstance(request, CandidateExecutionRequest):
+        raise ValueError("candidate execution request is malformed")
+    if not isinstance(request.source, str) or not isinstance(request.source_dir, str):
+        raise ValueError("candidate source and source directory must be strings")
+    if not isinstance(request.from_nextflow, bool):
+        raise ValueError("from_nextflow must be a boolean")
+    for name, value in (
+        ("title", request.title),
+        ("line_spread", request.line_spread),
+        ("logo", request.logo),
+        ("legend", request.legend),
+        ("theme", request.theme),
+        ("mode", request.mode),
+    ):
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"{name} must be a string or None")
+    if not isinstance(request.layout_options, LayoutOptionValues):
+        raise ValueError("layout options are malformed")
+    if not isinstance(request.caller_pins, LayoutCommitments):
+        raise ValueError("caller commitments are malformed")
+    if not isinstance(request.render, RenderConfigSnapshot):
+        raise ValueError("render configuration is malformed")
+    for name in (
+        "debug",
+        "responsive",
+        "embed_font",
+        "text_to_paths",
+        "inject_dark_mode_css",
+        "chrome_css",
+        "self_color_scheme",
+        "bare",
+    ):
+        if not isinstance(getattr(request.render, name), bool):
+            raise ValueError(f"render {name} must be a boolean")
+    if not isinstance(request.render.svg_class_prefix, str):
+        raise ValueError("render svg_class_prefix must be a string")
+    if request.render.baked_mode not in (None, "light", "dark"):
+        raise ValueError("render baked_mode must be light, dark, or None")
+    if not isinstance(request.candidates, tuple):
+        raise ValueError("candidates must be an immutable tuple")
+    if not isinstance(request.limits, ExecutionLimits):
+        raise ValueError("execution limits are malformed")
+    limits = request.limits
+    if (
+        not isinstance(limits.max_attempts, int)
+        or isinstance(limits.max_attempts, bool)
+        or limits.max_attempts < 1
+    ):
+        raise ValueError("max_attempts must include the mandatory baseline")
+    for label, timeout_value in (
+        ("per_attempt_timeout", limits.per_attempt_timeout),
+        ("total_deadline", limits.total_deadline),
+    ):
+        if not isinstance(timeout_value, (int, float)) or isinstance(
+            timeout_value, bool
+        ):
+            raise ValueError(f"{label} must be a finite positive number")
+        if not math.isfinite(float(timeout_value)) or timeout_value <= 0:
+            raise ValueError(f"{label} must be a finite positive number")
+    ids: set[str] = set()
+    for candidate in request.candidates:
+        if not isinstance(candidate, LayoutCandidate):
+            raise ValueError("candidate record is malformed")
+        if not isinstance(candidate.id, str) or not candidate.id:
+            raise ValueError("candidate ids must be non-empty")
+        if not isinstance(candidate.commitments, LayoutCommitments):
+            raise ValueError(f"candidate {candidate.id!r} commitments are malformed")
+        if candidate.id in ids:
+            raise ValueError(f"duplicate candidate id {candidate.id!r}")
+        ids.add(candidate.id)
+    return _layout_options(request.layout_options)
+
+
+def _production_input(
+    request: CandidateExecutionRequest,
+    layout_options: tuple[tuple[str, LayoutOptionScalar], ...],
+) -> _ProductionInput:
+    return _ProductionInput(
+        source=request.source,
+        source_dir=request.source_dir,
+        from_nextflow=request.from_nextflow,
+        title=request.title,
+        line_spread=request.line_spread,
+        logo=request.logo,
+        legend=request.legend,
+        theme=request.theme,
+        mode=request.mode,
+        layout_options=layout_options,
+        caller_pins=request.caller_pins,
+        render=request.render,
+    )
+
+
+def _attempt_input(
+    production: _ProductionInput,
+    index: int,
+    candidate: LayoutCandidate | None,
+) -> _AttemptInput:
+    return _AttemptInput(
+        production=production,
+        index=index,
+        kind=AttemptKind.BASELINE if candidate is None else AttemptKind.CANDIDATE,
+        candidate_id="" if candidate is None else candidate.id,
+        commitments=LayoutCommitments() if candidate is None else candidate.commitments,
+    )
+
+
+def execute_candidates(
+    request: CandidateExecutionRequest,
+    *,
+    _fault: _FaultInjection | None = None,
+) -> CandidateExecutionResult:
+    """Execute baseline first, then bounded candidates without selecting one."""
+    layout_options = _validate_request(request)
+    production = _production_input(request, layout_options)
+    context = multiprocessing.get_context("spawn")
+    started = time.monotonic()
+    total_deadline = started + request.limits.total_deadline
+    candidates = request.candidates[: max(0, request.limits.max_attempts - 1)]
+    limit_unattempted = request.candidates[len(candidates) :]
+
+    def run(index: int, candidate: LayoutCandidate | None) -> CandidateAttemptResult:
+        attempt = _attempt_input(production, index, candidate)
+        return _run_one(
+            context,
+            attempt,
+            time.monotonic() + request.limits.per_attempt_timeout,
+            total_deadline,
+            _fault,
+        )
+
+    baseline = run(0, None)
+    attempts: list[CandidateAttemptResult] = []
+    deadline_unattempted: tuple[LayoutCandidate, ...] = ()
+    for offset, candidate in enumerate(candidates, start=1):
+        if time.monotonic() >= total_deadline:
+            deadline_unattempted = candidates[offset - 1 :]
+            break
+        attempts.append(run(offset, candidate))
+
+    if deadline_unattempted:
+        stop_reason = StopReason.TOTAL_DEADLINE
+    elif limit_unattempted:
+        stop_reason = StopReason.ATTEMPT_LIMIT
+    else:
+        stop_reason = StopReason.COMPLETE
+    return CandidateExecutionResult(
+        baseline=baseline,
+        attempts=tuple(attempts),
+        unattempted=tuple(deadline_unattempted) + tuple(limit_unattempted),
+        stop_reason=stop_reason,
+    )

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -321,7 +321,13 @@ from nf_metro.layout.phases.spacing import (  # noqa: F401
     _struck_stations_and_collinear,
 )
 from nf_metro.layout.routing.context import is_far_side_around_below_left_entry
-from nf_metro.parser.model import LineSpread, MetroGraph, Section, is_bypass_v
+from nf_metro.parser.model import (
+    LayoutGeometryWarning,
+    LineSpread,
+    MetroGraph,
+    Section,
+    is_bypass_v,
+)
 from nf_metro.parser.validate import (
     CyclicGraphError,
     find_cycle,
@@ -638,7 +644,7 @@ def _compute_layout_scaled(
                 f"({min_required:.1f}) this graph's content requires; "
                 f"labels and captioned file-icons may collide. "
                 f"Omit --y-spacing to let the engine pick a safe value.",
-                UserWarning,
+                LayoutGeometryWarning,
                 stacklevel=2,
             )
     if x_spacing is None:

--- a/src/nf_metro/layout/routing/__init__.py
+++ b/src/nf_metro/layout/routing/__init__.py
@@ -18,6 +18,7 @@ from nf_metro.layout.routing.common import (
 )
 from nf_metro.layout.routing.core import (
     observe_route_edges,
+    observe_route_edges_centred,
     route_edges,
     route_edges_centred,
 )
@@ -32,4 +33,5 @@ __all__ = [
     "route_edges",
     "route_edges_centred",
     "observe_route_edges",
+    "observe_route_edges_centred",
 ]

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -402,3 +402,25 @@ def route_edges_centred(
     for sid, x in moves.items():
         graph.stations[sid].x = x
     return routes
+
+
+def observe_route_edges_centred(
+    graph: MetroGraph,
+    diagonal_run: float = DIAGONAL_RUN,
+    curve_radius: float = CURVE_RADIUS,
+    station_offsets: dict[tuple[str, str], float] | None = None,
+) -> RouteObservation:
+    """Route drawn geometry and return its context-local semantic observation."""
+    from nf_metro.layout.route_plan import RouteObservation
+
+    routes, moves, plan = _route_edges(
+        graph,
+        diagonal_run,
+        curve_radius,
+        station_offsets,
+        observe_plan=True,
+    )
+    for sid, x in moves.items():
+        graph.stations[sid].x = x
+    assert plan is not None
+    return RouteObservation(routes, plan)

--- a/src/nf_metro/layout/routing/core.py
+++ b/src/nf_metro/layout/routing/core.py
@@ -373,6 +373,11 @@ def observe_route_edges(
     return RouteObservation(routes, plan)
 
 
+def _settle_station_moves(graph: MetroGraph, moves: dict[str, float]) -> None:
+    for sid, x in moves.items():
+        graph.stations[sid].x = x
+
+
 def route_edges_centred(
     graph: MetroGraph,
     diagonal_run: float = DIAGONAL_RUN,
@@ -399,8 +404,7 @@ def route_edges_centred(
         station_offsets,
         observe_plan=False,
     )
-    for sid, x in moves.items():
-        graph.stations[sid].x = x
+    _settle_station_moves(graph, moves)
     return routes
 
 
@@ -420,7 +424,6 @@ def observe_route_edges_centred(
         station_offsets,
         observe_plan=True,
     )
-    for sid, x in moves.items():
-        graph.stations[sid].x = x
+    _settle_station_moves(graph, moves)
     assert plan is not None
     return RouteObservation(routes, plan)

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -85,6 +85,7 @@ from nf_metro.layout.routing.common import (
 from nf_metro.layout.routing.context import partial_flat_continuation_lines
 from nf_metro.parser.model import (
     Edge,
+    LayoutGeometryWarning,
     MetroGraph,
     PermissiveGuardWarning,
     PortSide,
@@ -5409,6 +5410,7 @@ def assert_render_curve_invariants(
             f"bridged across grid columns; routing draws a best-effort lead-in "
             f"and the bundle geometry through the drop may be imperfect. "
             f"{FLOW_ALIGNED_PORT_ADVICE}\n  {detail}",
+            category=LayoutGeometryWarning,
             stacklevel=2,
         )
         return

--- a/src/nf_metro/parser/commitments.py
+++ b/src/nf_metro/parser/commitments.py
@@ -1,0 +1,554 @@
+"""Typed pre-inference layout commitments for isolated candidate execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypeGuard
+
+from nf_metro.options import LineOrder, is_line_order
+from nf_metro.parser.model import FLOW_DIRECTIONS, MetroGraph, PortSide
+from nf_metro.parser.provenance import (
+    ConnectorEndpointKey,
+    ConnectorEndpointRole,
+    DecisionOrigin,
+    DecisionReason,
+    EndpointSideSelection,
+    FoldThresholdSource,
+    GridCell,
+    LineOrderSource,
+)
+from nf_metro.parser.route_topology import AuthoredRouteCapture, ConnectorId
+
+FlowDirection = Literal["LR", "RL", "TB", "BT"]
+
+
+def is_flow_direction(value: object) -> TypeGuard[FlowDirection]:
+    return isinstance(value, str) and value in FLOW_DIRECTIONS
+
+
+@dataclass(frozen=True, slots=True)
+class GridCommitment:
+    section_id: str
+    cell: GridCell
+
+
+@dataclass(frozen=True, slots=True)
+class DirectionCommitment:
+    section_id: str
+    direction: FlowDirection
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointCommitment:
+    connector_id: ConnectorId
+    role: ConnectorEndpointRole
+    side: PortSide
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutCommitments:
+    grids: tuple[GridCommitment, ...] = ()
+    fold_threshold: int | None = None
+    directions: tuple[DirectionCommitment, ...] = ()
+    endpoints: tuple[EndpointCommitment, ...] = ()
+    line_order: LineOrder | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutCommitmentOverlay:
+    """Caller pins plus one candidate proposal, applied as one transaction."""
+
+    caller: LayoutCommitments = LayoutCommitments()
+    candidate: LayoutCommitments = LayoutCommitments()
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointCommitmentSelection:
+    endpoint: ConnectorEndpointKey
+    selection: EndpointSideSelection
+
+
+@dataclass(frozen=True, slots=True)
+class AppliedLayoutCommitments:
+    """Resolver input that cannot mutate or broaden the submitted overlay."""
+
+    endpoints: tuple[EndpointCommitmentSelection, ...] = ()
+
+    def selection_for(
+        self,
+        connector_ids: tuple[ConnectorId, ...],
+        role: ConnectorEndpointRole,
+        index: dict[ConnectorEndpointKey, EndpointSideSelection] | None = None,
+    ) -> EndpointSideSelection | None:
+        if index is None:
+            index = {item.endpoint: item.selection for item in self.endpoints}
+        selections = tuple(
+            index[ConnectorEndpointKey(connector_id, role)]
+            for connector_id in connector_ids
+            if ConnectorEndpointKey(connector_id, role) in index
+        )
+        if not selections:
+            return None
+        sides = {item.side for item in selections}
+        if len(sides) != 1:
+            raise CommitmentConflictError(
+                f"{role.value} commitments disagree for one resolved connector group"
+            )
+        if len(selections) != len(connector_ids):
+            raise CommitmentConflictError(
+                f"{role.value} commitment covers only part of one resolved "
+                "connector group"
+            )
+        origins = {item.origin for item in selections}
+        reasons = {item.reason for item in selections}
+        if len(origins) != 1 or len(reasons) != 1:
+            raise CommitmentConflictError(
+                f"{role.value} commitments mix caller and candidate ownership"
+            )
+        return selections[0]
+
+
+class CommitmentValidationError(ValueError):
+    """A commitment record is malformed, duplicated, or names no target."""
+
+
+class CommitmentConflictError(ValueError):
+    """A candidate attempts to replace author or caller-owned layout input."""
+
+
+class CommitmentSettlementError(ValueError):
+    """Inference or resolution did not preserve an accepted commitment."""
+
+
+def _validate_grid_cell(cell: object) -> TypeGuard[GridCell]:
+    return (
+        isinstance(cell, tuple)
+        and len(cell) == 4
+        and all(isinstance(item, int) and not isinstance(item, bool) for item in cell)
+        and cell[0] >= 0
+        and cell[1] >= 0
+        and cell[2] >= 1
+        and cell[3] >= 1
+    )
+
+
+def _validate_commitments(
+    label: str,
+    commitments: LayoutCommitments,
+    section_ids: set[str],
+    connector_ids: set[ConnectorId],
+) -> None:
+    if not isinstance(commitments, LayoutCommitments):
+        raise CommitmentValidationError(f"{label} commitments are malformed")
+    for field_name in ("grids", "directions", "endpoints"):
+        if not isinstance(getattr(commitments, field_name), tuple):
+            raise CommitmentValidationError(
+                f"{label} {field_name} commitments must be an immutable tuple"
+            )
+
+    seen_grids: set[str] = set()
+    for grid_commitment in commitments.grids:
+        if not isinstance(grid_commitment, GridCommitment):
+            raise CommitmentValidationError(f"{label} grid record is malformed")
+        if (
+            not isinstance(grid_commitment.section_id, str)
+            or not grid_commitment.section_id
+            or grid_commitment.section_id not in section_ids
+        ):
+            raise CommitmentValidationError(
+                f"{label} grid names unknown section {grid_commitment.section_id!r}"
+            )
+        if grid_commitment.section_id in seen_grids:
+            raise CommitmentValidationError(
+                f"{label} repeats grid commitment for {grid_commitment.section_id!r}"
+            )
+        seen_grids.add(grid_commitment.section_id)
+        if not _validate_grid_cell(grid_commitment.cell):
+            raise CommitmentValidationError(
+                f"{label} grid for {grid_commitment.section_id!r} must be "
+                "(nonnegative col, nonnegative row, positive rowspan, "
+                "positive colspan)"
+            )
+
+    seen_directions: set[str] = set()
+    for direction_commitment in commitments.directions:
+        if not isinstance(direction_commitment, DirectionCommitment):
+            raise CommitmentValidationError(f"{label} direction record is malformed")
+        if (
+            not isinstance(direction_commitment.section_id, str)
+            or not direction_commitment.section_id
+            or direction_commitment.section_id not in section_ids
+        ):
+            raise CommitmentValidationError(
+                f"{label} direction names unknown section "
+                f"{direction_commitment.section_id!r}"
+            )
+        if direction_commitment.section_id in seen_directions:
+            raise CommitmentValidationError(
+                f"{label} repeats direction commitment for "
+                f"{direction_commitment.section_id!r}"
+            )
+        seen_directions.add(direction_commitment.section_id)
+        if not is_flow_direction(direction_commitment.direction):
+            raise CommitmentValidationError(
+                f"{label} direction for {direction_commitment.section_id!r} "
+                "must be LR/RL/TB/BT"
+            )
+
+    seen_endpoints: set[ConnectorEndpointKey] = set()
+    for endpoint_commitment in commitments.endpoints:
+        if not isinstance(endpoint_commitment, EndpointCommitment):
+            raise CommitmentValidationError(f"{label} endpoint record is malformed")
+        if (
+            not isinstance(endpoint_commitment.connector_id, str)
+            or endpoint_commitment.connector_id not in connector_ids
+        ):
+            raise CommitmentValidationError(
+                f"{label} endpoint names unknown connector "
+                f"{endpoint_commitment.connector_id!r}"
+            )
+        if not isinstance(endpoint_commitment.role, ConnectorEndpointRole):
+            raise CommitmentValidationError(f"{label} endpoint role is invalid")
+        if not isinstance(endpoint_commitment.side, PortSide):
+            raise CommitmentValidationError(f"{label} endpoint side is invalid")
+        endpoint = ConnectorEndpointKey(
+            endpoint_commitment.connector_id, endpoint_commitment.role
+        )
+        if endpoint in seen_endpoints:
+            raise CommitmentValidationError(
+                f"{label} repeats {endpoint_commitment.role.value} commitment for "
+                f"{endpoint_commitment.connector_id!r}"
+            )
+        seen_endpoints.add(endpoint)
+
+    fold = commitments.fold_threshold
+    if fold is not None and (
+        not isinstance(fold, int) or isinstance(fold, bool) or fold <= 0
+    ):
+        raise CommitmentValidationError(f"{label} fold threshold must be positive")
+    if commitments.line_order is not None and not is_line_order(commitments.line_order):
+        raise CommitmentValidationError(
+            f"{label} line order must be 'definition' or 'span'"
+        )
+
+
+def _grid_index(commitments: LayoutCommitments) -> dict[str, GridCell]:
+    return {item.section_id: item.cell for item in commitments.grids}
+
+
+def _direction_index(commitments: LayoutCommitments) -> dict[str, FlowDirection]:
+    return {item.section_id: item.direction for item in commitments.directions}
+
+
+def _endpoint_index(
+    commitments: LayoutCommitments,
+) -> dict[ConnectorEndpointKey, PortSide]:
+    return {
+        ConnectorEndpointKey(item.connector_id, item.role): item.side
+        for item in commitments.endpoints
+    }
+
+
+def _candidate_conflicts(
+    graph: MetroGraph, overlay: LayoutCommitmentOverlay
+) -> tuple[str, ...]:
+    provenance = graph.layout_provenance
+    authored = provenance.authored
+    if authored is None:
+        raise RuntimeError("layout commitments require captured provenance")
+
+    caller_grids = _grid_index(overlay.caller)
+    caller_directions = _direction_index(overlay.caller)
+    caller_endpoints = _endpoint_index(overlay.caller)
+    authored_grids = {item.section_id: item.value for item in authored.grids}
+    authored_directions = {item.section_id: item.value for item in authored.directions}
+    authored_endpoints = authored.endpoint_values_index()
+    conflicts: list[str] = []
+
+    for grid_commitment in overlay.candidate.grids:
+        owned_grid = caller_grids.get(
+            grid_commitment.section_id,
+            authored_grids.get(grid_commitment.section_id),
+        )
+        if owned_grid is not None and owned_grid != grid_commitment.cell:
+            conflicts.append(f"grid:{grid_commitment.section_id}")
+    for direction_commitment in overlay.candidate.directions:
+        owned_direction = caller_directions.get(
+            direction_commitment.section_id,
+            authored_directions.get(direction_commitment.section_id),
+        )
+        if (
+            owned_direction is not None
+            and owned_direction != direction_commitment.direction
+        ):
+            conflicts.append(f"direction:{direction_commitment.section_id}")
+
+    fold = overlay.candidate.fold_threshold
+    fold_intent = authored.fold_threshold
+    if fold is not None:
+        owned_fold = overlay.caller.fold_threshold
+        if (
+            owned_fold is None
+            and fold_intent.selected_source is not FoldThresholdSource.DEFAULT
+        ):
+            owned_fold = fold_intent.selected_value
+        if owned_fold is not None and fold != owned_fold:
+            conflicts.append("fold-threshold")
+
+    line_order = overlay.candidate.line_order
+    line_intent = authored.line_order
+    if line_order is not None:
+        owned_order = overlay.caller.line_order
+        if (
+            owned_order is None
+            and line_intent.selected_source is not LineOrderSource.DEFAULT
+        ):
+            owned_order = line_intent.selected_value
+        if owned_order is not None and line_order != owned_order:
+            conflicts.append("line-order")
+
+    for endpoint, side in _endpoint_index(overlay.candidate).items():
+        caller_side = caller_endpoints.get(endpoint)
+        authored_sides = authored_endpoints.get(endpoint, ())
+        if caller_side is not None:
+            if caller_side is not side:
+                conflicts.append(f"{endpoint.role.value}:{endpoint.connector_id}")
+        elif authored_sides and not all(value is side for value in authored_sides):
+            conflicts.append(f"{endpoint.role.value}:{endpoint.connector_id}")
+    return tuple(conflicts)
+
+
+def apply_layout_commitment_overlay(
+    graph: MetroGraph,
+    routes: AuthoredRouteCapture,
+    overlay: LayoutCommitmentOverlay,
+) -> AppliedLayoutCommitments:
+    """Validate the complete overlay, then apply it atomically before inference."""
+    section_ids = set(graph.sections)
+    connector_ids = {item.key.id for item in routes.edges}
+    _validate_commitments("caller", overlay.caller, section_ids, connector_ids)
+    _validate_commitments("candidate", overlay.candidate, section_ids, connector_ids)
+    conflicts = _candidate_conflicts(graph, overlay)
+    if conflicts:
+        raise CommitmentConflictError(
+            "candidate conflicts with author or caller: " + ", ".join(conflicts)
+        )
+
+    provenance = graph.layout_provenance
+    caller_grids = _grid_index(overlay.caller)
+    candidate_grids = _grid_index(overlay.candidate)
+    for section_id, grid_value in caller_grids.items():
+        graph.grid_overrides[section_id] = grid_value
+        provenance.record_committed_grid(
+            section_id,
+            grid_value,
+            DecisionOrigin.AUTHORED,
+            DecisionReason.CALLER_COMMITMENT,
+        )
+    for section_id, grid_value in candidate_grids.items():
+        if section_id in caller_grids:
+            continue
+        grid_decision = provenance.grid_decision(section_id)
+        if grid_decision is not None and grid_decision.is_author_owned:
+            continue
+        graph.grid_overrides[section_id] = grid_value
+        provenance.record_committed_grid(
+            section_id,
+            grid_value,
+            DecisionOrigin.INFERRED,
+            DecisionReason.CANDIDATE_COMMITMENT,
+        )
+
+    caller_directions = _direction_index(overlay.caller)
+    candidate_directions = _direction_index(overlay.candidate)
+    for section_id, direction_value in caller_directions.items():
+        graph.sections[section_id].direction = direction_value
+        provenance.record_committed_direction(
+            section_id,
+            direction_value,
+            DecisionOrigin.AUTHORED,
+            DecisionReason.CALLER_COMMITMENT,
+        )
+    for section_id, direction_value in candidate_directions.items():
+        if section_id in caller_directions:
+            continue
+        direction_decision = provenance.direction_decision(section_id)
+        if direction_decision is not None and direction_decision.is_author_owned:
+            continue
+        graph.sections[section_id].direction = direction_value
+        provenance.record_committed_direction(
+            section_id,
+            direction_value,
+            DecisionOrigin.INFERRED,
+            DecisionReason.CANDIDATE_COMMITMENT,
+        )
+
+    caller_fold = overlay.caller.fold_threshold
+    if caller_fold is not None:
+        graph.fold_threshold = caller_fold
+    fold = overlay.candidate.fold_threshold
+    if (
+        fold is not None
+        and caller_fold is None
+        and graph.layout_provenance.authored is not None
+    ):
+        if (
+            graph.layout_provenance.authored.fold_threshold.selected_source
+            is FoldThresholdSource.DEFAULT
+        ):
+            graph.fold_threshold = fold
+            provenance.record_candidate_fold_threshold(fold)
+
+    caller_line_order = overlay.caller.line_order
+    if caller_line_order is not None:
+        graph.line_order = caller_line_order
+    line_order = overlay.candidate.line_order
+    if (
+        line_order is not None
+        and caller_line_order is None
+        and graph.layout_provenance.authored is not None
+    ):
+        if (
+            graph.layout_provenance.authored.line_order.selected_source
+            is LineOrderSource.DEFAULT
+        ):
+            graph.line_order = line_order
+            provenance.record_candidate_line_order(line_order)
+
+    caller_endpoints = _endpoint_index(overlay.caller)
+    candidate_endpoints = _endpoint_index(overlay.candidate)
+    authored_endpoints = (
+        provenance.authored.endpoint_values_index()
+        if provenance.authored is not None
+        else {}
+    )
+    selections: list[EndpointCommitmentSelection] = []
+    for endpoint, side in caller_endpoints.items():
+        selections.append(
+            EndpointCommitmentSelection(
+                endpoint,
+                EndpointSideSelection(
+                    side,
+                    DecisionOrigin.AUTHORED,
+                    True,
+                    DecisionReason.CALLER_COMMITMENT,
+                ),
+            )
+        )
+    for endpoint, side in candidate_endpoints.items():
+        if endpoint in caller_endpoints:
+            continue
+        authored_sides = authored_endpoints.get(endpoint, ())
+        if authored_sides and all(value is side for value in authored_sides):
+            continue
+        selections.append(
+            EndpointCommitmentSelection(
+                endpoint,
+                EndpointSideSelection(
+                    side,
+                    DecisionOrigin.INFERRED,
+                    True,
+                    DecisionReason.CANDIDATE_COMMITMENT,
+                ),
+            )
+        )
+    return AppliedLayoutCommitments(tuple(selections))
+
+
+def verify_settled_commitments(
+    graph: MetroGraph, overlay: LayoutCommitmentOverlay
+) -> None:
+    """Prove that every caller and candidate pin survived inference exactly."""
+    connectors = (
+        {item.id: item for item in graph.route_topology.connectors}
+        if graph.route_topology is not None
+        else {}
+    )
+    for commitments in (overlay.caller, overlay.candidate):
+        for grid_commitment in commitments.grids:
+            grid_decision = graph.layout_provenance.grid_decision(
+                grid_commitment.section_id
+            )
+            grid_section = graph.sections.get(grid_commitment.section_id)
+            settled_grid = (
+                (
+                    grid_section.grid_col,
+                    grid_section.grid_row,
+                    grid_section.grid_row_span,
+                    grid_section.grid_col_span,
+                )
+                if grid_section is not None
+                else None
+            )
+            if (
+                grid_decision is None
+                or grid_decision.value != grid_commitment.cell
+                or not grid_decision.locked
+                or settled_grid != grid_commitment.cell
+            ):
+                raise CommitmentSettlementError(
+                    f"grid commitment for {grid_commitment.section_id!r} "
+                    f"settled as {settled_grid!r}"
+                )
+        for direction_commitment in commitments.directions:
+            direction_decision = graph.layout_provenance.direction_decision(
+                direction_commitment.section_id
+            )
+            direction_section = graph.sections.get(direction_commitment.section_id)
+            if (
+                direction_decision is None
+                or direction_decision.value != direction_commitment.direction
+                or not direction_decision.locked
+                or direction_section is None
+                or direction_section.direction != direction_commitment.direction
+            ):
+                raise CommitmentSettlementError(
+                    f"direction commitment for {direction_commitment.section_id!r} "
+                    "was not preserved"
+                )
+        for endpoint_commitment in commitments.endpoints:
+            endpoint = ConnectorEndpointKey(
+                endpoint_commitment.connector_id, endpoint_commitment.role
+            )
+            endpoint_decision = graph.layout_provenance.endpoint_decision(endpoint)
+            connector = connectors.get(endpoint_commitment.connector_id)
+            settled_side = (
+                connector.exit_side
+                if connector is not None
+                and endpoint_commitment.role is ConnectorEndpointRole.EXIT
+                else connector.entry_side
+                if connector is not None
+                else None
+            )
+            if (
+                endpoint_decision is None
+                or endpoint_decision.value is not endpoint_commitment.side
+                or not endpoint_decision.locked
+                or settled_side is not endpoint_commitment.side
+            ):
+                raise CommitmentSettlementError(
+                    f"{endpoint_commitment.role.value} commitment for "
+                    f"{endpoint_commitment.connector_id!r} was not preserved"
+                )
+        if commitments.fold_threshold is not None:
+            fold_decision = graph.layout_provenance.fold_threshold_decision
+            if (
+                fold_decision is None
+                or fold_decision.value != commitments.fold_threshold
+                or not fold_decision.locked
+                or graph.fold_threshold != commitments.fold_threshold
+            ):
+                raise CommitmentSettlementError(
+                    "fold-threshold commitment was not preserved"
+                )
+        if commitments.line_order is not None:
+            line_order_decision = graph.layout_provenance.line_order_decision
+            if (
+                line_order_decision is None
+                or line_order_decision.value != commitments.line_order
+                or not line_order_decision.locked
+                or graph.line_order != commitments.line_order
+            ):
+                raise CommitmentSettlementError(
+                    "line-order commitment was not preserved"
+                )

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -21,6 +21,11 @@ from collections import defaultdict
 from collections.abc import Callable
 
 from nf_metro.options import LineOrder, is_line_order
+from nf_metro.parser.commitments import (
+    AppliedLayoutCommitments,
+    LayoutCommitmentOverlay,
+    apply_layout_commitment_overlay,
+)
 from nf_metro.parser.directives import _apply_directive
 from nf_metro.parser.grammar import (
     _Comment,
@@ -195,6 +200,8 @@ def parse_metro_mermaid(
     auto_process: bool | None = None,
     process_scope: str | None = None,
     caller_line_order: LineOrder | None = None,
+    *,
+    _layout_commitments: LayoutCommitmentOverlay | None = None,
 ) -> MetroGraph:
     """Parse a Mermaid graph definition with %%metro directives.
 
@@ -225,6 +232,7 @@ def parse_metro_mermaid(
         auto_process,
         process_scope,
         caller_line_order,
+        layout_commitments=_layout_commitments,
     )
     return graph
 
@@ -259,12 +267,15 @@ def _finalize_graph(
     auto_process: bool | None = None,
     process_scope: str | None = None,
     caller_line_order: LineOrder | None = None,
+    *,
+    layout_commitments: LayoutCommitmentOverlay | None = None,
 ) -> None:
     """Validate, run the post-parse resolution, and apply buffered metadata."""
     _validate_edge_annotations(graph)
+    authored_routes = capture_authored_routes(graph)
     graph.layout_provenance.capture_authored_intent(
         graph,
-        capture_authored_routes(graph),
+        authored_routes,
         max_station_columns,
         caller_line_order,
     )
@@ -276,13 +287,19 @@ def _finalize_graph(
     if graph.sections:
         _create_implicit_section(graph)
 
+    applied_commitments = (
+        apply_layout_commitment_overlay(graph, authored_routes, layout_commitments)
+        if layout_commitments is not None
+        else AppliedLayoutCommitments()
+    )
+
     # Layout inference (interchange expansion, section grids, port/junction
     # resolution) assumes the graph is a DAG. A cyclic graph is rejected at the
     # render boundary (compute_layout) and reported by validate_graph, so leave
     # it un-inferred here rather than feed a distorted size estimate into
     # strategy selection.
     if find_cycle(graph) is None and find_section_cycle(graph) is None:
-        _infer_layout(graph, max_station_columns)
+        _infer_layout(graph, max_station_columns, applied_commitments)
 
     # A caller value (the --auto-process / --process-scope CLI flags) wins over
     # the matching %%metro directive set during statement application.
@@ -294,7 +311,11 @@ def _finalize_graph(
     _apply_pending_metadata(graph)
 
 
-def _infer_layout(graph: MetroGraph, max_station_columns: int | None) -> None:
+def _infer_layout(
+    graph: MetroGraph,
+    max_station_columns: int | None,
+    commitments: AppliedLayoutCommitments = AppliedLayoutCommitments(),
+) -> None:
     """Run interchange expansion, section-grid inference, and section resolution.
 
     The graph must be acyclic: the section-grid size estimator and the
@@ -348,7 +369,9 @@ def _infer_layout(graph: MetroGraph, max_station_columns: int | None) -> None:
             if relocated:
                 graph._fold_compressed_sections = relocated
         _insert_terminus_convergence_stations(graph, authored_lineage)
-        endpoint_resolution = resolve_section_endpoints(graph, authored_lineage)
+        endpoint_resolution = resolve_section_endpoints(
+            graph, authored_lineage, commitments
+        )
         graph.route_topology = build_route_topology(
             authored_capture, authored_lineage, endpoint_resolution
         )

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -23,7 +23,11 @@ class RowGridInfo(TypedDict):
     max_y_pad: float
 
 
-class PermissiveGuardWarning(UserWarning):
+class LayoutGeometryWarning(UserWarning):
+    """A rendered layout is usable but carries a known geometry defect."""
+
+
+class PermissiveGuardWarning(LayoutGeometryWarning):
     """A layout/render guard failure downgraded to a warning under ``graph.permissive``.
 
     Distinct from an ordinary :class:`UserWarning` so a caller collecting

--- a/src/nf_metro/parser/provenance.py
+++ b/src/nf_metro/parser/provenance.py
@@ -52,6 +52,8 @@ class DecisionReason(str, Enum):
     RESOLUTION_SIDE_SELECTION = "resolution-side-selection"
     FOLD_RELOCATED_SIDE = "fold-relocated-side"
     FLOW_REANCHORED_SIDE = "flow-reanchored-side"
+    CALLER_COMMITMENT = "caller-commitment"
+    CANDIDATE_COMMITMENT = "candidate-commitment"
 
 
 class FoldThresholdSource(str, Enum):
@@ -491,6 +493,58 @@ class LayoutProvenance:
             value, DecisionOrigin.INFERRED, locked, reason, authored_values
         )
 
+    def record_committed_grid(
+        self,
+        section_id: str,
+        value: GridCell,
+        origin: DecisionOrigin,
+        reason: DecisionReason,
+    ) -> None:
+        """Record a caller or candidate grid pin before inference."""
+        current = self.grids.get(section_id)
+        authored_values = current.authored_values if current is not None else ()
+        self.grids[section_id] = EffectiveDecision(
+            value, origin, True, reason, authored_values
+        )
+
+    def record_committed_direction(
+        self,
+        section_id: str,
+        value: str,
+        origin: DecisionOrigin,
+        reason: DecisionReason,
+    ) -> None:
+        """Record a caller or candidate direction pin before inference."""
+        current = self.directions.get(section_id)
+        authored_values = current.authored_values if current is not None else ()
+        self.directions[section_id] = EffectiveDecision(
+            value, origin, True, reason, authored_values
+        )
+
+    def record_candidate_fold_threshold(self, value: int) -> None:
+        """Record a candidate fold pin when no author or caller owns it."""
+        current = self.fold_threshold_decision
+        authored_values = current.authored_values if current is not None else ()
+        self.fold_threshold_decision = EffectiveDecision(
+            value,
+            DecisionOrigin.INFERRED,
+            True,
+            DecisionReason.CANDIDATE_COMMITMENT,
+            authored_values,
+        )
+
+    def record_candidate_line_order(self, value: LineOrder) -> None:
+        """Record a candidate line-order pin when no author or caller owns it."""
+        current = self.line_order_decision
+        authored_values = current.authored_values if current is not None else ()
+        self.line_order_decision = EffectiveDecision(
+            value,
+            DecisionOrigin.INFERRED,
+            True,
+            DecisionReason.CANDIDATE_COMMITMENT,
+            authored_values,
+        )
+
     def record_endpoint_selection(
         self,
         endpoint: ConnectorEndpointKey,
@@ -504,7 +558,12 @@ class LayoutProvenance:
         authored_matches = bool(authored_values) and all(
             value is selection.side for value in authored_values
         )
-        if origin is DecisionOrigin.AUTHORED and not authored_matches:
+        caller_owned = reason is DecisionReason.CALLER_COMMITMENT
+        if (
+            origin is DecisionOrigin.AUTHORED
+            and not authored_matches
+            and not caller_owned
+        ):
             origin = DecisionOrigin.INFERRED
             locked = False
             reason = DecisionReason.RESOLUTION_SIDE_SELECTION

--- a/src/nf_metro/parser/resolve.py
+++ b/src/nf_metro/parser/resolve.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, replace
 import networkx as nx
 
 from nf_metro.graph_views import directed_graph, longest_path_layers
+from nf_metro.parser.commitments import AppliedLayoutCommitments
 from nf_metro.parser.model import (
     BYPASS_V_PREFIX,
     CONVERGE_PREFIX,
@@ -699,7 +700,9 @@ class SectionEndpointResolution:
 
 
 def resolve_section_endpoints(
-    graph: MetroGraph, lineage: AuthoredEdgeLineage
+    graph: MetroGraph,
+    lineage: AuthoredEdgeLineage,
+    commitments: AppliedLayoutCommitments = AppliedLayoutCommitments(),
 ) -> SectionEndpointResolution:
     """Resolve inter-section endpoint sides once, before creating synthetic ports."""
     internal_edges, inter_section_edges = _classify_edges(graph)
@@ -719,6 +722,7 @@ def resolve_section_endpoints(
         exit_sides,
         lineage,
         provenance,
+        commitments,
     )
     return SectionEndpointResolution(
         internal_edges=internal_edges,
@@ -1408,6 +1412,7 @@ def _exit_side_for_edge(
     exit_sides: dict[tuple[str, str], set[PortSide]],
     entry_side_for_line: dict[tuple[str, str], EndpointSideSelection],
     provenance: _EndpointProvenanceContext,
+    entry_override: EndpointSideSelection | None = None,
 ) -> EndpointSideSelection:
     """Choose the exit side an inter-section edge leaves its source by.
 
@@ -1431,7 +1436,7 @@ def _exit_side_for_edge(
             PortSide.RIGHT,
         )
 
-    entry_selection = entry_side_for_line.get((tgt_sec, edge.line_id))
+    entry_selection = entry_override or entry_side_for_line.get((tgt_sec, edge.line_id))
     entry_side = entry_selection.side if entry_selection is not None else PortSide.LEFT
 
     preferred: PortSide | None
@@ -1474,9 +1479,11 @@ def _group_inter_section_edges(
     exit_sides: dict[tuple[str, str], set[PortSide]],
     lineage: AuthoredEdgeLineage,
     provenance: _EndpointProvenanceContext,
+    commitments: AppliedLayoutCommitments,
 ) -> tuple[ResolvedConnectorEndpoint, ...]:
     """Resolve current inter-section endpoints and their authored identities."""
     connectors: list[ResolvedConnectorEndpoint] = []
+    commitment_index = {item.endpoint: item.selection for item in commitments.endpoints}
 
     for edge in inter_section_edges:
         src_sec = graph.section_for_station(edge.source)
@@ -1484,6 +1491,7 @@ def _group_inter_section_edges(
         # _classify_edges only files an edge as inter-section when both
         # endpoints resolve to a section, so neither lookup is None here.
         assert src_sec is not None and tgt_sec is not None
+        connector_ids = tuple(key.id for key in lineage.origins(edge))
         entry_selection = entry_side_for_line.get((tgt_sec, edge.line_id))
         if entry_selection is None:
             entry_selection = _endpoint_selection(
@@ -1493,6 +1501,18 @@ def _group_inter_section_edges(
                 edge.line_id,
                 PortSide.LEFT,
             )
+        committed_entry = commitments.selection_for(
+            connector_ids,
+            ConnectorEndpointRole.ENTRY,
+            commitment_index,
+        )
+        if committed_entry is not None:
+            entry_selection = committed_entry
+        committed_exit = commitments.selection_for(
+            connector_ids,
+            ConnectorEndpointRole.EXIT,
+            commitment_index,
+        )
         exit_selection = _exit_side_for_edge(
             graph,
             edge,
@@ -1501,9 +1521,11 @@ def _group_inter_section_edges(
             exit_sides,
             entry_side_for_line,
             provenance,
+            committed_entry,
         )
+        if committed_exit is not None:
+            exit_selection = committed_exit
 
-        connector_ids = tuple(key.id for key in lineage.origins(edge))
         for connector_id in connector_ids:
             exit_endpoint = graph.layout_provenance.endpoint_key(
                 connector_id, ConnectorEndpointRole.EXIT

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-__all__ = ["build_render_plan", "emit_render_plan", "render_svg"]
+__all__ = [
+    "ObservedRenderPlan",
+    "build_observed_render_plan",
+    "build_render_plan",
+    "emit_render_plan",
+    "render_svg",
+]
 
 import copy
 import html
@@ -39,10 +45,12 @@ from nf_metro.layout.phases.guards import (
     render_header_collision,
 )
 from nf_metro.layout.phases.spacing import _bypass_label_obstacles
+from nf_metro.layout.route_plan import RoutePlan
 from nf_metro.layout.routing import (
     RoutedPath,
     apply_route_offsets,
     compute_station_offsets,
+    observe_route_edges_centred,
     route_edges_centred,
 )
 from nf_metro.layout.routing.corners import (
@@ -63,6 +71,7 @@ from nf_metro.parser.model import (
     MARKER_FILL_SOLID,
     MARKER_SHAPE_PILL,
     Interchange,
+    LayoutGeometryWarning,
     MarkerStyle,
     MetroGraph,
     Section,
@@ -255,6 +264,7 @@ def _position_legend(
         ):
             warnings.warn(
                 f"legend placed at {graph.legend_at} overlaps a section or route.",
+                category=LayoutGeometryWarning,
                 stacklevel=2,
             )
         return legend_x, legend_y, legend_w, legend_h, show_legend
@@ -313,6 +323,7 @@ def _position_legend(
         ):
             warnings.warn(
                 f"legend pinned at '{pos}' overlaps a section or route.",
+                category=LayoutGeometryWarning,
                 stacklevel=2,
             )
     elif pos not in ("bottom", "right") and _legend_overlaps_content(
@@ -505,6 +516,60 @@ def render_svg(
     return apply_font_portability(svg, font_portability)
 
 
+class ObservedRenderPlan(NamedTuple):
+    """A RenderPlan paired with the final production routing observation."""
+
+    plan: RenderPlan
+    route_plan: RoutePlan
+
+
+def _build_render_plan_result(
+    graph: MetroGraph,
+    theme: Theme,
+    width: int | None = None,
+    height: int | None = None,
+    padding: float = CANVAS_PADDING,
+    *,
+    debug: bool = False,
+    legend_position: str | None = None,
+    chrome_css: bool = True,
+    bare: bool = False,
+    observe_routes: bool = False,
+) -> tuple[RenderPlan, RoutePlan | None]:
+    """Build a render plan and optionally observe its final routing pass."""
+    scaled_theme = _scale_theme_strokes(
+        _scale_theme_fonts(theme, graph.font_scale), graph.stroke_scale
+    )
+    with (
+        font_scale_context(graph.font_scale),
+        stroke_scale_context(graph.stroke_scale),
+    ):
+        try:
+            plan, route_plan = _build_render_plan_scaled(
+                graph,
+                scaled_theme,
+                width=width if width is not None else graph.width,
+                height=height if height is not None else graph.height,
+                padding=padding,
+                debug=debug,
+                legend_position=legend_position,
+                chrome_css=chrome_css,
+                bare=bare,
+                observe_routes=observe_routes,
+            )
+        except (CurveInvariantError, SectionHeaderClashError) as exc:
+            reframed = _fold_threshold_error(graph)
+            if reframed is not None:
+                raise reframed from exc
+            raise
+
+    if _fold_back_under_compression(graph):
+        reframed = _fold_threshold_error(graph)
+        if reframed is not None:
+            raise reframed
+    return plan, route_plan
+
+
 def build_render_plan(
     graph: MetroGraph,
     theme: Theme,
@@ -518,36 +583,47 @@ def build_render_plan(
     bare: bool = False,
 ) -> RenderPlan:
     """Build an immutable render plan without changing the caller's graph."""
-    scaled_theme = _scale_theme_strokes(
-        _scale_theme_fonts(theme, graph.font_scale), graph.stroke_scale
+    plan, _route_plan = _build_render_plan_result(
+        graph,
+        theme,
+        width,
+        height,
+        padding,
+        debug=debug,
+        legend_position=legend_position,
+        chrome_css=chrome_css,
+        bare=bare,
     )
-    with (
-        font_scale_context(graph.font_scale),
-        stroke_scale_context(graph.stroke_scale),
-    ):
-        try:
-            plan = _build_render_plan_scaled(
-                graph,
-                scaled_theme,
-                width=width if width is not None else graph.width,
-                height=height if height is not None else graph.height,
-                padding=padding,
-                debug=debug,
-                legend_position=legend_position,
-                chrome_css=chrome_css,
-                bare=bare,
-            )
-        except (CurveInvariantError, SectionHeaderClashError) as exc:
-            reframed = _fold_threshold_error(graph)
-            if reframed is not None:
-                raise reframed from exc
-            raise
-
-    if _fold_back_under_compression(graph):
-        reframed = _fold_threshold_error(graph)
-        if reframed is not None:
-            raise reframed
     return plan
+
+
+def build_observed_render_plan(
+    graph: MetroGraph,
+    theme: Theme,
+    width: int | None = None,
+    height: int | None = None,
+    padding: float = CANVAS_PADDING,
+    *,
+    debug: bool = False,
+    legend_position: str | None = None,
+    chrome_css: bool = True,
+    bare: bool = False,
+) -> ObservedRenderPlan:
+    """Build a plan and observe the final centred route invocation it used."""
+    plan, route_plan = _build_render_plan_result(
+        graph,
+        theme,
+        width,
+        height,
+        padding,
+        debug=debug,
+        legend_position=legend_position,
+        chrome_css=chrome_css,
+        bare=bare,
+        observe_routes=True,
+    )
+    assert route_plan is not None
+    return ObservedRenderPlan(plan, route_plan)
 
 
 def _fold_threshold_error(graph: MetroGraph) -> FoldThresholdError | None:
@@ -630,11 +706,22 @@ def _scale_theme_strokes(theme: Theme, scale: float) -> Theme:
 
 
 def _settle_render_geometry(
-    graph: MetroGraph, theme: Theme, offset_step: float, section_y_gap: float
-) -> tuple[dict[tuple[str, str], float], list[RoutedPath], list[LabelPlacement]]:
+    graph: MetroGraph,
+    theme: Theme,
+    offset_step: float,
+    section_y_gap: float,
+    *,
+    observe_routes: bool = False,
+) -> tuple[
+    dict[tuple[str, str], float],
+    list[RoutedPath],
+    list[LabelPlacement],
+    RoutePlan | None,
+]:
     """Route, place labels, and reconcile a header collision for the render.
 
-    Returns the settled ``(station_offsets, routes, labels)``.  Label wrapping
+    Returns settled station offsets, routes, labels, and optional route plan.
+    Label wrapping
     needs the theme's font/icon metrics, so it runs here rather than in
     ``compute_layout``; when it grows a section's bbox downward it can push the
     lower section's header badge up into the box above.  Only that genuine
@@ -666,8 +753,18 @@ def _settle_render_geometry(
             label_angle=graph.label_angle or 0.0,
         )
 
+    def _route(
+        station_offsets: dict[tuple[str, str], float],
+    ) -> tuple[list[RoutedPath], RoutePlan | None]:
+        if not observe_routes:
+            return route_edges_centred(graph, station_offsets=station_offsets), None
+        observation = observe_route_edges_centred(
+            graph, station_offsets=station_offsets
+        )
+        return observation.routes, observation.plan
+
     station_offsets = compute_station_offsets(graph, offset_step=offset_step)
-    routes = route_edges_centred(graph, station_offsets=station_offsets)
+    routes, route_plan = _route(station_offsets)
     effective_strict = graph.strict and not graph.permissive
     assert_render_curve_invariants(graph, routes, station_offsets)
     assert_render_layout_invariants(
@@ -682,11 +779,11 @@ def _settle_render_geometry(
         # re-route does not seat a bypass corner against a stale box.
         graph.bypass_label_obstacles = _bypass_label_obstacles(graph)
         station_offsets = compute_station_offsets(graph, offset_step=offset_step)
-        routes = route_edges_centred(graph, station_offsets=station_offsets)
+        routes, route_plan = _route(station_offsets)
         labels = _place(station_offsets, routes)
         assert_render_curve_invariants(graph, routes, station_offsets)
     assert_render_header_clearance(graph, strict=effective_strict)
-    return station_offsets, routes, labels
+    return station_offsets, routes, labels, route_plan
 
 
 def _copy_graph_for_render(source_graph: MetroGraph) -> MetroGraph:
@@ -712,7 +809,8 @@ def _build_render_plan_scaled(
     legend_position: str | None,
     chrome_css: bool = True,
     bare: bool = False,
-) -> RenderPlan:
+    observe_routes: bool = False,
+) -> tuple[RenderPlan, RoutePlan | None]:
     """Finish render geometry on a private graph copy and freeze the result."""
     graph = _copy_graph_for_render(source_graph)
     effective_legend_position = (
@@ -723,8 +821,12 @@ def _build_render_plan_scaled(
     section_y_gap = (
         graph.section_y_gap if graph.section_y_gap is not None else SECTION_Y_GAP
     )
-    station_offsets, routes, labels = _settle_render_geometry(
-        graph, theme, offset_step, section_y_gap
+    station_offsets, routes, labels, route_plan = _settle_render_geometry(
+        graph,
+        theme,
+        offset_step,
+        section_y_gap,
+        observe_routes=observe_routes,
     )
     line_priority = {line_id: index for index, line_id in enumerate(graph.lines)}
     edge_routes = sorted(
@@ -905,7 +1007,7 @@ def _build_render_plan_scaled(
         debug=debug,
         chrome_css=chrome_css,
         bare=bare,
-    )
+    ), route_plan
 
 
 def emit_render_plan(

--- a/tests/candidate_executor_oracle.py
+++ b/tests/candidate_executor_oracle.py
@@ -1,0 +1,37 @@
+"""Emit #1645 worker observations for an outer PYTHONHASHSEED process."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from nf_metro.candidate_executor import (
+    CandidateExecutionRequest,
+    ExecutionLimits,
+    _attempt_to_bytes,
+    execute_candidates,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    observations: dict[str, str] = {}
+    for seed in (15, 41, 72, 77):
+        path = ROOT / f"tests/fixtures/hash_seed_determinism/seed_{seed}.mmd"
+        result = execute_candidates(
+            CandidateExecutionRequest(
+                path.read_text(),
+                source_dir=str(path.parent),
+                limits=ExecutionLimits(1, 20.0, 30.0),
+            )
+        )
+        observations[str(seed)] = hashlib.sha256(
+            _attempt_to_bytes(result.baseline)
+        ).hexdigest()
+    print(json.dumps(observations, sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/candidate_executor/control.mmd
+++ b/tests/fixtures/candidate_executor/control.mmd
@@ -1,0 +1,19 @@
+%%metro title: Candidate executor control
+%%metro style: nfcore
+%%metro mode: dark
+%%metro logo: examples/placeholder_logo.png
+%%metro line: main | Main | #1f78b4
+%%metro line: qc | Quality | #33a02c
+
+graph LR
+    subgraph intake [Intake]
+        reads[Reads]
+        trim[Trim]
+        reads -->|main,qc| trim
+    end
+    subgraph analysis [Analysis]
+        align[Align]
+        report[Report]
+        align -->|main| report
+    end
+    trim -->|main| align

--- a/tests/test_candidate_executor.py
+++ b/tests/test_candidate_executor.py
@@ -1,0 +1,828 @@
+"""Contract tests for isolated, bounded layout-candidate execution."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import struct
+import subprocess
+import sys
+import warnings
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from click.testing import CliRunner
+
+import nf_metro.candidate_executor as candidate_executor
+from nf_metro.api import (
+    RenderConfig,
+    _prepare_graph_state,
+    render_graph_result,
+    render_string,
+    resolve_theme,
+)
+from nf_metro.candidate_executor import (
+    CandidateExecutionRequest,
+    CandidateStage,
+    CandidateStatus,
+    DirectionCommitment,
+    EndpointCommitment,
+    ExecutionLimits,
+    GridCommitment,
+    LayoutCandidate,
+    LayoutCommitments,
+    LayoutOptionValue,
+    LayoutOptionValues,
+    RenderConfigSnapshot,
+    StopReason,
+    _canonical_evidence,
+    _canonical_json,
+    _FaultAction,
+    _FaultInjection,
+    _graph_evidence,
+    execute_candidates,
+)
+from nf_metro.cli import cli
+from nf_metro.layout import compute_layout
+from nf_metro.layout.route_plan import RoutePlanDiagnostic, serialize_route_plan
+from nf_metro.parser.commitments import (
+    CommitmentSettlementError,
+    LayoutCommitmentOverlay,
+    verify_settled_commitments,
+)
+from nf_metro.parser.model import LayoutGeometryWarning, PortSide
+from nf_metro.parser.provenance import ConnectorEndpointRole
+from nf_metro.render.svg import ObservedRenderPlan, build_observed_render_plan
+from nf_metro.render.validate import (
+    LABEL_STRIKE,
+    MARKER_CROSS,
+    OFFSET_COLLAPSE,
+    RenderFinding,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTROL_PATH = ROOT / "tests/fixtures/candidate_executor/control.mmd"
+CONTROL_SOURCE = CONTROL_PATH.read_text()
+
+PINNED_SOURCE = """\
+%%metro line: main | Main | #ff0000
+%%metro fold_threshold: 9
+%%metro line_order: definition
+%%metro grid: left | 0,0
+%%metro grid: right | 1,0
+graph LR
+    subgraph left [Left]
+        %%metro direction: LR
+        %%metro exit: right | main
+        a[A]
+        b[B]
+        a -->|main| b
+    end
+    subgraph right [Right]
+        %%metro direction: LR
+        %%metro entry: left | main
+        c[C]
+        d[D]
+        c -->|main| d
+    end
+    b -->|main| c
+"""
+
+
+def _request(**changes: Any) -> CandidateExecutionRequest:
+    request = CandidateExecutionRequest(
+        CONTROL_SOURCE,
+        source_dir=str(ROOT),
+        limits=ExecutionLimits(8, 10.0, 30.0),
+    )
+    return replace(request, **changes)
+
+
+def _connector_id(source: str = CONTROL_SOURCE) -> str:
+    graph = _prepare_graph_state(source, source_dir=str(ROOT))
+    assert graph.route_topology is not None
+    return str(graph.route_topology.connectors[0].id)
+
+
+def _direct_result(
+    request: CandidateExecutionRequest,
+    candidate: LayoutCandidate | None = None,
+    fault: _FaultInjection | None = None,
+):
+    options = candidate_executor._validate_request(request)
+    production = candidate_executor._production_input(request, options)
+    attempt = candidate_executor._attempt_input(production, 0, candidate)
+    return candidate_executor._evaluate_attempt(attempt, fault)
+
+
+def test_checked_in_control_returns_complete_accepted_evidence() -> None:
+    result = execute_candidates(_request(limits=ExecutionLimits(1, 10.0, 20.0)))
+
+    baseline = result.baseline
+    assert baseline.status is CandidateStatus.ACCEPTED
+    assert baseline.worker_exit_code == 0
+    assert baseline.evidence.graph is not None
+    assert baseline.evidence.route_plan is not None
+    assert baseline.evidence.render_plan is not None
+    assert baseline.evidence.svg is not None
+    assert len(baseline.evidence.svg.content) > candidate_executor._MAX_FRAME_BYTES
+    assert not baseline.evidence.graph_findings
+    assert not baseline.evidence.route_findings
+    assert not baseline.evidence.artifact_findings
+
+
+def test_noop_attempt_matches_the_complete_production_pipeline() -> None:
+    layout_options = LayoutOptionValues(
+        (
+            LayoutOptionValue("fold_threshold", 12),
+            LayoutOptionValue("line_order", "span"),
+            LayoutOptionValue("x_spacing", 72.0),
+        )
+    )
+    render = RenderConfigSnapshot(
+        responsive=True,
+        svg_class_prefix="candidate",
+        chrome_css=False,
+        self_color_scheme=False,
+        baked_mode="light",
+    )
+    request = _request(
+        theme="seqera",
+        mode="light",
+        layout_options=layout_options,
+        render=render,
+        limits=ExecutionLimits(1, 10.0, 20.0),
+    )
+    baseline = execute_candidates(request).baseline
+    assert baseline.status is CandidateStatus.ACCEPTED
+
+    options = dict(candidate_executor._validate_request(request))
+    graph = _prepare_graph_state(
+        request.source,
+        source_dir=request.source_dir,
+        layout_options=options,
+        bare=render.bare,
+    )
+    compute_layout(graph, validate=True)
+    theme = resolve_theme(request.theme, graph, mode=request.mode)
+    observed = build_observed_render_plan(
+        graph,
+        theme,
+        debug=render.debug,
+        chrome_css=render.chrome_css,
+        bare=render.bare,
+    )
+    production = render_graph_result(
+        graph,
+        theme,
+        RenderConfig(
+            responsive=render.responsive,
+            svg_class_prefix=render.svg_class_prefix,
+            chrome_css=render.chrome_css,
+            self_color_scheme=render.self_color_scheme,
+            baked_mode=render.baked_mode,
+            bare=render.bare,
+        ),
+    )
+
+    assert observed.plan == production.plan
+    assert baseline.evidence.graph == _graph_evidence(
+        graph, candidate_executor.GraphState.SETTLED
+    )
+    assert baseline.evidence.route_plan is not None
+    assert baseline.evidence.route_plan.content == serialize_route_plan(
+        observed.route_plan
+    )
+    assert baseline.evidence.render_plan == _canonical_evidence(observed.plan)
+    assert baseline.evidence.svg is not None
+    assert baseline.evidence.svg.content == production.content
+    assert baseline.evidence.render_plan.content.find(str(ROOT)) >= 0
+
+
+def test_noop_candidate_matches_baseline_evidence() -> None:
+    candidate = LayoutCandidate("noop")
+    result = execute_candidates(
+        _request(
+            candidates=(candidate,),
+            limits=ExecutionLimits(2, 10.0, 30.0),
+        )
+    )
+
+    assert result.attempts[0].status is CandidateStatus.ACCEPTED
+    assert result.attempts[0].evidence == result.baseline.evidence
+
+
+def test_a_b_a_attempts_are_isolated() -> None:
+    candidates = (
+        LayoutCandidate("a-before"),
+        LayoutCandidate(
+            "bad-middle",
+            LayoutCommitments(grids=(GridCommitment("missing", (0, 0, 1, 1)),)),
+        ),
+        LayoutCandidate("a-after"),
+    )
+    result = execute_candidates(
+        _request(
+            candidates=candidates,
+            limits=ExecutionLimits(4, 10.0, 40.0),
+        )
+    )
+
+    before, middle, after = result.attempts
+    assert middle.status is CandidateStatus.VALIDATION_REJECTION
+    assert before.status is after.status is CandidateStatus.ACCEPTED
+    assert before.evidence == after.evidence == result.baseline.evidence
+
+
+def test_authored_grid_fold_direction_endpoint_and_order_conflicts() -> None:
+    connector = _connector_id(PINNED_SOURCE)
+    conflicts = (
+        LayoutCandidate(
+            "grid",
+            LayoutCommitments(grids=(GridCommitment("left", (3, 0, 1, 1)),)),
+        ),
+        LayoutCandidate("fold", LayoutCommitments(fold_threshold=3)),
+        LayoutCandidate(
+            "direction",
+            LayoutCommitments(
+                directions=(DirectionCommitment("left", cast(Any, "TB")),)
+            ),
+        ),
+        LayoutCandidate(
+            "endpoint",
+            LayoutCommitments(
+                endpoints=(
+                    EndpointCommitment(
+                        cast(Any, connector),
+                        ConnectorEndpointRole.EXIT,
+                        PortSide.BOTTOM,
+                    ),
+                )
+            ),
+        ),
+        LayoutCandidate("order", LayoutCommitments(line_order="span")),
+    )
+    result = execute_candidates(
+        CandidateExecutionRequest(
+            PINNED_SOURCE,
+            source_dir=str(ROOT),
+            candidates=conflicts,
+            limits=ExecutionLimits(6, 10.0, 40.0),
+        )
+    )
+
+    assert all(
+        item.status is CandidateStatus.VALIDATION_REJECTION
+        and item.stage is CandidateStage.PREPARATION
+        for item in result.attempts
+    )
+
+
+def test_caller_pins_override_source_and_reject_different_candidates() -> None:
+    connector = _connector_id()
+    caller = LayoutCommitments(
+        grids=(
+            GridCommitment("intake", (0, 0, 1, 1)),
+            GridCommitment("analysis", (1, 0, 1, 1)),
+        ),
+        directions=(
+            DirectionCommitment("intake", "LR"),
+            DirectionCommitment("analysis", "LR"),
+        ),
+        endpoints=(
+            EndpointCommitment(
+                cast(Any, connector), ConnectorEndpointRole.EXIT, PortSide.RIGHT
+            ),
+            EndpointCommitment(
+                cast(Any, connector), ConnectorEndpointRole.ENTRY, PortSide.LEFT
+            ),
+        ),
+    )
+    conflicts = (
+        LayoutCandidate(
+            "grid",
+            LayoutCommitments(grids=(GridCommitment("intake", (4, 0, 1, 1)),)),
+        ),
+        LayoutCandidate(
+            "direction",
+            LayoutCommitments(directions=(DirectionCommitment("intake", "TB"),)),
+        ),
+        LayoutCandidate(
+            "entry",
+            LayoutCommitments(
+                endpoints=(
+                    EndpointCommitment(
+                        cast(Any, connector),
+                        ConnectorEndpointRole.ENTRY,
+                        PortSide.TOP,
+                    ),
+                )
+            ),
+        ),
+        LayoutCandidate("fold", LayoutCommitments(fold_threshold=3)),
+        LayoutCandidate("order", LayoutCommitments(line_order="definition")),
+    )
+    request = _request(
+        caller_pins=caller,
+        layout_options=LayoutOptionValues(
+            (
+                LayoutOptionValue("fold_threshold", 12),
+                LayoutOptionValue("line_order", "span"),
+            )
+        ),
+        candidates=conflicts,
+        limits=ExecutionLimits(6, 10.0, 40.0),
+    )
+    result = execute_candidates(request)
+
+    assert result.baseline.status is CandidateStatus.ACCEPTED
+    assert all(
+        item.status is CandidateStatus.VALIDATION_REJECTION for item in result.attempts
+    )
+
+
+def test_same_value_caller_and_candidate_pins_are_noops() -> None:
+    connector = _connector_id()
+    pins = LayoutCommitments(
+        grids=(
+            GridCommitment("intake", (0, 0, 1, 1)),
+            GridCommitment("analysis", (1, 0, 1, 1)),
+        ),
+        fold_threshold=12,
+        directions=(
+            DirectionCommitment("intake", "LR"),
+            DirectionCommitment("analysis", "LR"),
+        ),
+        endpoints=(
+            EndpointCommitment(
+                cast(Any, connector), ConnectorEndpointRole.EXIT, PortSide.RIGHT
+            ),
+            EndpointCommitment(
+                cast(Any, connector), ConnectorEndpointRole.ENTRY, PortSide.LEFT
+            ),
+        ),
+        line_order="span",
+    )
+    result = execute_candidates(
+        _request(
+            caller_pins=pins,
+            candidates=(LayoutCandidate("same", pins),),
+            limits=ExecutionLimits(2, 10.0, 30.0),
+        )
+    )
+
+    assert result.baseline.status is CandidateStatus.ACCEPTED
+    assert result.attempts[0].status is CandidateStatus.ACCEPTED
+    assert result.attempts[0].evidence == result.baseline.evidence
+
+
+@pytest.mark.parametrize(
+    "commitments",
+    [
+        LayoutCommitments(
+            grids=(
+                GridCommitment("intake", (0, 0, 1, 1)),
+                GridCommitment("intake", (0, 0, 1, 1)),
+            )
+        ),
+        LayoutCommitments(grids=(GridCommitment("intake", (-1, 0, 1, 1)),)),
+        LayoutCommitments(
+            directions=(DirectionCommitment("intake", cast(Any, "SIDEWAYS")),)
+        ),
+        LayoutCommitments(fold_threshold=-1),
+        LayoutCommitments(line_order=cast(Any, "lexical")),
+        LayoutCommitments(grids=(cast(Any, object()),)),
+    ],
+)
+def test_malformed_and_duplicate_commitments_are_validation_rejections(
+    commitments: LayoutCommitments,
+) -> None:
+    result = execute_candidates(
+        _request(
+            candidates=(LayoutCandidate("invalid", commitments),),
+            limits=ExecutionLimits(2, 10.0, 30.0),
+        )
+    )
+
+    assert result.attempts[0].status is CandidateStatus.VALIDATION_REJECTION
+    assert result.attempts[0].stage is CandidateStage.PREPARATION
+
+
+def test_duplicate_candidate_ids_and_invalid_layout_options_fail_preflight() -> None:
+    with pytest.raises(ValueError, match="duplicate candidate id"):
+        execute_candidates(
+            _request(candidates=(LayoutCandidate("x"), LayoutCandidate("x")))
+        )
+    with pytest.raises(ValueError, match="duplicate caller layout option"):
+        execute_candidates(
+            _request(
+                layout_options=LayoutOptionValues(
+                    (
+                        LayoutOptionValue("x_spacing", 50.0),
+                        LayoutOptionValue("x_spacing", 60.0),
+                    )
+                )
+            )
+        )
+    with pytest.raises(ValueError, match="invalid caller layout option"):
+        execute_candidates(
+            _request(
+                layout_options=LayoutOptionValues(
+                    (LayoutOptionValue("fold_threshold", True),)
+                )
+            )
+        )
+    with pytest.raises(ValueError, match="candidate ids"):
+        execute_candidates(_request(candidates=(LayoutCandidate(cast(Any, 7)),)))
+
+
+@pytest.mark.parametrize(
+    ("name", "option", "pin"),
+    [
+        ("fold_threshold", 12, LayoutCommitments(fold_threshold=9)),
+        ("line_order", "span", LayoutCommitments(line_order="definition")),
+    ],
+)
+def test_conflicting_caller_option_and_commitment_are_rejected(
+    name: str,
+    option: int | str,
+    pin: LayoutCommitments,
+) -> None:
+    result = execute_candidates(
+        _request(
+            caller_pins=pin,
+            layout_options=LayoutOptionValues((LayoutOptionValue(name, option),)),
+            limits=ExecutionLimits(1, 10.0, 20.0),
+        )
+    ).baseline
+
+    assert result.status is CandidateStatus.VALIDATION_REJECTION
+    assert result.stage is CandidateStage.PREPARATION
+
+
+def test_settlement_checks_fold_value_on_the_graph() -> None:
+    pins = LayoutCommitments(fold_threshold=12)
+    overlay = LayoutCommitmentOverlay(caller=pins)
+    graph = _prepare_graph_state(
+        CONTROL_SOURCE,
+        source_dir=str(ROOT),
+        layout_commitments=overlay,
+    )
+    compute_layout(graph, validate=True)
+    graph.fold_threshold = 13
+
+    with pytest.raises(CommitmentSettlementError, match="fold-threshold"):
+        verify_settled_commitments(graph, overlay)
+
+
+def test_settlement_checks_endpoint_side_on_route_topology() -> None:
+    connector_id = _connector_id()
+    pins = LayoutCommitments(
+        endpoints=(
+            EndpointCommitment(
+                cast(Any, connector_id),
+                ConnectorEndpointRole.EXIT,
+                PortSide.RIGHT,
+            ),
+        )
+    )
+    overlay = LayoutCommitmentOverlay(caller=pins)
+    graph = _prepare_graph_state(
+        CONTROL_SOURCE,
+        source_dir=str(ROOT),
+        layout_commitments=overlay,
+    )
+    compute_layout(graph, validate=True)
+    assert graph.route_topology is not None
+    connector = graph.route_topology.connectors[0]
+    graph.route_topology = replace(
+        graph.route_topology,
+        connectors=(
+            replace(connector, exit_side=PortSide.BOTTOM),
+            *graph.route_topology.connectors[1:],
+        ),
+    )
+
+    with pytest.raises(CommitmentSettlementError, match="exit commitment"):
+        verify_settled_commitments(graph, overlay)
+
+
+def test_attempt_limit_reports_unattempted_candidates_explicitly() -> None:
+    candidates = tuple(LayoutCandidate(name) for name in ("a", "b", "c"))
+    result = execute_candidates(
+        _request(
+            candidates=candidates,
+            limits=ExecutionLimits(2, 10.0, 30.0),
+        )
+    )
+
+    assert result.attempt_count == 2
+    assert [item.candidate_id for item in result.attempts] == ["a"]
+    assert [item.id for item in result.unattempted] == ["b", "c"]
+    assert result.stop_reason is StopReason.ATTEMPT_LIMIT
+
+
+def test_per_attempt_timeout_reaps_the_worker() -> None:
+    result = execute_candidates(
+        _request(limits=ExecutionLimits(1, 0.05, 1.0)),
+        _fault=_FaultInjection(_FaultAction.BLOCK),
+    )
+
+    assert result.baseline.status is CandidateStatus.TIMEOUT
+    assert result.baseline.failure is not None
+    assert result.baseline.failure.message == "per-attempt deadline exceeded"
+    assert not __import__("multiprocessing").active_children()
+
+
+def test_total_deadline_stops_dispatch_without_inventing_attempts() -> None:
+    candidate = LayoutCandidate("never-started")
+    result = execute_candidates(
+        _request(
+            candidates=(candidate,),
+            limits=ExecutionLimits(2, 1.0, 0.05),
+        ),
+        _fault=_FaultInjection(_FaultAction.BLOCK),
+    )
+
+    assert result.baseline.status is CandidateStatus.TIMEOUT
+    assert result.attempts == ()
+    assert result.unattempted == (candidate,)
+    assert result.stop_reason is StopReason.TOTAL_DEADLINE
+
+
+@pytest.mark.parametrize(
+    ("fault", "status", "code"),
+    [
+        (
+            _FaultInjection(_FaultAction.CRASH),
+            CandidateStatus.WORKER_CRASH,
+            "nonzero-exit",
+        ),
+        (
+            _FaultInjection(_FaultAction.CLEAN_NO_PAYLOAD),
+            CandidateStatus.INFRASTRUCTURE_FAILURE,
+            "no-payload",
+        ),
+        (
+            _FaultInjection(_FaultAction.MALFORMED_PAYLOAD),
+            CandidateStatus.INFRASTRUCTURE_FAILURE,
+            "invalid-payload",
+        ),
+        (
+            _FaultInjection(_FaultAction.PAYLOAD_THEN_CRASH),
+            CandidateStatus.WORKER_CRASH,
+            "nonzero-exit",
+        ),
+    ],
+)
+def test_worker_crash_and_communication_outcomes_are_distinct(
+    fault: _FaultInjection,
+    status: CandidateStatus,
+    code: str,
+) -> None:
+    result = execute_candidates(
+        _request(limits=ExecutionLimits(1, 10.0, 20.0)), _fault=fault
+    )
+
+    assert result.baseline.status is status
+    assert result.baseline.failure is not None
+    assert result.baseline.failure.infrastructure_code == code
+    assert result.baseline.worker_exit_code is not None
+
+
+def test_completed_payload_followed_by_hang_times_out_with_evidence() -> None:
+    result = execute_candidates(
+        _request(limits=ExecutionLimits(1, 1.0, 2.0)),
+        _fault=_FaultInjection(_FaultAction.PAYLOAD_THEN_BLOCK),
+    )
+
+    assert result.baseline.status is CandidateStatus.TIMEOUT
+    assert result.baseline.evidence.svg is not None
+    assert result.baseline.worker_exit_code is not None
+
+
+def test_coordinator_failure_reaps_the_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def failed_wait(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise RuntimeError("injected coordinator failure")
+
+    monkeypatch.setattr(candidate_executor, "wait", failed_wait)
+    result = execute_candidates(
+        _request(limits=ExecutionLimits(1, 10.0, 20.0))
+    ).baseline
+
+    assert result.status is CandidateStatus.INFRASTRUCTURE_FAILURE
+    assert result.failure is not None
+    assert result.failure.infrastructure_code == "coordinator-failure"
+    assert not __import__("multiprocessing").active_children()
+
+
+def test_protocol_rejects_reset_and_wrong_chunk_size() -> None:
+    empty_digest = hashlib.sha256(b"").hexdigest()
+    assembler = candidate_executor._ProtocolAssembler()
+    assembler.feed(
+        candidate_executor._canonical_bytes(
+            {
+                "version": 1,
+                "sequence": 0,
+                "kind": "result-start",
+                "length": 0,
+                "sha256": empty_digest,
+                "chunks": 1,
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="chunk count or state"):
+        assembler.feed(
+            candidate_executor._canonical_bytes(
+                {
+                    "version": 1,
+                    "sequence": 1,
+                    "kind": "result-start",
+                    "length": 0,
+                    "sha256": empty_digest,
+                    "chunks": 1,
+                }
+            )
+        )
+
+    assembler = candidate_executor._ProtocolAssembler()
+    assembler.feed(
+        candidate_executor._canonical_bytes(
+            {
+                "version": 1,
+                "sequence": 0,
+                "kind": "result-start",
+                "length": 1,
+                "sha256": hashlib.sha256(b"x").hexdigest(),
+                "chunks": 1,
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="chunk length"):
+        assembler.feed(b"D" + struct.pack(">QI", 1, 0))
+
+
+@pytest.mark.parametrize(
+    ("stage", "present", "absent"),
+    [
+        (CandidateStage.PREPARATION, None, "graph"),
+        (CandidateStage.GRAPH_VALIDATION, None, "graph"),
+        (CandidateStage.LAYOUT, "graph", "route_plan"),
+        (CandidateStage.COMMITMENT_VERIFICATION, "graph", "route_plan"),
+        (CandidateStage.ROUTE_PLAN, "graph", "route_plan"),
+        (CandidateStage.RENDER_PLAN, "route_plan", "render_plan"),
+        (CandidateStage.SVG_EMISSION, "render_plan", "svg"),
+        (CandidateStage.ARTIFACT_VALIDATION, "svg", "artifact_findings"),
+    ],
+)
+def test_injected_stage_failures_retain_completed_evidence(
+    stage: CandidateStage,
+    present: str | None,
+    absent: str,
+) -> None:
+    result = execute_candidates(
+        _request(limits=ExecutionLimits(1, 10.0, 20.0)),
+        _fault=_FaultInjection(_FaultAction.RAISE, stage),
+    ).baseline
+
+    assert result.status is CandidateStatus.ENGINE_FAILURE
+    assert result.stage is stage
+    if present is not None:
+        assert getattr(result.evidence, present)
+    assert not getattr(result.evidence, absent)
+    assert result.worker_exit_code == 0
+    assert not __import__("multiprocessing").active_children()
+
+
+@pytest.mark.parametrize("message", ["geometry warning one", "renamed warning"])
+def test_typed_geometry_warning_rejects_without_message_matching(
+    monkeypatch: pytest.MonkeyPatch,
+    message: str,
+) -> None:
+    real_emit = candidate_executor._emit_svg_plan
+
+    def warned(*args: Any, **kwargs: Any) -> str:
+        warnings.warn(message, LayoutGeometryWarning)
+        return real_emit(*args, **kwargs)
+
+    monkeypatch.setattr(candidate_executor, "_emit_svg_plan", warned)
+    result = _direct_result(_request())
+
+    assert result.status is CandidateStatus.VALIDATION_REJECTION
+    assert result.stage is CandidateStage.SVG_EMISSION
+    assert result.evidence.diagnostics[-1].message == message
+
+
+def test_benign_warning_remains_an_ordered_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_emit = candidate_executor._emit_svg_plan
+
+    def warned(*args: Any, **kwargs: Any) -> str:
+        warnings.warn("benign diagnostic", UserWarning)
+        return real_emit(*args, **kwargs)
+
+    monkeypatch.setattr(candidate_executor, "_emit_svg_plan", warned)
+    result = _direct_result(_request())
+
+    assert result.status is CandidateStatus.ACCEPTED
+    assert result.evidence.diagnostics[-1].message == "benign diagnostic"
+
+
+@pytest.mark.parametrize("kind", [LABEL_STRIKE, MARKER_CROSS, OFFSET_COLLAPSE])
+def test_plan_aware_artifact_findings_reject(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+) -> None:
+    def finding(svg: str, *, plan: object) -> list[RenderFinding]:
+        assert "<svg" in svg
+        assert plan is not None
+        return [
+            RenderFinding(
+                kind,
+                "main",
+                "reads",
+                "injected artifact finding",
+                ((0.0, 0.0), (1.0, 1.0)),
+            )
+        ]
+
+    monkeypatch.setattr(candidate_executor, "validate_render", finding)
+    result = _direct_result(_request())
+
+    assert result.status is CandidateStatus.VALIDATION_REJECTION
+    assert result.stage is CandidateStage.ARTIFACT_VALIDATION
+    assert result.evidence.artifact_findings[0].kind == kind
+    assert result.evidence.svg is not None
+
+
+def test_final_route_plan_diagnostics_are_structured_rejections(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_build = candidate_executor.build_observed_render_plan
+
+    def diagnosed(*args: Any, **kwargs: Any) -> ObservedRenderPlan:
+        observed = real_build(*args, **kwargs)
+        route_plan = replace(
+            observed.route_plan,
+            diagnostics=(RoutePlanDiagnostic(None, "injected", "route rejected"),),
+        )
+        return ObservedRenderPlan(observed.plan, route_plan)
+
+    monkeypatch.setattr(candidate_executor, "build_observed_render_plan", diagnosed)
+    result = _direct_result(_request())
+
+    assert result.status is CandidateStatus.VALIDATION_REJECTION
+    assert result.stage is CandidateStage.ROUTE_VALIDATION
+    assert result.evidence.route_findings[0].code == "injected"
+    assert result.evidence.render_plan is not None
+
+
+def test_general_mapping_keys_are_canonical_but_sequences_remain_ordered() -> None:
+    assert _canonical_json({"b": 2, "a": 1}) == _canonical_json({"a": 1, "b": 2})
+    assert _canonical_json(("a", "b")) != _canonical_json(("b", "a"))
+
+
+def test_normal_api_and_cli_never_invoke_candidate_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def forbidden(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("normal render path invoked candidate execution")
+
+    monkeypatch.setattr(candidate_executor, "execute_candidates", forbidden)
+    assert "<svg" in render_string(CONTROL_SOURCE)
+    source = tmp_path / "normal.mmd"
+    output = tmp_path / "normal.svg"
+    source.write_text(CONTROL_SOURCE.replace("examples/", f"{ROOT}/examples/"))
+    invocation = CliRunner().invoke(cli, ["render", str(source), "-o", str(output)])
+    assert invocation.exit_code == 0, invocation.output
+    assert "<svg" in output.read_text()
+
+
+def test_frozen_sources_are_results_not_frozen_stages_across_hash_seeds() -> None:
+    script = ROOT / "tests/candidate_executor_oracle.py"
+    observations: list[dict[str, str]] = []
+    for seed in ("0", "1", "2", "5", "43", "random"):
+        env = os.environ.copy()
+        env["PYTHONHASHSEED"] = seed
+        env["PYTHONPATH"] = str(ROOT / "src")
+        completed = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=ROOT,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=240,
+        )
+        observations.append(json.loads(completed.stdout))
+
+    assert all(item == observations[0] for item in observations[1:])

--- a/tests/test_route_topology.py
+++ b/tests/test_route_topology.py
@@ -962,7 +962,7 @@ def test_corpus_topology_shapes_match_byte_identical_resolved_graphs() -> None:
         )
 
     assert digest.hexdigest() == (
-        "45b7eb91af27f76dbb0c1ed78317a541aa6ae2a695fb475c8ee808ec3f2ddaf3"
+        "463548fe77fc5237523f7c62181dce625169a61fc73dfafdacba819a319b350a"
     )
     assert saw_bypass_path
 


### PR DESCRIPTION
Closes #1645

## Why

Layout recovery will eventually explore alternative layout decisions. Before that can be safe, nf-metro needs a trustworthy way to answer one narrower question: what does this exact candidate produce when it runs through the real engine?

This PR adds that evaluation boundary. It does not generate, rank, select, or retry candidates, and normal renders never invoke it.

## What changed

- Adds immutable request, candidate, evidence, failure, and result records. A mandatory baseline runs before any candidate.
- Adds typed pre-inference commitments for section grids, directions, fold threshold, connector entry and exit sides, and line ordering. Malformed, duplicate, unknown, partial, and conflicting commitments are rejected before inference.
- Applies caller and candidate commitments through one parser boundary, records their provenance, and verifies both provenance and settled graph state after layout.
- Runs every attempt in a fresh spawned process with independent attempt limits, per-attempt deadlines, a total deadline, bounded framed IPC, strict payload validation, and deterministic cleanup.
- Uses the production preparation and SVG emission paths. Evidence records the settled graph, final route plan used by the RenderPlan, RenderPlan, exact SVG, diagnostics, and structured validation findings.
- Treats typed geometry warnings as rejection evidence while retaining ordinary warnings as ordered diagnostics.
- Adds a checked-in success control, injected stage and process failures, A-B-A isolation, production parity, large-payload IPC, settlement mutation checks, and cross-hash determinism coverage.

## Safety properties

The normal CLI and Python API do not import or call candidate execution. A no-op candidate matches the mandatory baseline, and the executor emits the same SVG as the production path for the same request. General mappings are canonicalised by key, while semantic sequences retain their order.

The IPC frame size uses the POSIX minimum atomic pipe-write guarantee. The coordinator rechecks deadlines between bounded receive batches and reaps the worker on success, timeout, crash, malformed communication, spawn failure, and unexpected coordinator failure.

## Verification

- 45 focused candidate-executor contract tests
- Cross-process oracle under hash seeds 0, 1, 2, 5, 43, and random
- 567 parser, provenance, route-plan, and route-topology tests
- 319 rendered-geometry validation tests
- Production API and RenderPlan parity tests
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy`
- All commit hooks

CI remains authoritative for the full suite and render comparison. This change is expected to produce no render differences.