### PR TITLE
Fix oversized playground bug-report URLs

### DIFF
--- a/website/playground-tests/playground.spec.js
+++ b/website/playground-tests/playground.spec.js
@@ -1,4 +1,6 @@
 const { test, expect } = require("@playwright/test");
+const fs = require("fs");
+const path = require("path");
 
 // One shared page booted once: the Pyodide cold-start is too slow to repeat per
 // test. Tests run serially and each leaves the editor in a known state.
@@ -16,6 +18,16 @@ async function waitReady(p) {
 async function openAdvanced() {
   await page.evaluate(() => {
     document.getElementById("advanced").open = true;
+  });
+}
+
+async function suppressNextPopup() {
+  await page.evaluate(() => {
+    const open = window.open;
+    window.open = () => {
+      window.open = open;
+      return null;
+    };
   });
 }
 
@@ -432,9 +444,8 @@ test("bug report builds a prefilled GitHub issue with the map and explanation", 
     window.__nfMetro.setValue(
       "%%metro line: q | Q | #abc\ngraph LR\n  uniquenode[Unique] -->|q| other[Other]\n",
     );
-    // Prevent the real github.com tab from opening during the test.
-    window.open = () => null;
   });
+  await suppressNextPopup();
 
   await page.locator("#btn-report").click();
   await expect(page.locator("#report-modal")).toBeVisible();
@@ -448,6 +459,9 @@ test("bug report builds a prefilled GitHub issue with the map and explanation", 
   await page.locator("#report-submit").click();
 
   await expect(page.locator("#report-modal")).toBeHidden();
+  await expect
+    .poll(() => page.evaluate(() => window.__nfMetroLastIssueUrl))
+    .not.toBeNull();
   const issueUrl = await page.evaluate(() => window.__nfMetroLastIssueUrl);
   const u = new URL(issueUrl);
   expect(u.host).toBe("github.com");
@@ -456,7 +470,33 @@ test("bug report builds a prefilled GitHub issue with the map and explanation", 
   const body = u.searchParams.get("body");
   expect(body).toContain("Edge renders backwards from uniquenode");
   expect(body).toContain("uniquenode[Unique]");
-  expect(body).toContain("#mmd=");
+  expect(body).toContain("#mmd-gz=");
+});
+
+test("bug report URL stays within GitHub's request limit", async () => {
+  const source = fs.readFileSync(
+    path.join(
+      __dirname,
+      "../../examples/topologies/packed_cell_right_exit_left_entry_wrap.mmd",
+    ),
+    "utf8",
+  );
+  await page.evaluate((value) => {
+    window.__nfMetro.setValue(value);
+    window.__nfMetroLastIssueUrl = null;
+  }, source);
+  await suppressNextPopup();
+
+  await page.locator("#btn-report").click();
+  await page.locator("#report-text").fill("Genomeassembler map renders badly");
+  await page.locator("#report-submit").click();
+
+  await expect
+    .poll(() => page.evaluate(() => window.__nfMetroLastIssueUrl))
+    .not.toBeNull();
+  const issueUrl = await page.evaluate(() => window.__nfMetroLastIssueUrl);
+  expect(issueUrl.length).toBeLessThanOrEqual(7500);
+  expect(new URL(issueUrl).searchParams.get("body")).toContain("#mmd-gz=");
 });
 
 test("share link round-trips the editor content", async () => {

--- a/website/public/playground/app.js
+++ b/website/public/playground/app.js
@@ -1883,15 +1883,32 @@ async function copySource() {
 
 /* ----------------------------- bug report ----------------------------- */
 
-function buildIssueUrl(explanation) {
-  const opts = currentOptions();
-  const mmd = editor.getValue();
-  const MAX = 6000;
-  const mmdBlock =
-    mmd.length > MAX
-      ? mmd.slice(0, MAX) + "\n... (truncated; full map in the reproduce link)"
-      : mmd;
+const MAX_ISSUE_URL_LENGTH = 7500;
+const MAX_ISSUE_SOURCE_LENGTH = 6000;
+const MAX_ISSUE_EXPLANATION_LENGTH = 3000;
+
+function issueSourceBlock(mmd, limit, hasReproduceLink) {
+  if (mmd.length <= limit) return mmd;
+  const location = hasReproduceLink
+    ? "full map in the reproduce link"
+    : "attach the full .mmd file to this issue";
+  return mmd.slice(0, limit) + `\n... (truncated; ${location})`;
+}
+
+function issueExplanationBlock(explanation, limit) {
+  if (explanation.length <= limit) return explanation;
+  return (
+    explanation.slice(0, limit) +
+    "\n... (truncated; add the remaining details after opening this issue)"
+  );
+}
+
+function issueUrl(explanation, opts, mmd, sourceLimit, reproduceUrl) {
+  const mmdBlock = issueSourceBlock(mmd, sourceLimit, Boolean(reproduceUrl));
   const lo = opts.layout_options;
+  const reproduce = reproduceUrl
+    ? `[Open this map in the playground](${reproduceUrl})`
+    : "The map is too large for a reproduce link. Attach the `.mmd` file to this issue.";
   const body = `## What's wrong
 
 ${explanation}
@@ -1904,7 +1921,7 @@ ${mmdBlock}
 
 ## Reproduce
 
-[Open this map in the playground](${shareUrl()})
+${reproduce}
 
 ## Environment
 
@@ -1926,6 +1943,73 @@ ${mmdBlock}
   return `https://github.com/${REPO}/issues/new?${params.toString()}`;
 }
 
+function fitIssueUrl(explanation, opts, mmd, reproduceUrl) {
+  let low = 0;
+  let high = Math.min(mmd.length, MAX_ISSUE_SOURCE_LENGTH);
+  let best = issueUrl(explanation, opts, mmd, 0, reproduceUrl);
+  if (best.length > MAX_ISSUE_URL_LENGTH) return null;
+  const fullest = issueUrl(explanation, opts, mmd, high, reproduceUrl);
+  if (fullest.length <= MAX_ISSUE_URL_LENGTH) return fullest;
+  if (high === mmd.length) high -= 1;
+
+  while (low <= high) {
+    const limit = Math.floor((low + high) / 2);
+    const candidate = issueUrl(explanation, opts, mmd, limit, reproduceUrl);
+    if (candidate.length <= MAX_ISSUE_URL_LENGTH) {
+      best = candidate;
+      low = limit + 1;
+    } else {
+      high = limit - 1;
+    }
+  }
+  return best;
+}
+
+function fitIssueExplanation(explanation, opts, mmd) {
+  let low = 0;
+  let high = Math.min(explanation.length, MAX_ISSUE_EXPLANATION_LENGTH);
+  let best = issueUrl(
+    issueExplanationBlock(explanation, 0),
+    opts,
+    mmd,
+    0,
+    null,
+  );
+
+  while (low <= high) {
+    const limit = Math.floor((low + high) / 2);
+    const candidate = issueUrl(
+      issueExplanationBlock(explanation, limit),
+      opts,
+      mmd,
+      0,
+      null,
+    );
+    if (candidate.length <= MAX_ISSUE_URL_LENGTH) {
+      best = candidate;
+      low = limit + 1;
+    } else {
+      high = limit - 1;
+    }
+  }
+  return best;
+}
+
+async function buildIssueUrl(explanation) {
+  const opts = currentOptions();
+  const mmd = editor.getValue();
+  const issueExplanation = issueExplanationBlock(
+    explanation,
+    MAX_ISSUE_EXPLANATION_LENGTH,
+  );
+  const reproduceUrl = await compressedShareUrl();
+  return (
+    fitIssueUrl(issueExplanation, opts, mmd, reproduceUrl) ||
+    fitIssueUrl(issueExplanation, opts, mmd, null) ||
+    fitIssueExplanation(explanation, opts, mmd)
+  );
+}
+
 function openReport() {
   el("report-text").value = "";
   el("report-submit").disabled = true;
@@ -1937,18 +2021,20 @@ function closeReport() {
   el("report-modal").classList.add("hidden");
 }
 
-function submitReport() {
+async function submitReport() {
   const explanation = el("report-text").value.trim();
   if (!explanation) {
     el("report-text").focus();
     return;
   }
-  const url = buildIssueUrl(explanation);
+  const reportWindow = window.open("about:blank", "_blank");
+  if (reportWindow) reportWindow.opener = null;
+  closeReport();
+  const url = await buildIssueUrl(explanation);
   // Exposed so the e2e suite can assert the prefilled issue without
   // navigating to github.com.
   window.__nfMetroLastIssueUrl = url;
-  window.open(url, "_blank", "noopener");
-  closeReport();
+  if (reportWindow) reportWindow.location.href = url;
 }
 
 /* -------------------------- nextflow import --------------------------- */

--- a/website/public/playground/app.js
+++ b/website/public/playground/app.js
@@ -1791,10 +1791,6 @@ function _b64urlToBytes(b64) {
   return Uint8Array.from(bin, (c) => c.charCodeAt(0));
 }
 
-function b64urlEncode(str) {
-  return _bytesToB64url(new TextEncoder().encode(str));
-}
-
 function b64urlDecode(b64) {
   return new TextDecoder().decode(_b64urlToBytes(b64));
 }
@@ -1848,15 +1844,9 @@ function _pageUrl(hash) {
   return location.origin + location.pathname + location.search + hash;
 }
 
-function shareUrl() {
+async function compressedShareUrl(source = editor.getValue()) {
   return _pageUrl(
-    "#mmd=" + encodeURIComponent(b64urlEncode(editor.getValue())),
-  );
-}
-
-async function compressedShareUrl() {
-  return _pageUrl(
-    "#mmd-gz=" + encodeURIComponent(await b64urlEncodeGz(editor.getValue())),
+    "#mmd-gz=" + encodeURIComponent(await b64urlEncodeGz(source)),
   );
 }
 
@@ -2002,9 +1992,13 @@ async function buildIssueUrl(explanation) {
     explanation,
     MAX_ISSUE_EXPLANATION_LENGTH,
   );
-  const reproduceUrl = await compressedShareUrl();
+  const reproduceUrl = await compressedShareUrl(mmd);
+  const withReproduce =
+    reproduceUrl.length < MAX_ISSUE_URL_LENGTH
+      ? fitIssueUrl(issueExplanation, opts, mmd, reproduceUrl)
+      : null;
   return (
-    fitIssueUrl(issueExplanation, opts, mmd, reproduceUrl) ||
+    withReproduce ||
     fitIssueUrl(issueExplanation, opts, mmd, null) ||
     fitIssueExplanation(explanation, opts, mmd)
   );


### PR DESCRIPTION
## Summary

- compress playground reproduce links before adding them to bug reports
- cap generated GitHub issue URLs at 7,500 characters by budgeting embedded source and falling back to an attachment prompt when necessary
- add a Playwright regression using the genomeassembler topology that exceeded GitHub's request limit

Fixes #1628

## Test plan

- [x] targeted bug-report and share-link Playwright tests
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `mypy`
- [x] all-files Prettier hook
- [x] GitHub Actions
- [x] render-preview verdict: no visual changes detected

Generated with Codex
