### PR TITLE
CI hygiene: bound jobs and gate expensive work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -23,6 +24,7 @@ jobs:
 
   format:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Runs the prettier hook from prek.toml (web/docs files; Python is handled
@@ -34,8 +36,11 @@ jobs:
           extra-args: prettier --all-files
 
   test:
+    needs: [lint, format]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
+      fail-fast: true
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
         split: [1, 2, 3]
@@ -49,10 +54,14 @@ jobs:
       - run: pip install -e ".[dev,font]"
       - run: >-
           pytest --splits 3 --group ${{ matrix.split }}
+          --splitting-algorithm least_duration --durations=25
           --ignore=tests/test_routing_gate_coverage.py
 
   routing-gates:
+    name: Routing gate coverage (Python 3.11)
+    needs: [lint, format]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,15 @@ jobs:
         with:
           extra-args: prettier --all-files
 
+  render-diff:
+    if: github.event_name == 'pull_request'
+    needs: [lint, format]
+    uses: ./.github/workflows/pr-renders.yml
+    with:
+      base-sha: ${{ github.event.pull_request.base.sha }}
+      head-sha: ${{ github.event.pull_request.head.sha }}
+      pr-number: ${{ github.event.number }}
+
   test:
     needs: [lint, format]
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   links:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/playground-e2e.yml
+++ b/.github/workflows/playground-e2e.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/pr-render-publish.yml
+++ b/.github/workflows/pr-render-publish.yml
@@ -2,7 +2,7 @@ name: Publish render preview
 
 on:
   workflow_run:
-    workflows: ["PR render preview"]
+    workflows: ["CI"]
     types: [requested, completed]
 
 permissions:
@@ -14,40 +14,67 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event.workflow_run.event == 'pull_request'
+    outputs:
+      artifact: ${{ steps.context.outputs.artifact }}
+      pr: ${{ steps.context.outputs.pr }}
+    steps:
+      - name: Resolve workflow context
+        id: context
+        env:
+          ACTION: ${{ github.event.action }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PAYLOAD_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          pr="$PAYLOAD_PR"
+          if [ -z "$pr" ]; then
+            pr=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" \
+              --jq 'map(select(.state == "open"))[0].number // empty')
+          fi
+
+          artifact=false
+          if [ "$ACTION" = "completed" ]; then
+            artifact_id=$(gh api \
+              "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts?name=render-preview" \
+              --jq '.artifacts[0].id // empty')
+            if [ -n "$artifact_id" ]; then
+              artifact=true
+            fi
+          fi
+
+          echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+
   pending:
+    needs: resolve
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.action == 'requested'
     steps:
-      - name: Resolve PR number from head SHA
-        id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR=$(gh api --paginate \
-            "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
-            --jq ".[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\") | .number" \
-            | head -n1)
-          echo "number=$PR" >> "$GITHUB_OUTPUT"
-
       - name: Mark preview as rendering
-        if: steps.pr.outputs.number != ''
+        if: needs.resolve.outputs.pr != ''
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: render-preview
-          number: ${{ steps.pr.outputs.number }}
+          number: ${{ needs.resolve.outputs.pr }}
           message: |
             **Render preview**: :hourglass_flowing_sand: rendering in progress...
 
   publish:
+    needs: resolve
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.action == 'completed' &&
-      github.event.workflow_run.conclusion == 'success'
+      needs.resolve.outputs.artifact == 'true'
     steps:
       - name: Download preview artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -128,30 +155,20 @@ jobs:
             **Render preview**: no visual changes detected. All renders match `main`.
 
   failed:
+    needs: resolve
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.action == 'completed' &&
-      github.event.workflow_run.conclusion != 'success'
+      needs.resolve.outputs.artifact != 'true'
     steps:
-      - name: Resolve PR number from head SHA
-        id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR=$(gh api --paginate \
-            "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
-            --jq ".[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\") | .number" \
-            | head -n1)
-          echo "number=$PR" >> "$GITHUB_OUTPUT"
-
       - name: Report preview failure
-        if: steps.pr.outputs.number != ''
+        if: needs.resolve.outputs.pr != ''
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: render-preview
-          number: ${{ steps.pr.outputs.number }}
+          number: ${{ needs.resolve.outputs.pr }}
           message: |
             **Render preview** was not generated because a prerequisite check or the render job failed.
             Inspect the [workflow run](${{ github.event.workflow_run.html_url }}) for details.

--- a/.github/workflows/pr-render-publish.yml
+++ b/.github/workflows/pr-render-publish.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   pending:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.action == 'requested'
@@ -42,6 +43,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.action == 'completed' &&
@@ -124,3 +126,32 @@ jobs:
           number: ${{ steps.meta.outputs.pr }}
           message: |
             **Render preview**: no visual changes detected. All renders match `main`.
+
+  failed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.action == 'completed' &&
+      github.event.workflow_run.conclusion != 'success'
+    steps:
+      - name: Resolve PR number from head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+            --jq ".[] | select(.head.sha == \"${{ github.event.workflow_run.head_sha }}\") | .number" \
+            | head -n1)
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Report preview failure
+        if: steps.pr.outputs.number != ''
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        with:
+          header: render-preview
+          number: ${{ steps.pr.outputs.number }}
+          message: |
+            **Render preview** was not generated because a prerequisite check or the render job failed.
+            Inspect the [workflow run](${{ github.event.workflow_run.html_url }}) for details.

--- a/.github/workflows/pr-renders.yml
+++ b/.github/workflows/pr-renders.yml
@@ -1,39 +1,23 @@
 name: PR render preview
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_call:
+    inputs:
+      base-sha:
+        required: true
+        type: string
+      head-sha:
+        required: true
+        type: string
+      pr-number:
+        required: true
+        type: number
 
 permissions:
   contents: read
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-      - run: pip install -e ".[dev]"
-      - run: ruff check src/ tests/
-      - run: ruff format --check src/ tests/
-      - run: mypy
-
-  format:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
-        with:
-          extra-args: prettier --all-files
-
   render-diff:
-    needs: [lint, format]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -53,13 +37,13 @@ jobs:
       - name: Determine render strategy
         id: strategy
         run: |
-          base='${{ github.event.pull_request.base.sha }}'
-          head='${{ github.event.pull_request.head.sha }}'
+          base='${{ inputs.base-sha }}'
+          head='${{ inputs.head-sha }}'
           echo "render_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           base_render_key="$(
             git ls-tree -r "$base" -- \
               pyproject.toml src scripts/build_gallery.py scripts/gallery.yaml \
-              examples tests/fixtures \
+              examples tests/fixtures tests/layout_metrics.py \
               | git hash-object --stdin
           )"
           echo "base_render_key=$base_render_key" >> "$GITHUB_OUTPUT"
@@ -119,7 +103,7 @@ jobs:
           set +e
           python scripts/build_render_diff.py \
             /tmp/base_renders /tmp/pr_renders /tmp/diff_site \
-            --pr ${{ github.event.number }} \
+            --pr ${{ inputs.pr-number }} \
             --marker ${{ github.run_id }}
           EXIT_CODE=$?
           set -e
@@ -137,7 +121,7 @@ jobs:
       - name: Stage preview metadata
         run: |
           mkdir -p /tmp/diff_site /tmp/preview_meta
-          echo "${{ github.event.number }}" > /tmp/preview_meta/pr_number.txt
+          echo "${{ inputs.pr-number }}" > /tmp/preview_meta/pr_number.txt
           echo "${{ steps.diff.outputs.has_changes }}" > /tmp/preview_meta/has_changes.txt
 
       - name: Upload preview artifact

--- a/.github/workflows/pr-renders.yml
+++ b/.github/workflows/pr-renders.yml
@@ -8,8 +8,34 @@ permissions:
   contents: read
 
 jobs:
-  render-diff:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: pip install -e ".[dev]"
+      - run: ruff check src/ tests/
+      - run: ruff format --check src/ tests/
+      - run: mypy
+
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
+        with:
+          extra-args: prettier --all-files
+
+  render-diff:
+    needs: [lint, format]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -30,6 +56,13 @@ jobs:
           base='${{ github.event.pull_request.base.sha }}'
           head='${{ github.event.pull_request.head.sha }}'
           echo "render_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          base_render_key="$(
+            git ls-tree -r "$base" -- \
+              pyproject.toml src scripts/build_gallery.py scripts/gallery.yaml \
+              examples tests/fixtures \
+              | git hash-object --stdin
+          )"
+          echo "base_render_key=$base_render_key" >> "$GITHUB_OUTPUT"
           changed="$(git diff --name-only "$base" "$head")"
           echo "Changed files:"; echo "$changed"
           allowed='^(examples/|tests/fixtures/).*\.mmd$'
@@ -42,14 +75,14 @@ jobs:
           fi
           printf '%s\n' "$changed" > /tmp/changed_mmd.txt
 
-      # Base renders depend only on the base SHA, so cache them. Re-pushes to a
-      # PR share the same base SHA and reuse this instead of re-rendering.
+      # Only files that can affect gallery output belong in the cache key. A base
+      # branch update that changes unrelated files can reuse the rendered corpus.
       - name: Cache base renders
         id: base-cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/base_renders
-          key: render-base-${{ github.event.pull_request.base.sha }}
+          key: render-base-${{ steps.strategy.outputs.base_render_key }}
 
       - name: Install (PR head)
         run: pip install -e ".[docs]"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -25,6 +26,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: pypi
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -41,6 +41,12 @@ mypy src/
 
 The topology suite parametrizes over every `.mmd` in `examples/topologies/` and runs the full layout oracle against each one. It is the most sensitive regression check, so it is worth running after any layout change.
 
+CI balances its three test shards from the committed `.test_durations` file and reports the 25 slowest tests in each shard. Refresh the timings after a substantial change to test count or runtime, then review and commit the updated file:
+
+```bash frame="terminal"
+pytest --store-durations --clean-durations
+```
+
 ## Before opening a PR
 
 <Steps>

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -124,7 +124,7 @@ The corollary: once a check is in, it stays in. If a check fires incorrectly, fi
 
 Automated geometry checks verify the coordinates are correct; they can't verify the result _looks_ right. For layout or rendering changes, visual review is essential.
 
-**Via CI (preferred):** push to a PR. `.github/workflows/pr-renders.yml` renders the gallery on both the PR branch and the base, builds a side-by-side before/after for every SVG that changed, and publishes the diff (the comment on your PR links to it). Scroll through and confirm nothing regressed.
+**Via CI (preferred):** push to a PR. The CI workflow invokes `.github/workflows/pr-renders.yml` after lint and format pass, renders the gallery on both the PR branch and the base, builds a side-by-side before/after for every SVG that changed, and publishes the diff (the comment on your PR links to it). Scroll through and confirm nothing regressed.
 
 **Locally:** render individual examples directly:
 

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,63 @@
+"""Repository invariants for GitHub Actions resource usage."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+JOB_HEADER = re.compile(r"^  (?P<name>[A-Za-z0-9_-]+):\n", re.MULTILINE)
+
+
+def _jobs(path: Path) -> dict[str, str]:
+    text = path.read_text()
+    _, jobs = text.split("\njobs:\n", maxsplit=1)
+    matches = list(JOB_HEADER.finditer(jobs))
+    return {
+        match.group("name"): jobs[
+            match.start() : matches[index + 1].start()
+            if index + 1 < len(matches)
+            else None
+        ]
+        for index, match in enumerate(matches)
+    }
+
+
+@pytest.mark.parametrize(
+    "workflow",
+    sorted(WORKFLOWS.glob("*.yml")),
+    ids=lambda path: path.name,
+)
+def test_every_workflow_job_has_a_finite_timeout(workflow: Path):
+    for job_name, job in _jobs(workflow).items():
+        match = re.search(r"^    timeout-minutes: (?P<minutes>\d+)$", job, re.MULTILINE)
+        assert match, f"{workflow.name}:{job_name} has no timeout-minutes"
+        assert int(match.group("minutes")) > 0
+
+
+@pytest.mark.parametrize("job_name", ["test", "routing-gates"])
+def test_expensive_ci_jobs_wait_for_fast_checks(job_name: str):
+    job = _jobs(WORKFLOWS / "ci.yml")[job_name]
+    assert re.search(r"^    needs: \[lint, format\]$", job, re.MULTILINE)
+
+
+def test_test_matrix_uses_committed_timings_and_reports_slow_tests():
+    job = _jobs(WORKFLOWS / "ci.yml")["test"]
+    assert (ROOT / ".test_durations").is_file()
+    assert "fail-fast: true" in job
+    assert "--splitting-algorithm least_duration" in job
+    assert "--durations=25" in job
+
+
+def test_render_diff_waits_for_fast_checks_and_uses_content_cache_key():
+    workflow = WORKFLOWS / "pr-renders.yml"
+    jobs = _jobs(workflow)
+    assert re.search(
+        r"^    needs: \[lint, format\]$", jobs["render-diff"], re.MULTILINE
+    )
+    assert "base_render_key=" in jobs["render-diff"]
+    assert (
+        "key: render-base-${{ steps.strategy.outputs.base_render_key }}"
+        in jobs["render-diff"]
+    )

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -32,8 +32,14 @@ def _jobs(path: Path) -> dict[str, str]:
 def test_every_workflow_job_has_a_finite_timeout(workflow: Path):
     for job_name, job in _jobs(workflow).items():
         match = re.search(r"^    timeout-minutes: (?P<minutes>\d+)$", job, re.MULTILINE)
-        assert match, f"{workflow.name}:{job_name} has no timeout-minutes"
-        assert int(match.group("minutes")) > 0
+        if match:
+            assert int(match.group("minutes")) > 0
+            continue
+        assert re.search(
+            r"^    uses: \./\.github/workflows/[A-Za-z0-9_-]+\.yml$",
+            job,
+            re.MULTILINE,
+        ), f"{workflow.name}:{job_name} has no timeout-minutes"
 
 
 @pytest.mark.parametrize("job_name", ["test", "routing-gates"])
@@ -51,13 +57,20 @@ def test_test_matrix_uses_committed_timings_and_reports_slow_tests():
 
 
 def test_render_diff_waits_for_fast_checks_and_uses_content_cache_key():
-    workflow = WORKFLOWS / "pr-renders.yml"
-    jobs = _jobs(workflow)
-    assert re.search(
-        r"^    needs: \[lint, format\]$", jobs["render-diff"], re.MULTILINE
-    )
-    assert "base_render_key=" in jobs["render-diff"]
+    caller = _jobs(WORKFLOWS / "ci.yml")["render-diff"]
+    assert re.search(r"^    needs: \[lint, format\]$", caller, re.MULTILINE)
+    assert "uses: ./.github/workflows/pr-renders.yml" in caller
+
+    render_job = _jobs(WORKFLOWS / "pr-renders.yml")["render-diff"]
+    assert "base_render_key=" in render_job
+    assert "tests/layout_metrics.py" in render_job
     assert (
-        "key: render-base-${{ steps.strategy.outputs.base_render_key }}"
-        in jobs["render-diff"]
+        "key: render-base-${{ steps.strategy.outputs.base_render_key }}" in render_job
     )
+
+
+def test_render_publisher_follows_ci_artifact_instead_of_ci_conclusion():
+    workflow = (WORKFLOWS / "pr-render-publish.yml").read_text()
+    assert 'workflows: ["CI"]' in workflow
+    assert "actions/runs/${RUN_ID}/artifacts?name=render-preview" in workflow
+    assert "needs.resolve.outputs.artifact == 'true'" in workflow


### PR DESCRIPTION
## Summary

- add finite timeouts to every executable workflow job and gate tests, routing coverage, and render previews behind lint and format
- balance the test matrix with committed timings, report slow tests, document timing refresh, and make the Python 3.11 routing constraint explicit
- reuse base renders through a render-input content key and publish previews from their artifact independently of later test results
- add repository invariants covering timeout, gating, sharding, caching, and preview-publication configuration

Fixes #1370

## Test plan

- [x] `pytest tests/test_ci_workflows.py -q --no-header -n 0` (13 passed)
- [x] `actionlint`
- [x] `prek run --all-files`
- [x] GitHub Actions CI
- [x] Visual review of [render preview](https://seqeralabs.github.io/nf-metro/_pr/1682/)
- [x] Render-preview verdict: no visual changes detected

Generated with Codex
