### PR TITLE
Complete orientation-equivalence enforcement ratchets

### DIFF
--- a/tests/orientation_signature.py
+++ b/tests/orientation_signature.py
@@ -5,7 +5,7 @@ whichever way the flow runs, so the *distances* a layout puts between stations
 are not expected to survive a quarter turn.  What must survive is everything the
 engine decides structurally -- which station comes next along the flow, which
 lane it sits in, which side a port is pinned to, how far a port sits from the
-box edge it is pinned to, and which sections' box edges are made to agree.
+box edge it is pinned to.
 
 So a signature is split in two:
 
@@ -17,8 +17,8 @@ So a signature is split in two:
 :func:`relational_signature`
     Constant-driven clearances and boolean relationships (a port's clearance to
     its pinned edge, whether an entry port precedes its section's stations in
-    flow order, whether cell-mates' leading box edges agree).  Also compared for
-    exact equality, because none of it is a function of glyph extents.
+    flow order). Also compared for exact equality, because none of it is a
+    function of glyph extents.
 """
 
 from __future__ import annotations
@@ -136,29 +136,6 @@ class PortRelation:
 @dataclass(frozen=True)
 class RelationalSignature:
     ports: dict[str, PortRelation] = field(default_factory=dict)
-    # (axis, index) -> whether the sections sharing that grid row/column agree on
-    # one of the two box edges perpendicular to the group's own axis: top or
-    # bottom for a row of side-by-side sections, left or right for a column of
-    # stacked ones.
-    #
-    # Which of the pair is deliberately aligned is not itself rotation-invariant
-    # (a quarter turn carries a row's top onto a column's right), and the other
-    # edge of the pair agrees only when the members happen to be equally deep --
-    # an accident of glyph extents. That the group agrees on *an* edge is the
-    # part the engine decides, so that is what the signature records.
-    #
-    # This family is weaker than the rest of the signature, and a divergence in
-    # it is a lead rather than a proof.  A pass that levels a group's edges can
-    # be followed by one that reclaims each box back to its own content, and
-    # content extents are glyph-driven: two boxes then share an edge only where
-    # their content offsets happen to coincide.  So a group_alignment difference
-    # between two orientations can come from label metrics rather than from two
-    # code paths, and each one needs its mechanism identified before it is
-    # treated as a defect.
-    #
-    # The other families do not have this weakness: they are ordinals or
-    # constant-driven clearances, with no dependence on text.
-    aligned_groups: dict[tuple[str, int], bool] = field(default_factory=dict)
 
 
 def _flow_extent(graph: MetroGraph, section: Section) -> tuple[float, float] | None:
@@ -209,22 +186,15 @@ def relational_signature(graph: MetroGraph) -> RelationalSignature:
             follows_stations=follows,
         )
 
-    aligned: dict[tuple[str, int], bool] = {}
-    for axis, index_of, edges in (
-        ("row", lambda s: s.grid_row, ("top", "bottom")),
-        ("col", lambda s: s.grid_col, ("left", "right")),
-    ):
-        groups: dict[int, list[Section]] = {}
-        for section in graph.sections.values():
-            groups.setdefault(index_of(section), []).append(section)
-        for index, members in groups.items():
-            if len(members) < 2:
-                continue
-            aligned[(axis, index)] = any(
-                len({round(_box_edges(s)[edge], 1) for s in members}) == 1
-                for edge in edges
-            )
-    return RelationalSignature(ports=ports, aligned_groups=aligned)
+    return RelationalSignature(ports=ports)
+
+
+NON_INVARIANT_MEASURES = {
+    "group_alignment": (
+        "box-edge agreement depends on glyph-driven content extents, which a "
+        "quarter turn does not preserve"
+    )
+}
 
 
 DIVERGENCE_FAMILIES = frozenset(
@@ -237,7 +207,6 @@ DIVERGENCE_FAMILIES = frozenset(
         "port_perpendicular",
         "port_clearance",
         "port_flow_end",
-        "group_alignment",
     }
 )
 """Every property :func:`divergences` reports on.
@@ -265,25 +234,6 @@ class Divergence:
 
     def __str__(self) -> str:
         return f"[{self.family}] {self.detail}"
-
-
-def _map_group_key(
-    key: tuple[str, int], orientation: Orientation, dims: tuple[int, int]
-) -> tuple[str, int]:
-    """Carry a grid-group key through *orientation*.
-
-    A quarter turn sends a row onto a column and vice versa; the reflection
-    renumbers columns.  Mirrors the cell remap in
-    :meth:`Orientation.cell` at the level of whole rows and columns.
-    """
-    axis, index = key
-    cols, rows = dims
-    if orientation.mirrored and axis == "col":
-        index = cols - 1 - index
-    for _ in range(orientation.quarter_turns):
-        axis, index = ("col", rows - 1 - index) if axis == "row" else ("row", index)
-        cols, rows = rows, cols
-    return (axis, index)
 
 
 def _grid_dims(ordinals: dict[str, SectionOrdinals]) -> tuple[int, int]:
@@ -380,17 +330,4 @@ def divergences(
                     )
                 )
 
-    for key, ref_aligned in ref_r.aligned_groups.items():
-        want_key = _map_group_key(key, orientation, dims)
-        img_aligned = img_r.aligned_groups.get(want_key)
-        if img_aligned is None:
-            found.append(Divergence("group_alignment", f"grid group {want_key} absent"))
-        elif img_aligned != ref_aligned:
-            found.append(
-                Divergence(
-                    "group_alignment",
-                    f"grid group {key} -> {want_key}: shares an edge "
-                    f"{img_aligned}, expected {ref_aligned}",
-                )
-            )
     return found

--- a/tests/single_axis_ratchet.py
+++ b/tests/single_axis_ratchet.py
@@ -33,6 +33,9 @@ class _FieldReads(ast.NodeVisitor):
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         return
 
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return
+
 
 def _classify(
     node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
@@ -63,7 +66,44 @@ class _FunctionCollector(ast.NodeVisitor):
         self.generic_visit(node)
         self.scope.pop()
 
+    def _visit_default(
+        self, function_name: str, argument: ast.arg, default: ast.expr
+    ) -> None:
+        if isinstance(default, ast.Lambda):
+            self._visit_lambda(default, f"default:{function_name}.{argument.arg}")
+        else:
+            self.visit(default)
+
+    def _visit_argument_defaults(self, owner: str, arguments: ast.arguments) -> None:
+        positional = [*arguments.posonlyargs, *arguments.args]
+        for argument, default in zip(
+            positional[-len(arguments.defaults) :], arguments.defaults
+        ):
+            self._visit_default(owner, argument, default)
+        for argument, default in zip(arguments.kwonlyargs, arguments.kw_defaults):
+            if default is not None:
+                self._visit_default(owner, argument, default)
+
+    def _visit_definition_expressions(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_argument_defaults(node.name, node.args)
+        positional = [*node.args.posonlyargs, *node.args.args]
+        arguments = [*positional, *node.args.kwonlyargs]
+        if node.args.vararg is not None:
+            arguments.append(node.args.vararg)
+        if node.args.kwarg is not None:
+            arguments.append(node.args.kwarg)
+        for argument in arguments:
+            if argument.annotation is not None:
+                self.visit(argument.annotation)
+        if node.returns is not None:
+            self.visit(node.returns)
+
     def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._visit_definition_expressions(node)
         name_parts = [*self.scope, node.name]
         qualname = ".".join(name_parts)
         if result := _classify(node):
@@ -80,18 +120,39 @@ class _FunctionCollector(ast.NodeVisitor):
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._visit_function(node)
 
-    def visit_Lambda(self, node: ast.Lambda) -> None:
+    def _visit_lambda(self, node: ast.Lambda, role: str | None = None) -> None:
         parent = ".".join(self.scope)
-        ordinal = self.lambda_ordinals.get(parent, 0) + 1
-        self.lambda_ordinals[parent] = ordinal
-        name = f"<lambda>#{ordinal}"
+        base = f"<lambda:{role}>" if role else "<lambda>"
+        ordinal_key = f"{parent}.{base}"
+        ordinal = self.lambda_ordinals.get(ordinal_key, 0) + 1
+        self.lambda_ordinals[ordinal_key] = ordinal
+        name = base if role and ordinal == 1 else f"{base}#{ordinal}"
         qualname = f"{parent}.{name}" if parent else name
+        owner = role.removeprefix("default:") if role else name
+        self._visit_argument_defaults(owner, node.args)
         if result := _classify(node):
             axis, fields = result
             self.sites[qualname] = SingleAxisSite(axis, fields, node.lineno)
         self.scope.extend((name, "<locals>"))
         self.visit(node.body)
         del self.scope[-2:]
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_lambda(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if isinstance(node.value, ast.Lambda) and len(node.targets) == 1:
+            target = node.targets[0]
+            role = f"assigned:{target.id}" if isinstance(target, ast.Name) else None
+            self._visit_lambda(node.value, role)
+            return
+        self.generic_visit(node)
+
+    def visit_keyword(self, node: ast.keyword) -> None:
+        if isinstance(node.value, ast.Lambda) and node.arg is not None:
+            self._visit_lambda(node.value, f"keyword:{node.arg}")
+            return
+        self.generic_visit(node)
 
 
 def _sites_from_source(

--- a/tests/single_axis_ratchet.py
+++ b/tests/single_axis_ratchet.py
@@ -1,0 +1,106 @@
+"""AST support for counting layout functions that encode only one axis."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+X_FIELDS = frozenset({"bbox_x", "bbox_w", "grid_col", "grid_col_span", "offset_x"})
+Y_FIELDS = frozenset({"bbox_y", "bbox_h", "grid_row", "grid_row_span", "offset_y"})
+
+
+@dataclass(frozen=True)
+class SingleAxisSite:
+    axis: str
+    fields: frozenset[str]
+    line: int
+
+
+class _FieldReads(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.fields: set[str] = set()
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if isinstance(node.ctx, ast.Load):
+            self.fields.add(node.attr)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        return
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        return
+
+
+def _classify(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[str, frozenset[str]] | None:
+    reads = _FieldReads()
+    for statement in node.body:
+        reads.visit(statement)
+    x_fields = frozenset(reads.fields & X_FIELDS)
+    y_fields = frozenset(reads.fields & Y_FIELDS)
+    if len(x_fields) >= 2 and not y_fields:
+        return ("x", x_fields)
+    if len(y_fields) >= 2 and not x_fields:
+        return ("y", y_fields)
+    return None
+
+
+class _FunctionCollector(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.scope: list[str] = []
+        self.sites: dict[str, SingleAxisSite] = {}
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.scope.append(node.name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        name_parts = [*self.scope, node.name]
+        qualname = ".".join(name_parts)
+        if result := _classify(node):
+            axis, fields = result
+            self.sites[qualname] = SingleAxisSite(axis, fields, node.lineno)
+        self.scope.extend((node.name, "<locals>"))
+        for statement in node.body:
+            self.visit(statement)
+        del self.scope[-2:]
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+
+def _sites_from_source(
+    source: str, filename: str = "<unknown>"
+) -> dict[str, SingleAxisSite]:
+    collector = _FunctionCollector()
+    collector.visit(ast.parse(source, filename=filename))
+    return collector.sites
+
+
+def single_axis_sites_from_source(
+    source: str,
+) -> dict[str, tuple[str, frozenset[str]]]:
+    """Classify functions in an in-memory source used by detector unit tests."""
+    return {
+        name: (site.axis, site.fields)
+        for name, site in _sites_from_source(source).items()
+    }
+
+
+def single_axis_sites(layout_dir: Path) -> dict[str, SingleAxisSite]:
+    """Every one-axis function below *layout_dir*, keyed by stable qualname."""
+    sites: dict[str, SingleAxisSite] = {}
+    for path in sorted(layout_dir.rglob("*.py")):
+        relative = path.relative_to(layout_dir).as_posix()
+        for qualname, site in _sites_from_source(
+            path.read_text(), filename=str(path)
+        ).items():
+            sites[f"{relative}::{qualname}"] = site
+    return sites

--- a/tests/single_axis_ratchet.py
+++ b/tests/single_axis_ratchet.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 
 X_FIELDS = frozenset({"bbox_x", "bbox_w", "grid_col", "grid_col_span", "offset_x"})
@@ -34,11 +35,14 @@ class _FieldReads(ast.NodeVisitor):
 
 
 def _classify(
-    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
 ) -> tuple[str, frozenset[str]] | None:
     reads = _FieldReads()
-    for statement in node.body:
-        reads.visit(statement)
+    if isinstance(node, ast.Lambda):
+        reads.visit(node.body)
+    else:
+        for statement in node.body:
+            reads.visit(statement)
     x_fields = frozenset(reads.fields & X_FIELDS)
     y_fields = frozenset(reads.fields & Y_FIELDS)
     if len(x_fields) >= 2 and not y_fields:
@@ -52,6 +56,7 @@ class _FunctionCollector(ast.NodeVisitor):
     def __init__(self) -> None:
         self.scope: list[str] = []
         self.sites: dict[str, SingleAxisSite] = {}
+        self.lambda_ordinals: dict[str, int] = {}
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.scope.append(node.name)
@@ -75,6 +80,19 @@ class _FunctionCollector(ast.NodeVisitor):
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._visit_function(node)
 
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        parent = ".".join(self.scope)
+        ordinal = self.lambda_ordinals.get(parent, 0) + 1
+        self.lambda_ordinals[parent] = ordinal
+        name = f"<lambda>#{ordinal}"
+        qualname = f"{parent}.{name}" if parent else name
+        if result := _classify(node):
+            axis, fields = result
+            self.sites[qualname] = SingleAxisSite(axis, fields, node.lineno)
+        self.scope.extend((name, "<locals>"))
+        self.visit(node.body)
+        del self.scope[-2:]
+
 
 def _sites_from_source(
     source: str, filename: str = "<unknown>"
@@ -94,6 +112,7 @@ def single_axis_sites_from_source(
     }
 
 
+@cache
 def single_axis_sites(layout_dir: Path) -> dict[str, SingleAxisSite]:
     """Every one-axis function below *layout_dir*, keyed by stable qualname."""
     sites: dict[str, SingleAxisSite] = {}

--- a/tests/test_direction_predicate_ratchet.py
+++ b/tests/test_direction_predicate_ratchet.py
@@ -3,11 +3,10 @@
 ``test_tb_branch_ratchet`` counts bare ``"TB"`` references.  The other way a
 heuristic gets keyed to an orientation is a membership test or lookup table over
 a *proper subset* of the flow directions -- ``direction in ("LR", "RL")``,
-``_FLIP_HORIZONTAL = {"LR": "RL", "RL": "LR"}`` -- which names no single
-direction and so slips past that counter, yet makes a geometry's handling
-depend on which way it happens to be turned.  Each such subset is
-some axis property spelled out by hand, and a partial spelling is how one
-orientation of a shape ends up on a different code path from another.
+``_FLIP_HORIZONTAL = {"LR": "RL", "RL": "LR"}`` -- or a predicate that hides
+the same distinction behind a name such as ``tb_positive_fan``.  Each such
+subset is some axis property spelled out by hand, and a partial spelling is how
+one orientation of a shape ends up on a different code path from another.
 
 ``AxisFrame`` (``layout/geometry.py``) already supplies the properties:
 
@@ -25,14 +24,16 @@ subset               the property it is standing in for
 ``layout/geometry.py`` is exempt: it is where those accessors are defined, so
 its direction literals are the vocabulary rather than a use of it.
 
-The bound is an upper one.  Lower ``_BASELINE`` whenever a call site migrates
-onto the accessors, and never raise it.
+The bounds are upper ones. Lower them whenever a call site migrates onto the
+accessors, and never raise them.
 """
 
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
+from typing import Callable
 
 from nf_metro.parser.model import FLOW_DIRECTIONS
 
@@ -44,10 +45,12 @@ _SCANNED_PACKAGES = ("layout", "parser", "render")
 # The accessors' own definitions, not a use of them.
 _EXEMPT = frozenset({"layout/geometry.py"})
 
-# Lower this (never raise it) when a call site migrates onto AxisFrame.
-_BASELINE = 64
+# Lower these (never raise them) when a call site migrates onto AxisFrame.
+_LITERAL_BASELINE = 64
+_NAMED_BASELINE = 139
 
 _FLOWS = frozenset(FLOW_DIRECTIONS)
+_FLOW_NAME_TOKENS = frozenset(flow.lower() for flow in _FLOWS)
 
 
 def _direction_subset(node: ast.expr) -> frozenset[str]:
@@ -78,10 +81,32 @@ def _is_partial(subset: frozenset[str]) -> bool:
     return 2 <= len(subset) < len(_FLOWS)
 
 
-def _sites_in(path: Path) -> list[tuple[int, str]]:
-    """Every partial direction-keyed table or membership test in *path*."""
+def _qualified_name(node: ast.expr) -> str | None:
+    """The dotted identifier named by *node*, excluding calls and expressions."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _qualified_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def _direction_named(node: ast.expr) -> str | None:
+    """A direction-keyed identifier carried by *node*, if one is explicit."""
+    name = _qualified_name(node)
+    if name is None:
+        return None
+    tokens = {part.lower() for part in re.findall(r"[A-Za-z]+", name)}
+    if tokens & _FLOW_NAME_TOKENS:
+        return name.rsplit(".", 1)[-1]
+    return None
+
+
+def _literal_sites_in(path: Path) -> list[tuple[int, str]]:
+    """Every literal direction-keyed table or membership test in *path*."""
     found: list[tuple[int, str]] = []
-    for node in ast.walk(ast.parse(path.read_text(), filename=str(path))):
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
             subset = _direction_subset(node.value)
             if _is_partial(subset):
@@ -96,20 +121,47 @@ def _sites_in(path: Path) -> list[tuple[int, str]]:
                 subset = _direction_subset(comparator)
                 if _is_partial(subset):
                     found.append((node.lineno, f"membership in {sorted(subset)}"))
-    return found
+    return sorted(found)
 
 
-def direction_predicate_sites() -> dict[str, list[tuple[int, str]]]:
-    """Map each scanned module (relative to ``src/nf_metro``) to its sites."""
+def _named_sites_in(path: Path) -> list[tuple[int, str]]:
+    """Every direction-named membership or helper call in *path*."""
+    found: list[tuple[int, str]] = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Compare) and any(
+            isinstance(op, (ast.In, ast.NotIn)) for op in node.ops
+        ):
+            for comparator in node.comparators:
+                if name := _direction_named(comparator):
+                    found.append((node.lineno, f"membership in named predicate {name}"))
+        elif isinstance(node, ast.Call) and (name := _direction_named(node.func)):
+            found.append((node.lineno, f"call to direction-keyed helper {name}"))
+    return sorted(set(found))
+
+
+def _scan(
+    detector: Callable[[Path], list[tuple[int, str]]],
+) -> dict[str, list[tuple[int, str]]]:
     out: dict[str, list[tuple[int, str]]] = {}
     for package in _SCANNED_PACKAGES:
         for path in sorted((_SRC / package).rglob("*.py")):
             relative = path.relative_to(_SRC).as_posix()
             if relative in _EXEMPT:
                 continue
-            if sites := _sites_in(path):
+            if sites := detector(path):
                 out[relative] = sites
     return out
+
+
+def direction_predicate_sites() -> dict[str, list[tuple[int, str]]]:
+    """Map each scanned module to literal direction-container sites."""
+    return _scan(_literal_sites_in)
+
+
+def named_direction_predicate_sites() -> dict[str, list[tuple[int, str]]]:
+    """Map each scanned module to direction-keyed named sites."""
+    return _scan(_named_sites_in)
 
 
 def _breakdown(sites: dict[str, list[tuple[int, str]]]) -> str:
@@ -119,7 +171,7 @@ def _breakdown(sites: dict[str, list[tuple[int, str]]]) -> str:
     )
 
 
-def test_no_new_direction_keyed_predicates() -> None:
+def test_no_new_literal_direction_keyed_predicates() -> None:
     total = sum(len(v) for v in direction_predicate_sites().values())
 
     # Guard against the counter silently matching nothing (packages moved, the
@@ -129,8 +181,9 @@ def test_no_new_direction_keyed_predicates() -> None:
         "may be broken or the packages restructured"
     )
 
-    assert total <= _BASELINE, (
-        f"direction-keyed predicate count rose to {total} (baseline {_BASELINE}).\n"
+    assert total <= _LITERAL_BASELINE, (
+        "literal direction-keyed predicate count rose to "
+        f"{total} (baseline {_LITERAL_BASELINE}).\n"
         "A heuristic that needs to know a section's axis or flow sense should ask "
         "AxisFrame (layout/geometry.py: lanes_run_along_x/y, AxisFrame.flow_sign, "
         "AxisFrame.secondary_sign_for) rather than testing membership of a subset "
@@ -138,6 +191,27 @@ def test_no_new_direction_keyed_predicates() -> None:
         f"geometry reaches a different code path from another.\n  "
         f"{_breakdown(direction_predicate_sites())}"
     )
+
+
+def test_no_new_named_direction_keyed_predicates() -> None:
+    sites = named_direction_predicate_sites()
+    total = sum(len(found) for found in sites.values())
+
+    assert total <= _NAMED_BASELINE, (
+        f"named direction-keyed site count rose to {total} "
+        f"(baseline {_NAMED_BASELINE}).\n"
+        "A direction embedded in a helper or collection name hides the same "
+        "orientation split as a literal. Express the property through AxisFrame "
+        "or add an orientation-neutral classifier instead.\n  "
+        f"{_breakdown(sites)}"
+    )
+
+
+def test_direction_predicate_baselines_are_current() -> None:
+    literal_total = sum(len(v) for v in direction_predicate_sites().values())
+    named_total = sum(len(v) for v in named_direction_predicate_sites().values())
+    assert literal_total == _LITERAL_BASELINE
+    assert named_total == _NAMED_BASELINE
 
 
 def test_exempt_modules_exist() -> None:
@@ -154,3 +228,40 @@ def test_geometry_defines_the_accessors_the_ratchet_points_at() -> None:
         assert hasattr(geometry, name), f"geometry.{name} is missing"
     for name in ("flow_sign", "secondary_sign_for", "axes_for_direction"):
         assert hasattr(geometry.AxisFrame, name), f"AxisFrame.{name} is missing"
+
+
+def test_named_direction_membership_is_counted(tmp_path: Path) -> None:
+    source = tmp_path / "named_membership.py"
+    source.write_text(
+        "def selected(section_id, tb_positive_fan):\n"
+        "    return section_id in tb_positive_fan\n"
+    )
+
+    assert _named_sites_in(source) == [
+        (2, "membership in named predicate tb_positive_fan")
+    ]
+
+
+def test_named_direction_predicate_call_is_counted(tmp_path: Path) -> None:
+    source = tmp_path / "named_call.py"
+    source.write_text(
+        "def selected(section):\n"
+        "    if is_tb_positive_fan(section):\n"
+        "        return True\n"
+        "    return False\n"
+    )
+
+    assert _named_sites_in(source) == [
+        (2, "call to direction-keyed helper is_tb_positive_fan")
+    ]
+
+
+def test_named_direction_classifier_call_is_counted(tmp_path: Path) -> None:
+    source = tmp_path / "named_classifier.py"
+    source.write_text(
+        "def selected(graph):\n    return tb_positive_fan_sections(graph)\n"
+    )
+
+    assert _named_sites_in(source) == [
+        (2, "call to direction-keyed helper tb_positive_fan_sections")
+    ]

--- a/tests/test_direction_predicate_ratchet.py
+++ b/tests/test_direction_predicate_ratchet.py
@@ -48,10 +48,17 @@ _EXEMPT = frozenset({"layout/geometry.py"})
 
 # Lower these (never raise them) when a call site migrates onto AxisFrame.
 _LITERAL_BASELINE = 64
-_NAMED_BASELINE = 139
+_NAMED_BASELINE = 283
 
 _FLOWS = frozenset(FLOW_DIRECTIONS)
 _FLOW_NAME_TOKENS = frozenset(flow.lower() for flow in _FLOWS)
+_AXIS_NAME_TOKENS = frozenset({"horizontal", "vertical"})
+_FLOW_NAME_PHRASES = (
+    ("left", "to", "right"),
+    ("right", "to", "left"),
+    ("top", "to", "bottom"),
+    ("bottom", "to", "top"),
+)
 
 
 def _direction_subset(node: ast.expr) -> frozenset[str]:
@@ -92,26 +99,70 @@ def _qualified_name(node: ast.expr) -> str | None:
     return None
 
 
-def _direction_named(node: ast.expr) -> str | None:
-    """A direction-keyed identifier carried by *node*, if one is explicit."""
+def _name_is_direction_keyed(name: str) -> bool:
+    """Whether *name* explicitly describes a flow direction or axis."""
+    tokens = tuple(part.lower() for part in re.findall(r"[A-Za-z]+", name))
+    if set(tokens) & (_FLOW_NAME_TOKENS | _AXIS_NAME_TOKENS):
+        return True
+    return any(
+        tokens[index : index + len(phrase)] == phrase
+        for phrase in _FLOW_NAME_PHRASES
+        for index in range(len(tokens) - len(phrase) + 1)
+    )
+
+
+def _direction_origin(
+    node: ast.expr, aliases: dict[str, frozenset[str]]
+) -> tuple[str, frozenset[str]] | None:
+    """The displayed and canonical direction name carried by *node*."""
+    if isinstance(node, ast.Call):
+        return _direction_origin(node.func, aliases)
     name = _qualified_name(node)
     if name is None:
         return None
-    tokens = {part.lower() for part in re.findall(r"[A-Za-z]+", name)}
-    if tokens & _FLOW_NAME_TOKENS:
-        return name
+    if _name_is_direction_keyed(name):
+        return (name, frozenset({name}))
+    if isinstance(node, ast.Name) and (origins := aliases.get(name)):
+        origin_label = ", ".join(sorted(origins))
+        return (f"{name} (alias of {origin_label})", origins)
     return None
 
 
-def _literal_sites_in(path: Path) -> list[tuple[int, str]]:
-    """Every literal direction-keyed table or membership test in *path*."""
+def _direction_named(
+    node: ast.expr, aliases: dict[str, frozenset[str]] | None = None
+) -> str | None:
+    """A direction-keyed identifier carried by *node*, if one is explicit."""
+    result = _direction_origin(node, aliases or {})
+    return result[0] if result else None
+
+
+def _assigned_names(node: ast.expr) -> set[str]:
+    """Plain names bound by an assignment target."""
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, (ast.Tuple, ast.List)):
+        return {name for element in node.elts for name in _assigned_names(element)}
+    return set()
+
+
+def _literal_sites_from_source(
+    source: str, filename: str = "<unknown>"
+) -> list[tuple[int, str]]:
+    """Every literal direction-keyed table or membership test in source."""
     found: list[tuple[int, str]] = []
-    tree = ast.parse(path.read_text(), filename=str(path))
+    tree = ast.parse(source, filename=filename)
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
+        if isinstance(node, (ast.Assign, ast.AnnAssign)) and node.value is not None:
             subset = _direction_subset(node.value)
             if _is_partial(subset):
-                names = ", ".join(t.id for t in node.targets if isinstance(t, ast.Name))
+                targets = (
+                    node.targets if isinstance(node, ast.Assign) else [node.target]
+                )
+                names = ", ".join(
+                    name
+                    for target in targets
+                    for name in sorted(_assigned_names(target))
+                )
                 found.append(
                     (node.lineno, f"table {names or '<unnamed>'} over {sorted(subset)}")
                 )
@@ -125,20 +176,255 @@ def _literal_sites_in(path: Path) -> list[tuple[int, str]]:
     return sorted(found)
 
 
-def _named_sites_in(path: Path) -> list[tuple[int, str]]:
-    """Every direction-named membership or helper call in *path*."""
-    found: list[tuple[int, str]] = []
-    tree = ast.parse(path.read_text(), filename=str(path))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Compare) and any(
-            isinstance(op, (ast.In, ast.NotIn)) for op in node.ops
-        ):
+def _literal_sites_in(path: Path) -> list[tuple[int, str]]:
+    return _literal_sites_from_source(path.read_text(), filename=str(path))
+
+
+class _NamedSiteCollector(ast.NodeVisitor):
+    """Find named sites while tracking simple aliases in lexical scopes."""
+
+    def __init__(self) -> None:
+        self.aliases: list[dict[str, frozenset[str]]] = [{}]
+        self.scope_kinds = ["module"]
+        self.conditional_depth = 0
+        self.found: set[tuple[int, str]] = set()
+
+    @property
+    def scope(self) -> dict[str, frozenset[str]]:
+        return self.aliases[-1]
+
+    def _bind(self, targets: list[ast.expr], value: ast.expr) -> None:
+        origin = _direction_origin(value, self.scope)
+        for target in targets:
+            for name in _assigned_names(target):
+                if origin:
+                    previous = self.scope.get(name, frozenset())
+                    self.scope[name] = (
+                        previous | origin[1] if self.conditional_depth else origin[1]
+                    )
+                elif not self.conditional_depth:
+                    self.scope.pop(name, None)
+
+    def _invalidate(self, targets: list[ast.expr]) -> None:
+        if self.conditional_depth:
+            return
+        for target in targets:
+            for name in _assigned_names(target):
+                self.scope.pop(name, None)
+
+    def _scope_without_arguments(
+        self, arguments: ast.arguments
+    ) -> dict[str, frozenset[str]]:
+        enclosing = next(
+            aliases
+            for aliases, kind in reversed(list(zip(self.aliases, self.scope_kinds)))
+            if kind != "class"
+        )
+        local = enclosing.copy()
+        names = [
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+        ]
+        if arguments.vararg:
+            names.append(arguments.vararg)
+        if arguments.kwarg:
+            names.append(arguments.kwarg)
+        for argument in names:
+            local.pop(argument.arg, None)
+        return local
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        self._bind(node.targets, node.value)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self.visit(node.annotation)
+        if node.value is not None:
+            self.visit(node.value)
+            self._bind([node.target], node.value)
+        else:
+            self._invalidate([node.target])
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.visit(node.value)
+        self._bind([node.target], node.value)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for imported in node.names:
+            bound = imported.asname or imported.name
+            origin = ".".join(part for part in (node.module, imported.name) if part)
+            if _name_is_direction_keyed(origin):
+                previous = self.scope.get(bound, frozenset())
+                imported_origins = frozenset({origin})
+                self.scope[bound] = (
+                    previous | imported_origins
+                    if self.conditional_depth
+                    else imported_origins
+                )
+            elif not self.conditional_depth:
+                self.scope.pop(bound, None)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for imported in node.names:
+            bound = imported.asname or imported.name.split(".", maxsplit=1)[0]
+            if not self.conditional_depth:
+                self.scope.pop(bound, None)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self.visit(node.value)
+        self._invalidate([node.target])
+
+    def visit_Delete(self, node: ast.Delete) -> None:
+        self._invalidate(node.targets)
+
+    def _visit_for(self, node: ast.For | ast.AsyncFor) -> None:
+        self.visit(node.iter)
+        self.conditional_depth += 1
+        self._invalidate([node.target])
+        for statement in [*node.body, *node.orelse]:
+            self.visit(statement)
+        self.conditional_depth -= 1
+
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_for(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._visit_for(node)
+
+    def visit_If(self, node: ast.If) -> None:
+        self.visit(node.test)
+        self.conditional_depth += 1
+        for statement in [*node.body, *node.orelse]:
+            self.visit(statement)
+        self.conditional_depth -= 1
+
+    def visit_While(self, node: ast.While) -> None:
+        self.visit(node.test)
+        self.conditional_depth += 1
+        for statement in [*node.body, *node.orelse]:
+            self.visit(statement)
+        self.conditional_depth -= 1
+
+    def _visit_try(self, node: ast.Try | ast.TryStar) -> None:
+        self.conditional_depth += 1
+        for statement in [*node.body, *node.handlers, *node.orelse]:
+            self.visit(statement)
+        self.conditional_depth -= 1
+        for statement in node.finalbody:
+            self.visit(statement)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        self._visit_try(node)
+
+    def visit_TryStar(self, node: ast.TryStar) -> None:
+        self._visit_try(node)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        self.visit(node.subject)
+        self.conditional_depth += 1
+        for case in node.cases:
+            if case.guard is not None:
+                self.visit(case.guard)
+            for statement in case.body:
+                self.visit(statement)
+        self.conditional_depth -= 1
+
+    def _visit_with(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self._invalidate([item.optional_vars])
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_With(self, node: ast.With) -> None:
+        self._visit_with(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._visit_with(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.type is not None:
+            self.visit(node.type)
+        if node.name is not None and not self.conditional_depth:
+            self.scope.pop(node.name, None)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        if any(isinstance(op, (ast.In, ast.NotIn)) for op in node.ops):
             for comparator in node.comparators:
-                if name := _direction_named(comparator):
-                    found.append((node.lineno, f"membership in named predicate {name}"))
-        elif isinstance(node, ast.Call) and (name := _direction_named(node.func)):
-            found.append((node.lineno, f"call to direction-keyed helper {name}"))
-    return sorted(set(found))
+                if name := _direction_named(comparator, self.scope):
+                    self.found.add(
+                        (node.lineno, f"membership in named predicate {name}")
+                    )
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if name := _direction_named(node.func, self.scope):
+            self.found.add((node.lineno, f"call to direction-keyed helper {name}"))
+        self.generic_visit(node)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in [*node.args.defaults, *node.args.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+        if node.returns is not None:
+            self.visit(node.returns)
+
+        self.aliases.append(self._scope_without_arguments(node.args))
+        self.scope_kinds.append("function")
+        for statement in node.body:
+            self.visit(statement)
+        self.aliases.pop()
+        self.scope_kinds.pop()
+        if not self.conditional_depth:
+            self.scope.pop(node.name, None)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self.aliases.append(self._scope_without_arguments(node.args))
+        self.scope_kinds.append("function")
+        self.visit(node.body)
+        self.aliases.pop()
+        self.scope_kinds.pop()
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        self.aliases.append(self.scope.copy())
+        self.scope_kinds.append("class")
+        for statement in node.body:
+            self.visit(statement)
+        self.aliases.pop()
+        self.scope_kinds.pop()
+        if not self.conditional_depth:
+            self.scope.pop(node.name, None)
+
+
+def _named_sites_from_source(
+    source: str, filename: str = "<unknown>"
+) -> list[tuple[int, str]]:
+    """Every direction-named membership or helper call in source."""
+    collector = _NamedSiteCollector()
+    collector.visit(ast.parse(source, filename=filename))
+    return sorted(collector.found)
+
+
+def _named_sites_in(path: Path) -> list[tuple[int, str]]:
+    return _named_sites_from_source(path.read_text(), filename=str(path))
 
 
 def _scan(
@@ -233,50 +519,188 @@ def test_geometry_defines_the_accessors_the_ratchet_points_at() -> None:
         assert hasattr(geometry.AxisFrame, name), f"AxisFrame.{name} is missing"
 
 
-def test_named_direction_membership_is_counted(tmp_path: Path) -> None:
-    source = tmp_path / "named_membership.py"
-    source.write_text(
+def test_named_direction_membership_is_counted() -> None:
+    source = (
         "def selected(section_id, tb_positive_fan):\n"
         "    return section_id in tb_positive_fan\n"
     )
 
-    assert _named_sites_in(source) == [
+    assert _named_sites_from_source(source) == [
         (2, "membership in named predicate tb_positive_fan")
     ]
 
 
-def test_named_direction_predicate_call_is_counted(tmp_path: Path) -> None:
-    source = tmp_path / "named_call.py"
-    source.write_text(
+def test_named_direction_predicate_call_is_counted() -> None:
+    source = (
         "def selected(section):\n"
         "    if is_tb_positive_fan(section):\n"
         "        return True\n"
         "    return False\n"
     )
 
-    assert _named_sites_in(source) == [
+    assert _named_sites_from_source(source) == [
         (2, "call to direction-keyed helper is_tb_positive_fan")
     ]
 
 
-def test_named_direction_classifier_call_is_counted(tmp_path: Path) -> None:
-    source = tmp_path / "named_classifier.py"
-    source.write_text(
-        "def selected(graph):\n    return tb_positive_fan_sections(graph)\n"
-    )
+def test_named_direction_classifier_call_is_counted() -> None:
+    source = "def selected(graph):\n    return tb_positive_fan_sections(graph)\n"
 
-    assert _named_sites_in(source) == [
+    assert _named_sites_from_source(source) == [
         (2, "call to direction-keyed helper tb_positive_fan_sections")
     ]
 
 
-def test_direction_named_receiver_is_reported_in_full(tmp_path: Path) -> None:
-    source = tmp_path / "named_receiver.py"
-    source.write_text(
+def test_direction_named_receiver_is_reported_in_full() -> None:
+    source = (
         "def selected(tb_positive_fan, section_id):\n"
         "    tb_positive_fan.add(section_id)\n"
     )
 
-    assert _named_sites_in(source) == [
+    assert _named_sites_from_source(source) == [
         (2, "call to direction-keyed helper tb_positive_fan.add")
+    ]
+
+
+def test_semantic_direction_names_are_counted() -> None:
+    source = (
+        "def selected(section_id, vertical_positive_fan):\n"
+        "    if section_id in vertical_positive_fan:\n"
+        "        return left_to_right_sections()\n"
+        "    return horizontal_return_sections()\n"
+    )
+
+    assert _named_sites_from_source(source) == [
+        (2, "membership in named predicate vertical_positive_fan"),
+        (3, "call to direction-keyed helper left_to_right_sections"),
+        (4, "call to direction-keyed helper horizontal_return_sections"),
+    ]
+
+
+def test_direction_named_helper_alias_is_counted() -> None:
+    source = (
+        "def selected(graph):\n"
+        "    classifier = tb_positive_fan_sections\n"
+        "    return classifier(graph)\n"
+    )
+
+    assert _named_sites_from_source(source) == [
+        (
+            3,
+            "call to direction-keyed helper "
+            "classifier (alias of tb_positive_fan_sections)",
+        )
+    ]
+
+
+def test_imported_direction_named_helper_alias_is_counted() -> None:
+    source = (
+        "from package import vertical_positive_fan_sections as classifier\n"
+        "\n"
+        "def selected(graph):\n"
+        "    return classifier(graph)\n"
+    )
+
+    assert _named_sites_from_source(source) == [
+        (
+            4,
+            "call to direction-keyed helper "
+            "classifier (alias of package.vertical_positive_fan_sections)",
+        )
+    ]
+
+
+def test_direction_named_result_alias_membership_is_counted() -> None:
+    source = (
+        "def selected(graph, section_id):\n"
+        "    fan = vertical_positive_fan_sections(graph)\n"
+        "    return section_id in fan\n"
+    )
+
+    assert _named_sites_from_source(source) == [
+        (2, "call to direction-keyed helper vertical_positive_fan_sections"),
+        (
+            3,
+            "membership in named predicate "
+            "fan (alias of vertical_positive_fan_sections)",
+        ),
+    ]
+
+
+def test_alias_tracking_respects_class_scope() -> None:
+    source = (
+        "from package import vertical_classifier as classifier\n"
+        "class Example:\n"
+        "    classifier = plain_classifier\n"
+        "    def selected(self):\n"
+        "        return classifier()\n"
+    )
+
+    assert _named_sites_from_source(source) == [
+        (
+            5,
+            "call to direction-keyed helper "
+            "classifier (alias of package.vertical_classifier)",
+        )
+    ]
+
+
+def test_conditional_rebinding_preserves_possible_direction_alias() -> None:
+    source = (
+        "from package import vertical_classifier as classifier\n"
+        "if flag:\n"
+        "    classifier = plain_classifier\n"
+        "classifier(graph)\n"
+    )
+
+    assert _named_sites_from_source(source) == [
+        (
+            4,
+            "call to direction-keyed helper "
+            "classifier (alias of package.vertical_classifier)",
+        )
+    ]
+
+
+def test_loop_target_preserves_possible_direction_alias() -> None:
+    source = (
+        "from package import vertical_classifier as classifier\n"
+        "for classifier in classifiers:\n"
+        "    pass\n"
+        "classifier()\n"
+    )
+
+    assert _named_sites_from_source(source) == [
+        (
+            4,
+            "call to direction-keyed helper "
+            "classifier (alias of package.vertical_classifier)",
+        )
+    ]
+
+
+def test_exception_target_preserves_possible_direction_alias() -> None:
+    source = (
+        "def select(graph):\n"
+        "    classifier = vertical_classifier\n"
+        "    try:\n"
+        "        work()\n"
+        "    except Exception as classifier:\n"
+        "        pass\n"
+        "    return classifier(graph)\n"
+    )
+
+    assert _named_sites_from_source(source) == [
+        (
+            7,
+            "call to direction-keyed helper classifier (alias of vertical_classifier)",
+        )
+    ]
+
+
+def test_annotated_direction_table_is_counted() -> None:
+    source = '_REVERSALS: dict[str, str] = {"LR": "RL", "RL": "LR"}\n'
+
+    assert _literal_sites_from_source(source) == [
+        (1, "table _REVERSALS over ['LR', 'RL']")
     ]

--- a/tests/test_direction_predicate_ratchet.py
+++ b/tests/test_direction_predicate_ratchet.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import ast
 import re
+from functools import cache
 from pathlib import Path
 from typing import Callable
 
@@ -98,7 +99,7 @@ def _direction_named(node: ast.expr) -> str | None:
         return None
     tokens = {part.lower() for part in re.findall(r"[A-Za-z]+", name)}
     if tokens & _FLOW_NAME_TOKENS:
-        return name.rsplit(".", 1)[-1]
+        return name
     return None
 
 
@@ -154,11 +155,13 @@ def _scan(
     return out
 
 
+@cache
 def direction_predicate_sites() -> dict[str, list[tuple[int, str]]]:
     """Map each scanned module to literal direction-container sites."""
     return _scan(_literal_sites_in)
 
 
+@cache
 def named_direction_predicate_sites() -> dict[str, list[tuple[int, str]]]:
     """Map each scanned module to direction-keyed named sites."""
     return _scan(_named_sites_in)
@@ -264,4 +267,16 @@ def test_named_direction_classifier_call_is_counted(tmp_path: Path) -> None:
 
     assert _named_sites_in(source) == [
         (2, "call to direction-keyed helper tb_positive_fan_sections")
+    ]
+
+
+def test_direction_named_receiver_is_reported_in_full(tmp_path: Path) -> None:
+    source = tmp_path / "named_receiver.py"
+    source.write_text(
+        "def selected(tb_positive_fan, section_id):\n"
+        "    tb_positive_fan.add(section_id)\n"
+    )
+
+    assert _named_sites_in(source) == [
+        (2, "call to direction-keyed helper tb_positive_fan.add")
     ]

--- a/tests/test_orientation_equivalence.py
+++ b/tests/test_orientation_equivalence.py
@@ -10,8 +10,8 @@ The oracle compares only what a transform genuinely preserves.  Rotating a map
 does not rotate its text, so the *distances* between stations are free to change
 with glyph extents; what must not change is anything the engine decides -- flow
 ranks and lanes, port sides, a port's clearance to the edge it is pinned to,
-which end of the flow a port is seated at, and which grid groups are aligned.
-:mod:`orientation_signature` defines those measures.
+and which end of the flow a port is seated at. :mod:`orientation_signature`
+defines those measures.
 
 ``KNOWN_DIVERGENCES`` records the residuals that do not hold yet, each naming the
 defect behind it.  Which families an orbit member exhibits is only known once it
@@ -29,6 +29,7 @@ import warnings
 from functools import lru_cache
 from pathlib import Path
 
+import orientation_signature
 import pytest
 from conftest import content_corpus
 from orientation_signature import DIVERGENCE_FAMILIES, divergences
@@ -47,63 +48,6 @@ from nf_metro.parser.model import MetroGraph
 # A residual is excepted by the *kind* of defect behind it, so one entry covers
 # every orbit member the same defect breaks.
 KNOWN_DIVERGENCES: dict[tuple[str, str], str] = {
-    # Whether a grid group shares a box edge is decided by a content-hug policy
-    # on both axes: a row's bbox top hugs its content (_fit_bboxes_to_content_top)
-    # and a column's box edges are levelled only across mates whose content
-    # nearest that edge stands at one X (Stage 3.6).  Hugged edges coincide only
-    # when the members' content extents happen to match, and a rotation does not
-    # carry text extents with it, so the boolean is not rotation-invariant where
-    # the hug wins over the flush.
-    **{
-        (stem, "group_alignment"): (
-            "hugged row tops coincide only when the row-mates' content-top "
-            "padding matches, which a quarter turn does not preserve (#1545)"
-        )
-        for stem in (
-            "bt_perp_left_entry_right_exit",
-            "lr_to_tb_top_drop_two_lines",
-            "tb_two_line_vert_seam",
-        )
-    },
-    # A column mate whose content starts at a different X is held out of the
-    # Stage 3.6 levelling, because levelling it would trade the shared edge for a
-    # widened runway spread.  The Stage 3.3 perpendicular-entry runway is what
-    # puts the content at a different X here: it re-wraps the box around the
-    # shifted run, moving the box's own edge with it.
-    **{
-        (stem, "group_alignment"): (
-            "column mate held out of the levelling because the perpendicular-entry "
-            "runway moved its content off the column's content X (#1545)"
-        )
-        for stem in (
-            "bt_exit_top_above",
-            "bt_exit_top_above_2line",
-            "bt_to_tb",
-            "lr_top_entry_cross_column",
-            "lr_top_entry_cross_column_two_line",
-        )
-    },
-    # Both levelling passes act on maximal runs of *adjacent* rows / columns, so
-    # a group with a hole in it is levelled as separate runs and any shared edge
-    # across the hole is incidental.
-    **{
-        (stem, "group_alignment"): (
-            "grid group's members sit in non-adjacent cells, so no single run "
-            "levels them (#1545)"
-        )
-        for stem in ("lr_to_tb_top_cross_col",)
-    },
-    # A column of same-flow sections lands on one edge only when their leftward
-    # box overhangs match: Stage 1.5 absorbs the largest overhang globally, so a
-    # member with a smaller one is seated further in, and its content moves with
-    # it out of the levelling's reach.
-    **{
-        (stem, "group_alignment"): (
-            "column mates seated apart by their differing box overhangs, which "
-            "the global Stage 1.5 absorption does not equalise (#1545)"
-        )
-        for stem in ("orbit_perp_exit_back_row_entry",)
-    },
     # _infer_flow_exit_hints_with_drops's perpendicular-drop exception tests only
     # whether the TARGET section is vertical, so a vertical-flow source feeding a
     # same-row horizontal target keeps a flow-aligned exit instead of turning
@@ -269,6 +213,13 @@ def test_stated_exceptions_name_real_families() -> None:
         f"unknown divergence family in KNOWN_DIVERGENCES: {unknown}. "
         f"Known families: {sorted(DIVERGENCE_FAMILIES)}"
     )
+
+
+def test_group_alignment_is_explicitly_non_invariant() -> None:
+    """Glyph-driven box alignment cannot act as rotation-equivalence evidence."""
+    assert "group_alignment" not in DIVERGENCE_FAMILIES
+    reason = orientation_signature.NON_INVARIANT_MEASURES["group_alignment"]
+    assert "glyph" in reason.lower()
 
 
 def test_identity_transform_is_a_no_op() -> None:

--- a/tests/test_single_axis_ratchet.py
+++ b/tests/test_single_axis_ratchet.py
@@ -1,0 +1,171 @@
+"""Ratchet on layout functions that encode only one coordinate axis.
+
+A function that reads at least two X-family geometry fields and no Y-family
+fields, or vice versa, can be a missing rotation counterpart without naming a
+flow direction. The bound keeps that otherwise invisible class countable and
+non-increasing. Explicitly axis-scoped primitives are exempt only with a stable
+site key and a reason.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from single_axis_ratchet import single_axis_sites, single_axis_sites_from_source
+
+_LAYOUT_DIR = Path(__file__).resolve().parents[1] / "src" / "nf_metro" / "layout"
+
+_BASELINE = {"x": 27, "y": 48}
+
+_EXEMPTIONS = {
+    "labels.py::_clamp_label_to_section": (
+        "horizontal label clamping has a separately named vertical primitive"
+    ),
+    "labels.py::_clamp_label_vertical": (
+        "vertical label clamping has a separately named horizontal primitive"
+    ),
+    "phases/_common.py::_bbox_cols_overlap": (
+        "column overlap is an explicitly X-scoped interval primitive"
+    ),
+    "phases/_common.py::_canvas_width": ("canvas width is intrinsically an X extent"),
+    "phases/_common.py::_expand_bbox_for_y": (
+        "the name and contract explicitly expand one Y extent"
+    ),
+    "route_reservations.py::_section_x_overlaps": (
+        "X overlap has a paired Y overlap primitive"
+    ),
+    "route_reservations.py::_section_y_overlaps": (
+        "Y overlap has a paired X overlap primitive"
+    ),
+    "route_reservations.py::_row_end": ("row end has a paired column end primitive"),
+    "route_reservations.py::_column_end": ("column end has a paired row end primitive"),
+    "routing/inter_section_handlers.py::_section_right_edge": (
+        "right edge has a paired left edge primitive"
+    ),
+    "routing/inter_section_handlers.py::_section_left_edge": (
+        "left edge has a paired right edge primitive"
+    ),
+    "section_placement.py::_effective_section_width": (
+        "the helper computes an explicitly horizontal extent"
+    ),
+    "section_placement.py::_compute_row_heights": (
+        "the helper computes explicitly vertical row extents"
+    ),
+    "section_placement.py::_rows_overlap": (
+        "row overlap has a paired column overlap primitive"
+    ),
+    "section_placement.py::_cols_overlap": (
+        "column overlap has a paired row overlap primitive"
+    ),
+    "section_placement.py::_enforce_min_column_gaps": (
+        "column-gap enforcement has a paired row-gap pass"
+    ),
+    "section_placement.py::_enforce_min_row_gaps": (
+        "row-gap enforcement has a paired column-gap pass"
+    ),
+}
+
+
+def _unexempted_sites():
+    return {
+        key: site
+        for key, site in single_axis_sites(_LAYOUT_DIR).items()
+        if key not in _EXEMPTIONS
+    }
+
+
+def _breakdown(axis: str) -> str:
+    return "\n  ".join(
+        f"{key}:{site.line} reads {sorted(site.fields)}"
+        for key, site in _unexempted_sites().items()
+        if site.axis == axis
+    )
+
+
+def test_no_new_single_axis_geometry_functions() -> None:
+    sites = _unexempted_sites()
+    for axis, baseline in _BASELINE.items():
+        total = sum(site.axis == axis for site in sites.values())
+        assert total <= baseline, (
+            f"{axis.upper()}-only geometry function count rose to {total} "
+            f"(baseline {baseline}). A pass that reads one geometry-field family "
+            "needs an orientation-neutral implementation or a reasoned exemption; "
+            "otherwise one rotation can silently lack a counterpart.\n  "
+            f"{_breakdown(axis)}"
+        )
+
+
+def test_single_axis_baseline_is_current() -> None:
+    sites = _unexempted_sites()
+    current = {
+        axis: sum(site.axis == axis for site in sites.values()) for axis in _BASELINE
+    }
+    assert current == _BASELINE, (
+        f"single-axis baseline is {_BASELINE}, live counts are {current}; lower the "
+        "baseline after removing a site, or add a reasoned exemption for a "
+        "legitimate axis-scoped primitive"
+    )
+
+
+def test_single_axis_exemptions_are_live_and_reasoned() -> None:
+    sites = single_axis_sites(_LAYOUT_DIR)
+    stale = sorted(set(_EXEMPTIONS) - set(sites))
+    assert not stale, f"single-axis exemptions no longer detected: {stale}"
+    unreasoned = sorted(
+        key for key, reason in _EXEMPTIONS.items() if not reason.strip()
+    )
+    assert not unreasoned, f"single-axis exemptions without reasons: {unreasoned}"
+
+
+def test_reads_two_y_fields_without_x_fields() -> None:
+    source = """
+def row_end(section):
+    return section.bbox_y + section.bbox_h
+"""
+
+    assert single_axis_sites_from_source(source) == {
+        "row_end": ("y", frozenset({"bbox_y", "bbox_h"}))
+    }
+
+
+def test_reads_two_x_fields_without_y_fields() -> None:
+    source = """
+def column_end(section):
+    return section.grid_col + section.grid_col_span
+"""
+
+    assert single_axis_sites_from_source(source) == {
+        "column_end": ("x", frozenset({"grid_col", "grid_col_span"}))
+    }
+
+
+def test_ignores_functions_that_read_both_axes() -> None:
+    source = """
+def box_area(section):
+    return section.bbox_w * section.bbox_h
+"""
+
+    assert single_axis_sites_from_source(source) == {}
+
+
+def test_ignores_one_field_repeated() -> None:
+    source = """
+def repeated(section):
+    return section.bbox_y + section.bbox_y
+"""
+
+    assert single_axis_sites_from_source(source) == {}
+
+
+def test_nested_functions_are_classified_independently() -> None:
+    source = """
+def outer(section):
+    def inner(item):
+        return item.bbox_x + item.bbox_w
+    return section.bbox_y + section.bbox_h
+"""
+
+    assert single_axis_sites_from_source(source) == {
+        "outer": ("y", frozenset({"bbox_y", "bbox_h"})),
+        "outer.<locals>.inner": ("x", frozenset({"bbox_x", "bbox_w"})),
+    }

--- a/tests/test_single_axis_ratchet.py
+++ b/tests/test_single_axis_ratchet.py
@@ -29,7 +29,10 @@ _EXEMPTIONS = {
     ),
     "phases/_common.py::_canvas_width": ("canvas width is intrinsically an X extent"),
     "phases/_common.py::_expand_bbox_for_y": (
-        "the name and contract explicitly expand one Y extent"
+        "the bbox edge mutation is intrinsically Y-scoped and serves port Y placement"
+    ),
+    "phases/_common.py::_grid_rows_top_to_bottom": (
+        "the row-local grouping contract delegates column ordering to its callback"
     ),
     "route_reservations.py::_section_x_overlaps": (
         "X overlap has a paired Y overlap primitive"
@@ -57,21 +60,21 @@ _EXEMPTIONS = {
     "section_placement.py::_cols_overlap": (
         "column overlap has a paired row overlap primitive"
     ),
-    "section_placement.py::_enforce_min_column_gaps": (
-        "column-gap enforcement has a paired row-gap pass"
-    ),
-    "section_placement.py::_enforce_min_column_gaps.<locals>.<lambda>#1": (
-        "the callback computes the right edge for the X-scoped column-gap pass"
-    ),
-    "section_placement.py::_enforce_min_column_gaps.<locals>.<lambda>#2": (
-        "the callback computes the left edge for the X-scoped column-gap pass"
-    ),
+    (
+        "section_placement.py::_enforce_min_column_gaps.<locals>."
+        "<lambda:keyword:right_extent>"
+    ): ("the callback computes the right edge for the X-scoped column-gap pass"),
+    (
+        "section_placement.py::_enforce_min_column_gaps.<locals>."
+        "<lambda:keyword:left_extent>"
+    ): ("the callback computes the left edge for the X-scoped column-gap pass"),
     "section_placement.py::_enforce_min_row_gaps": (
         "row-gap enforcement has a paired column-gap pass"
     ),
-    "section_placement.py::reenforce_column_gaps.<locals>.<lambda>#1": (
-        "the callback computes the right edge for the X-scoped column-gap pass"
-    ),
+    (
+        "section_placement.py::reenforce_column_gaps.<locals>."
+        "<lambda:keyword:right_extent>"
+    ): ("the callback computes the right edge for the X-scoped column-gap pass"),
 }
 
 
@@ -189,16 +192,40 @@ def column_edges():
 """
 
     assert single_axis_sites_from_source(source) == {
-        "column_edges": (
-            "x",
-            frozenset({"bbox_x", "bbox_w", "offset_x"}),
-        ),
-        "column_edges.<locals>.<lambda>#1": (
+        "column_edges.<locals>.<lambda:assigned:left>": (
             "x",
             frozenset({"bbox_x", "offset_x"}),
         ),
-        "column_edges.<locals>.<lambda>#2": (
+        "column_edges.<locals>.<lambda:assigned:right>": (
             "x",
             frozenset({"bbox_x", "bbox_w"}),
         ),
+    }
+
+
+def test_lambda_defaults_are_classified_independently() -> None:
+    source = """
+def select(edge=lambda section: section.bbox_x + section.bbox_w):
+    return edge
+"""
+
+    assert single_axis_sites_from_source(source) == {
+        "<lambda:default:select.edge>": (
+            "x",
+            frozenset({"bbox_x", "bbox_w"}),
+        )
+    }
+
+
+def test_defaults_on_lambdas_are_classified_independently() -> None:
+    source = """
+def select(factory=lambda edge=(lambda section: section.bbox_x + section.bbox_w): edge):
+    return factory
+"""
+
+    assert single_axis_sites_from_source(source) == {
+        "<lambda:default:select.factory.edge>": (
+            "x",
+            frozenset({"bbox_x", "bbox_w"}),
+        )
     }

--- a/tests/test_single_axis_ratchet.py
+++ b/tests/test_single_axis_ratchet.py
@@ -60,8 +60,17 @@ _EXEMPTIONS = {
     "section_placement.py::_enforce_min_column_gaps": (
         "column-gap enforcement has a paired row-gap pass"
     ),
+    "section_placement.py::_enforce_min_column_gaps.<locals>.<lambda>#1": (
+        "the callback computes the right edge for the X-scoped column-gap pass"
+    ),
+    "section_placement.py::_enforce_min_column_gaps.<locals>.<lambda>#2": (
+        "the callback computes the left edge for the X-scoped column-gap pass"
+    ),
     "section_placement.py::_enforce_min_row_gaps": (
         "row-gap enforcement has a paired column-gap pass"
+    ),
+    "section_placement.py::reenforce_column_gaps.<locals>.<lambda>#1": (
+        "the callback computes the right edge for the X-scoped column-gap pass"
     ),
 }
 
@@ -168,4 +177,28 @@ def outer(section):
     assert single_axis_sites_from_source(source) == {
         "outer": ("y", frozenset({"bbox_y", "bbox_h"})),
         "outer.<locals>.inner": ("x", frozenset({"bbox_x", "bbox_w"})),
+    }
+
+
+def test_lambdas_are_classified_with_stable_per_scope_keys() -> None:
+    source = """
+def column_edges():
+    left = lambda section: section.bbox_x + section.offset_x
+    right = lambda section: section.bbox_x + section.bbox_w
+    return left, right
+"""
+
+    assert single_axis_sites_from_source(source) == {
+        "column_edges": (
+            "x",
+            frozenset({"bbox_x", "bbox_w", "offset_x"}),
+        ),
+        "column_edges.<locals>.<lambda>#1": (
+            "x",
+            frozenset({"bbox_x", "offset_x"}),
+        ),
+        "column_edges.<locals>.<lambda>#2": (
+            "x",
+            frozenset({"bbox_x", "bbox_w"}),
+        ),
     }


### PR DESCRIPTION
## Summary

- add a source ratchet for single-axis layout functions and lambdas, with separate X/Y baselines, structural lambda keys, definition-default coverage, and reasoned live exemptions for explicitly axis-scoped primitives
- extend the direction-predicate ratchet to count annotated literal tables plus direction-named helpers and memberships, including semantic axis names and conservatively tracked aliases
- demote glyph-dependent group alignment from the rotation oracle, leaving only falsifiable port-side and port-perpendicular exceptions

Fixes #1564

## Test plan

- [x] Focused ratchet and orientation suite: 238 passed, 4 existing port-oracle xfails
- [x] ruff check src/ tests/
- [x] ruff format --check src/ tests/
- [x] mypy
- [x] prek run --all-files
- [x] Full CI matrix passes on Python 3.11, 3.12, and 3.13
- [x] Visual review of the render preview: https://seqeralabs.github.io/nf-metro/_pr/1684/
- [x] Render-preview verdict: no visual changes detected

Generated with Codex