### PR TITLE
ci: restore independent render previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,6 @@ jobs:
         with:
           extra-args: prettier --all-files
 
-  render-diff:
-    if: github.event_name == 'pull_request'
-    needs: [lint, format]
-    uses: ./.github/workflows/pr-renders.yml
-    with:
-      base-sha: ${{ github.event.pull_request.base.sha }}
-      head-sha: ${{ github.event.pull_request.head.sha }}
-      pr-number: ${{ github.event.number }}
-
   test:
     needs: [lint, format]
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-render-publish.yml
+++ b/.github/workflows/pr-render-publish.yml
@@ -2,7 +2,7 @@ name: Publish render preview
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["PR render preview"]
     types: [requested, completed]
 
 permissions:

--- a/.github/workflows/pr-renders.yml
+++ b/.github/workflows/pr-renders.yml
@@ -1,17 +1,8 @@
 name: PR render preview
 
 on:
-  workflow_call:
-    inputs:
-      base-sha:
-        required: true
-        type: string
-      head-sha:
-        required: true
-        type: string
-      pr-number:
-        required: true
-        type: number
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
@@ -37,8 +28,8 @@ jobs:
       - name: Determine render strategy
         id: strategy
         run: |
-          base='${{ inputs.base-sha }}'
-          head='${{ inputs.head-sha }}'
+          base='${{ github.event.pull_request.base.sha }}'
+          head='${{ github.event.pull_request.head.sha }}'
           echo "render_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           base_render_key="$(
             git ls-tree -r "$base" -- \
@@ -103,7 +94,7 @@ jobs:
           set +e
           python scripts/build_render_diff.py \
             /tmp/base_renders /tmp/pr_renders /tmp/diff_site \
-            --pr ${{ inputs.pr-number }} \
+            --pr ${{ github.event.number }} \
             --marker ${{ github.run_id }}
           EXIT_CODE=$?
           set -e
@@ -121,7 +112,7 @@ jobs:
       - name: Stage preview metadata
         run: |
           mkdir -p /tmp/diff_site /tmp/preview_meta
-          echo "${{ inputs.pr-number }}" > /tmp/preview_meta/pr_number.txt
+          echo "${{ github.event.number }}" > /tmp/preview_meta/pr_number.txt
           echo "${{ steps.diff.outputs.has_changes }}" > /tmp/preview_meta/has_changes.txt
 
       - name: Upload preview artifact

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -56,11 +56,12 @@ def test_test_matrix_uses_committed_timings_and_reports_slow_tests():
     assert "--durations=25" in job
 
 
-def test_render_diff_waits_for_fast_checks_and_uses_content_cache_key():
-    caller = _jobs(WORKFLOWS / "ci.yml")["render-diff"]
-    assert re.search(r"^    needs: \[lint, format\]$", caller, re.MULTILINE)
-    assert "uses: ./.github/workflows/pr-renders.yml" in caller
+def test_render_diff_runs_independently_and_uses_content_cache_key():
+    assert "render-diff" not in _jobs(WORKFLOWS / "ci.yml")
 
+    workflow = (WORKFLOWS / "pr-renders.yml").read_text()
+    assert re.search(r"^  pull_request:$", workflow, re.MULTILINE)
+    assert "branches: [main]" in workflow
     render_job = _jobs(WORKFLOWS / "pr-renders.yml")["render-diff"]
     assert "base_render_key=" in render_job
     assert "tests/layout_metrics.py" in render_job
@@ -69,8 +70,8 @@ def test_render_diff_waits_for_fast_checks_and_uses_content_cache_key():
     )
 
 
-def test_render_publisher_follows_ci_artifact_instead_of_ci_conclusion():
+def test_render_publisher_follows_render_workflow_artifact():
     workflow = (WORKFLOWS / "pr-render-publish.yml").read_text()
-    assert 'workflows: ["CI"]' in workflow
+    assert 'workflows: ["PR render preview"]' in workflow
     assert "actions/runs/${RUN_ID}/artifacts?name=render-preview" in workflow
     assert "needs.resolve.outputs.artifact == 'true'" in workflow


### PR DESCRIPTION
## Summary

- Run the PR render-preview workflow directly from `pull_request` events instead of calling it from the main CI workflow.
- Publish render artifacts as soon as the standalone render workflow completes.
- Preserve the content-based base-render cache, finite timeouts, and workflow contract coverage.

## Test plan

- [x] `pytest -q tests/test_ci_workflows.py`
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `mypy`
- [x] Repository Prettier hook across all files
- [x] Commit hooks

Generated with Codex
