### PR TITLE
Make section numbering follow visual rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ graph LR
 - `%%metro entry: <side> | <line_ids>` - which lines enter and from which side (`left`, `right`, `top`, `bottom`)
 - `%%metro exit: <side> | <line_ids>` - which lines exit and to which side
 - `%%metro direction: <dir>` - section flow direction: `LR` (default), `RL` (right-to-left), or `TB` (top-to-bottom)
+- `%%metro number: <positive_integer>` - override the section's number badge
 
 #### Stations and edges
 
@@ -405,6 +406,7 @@ Edges between stations in different sections go outside all `subgraph`/`end` blo
 | `%%metro entry: <side> \| <lines>`                               | Section          | Entry port hint                                                                                                                                                                                  |
 | `%%metro exit: <side> \| <lines>`                                | Section          | Exit port hint                                                                                                                                                                                   |
 | `%%metro direction: <dir>`                                       | Section          | Flow direction: `LR`, `RL`, `TB`                                                                                                                                                                 |
+| `%%metro number: <positive_integer>`                             | Section          | Override the section's number badge                                                                                                                                                              |
 
 ## Live progress
 

--- a/docs/dev/layout_pipeline.mdx
+++ b/docs/dev/layout_pipeline.mdx
@@ -143,8 +143,10 @@ system, then place the sections on the global grid (still local-coord).
   grid so they agree on pitch and slot count.
 - **Stage 1.3**: Place sections on the canvas grid by topological
   layering of the section DAG.
-- **Stage 1.4**: Renumber sections by dependency wave so producers precede
-  consumers, using visual row and horizontal flow to order ties. Preserve any
+- **Stage 1.4**: Renumber sections by connected route continuity. Prefer the
+  nearest connected section on the current visual lane, keep parallel branch
+  starts together, and complete independent merge inputs before their join. A
+  dominant row may finish before a secondary route rejoins it. Preserve any
   authored `%%metro number:` values and fill automatic sections with the lowest
   unused positive numbers.
 - **Stage 1.5**: Grow `x_offset` / `y_offset` if section local extents

--- a/docs/dev/layout_pipeline.mdx
+++ b/docs/dev/layout_pipeline.mdx
@@ -143,10 +143,10 @@ system, then place the sections on the global grid (still local-coord).
   grid so they agree on pitch and slot count.
 - **Stage 1.3**: Place sections on the canvas grid by topological
   layering of the section DAG.
-- **Stage 1.4**: Renumber sections by visual reading order (rows from top
-  to bottom, following horizontal flow within each row) so the numbering
-  follows the eye. Preserve any authored `%%metro number:` values and fill
-  automatic sections with the lowest unused positive numbers.
+- **Stage 1.4**: Renumber sections by dependency wave so producers precede
+  consumers, using visual row and horizontal flow to order ties. Preserve any
+  authored `%%metro number:` values and fill automatic sections with the lowest
+  unused positive numbers.
 - **Stage 1.5**: Grow `x_offset` / `y_offset` if section local extents
   overshoot the canvas origin.
 

--- a/docs/dev/layout_pipeline.mdx
+++ b/docs/dev/layout_pipeline.mdx
@@ -143,8 +143,10 @@ system, then place the sections on the global grid (still local-coord).
   grid so they agree on pitch and slot count.
 - **Stage 1.3**: Place sections on the canvas grid by topological
   layering of the section DAG.
-- **Stage 1.4**: Renumber sections by visual reading order (column
-  first, then row) so the legend numbering follows the eye.
+- **Stage 1.4**: Renumber sections by visual reading order (rows from top
+  to bottom, following horizontal flow within each row) so the numbering
+  follows the eye. Preserve any authored `%%metro number:` values and fill
+  automatic sections with the lowest unused positive numbers.
 - **Stage 1.5**: Grow `x_offset` / `y_offset` if section local extents
   overshoot the canvas origin.
 

--- a/docs/dev/parser.mdx
+++ b/docs/dev/parser.mdx
@@ -187,7 +187,7 @@ name** and mapping to a `(value, graph) -> None` handler. Exact-key
 lookup means handler order is irrelevant and a key that is a prefix of
 another (`legend` vs `legend_combo`, `logo` vs `logo_scale`) cannot
 shadow it. Three families are dispatched separately because they need
-more than the value alone: `entry` / `exit` / `direction` need the
+more than the value alone: `entry` / `exit` / `direction` / `number` need the
 enclosing section, and the icon keys `file` / `files` / `dir` need the
 key itself to choose the icon type. A key matching none of these is
 ignored with a `UserWarning`.
@@ -212,6 +212,7 @@ The directives `_apply_directive` recognises:
 | `line_order:`                                                           | `definition` or `span` line ordering                                                            |
 | `entry:` / `exit:` (inside a subgraph)                                  | stored as port **hints** on the section                                                         |
 | `direction:`                                                            | section flow `LR` / `RL` / `TB`                                                                 |
+| `number:` (inside a subgraph)                                           | pin the section's positive-integer number badge                                                 |
 | `grid:`                                                                 | manual section grid placement                                                                   |
 | `compact_offsets:` / `center_ports:`                                    | bundle layout toggles                                                                           |
 | `diamond_style:`                                                        | fork-join layout `straight` / `symmetric`                                                       |

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -350,7 +350,7 @@ These go inside `subgraph` blocks.
 
 Entry/exit hints tell the layout engine which side of the section box lines should enter or leave from. Most of the time you can **omit these entirely** and let the auto-layout engine figure it out. They are useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others).
 
-Section numbers normally follow the visual rows and their horizontal flow. An explicit `number:` stays fixed, and automatic sections use the lowest positive numbers not already reserved. Duplicate or invalid overrides are ignored with a warning.
+Automatic section numbers follow dependency waves, so every producer is numbered before its consumers. Sections in the same wave follow their visual rows and horizontal flow. An explicit `number:` stays fixed, and automatic sections use the lowest positive numbers not already reserved. Duplicate or invalid overrides are ignored with a warning.
 
 ## CLI flags and directive precedence
 

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -341,13 +341,16 @@ The lanes are listed one rail per pipe-group; commas bundle several lines onto t
 
 These go inside `subgraph` blocks.
 
-| Directive                          | Description                                              |
-| ---------------------------------- | -------------------------------------------------------- |
-| `%%metro entry: <side> \| <lines>` | Entry port hint. Sides: `left`, `right`, `top`, `bottom` |
-| `%%metro exit: <side> \| <lines>`  | Exit port hint. Sides: `left`, `right`, `top`, `bottom`  |
-| `%%metro direction: <dir>`         | Internal flow direction: `LR`, `RL`, or `TB`             |
+| Directive                            | Description                                              |
+| ------------------------------------ | -------------------------------------------------------- |
+| `%%metro entry: <side> \| <lines>`   | Entry port hint. Sides: `left`, `right`, `top`, `bottom` |
+| `%%metro exit: <side> \| <lines>`    | Exit port hint. Sides: `left`, `right`, `top`, `bottom`  |
+| `%%metro direction: <dir>`           | Internal flow direction: `LR`, `RL`, or `TB`             |
+| `%%metro number: <positive_integer>` | Override the section's number badge                      |
 
 Entry/exit hints tell the layout engine which side of the section box lines should enter or leave from. Most of the time you can **omit these entirely** and let the auto-layout engine figure it out. They are useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others).
+
+Section numbers normally follow the visual rows and their horizontal flow. An explicit `number:` stays fixed, and automatic sections use the lowest positive numbers not already reserved. Duplicate or invalid overrides are ignored with a warning.
 
 ## CLI flags and directive precedence
 

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -350,7 +350,7 @@ These go inside `subgraph` blocks.
 
 Entry/exit hints tell the layout engine which side of the section box lines should enter or leave from. Most of the time you can **omit these entirely** and let the auto-layout engine figure it out. They are useful when you want lines to exit from different sides of the same section (e.g., right for some lines, bottom for others).
 
-Automatic section numbers follow dependency waves, so every producer is numbered before its consumers. Sections in the same wave follow their visual rows and horizontal flow. An explicit `number:` stays fixed, and automatic sections use the lowest positive numbers not already reserved. Duplicate or invalid overrides are ignored with a warning.
+Automatic section numbers follow connected visual routes. Numbering prefers the nearest connected section on the current row, keeps parallel branch starts together, and completes independent inputs before a merge. A clear primary row can finish before numbering a secondary route that rejoins it. An explicit `number:` stays fixed, and automatic sections use the lowest positive numbers not already reserved. Duplicate or invalid overrides are ignored with a warning.
 
 ## CLI flags and directive precedence
 

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -387,13 +387,15 @@ in pipeline order.
   non-overlap) holds at the final boundary.
 
 ### Stage 1.4: renumber sections
-- **Purpose**: Renumber sections by visual reading order (row, then
-  flow-oriented column) so legend / debug numbering follows the eye.
+- **Purpose**: Renumber sections by dependency wave, then visual reading order,
+  so producers precede consumers and ties follow the eye.
 - **Helper**: `_renumber_sections_by_grid` (`phases/canvas.py`).
 - **Precondition**: Section grid positions and directions finalised.
-- **Postcondition**: Automatic `section.number` values increase top-to-bottom
-  between rows and with the horizontal flow within a row. Authored numbers are
-  preserved, and automatic sections take the lowest unused positive numbers.
+- **Postcondition**: Within each disconnected flow, every automatically
+  numbered producer has a lower `section.number` than its consumers. Dependency
+  ties increase top-to-bottom between rows and with horizontal flow within a
+  row. Authored numbers are preserved, and automatic sections take the lowest
+  unused positive numbers.
 - **Invariants preserved**: Section IDs, station coords, bboxes,
   edges. Pure metadata pass.
 - **Related tests**: none directly (cosmetic / debug-only).

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -389,7 +389,7 @@ in pipeline order.
 ### Stage 1.4: renumber sections
 - **Purpose**: Renumber sections by connected route continuity, using visual
   lanes to choose between alternative continuations.
-- **Helper**: `_renumber_sections_by_grid` (`phases/canvas.py`).
+- **Helper**: `_renumber_sections_by_route` (`phases/canvas.py`).
 - **Precondition**: Section grid positions and directions finalised.
 - **Postcondition**: Each disconnected flow is numbered completely before the
   next. The nearest connected section on the current lane is preferred;

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -387,16 +387,17 @@ in pipeline order.
   non-overlap) holds at the final boundary.
 
 ### Stage 1.4: renumber sections
-- **Purpose**: Renumber sections by visual reading order (sweep, col,
-  row) so legend / debug numbering follows the eye.
+- **Purpose**: Renumber sections by visual reading order (row, then
+  flow-oriented column) so legend / debug numbering follows the eye.
 - **Helper**: `_renumber_sections_by_grid` (`phases/canvas.py`).
 - **Precondition**: Section grid positions and directions finalised.
-- **Postcondition**: `section.display_number` reflects sweep-major,
-  column-then-row order.
+- **Postcondition**: Automatic `section.number` values increase top-to-bottom
+  between rows and with the horizontal flow within a row. Authored numbers are
+  preserved, and automatic sections take the lowest unused positive numbers.
 - **Invariants preserved**: Section IDs, station coords, bboxes,
   edges. Pure metadata pass.
 - **Related tests**: none directly (cosmetic / debug-only).
-- **Lifecycle:** invariant - `display_number` metadata is final
+- **Lifecycle:** invariant - `number` metadata is final
   (cosmetic, never recomputed).
 
 ### Stage 1.5: offset overshoot correction

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -387,18 +387,19 @@ in pipeline order.
   non-overlap) holds at the final boundary.
 
 ### Stage 1.4: renumber sections
-- **Purpose**: Renumber sections by dependency wave, then visual reading order,
-  so producers precede consumers and ties follow the eye.
+- **Purpose**: Renumber sections by connected route continuity, using visual
+  lanes to choose between alternative continuations.
 - **Helper**: `_renumber_sections_by_grid` (`phases/canvas.py`).
 - **Precondition**: Section grid positions and directions finalised.
-- **Postcondition**: Within each disconnected flow, every automatically
-  numbered producer has a lower `section.number` than its consumers. Dependency
-  ties increase top-to-bottom between rows and with horizontal flow within a
-  row. Authored numbers are preserved, and automatic sections take the lowest
-  unused positive numbers.
+- **Postcondition**: Each disconnected flow is numbered completely before the
+  next. The nearest connected section on the current lane is preferred;
+  parallel branch starts remain together; joins wait for aligned or independent
+  predecessor routes. A secondary cross-row route may rejoin a section already
+  numbered on a dominant row. Authored numbers are preserved, and automatic
+  sections take the lowest unused positive numbers.
 - **Invariants preserved**: Section IDs, station coords, bboxes,
   edges. Pure metadata pass.
-- **Related tests**: none directly (cosmetic / debug-only).
+- **Related tests**: `tests/test_section_numbering.py`.
 - **Lifecycle:** invariant - `number` metadata is final
   (cosmetic, never recomputed).
 

--- a/src/nf_metro/layout/engine.py
+++ b/src/nf_metro/layout/engine.py
@@ -100,7 +100,7 @@ from nf_metro.layout.phases.bbox import (  # noqa: F401
     refit_tops_after_entry_resnap,
 )
 from nf_metro.layout.phases.canvas import (  # noqa: F401
-    _renumber_sections_by_grid,
+    _renumber_sections_by_route,
     _shift_graph_into_canvas,
     _translate_graph_y,
 )
@@ -1406,8 +1406,8 @@ def _compute_section_layout(
         _guard_independent_components_disjoint(graph, "after Stage 1.3")
         _guard_multi_section_cell_packed(graph, "after Stage 1.3")
 
-    # Stage 1.4: Renumber sections by visual reading order (row, col)
-    _renumber_sections_by_grid(graph)
+    # Stage 1.4: Renumber sections along connected visual routes
+    _renumber_sections_by_route(graph)
     _snap(graph, "1.4")
 
     # Stage 1.5: Adapt x/y_offset for left/top overshoot.

--- a/src/nf_metro/layout/phases/canvas.py
+++ b/src/nf_metro/layout/phases/canvas.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from nf_metro.graph_views import directed_graph
 from nf_metro.layout.constants import (
     TITLE_BAND_CLEARANCE,
     TITLE_BAND_OVERLAP_FLOOR,
@@ -11,110 +10,69 @@ from nf_metro.layout.phases.bbox import (
     _min_drawn_section_bbox_top,
     _min_section_bbox_top,
 )
-from nf_metro.parser.model import MetroGraph, Section
+from nf_metro.parser.model import MetroGraph
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:
     """Renumber sections by visual reading order.
 
-    Groups sections into flow sweeps separated by fold boundaries:
-    each left-to-right (or right-to-left) run is one sweep, with
-    TB fold sections belonging to the sweep they terminate.  Within
-    each sweep, sections are numbered by (grid_col, grid_row) so
-    columns go left-to-right and stacked sections go top-to-bottom.
-    All numbers in sweep N+1 are greater than those in sweep N.
+    Rows are numbered top-to-bottom.  Within each row, numbering follows
+    the row's horizontal flow, so ordinary rows read left-to-right and
+    folded return rows read right-to-left.  Authored numbers are reserved;
+    automatic sections receive the lowest unused positive numbers.
     """
-    from collections import deque
-
     section_rank = {sid: rank for rank, sid in enumerate(graph.sections)}
-    section_edges = (
-        sorted(
-            (
-                (src, tgt)
-                for src, tgt in graph.section_dag.section_edges
-                if src in graph.sections and tgt in graph.sections
-            ),
-            key=lambda edge: (section_rank[edge[0]], section_rank[edge[1]]),
+    section_edges = graph.section_dag.section_edges if graph.section_dag else set()
+    rows: dict[int, list[str]] = {}
+    for sid, section in graph.sections.items():
+        rows.setdefault(section.grid_row, []).append(sid)
+
+    ordered_ids: list[str] = []
+    for row in sorted(rows):
+        row_ids = rows[row]
+        row_set = set(row_ids)
+        flow_score = sum(
+            graph.sections[tgt].grid_col - graph.sections[src].grid_col
+            for src, tgt in section_edges
+            if src in row_set
+            and tgt in row_set
+            and graph.sections[src].grid_col != graph.sections[tgt].grid_col
         )
-        if graph.section_dag
-        else []
-    )
-    dag = directed_graph(graph.sections, section_edges)
+        if flow_score == 0:
+            flow_score = sum(
+                1 if graph.sections[sid].direction == "LR" else -1
+                for sid in row_ids
+                if graph.sections[sid].direction in ("LR", "RL")
+            )
 
-    secs = graph.sections
-
-    def _is_direction_change(src: str, tgt: str) -> bool:
-        """True when flow direction reverses between two sections."""
-        sd, td = secs[src].direction, secs[tgt].direction
-        # TB->LR/RL: only counts if the TB's predecessors flowed
-        # the opposite way (i.e. TB is a fold boundary).
-        if sd == "TB" and td in ("LR", "RL"):
-            for pred in dag.predecessors(src):
-                pd = secs[pred].direction
-                if pd in ("LR", "RL") and pd != td:
-                    return True
-            return False
-        if sd in ("LR", "RL") and td in ("LR", "RL") and sd != td:
-            return True
-        return False
-
-    sweep: dict[str, int] = {}
-    roots = [n for n in dag.nodes() if dag.in_degree(n) == 0]
-    q: deque[str] = deque()
-    for r in roots:
-        sweep[r] = 0
-        q.append(r)
-
-    while q:
-        node = q.popleft()
-        for succ in sorted(dag.successors(node), key=section_rank.__getitem__):
-            new_depth = sweep[node]
-            if _is_direction_change(node, succ):
-                new_depth = sweep[node] + 1
-            if succ not in sweep or new_depth < sweep[succ]:
-                sweep[succ] = new_depth
-                q.append(succ)
-
-    for sid in graph.sections:
-        if sid not in sweep:
-            sweep[sid] = 0
-
-    # Disconnected components: number each flow fully before the next,
-    # ordered by the topmost grid_row so top flows come first.
-    from nf_metro.layout.section_placement import _weakly_connected_components
-
-    component_edges = graph.section_dag.section_edges if graph.section_dag else set()
-    comp_idx: dict[str, int] = {}
-    for rank, comp in enumerate(
-        sorted(
-            _weakly_connected_components(graph, component_edges),
-            key=lambda component: (
-                min(graph.sections[sid].grid_row for sid in component),
-                min(section_rank[sid] for sid in component),
-            ),
+        right_to_left = flow_score < 0
+        ordered_ids.extend(
+            sorted(
+                row_ids,
+                key=lambda sid: (
+                    -graph.sections[sid].grid_col
+                    if right_to_left
+                    else graph.sections[sid].grid_col,
+                    section_rank[sid],
+                ),
+            )
         )
-    ):
-        for sid in comp:
-            comp_idx[sid] = rank
 
-    # Determine flow direction for each sweep: RL sweeps number
-    # columns right-to-left (descending grid_col) to match the flow.
-    sweep_is_rl: dict[int, bool] = {}
-    for sid, s in graph.sections.items():
-        sw = sweep[sid]
-        if sw not in sweep_is_rl and s.direction == "RL":
-            sweep_is_rl[sw] = True
-        elif sw not in sweep_is_rl and s.direction == "LR":
-            sweep_is_rl[sw] = False
-
-    def _sort_key(s: Section) -> tuple[int, int, int, int, int]:
-        sw = sweep[s.id]
-        col = -s.grid_col if sweep_is_rl.get(sw, False) else s.grid_col
-        return (comp_idx.get(s.id, 0), sw, col, s.grid_row, section_rank[s.id])
-
-    sorted_sections = sorted(graph.sections.values(), key=_sort_key)
-    for i, section in enumerate(sorted_sections, start=1):
-        section.number = i
+    reserved = {
+        section.number_override
+        for section in graph.sections.values()
+        if section.number_override is not None
+    }
+    next_number = 1
+    for sid in ordered_ids:
+        section = graph.sections[sid]
+        if section.number_override is not None:
+            section.number = section.number_override
+            continue
+        while next_number in reserved:
+            next_number += 1
+        section.number = next_number
+        next_number += 1
 
 
 def _translate_graph_y(graph: MetroGraph, shift: float) -> None:

--- a/src/nf_metro/layout/phases/canvas.py
+++ b/src/nf_metro/layout/phases/canvas.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from nf_metro.graph_views import directed_graph, longest_path_layers
 from nf_metro.layout.constants import (
     TITLE_BAND_CLEARANCE,
     TITLE_BAND_OVERLAP_FLOOR,
@@ -14,13 +13,83 @@ from nf_metro.layout.phases.bbox import (
 from nf_metro.parser.model import MetroGraph
 
 
+def _section_row_directions(
+    graph: MetroGraph, section_edges: set[tuple[str, str]]
+) -> dict[int, bool]:
+    rows: dict[int, list[str]] = {}
+    for sid, section in graph.sections.items():
+        rows.setdefault(section.grid_row, []).append(sid)
+
+    result: dict[int, bool] = {}
+    for row, row_ids in rows.items():
+        row_set = set(row_ids)
+        flow_score = sum(
+            graph.sections[target].grid_col - graph.sections[source].grid_col
+            for source, target in section_edges
+            if source in row_set
+            and target in row_set
+            and graph.sections[source].grid_col != graph.sections[target].grid_col
+        )
+        if flow_score == 0:
+            flow_score = sum(
+                1 if graph.sections[sid].direction == "LR" else -1
+                for sid in row_ids
+                if graph.sections[sid].direction in ("LR", "RL")
+            )
+        result[row] = flow_score < 0
+    return result
+
+
+def _reachable_sections(start: str, adjacency: dict[str, set[str]]) -> set[str]:
+    found = {start}
+    pending = [start]
+    while pending:
+        current = pending.pop()
+        for adjacent in adjacency[current] - found:
+            found.add(adjacent)
+            pending.append(adjacent)
+    return found
+
+
+def _parallel_branch_sets(
+    graph: MetroGraph,
+    outgoing: dict[str, set[str]],
+    descendant_sets: dict[str, set[str]],
+) -> tuple[dict[str, set[str]], set[str]]:
+    parallel_peers: dict[str, set[str]] = {sid: set() for sid in graph.sections}
+    parallel_joins: set[str] = set()
+    for targets in outgoing.values():
+        targets_by_stage: dict[int, set[str]] = {}
+        for target in targets:
+            targets_by_stage.setdefault(graph.sections[target].grid_col, set()).add(
+                target
+            )
+        for peers in targets_by_stage.values():
+            if len(peers) < 2 or any(
+                other in descendant_sets[peer]
+                for peer in peers
+                for other in peers - {peer}
+            ):
+                continue
+            branch_reach = [descendant_sets[peer] for peer in peers]
+            common = branch_reach[0].copy()
+            for reachable in branch_reach[1:]:
+                common.intersection_update(reachable)
+            for peer in peers:
+                parallel_peers[peer].update(peers - {peer})
+            parallel_joins.update(common)
+    return parallel_peers, parallel_joins
+
+
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:
-    """Renumber sections by dependency wave and visual reading order.
+    """Renumber sections by connected route continuity and visual reading order.
 
     Each disconnected flow is numbered fully before the next.  Within a flow,
-    every producer wave precedes its consumers; visual row and horizontal flow
-    break ties within a wave.  Authored numbers are reserved, and automatic
-    sections receive the lowest unused positive numbers.
+    numbering follows connected sections along the nearest visual lane.  Parallel
+    branches and independent merge inputs are completed before their join, while
+    a dominant visual route may finish before a secondary route rejoins it.
+    Authored numbers are reserved, and automatic sections receive the lowest
+    unused positive numbers.
     """
     from nf_metro.layout.section_placement import _weakly_connected_components
 
@@ -32,68 +101,147 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
         )
         if src in graph.sections and tgt in graph.sections
     }
-    rows: dict[int, list[str]] = {}
-    for sid, section in graph.sections.items():
-        rows.setdefault(section.grid_row, []).append(sid)
+    outgoing: dict[str, set[str]] = {sid: set() for sid in graph.sections}
+    incoming: dict[str, set[str]] = {sid: set() for sid in graph.sections}
+    for source, target in section_edges:
+        outgoing[source].add(target)
+        incoming[target].add(source)
 
-    row_is_rl: dict[int, bool] = {}
-    for row, row_ids in rows.items():
-        row_set = set(row_ids)
-        flow_score = sum(
-            graph.sections[tgt].grid_col - graph.sections[src].grid_col
-            for src, tgt in section_edges
-            if src in row_set
-            and tgt in row_set
-            and graph.sections[src].grid_col != graph.sections[tgt].grid_col
+    row_is_rl = _section_row_directions(graph, section_edges)
+
+    def stage_coordinate(sid: str) -> int:
+        return graph.sections[sid].grid_col
+
+    def lane_coordinate(sid: str) -> int:
+        return graph.sections[sid].grid_row
+
+    descendant_sets = {
+        sid: _reachable_sections(sid, outgoing) for sid in graph.sections
+    }
+    ancestor_sets = {sid: _reachable_sections(sid, incoming) for sid in graph.sections}
+    parallel_peers, parallel_joins = _parallel_branch_sets(
+        graph, outgoing, descendant_sets
+    )
+
+    def visual_key(sid: str) -> tuple[int, int, int]:
+        section = graph.sections[sid]
+        column = -section.grid_col if row_is_rl[section.grid_row] else section.grid_col
+        return section.grid_row, column, section_rank[sid]
+
+    def continuation_key(
+        source: str, target: str
+    ) -> tuple[bool, int, tuple[int, int, int]]:
+        source_section = graph.sections[source]
+        target_section = graph.sections[target]
+        same_lane = lane_coordinate(source) == lane_coordinate(target)
+        distance = abs(source_section.grid_col - target_section.grid_col) + abs(
+            source_section.grid_row - target_section.grid_row
         )
-        if flow_score == 0:
-            flow_score = sum(
-                1 if graph.sections[sid].direction == "LR" else -1
-                for sid in row_ids
-                if graph.sections[sid].direction in ("LR", "RL")
-            )
-        row_is_rl[row] = flow_score < 0
+        return not same_lane, distance, visual_key(target)
 
     components = sorted(
         _weakly_connected_components(graph, section_edges),
-        key=lambda component: (
-            min(graph.sections[sid].grid_row for sid in component),
-            min(graph.sections[sid].grid_col for sid in component),
-            min(section_rank[sid] for sid in component),
-        ),
+        key=lambda component: min(visual_key(sid) for sid in component),
     )
 
     ordered_ids: list[str] = []
-    for component in components:
-        component_ids = sorted(component, key=section_rank.__getitem__)
-        component_edges = sorted(
-            (
-                (src, tgt)
-                for src, tgt in section_edges
-                if src in component and tgt in component
-            ),
-            key=lambda edge: (section_rank[edge[0]], section_rank[edge[1]]),
-        )
-        layers = longest_path_layers(
-            directed_graph(component_ids, component_edges), component_ids
-        )
-        waves: dict[tuple[int, int], list[str]] = {}
-        for sid in component_ids:
-            section = graph.sections[sid]
-            waves.setdefault((layers[sid], section.grid_row), []).append(sid)
+    visited: set[str] = set()
+    visit_index: dict[str, int] = {}
 
-        for (_, row), wave_ids in sorted(waves.items()):
-            ordered_ids.extend(
-                sorted(
-                    wave_ids,
-                    key=lambda sid: (
-                        -graph.sections[sid].grid_col
-                        if row_is_rl[row]
-                        else graph.sections[sid].grid_col,
-                        section_rank[sid],
+    def merge_is_blocked(target: str) -> bool:
+        seen = incoming[target] & visited
+        unseen = incoming[target] - visited
+        return bool(unseen) and (
+            target in parallel_joins
+            or any(
+                lane_coordinate(source) == lane_coordinate(target) for source in unseen
+            )
+            or any(
+                not (ancestor_sets[left] & ancestor_sets[right])
+                for left in seen
+                for right in unseen
+            )
+            or any(
+                stage_coordinate(left) == stage_coordinate(right)
+                for left in seen
+                for right in unseen
+            )
+        )
+
+    for component in components:
+        roots = [sid for sid in component if not (incoming[sid] & component)]
+        current = min(roots or component, key=visual_key)
+        deferred_targets: list[str] = []
+        while True:
+            visited.add(current)
+            visit_index[current] = len(ordered_ids)
+            ordered_ids.append(current)
+            remaining = component - visited
+            if not remaining:
+                break
+
+            peer_candidates = [
+                target
+                for target in parallel_peers[current] & remaining
+                if not merge_is_blocked(target)
+            ]
+            if peer_candidates:
+                deferred_targets.extend(
+                    target
+                    for target in sorted(
+                        outgoing[current] & remaining,
+                        key=lambda target: continuation_key(current, target),
+                    )
+                    if target not in peer_candidates
+                    and target not in deferred_targets
+                    and not merge_is_blocked(target)
+                )
+                current = min(peer_candidates, key=visual_key)
+                continue
+
+            deferred_candidates = [
+                target
+                for target in deferred_targets
+                if target in remaining and not merge_is_blocked(target)
+            ]
+            if deferred_candidates:
+                current = deferred_candidates[0]
+                deferred_targets.remove(current)
+                continue
+
+            direct = [
+                target
+                for target in outgoing[current] & remaining
+                if not merge_is_blocked(target)
+            ]
+            if direct:
+                current = min(
+                    direct,
+                    key=lambda target: continuation_key(current, target),
+                )
+                continue
+
+            frontier = [
+                target
+                for target in remaining
+                if incoming[target] & visited and not merge_is_blocked(target)
+            ]
+            if frontier:
+                current = min(
+                    frontier,
+                    key=lambda target: (
+                        -max(
+                            visit_index[source] for source in incoming[target] & visited
+                        ),
+                        visual_key(target),
                     ),
                 )
-            )
+                continue
+
+            remaining_roots = [
+                sid for sid in remaining if not (incoming[sid] & remaining)
+            ]
+            current = min(remaining_roots or remaining, key=visual_key)
 
     reserved = {
         section.number_override

--- a/src/nf_metro/layout/phases/canvas.py
+++ b/src/nf_metro/layout/phases/canvas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from nf_metro.graph_views import directed_graph, longest_path_layers
 from nf_metro.layout.constants import (
     TITLE_BAND_CLEARANCE,
     TITLE_BAND_OVERLAP_FLOOR,
@@ -14,22 +15,29 @@ from nf_metro.parser.model import MetroGraph
 
 
 def _renumber_sections_by_grid(graph: MetroGraph) -> None:
-    """Renumber sections by visual reading order.
+    """Renumber sections by dependency wave and visual reading order.
 
-    Rows are numbered top-to-bottom.  Within each row, numbering follows
-    the row's horizontal flow, so ordinary rows read left-to-right and
-    folded return rows read right-to-left.  Authored numbers are reserved;
-    automatic sections receive the lowest unused positive numbers.
+    Each disconnected flow is numbered fully before the next.  Within a flow,
+    every producer wave precedes its consumers; visual row and horizontal flow
+    break ties within a wave.  Authored numbers are reserved, and automatic
+    sections receive the lowest unused positive numbers.
     """
+    from nf_metro.layout.section_placement import _weakly_connected_components
+
     section_rank = {sid: rank for rank, sid in enumerate(graph.sections)}
-    section_edges = graph.section_dag.section_edges if graph.section_dag else set()
+    section_edges = {
+        (src, tgt)
+        for src, tgt in (
+            graph.section_dag.section_edges if graph.section_dag else set()
+        )
+        if src in graph.sections and tgt in graph.sections
+    }
     rows: dict[int, list[str]] = {}
     for sid, section in graph.sections.items():
         rows.setdefault(section.grid_row, []).append(sid)
 
-    ordered_ids: list[str] = []
-    for row in sorted(rows):
-        row_ids = rows[row]
+    row_is_rl: dict[int, bool] = {}
+    for row, row_ids in rows.items():
         row_set = set(row_ids)
         flow_score = sum(
             graph.sections[tgt].grid_col - graph.sections[src].grid_col
@@ -44,19 +52,48 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
                 for sid in row_ids
                 if graph.sections[sid].direction in ("LR", "RL")
             )
+        row_is_rl[row] = flow_score < 0
 
-        right_to_left = flow_score < 0
-        ordered_ids.extend(
-            sorted(
-                row_ids,
-                key=lambda sid: (
-                    -graph.sections[sid].grid_col
-                    if right_to_left
-                    else graph.sections[sid].grid_col,
-                    section_rank[sid],
-                ),
-            )
+    components = sorted(
+        _weakly_connected_components(graph, section_edges),
+        key=lambda component: (
+            min(graph.sections[sid].grid_row for sid in component),
+            min(graph.sections[sid].grid_col for sid in component),
+            min(section_rank[sid] for sid in component),
+        ),
+    )
+
+    ordered_ids: list[str] = []
+    for component in components:
+        component_ids = sorted(component, key=section_rank.__getitem__)
+        component_edges = sorted(
+            (
+                (src, tgt)
+                for src, tgt in section_edges
+                if src in component and tgt in component
+            ),
+            key=lambda edge: (section_rank[edge[0]], section_rank[edge[1]]),
         )
+        layers = longest_path_layers(
+            directed_graph(component_ids, component_edges), component_ids
+        )
+        waves: dict[tuple[int, int], list[str]] = {}
+        for sid in component_ids:
+            section = graph.sections[sid]
+            waves.setdefault((layers[sid], section.grid_row), []).append(sid)
+
+        for (_, row), wave_ids in sorted(waves.items()):
+            ordered_ids.extend(
+                sorted(
+                    wave_ids,
+                    key=lambda sid: (
+                        -graph.sections[sid].grid_col
+                        if row_is_rl[row]
+                        else graph.sections[sid].grid_col,
+                        section_rank[sid],
+                    ),
+                )
+            )
 
     reserved = {
         section.number_override

--- a/src/nf_metro/layout/phases/canvas.py
+++ b/src/nf_metro/layout/phases/canvas.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from functools import cache
+
+from nf_metro.layout.auto_layout import _transitive_successors
 from nf_metro.layout.constants import (
     TITLE_BAND_CLEARANCE,
     TITLE_BAND_OVERLAP_FLOOR,
@@ -20,16 +24,18 @@ def _section_row_directions(
     for sid, section in graph.sections.items():
         rows.setdefault(section.grid_row, []).append(sid)
 
+    flow_scores = {row: 0 for row in rows}
+    for source, target in section_edges:
+        source_section = graph.sections[source]
+        target_section = graph.sections[target]
+        if source_section.grid_row == target_section.grid_row:
+            flow_scores[source_section.grid_row] += (
+                target_section.grid_col - source_section.grid_col
+            )
+
     result: dict[int, bool] = {}
     for row, row_ids in rows.items():
-        row_set = set(row_ids)
-        flow_score = sum(
-            graph.sections[target].grid_col - graph.sections[source].grid_col
-            for source, target in section_edges
-            if source in row_set
-            and target in row_set
-            and graph.sections[source].grid_col != graph.sections[target].grid_col
-        )
+        flow_score = flow_scores[row]
         if flow_score == 0:
             flow_score = sum(
                 1 if graph.sections[sid].direction == "LR" else -1
@@ -40,21 +46,10 @@ def _section_row_directions(
     return result
 
 
-def _reachable_sections(start: str, adjacency: dict[str, set[str]]) -> set[str]:
-    found = {start}
-    pending = [start]
-    while pending:
-        current = pending.pop()
-        for adjacent in adjacency[current] - found:
-            found.add(adjacent)
-            pending.append(adjacent)
-    return found
-
-
 def _parallel_branch_sets(
     graph: MetroGraph,
     outgoing: dict[str, set[str]],
-    descendant_sets: dict[str, set[str]],
+    descendants: Callable[[str], frozenset[str]],
 ) -> tuple[dict[str, set[str]], set[str]]:
     parallel_peers: dict[str, set[str]] = {sid: set() for sid in graph.sections}
     parallel_joins: set[str] = set()
@@ -66,13 +61,11 @@ def _parallel_branch_sets(
             )
         for peers in targets_by_stage.values():
             if len(peers) < 2 or any(
-                other in descendant_sets[peer]
-                for peer in peers
-                for other in peers - {peer}
+                other in descendants(peer) for peer in peers for other in peers - {peer}
             ):
                 continue
-            branch_reach = [descendant_sets[peer] for peer in peers]
-            common = branch_reach[0].copy()
+            branch_reach = [descendants(peer) for peer in peers]
+            common = set(branch_reach[0])
             for reachable in branch_reach[1:]:
                 common.intersection_update(reachable)
             for peer in peers:
@@ -81,7 +74,7 @@ def _parallel_branch_sets(
     return parallel_peers, parallel_joins
 
 
-def _renumber_sections_by_grid(graph: MetroGraph) -> None:
+def _renumber_sections_by_route(graph: MetroGraph) -> None:
     """Renumber sections by connected route continuity and visual reading order.
 
     Each disconnected flow is numbered fully before the next.  Within a flow,
@@ -94,18 +87,15 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
     from nf_metro.layout.section_placement import _weakly_connected_components
 
     section_rank = {sid: rank for rank, sid in enumerate(graph.sections)}
-    section_edges = {
-        (src, tgt)
-        for src, tgt in (
-            graph.section_dag.section_edges if graph.section_dag else set()
-        )
-        if src in graph.sections and tgt in graph.sections
+    dag = graph.section_dag
+    section_edges = dag.section_edges if dag else set()
+    outgoing = {
+        sid: dag.successors.get(sid, set()) if dag else set() for sid in graph.sections
     }
-    outgoing: dict[str, set[str]] = {sid: set() for sid in graph.sections}
-    incoming: dict[str, set[str]] = {sid: set() for sid in graph.sections}
-    for source, target in section_edges:
-        outgoing[source].add(target)
-        incoming[target].add(source)
+    incoming = {
+        sid: dag.predecessors.get(sid, set()) if dag else set()
+        for sid in graph.sections
+    }
 
     row_is_rl = _section_row_directions(graph, section_edges)
 
@@ -115,13 +105,15 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
     def lane_coordinate(sid: str) -> int:
         return graph.sections[sid].grid_row
 
-    descendant_sets = {
-        sid: _reachable_sections(sid, outgoing) for sid in graph.sections
-    }
-    ancestor_sets = {sid: _reachable_sections(sid, incoming) for sid in graph.sections}
-    parallel_peers, parallel_joins = _parallel_branch_sets(
-        graph, outgoing, descendant_sets
-    )
+    @cache
+    def descendants(sid: str) -> frozenset[str]:
+        return frozenset({sid} | _transitive_successors(sid, outgoing))
+
+    @cache
+    def ancestors(sid: str) -> frozenset[str]:
+        return frozenset({sid} | _transitive_successors(sid, incoming))
+
+    parallel_peers, parallel_joins = _parallel_branch_sets(graph, outgoing, descendants)
 
     def visual_key(sid: str) -> tuple[int, int, int]:
         section = graph.sections[sid]
@@ -157,7 +149,7 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
                 lane_coordinate(source) == lane_coordinate(target) for source in unseen
             )
             or any(
-                not (ancestor_sets[left] & ancestor_sets[right])
+                ancestors(left).isdisjoint(ancestors(right))
                 for left in seen
                 for right in unseen
             )
@@ -172,11 +164,12 @@ def _renumber_sections_by_grid(graph: MetroGraph) -> None:
         roots = [sid for sid in component if not (incoming[sid] & component)]
         current = min(roots or component, key=visual_key)
         deferred_targets: list[str] = []
+        remaining = set(component)
         while True:
             visited.add(current)
             visit_index[current] = len(ordered_ids)
             ordered_ids.append(current)
-            remaining = component - visited
+            remaining.remove(current)
             if not remaining:
                 break
 

--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -2,8 +2,8 @@
 
 Each directive maps a ``key: value`` line onto the :class:`MetroGraph` (or the
 enclosing section). Graph-wide directives are routed through a registry; the
-section-scoped (entry/exit/direction) and file/files/dir icon directives need
-extra context and are handled by :func:`_apply_directive`.
+section-scoped (entry/exit/direction/number) and file/files/dir icon directives
+need extra context and are handled by :func:`_apply_directive`.
 """
 
 from __future__ import annotations
@@ -532,13 +532,13 @@ _GLOBAL_DIRECTIVE_HANDLERS.update(
 )
 
 # Directives that act on the enclosing subgraph rather than the whole graph.
-_SCOPED_DIRECTIVES = ("entry", "exit", "direction")
+_SCOPED_DIRECTIVES = ("entry", "exit", "direction", "number")
 
 
 def _apply_scoped_directive(
     key: str, value: str, graph: MetroGraph, section_id: str | None
 ) -> None:
-    """Apply a section-scoped directive (entry/exit/direction).
+    """Apply a section-scoped directive (entry/exit/direction/number).
 
     These only mean anything inside a subgraph; outside one they are warned
     about and ignored.
@@ -552,6 +552,16 @@ def _apply_scoped_directive(
             graph.layout_provenance.record_authored_direction(section_id, direction)
         else:
             _warn_malformed("direction", value, "LR/RL/TB/BT")
+    elif key == "number":
+        try:
+            number = int(value)
+        except ValueError:
+            _warn_malformed("number", value, "a positive integer")
+            return
+        if number < 1:
+            _warn_malformed("number", value, "a positive integer")
+            return
+        graph.sections[section_id].number_override = number
     else:
         _parse_port_hint(value, graph, section_id, is_entry=key == "entry")
 
@@ -575,3 +585,20 @@ def _apply_directive(
         handler(value, graph)
     else:
         _warn_directive(key, "unknown directive; ignoring")
+
+
+def _deduplicate_section_number_overrides(graph: MetroGraph) -> None:
+    """Keep the first surviving section for each authored badge number."""
+    owners: dict[int, str] = {}
+    for section in graph.sections.values():
+        number = section.number_override
+        if number is None:
+            continue
+        if conflict := owners.get(number):
+            _warn_directive(
+                "number",
+                f"{number} is already assigned to section {conflict!r}; ignoring",
+            )
+            section.number_override = None
+        else:
+            owners[number] = section.id

--- a/src/nf_metro/parser/directives.py
+++ b/src/nf_metro/parser/directives.py
@@ -506,7 +506,7 @@ def _make_layout_option_handler(
 # Graph-wide directives, keyed by exact name. The simple scalar/bool/enum
 # knobs are generated from the LAYOUT_OPTIONS registry (shared with the CLI);
 # the bespoke handlers below carry grammar the generic registry can't express.
-# Section-scoped (entry/exit/direction) and icon (file/files/dir) keys are
+# Section-scoped (entry/exit/direction/number) and icon (file/files/dir) keys are
 # dispatched separately in _apply_directive / _apply_scoped_directive.
 _GLOBAL_DIRECTIVE_HANDLERS: dict[str, Callable[[str, MetroGraph], None]] = {
     opt.name: _make_layout_option_handler(opt) for opt in LAYOUT_OPTIONS
@@ -588,7 +588,7 @@ def _apply_directive(
 
 
 def _deduplicate_section_number_overrides(graph: MetroGraph) -> None:
-    """Keep the first surviving section for each authored badge number."""
+    """Keep the first section assigned each authored badge number."""
     owners: dict[int, str] = {}
     for section in graph.sections.values():
         number = section.number_override

--- a/src/nf_metro/parser/mermaid.py
+++ b/src/nf_metro/parser/mermaid.py
@@ -26,7 +26,10 @@ from nf_metro.parser.commitments import (
     LayoutCommitmentOverlay,
     apply_layout_commitment_overlay,
 )
-from nf_metro.parser.directives import _apply_directive
+from nf_metro.parser.directives import (
+    _apply_directive,
+    _deduplicate_section_number_overrides,
+)
 from nf_metro.parser.grammar import (
     _Comment,
     _Directive,
@@ -284,6 +287,7 @@ def _finalize_graph(
 
     if graph.sections:
         _remove_empty_sections(graph)
+        _deduplicate_section_number_overrides(graph)
 
     # Re-check: _remove_empty_sections may have emptied graph.sections.
     if graph.sections:

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -352,7 +352,6 @@ class Section:
     id: str
     name: str
     number: int = 0
-    # Authored badge number applied by the final numbering pass.
     number_override: int | None = None
     station_ids: list[str] = field(default_factory=list)
     internal_edges: list[Edge] = field(default_factory=list)

--- a/src/nf_metro/parser/model.py
+++ b/src/nf_metro/parser/model.py
@@ -352,6 +352,8 @@ class Section:
     id: str
     name: str
     number: int = 0
+    # Authored badge number applied by the final numbering pass.
+    number_override: int | None = None
     station_ids: list[str] = field(default_factory=list)
     internal_edges: list[Edge] = field(default_factory=list)
     entry_ports: list[str] = field(default_factory=list)  # port IDs

--- a/tests/test_direction_predicate_ratchet.py
+++ b/tests/test_direction_predicate_ratchet.py
@@ -47,8 +47,8 @@ _SCANNED_PACKAGES = ("layout", "parser", "render")
 _EXEMPT = frozenset({"layout/geometry.py"})
 
 # Lower these (never raise them) when a call site migrates onto AxisFrame.
-_LITERAL_BASELINE = 64
-_NAMED_BASELINE = 283
+_LITERAL_BASELINE = 61
+_NAMED_BASELINE = 280
 
 _FLOWS = frozenset(FLOW_DIRECTIONS)
 _FLOW_NAME_TOKENS = frozenset(flow.lower() for flow in _FLOWS)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -461,6 +461,50 @@ def test_section_numbering():
     assert graph.sections["third"].number == 3
 
 
+def test_section_number_override():
+    text = (
+        "graph LR\n"
+        "    subgraph first [First]\n"
+        "        %%metro number: 7\n"
+        "        a[A]\n"
+        "    end\n"
+    )
+    graph = parse_metro_mermaid(text)
+    assert graph.sections["first"].number_override == 7
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "one"])
+def test_invalid_section_number_override_is_ignored(value):
+    text = (
+        "graph LR\n"
+        "    subgraph first [First]\n"
+        f"        %%metro number: {value}\n"
+        "        a[A]\n"
+        "    end\n"
+    )
+    with pytest.warns(UserWarning, match="expected a positive integer"):
+        graph = parse_metro_mermaid(text)
+    assert graph.sections["first"].number_override is None
+
+
+def test_duplicate_section_number_override_is_ignored():
+    text = (
+        "graph LR\n"
+        "    subgraph first [First]\n"
+        "        %%metro number: 2\n"
+        "        a[A]\n"
+        "    end\n"
+        "    subgraph second [Second]\n"
+        "        %%metro number: 2\n"
+        "        b[B]\n"
+        "    end\n"
+    )
+    with pytest.warns(UserWarning, match="already assigned to section 'first'"):
+        graph = parse_metro_mermaid(text)
+    assert graph.sections["first"].number_override == 2
+    assert graph.sections["second"].number_override is None
+
+
 def test_subgraph_without_display_name():
     """Subgraph without [display name] uses the id as name."""
     text = "graph LR\n    subgraph mysection\n        a[A]\n    end\n"

--- a/tests/test_section_numbering.py
+++ b/tests/test_section_numbering.py
@@ -1,7 +1,7 @@
-"""Tests for section numbering by visual reading order.
+"""Tests for dependency-aware section numbering.
 
-After layout, automatic sections are numbered top-to-bottom.  Sections within
-a row follow its horizontal flow direction, while authored numbers stay fixed.
+After layout, automatic sections are numbered by dependency wave.  Visual row
+and horizontal flow break ties, while authored numbers stay fixed.
 """
 
 from __future__ import annotations
@@ -33,11 +33,6 @@ def variantprioritization():
 
 
 @pytest.fixture(scope="module")
-def variantbenchmarking():
-    return _load("variantbenchmarking")
-
-
-@pytest.fixture(scope="module")
 def rnaseq_auto():
     return _load("rnaseq_auto")
 
@@ -58,16 +53,16 @@ def asymmetric_tree():
 
 
 class TestSectionNumberingOrder:
-    """Section numbers should follow visual reading order."""
+    """Automatic numbers should follow dependencies, then visual order."""
 
     def test_numbers_are_sequential(self, variantprioritization):
         """Section numbers should be 1..N with no gaps."""
         numbers = sorted(s.number for s in variantprioritization.sections.values())
         assert numbers == list(range(1, len(variantprioritization.sections) + 1))
 
-    def test_all_examples_sequential(self):
-        """Every example with sections should have sequential numbering."""
-        for mmd_path in sorted(EXAMPLES_DIR.glob("*.mmd")):
+    def test_all_examples_sequential_and_dependency_ordered(self):
+        """Every example should number producers before their consumers."""
+        for mmd_path in sorted(EXAMPLES_DIR.rglob("*.mmd")):
             text = mmd_path.read_text()
             g = parse_metro_mermaid(text)
             if not g.sections:
@@ -77,20 +72,14 @@ class TestSectionNumberingOrder:
             assert numbers == list(range(1, len(g.sections) + 1)), (
                 f"{mmd_path.name}: section numbers not sequential: {numbers}"
             )
-
-    def test_rows_are_numbered_top_to_bottom(
-        self, variantprioritization, variantbenchmarking, rnaseq_auto
-    ):
-        for graph in (variantprioritization, variantbenchmarking, rnaseq_auto):
-            rows = [
-                section.grid_row
-                for section in sorted(
-                    graph.sections.values(), key=lambda section: section.number
+            section_edges = g.section_dag.section_edges if g.section_dag else set()
+            for source, target in section_edges:
+                assert g.sections[source].number < g.sections[target].number, (
+                    f"{mmd_path.name}: producer {source!r} is numbered after "
+                    f"consumer {target!r}"
                 )
-            ]
-            assert rows == sorted(rows)
 
-    def test_lr_rows_are_numbered_left_to_right(self, variantprioritization):
+    def test_dependency_waves_precede_visual_row_order(self, variantprioritization):
         ordered_ids = [
             section.id
             for section in sorted(
@@ -100,10 +89,10 @@ class TestSectionNumberingOrder:
         ]
         assert ordered_ids == [
             "preprocessing",
-            "format_files",
-            "run_pcgr",
             "get_reference",
+            "format_files",
             "run_cpsr",
+            "run_pcgr",
         ]
 
     def test_rl_rows_are_numbered_right_to_left(self, longread_variant_calling):
@@ -117,9 +106,7 @@ class TestSectionNumberingOrder:
         )
         assert [section.grid_col for section in return_row] == [5, 4, 3, 2, 1, 0]
 
-    def test_row_edge_sets_flow_when_section_directions_are_mixed(
-        self, leftward_bypass
-    ):
+    def test_connected_flow_precedes_a_disconnected_rowmate(self, leftward_bypass):
         ordered_ids = [
             section.id
             for section in sorted(
@@ -131,7 +118,64 @@ class TestSectionNumberingOrder:
                 key=lambda section: section.number,
             )
         ]
-        assert ordered_ids == ["source", "blocker", "target"]
+        assert ordered_ids == ["source", "target", "blocker"]
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            (
+                "guide/03_fan_out",
+                [
+                    "preprocessing",
+                    "wgs_analysis",
+                    "wes_analysis",
+                    "panel_analysis",
+                    "annotation",
+                ],
+            ),
+            (
+                "guide/04_directions",
+                [
+                    "preprocessing",
+                    "rna_analysis",
+                    "dna_analysis",
+                    "postprocessing",
+                    "reporting",
+                ],
+            ),
+            (
+                "rnaseq_auto",
+                [
+                    "preprocessing",
+                    "genome_align",
+                    "pseudo_align",
+                    "postprocessing",
+                    "qc_report",
+                ],
+            ),
+            (
+                "topologies/around_below_ep_col_gt0",
+                ["source", "middle", "target"],
+            ),
+            (
+                "topologies/around_section_below",
+                ["source", "middle", "target"],
+            ),
+            (
+                "topologies/corridor_narrow_gap_fallback",
+                ["source", "tall", "target"],
+            ),
+        ],
+    )
+    def test_reviewed_render_order(self, name, expected):
+        graph = _load(name)
+        ordered_ids = [
+            section.id
+            for section in sorted(
+                graph.sections.values(), key=lambda section: section.number
+            )
+        ]
+        assert ordered_ids == expected
 
     def test_authored_number_is_reserved_while_automatic_numbers_fill_gaps(self):
         text = (

--- a/tests/test_section_numbering.py
+++ b/tests/test_section_numbering.py
@@ -12,16 +12,31 @@ import pytest
 
 from nf_metro.layout.engine import compute_layout
 from nf_metro.parser.mermaid import parse_metro_mermaid
+from nf_metro.parser.model import MetroGraph
 
 EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
 
 
-def _load(name: str):
+def _load(name: str) -> MetroGraph:
     """Parse and lay out an example pipeline."""
     text = (EXAMPLES_DIR / f"{name}.mmd").read_text()
     g = parse_metro_mermaid(text)
     compute_layout(g)
     return g
+
+
+def _ordered_section_ids(graph: MetroGraph, *, row: int | None = None) -> list[str]:
+    return [
+        section.id
+        for section in sorted(
+            (
+                section
+                for section in graph.sections.values()
+                if row is None or section.grid_row == row
+            ),
+            key=lambda section: section.number,
+        )
+    ]
 
 
 # Module-scoped fixtures to avoid redundant compute_layout calls.
@@ -96,14 +111,7 @@ class TestSectionNumberingOrder:
                 )
 
     def test_connected_routes_precede_secondary_inputs(self, variantprioritization):
-        ordered_ids = [
-            section.id
-            for section in sorted(
-                variantprioritization.sections.values(),
-                key=lambda section: section.number,
-            )
-        ]
-        assert ordered_ids == [
+        assert _ordered_section_ids(variantprioritization) == [
             "preprocessing",
             "format_files",
             "get_reference",
@@ -114,14 +122,7 @@ class TestSectionNumberingOrder:
     def test_longread_primary_route_precedes_secondary_inputs(
         self, longread_variant_calling
     ):
-        ordered_ids = [
-            section.id
-            for section in sorted(
-                longread_variant_calling.sections.values(),
-                key=lambda section: section.number,
-            )
-        ]
-        assert ordered_ids == [
+        assert _ordered_section_ids(longread_variant_calling) == [
             "preprocessing",
             "small_variants",
             "phasing",
@@ -134,18 +135,11 @@ class TestSectionNumberingOrder:
         ]
 
     def test_connected_flow_precedes_a_disconnected_rowmate(self, leftward_bypass):
-        ordered_ids = [
-            section.id
-            for section in sorted(
-                (
-                    section
-                    for section in leftward_bypass.sections.values()
-                    if section.grid_row == 0
-                ),
-                key=lambda section: section.number,
-            )
+        assert _ordered_section_ids(leftward_bypass, row=0) == [
+            "source",
+            "target",
+            "blocker",
         ]
-        assert ordered_ids == ["source", "target", "blocker"]
 
     @pytest.mark.parametrize(
         ("name", "expected"),
@@ -212,13 +206,7 @@ class TestSectionNumberingOrder:
     )
     def test_reviewed_render_order(self, name, expected):
         graph = _load(name)
-        ordered_ids = [
-            section.id
-            for section in sorted(
-                graph.sections.values(), key=lambda section: section.number
-            )
-        ]
-        assert ordered_ids == expected
+        assert _ordered_section_ids(graph) == expected
 
     def test_authored_number_is_reserved_while_automatic_numbers_fill_gaps(self):
         text = (

--- a/tests/test_section_numbering.py
+++ b/tests/test_section_numbering.py
@@ -1,7 +1,7 @@
-"""Tests for dependency-aware section numbering.
+"""Tests for connectivity-aware section numbering.
 
-After layout, automatic sections are numbered by dependency wave.  Visual row
-and horizontal flow break ties, while authored numbers stay fixed.
+After layout, automatic sections follow connected visual routes.  Parallel
+branches complete before their join, while authored numbers stay fixed.
 """
 
 from __future__ import annotations
@@ -53,15 +53,15 @@ def asymmetric_tree():
 
 
 class TestSectionNumberingOrder:
-    """Automatic numbers should follow dependencies, then visual order."""
+    """Automatic numbers should follow connected visual routes."""
 
     def test_numbers_are_sequential(self, variantprioritization):
         """Section numbers should be 1..N with no gaps."""
         numbers = sorted(s.number for s in variantprioritization.sections.values())
         assert numbers == list(range(1, len(variantprioritization.sections) + 1))
 
-    def test_all_examples_sequential_and_dependency_ordered(self):
-        """Every example should number producers before their consumers."""
+    def test_all_examples_sequential_with_only_cross_row_route_returns(self):
+        """Backward edges should only rejoin a completed route from another row."""
         for mmd_path in sorted(EXAMPLES_DIR.rglob("*.mmd")):
             text = mmd_path.read_text()
             g = parse_metro_mermaid(text)
@@ -73,13 +73,29 @@ class TestSectionNumberingOrder:
                 f"{mmd_path.name}: section numbers not sequential: {numbers}"
             )
             section_edges = g.section_dag.section_edges if g.section_dag else set()
+
+            def lane(sid: str) -> int:
+                return g.sections[sid].grid_row
+
             for source, target in section_edges:
-                assert g.sections[source].number < g.sections[target].number, (
-                    f"{mmd_path.name}: producer {source!r} is numbered after "
-                    f"consumer {target!r}"
+                if g.sections[source].number < g.sections[target].number:
+                    continue
+                earlier_predecessors = [
+                    predecessor
+                    for predecessor, candidate in section_edges
+                    if candidate == target
+                    and g.sections[predecessor].number < g.sections[target].number
+                ]
+                assert lane(source) != lane(target)
+                assert any(
+                    lane(predecessor) == lane(target)
+                    for predecessor in earlier_predecessors
+                ), (
+                    f"{mmd_path.name}: {source!r} rejoins {target!r} without an "
+                    "earlier predecessor continuing along the target row"
                 )
 
-    def test_dependency_waves_precede_visual_row_order(self, variantprioritization):
+    def test_connected_routes_precede_secondary_inputs(self, variantprioritization):
         ordered_ids = [
             section.id
             for section in sorted(
@@ -89,22 +105,33 @@ class TestSectionNumberingOrder:
         ]
         assert ordered_ids == [
             "preprocessing",
-            "get_reference",
             "format_files",
+            "get_reference",
             "run_cpsr",
             "run_pcgr",
         ]
 
-    def test_rl_rows_are_numbered_right_to_left(self, longread_variant_calling):
-        return_row = sorted(
-            (
-                section
-                for section in longread_variant_calling.sections.values()
-                if section.grid_row == 1
-            ),
-            key=lambda section: section.number,
-        )
-        assert [section.grid_col for section in return_row] == [5, 4, 3, 2, 1, 0]
+    def test_longread_primary_route_precedes_secondary_inputs(
+        self, longread_variant_calling
+    ):
+        ordered_ids = [
+            section.id
+            for section in sorted(
+                longread_variant_calling.sections.values(),
+                key=lambda section: section.number,
+            )
+        ]
+        assert ordered_ids == [
+            "preprocessing",
+            "small_variants",
+            "phasing",
+            "structural_variants",
+            "jointcalling",
+            "annotation",
+            "cnv_calling",
+            "tr_calling",
+            "reports",
+        ]
 
     def test_connected_flow_precedes_a_disconnected_rowmate(self, leftward_bypass):
         ordered_ids = [
@@ -164,6 +191,22 @@ class TestSectionNumberingOrder:
             (
                 "topologies/corridor_narrow_gap_fallback",
                 ["source", "tall", "target"],
+            ),
+            (
+                "topologies/bottom_row_climb_clear_corridor",
+                ["feed", "mid_a", "mid_b", "dest", "low"],
+            ),
+            (
+                "topologies/convergence_stacked_sink",
+                ["prep", "align", "dedup", "aux", "repeats", "merge_pt", "report"],
+            ),
+            (
+                "topologies/junction_entry_align",
+                ["pre", "src", "dst_a", "dst_b", "beta_extra_1", "beta_extra_2"],
+            ),
+            (
+                "topologies/merge_trunk_over_low_section",
+                ["ingest", "tall", "proc2", "collect", "sub"],
             ),
         ],
     )

--- a/tests/test_section_numbering.py
+++ b/tests/test_section_numbering.py
@@ -1,8 +1,7 @@
-"""Tests for section numbering by visual reading order (#217).
+"""Tests for section numbering by visual reading order.
 
-After layout, sections are numbered by flow sweep then (grid_col,
-grid_row).  Each left-to-right or right-to-left run is one sweep,
-with TB fold sections belonging to the sweep they terminate.
+After layout, automatic sections are numbered top-to-bottom.  Sections within
+a row follow its horizontal flow direction, while authored numbers stay fixed.
 """
 
 from __future__ import annotations
@@ -44,6 +43,16 @@ def rnaseq_auto():
 
 
 @pytest.fixture(scope="module")
+def longread_variant_calling():
+    return _load("longread_variant_calling")
+
+
+@pytest.fixture(scope="module")
+def leftward_bypass():
+    return _load("topologies/bypass_left_entry_from_right")
+
+
+@pytest.fixture(scope="module")
 def asymmetric_tree():
     return _load("topologies/asymmetric_tree")
 
@@ -69,27 +78,85 @@ class TestSectionNumberingOrder:
                 f"{mmd_path.name}: section numbers not sequential: {numbers}"
             )
 
-    def test_within_sweep_columns_increase(
+    def test_rows_are_numbered_top_to_bottom(
         self, variantprioritization, variantbenchmarking, rnaseq_auto
     ):
-        """Within each flow sweep, numbers increase left-to-right.
+        for graph in (variantprioritization, variantbenchmarking, rnaseq_auto):
+            rows = [
+                section.grid_row
+                for section in sorted(
+                    graph.sections.values(), key=lambda section: section.number
+                )
+            ]
+            assert rows == sorted(rows)
 
-        Sections at the same column should be numbered top-to-bottom.
-        """
-        for name, g in [
-            ("variantprioritization", variantprioritization),
-            ("variantbenchmarking", variantbenchmarking),
-            ("rnaseq_auto", rnaseq_auto),
-        ]:
-            secs = sorted(g.sections.values(), key=lambda s: s.number)
-            for i in range(len(secs) - 1):
-                a, b = secs[i], secs[i + 1]
-                if a.grid_col == b.grid_col:
-                    assert a.grid_row <= b.grid_row, (
-                        f"{name}: #{a.number} {a.name} (row {a.grid_row}) "
-                        f"before #{b.number} {b.name} (row {b.grid_row}) "
-                        f"at col {a.grid_col}"
-                    )
+    def test_lr_rows_are_numbered_left_to_right(self, variantprioritization):
+        ordered_ids = [
+            section.id
+            for section in sorted(
+                variantprioritization.sections.values(),
+                key=lambda section: section.number,
+            )
+        ]
+        assert ordered_ids == [
+            "preprocessing",
+            "format_files",
+            "run_pcgr",
+            "get_reference",
+            "run_cpsr",
+        ]
+
+    def test_rl_rows_are_numbered_right_to_left(self, longread_variant_calling):
+        return_row = sorted(
+            (
+                section
+                for section in longread_variant_calling.sections.values()
+                if section.grid_row == 1
+            ),
+            key=lambda section: section.number,
+        )
+        assert [section.grid_col for section in return_row] == [5, 4, 3, 2, 1, 0]
+
+    def test_row_edge_sets_flow_when_section_directions_are_mixed(
+        self, leftward_bypass
+    ):
+        ordered_ids = [
+            section.id
+            for section in sorted(
+                (
+                    section
+                    for section in leftward_bypass.sections.values()
+                    if section.grid_row == 0
+                ),
+                key=lambda section: section.number,
+            )
+        ]
+        assert ordered_ids == ["source", "blocker", "target"]
+
+    def test_authored_number_is_reserved_while_automatic_numbers_fill_gaps(self):
+        text = (
+            "%%metro line: main | Main | #ff0000\n"
+            "graph LR\n"
+            "    subgraph first [First]\n"
+            "        a[A]\n"
+            "    end\n"
+            "    subgraph second [Second]\n"
+            "        %%metro number: 7\n"
+            "        b[B]\n"
+            "    end\n"
+            "    subgraph third [Third]\n"
+            "        c[C]\n"
+            "    end\n"
+            "    a -->|main| b\n"
+            "    b -->|main| c\n"
+        )
+        graph = parse_metro_mermaid(text)
+        compute_layout(graph)
+        assert {sid: section.number for sid, section in graph.sections.items()} == {
+            "first": 1,
+            "second": 7,
+            "third": 2,
+        }
 
     def test_fold_return_row_numbered_after_forward_row(self, rnaseq_auto):
         """RL sections after a fold should have higher numbers than all
@@ -108,7 +175,6 @@ class TestSectionNumberingOrder:
             )
 
     def test_asymmetric_top_row_sequential(self, asymmetric_tree):
-        """In asymmetric_tree, the top row should be numbered sequentially."""
         top_row = sorted(
             (s for s in asymmetric_tree.sections.values() if s.grid_row == 0),
             key=lambda s: s.grid_col,

--- a/tests/test_tb_branch_ratchet.py
+++ b/tests/test_tb_branch_ratchet.py
@@ -14,7 +14,7 @@ from pathlib import Path
 _LAYOUT_DIR = Path(__file__).resolve().parents[1] / "src/nf_metro/layout"
 
 # Lower this (never raise it) when a heuristic migrates onto AxisFrame.
-_BASELINE_TB_BRANCHES = 20
+_BASELINE_TB_BRANCHES = 19
 
 
 def _count_in_file(path: Path) -> int:
@@ -43,7 +43,7 @@ def test_no_new_tb_branches() -> None:
 
     # Guard against the counter silently matching nothing (modules moved, AST
     # walk broken): the engine genuinely carries dozens of TB references today.
-    assert total >= 20, (
+    assert total >= 15, (
         f"expected many TB references, found {total} - the counter may be "
         "broken or the layout package restructured"
     )


### PR DESCRIPTION
## Summary

- number each disconnected flow by following connected visual routes
- prefer the nearest connected section on the current row, while keeping parallel branch starts together and resuming their continuations in sibling order
- complete aligned and independent merge inputs before their join, while allowing a clear primary row to finish before a secondary cross-row route rejoins it
- preserve visual flow direction within rows
- add a section-scoped %%metro number directive for explicit badge overrides
- validate positive overrides, warn on duplicates, and fill automatic sections with unused positive numbers
- document the automatic and authored numbering rules and cover reviewed renders with corpus-wide regressions

## Testing

- ruff check src/ tests/
- ruff format --check src/ tests/
- mypy
- prek run prettier --all-files
- 173 parser, numbering, determinism, and direction-ratchet tests passed
- all 300 example definitions assert sequential automatic numbers and constrain backward edges to secondary cross-row route returns
- all 310 gallery renders generated successfully
- local visual inspection of the four connectivity counterexamples