### PR TITLE
fix(layout): re-derive junction placement whenever sections move

### DIFF
--- a/src/nf_metro/layout/phases/bbox.py
+++ b/src/nf_metro/layout/phases/bbox.py
@@ -39,6 +39,7 @@ from nf_metro.layout.phases._common import (
     port_edge_inset,
     section_anchor_edge,
 )
+from nf_metro.layout.phases.junctions import _position_junctions
 from nf_metro.layout.phases.single_section import (
     _terminus_y_overhang,
     angled_label_reach,
@@ -136,8 +137,12 @@ def _aggregate_bypass_spans(
 def _shift_rows_from(graph: MetroGraph, from_row: int, deficit: float) -> None:
     """Shift every section at or below *from_row* down by *deficit*.
 
-    Moves the sections' bboxes and their stations/ports together. Junctions live
-    in inter-section space and are reproduced by routing, so they are not moved.
+    Moves the sections' bboxes and their stations/ports together, then
+    re-derives junction placement from the moved ports: a junction's
+    coordinates are a function of the ports it joins (a fan-out junction is
+    pinned to its exit port's Y, a merge junction to its entry port's Y), so
+    a translation that left junctions behind would strand them off the
+    bundle they belong to.
     """
     for s in graph.sections.values():
         if s.grid_row < from_row:
@@ -150,6 +155,7 @@ def _shift_rows_from(graph: MetroGraph, from_row: int, deficit: float) -> None:
             port = graph.ports.get(stid)
             if port is not None:
                 port.y += deficit
+    _position_junctions(graph)
 
 
 def push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) -> bool:
@@ -171,8 +177,7 @@ def push_lower_rows_after_bbox_grow(graph: MetroGraph, section_y_gap: float) -> 
     columns can sit with smaller (or no) vertical separation without
     visual interference.  If a positive deficit remains, shift row
     ``r`` and below downward by that deficit (sections + stations +
-    ports).  Junctions live in inter-section space and are reproduced
-    by routing.
+    ports + the junctions those ports anchor).
 
     Returns ``True`` when any row was shifted, so a render-time caller
     can recompute the geometry that tracks the moved sections.

--- a/src/nf_metro/layout/routing/invariants.py
+++ b/src/nf_metro/layout/routing/invariants.py
@@ -4130,7 +4130,7 @@ def _iter_merge_convergences(
     """
     by_key = {(r.edge.source, r.edge.target, r.line_id): r for r in routes}
     topology = build_route_topology_query(graph)
-    merge_ports = (
+    merge_ports: tuple[tuple[str, str | None], ...] = (
         tuple(
             (convergence.junction_id, convergence.entry_port_id)
             for convergence in topology.convergences

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -44,6 +44,7 @@ from nf_metro.layout.phases.guards import (
     iter_opposing_line_overlaps,
     render_header_collision,
 )
+from nf_metro.layout.phases.junctions import _position_junctions
 from nf_metro.layout.phases.spacing import _bypass_label_obstacles
 from nf_metro.layout.route_plan import RoutePlan
 from nf_metro.layout.routing import (
@@ -72,6 +73,7 @@ from nf_metro.parser.model import (
     MARKER_SHAPE_PILL,
     Interchange,
     LayoutGeometryWarning,
+    LineSpread,
     MarkerStyle,
     MetroGraph,
     Section,
@@ -755,6 +757,15 @@ def _settle_render_geometry(
     legitimately moves a bbox edge past an invisible port, which the port guards
     would otherwise flag); the header-clearance guard runs last, on the settled
     geometry.
+
+    Junction coordinates are a function of the ports they join rather than
+    independent data, so they are re-derived from the incoming section geometry
+    before anything is routed.  That keeps routing self-consistent no matter
+    which stage last moved a section: a junction left at a stale Y sits off the
+    bundle it belongs to and the connector into it degenerates into a
+    sub-radius dogleg.  A graph-wide rail layout anchors its junctions on
+    per-line rail Ys instead, by a rule the port-derived placement does not
+    reproduce, so it is exempt.
     """
 
     def _place(
@@ -788,6 +799,8 @@ def _settle_render_geometry(
         )
         return observation.routes, observation.plan
 
+    if graph.line_spread is not LineSpread.RAILS:
+        _position_junctions(graph)
     station_offsets = compute_station_offsets(graph, offset_step=offset_step)
     routes, route_plan = _route(station_offsets)
     effective_strict = graph.strict and not graph.permissive

--- a/tests/test_row_translation_junction_anchor.py
+++ b/tests/test_row_translation_junction_anchor.py
@@ -1,0 +1,102 @@
+"""Render coherence under a rigid downward translation of a grid row.
+
+Translating a row (its sections, their stations and their ports) by a small
+amount is layout-neutral: nothing inside the row moves relative to anything
+else in it.  Junction stations, though, live outside any section, and their
+coordinates are derived rather than authored - a fan-out junction is pinned to
+the Y of the exit port that feeds it, a merge junction to the Y of the entry
+port it feeds.  A translation that leaves a junction at its old Y strands it
+off the bundle it belongs to, and the exit-port-to-junction connector
+degenerates into a dogleg too short to carry a curve radius.
+
+``examples/topologies/complex_multipath.mmd`` exposes this: its
+``full_preprocess`` right-exit fan-out junction sits ``JUNCTION_MARGIN`` from
+the exit port, so a few pixels of stranding is enough to turn a straight
+connector into a sub-radius Z.
+
+A graph-wide rail layout is the one place where the port-derived placement is
+not the authority: it seats junctions on per-line rail Ys instead, so the
+re-derivation must leave those alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nf_metro.api import prepare_graph, resolve_theme
+from nf_metro.layout.phases.bbox import _shift_rows_from
+from nf_metro.layout.phases.guards import _guard_fanout_junction_shares_exit_port_y
+from nf_metro.parser.model import MetroGraph
+from nf_metro.render.svg import build_render_plan, render_svg
+
+FIXTURE = (
+    Path(__file__).parent.parent / "examples" / "topologies" / "complex_multipath.mmd"
+)
+
+RAIL_DIVERGENCE = """%%metro title: Rail Divergence
+%%metro line_spread: rails
+%%metro line: a | A | #e63946
+%%metro line: b | B | #2db572
+
+graph LR
+    subgraph s1 [One]
+        n1[Start]
+        n2[Split]
+        n1 -->|a,b| n2
+    end
+    subgraph s2 [Two]
+        n3[Left]
+    end
+    subgraph s3 [Three]
+        n4[Right]
+    end
+    n2 -->|a| n3
+    n2 -->|b| n4
+"""
+
+
+def _translate_rows_stranding_junctions(
+    graph: MetroGraph, from_row: int, amount: float
+) -> None:
+    """Move sections at or below *from_row* down by *amount*, junctions aside.
+
+    Deliberately narrower than :func:`_shift_rows_from`: omitting the junction
+    re-derivation is what puts the render path in front of a graph whose
+    junctions were left behind by whatever moved the sections.
+    """
+    for section in graph.sections.values():
+        if section.grid_row < from_row:
+            continue
+        section.bbox_y += amount
+        for station_id in section.station_ids:
+            station = graph.stations.get(station_id)
+            if station is not None:
+                station.y += amount
+            port = graph.ports.get(station_id)
+            if port is not None:
+                port.y += amount
+
+
+@pytest.mark.parametrize("amount", range(0, 25))
+def test_row_translation_renders(amount: int) -> None:
+    graph = prepare_graph(FIXTURE.read_text(), source_dir=str(FIXTURE.parent))
+    _translate_rows_stranding_junctions(graph, 1, amount)
+    render_svg(graph, resolve_theme(None, graph))
+
+
+@pytest.mark.parametrize("amount", [6.0, 17.5, 40.0])
+def test_shift_rows_keeps_junctions_on_their_exit_ports(amount: float) -> None:
+    graph = prepare_graph(FIXTURE.read_text(), source_dir=str(FIXTURE.parent))
+    _shift_rows_from(graph, 1, amount)
+    _guard_fanout_junction_shares_exit_port_y(graph, "row-shift")
+
+
+def test_rail_layout_junctions_keep_their_rail_y() -> None:
+    graph = prepare_graph(RAIL_DIVERGENCE)
+    junction_id = next(iter(graph.junctions))
+    rail_xy = (graph.stations[junction_id].x, graph.stations[junction_id].y)
+    plan = build_render_plan(graph, resolve_theme(None, graph))
+    planned = plan.graph.stations[junction_id]
+    assert (planned.x, planned.y) == rail_xy


### PR DESCRIPTION
## What

A junction's coordinates are a **derived** quantity, not authored data: a fan-out junction is pinned to its exit port's Y, a merge junction to its entry port's Y. `layout/CONTRACT.md` already states this as an invariant of Stage 5.1 - *"junctions track their ports at the final boundary, re-established after every later port move"* - and the Tier-B guard `_guard_fanout_junction_shares_exit_port_y` enforces it.

The row-translation primitive `_shift_rows_from` did not honour that contract. It moved sections, their stations and their ports, and left junctions where they were, on the stated premise that junctions "live in inter-section space and are reproduced by routing". They are not: they are `Station`s with stored coordinates that routing reads directly. Any row translation therefore stranded them.

`examples/topologies/complex_multipath.mmd` shows what that costs. Its `full_preprocess` right exit port sits at y=295 and `__junction_11` sits 10px away at (470, 295), so the three-line connector between them is a straight horizontal run. Translate grid row 1 down and the junction stays behind, turning that 10px connector into a Z that has to absorb the whole offset inside 10px of runway - less than one curve radius. The render aborts, with the failure mode depending on how far the junction was stranded:

| stranding | failure |
| --: | --- |
| 1px | `[undeclared gap channel]` - plus a bundle-order flip and a corner whose arc centres are 6.4px apart |
| 2-6px | `exit-turn plan ...: planned member emitted without a source turn` |
| 10px | `[inter-section orthogonal turn starved below a formed curve]` - turn at (476, 309) rounds to radius 1.0 against a requested 10.0 |

All three bands are the same edge (`full_preprocess__exit_right_1 -> __junction_11`) and the same root cause.

## Changes

- `_shift_rows_from` re-derives junction placement after translating a row, restoring the contract it was breaking.
- `_settle_render_geometry` re-derives junction placement before routing, so routing input is self-consistent regardless of which stage last moved a section. A graph-wide rail layout seats junctions on per-line rail Ys by a rule the port-derived placement does not reproduce, so it is exempt.
- `tests/test_row_translation_junction_anchor.py` sweeps a rigid row translation over `complex_multipath.mmd` and asserts the render succeeds, asserts `_shift_rows_from` leaves junctions on their exit ports (via the existing guard), and locks the rail-layout exemption.
- A type annotation on `merge_ports` in the convergence invariant reader, which current mypy releases reject.

## Verification

- Full suite: 47800 passed, 138 skipped, 13 xfailed.
- Render corpus (367 `.mmd` under `examples/` and `tests/fixtures/`) is **byte-identical** to `main`: 0 hashes changed, the same 13 pre-existing errors on both sides, none newly erroring and none newly rendering. Re-derivation is a no-op wherever the layout already satisfies its own invariant.
- Measured cost: 0.003s of `_position_junctions` across 259 renders of the topology corpus.
- `prek run --all-files` clean; routing gate-coverage baseline unchanged.