### PR TITLE
Fix canvas corridor content-side clearance

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -1713,35 +1713,19 @@ in pipeline order.
   reserved and bank all of it on the side facing content, leaving its stroke and
   chevron drawn through the margin and clipped by the viewport. Across the
   `examples` and `tests/fixtures` corpus, 144 canvas corridors are realised and
-  none is short of its canvas margin or of total capacity, measured either from
-  the published claim interval or from the drawn polylines. A canvas corridor's
-  *content*-facing side is not gated here, because no growth of the canvas moves
-  a section box edge or header badge. 28 of those 144 keep less than the
-  clearance they claim from that content when their drawn ink is measured (29 from
-  the published claim interval), 18 of them an over-top band within the band
-  `INTER_ROW_HEADER_CLEARANCE` reserves for a header badge. That clearance is a
-  longitudinally blind envelope, and it is charged at routing time, before any
-  caption has a position: it assumes the badge protrudes above `bbox_y` as
-  `section_header_top` states, and where a section draws its caption below or
-  beside its box, or at an x the band does not reach, the reserved band holds no
-  badge. The reservation cannot be narrowed to the caption drawn, because the
-  caption is chosen from the routed polylines and the routes are placed against
-  this clearance (see *A caption's reserved band is the one on the side it took*);
-  reserving the band unconditionally is what keeps the caption's default position
-  always available, and its cost is slack rather than a defect. Measured
-  over all 28, the count of fixtures in which route ink enters a drawn badge's own
-  box is zero, so gating this side today would refuse renders for clearance from
-  something not drawn there. Each is instead published as an attributed
-  `reservation-deficit` record on the plan for the box-edge and header guards to
-  own, and tightening the claim to the badge actually drawn is #1693. That issue
-  is not closed by localising the claim alone: `INTER_ROW_HEADER_CLEARANCE` is
-  `SECTION_HEADER_PROTRUSION + INTER_ROW_EDGE_CLEARANCE`, and charging only the
-  edge clearance where no badge is drawn under the run still leaves 10 of the 18
-  short, because they keep 22px of the 26px edge clearance rather than the full
-  26 that 8 of them keep. The remaining 10 deficits are 2 to 6px short of
-  `EDGE_TO_BUNDLE_CLEARANCE` or `INTER_ROW_EDGE_CLEARANCE` against a box edge with
-  no badge involved. Gating the content side therefore needs those corridors moved
-  off the box edges they hug, not a narrower claim.
+  none is short of its canvas margin, content margin, or total capacity. The
+  content boundary is resolved after header placement, against the final route
+  polylines. A section box contributes its edge only over the corridor's declared
+  longitudinal interval. A header contributes its drawn keepout only where that
+  keepout overlaps the same interval and protrudes toward the corridor. The
+  effective clearance is `INTER_ROW_EDGE_CLEARANCE` for horizontal box edges,
+  `EDGE_TO_BUNDLE_CLEARANCE` for vertical box edges, and
+  `SECTION_HEADER_ROUTE_CLEARANCE` for header ink. The corridor-normalisation
+  pass seats movable canvas runs inside the corresponding box-edge band. Planned
+  right-entry fans include their full outer-lane offset when placing their owned
+  descent channel. `assert_canvas_corridors_hold_their_claims` gates the minimum
+  of canvas-edge slack, content-side slack, and total capacity slack, so a
+  content-side graze fails the same strict path as a clipped canvas margin.
 - **Transactional**: The pre-settlement coordinates are restored before any
   exception propagates, so a failure leaves the graph as settlement found it.
   The reservation ledger is read-only here.
@@ -2078,14 +2062,17 @@ at render time and 4 do so on a pass with nothing behind it.
 
 ### A caption's reserved band is the one on the side it took
 
-`SECTION_HEADER_PROTRUSION` above a box top is the band the layout reserves for
-that box's caption, and `section_header_top` states it. Routing is charged against
-it (`section_header_safe_cap`, `INTER_ROW_HEADER_CLEARANCE`), and that charge is
-unconditional because it is made before any caption has a position: the caption is
-picked from the routed polylines it has to avoid, so a reservation that followed
-the caption would be a route-place-route fixpoint. What the reservation buys is
-that the caption's default top-left position is always available, and what it
-costs where the caption goes elsewhere is slack.
+`SECTION_HEADER_PROTRUSION` above a box top is the prospective band the layout
+reserves for that box's caption, and `section_header_top` states it. Gap routing
+is charged against it (`section_header_safe_cap`, `INTER_ROW_HEADER_CLEARANCE`)
+before any caption has a position: the caption is picked from the routed
+polylines it has to avoid, so routing against the final caption would require a
+route-place-route fixpoint. What that prospective reservation buys is that the
+caption's default top-left position is available. Final canvas-corridor
+realisation is retrospective instead: it reads the chosen header keepout and
+the emitted run's longitudinal span, then treats only ink that overlaps that
+span as a blocker. A caption placed elsewhere therefore does not create empty
+reserved space beside the canvas run.
 
 A fixed band above `bbox_y` is therefore the wrong thing to hold a *drawn* caption
 to, in both directions. It is too small: a wrapped title grows away from the box

--- a/src/nf_metro/layout/constants.py
+++ b/src/nf_metro/layout/constants.py
@@ -146,6 +146,9 @@ The numbered circle center sits at bbox_y - circle_r - Y_OFFSET
 11px above that, totaling 26px above bbox_y.
 """
 
+SECTION_HEADER_ROUTE_CLEARANCE: float = 4.0
+"""Minimum gap between routed ink and a drawn section-header keepout."""
+
 MIN_INTER_SECTION_ROW_GAP: float = 12.0
 """Minimum visual gap between section bottom and the next section's header.
 

--- a/src/nf_metro/layout/phases/guards.py
+++ b/src/nf_metro/layout/phases/guards.py
@@ -6296,11 +6296,13 @@ def _canvas_corridor_deficit_detail(
     realised: RealisedRouteReservation,
     region: CanvasRegion,
     edge_slack: float,
+    content_slack: float,
 ) -> str:
-    """Name the corridor, then which of its two claims fell short and by how much."""
+    """Name the corridor and its edge, content, and capacity slacks."""
     return (
         f"{_corridor_deficit_detail(reservation, realised)}, leaving "
         f"{edge_slack:+.1f}px of slack on its {region.side.value} canvas margin "
+        f"and {content_slack:+.1f}px on its content side, "
         f"and {realised.capacity_slack:+.1f}px of total capacity"
     )
 
@@ -6369,18 +6371,20 @@ def assert_canvas_corridors_hold_their_claims(
     widenable by growing the canvas, so a deficit here is an arrangement the
     render cannot honour rather than a limit of any one stage.
 
-    Two numbers are measured, because the margin and the total are different
-    claims and either can be the one that fails.  The margin is
+    Three numbers are measured because either side or the total can fail. The
+    canvas margin is
     :func:`canvas_edge_slack`: the gap between the ink drawn on the canvas side
     of the corridor and the edge itself, which is what decides whether a stroke
     or a direction chevron is clipped.  Capacity is the corridor's total room,
     which a corridor can hold in full while spending all of it on its content
-    side.  The content-facing side is a section box edge or header badge rather
-    than a canvas matter, and no growth of the canvas moves it; a shortfall
-    there is published as a ``reservation-deficit`` diagnostic on the plan and
-    owned by the box-edge and header guards.
+    side. The opposite margin is measured against the section edge or header
+    keepout actually drawn beside the run.
     """
-    from nf_metro.layout.route_reservations import CanvasRegion, canvas_edge_slack
+    from nf_metro.layout.route_reservations import (
+        CanvasRegion,
+        canvas_content_slack,
+        canvas_edge_slack,
+    )
 
     by_id = {item.id: item for item in plan.reservations}
     worst: tuple[float, str] | None = None
@@ -6389,22 +6393,27 @@ def assert_canvas_corridors_hold_their_claims(
         if reservation is None or not isinstance(reservation.region, CanvasRegion):
             continue
         edge_slack = canvas_edge_slack(reservation.region, realised)
-        slack = min(edge_slack, realised.capacity_slack)
+        content_slack = canvas_content_slack(reservation.region, realised)
+        slack = min(edge_slack, content_slack, realised.capacity_slack)
         if slack >= -COORD_TOLERANCE:
             continue
         if worst is None or slack < worst[0]:
             worst = (
                 slack,
                 _canvas_corridor_deficit_detail(
-                    reservation, realised, reservation.region, edge_slack
+                    reservation,
+                    realised,
+                    reservation.region,
+                    edge_slack,
+                    content_slack,
                 ),
             )
     if worst is None:
         return
     msg = (
         "a canvas-margin corridor is drawn with less clearance than it "
-        f"reserved: {worst[1]}.  Widen the canvas, or move the run off the "
-        "margin, rather than drawing it through a clearance it does not have."
+        f"reserved: {worst[1]}.  Widen the canvas or move the run away from "
+        "the blocking edge rather than drawing through unavailable clearance."
     )
     if strict:
         raise LayoutInvariantError(msg)

--- a/src/nf_metro/layout/route_reservations.py
+++ b/src/nf_metro/layout/route_reservations.py
@@ -20,6 +20,7 @@ from nf_metro.layout.constants import (
     INTER_ROW_EDGE_CLEARANCE,
     INTER_ROW_HEADER_CLEARANCE,
     SAME_COORD_TOLERANCE,
+    SECTION_HEADER_ROUTE_CLEARANCE,
 )
 from nf_metro.layout.geometry import (
     cotravelling_lane_clearance,
@@ -79,6 +80,7 @@ SECTION_BOTTOM_BLOCKER = "section-bottom"
 SECTION_HEADER_BLOCKER = "section-header"
 SECTION_LEFT_BLOCKER = "section-left"
 SECTION_RIGHT_BLOCKER = "section-right"
+SECTION_TOP_BLOCKER = "section-top"
 LAUNCH_ANCHOR_BLOCKER = "launch-anchor"
 """Names the station a corridor's own runs launch from, when it bounds them.
 
@@ -409,10 +411,14 @@ class RealisedRouteReservation:
     positive_side_slack: float
     negative_blocker_ids: tuple[str, ...]
     positive_blocker_ids: tuple[str, ...]
+    negative_side_clearance: float
+    positive_side_clearance: float
     coordinate_regime: CoordinateRegime = CoordinateRegime.LAYOUT_CANVAS
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = ()
 
     def __post_init__(self) -> None:
+        if self.negative_side_clearance < 0 or self.positive_side_clearance < 0:
+            raise ValueError("realised corridor clearances cannot be negative")
         if self.allocation_axis is DemandAxis.BOTH:
             raise ValueError("a corridor realisation allocates one canvas axis")
         if self.longitudinal_axis is DemandAxis.BOTH:
@@ -447,6 +453,17 @@ def canvas_edge_slack(
         realised.negative_side_slack
         if region.side in CANVAS_EDGE_ON_NEGATIVE_SIDE
         else realised.positive_side_slack
+    )
+
+
+def canvas_content_slack(
+    region: CanvasRegion, realised: RealisedRouteReservation
+) -> float:
+    """*realised*'s clearance from the content opposite its canvas edge."""
+    return (
+        realised.positive_side_slack
+        if region.side in CANVAS_EDGE_ON_NEGATIVE_SIDE
+        else realised.negative_side_slack
     )
 
 
@@ -631,6 +648,8 @@ class _RegionMeasurement:
     end: float
     negative_blocker_ids: tuple[str, ...]
     positive_blocker_ids: tuple[str, ...]
+    negative_side_clearance: float | None = None
+    positive_side_clearance: float | None = None
 
 
 def _stable_id(prefix: str, *parts: object) -> str:
@@ -968,6 +987,60 @@ def gap_corridor_clearance_band(
         if best is None or width < best[0]:
             best = (width, band)
     return None if best is None else best[1]
+
+
+def canvas_corridor_clearance_band(
+    graph: MetroGraph,
+    orientation: CorridorOrientation,
+    coordinate: float,
+    longitudinal_start: float,
+    longitudinal_end: float,
+) -> GapCorridorBand | None:
+    """The box-edge clearance band for a run outside all placed content."""
+    extents = _ContentExtents.of(graph)
+    if orientation is CorridorOrientation.HORIZONTAL:
+        sections = tuple(
+            section
+            for section in extents.sections
+            if _section_x_overlaps(section, longitudinal_start, longitudinal_end)
+        )
+        if not sections:
+            return None
+        if coordinate < extents.top:
+            return GapCorridorBand(
+                -1,
+                -math.inf,
+                min(section.bbox_y for section in sections) - INTER_ROW_EDGE_CLEARANCE,
+            )
+        if coordinate > extents.bottom:
+            return GapCorridorBand(
+                -1,
+                max(section.bbox_y + section.bbox_h for section in sections)
+                + INTER_ROW_EDGE_CLEARANCE,
+                math.inf,
+            )
+        return None
+    sections = tuple(
+        section
+        for section in extents.sections
+        if _section_y_overlaps(section, longitudinal_start, longitudinal_end)
+    )
+    if not sections:
+        return None
+    if coordinate < extents.left:
+        return GapCorridorBand(
+            -1,
+            -math.inf,
+            min(section.bbox_x for section in sections) - EDGE_TO_BUNDLE_CLEARANCE,
+        )
+    if coordinate > extents.right:
+        return GapCorridorBand(
+            -1,
+            max(section.bbox_x + section.bbox_w for section in sections)
+            + EDGE_TO_BUNDLE_CLEARANCE,
+            math.inf,
+        )
+    return None
 
 
 def _candidate_row_gaps(
@@ -1632,7 +1705,7 @@ def _clearances(
         if isinstance(region, CanvasRegion) and region.side is CanvasSide.TOP:
             return (
                 canvas_edge_clearance(),
-                INTER_ROW_HEADER_CLEARANCE,
+                INTER_ROW_EDGE_CLEARANCE,
                 (
                     KeepOutClass.CANVAS,
                     KeepOutClass.HEADER,
@@ -2227,6 +2300,37 @@ def _build_symbolic_records(
     )
 
 
+class _ContentBoundary(NamedTuple):
+    blocker_id: str
+    coordinate: float
+    clearance: float
+
+
+def _content_boundary(
+    candidates: Iterable[_ContentBoundary], *, negative_side: bool
+) -> tuple[float, float, tuple[str, ...]]:
+    """The drawn obstacle that leaves the least usable canvas-side room."""
+    ordered = tuple(candidates)
+    if not ordered:
+        raise ValueError("corridor boundary has no settled blocker")
+
+    def allowed(item: _ContentBoundary) -> float:
+        return item.coordinate + item.clearance * (1 if negative_side else -1)
+
+    limit = (max if negative_side else min)(allowed(item) for item in ordered)
+    selected = min(
+        (item for item in ordered if abs(allowed(item) - limit) <= COORD_TOLERANCE),
+        key=lambda item: (item.coordinate, item.clearance, item.blocker_id),
+    )
+    blockers = tuple(
+        item.blocker_id
+        for item in ordered
+        if abs(item.coordinate - selected.coordinate) <= COORD_TOLERANCE
+        and abs(item.clearance - selected.clearance) <= COORD_TOLERANCE
+    )
+    return selected.coordinate, selected.clearance, blockers
+
+
 def _canvas_region_measurement(
     graph: MetroGraph,
     region: CanvasRegion,
@@ -2234,7 +2338,9 @@ def _canvas_region_measurement(
     longitudinal_end: float,
     canvas_width: float,
     canvas_height: float,
+    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
 ) -> _RegionMeasurement:
+    keepouts = header_keepouts or {}
     if region.side in {CanvasSide.TOP, CanvasSide.BOTTOM}:
         sections = tuple(
             section
@@ -2243,25 +2349,64 @@ def _canvas_region_measurement(
             and _section_x_overlaps(section, longitudinal_start, longitudinal_end)
         )
         if region.side is CanvasSide.TOP:
-            end, positive = _edge_blockers(
-                (
-                    (f"{SECTION_HEADER_BLOCKER}:{section.id}", section.bbox_y)
-                    for section in sections
-                ),
-                maximum=False,
-            )
-            return _RegionMeasurement(0.0, end, ("canvas:top",), positive)
-        start, negative = _edge_blockers(
-            (
-                (
-                    f"{SECTION_BOTTOM_BLOCKER}:{section.id}",
-                    section.bbox_y + section.bbox_h,
+            candidates = [
+                _ContentBoundary(
+                    f"{SECTION_TOP_BLOCKER}:{section.id}",
+                    section.bbox_y,
+                    INTER_ROW_EDGE_CLEARANCE,
                 )
                 for section in sections
-            ),
-            maximum=True,
+            ]
+            candidates.extend(
+                _ContentBoundary(
+                    f"{SECTION_HEADER_BLOCKER}:{section.id}",
+                    keepout[1],
+                    SECTION_HEADER_ROUTE_CLEARANCE,
+                )
+                for section in sections
+                if (keepout := keepouts.get(section.id)) is not None
+                and keepout[1] < section.bbox_y - COORD_TOLERANCE
+                and _overlaps(
+                    keepout[0], keepout[2], longitudinal_start, longitudinal_end
+                )
+            )
+            end, clearance, positive = _content_boundary(
+                candidates, negative_side=False
+            )
+            return _RegionMeasurement(
+                0.0,
+                end,
+                ("canvas:top",),
+                positive,
+                positive_side_clearance=clearance,
+            )
+        candidates = [
+            _ContentBoundary(
+                f"{SECTION_BOTTOM_BLOCKER}:{section.id}",
+                section.bbox_y + section.bbox_h,
+                INTER_ROW_EDGE_CLEARANCE,
+            )
+            for section in sections
+        ]
+        candidates.extend(
+            _ContentBoundary(
+                f"{SECTION_HEADER_BLOCKER}:{section.id}",
+                keepout[3],
+                SECTION_HEADER_ROUTE_CLEARANCE,
+            )
+            for section in sections
+            if (keepout := keepouts.get(section.id)) is not None
+            and keepout[3] > section.bbox_y + section.bbox_h + COORD_TOLERANCE
+            and _overlaps(keepout[0], keepout[2], longitudinal_start, longitudinal_end)
         )
-        return _RegionMeasurement(start, canvas_height, negative, ("canvas:bottom",))
+        start, clearance, negative = _content_boundary(candidates, negative_side=True)
+        return _RegionMeasurement(
+            start,
+            canvas_height,
+            negative,
+            ("canvas:bottom",),
+            negative_side_clearance=clearance,
+        )
     sections = tuple(
         section
         for section in graph.sections.values()
@@ -2269,22 +2414,60 @@ def _canvas_region_measurement(
         and _section_y_overlaps(section, longitudinal_start, longitudinal_end)
     )
     if region.side is CanvasSide.LEFT:
-        end, positive = _edge_blockers(
-            (
-                (f"{SECTION_LEFT_BLOCKER}:{section.id}", section.bbox_x)
-                for section in sections
-            ),
-            maximum=False,
-        )
-        return _RegionMeasurement(0.0, end, ("canvas:left",), positive)
-    start, negative = _edge_blockers(
-        (
-            (f"{SECTION_RIGHT_BLOCKER}:{section.id}", section.bbox_x + section.bbox_w)
+        candidates = [
+            _ContentBoundary(
+                f"{SECTION_LEFT_BLOCKER}:{section.id}",
+                section.bbox_x,
+                EDGE_TO_BUNDLE_CLEARANCE,
+            )
             for section in sections
-        ),
-        maximum=True,
+        ]
+        candidates.extend(
+            _ContentBoundary(
+                f"{SECTION_HEADER_BLOCKER}:{section.id}",
+                keepout[0],
+                SECTION_HEADER_ROUTE_CLEARANCE,
+            )
+            for section in sections
+            if (keepout := keepouts.get(section.id)) is not None
+            and keepout[0] < section.bbox_x - COORD_TOLERANCE
+            and _overlaps(keepout[1], keepout[3], longitudinal_start, longitudinal_end)
+        )
+        end, clearance, positive = _content_boundary(candidates, negative_side=False)
+        return _RegionMeasurement(
+            0.0,
+            end,
+            ("canvas:left",),
+            positive,
+            positive_side_clearance=clearance,
+        )
+    candidates = [
+        _ContentBoundary(
+            f"{SECTION_RIGHT_BLOCKER}:{section.id}",
+            section.bbox_x + section.bbox_w,
+            EDGE_TO_BUNDLE_CLEARANCE,
+        )
+        for section in sections
+    ]
+    candidates.extend(
+        _ContentBoundary(
+            f"{SECTION_HEADER_BLOCKER}:{section.id}",
+            keepout[2],
+            SECTION_HEADER_ROUTE_CLEARANCE,
+        )
+        for section in sections
+        if (keepout := keepouts.get(section.id)) is not None
+        and keepout[2] > section.bbox_x + section.bbox_w + COORD_TOLERANCE
+        and _overlaps(keepout[1], keepout[3], longitudinal_start, longitudinal_end)
     )
-    return _RegionMeasurement(start, canvas_width, negative, ("canvas:right",))
+    start, clearance, negative = _content_boundary(candidates, negative_side=True)
+    return _RegionMeasurement(
+        start,
+        canvas_width,
+        negative,
+        ("canvas:right",),
+        negative_side_clearance=clearance,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -2335,6 +2518,29 @@ def _projected_claim_bounds(
     )
 
 
+def _drawn_claim_bounds(
+    reservation: RouteReservation,
+    route_polylines: Sequence[Sequence[tuple[float, float]]],
+) -> _ProjectedClaimBounds:
+    """Canvas-run bounds read from the final polylines the renderer emits."""
+    allocation_axis, longitudinal_axis = _reservation_axes(reservation)
+    allocation_index = 0 if allocation_axis is DemandAxis.X else 1
+    longitudinal_index = 0 if longitudinal_axis is DemandAxis.X else 1
+    points = tuple(
+        route_polylines[claim.path_rank][rank]
+        for claim in reservation.claims
+        for rank in range(claim.segment_rank, claim.segment_end_rank + 2)
+    )
+    return _ProjectedClaimBounds(
+        allocation_axis,
+        longitudinal_axis,
+        min(point[longitudinal_index] for point in points),
+        max(point[longitudinal_index] for point in points),
+        min(point[allocation_index] for point in points),
+        max(point[allocation_index] for point in points),
+    )
+
+
 def _launch_anchored_measurement(
     graph: MetroGraph,
     reservation: RouteReservation,
@@ -2375,7 +2581,13 @@ def _launch_anchored_measurement(
                 end, positive = edge, [blocker_id]
             elif edge < end + COORD_TOLERANCE:
                 positive.append(blocker_id)
-    return _RegionMeasurement(start, end, tuple(negative), tuple(positive))
+    return replace(
+        measurement,
+        start=start,
+        end=end,
+        negative_blocker_ids=tuple(negative),
+        positive_blocker_ids=tuple(positive),
+    )
 
 
 def _realise_one(
@@ -2384,12 +2596,18 @@ def _realise_one(
     canvas_width: float | None,
     canvas_height: float | None,
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = (),
+    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
+    route_polylines: Sequence[Sequence[tuple[float, float]]] | None = None,
 ) -> RealisedRouteReservation | None:
     if isinstance(reservation.region, CanvasRegion) and (
         canvas_width is None or canvas_height is None
     ):
         return None
-    projected = _projected_claim_bounds(reservation, coordinate_translations)
+    projected = (
+        _drawn_claim_bounds(reservation, route_polylines)
+        if isinstance(reservation.region, CanvasRegion) and route_polylines is not None
+        else _projected_claim_bounds(reservation, coordinate_translations)
+    )
     longitudinal_start = projected.longitudinal_start
     longitudinal_end = projected.longitudinal_end
     occupied_start = projected.occupied_start
@@ -2424,9 +2642,26 @@ def _realise_one(
             longitudinal_end,
             canvas_width,
             canvas_height,
+            header_keepouts,
         )
     measurement = _launch_anchored_measurement(
         graph, reservation, measurement, occupied_start, occupied_end
+    )
+    negative_clearance = (
+        reservation.negative_side_clearance
+        if measurement.negative_side_clearance is None
+        else measurement.negative_side_clearance
+    )
+    positive_clearance = (
+        reservation.positive_side_clearance
+        if measurement.positive_side_clearance is None
+        else measurement.positive_side_clearance
+    )
+    required = (
+        negative_clearance
+        + reservation.bundle_width
+        + reservation.peer_width
+        + positive_clearance
     )
     available = measured_distance(measurement.start, measurement.end)
     return RealisedRouteReservation(
@@ -2441,12 +2676,14 @@ def _realise_one(
         occupied_start,
         occupied_end,
         available,
-        reservation.minimum_width,
-        available - reservation.minimum_width,
-        occupied_start - (measurement.start + reservation.negative_side_clearance),
-        measurement.end - reservation.positive_side_clearance - occupied_end,
+        required,
+        available - required,
+        occupied_start - (measurement.start + negative_clearance),
+        measurement.end - positive_clearance - occupied_end,
         measurement.negative_blocker_ids,
         measurement.positive_blocker_ids,
+        negative_clearance,
+        positive_clearance,
         CoordinateRegime.LAYOUT_CANVAS,
         coordinate_translations,
     )
@@ -2459,6 +2696,7 @@ def realise_reservation(
     canvas_width: float | None = None,
     canvas_height: float | None = None,
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = (),
+    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
 ) -> RealisedRouteReservation | None:
     """Measure one reservation against *graph* as it currently stands.
 
@@ -2474,6 +2712,7 @@ def realise_reservation(
         canvas_width,
         canvas_height,
         coordinate_translations,
+        header_keepouts,
     )
 
 
@@ -2528,8 +2767,8 @@ def drawn_corridor_containment(
         for rank in range(claim.segment_rank, claim.segment_end_rank + 2)
     )
     return DrawnCorridorContainment(
-        realised.region_start + reservation.negative_side_clearance,
-        realised.region_end - reservation.positive_side_clearance,
+        realised.region_start + realised.negative_side_clearance,
+        realised.region_end - realised.positive_side_clearance,
         min(drawn),
         max(drawn),
     )
@@ -2541,6 +2780,7 @@ def _realise_all(
     canvas_width: float | None,
     canvas_height: float | None,
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = (),
+    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
 ) -> tuple[RealisedRouteReservation, ...]:
     realised = (
         _realise_one(
@@ -2549,6 +2789,7 @@ def _realise_all(
             canvas_width,
             canvas_height,
             coordinate_translations,
+            header_keepouts,
         )
         for reservation in reservations
     )
@@ -2910,6 +3151,23 @@ def _section_blocker_ids(
     return tuple(item for item in blocker_ids if not item.startswith(marker))
 
 
+def _valid_canvas_content_blockers(
+    plan: RoutePlan, blocker_ids: tuple[str, ...], prefixes: tuple[str, ...]
+) -> bool:
+    """Whether every blocker names one section edge or header in *plan*."""
+    if not blocker_ids or len(set(blocker_ids)) != len(blocker_ids):
+        return False
+    section_ids = _section_grid_cells(plan)
+    return all(
+        any(
+            blocker_id.startswith(f"{prefix}:")
+            and blocker_id.removeprefix(f"{prefix}:") in section_ids
+            for prefix in prefixes
+        )
+        for blocker_id in blocker_ids
+    )
+
+
 def _validate_blocker_ids(
     plan: RoutePlan,
     reservation: RouteReservation,
@@ -2949,36 +3207,28 @@ def _validate_blocker_ids(
             negative_side=False,
         )
     elif region.side is CanvasSide.TOP:
-        valid = negative_ids == ("canvas:top",) and _valid_section_blockers(
+        valid = negative_ids == ("canvas:top",) and _valid_canvas_content_blockers(
             plan,
-            reservation,
             positive_ids,
-            prefix=SECTION_HEADER_BLOCKER,
-            negative_side=False,
+            (SECTION_TOP_BLOCKER, SECTION_HEADER_BLOCKER),
         )
     elif region.side is CanvasSide.BOTTOM:
-        valid = _valid_section_blockers(
+        valid = _valid_canvas_content_blockers(
             plan,
-            reservation,
             negative_ids,
-            prefix=SECTION_BOTTOM_BLOCKER,
-            negative_side=True,
+            (SECTION_BOTTOM_BLOCKER, SECTION_HEADER_BLOCKER),
         ) and positive_ids == ("canvas:bottom",)
     elif region.side is CanvasSide.LEFT:
-        valid = negative_ids == ("canvas:left",) and _valid_section_blockers(
+        valid = negative_ids == ("canvas:left",) and _valid_canvas_content_blockers(
             plan,
-            reservation,
             positive_ids,
-            prefix=SECTION_LEFT_BLOCKER,
-            negative_side=False,
+            (SECTION_LEFT_BLOCKER, SECTION_HEADER_BLOCKER),
         )
     else:
-        valid = _valid_section_blockers(
+        valid = _valid_canvas_content_blockers(
             plan,
-            reservation,
             negative_ids,
-            prefix=SECTION_RIGHT_BLOCKER,
-            negative_side=True,
+            (SECTION_RIGHT_BLOCKER, SECTION_HEADER_BLOCKER),
         ) and positive_ids == ("canvas:right",)
     if not valid:
         raise ValueError("realised reservation has invalid boundary blocker ids")
@@ -2993,25 +3243,35 @@ def _validate_reservation_realisation(
     expected_bounds = _projected_claim_bounds(
         reservation, realised.coordinate_translations
     )
-    expected_longitudinal_start = expected_bounds.longitudinal_start
-    expected_longitudinal_end = expected_bounds.longitudinal_end
-    expected_occupied_start = expected_bounds.occupied_start
-    expected_occupied_end = expected_bounds.occupied_end
-    expected_capacity = realised.available_width - reservation.minimum_width
+    if isinstance(reservation.region, CanvasRegion):
+        expected_longitudinal_start = realised.longitudinal_start
+        expected_longitudinal_end = realised.longitudinal_end
+        expected_occupied_start = realised.occupied_start
+        expected_occupied_end = realised.occupied_end
+    else:
+        expected_longitudinal_start = expected_bounds.longitudinal_start
+        expected_longitudinal_end = expected_bounds.longitudinal_end
+        expected_occupied_start = expected_bounds.occupied_start
+        expected_occupied_end = expected_bounds.occupied_end
+    expected_required = (
+        realised.negative_side_clearance
+        + reservation.bundle_width
+        + reservation.peer_width
+        + realised.positive_side_clearance
+    )
+    expected_capacity = realised.available_width - expected_required
     expected_negative = realised.occupied_start - (
-        realised.region_start + reservation.negative_side_clearance
+        realised.region_start + realised.negative_side_clearance
     )
     expected_positive = (
-        realised.region_end
-        - reservation.positive_side_clearance
-        - realised.occupied_end
+        realised.region_end - realised.positive_side_clearance - realised.occupied_end
     )
     expected_coordinate = (realised.occupied_start + realised.occupied_end) / 2
     if (
         realised.allocation_axis is not allocation_axis
         or realised.longitudinal_axis is not longitudinal_axis
         or realised.coordinate_regime is not CoordinateRegime.LAYOUT_CANVAS
-        or not _same_measurement(realised.required_width, reservation.minimum_width)
+        or not _same_measurement(realised.required_width, expected_required)
         or not _same_measurement(realised.capacity_slack, expected_capacity)
         or not _same_measurement(realised.negative_side_slack, expected_negative)
         or not _same_measurement(realised.positive_side_slack, expected_positive)
@@ -3759,6 +4019,8 @@ def realise_route_reservations(
     canvas_width: float,
     canvas_height: float,
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = (),
+    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
+    route_polylines: Sequence[Sequence[tuple[float, float]]] | None = None,
 ) -> RoutePlan:
     """Refresh the realised ledger against final render canvas bounds.
 
@@ -3783,6 +4045,8 @@ def realise_route_reservations(
                 canvas_width,
                 canvas_height,
                 held_translations.get(reservation.id, coordinate_translations),
+                header_keepouts,
+                route_polylines,
             )
         )
         is not None

--- a/src/nf_metro/layout/route_reservations.py
+++ b/src/nf_metro/layout/route_reservations.py
@@ -164,6 +164,26 @@ class CanvasRegion:
 
 CorridorRegion: TypeAlias = RowGapRegion | ColumnGapRegion | CanvasRegion
 
+
+class CanvasRect(NamedTuple):
+    """Axis-aligned final-render bounds."""
+
+    left: float
+    top: float
+    right: float
+    bottom: float
+
+
+@dataclass(frozen=True, slots=True)
+class FinalCanvasGeometry:
+    """Final canvas evidence needed to realise canvas reservations."""
+
+    width: float
+    height: float
+    header_keepouts: Mapping[str, CanvasRect]
+    route_polylines: Sequence[Sequence[tuple[float, float]]]
+
+
 CANVAS_EDGE_ON_NEGATIVE_SIDE: frozenset[CanvasSide] = frozenset(
     (CanvasSide.TOP, CanvasSide.LEFT)
 )
@@ -449,21 +469,27 @@ def canvas_edge_slack(
     spend all of that room on its content side and be drawn hard against the
     edge.
     """
-    return (
-        realised.negative_side_slack
-        if region.side in CANVAS_EDGE_ON_NEGATIVE_SIDE
-        else realised.positive_side_slack
-    )
+    return _canvas_side_slack(region, realised, canvas_side=True)
 
 
 def canvas_content_slack(
     region: CanvasRegion, realised: RealisedRouteReservation
 ) -> float:
     """*realised*'s clearance from the content opposite its canvas edge."""
+    return _canvas_side_slack(region, realised, canvas_side=False)
+
+
+def _canvas_side_slack(
+    region: CanvasRegion,
+    realised: RealisedRouteReservation,
+    *,
+    canvas_side: bool,
+) -> float:
+    edge_is_negative = region.side in CANVAS_EDGE_ON_NEGATIVE_SIDE
     return (
-        realised.positive_side_slack
-        if region.side in CANVAS_EDGE_ON_NEGATIVE_SIDE
-        else realised.negative_side_slack
+        realised.negative_side_slack
+        if edge_is_negative is canvas_side
+        else realised.positive_side_slack
     )
 
 
@@ -925,7 +951,7 @@ class GapCorridorBand(NamedTuple):
     caller, since only it knows which side a later widening can reach.
     """
 
-    boundary: int
+    boundary: int | None
     lo: float
     hi: float
 
@@ -1008,13 +1034,13 @@ def canvas_corridor_clearance_band(
             return None
         if coordinate < extents.top:
             return GapCorridorBand(
-                -1,
+                None,
                 -math.inf,
                 min(section.bbox_y for section in sections) - INTER_ROW_EDGE_CLEARANCE,
             )
         if coordinate > extents.bottom:
             return GapCorridorBand(
-                -1,
+                None,
                 max(section.bbox_y + section.bbox_h for section in sections)
                 + INTER_ROW_EDGE_CLEARANCE,
                 math.inf,
@@ -1029,13 +1055,13 @@ def canvas_corridor_clearance_band(
         return None
     if coordinate < extents.left:
         return GapCorridorBand(
-            -1,
+            None,
             -math.inf,
             min(section.bbox_x for section in sections) - EDGE_TO_BUNDLE_CLEARANCE,
         )
     if coordinate > extents.right:
         return GapCorridorBand(
-            -1,
+            None,
             max(section.bbox_x + section.bbox_w for section in sections)
             + EDGE_TO_BUNDLE_CLEARANCE,
             math.inf,
@@ -2338,134 +2364,82 @@ def _canvas_region_measurement(
     longitudinal_end: float,
     canvas_width: float,
     canvas_height: float,
-    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
+    header_keepouts: Mapping[str, CanvasRect] | None = None,
 ) -> _RegionMeasurement:
     keepouts = header_keepouts or {}
-    if region.side in {CanvasSide.TOP, CanvasSide.BOTTOM}:
-        sections = tuple(
-            section
-            for section in graph.sections.values()
-            if section.bbox_w > 0
-            and _section_x_overlaps(section, longitudinal_start, longitudinal_end)
+    allocates_y = region.side in {CanvasSide.TOP, CanvasSide.BOTTOM}
+    canvas_edge_is_negative = region.side in CANVAS_EDGE_ON_NEGATIVE_SIDE
+    side_prefix = {
+        CanvasSide.TOP: SECTION_TOP_BLOCKER,
+        CanvasSide.RIGHT: SECTION_RIGHT_BLOCKER,
+        CanvasSide.BOTTOM: SECTION_BOTTOM_BLOCKER,
+        CanvasSide.LEFT: SECTION_LEFT_BLOCKER,
+    }[region.side]
+    box_clearance = (
+        INTER_ROW_EDGE_CLEARANCE if allocates_y else EDGE_TO_BUNDLE_CLEARANCE
+    )
+
+    candidates: list[_ContentBoundary] = []
+    for section in graph.sections.values():
+        box_start = section.bbox_y if allocates_y else section.bbox_x
+        box_size = section.bbox_h if allocates_y else section.bbox_w
+        overlaps_run = (
+            _section_x_overlaps(section, longitudinal_start, longitudinal_end)
+            if allocates_y
+            else _section_y_overlaps(section, longitudinal_start, longitudinal_end)
         )
-        if region.side is CanvasSide.TOP:
-            candidates = [
-                _ContentBoundary(
-                    f"{SECTION_TOP_BLOCKER}:{section.id}",
-                    section.bbox_y,
-                    INTER_ROW_EDGE_CLEARANCE,
-                )
-                for section in sections
-            ]
-            candidates.extend(
+        if box_size <= 0 or not overlaps_run:
+            continue
+        box_end = box_start + box_size
+        box_edge = box_start if canvas_edge_is_negative else box_end
+        candidates.append(
+            _ContentBoundary(f"{side_prefix}:{section.id}", box_edge, box_clearance)
+        )
+
+        keepout = keepouts.get(section.id)
+        if keepout is None:
+            continue
+        header_start = keepout.top if allocates_y else keepout.left
+        header_end = keepout.bottom if allocates_y else keepout.right
+        header_edge = header_start if canvas_edge_is_negative else header_end
+        header_overlaps_run = _overlaps(
+            keepout.left if allocates_y else keepout.top,
+            keepout.right if allocates_y else keepout.bottom,
+            longitudinal_start,
+            longitudinal_end,
+        )
+        header_is_outside = (
+            header_edge < box_start - COORD_TOLERANCE
+            if canvas_edge_is_negative
+            else header_edge > box_end + COORD_TOLERANCE
+        )
+        if header_is_outside and header_overlaps_run:
+            candidates.append(
                 _ContentBoundary(
                     f"{SECTION_HEADER_BLOCKER}:{section.id}",
-                    keepout[1],
+                    header_edge,
                     SECTION_HEADER_ROUTE_CLEARANCE,
                 )
-                for section in sections
-                if (keepout := keepouts.get(section.id)) is not None
-                and keepout[1] < section.bbox_y - COORD_TOLERANCE
-                and _overlaps(
-                    keepout[0], keepout[2], longitudinal_start, longitudinal_end
-                )
             )
-            end, clearance, positive = _content_boundary(
-                candidates, negative_side=False
-            )
-            return _RegionMeasurement(
-                0.0,
-                end,
-                ("canvas:top",),
-                positive,
-                positive_side_clearance=clearance,
-            )
-        candidates = [
-            _ContentBoundary(
-                f"{SECTION_BOTTOM_BLOCKER}:{section.id}",
-                section.bbox_y + section.bbox_h,
-                INTER_ROW_EDGE_CLEARANCE,
-            )
-            for section in sections
-        ]
-        candidates.extend(
-            _ContentBoundary(
-                f"{SECTION_HEADER_BLOCKER}:{section.id}",
-                keepout[3],
-                SECTION_HEADER_ROUTE_CLEARANCE,
-            )
-            for section in sections
-            if (keepout := keepouts.get(section.id)) is not None
-            and keepout[3] > section.bbox_y + section.bbox_h + COORD_TOLERANCE
-            and _overlaps(keepout[0], keepout[2], longitudinal_start, longitudinal_end)
-        )
-        start, clearance, negative = _content_boundary(candidates, negative_side=True)
-        return _RegionMeasurement(
-            start,
-            canvas_height,
-            negative,
-            ("canvas:bottom",),
-            negative_side_clearance=clearance,
-        )
-    sections = tuple(
-        section
-        for section in graph.sections.values()
-        if section.bbox_h > 0
-        and _section_y_overlaps(section, longitudinal_start, longitudinal_end)
+
+    content_edge, clearance, blockers = _content_boundary(
+        candidates, negative_side=not canvas_edge_is_negative
     )
-    if region.side is CanvasSide.LEFT:
-        candidates = [
-            _ContentBoundary(
-                f"{SECTION_LEFT_BLOCKER}:{section.id}",
-                section.bbox_x,
-                EDGE_TO_BUNDLE_CLEARANCE,
-            )
-            for section in sections
-        ]
-        candidates.extend(
-            _ContentBoundary(
-                f"{SECTION_HEADER_BLOCKER}:{section.id}",
-                keepout[0],
-                SECTION_HEADER_ROUTE_CLEARANCE,
-            )
-            for section in sections
-            if (keepout := keepouts.get(section.id)) is not None
-            and keepout[0] < section.bbox_x - COORD_TOLERANCE
-            and _overlaps(keepout[1], keepout[3], longitudinal_start, longitudinal_end)
-        )
-        end, clearance, positive = _content_boundary(candidates, negative_side=False)
+    canvas_size = canvas_height if allocates_y else canvas_width
+    canvas_blocker = (f"canvas:{region.side.value}",)
+    if canvas_edge_is_negative:
         return _RegionMeasurement(
             0.0,
-            end,
-            ("canvas:left",),
-            positive,
+            content_edge,
+            canvas_blocker,
+            blockers,
             positive_side_clearance=clearance,
         )
-    candidates = [
-        _ContentBoundary(
-            f"{SECTION_RIGHT_BLOCKER}:{section.id}",
-            section.bbox_x + section.bbox_w,
-            EDGE_TO_BUNDLE_CLEARANCE,
-        )
-        for section in sections
-    ]
-    candidates.extend(
-        _ContentBoundary(
-            f"{SECTION_HEADER_BLOCKER}:{section.id}",
-            keepout[2],
-            SECTION_HEADER_ROUTE_CLEARANCE,
-        )
-        for section in sections
-        if (keepout := keepouts.get(section.id)) is not None
-        and keepout[2] > section.bbox_x + section.bbox_w + COORD_TOLERANCE
-        and _overlaps(keepout[1], keepout[3], longitudinal_start, longitudinal_end)
-    )
-    start, clearance, negative = _content_boundary(candidates, negative_side=True)
     return _RegionMeasurement(
-        start,
-        canvas_width,
-        negative,
-        ("canvas:right",),
+        content_edge,
+        canvas_size,
+        blockers,
+        canvas_blocker,
         negative_side_clearance=clearance,
     )
 
@@ -2526,18 +2500,29 @@ def _drawn_claim_bounds(
     allocation_axis, longitudinal_axis = _reservation_axes(reservation)
     allocation_index = 0 if allocation_axis is DemandAxis.X else 1
     longitudinal_index = 0 if longitudinal_axis is DemandAxis.X else 1
-    points = tuple(
-        route_polylines[claim.path_rank][rank]
+    coordinates = (
+        (
+            route_polylines[claim.path_rank][rank][longitudinal_index],
+            route_polylines[claim.path_rank][rank][allocation_index],
+        )
         for claim in reservation.claims
         for rank in range(claim.segment_rank, claim.segment_end_rank + 2)
     )
+    first_longitudinal, first_allocation = next(coordinates)
+    longitudinal_start = longitudinal_end = first_longitudinal
+    occupied_start = occupied_end = first_allocation
+    for longitudinal, allocation in coordinates:
+        longitudinal_start = min(longitudinal_start, longitudinal)
+        longitudinal_end = max(longitudinal_end, longitudinal)
+        occupied_start = min(occupied_start, allocation)
+        occupied_end = max(occupied_end, allocation)
     return _ProjectedClaimBounds(
         allocation_axis,
         longitudinal_axis,
-        min(point[longitudinal_index] for point in points),
-        max(point[longitudinal_index] for point in points),
-        min(point[allocation_index] for point in points),
-        max(point[allocation_index] for point in points),
+        longitudinal_start,
+        longitudinal_end,
+        occupied_start,
+        occupied_end,
     )
 
 
@@ -2596,7 +2581,7 @@ def _realise_one(
     canvas_width: float | None,
     canvas_height: float | None,
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = (),
-    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
+    header_keepouts: Mapping[str, CanvasRect] | None = None,
     route_polylines: Sequence[Sequence[tuple[float, float]]] | None = None,
 ) -> RealisedRouteReservation | None:
     if isinstance(reservation.region, CanvasRegion) and (
@@ -2696,7 +2681,7 @@ def realise_reservation(
     canvas_width: float | None = None,
     canvas_height: float | None = None,
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = (),
-    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
+    header_keepouts: Mapping[str, CanvasRect] | None = None,
 ) -> RealisedRouteReservation | None:
     """Measure one reservation against *graph* as it currently stands.
 
@@ -2780,7 +2765,7 @@ def _realise_all(
     canvas_width: float | None,
     canvas_height: float | None,
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = (),
-    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
+    header_keepouts: Mapping[str, CanvasRect] | None = None,
 ) -> tuple[RealisedRouteReservation, ...]:
     realised = (
         _realise_one(
@@ -4016,11 +4001,8 @@ def realise_route_reservations(
     plan: RoutePlan,
     graph: MetroGraph,
     *,
-    canvas_width: float,
-    canvas_height: float,
+    final_canvas: FinalCanvasGeometry,
     coordinate_translations: tuple[ReservationCoordinateTranslation, ...] = (),
-    header_keepouts: Mapping[str, tuple[float, float, float, float]] | None = None,
-    route_polylines: Sequence[Sequence[tuple[float, float]]] | None = None,
 ) -> RoutePlan:
     """Refresh the realised ledger against final render canvas bounds.
 
@@ -4042,11 +4024,11 @@ def realise_route_reservations(
             item := _realise_one(
                 graph,
                 reservation,
-                canvas_width,
-                canvas_height,
+                final_canvas.width,
+                final_canvas.height,
                 held_translations.get(reservation.id, coordinate_translations),
-                header_keepouts,
-                route_polylines,
+                final_canvas.header_keepouts,
+                final_canvas.route_polylines,
             )
         )
         is not None

--- a/src/nf_metro/layout/routing/inter_section_handlers.py
+++ b/src/nf_metro/layout/routing/inter_section_handlers.py
@@ -2137,8 +2137,11 @@ def _route_planned_bottom_exit_right_landings(
     source_lines = plan.offset_line_order
     if not source_lines or edge.line_id not in source_lines:
         raise RuntimeError(f"planned fan {plan.id!s} lost its source lane order")
-    corridor_x = _right_entry_descent_x(ctx, right_edge, len(source_lines))
     source_offsets = {line_id: -exit_x_offset(line_id) for line_id in source_lines}
+    corridor_x = max(
+        _right_entry_descent_x(ctx, right_edge, len(source_lines)),
+        right_edge + SECTION_ROUTE_CLEARANCE + max(source_offsets.values()),
+    )
     launch_y = _planned_fan_launch_y(
         ctx, edge, src.y, plan.entry_runway, source_offsets, source_lines
     )

--- a/src/nf_metro/layout/routing/reserved_bands.py
+++ b/src/nf_metro/layout/routing/reserved_bands.py
@@ -119,20 +119,21 @@ def corridor_clearance_band(
     orientation = (
         CorridorOrientation.HORIZONTAL if axis == 1 else CorridorOrientation.VERTICAL
     )
+    run_lo, run_hi = sorted((run_start, run_end))
     gap = gap_corridor_clearance_band(
         graph,
         orientation,
         grid_span_for_sections(graph, section_ids),
         coordinate,
-        min(run_start, run_end),
-        max(run_start, run_end),
+        run_lo,
+        run_hi,
     )
     return gap or canvas_corridor_clearance_band(
         graph,
         orientation,
         coordinate,
-        min(run_start, run_end),
-        max(run_start, run_end),
+        run_lo,
+        run_hi,
     )
 
 

--- a/src/nf_metro/layout/routing/reserved_bands.py
+++ b/src/nf_metro/layout/routing/reserved_bands.py
@@ -112,13 +112,24 @@ def corridor_clearance_band(
     from nf_metro.layout.route_plan import grid_span_for_sections
     from nf_metro.layout.route_reservations import (
         CorridorOrientation,
+        canvas_corridor_clearance_band,
         gap_corridor_clearance_band,
     )
 
-    return gap_corridor_clearance_band(
+    orientation = (
+        CorridorOrientation.HORIZONTAL if axis == 1 else CorridorOrientation.VERTICAL
+    )
+    gap = gap_corridor_clearance_band(
         graph,
-        CorridorOrientation.HORIZONTAL if axis == 1 else CorridorOrientation.VERTICAL,
+        orientation,
         grid_span_for_sections(graph, section_ids),
+        coordinate,
+        min(run_start, run_end),
+        max(run_start, run_end),
+    )
+    return gap or canvas_corridor_clearance_band(
+        graph,
+        orientation,
         coordinate,
         min(run_start, run_end),
         max(run_start, run_end),

--- a/src/nf_metro/render/constants.py
+++ b/src/nf_metro/render/constants.py
@@ -4,7 +4,11 @@ Centralizes magic numbers from svg.py, legend.py, animate.py, and icons.py.
 Theme-dependent values remain in style.py.
 """
 
-from nf_metro.layout.constants import CURVE_RADIUS, ICON_CAPTION_GAP
+from nf_metro.layout.constants import (
+    CURVE_RADIUS,
+    ICON_CAPTION_GAP,
+    SECTION_HEADER_ROUTE_CLEARANCE,
+)
 from nf_metro.layout.constants import ICON_INTER_GAP as ICON_INTER_GAP  # re-export
 from nf_metro.layout.constants import (
     RAIL_KNOB_RADIUS_RATIO as RAIL_KNOB_RADIUS_RATIO,  # re-export
@@ -97,7 +101,7 @@ SECTION_NUM_Y_OFFSET: int = 4
 SECTION_LABEL_TEXT_OFFSET: int = 5
 """Text X offset from section number circle."""
 
-SECTION_HEADER_ROUTE_PAD: float = 4.0
+SECTION_HEADER_ROUTE_PAD: float = SECTION_HEADER_ROUTE_CLEARANCE
 """Slack between a section header's extent and a route, below which the route
 counts as clashing with the header.
 

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -67,6 +67,8 @@ from nf_metro.layout.route_plan import (
     RouteSystem,
 )
 from nf_metro.layout.route_reservations import (
+    CanvasRect,
+    FinalCanvasGeometry,
     ReservationCoordinateTranslation,
     adopt_route_reservation_ledger,
     realise_route_reservations,
@@ -1468,14 +1470,16 @@ def _build_render_plan_scaled(
     route_plan = realise_route_reservations(
         route_plan,
         graph,
-        canvas_width=svg_width,
-        canvas_height=svg_height,
+        final_canvas=FinalCanvasGeometry(
+            svg_width,
+            svg_height,
+            {
+                section_id: CanvasRect(*placement.keepout)
+                for section_id, placement in header_placements.items()
+            },
+            route_polylines,
+        ),
         coordinate_translations=settlement_translations,
-        header_keepouts={
-            section_id: placement.keepout
-            for section_id, placement in header_placements.items()
-        },
-        route_polylines=route_polylines,
     )
     assert_canvas_corridors_hold_their_claims(
         route_plan, strict=graph.strict and not graph.permissive

--- a/src/nf_metro/render/svg.py
+++ b/src/nf_metro/render/svg.py
@@ -1471,6 +1471,11 @@ def _build_render_plan_scaled(
         canvas_width=svg_width,
         canvas_height=svg_height,
         coordinate_translations=settlement_translations,
+        header_keepouts={
+            section_id: placement.keepout
+            for section_id, placement in header_placements.items()
+        },
+        route_polylines=route_polylines,
     )
     assert_canvas_corridors_hold_their_claims(
         route_plan, strict=graph.strict and not graph.permissive

--- a/tests/test_envelope_settlement.py
+++ b/tests/test_envelope_settlement.py
@@ -1568,15 +1568,25 @@ def test_a_short_canvas_margin_fails_the_strict_path_at_full_capacity() -> None:
     assert "-4.0px" in message
 
 
-def test_a_canvas_corridor_short_of_its_content_side_is_recorded_not_silent() -> None:
-    """A canvas corridor's content-facing side is evidence, not a hard stop.
-
-    That side is a section box edge or header badge, which no growth of the
-    canvas moves, so it is published as an attributed ``reservation-deficit``
-    record and left to the box-edge and header guards rather than aborting the
-    render for a margin the canvas does not own.
-    """
-    path = TOPOLOGIES / "bt_to_lr.mmd"
+@pytest.mark.parametrize(
+    ("path", "side"),
+    (
+        (TOPOLOGIES / "bt_to_lr.mmd", CanvasSide.TOP),
+        (TOPOLOGIES / "cross_col_top_entry.mmd", CanvasSide.TOP),
+        (TOPOLOGIES / "lr_perp_top_exit_side_entry.mmd", CanvasSide.TOP),
+        (TOPOLOGIES / "bypass_leftward_far_side_entry.mmd", CanvasSide.BOTTOM),
+        (TOPOLOGIES / "stacked_left_exit_drop.mmd", CanvasSide.LEFT),
+        (
+            TOPOLOGIES / "bottom_exit_stacked_right_entry_fan.mmd",
+            CanvasSide.RIGHT,
+        ),
+    ),
+    ids=lambda item: item.name if isinstance(item, Path) else item.value,
+)
+def test_every_canvas_corridor_holds_its_content_side(
+    path: Path, side: CanvasSide
+) -> None:
+    """The realised claim measures the content drawn beside its own run."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         graph = prepare_graph(path.read_text(), source_dir=str(path.parent))
@@ -1585,26 +1595,82 @@ def test_a_canvas_corridor_short_of_its_content_side_is_recorded_not_silent() ->
     reservation = next(
         item
         for item in plan.reservations
-        if isinstance(item.region, CanvasRegion) and item.region.side is CanvasSide.TOP
+        if isinstance(item.region, CanvasRegion) and item.region.side is side
     )
     realised = query.realised_reservation(reservation.id)
     assert realised is not None
-    assert realised.positive_side_slack < -1.0
+    edge_is_negative = side in {CanvasSide.TOP, CanvasSide.LEFT}
+    content_side_slack = (
+        realised.positive_side_slack
+        if edge_is_negative
+        else realised.negative_side_slack
+    )
+    assert content_side_slack >= -COORD_TOLERANCE
     assert canvas_edge_slack(reservation.region, realised) >= -0.01
-
-    diagnostic = next(
+    assert not [
         item
         for item in plan.reservation_diagnostics
+        if item.reservation_id == reservation.id and item.code == "reservation-deficit"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("fixture", "expected_blocker"),
+    (
+        ("lr_perp_top_exit_side_entry.mmd", "section-top:mid"),
+        ("tb_bottom_exit_fork_diamond.mmd", "section-header:feed"),
+    ),
+)
+def test_a_top_canvas_corridor_is_bounded_by_content_over_its_own_run(
+    fixture: str, expected_blocker: str
+) -> None:
+    """A header only bounds the longitudinal interval occupied by its ink."""
+    path = TOPOLOGIES / fixture
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        graph = prepare_graph(path.read_text(), source_dir=str(path.parent))
+        plan = build_observed_render_plan(graph, resolve_theme(None, graph)).route_plan
+    reservation = next(
+        item
+        for item in plan.reservations
+        if isinstance(item.region, CanvasRegion) and item.region.side is CanvasSide.TOP
+    )
+    realised = next(
+        item
+        for item in plan.realised_reservations
         if item.reservation_id == reservation.id
     )
-    assert diagnostic.code == "reservation-deficit"
-    assert diagnostic.positive_side_slack == pytest.approx(realised.positive_side_slack)
+    assert realised.positive_blocker_ids == (expected_blocker,)
 
-    assert_canvas_corridors_hold_their_claims(plan, strict=True)
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        assert_canvas_corridors_hold_their_claims(plan, strict=False)
-    assert not [str(item.message) for item in caught]
+
+def test_a_short_canvas_content_side_fails_the_strict_path() -> None:
+    """A content blocker is as hard a boundary as the canvas edge."""
+    path = TOPOLOGIES / "bt_to_lr.mmd"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        graph = prepare_graph(path.read_text(), source_dir=str(path.parent))
+        plan = build_observed_render_plan(graph, resolve_theme(None, graph)).route_plan
+    reservation = next(
+        item
+        for item in plan.reservations
+        if isinstance(item.region, CanvasRegion) and item.region.side is CanvasSide.TOP
+    )
+    realised = next(
+        item
+        for item in plan.realised_reservations
+        if item.reservation_id == reservation.id
+    )
+    short = replace(
+        realised,
+        capacity_slack=max(realised.capacity_slack, 0.0),
+        negative_side_slack=max(realised.negative_side_slack, 0.0),
+        positive_side_slack=-4.0,
+    )
+
+    with pytest.raises(LayoutInvariantError, match="content"):
+        assert_canvas_corridors_hold_their_claims(
+            replace(plan, realised_reservations=(short,)), strict=True
+        )
 
 
 def test_a_canvas_edge_clearance_is_what_is_drawn_beside_the_edge() -> None:

--- a/tests/test_layout_invariants.py
+++ b/tests/test_layout_invariants.py
@@ -8156,6 +8156,16 @@ def test_routed_paths_clear_next_row_headers(fixture):
             seg_y = (y1 + y2) / 2
             seg_x_lo = min(x1, x2)
             seg_x_hi = max(x1, x2)
+            has_overlapping_section_above = any(
+                section.bbox_h > 0
+                and section.bbox_w > 0
+                and section.bbox_x < seg_x_hi
+                and section.bbox_x + section.bbox_w > seg_x_lo
+                and section.bbox_y + section.bbox_h <= seg_y + 0.5
+                for section in graph.sections.values()
+            )
+            if not has_overlapping_section_above:
+                continue
             for header_top, hx_lo, hx_hi, hsid in headers:
                 if seg_x_hi <= hx_lo or seg_x_lo >= hx_hi:
                     continue


### PR DESCRIPTION
## Summary

- realise canvas corridor blockers from final drawn route spans and placed section headers
- hold all four canvas sides to their content clearance, including the planned bottom-exit/right-entry fan
- tighten the strict guard and regression coverage so edge, content-side, and total-capacity deficits are all rejected
- scope the prospective next-row header invariant to inter-row corridors, leaving final canvas headers to the render-time keepout check

## Verification

- 435 targeted route reservation and settlement tests passed
- 325 corpus header-clearance invariant cases passed
- 28 routing gate coverage checks passed
- full suite reached 50,025 passes; its 10 branch-related failures passed after the invariant-scope correction, and all 3 localhost smoke failures passed outside the sandbox
- ruff format --check, ruff check, prettier, mypy, and all prek hooks passed
- local renders inspected for bt_to_lr and bottom_exit_stacked_right_entry_fan

Fixes #1693