### PR TITLE
Resolve exit-turn corner-radius ownership

### DIFF
--- a/src/nf_metro/layout/routing/exit_turns.py
+++ b/src/nf_metro/layout/routing/exit_turns.py
@@ -3279,12 +3279,7 @@ def snapshot_exit_turn_segments(
     routes: list[RoutedPath],
     plans: tuple[ExitTurnPlan, ...] = (),
 ) -> _ExitTurnSnapshot:
-    """Capture every planner-owned segment and hand-off after template emission.
-
-    Exit-turn plans own the turn axis and waypoint geometry. Corner radii are
-    resolved across coincident same-line routes after every member has emitted,
-    so they belong to the corner-radius unifier rather than an individual plan.
-    """
+    """Capture every planner-owned segment and hand-off after template emission."""
     values: dict[tuple[str, ...], _ExitTurnGeometryState] = {}
     for route in routes:
         if route.exit_turn_axis_id is not None:

--- a/src/nf_metro/layout/routing/exit_turns.py
+++ b/src/nf_metro/layout/routing/exit_turns.py
@@ -206,7 +206,6 @@ class _ExitTurnGeometryState:
     lead_in_start: tuple[float, float] | None
     segment_start: tuple[float, float] | None
     segment_end: tuple[float, float] | None
-    segment_radii: tuple[tuple[int, float], ...] | None
     transition_plan_id: str | None
     transition_points: tuple[tuple[float, float], ...] | None
     transition_radii: tuple[float, ...] | None
@@ -3280,7 +3279,12 @@ def snapshot_exit_turn_segments(
     routes: list[RoutedPath],
     plans: tuple[ExitTurnPlan, ...] = (),
 ) -> _ExitTurnSnapshot:
-    """Capture every planner-owned segment and hand-off after template emission."""
+    """Capture every planner-owned segment and hand-off after template emission.
+
+    Exit-turn plans own the turn axis and waypoint geometry. Corner radii are
+    resolved across coincident same-line routes after every member has emitted,
+    so they belong to the corner-radius unifier rather than an individual plan.
+    """
     values: dict[tuple[str, ...], _ExitTurnGeometryState] = {}
     for route in routes:
         if route.exit_turn_axis_id is not None:
@@ -3300,9 +3304,6 @@ def snapshot_exit_turn_segments(
                 RouteFamilyId.BOTTOM_ENTRY_L_SHAPE.value,
                 RouteFamilyId.BYPASS_FAMILY.value,
             }
-            radii = None
-            if route.curve_radii is not None and 0 <= rank - 1 < len(route.curve_radii):
-                radii = ((rank - 1, route.curve_radii[rank - 1]),)
             values[
                 (
                     "axis",
@@ -3316,7 +3317,6 @@ def snapshot_exit_turn_segments(
                 route.points[rank - 1],
                 route.points[rank],
                 None if landing_point_settled_later else route.points[rank + 1],
-                radii,
                 None,
                 None,
                 None,
@@ -3333,7 +3333,6 @@ def snapshot_exit_turn_segments(
                 )
             ] = _ExitTurnGeometryState(
                 route.exit_turn_family_id,
-                None,
                 None,
                 None,
                 None,

--- a/tests/test_exit_turn_planner.py
+++ b/tests/test_exit_turn_planner.py
@@ -2084,13 +2084,22 @@ def test_post_pass_snapshot_owns_family_direction_and_endpoints() -> None:
 
 
 @pytest.mark.parametrize(
-    "path",
+    ("path", "family_id"),
     (
-        TOPOLOGIES / "exit_run_three_drop_columns.mmd",
-        ROOT / "examples" / "genomeassembly_staggered.mmd",
+        (
+            TOPOLOGIES / "exit_run_three_drop_columns.mmd",
+            RouteFamilyId.STANDARD_L_SHAPE.value,
+        ),
+        (
+            ROOT / "examples" / "genomeassembly_staggered.mmd",
+            RouteFamilyId.MERGE_ENTRY.value,
+        ),
     ),
 )
-def test_post_pass_snapshot_leaves_corner_radius_to_unifier(path: Path) -> None:
+def test_post_pass_snapshot_leaves_corner_radius_to_unifier(
+    path: Path,
+    family_id: str,
+) -> None:
     _graph, _offsets, observation = _observe(path)
     routes = copy.deepcopy(observation.routes)
     route = next(
@@ -2099,6 +2108,7 @@ def test_post_pass_snapshot_leaves_corner_radius_to_unifier(path: Path) -> None:
         if item.exit_turn_axis_id is not None
         and item.exit_turn_segment_rank is not None
         and item.curve_radii is not None
+        and item.exit_turn_family_id == family_id
     )
     rank = route.exit_turn_segment_rank
     radius_index = rank - 1
@@ -2111,6 +2121,9 @@ def test_post_pass_snapshot_leaves_corner_radius_to_unifier(path: Path) -> None:
     )
     route.curve_radii[radius_index] = narrow_radius
     coincident_peer = copy.deepcopy(route)
+    coincident_peer.exit_turn_plan_id = None
+    coincident_peer.exit_turn_member_id = None
+    coincident_peer.exit_turn_family_id = None
     coincident_peer.exit_turn_axis_id = None
     coincident_peer.exit_turn_segment_rank = None
     assert coincident_peer.curve_radii is not None

--- a/tests/test_exit_turn_planner.py
+++ b/tests/test_exit_turn_planner.py
@@ -49,7 +49,10 @@ from nf_metro.layout.routing.common import (
     apply_route_offsets,
 )
 from nf_metro.layout.routing.context import _build_routing_context
-from nf_metro.layout.routing.corners import resolve_curve_radii
+from nf_metro.layout.routing.corners import (
+    concentric_corner_radius_at,
+    resolve_curve_radii,
+)
 from nf_metro.layout.routing.exit_turns import (
     ExitTurnInvariantError,
     assert_exit_turn_snapshot,
@@ -2044,7 +2047,7 @@ def test_declined_planned_emitter_names_the_system_and_connectors(
     )
 
 
-def test_post_pass_snapshot_owns_family_direction_endpoints_and_radii() -> None:
+def test_post_pass_snapshot_owns_family_direction_and_endpoints() -> None:
     _graph, _offsets, observation = _observe(
         TOPOLOGIES / "exit_run_three_drop_columns.mmd"
     )
@@ -2065,9 +2068,6 @@ def test_post_pass_snapshot_owns_family_direction_endpoints_and_radii() -> None:
         route.points[rank + 1],
         route.points[rank],
     )
-    if route.curve_radii is not None:
-        route.curve_radii[rank - 1] += 1.0
-
     with pytest.raises(ExitTurnInvariantError) as error:
         assert_exit_turn_snapshot(routes, snapshot, "test pass")
 
@@ -2080,6 +2080,42 @@ def test_post_pass_snapshot_owns_family_direction_endpoints_and_radii() -> None:
     assert all(
         str(connector_id) in str(error.value) for connector_id in plan.connector_ids
     )
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        TOPOLOGIES / "exit_run_three_drop_columns.mmd",
+        ROOT / "examples" / "genomeassembly_staggered.mmd",
+    ),
+)
+def test_post_pass_snapshot_leaves_corner_radius_to_unifier(path: Path) -> None:
+    _graph, _offsets, observation = _observe(path)
+    routes = copy.deepcopy(observation.routes)
+    snapshot = snapshot_exit_turn_segments(
+        routes,
+        observation.plan.exit_turn_plans,
+    )
+    route = next(
+        item
+        for item in routes
+        if item.exit_turn_axis_id is not None
+        and item.exit_turn_segment_rank is not None
+        and item.curve_radii is not None
+    )
+    rank = route.exit_turn_segment_rank
+    radius_index = rank - 1
+    points = route.points[radius_index : radius_index + 3]
+    old_radius = route.curve_radii[radius_index]
+    candidates = (
+        concentric_corner_radius_at(*points, -OFFSET_STEP),
+        concentric_corner_radius_at(*points, OFFSET_STEP),
+    )
+    route.curve_radii[radius_index] = next(
+        radius for radius in candidates if radius != old_radius
+    )
+
+    assert_exit_turn_snapshot(routes, snapshot, "corner-radius unification")
 
 
 def test_runtime_invariant_checks_every_station_owner() -> None:

--- a/tests/test_exit_turn_planner.py
+++ b/tests/test_exit_turn_planner.py
@@ -15,6 +15,7 @@ import pytest
 
 import nf_metro.layout.routing.exit_turns as exit_turns
 import nf_metro.layout.routing.inter_section_handlers as inter_handlers
+import nf_metro.layout.routing.normalize as normalize
 import nf_metro.layout.routing.offsets as routing_offsets
 from nf_metro.api import prepare_graph, render_string, resolve_theme
 from nf_metro.layout.constants import CURVE_RADIUS, DIAGONAL_RUN, OFFSET_STEP
@@ -2092,10 +2093,6 @@ def test_post_pass_snapshot_owns_family_direction_and_endpoints() -> None:
 def test_post_pass_snapshot_leaves_corner_radius_to_unifier(path: Path) -> None:
     _graph, _offsets, observation = _observe(path)
     routes = copy.deepcopy(observation.routes)
-    snapshot = snapshot_exit_turn_segments(
-        routes,
-        observation.plan.exit_turn_plans,
-    )
     route = next(
         item
         for item in routes
@@ -2106,15 +2103,27 @@ def test_post_pass_snapshot_leaves_corner_radius_to_unifier(path: Path) -> None:
     rank = route.exit_turn_segment_rank
     radius_index = rank - 1
     points = route.points[radius_index : radius_index + 3]
-    old_radius = route.curve_radii[radius_index]
-    candidates = (
-        concentric_corner_radius_at(*points, -OFFSET_STEP),
-        concentric_corner_radius_at(*points, OFFSET_STEP),
+    narrow_radius, wide_radius = sorted(
+        {
+            concentric_corner_radius_at(*points, -OFFSET_STEP),
+            concentric_corner_radius_at(*points, OFFSET_STEP),
+        }
     )
-    route.curve_radii[radius_index] = next(
-        radius for radius in candidates if radius != old_radius
+    route.curve_radii[radius_index] = narrow_radius
+    coincident_peer = copy.deepcopy(route)
+    coincident_peer.exit_turn_axis_id = None
+    coincident_peer.exit_turn_segment_rank = None
+    assert coincident_peer.curve_radii is not None
+    coincident_peer.curve_radii[radius_index] = wide_radius
+    routes.append(coincident_peer)
+    snapshot = snapshot_exit_turn_segments(
+        routes,
+        observation.plan.exit_turn_plans,
     )
 
+    normalize._unify_coincident_corner_radii(routes)
+
+    assert route.curve_radii[radius_index] == wide_radius
     assert_exit_turn_snapshot(routes, snapshot, "corner-radius unification")
 
 


### PR DESCRIPTION
## Summary

- assign coincident exit-turn corner radii to the final radius unifier instead of the per-member exit-turn snapshot
- preserve snapshot ownership of turn family, axis, waypoint geometry, and complete lane-transition geometry
- cover the ownership boundary on two planned route families with the real unifier

Fixes #1716

## Test plan

- [x] exit-turn planner, coincident-corner, and corner re-derivation tests pass (813 tests)
- [x] full suite passes (50,711 sandboxed passes plus 3 localhost smoke tests rerun with socket access)
- [x] routing gate-coverage ratchet passes
- [x] full-repository prek, ruff check, and ruff format checks pass
- [x] affected SVGs are byte-identical to `origin/main`
- [x] CI green across Python 3.11, 3.12, and 3.13
- [x] [render preview](https://seqeralabs.github.io/nf-metro/_pr/1723/): no visual changes detected

Generated with Codex
