### PR TITLE
Fail convergence construction defects at their source

### DIFF
--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -1989,6 +1989,11 @@ They are design evidence, not part of this specification.
   frozen. The classified templates draw the same two runs in the same gap, so
   retrying them would state nothing the plan did not and lose the attribution
   it carried.
+  **Construction failures are not dispositions.** Canonical convergence
+  construction either returns complete geometry or raises at the condition that
+  broke its contract. Only an upstream exit-turn ownership conflict produces a
+  non-owning convergence diagnostic. A private absent-axis signal selects the
+  outgoing continuation as trunk; it is not a failed plan.
   Reaching one is a statement that the map has no room, which is section
   placement's to give; [#1712](https://github.com/seqeralabs/nf-metro/issues/1712)
   carries the grant that would.

--- a/src/nf_metro/layout/CONTRACT.md
+++ b/src/nf_metro/layout/CONTRACT.md
@@ -1989,14 +1989,16 @@ They are design evidence, not part of this specification.
   frozen. The classified templates draw the same two runs in the same gap, so
   retrying them would state nothing the plan did not and lose the attribution
   it carried.
-  **Construction failures are not dispositions.** Canonical convergence
-  construction either returns complete geometry or raises at the condition that
-  broke its contract. Only an upstream exit-turn ownership conflict produces a
-  non-owning convergence diagnostic. A private absent-axis signal selects the
-  outgoing continuation as trunk; it is not a failed plan.
   Reaching one is a statement that the map has no room, which is section
   placement's to give; [#1712](https://github.com/seqeralabs/nf-metro/issues/1712)
   carries the grant that would.
+  **Construction failures are not dispositions.** Canonical convergence
+  construction either returns complete geometry or raises at the condition that
+  broke its contract. Only an upstream exit-turn ownership conflict produces a
+  non-owning convergence diagnostic. At the template-selection site, a private
+  absent-axis signal selects the outgoing continuation as trunk. Sites that
+  require a shared terminal axis convert the signal to a descriptive construction
+  error.
   Every decision the passes below **can** make they do make, and from the pair
   rather than from whichever run arrived last: laning only the arrival leaves
   one line's outward and return legs on one column whenever the arrival has no

--- a/src/nf_metro/layout/route_plan.py
+++ b/src/nf_metro/layout/route_plan.py
@@ -441,14 +441,6 @@ _FAN_HAS_NO_SECTION_FRAME = CompatibilityFamily(
     "a valid routing input, so the established templates draw these fans and "
     "support is permanent."
 )
-_CONVERGENCE_TEMPLATE_DECLINED = CompatibilityFamily(
-    "The convergence plan is semantically complete, and the canonical template "
-    "it asks for one member declined to build it or built no drawable run. The "
-    "failure is in the construction step beneath a stated plan, so it is the "
-    "template's gap or the plan's overreach rather than a property of the "
-    "input.",
-    _ISSUE.format(1713),
-)
 _UPSTREAM_EXIT_TURN_HOLDS_THE_FRAME = CompatibilityFamily(
     "An upstream exit turn already fixes the axis or landing this convergence "
     "would state, so the convergence adopts that settled frame rather than "
@@ -555,19 +547,6 @@ ROUTE_SYSTEM_COMPATIBILITY_REASONS: Mapping[str, Mapping[str, CompatibilityFamil
                 _reasons(_FAN_HAS_NO_SECTION_FRAME, "unsupported-fan-direction"),
             ),
             "convergence-plan": _registry(
-                _reasons(
-                    _CONVERGENCE_TEMPLATE_DECLINED,
-                    "convergence landing has no approach",
-                    "convergence template declined its member",
-                    "covered continuation is absent from its carrier",
-                    "direct convergence has no emitted terminal approach",
-                    "feeder template declined its member",
-                    "planned convergence member has no routing family",
-                    "planned trunk has no drawable segment",
-                    "primary trunk template declined its member",
-                    "primary trunk template emitted no shared run",
-                    "unsupported convergence shape",
-                ),
                 _reasons(
                     _UPSTREAM_EXIT_TURN_HOLDS_THE_FRAME,
                     "convergence alignment conflicts with an upstream exit turn",

--- a/src/nf_metro/layout/routing/convergences.py
+++ b/src/nf_metro/layout/routing/convergences.py
@@ -680,6 +680,17 @@ def _shared_terminal_axis(
     )
 
 
+def _required_shared_terminal_axis(
+    routes: tuple[RoutedPath, ...],
+    target_point: tuple[float, float],
+    reason: str,
+) -> tuple[ConvergenceTrunkAxis, int]:
+    try:
+        return _shared_terminal_axis(routes, target_point)
+    except _NoSharedTerminalAxis:
+        raise UnsupportedConvergenceError(reason) from None
+
+
 def _flank_run(
     axis: DemandAxis,
     flank_coordinate: float,
@@ -893,9 +904,10 @@ def _build_planned_convergence(
                     _connect_route_endpoint(
                         trial_routes[edge_key], direct_route.points[-1]
                     )
-                trunk_axis, carrier_rank = _shared_terminal_axis(
+                trunk_axis, carrier_rank = _required_shared_terminal_axis(
                     tuple(trial_routes[edge_key] for edge_key in incoming_edges),
                     direct_route.points[-1],
+                    "direct convergence has no emitted terminal approach",
                 )
                 trunk_edge_key = incoming_edges[carrier_rank]
                 primary_member_id = member_by_edge[trunk_edge_key]
@@ -1085,8 +1097,10 @@ def _build_planned_convergence(
                 item for item in ownership if item.member_id == primary_member_id
             )
             carrier_route = trial_routes[carrier_ownership.edge]
-            trunk_axis, _rank = _shared_terminal_axis(
-                (carrier_route,), continuation.end_point
+            trunk_axis, _rank = _required_shared_terminal_axis(
+                (carrier_route,),
+                continuation.end_point,
+                "covered continuation is absent from its carrier",
             )
             primary_reason = ConvergenceTrunkReason.SHARED_TERMINAL_APPROACH
             continuations = [
@@ -4022,7 +4036,7 @@ def build_convergence_plan_execution(
             system_plans = _reconcile_continuation_ownership(system_plans)
             system_plans = _reconcile_landing_handedness(system_plans, graph)
         except ConvergenceOwnershipConflict as error:
-            reason = str(error) or type(error).__name__
+            reason = str(error)
             system_plans = tuple(
                 _legacy_plan(scaffold, view, membership, reason)
                 for view, membership in zip(views, memberships, strict=True)

--- a/src/nf_metro/layout/routing/convergences.py
+++ b/src/nf_metro/layout/routing/convergences.py
@@ -106,6 +106,14 @@ class UnsupportedConvergenceError(ValueError):
     """Canonical templates cannot represent a complete convergence system."""
 
 
+class ConvergenceOwnershipConflict(UnsupportedConvergenceError):
+    """A complete convergence plan conflicts with an upstream geometry owner."""
+
+
+class _NoSharedTerminalAxis(ValueError):
+    """Trial routes require the outgoing continuation to own the trunk axis."""
+
+
 class ConvergencePlanningError(RuntimeError):
     """Semantic convergence membership is internally inconsistent."""
 
@@ -498,7 +506,7 @@ def _landing_from_trial(
             exit_turn_geometry = _exit_turn_geometry(route)
             _land_feeder_on_run(route, run, ctx)
             if exit_turn_geometry != _exit_turn_geometry(route):
-                raise UnsupportedConvergenceError(
+                raise ConvergenceOwnershipConflict(
                     "convergence landing conflicts with an upstream exit turn"
                 )
         _bake_route(route, ctx)
@@ -622,9 +630,7 @@ def _shared_terminal_axis(
                 )
             )
     if not segments:
-        raise UnsupportedConvergenceError(
-            "direct convergence has no emitted terminal approach"
-        )
+        raise _NoSharedTerminalAxis
     axis, coordinate, extent_start, extent_end, direction, rank = max(
         segments, key=lambda item: item[3] - item[2]
     )
@@ -864,7 +870,7 @@ def _build_planned_convergence(
             exit_turn_geometry[edge_key] != _exit_turn_geometry(route)
             for edge_key, route in trial_routes.items()
         ):
-            raise UnsupportedConvergenceError(
+            raise ConvergenceOwnershipConflict(
                 "convergence alignment conflicts with an upstream exit turn"
             )
     else:
@@ -875,7 +881,7 @@ def _build_planned_convergence(
                 tuple(trial_routes[edge_key] for edge_key in incoming_edges),
                 trial_routes[outgoing_edges[0]].points[-1],
             )
-        except UnsupportedConvergenceError:
+        except _NoSharedTerminalAxis:
             outgoing_edge_key = outgoing_edges[0]
             direct_route = trial_routes[outgoing_edge_key]
             if (
@@ -4015,7 +4021,7 @@ def build_convergence_plan_execution(
             )
             system_plans = _reconcile_continuation_ownership(system_plans)
             system_plans = _reconcile_landing_handedness(system_plans, graph)
-        except UnsupportedConvergenceError as error:
+        except ConvergenceOwnershipConflict as error:
             reason = str(error) or type(error).__name__
             system_plans = tuple(
                 _legacy_plan(scaffold, view, membership, reason)

--- a/tests/test_convergence_planner.py
+++ b/tests/test_convergence_planner.py
@@ -872,16 +872,8 @@ CONVERGENCE_CONSTRUCTION_FAILURES = (
 )
 
 
-@pytest.mark.parametrize(
-    "path",
-    (
-        FROZEN / "seed_15.mmd",
-        TOPOLOGIES / "merge_feeders_three_columns.mmd",
-    ),
-)
 def test_convergence_construction_failure_aborts_at_its_source(
     monkeypatch: pytest.MonkeyPatch,
-    path: Path,
 ) -> None:
     def reject(*_args, **_kwargs):
         raise UnsupportedConvergenceError("synthetic construction defect")
@@ -891,7 +883,7 @@ def test_convergence_construction_failure_aborts_at_its_source(
     with pytest.raises(
         UnsupportedConvergenceError, match="synthetic construction defect"
     ):
-        _observe(path)
+        _observe(FROZEN / "seed_15.mmd")
 
 
 def test_convergence_construction_failures_are_not_registered_dispositions() -> None:
@@ -905,6 +897,31 @@ def test_absent_shared_terminal_axis_is_an_optional_construction_result() -> Non
 
     with pytest.raises(convergence_routing._NoSharedTerminalAxis):
         convergence_routing._shared_terminal_axis((route,), (10.0, 10.0))
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "direct convergence has no emitted terminal approach",
+        "covered continuation is absent from its carrier",
+    ),
+)
+def test_required_shared_terminal_axis_names_the_broken_contract(reason: str) -> None:
+    route = RoutedPath(Edge("source", "target", "line"), "line", [(0.0, 0.0)])
+
+    with pytest.raises(UnsupportedConvergenceError, match=reason):
+        convergence_routing._required_shared_terminal_axis(
+            (route,), (10.0, 10.0), reason
+        )
+
+
+def test_absent_shared_terminal_axis_selects_the_outgoing_continuation() -> None:
+    observed = _observe(FROZEN / "seed_77.mmd")[2]
+
+    assert any(
+        plan.primary_trunk_reason is ConvergenceTrunkReason.OUTGOING_CONTINUATION
+        for plan in observed.plan.convergence_plans
+    )
 
 
 @pytest.mark.parametrize("error", (AssertionError("bug"), TypeError("bug")))

--- a/tests/test_convergence_planner.py
+++ b/tests/test_convergence_planner.py
@@ -13,6 +13,7 @@ from nf_metro.api import prepare_graph
 from nf_metro.layout.constants import CURVE_RADIUS
 from nf_metro.layout.geometry import point_to_polyline_distance
 from nf_metro.layout.route_plan import (
+    ROUTE_SYSTEM_COMPATIBILITY_REASONS,
     BindingKind,
     ConvergenceDisposition,
     ConvergenceEndpointRole,
@@ -857,29 +858,53 @@ def test_direct_trunk_axis_rotates_and_reverses(
     assert trunk.direction.value == direction
 
 
-def test_one_planning_failure_cannot_fall_back_to_unplanned_emission(
+CONVERGENCE_CONSTRUCTION_FAILURES = (
+    "convergence landing has no approach",
+    "convergence template declined its member",
+    "covered continuation is absent from its carrier",
+    "direct convergence has no emitted terminal approach",
+    "feeder template declined its member",
+    "planned convergence member has no routing family",
+    "planned trunk has no drawable segment",
+    "primary trunk template declined its member",
+    "primary trunk template emitted no shared run",
+    "unsupported convergence shape",
+)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        FROZEN / "seed_15.mmd",
+        TOPOLOGIES / "merge_feeders_three_columns.mmd",
+    ),
+)
+def test_convergence_construction_failure_aborts_at_its_source(
     monkeypatch: pytest.MonkeyPatch,
+    path: Path,
 ) -> None:
     def reject(*_args, **_kwargs):
-        raise UnsupportedConvergenceError("unsupported convergence shape")
+        raise UnsupportedConvergenceError("synthetic construction defect")
 
     monkeypatch.setattr(convergence_routing, "_build_planned_convergence", reject)
-    with pytest.raises(ValueError, match="has 0 geometry decisions"):
-        _observe(FROZEN / "seed_15.mmd")
 
-
-def test_unregistered_convergence_failure_cannot_open_compatibility(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def reject(*_args, **_kwargs):
-        raise UnsupportedConvergenceError("synthetic unregistered convergence failure")
-
-    monkeypatch.setattr(convergence_routing, "_build_planned_convergence", reject)
     with pytest.raises(
-        ValueError,
-        match="unregistered compatibility reason convergence-plan",
+        UnsupportedConvergenceError, match="synthetic construction defect"
     ):
-        _observe(FROZEN / "seed_15.mmd")
+        _observe(path)
+
+
+def test_convergence_construction_failures_are_not_registered_dispositions() -> None:
+    registered = ROUTE_SYSTEM_COMPATIBILITY_REASONS["convergence-plan"]
+
+    assert not set(CONVERGENCE_CONSTRUCTION_FAILURES) & registered.keys()
+
+
+def test_absent_shared_terminal_axis_is_an_optional_construction_result() -> None:
+    route = RoutedPath(Edge("source", "target", "line"), "line", [(0.0, 0.0)])
+
+    with pytest.raises(convergence_routing._NoSharedTerminalAxis):
+        convergence_routing._shared_terminal_axis((route,), (10.0, 10.0))
 
 
 @pytest.mark.parametrize("error", (AssertionError("bug"), TypeError("bug")))


### PR DESCRIPTION
## Summary

- retire ten stale convergence construction reasons from the disposition registry
- let construction defects propagate at their source instead of publishing a legacy convergence plan
- use a private absent-axis signal only for initial template selection, where it selects the outgoing continuation as trunk
- convert the same signal to descriptive construction errors at the two sites that require a shared terminal axis
- retain legacy convergence records only for upstream exit-turn ownership conflicts
- record the resulting ownership contract and regression coverage

Fixes #1713

## Test plan

- [x] convergence planner, final feasibility, and route-system emission suites pass (112 tests)
- [x] routing gate coverage passes (28 tests)
- [x] repository hooks pass: Ruff check/format, Prettier, mypy, YAML and whitespace checks
- [x] complete suite passes on the initial implementation (50,924 sandboxed passes plus all 3 loopback-server tests outside the sandbox)
- [x] `merge_feeders_three_columns.mmd` is byte-identical before and after (`0dbb7c52204f687eb86c0de5c818567202da089e7214a3d1ccdefd96c4be384a`)
- [x] CI matrix passes on the review-fix commit
- [x] render preview reports no visual changes against `main`

Generated with Codex
