### PR TITLE
docs(routing): remove stale compatibility terminology

### DIFF
--- a/docs/dev/layout_pipeline.mdx
+++ b/docs/dev/layout_pipeline.mdx
@@ -347,8 +347,8 @@ scaffold and settled routing context. The exit-turn planner compacts each
 supported group onto its active lanes, commits the offsets it owns across the
 source seam, and assigns source-side turn axes from that same order. The
 convergence planner freezes target trunks, ordered feeder joins, continuations,
-and endpoint ownership. The route-system executor freezes one planned or
-compatibility disposition for the complete system and each planned
+and endpoint ownership. The route-system executor freezes one planned
+disposition for the complete system and each planned
 inter-section family's stable ID. Ordinary and observed routing share this
 boundary. Always-on checks reject changes to a committed lane, axis, trunk,
 join, endpoint, or emission attribution and ensure every dedicated fan emission
@@ -357,7 +357,7 @@ is consumed exactly once.
 This is a routing-boundary contract, not a numbered layout stage. It does not
 move stations, ports, junctions, or section boxes. See
 [route planning and observation](/nf-metro/dev/route_plan/) for the plan
-records and fallback rules, and
+records and execution rules, and
 [route emission inventory](/nf-metro/dev/route_emission_inventory/) for the
 complete handler and post-pass ownership map.
 

--- a/src/nf_metro/layout/fan_plans.py
+++ b/src/nf_metro/layout/fan_plans.py
@@ -1611,7 +1611,7 @@ def _centreline_port_ids(
     laterally-offset branches carries lines the fan has already pulled off the
     centreline to keep them visually separated near the crossing; forcing it
     onto the raw centreline overrides whatever row its own section settles
-    those branches on downstream (#1711), and where the trunk ends inside the
+    those branches on downstream, and where the trunk ends inside the
     fan it drags the whole peeled bundle back up to a row nothing runs along.
 
     Where one branch does hold the centreline, read over every boundary port a

--- a/tests/test_envelope_settlement.py
+++ b/tests/test_envelope_settlement.py
@@ -1368,10 +1368,9 @@ def test_planned_convergence_reroutes_strictly_with_settled_column_bands(
     _rendered_plan(path)
 
 
-# Route systems the convergence planner puts on its compatibility disposition
-# for want of "a wider shared settlement".  Each one's corridors reach their
-# required width, which is the evidence that what limits them is a channel
-# decision rather than envelope allocation.
+# Route systems that require shared convergence settlement. Each one's
+# corridors reach their required width, which is the evidence that what limits
+# them is a channel decision rather than envelope allocation.
 SHARED_SETTLEMENT_CANDIDATES = (
     TOPOLOGIES / "exit_run_three_drop_columns.mmd",
     TOPOLOGIES / "merge_trunk_out_of_range_section.mmd",
@@ -1387,7 +1386,7 @@ SHARED_SETTLEMENT_CANDIDATES = (
 @pytest.mark.parametrize(
     "path", SHARED_SETTLEMENT_CANDIDATES, ids=lambda item: item.name
 )
-def test_compatibility_systems_are_not_short_of_corridor(path: Path) -> None:
+def test_shared_settlement_candidates_are_not_short_of_corridor(path: Path) -> None:
     observed = _rendered_plan(path, permissive=True)
     assert _capacity_deficits(observed.route_plan) == {}
 

--- a/tests/test_exit_turn_planner.py
+++ b/tests/test_exit_turn_planner.py
@@ -1895,7 +1895,7 @@ def test_a_chained_trunk_descent_is_seated_off_the_column_it_is_built_on() -> No
 
 
 def test_a_gap_seated_axis_uses_the_allocated_coordinate() -> None:
-    """The planned axis uses the seat that clears the compatibility channel.
+    """The planned axis uses the seat that clears the allocated channel.
 
     The fan's axes are derived from the grid edges its handler has to hand;
     ``normalize._materialize_gap_slots`` then seats the whole gap at once and
@@ -1930,7 +1930,7 @@ def test_a_gap_seated_axis_uses_the_allocated_coordinate() -> None:
     } == around_stack
 
 
-def test_planned_turn_owns_the_compatibility_channel_seat() -> None:
+def test_planned_turn_owns_the_channel_seat() -> None:
     graph, offsets, observation = _observe(
         FIXTURES / "planned_compatibility_channel_collision.mmd"
     )
@@ -1947,7 +1947,7 @@ def test_planned_turn_owns_the_compatibility_channel_seat() -> None:
 
 
 @pytest.mark.parametrize("fold", [1, 2, 3])
-def test_compatibility_claim_matches_the_emitted_channel_span(fold: int) -> None:
+def test_planned_claim_matches_the_emitted_channel_span(fold: int) -> None:
     source = (
         (TOPOLOGIES / "shared_sink_parallel.mmd")
         .read_text()


### PR DESCRIPTION
## Summary

- describe route-system execution as a single planned disposition
- rename settlement and exit-turn tests to use the current planned-routing terminology
- remove an issue-history reference from the fan centreline docstring

This is wording only. It does not change routing behaviour, assertions or fixtures.

The two substantive findings from the same stock-take are tracked separately in #1738 and #1739.

## Tests

- `python -m pytest -q tests/test_envelope_settlement.py tests/test_exit_turn_planner.py tests/test_fan_plans.py` (607 passed, 1 xfailed)
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
